### PR TITLE
Coq extraction script + simple ocaml translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ setup.log
 *.swo
 *.swp
 
+# coq
+*.glob
+*.vo
+*.vo.aux
+core/ml/*

--- a/core/extract-coq.sh
+++ b/core/extract-coq.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eou pipefail
+
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+mkdir -p "$SCRIPTPATH/ml"
+coqtop -compile "$SCRIPTPATH/hazel_core" > "$SCRIPTPATH/ml/hazel_core.ml"
+

--- a/core/hazel_core.v
+++ b/core/hazel_core.v
@@ -95,11 +95,19 @@ Module HTyp.
      simpl; 
      reflexivity.
    Qed.
-  
+
+   Definition matched_arrow (ty : t) : option (t * t) :=
+     match ty with
+     | Arrow ty1 ty2 (* MAArr *) => Some (ty1, ty2)
+     | Hole (* MAHole *) => Some (Hole, Hole)
+     | _ => None
+     end.
 
 End HTyp.
 
 Extract Inductive bool => "bool" ["true" "false"].
 Extract Constant negb => "not".
+Extract Inductive option => "option" ["Some" "None"].
+Extract Inductive prod => "" [""].
 Extraction HTyp.
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,8 +1,17 @@
+#!/bin/bash
+
+set -eou pipefail
+
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPTPATH"
+
 for f in `find . -name '*.ml'` ; \
 do ( \
 ocp-indent -i $f; \
 ); \
 done
+
+../core/extract-coq.sh
 
 ocamlbuild -use-ocamlfind \
   -pkgs js_of_ocaml,js_of_ocaml.ppx,js_of_ocaml.tyxml,tyxml,react,reactiveData,camomile \


### PR DESCRIPTION
Ported this code from `hazel_semantics.ml`

```ocaml
  let matched_arrow ty = match ty with
    | Arrow (ty1, ty2) (* MAArr *) -> Some (ty1, ty2)
    | Hole (* MAHole *) -> Some (Hole, Hole)
    | _ -> None
```

The coq definition extracts to this:

```ocaml
  (** val matched_arrow : t -> (t, t)  option **)

  let matched_arrow = function
  | Arrow (ty1, ty2) -> Some (ty1, ty2)
  | Hole -> Some (Hole, Hole)
  | _ -> None
 end
```