### PR TITLE
Fix path protocol for expression lines

### DIFF
--- a/src/View.re
+++ b/src/View.re
@@ -664,7 +664,7 @@ let rec of_hexp = (palette_stuff, prefix, rev_path, e) =>
           let r1 = of_hexp(palette_stuff, prefix, [2, ...rev_path_li], e1);
           of_LetLine(prefix, rev_path_li, rp, rann, r1);
         | UHExp.ExpLine(e1) =>
-          let r1 = of_hexp(palette_stuff, prefix, rev_path_li, e1);
+          let r1 = of_hexp(palette_stuff, prefix, [0, ...rev_path_li], e1);
           of_ExpLine(prefix, rev_path_li, r1);
         };
       let r2 = of_hexp(palette_stuff, prefix, [1, ...rev_path], e2);

--- a/src/semantics/Path.re
+++ b/src/semantics/Path.re
@@ -71,7 +71,7 @@ and of_zline_item = (zli: ZExp.zline_item): t =>
   }
 and of_zline_item' = (zli': ZExp.zline_item'): t =>
   switch (zli') {
-  | ZExp.ExpLineZ(ze) => of_zexp(ze)
+  | ZExp.ExpLineZ(ze) => cons'(0, of_zexp(ze))
   | ZExp.LetLineZP(zp, _, _) => cons'(0, of_zpat(zp))
   | ZExp.LetLineZA(_, zann, _) => cons'(1, of_ztyp(zann))
   | ZExp.LetLineZE(_, _, ze) => cons'(2, of_zexp(ze))
@@ -298,11 +298,12 @@ and follow_line_item =
   switch (path, li) {
   | (([], cursor_side), li) => Some(ZExp.CursorL(cursor_side, li))
   | (_, UHExp.EmptyLine) => None
-  | (_, UHExp.ExpLine(e)) =>
-    switch (follow_e(path, e)) {
+  | (([0, ...xs], cursor_side), UHExp.ExpLine(e)) =>
+    switch (follow_e((xs, cursor_side), e)) {
     | None => None
     | Some(ze) => Some(ZExp.DeeperL(ZExp.ExpLineZ(ze)))
     }
+  | (_, UHExp.ExpLine(_)) => None
   | (([0, ...xs], cursor_side), UHExp.LetLine(p, ann, e1)) =>
     switch (follow_pat((xs, cursor_side), p)) {
     | None => None


### PR DESCRIPTION
The initial implementation of lines items https://github.com/hazelgrove/hazel/pull/53/files had a path protocol where an expression line and the expression had the same path. Generally we only want the cursor to be on the expression in an expression line. However, because they share the same path, when doing an action that leaves the cursor at the end of exp on an exp line, the update view code would leave the cursor at the end of the line. This would lead to issues such as the cursor inspector reporting a line item instead of type Num as expected in the following scenario:
```
1|
_
```
This PR updates the path protocol so that expressions have distinct paths from their enclosing expression lines. In the future, we may want to restructure `UHExp` and `ZExp` in order to make redundant cursor positions impossible (e.g., end of line vs end of exp line, end of opseq vs end of last exp in opseq, etc).