### PR TITLE
Add js_of_ocaml-tyxml dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Hazel is implemented in OCaml and compiled to Javascript for the web browser via
   - We can now install the necessary dependencies.
 
     ```sh
-    > opam install js_of_ocaml tyxml deriving ppx_deriving reactiveData ocp-indent camomile
+    > opam install js_of_ocaml tyxml js_of_ocaml-tyxml deriving ppx_deriving reactiveData ocp-indent camomile
     ```
 
   - To make sure you have the latest versions of everything, ask `opam` to upgrade the packages if needed:


### PR DESCRIPTION
The `./build.sh ` step failed for me here before installing it.

(This was on a clean install on macOS 10.12.6, first time installing opam on this machine, following the instructions)