### PR TITLE
First attempt at variable splitting.

### DIFF
--- a/src/semantics/ZExp.re
+++ b/src/semantics/ZExp.re
@@ -179,6 +179,12 @@ let is_before_rule =
   | CursorR(OnDelim(0, Before), _) => true
   | _ => false;
 
+let rec cursor_on_var =
+  fun
+  | CursorE(OnText(_) as text, Var(_, _, _) as var) => Some((text, var))
+  | OpSeqZ(_, zexp, _) => cursor_on_var(zexp)
+  | _ => None;
+
 let rec is_after_block = (zblock: zblock): bool =>
   switch (zblock) {
   | BlockZL(_, _) => false


### PR DESCRIPTION
This pull request is not in a ready state. It's so David can keep track of my progress and help provide guidance.

----

Seems to work for nested expressions, but the cursor gets broken
when using keyboard navigation. Probably due to reusing the
variable info when splitting (?). Only tested one scenario so far,
which is:

 | = cursor
 <key> = input

abcd|efg
<+>
abcd + efg|
abcd + ef|g
<+>
abcd + ef + g|

Which seems to work.