### PR TITLE
Line swap

### DIFF
--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2531,6 +2531,7 @@ module Exp = {
       /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
+      /* handle corner case when the second to last line is an EmptyLine */
       | ([last], CursorL(_, EmptyLine)) => {
         let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole;
         let new_zblock = (prefix @ [last], ZExp.ExpLineZ(ZOpSeq.wrap(new_hole)), []) |> ZExp.prune_empty_hole_lines;
@@ -3841,11 +3842,12 @@ module Exp = {
       /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
+      /* handle corner case when the second to last line is an EmptyLine */
       | ([last], CursorL(_, EmptyLine)) => {
         let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole;
         let new_zblock = (prefix @ [last], ZExp.ExpLineZ(ZOpSeq.wrap(new_hole)), []) |> ZExp.prune_empty_hole_lines;
         Succeeded(
-          AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock)),
+          AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
         );
       }
       | ([hd, ...tl], _) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -252,7 +252,7 @@ module Typ = {
                           )) => {
                             let new_suffix = Seq.A(operator, S(operand, suffix));
                             let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(mk_ZOpSeq(new_zseq))
+                            Succeeded(mk_ZOpSeq(new_zseq));
                           }
     | (SwapRight, ZOperand(_, (_, E))) => Failed
     | (SwapRight, ZOperand(zoperand,
@@ -260,7 +260,7 @@ module Typ = {
                           )) => {
                             let new_prefix = Seq.A(operator, S(operand, prefix));
                             let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(mk_ZOpSeq(new_zseq))
+                            Succeeded(mk_ZOpSeq(new_zseq));
                           }
     /* Zipper */
     | (_, ZOperand(zoperand, (prefix, suffix))) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2796,6 +2796,7 @@ module Exp = {
 
     /* Invalid actions */
     | (UpdateApPalette(_), ZOperator(_)) => Failed
+    | (SwapUp | SwapDown, _)
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
 
@@ -3019,7 +3020,8 @@ module Exp = {
     /* Invalid actions at expression level */
     | (Construct(SLine), CursorE(OnText(_), _))
     | (Construct(SList), _) => Failed
-
+    | (SwapUp | SwapDown | SwapLeft | SwapRight, _) => Failed
+    
     /* Movement handled at top level */
     | (
         MoveTo(_) | MoveToBefore(_) | MoveToPrevHole | MoveToNextHole | MoveLeft |

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -295,9 +295,7 @@ module Typ = {
           SApPalette(_),
         ) |
         SwapUp |
-        SwapDown |
-        SwapLeft |
-        SwapRight,
+        SwapDown,
         _,
       ) =>
       Failed

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3652,7 +3652,7 @@ module Exp = {
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
       | Some((rest, last)) => {
-          let new_zrules = (rest, zline, ([last, ...suffix]));
+          let new_zrules = (rest, zrule, ([last, ...suffix]));
           Succeeded()
         }
       }
@@ -3660,7 +3660,7 @@ module Exp = {
       switch (suffix) {
       | [] => Failed
       | [hd, ...tl] => {
-          let new_zrules = ((prefix @ [hd]), zline, tl);
+          let new_zrules = ((prefix @ [hd]), zrule, tl);
           Succeeded((new_zrules, u_gen))
         }
       }

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2533,7 +2533,7 @@ module Exp = {
         Failed
       | ([last], CursorL(_, EmptyLine)) => {
         let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole;
-        let new_zblock = (prefix @ [last], new_hole, []) |> ZExp.prune_empty_hole_lines;
+        let new_zblock = (prefix @ [last], ZExp.ExpLineZ(ZOpSeq.wrap(new_hole)), []) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
         );
@@ -3843,7 +3843,7 @@ module Exp = {
         Failed
       | ([last], CursorL(_, EmptyLine)) => {
         let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole;
-        let new_zblock = (prefix @ [last], new_hole, []) |> ZExp.prune_empty_hole_lines;
+        let new_zblock = (prefix @ [last], ZExp.ExpLineZ(ZOpSeq.wrap(new_hole)), []) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock)),
         );

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2243,7 +2243,11 @@ module Exp = {
     | Construct(_)
     | Delete
     | Backspace
-    | UpdateApPalette(_) =>
+    | UpdateApPalette(_)
+    | SwapLeft
+    | SwapRight
+    | SwapUp
+    | SwapDown =>
       failwith(
         __LOC__
         ++ ": expected movement action, got "
@@ -2296,7 +2300,11 @@ module Exp = {
     | Construct(_)
     | Delete
     | Backspace
-    | UpdateApPalette(_) =>
+    | UpdateApPalette(_)
+    | SwapLeft
+    | SwapRight
+    | SwapUp
+    | SwapDown =>
       failwith(
         __LOC__
         ++ ": expected movement action, got "

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3656,7 +3656,7 @@ module Exp = {
           Succeeded()
         }
       }
-    | (SwapDown, CursorR(_), RuleZP(_)) =>
+    | (SwapDown, CursorR(_) | RuleZP(_)) =>
       switch (suffix) {
       | [] => Failed
       | [hd, ...tl] => {

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2532,7 +2532,7 @@ module Exp = {
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
       | ([last], CursorL(_, EmptyLine)) => {
-        let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole(u_gen);
+        let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole;
         let new_zblock = (prefix @ [last], new_hole, []) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
@@ -3841,6 +3841,13 @@ module Exp = {
       /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
+      | ([last], CursorL(_, EmptyLine)) => {
+        let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole;
+        let new_zblock = (prefix @ [last], new_hole, []) |> ZExp.prune_empty_hole_lines;
+        Succeeded(
+          SynDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock)),
+        );
+      }
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2531,10 +2531,11 @@ module Exp = {
       /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
-      /* doesn't perform syn_fix_holes_z when second to last is EmptyLine to avoid generating a new hole */
+      /** doesn't perform syn_fix_holes_z when second to last line
+       *  is EmptyLine to avoid generating a new hole */
       | ([last], CursorL(_, EmptyLine)) => 
         let new_zblock = (prefix @ [last], zline, []) |> ZExp.prune_empty_hole_lines;
-        Succeeded(SynDone(new_zblock, ty, u_gen));
+        Succeeded(SynDone((new_zblock, ty, u_gen)));
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2531,6 +2531,13 @@ module Exp = {
       /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
+      | ([last], CursorL(_, EmptyLine)) => {
+        let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole(u_gen);
+        let new_zblock = (prefix @ [last], new_hole, []) |> ZExp.prune_empty_hole_lines;
+        Succeeded(
+          SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
+        );
+      }
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2520,7 +2520,7 @@ module Exp = {
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
       | Some((rest, last)) =>
-        let new_zblock = (rest, zline, [last, ...suffix]);
+        let new_zblock = (rest, zline, [last, ...suffix]) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
         );
@@ -2532,7 +2532,7 @@ module Exp = {
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
       | ([hd, ...tl], _) =>
-        let new_zblock = (prefix @ [hd], zline, tl);
+        let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
         );
@@ -3823,7 +3823,7 @@ module Exp = {
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
       | Some((rest, last)) =>
-        let new_zblock = (rest, zline, [last, ...suffix]);
+        let new_zblock = (rest, zline, [last, ...suffix]) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
         );
@@ -3835,7 +3835,7 @@ module Exp = {
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
       | ([hd, ...tl], _) =>
-        let new_zblock = (prefix @ [hd], zline, tl);
+        let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
         );

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3804,9 +3804,11 @@ module Exp = {
         }
       }
     | (SwapDown, _) when ZExp.line_can_be_swapped(zline) =>
-      switch(suffix) {
-      | [] => Failed
-      | [hd, ...tl] => {
+      switch(suffix, zline) {
+      | ([], _) => Failed
+      /* avoid swap down fot the Let line if it is second to last */
+      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) => Failed
+      | ([hd, ...tl], _) => {
           let new_zblock = ((prefix @ [hd]), zline, tl);
           Succeeded(
             AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty))

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -295,7 +295,9 @@ module Typ = {
           SApPalette(_),
         ) |
         SwapUp |
-        SwapDown,
+        SwapDown |
+        SwapLeft |
+        SwapRight,
         _,
       ) =>
       Failed

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2722,6 +2722,8 @@ module Exp = {
 
     /* Invalid actions */
     | (UpdateApPalette(_), ZOperator(_)) => Failed
+    | (SwapLeft, ZOperator(_))
+    | (SwapRight, ZOperator(_)) => Failed
 
     /* Movement handled at top level */
     | (
@@ -2833,6 +2835,24 @@ module Exp = {
       };
       let new_zblock = ([new_line], new_zline, []);
       Succeeded(SynDone((new_zblock, ty, u_gen)));
+
+    /* SwapLeft and SwapRight */
+    | (SwapLeft, ZOperand(_, (E, _))) => Failed
+    | (SwapLeft, ZOperand(zoperand, 
+                          (A(operator, S(operand, new_prefix)), suffix)
+                          )) => {
+                            let new_suffix = A(operator, S(operand, suffix));
+                            let new_zseq = ZOperand(zoperand, (new_prefix, new_suffix));
+                            Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
+                          }
+    | (SwapRight, ZOperand(_, (_, E))) => Failed
+    | (SwapRight, ZOperand(zoperand, 
+                          (prefix, A(operator, S(operand, new_suffix)))
+                          )) => {
+                            let new_prefix = A(operator, S(operand, prefix));
+                            let new_zseq = ZOperand(zoperand, (new_prefix, new_suffix));
+                            Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
+                          }
 
     /* Zipper */
 

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3997,7 +3997,8 @@ module Exp = {
                           )) => {
                             let new_suffix = Seq.A(operator, S(operand, suffix));
                             let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
+                            Outcome.Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty))
+                            |> wrap_in_AnaDone;
                           }
     | (SwapRight, ZOperand(_, (_, E))) => Failed
     | (SwapRight, ZOperand(zoperand,
@@ -4005,7 +4006,8 @@ module Exp = {
                           )) => {
                             let new_prefix = Seq.A(operator, S(operand, prefix));
                             let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
+                            Outcome.Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty))
+                            |> wrap_in_AnaDone;
                           }
 
     /* Zipper */

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2519,16 +2519,20 @@ module Exp = {
     | SwapUp when ZExp.line_can_be_swapped(zline) =>
       switch (ListUtil.split_last(prefix), zline |> ZExp.erase_zline, suffix) {
       | (None, _, _) => Failed
-      | (Some((_, LetLine(_))), ExpLine(OpSeq(_, S(EmptyHole(_), E))), []) => Failed
+      | (Some((_, LetLine(_))), ExpLine(OpSeq(_, S(EmptyHole(_), E))), []) =>
+        Failed
       /* handle the corner case when swapping the last line up where the second to last line is EmptyLine */
-      | (Some((rest, EmptyLine)), _, []) => 
+      | (Some((rest, EmptyLine)), _, []) =>
         let (new_hole, u_gen) = u_gen |> UHExp.new_EmptyHole;
-        let new_zblock = (rest, zline, UHExp.Block.wrap(new_hole)) |> ZExp.prune_empty_hole_lines;
+        let new_zblock =
+          (rest, zline, UHExp.Block.wrap(new_hole))
+          |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
         );
       | (Some((rest, last)), _, _) =>
-        let new_zblock = (rest, zline, [last, ...suffix]) |> ZExp.prune_empty_hole_lines;
+        let new_zblock =
+          (rest, zline, [last, ...suffix]) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
         );
@@ -2540,15 +2544,17 @@ module Exp = {
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
       /* handle corner case when the second to last line is an EmptyLine */
-      | ([last], CursorL(_, EmptyLine)) => {
+      | ([last], CursorL(_, EmptyLine)) =>
         let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole;
-        let new_zblock = (prefix @ [last], ZExp.ExpLineZ(ZOpSeq.wrap(new_hole)), []) |> ZExp.prune_empty_hole_lines;
+        let new_zblock =
+          (prefix @ [last], ZExp.ExpLineZ(ZOpSeq.wrap(new_hole)), [])
+          |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
         );
-      }
       | ([hd, ...tl], _) =>
-        let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
+        let new_zblock =
+          (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
         );
@@ -3838,16 +3844,20 @@ module Exp = {
     | (SwapUp, _) when ZExp.line_can_be_swapped(zline) =>
       switch (ListUtil.split_last(prefix), zline |> ZExp.erase_zline, suffix) {
       | (None, _, _) => Failed
-      | (Some((_, LetLine(_))), ExpLine(OpSeq(_, S(EmptyHole(_), E))), []) => Failed
+      | (Some((_, LetLine(_))), ExpLine(OpSeq(_, S(EmptyHole(_), E))), []) =>
+        Failed
       /* handle the corner case when swapping the last line up where the second to last line is EmptyLine */
       | (Some((rest, EmptyLine)), _, []) =>
         let (new_hole, u_gen) = u_gen |> UHExp.new_EmptyHole;
-        let new_zblock = (rest, zline, UHExp.Block.wrap(new_hole)) |> ZExp.prune_empty_hole_lines;
+        let new_zblock =
+          (rest, zline, UHExp.Block.wrap(new_hole))
+          |> ZExp.prune_empty_hole_lines;
         Succeeded(
           AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
         );
       | (Some((rest, last)), _, _) =>
-        let new_zblock = (rest, zline, [last, ...suffix]) |> ZExp.prune_empty_hole_lines;
+        let new_zblock =
+          (rest, zline, [last, ...suffix]) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
         );
@@ -3859,15 +3869,17 @@ module Exp = {
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
       /* handle corner case when the second to last line is an EmptyLine */
-      | ([last], CursorL(_, EmptyLine)) => {
+      | ([last], CursorL(_, EmptyLine)) =>
         let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole;
-        let new_zblock = (prefix @ [last], ZExp.ExpLineZ(ZOpSeq.wrap(new_hole)), []) |> ZExp.prune_empty_hole_lines;
+        let new_zblock =
+          (prefix @ [last], ZExp.ExpLineZ(ZOpSeq.wrap(new_hole)), [])
+          |> ZExp.prune_empty_hole_lines;
         Succeeded(
           AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
         );
-      }
       | ([hd, ...tl], _) =>
-        let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
+        let new_zblock =
+          (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
         );

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2528,8 +2528,8 @@ module Exp = {
     | SwapDown when ZExp.line_can_be_swapped(zline) =>
       switch (suffix, zline) {
       | ([], _) => Failed
-      /* avoid swap down for the Let line if it is second to last */
-      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
+      /* avoid swap down for the Let line  and EmptyLine if it is second to last */
+      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_) | EmptyLine)) =>
         Failed
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
@@ -3831,8 +3831,8 @@ module Exp = {
     | (SwapDown, _) when ZExp.line_can_be_swapped(zline) =>
       switch (suffix, zline) {
       | ([], _) => Failed
-      /* avoid swap down for the Let line if it is second to last */
-      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
+      /* avoid swap down for the Let line and EmptyLine if it is second to last */
+      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_) | EmptyLine)) =>
         Failed
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -256,7 +256,7 @@ module Typ = {
                           }
     | (SwapRight, ZOperand(_, (_, E))) => Failed
     | (SwapRight, ZOperand(zoperand,
-                          (prefix, A(operator S(operand, new_suffix)))
+                          (prefix, A(operator, S(operand, new_suffix)))
                           )) => {
                             let new_prefix = Seq.A(operator, S(operand, prefix));
                             let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -181,7 +181,9 @@ module Typ = {
         Construct(
           SAsc | SLet | SLine | SLam | SListNil | SInj(_) | SCase |
           SApPalette(_),
-        ),
+        ) |
+        SwapUp | 
+        SwapDown,
         _,
       )
     /* Invalid cursor positions */

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2510,7 +2510,7 @@ module Exp = {
       switch (suffix, zline) {
       | ([], _) => Failed
       /* avoid swap down for the Let line if it is second to last */
-      | ([single_line], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) => Failed
+      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) => Failed
       | ([hd, ...tl], _) => {
           let new_zblock = ((prefix @ [hd]), zline, tl);
           Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3831,7 +3831,7 @@ module Exp = {
     | (SwapDown, _) when ZExp.line_can_be_swapped(zline) =>
       switch (suffix, zline) {
       | ([], _) => Failed
-      /* avoid swap down fot the Let line if it is second to last */
+      /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
       | ([hd, ...tl], _) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3643,6 +3643,8 @@ module Exp = {
       }
     | (Construct(_) | UpdateApPalette(_), CursorR(OnDelim(_), _)) => Failed
 
+    /* Invalid swap actions */
+    | (SwapUp | SwapDown | SwapLeft | SwapRight, _) => Failed
     /* Zipper */
     | (_, RuleZP(zp, clause)) =>
       switch (Pat.ana_perform(ctx, u_gen, a, zp, pat_ty)) {

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3773,7 +3773,7 @@ module Exp = {
     /* No construction handled at block level */
     
     /* SwapUp and SwapDown is handled at block level */
-    | (SwapUp, _) => 
+    | (SwapUp, _) when ZExp.line_can_be_swapped(zline) => 
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
       | Some((rest, last)) => {
@@ -3783,7 +3783,7 @@ module Exp = {
           )
         }
       }
-    | (SwapDown, _) =>
+    | (SwapDown, _) when ZExp.line_can_be_swapped(zline) =>
       switch(suffix) {
       | [] => Failed
       | [hd, ...tl] => {
@@ -3867,7 +3867,7 @@ module Exp = {
 
     /* Invalid actions */
     | (UpdateApPalette(_), ZOperator(_)) => Failed
-    | (SwapUp | SwapDown, _) => Failed
+    | (SwapUp | SwapDown, ZOperator(_)) => Failed
 
     /* Movement handled at top level */
     | (
@@ -4126,7 +4126,7 @@ module Exp = {
       Failed
 
     /* Invalid swap actions */
-    | (SwapUp | SwapDown, _) => Failed
+    | (SwapUp | SwapDown, CursorE(_) | LamZP(_) | LamZA(_) | CaseZA(_)) => Failed
 
     | (_, CursorE(cursor, operand))
         when !ZExp.is_valid_cursor_operand(cursor, operand) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2499,7 +2499,7 @@ module Exp = {
     /* No construction handled at block level */
 
     /* SwapUp and SwapDown is handled at block level */
-    | SwapUp when ZExp.is_CursorL(zline) => 
+    | SwapUp when ZExp.line_can_be_swapped(zline) => 
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
       | Some((rest, last)) => {
@@ -2507,7 +2507,7 @@ module Exp = {
           Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
         }
       }  
-    | SwapDown when ZExp.is_CursorL(zline) =>
+    | SwapDown when ZExp.line_can_be_swapped(zline) =>
       switch (suffix) {
       | [] => Failed
       | [hd, ...tl] => {

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2515,8 +2515,6 @@ module Exp = {
           Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
         }
       }
-        
-                 // when prefix is not empty, use ListUtil.last to get the last line in prefix
     
     /* Zipper */
     | _ =>
@@ -2714,8 +2712,7 @@ module Exp = {
     | (Construct(_) | UpdateApPalette(_), CursorL(_)) => Failed
 
     /* Invalid swap actions */
-    | (SwapUp, _)
-    | (SwapDown, _) => Failed
+    | (SwapUp | SwapDown, CursorL(_) | LetLineZP(_) | LetLineZA(_)) => Failed
     | (SwapLeft, CursorL(_))
     | (SwapRight, CursorL(_)) => Failed
 
@@ -2822,7 +2819,7 @@ module Exp = {
 
     /* Invalid actions */
     | (UpdateApPalette(_), ZOperator(_)) => Failed
-    | (SwapUp | SwapDown, _)
+    | (SwapUp | SwapDown, ZOperator(_)) => Failed
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
 
@@ -3046,7 +3043,7 @@ module Exp = {
     /* Invalid actions at expression level */
     | (Construct(SLine), CursorE(OnText(_), _))
     | (Construct(SList), _) => Failed
-    | (SwapUp | SwapDown, _) => Failed
+    | (SwapUp | SwapDown, CursorE(_) | LamZP(_) | LamZA(_) | CaseZA(_)) => Failed
     
     /* Movement handled at top level */
     | (

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2404,6 +2404,26 @@ module Exp = {
 
     /* No construction handled at block level */
 
+    /* SwapUp and SwapDown is handled at block level */
+    | SwapUp => 
+      switch (ListUtil.split_last(prefix)) {
+      | None => Failed
+      | Some(rest, last) => {
+          let new_zblock = (rest, zline, ([last] @ suffix));
+          Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
+        }
+      }  
+    | SwapDown =>
+      switch (suffix) {
+      | [] => Failed
+      | [hd, ...tl] => {
+          let new_zblock = (([hd] @ prefix, zline, tl));
+          Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
+        }
+      }
+        
+                 // when prefix is not empty, use ListUtil.last to get the last line in prefix
+    
     /* Zipper */
     | _ =>
       switch (Statics.Exp.syn_lines(ctx, prefix)) {

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2507,9 +2507,11 @@ module Exp = {
         }
       }  
     | SwapDown when ZExp.line_can_be_swapped(zline) =>
-      switch (suffix) {
-      | [] => Failed
-      | [hd, ...tl] => {
+      switch (suffix, zline) {
+      | ([], _) => Failed
+      /* avoid swap down for the Let line if it is second to last */
+      | ([single_line], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) => Failed
+      | ([hd, ...tl], _) => {
           let new_zblock = ((prefix @ [hd]), zline, tl);
           Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
         }

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -246,16 +246,16 @@ module Typ = {
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
     
-    | (SwapLeft, ZOperand(_, (E, _))) => Failed
-    | (SwapLeft, ZOperand(zoperand,
+    | (SwapLeft, ZOperand(CursorT(_), (E, _))) => Failed
+    | (SwapLeft, ZOperand(CursorT(_) as zoperand,
                           (A(operator, S(operand, new_prefix)), suffix)
                           )) => {
                             let new_suffix = Seq.A(operator, S(operand, suffix));
                             let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
                             Succeeded(mk_ZOpSeq(new_zseq));
                           }
-    | (SwapRight, ZOperand(_, (_, E))) => Failed
-    | (SwapRight, ZOperand(zoperand,
+    | (SwapRight, ZOperand(CursorT(_), (_, E))) => Failed
+    | (SwapRight, ZOperand(CursorT(_) as zoperand,
                           (prefix, A(operator, S(operand, new_suffix)))
                           )) => {
                             let new_prefix = Seq.A(operator, S(operand, prefix));
@@ -295,9 +295,7 @@ module Typ = {
           SApPalette(_),
         ) |
         SwapUp |
-        SwapDown |
-        SwapLeft |
-        SwapRight,
+        SwapDown,
         _,
       ) =>
       Failed
@@ -376,6 +374,9 @@ module Typ = {
       | None => Failed
       | Some(op) => Succeeded(construct_operator(op, zoperand, (E, E)))
       }
+
+    /* Invalid SwapLeft and SwapRight actions */
+    | (SwapLeft | SwapRight, CursorT(_)) => Failed
 
     /* Zipper Cases */
     | (_, ParenthesizedZ(zbody)) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2528,8 +2528,8 @@ module Exp = {
     | SwapDown when ZExp.line_can_be_swapped(zline) =>
       switch (suffix, zline) {
       | ([], _) => Failed
-      /* avoid swap down for the Let line  and EmptyLine if it is second to last */
-      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_) | EmptyLine)) =>
+      /* avoid swap down for the Let line if it is second to last */
+      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
@@ -3831,8 +3831,8 @@ module Exp = {
     | (SwapDown, _) when ZExp.line_can_be_swapped(zline) =>
       switch (suffix, zline) {
       | ([], _) => Failed
-      /* avoid swap down for the Let line and EmptyLine if it is second to last */
-      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_) | EmptyLine)) =>
+      /* avoid swap down for the Let line if it is second to last */
+      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3645,8 +3645,25 @@ module Exp = {
     | (Construct(_) | UpdateApPalette(_), CursorR(OnDelim(_), _)) => Failed
 
     /* Invalid swap actions */
-    | (SwapUp | SwapDown, _) => Failed
     | (SwapLeft | SwapRight, CursorR(_)) => Failed
+
+    /* SwapUp and SwapDown actions */
+    | (SwapUp, CursorR(_) | RuleZP(_)) =>
+      switch (ListUtil.split_last(prefix)) {
+      | None => Failed
+      | Some((rest, last)) => {
+          let new_zrules = (rest, zline, ([last, ...suffix]));
+          Succeeded()
+        }
+      }
+    | (SwapDown, CursorR(_), RuleZP(_)) =>
+      switch (suffix) {
+      | [] => Failed
+      | [hd, ...tl] => {
+          let new_zrules = ((prefix @ [hd]), zline, tl);
+          Succeeded((new_zrules, u_gen))
+        }
+      }
 
     /* Zipper */
     | (_, RuleZP(zp, clause)) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -246,7 +246,7 @@ module Typ = {
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
     
-    | (SwapLeft, Zoperand(_, (E, _))) => Failed
+    | (SwapLeft, ZOperand(_, (E, _))) => Failed
     | (SwapLeft, ZOperand(zoperand,
                           (A(operator, S(operand, new_prefix)), suffix)
                           )) => {
@@ -255,7 +255,7 @@ module Typ = {
                             Succeeded(mk_ZOpSeq(new_zseq))
                           }
     | (SwapRight, ZOperand(_, (_, E))) => Failed
-    | (SwapRight, Zoperand(zoperand,
+    | (SwapRight, ZOperand(zoperand,
                           (prefix, A(operator S(operand, new_suffix)))
                           )) => {
                             let new_prefix = Seq.A(operator, S(operand, prefix));

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2937,16 +2937,16 @@ module Exp = {
       Succeeded(SynDone((new_zblock, ty, u_gen)));
 
     /* SwapLeft and SwapRight */
-    | (SwapLeft, ZOperand(_, (E, _))) => Failed
-    | (SwapLeft, ZOperand(zoperand, 
+    | (SwapLeft, ZOperand(CursorE(_), (E, _))) => Failed
+    | (SwapLeft, ZOperand(CursorE(_) as zoperand, 
                           (A(operator, S(operand, new_prefix)), suffix)
                           )) => {
                             let new_suffix = Seq.A(operator, S(operand, suffix));
                             let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
                             Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
                           }
-    | (SwapRight, ZOperand(_, (_, E))) => Failed
-    | (SwapRight, ZOperand(zoperand, 
+    | (SwapRight, ZOperand(CursorE(_), (_, E))) => Failed
+    | (SwapRight, ZOperand(CursorE(_) as zoperand, 
                           (prefix, A(operator, S(operand, new_suffix)))
                           )) => {
                             let new_prefix = Seq.A(operator, S(operand, prefix));
@@ -3045,7 +3045,7 @@ module Exp = {
     /* Invalid actions at expression level */
     | (Construct(SLine), CursorE(OnText(_), _))
     | (Construct(SList), _) => Failed
-    | (SwapUp | SwapDown | SwapLeft | SwapRight, _) => Failed
+    | (SwapUp | SwapDown, _) => Failed
     
     /* Movement handled at top level */
     | (
@@ -3381,6 +3381,8 @@ module Exp = {
       Succeeded(SynDone((new_ze, ty, u_gen)));
     | (Construct(SLine), CursorE(_)) => Failed
 
+    /* Invalid SwapLeft and SwapRight actions */
+    | (SwapLeft | SwapRight, CursorE(_)) => Failed
     /* Zipper Cases */
     | (_, ParenthesizedZ(zbody)) =>
       switch (syn_perform(ctx, a, (zbody, ty, u_gen))) {
@@ -4018,8 +4020,8 @@ module Exp = {
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
 
-    | (SwapLeft, ZOperand(_, (E, _))) => Failed
-    | (SwapLeft, ZOperand(zoperand,
+    | (SwapLeft, ZOperand(CursorE(_), (E, _))) => Failed
+    | (SwapLeft, ZOperand(CursorE(_) as zoperand,
                           (A(operator, S(operand, new_prefix)), suffix)
                           )) => {
                             let new_suffix = Seq.A(operator, S(operand, suffix));
@@ -4027,8 +4029,8 @@ module Exp = {
                             Outcome.Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty))
                             |> wrap_in_AnaDone;
                           }
-    | (SwapRight, ZOperand(_, (_, E))) => Failed
-    | (SwapRight, ZOperand(zoperand,
+    | (SwapRight, ZOperand(CursorE(_), (_, E))) => Failed
+    | (SwapRight, ZOperand(CursorE(_) as zoperand,
                           (prefix, A(operator, S(operand, new_suffix)))
                           )) => {
                             let new_prefix = Seq.A(operator, S(operand, prefix));
@@ -4124,7 +4126,7 @@ module Exp = {
       Failed
 
     /* Invalid swap actions */
-    | (SwapUp | SwapDown | SwapLeft | SwapRight, _) => Failed
+    | (SwapUp | SwapDown, _) => Failed
 
     | (_, CursorE(cursor, operand))
         when !ZExp.is_valid_cursor_operand(cursor, operand) =>
@@ -4433,6 +4435,9 @@ module Exp = {
       );
       Succeeded(AnaDone((new_ze, u_gen)));
     | (Construct(SLine), CursorE(_)) => Failed
+
+    /* Invalid SwapLeft and SwapRight actions */
+    | (SwapLeft | SwapRight, CursorE(_)) => Failed
 
     /* Zipper Cases */
     | (_, ParenthesizedZ(zbody)) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -1414,6 +1414,7 @@ module Pat = {
 
     /* Invalid actions */
     | (UpdateApPalette(_), ZOperator(_)) => Failed
+    | (SwapUp | SwapDown, _) => Failed
 
     /* Movement handled at top level */
     | (
@@ -1532,6 +1533,27 @@ module Pat = {
           construct_operator(u_gen, operator, zoperand, surround);
         Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, zseq, ty));
       }
+
+    /* invalid swap actions */
+    | (SwapLeft, ZOperator(_))
+    | (SwapRight, ZOperator(_)) => Failed
+    
+    | (SwapLeft, ZOperand(_, (E, _))) => Failed
+    | (SwapLeft, ZOperand(zoperand,
+                          (A(operator, S(operand, new_prefix)), suffix)
+                          )) => {
+                            let new_suffix = Seq.A(operator, S(operand, suffix));
+                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+                            Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
+                          }
+    | (SwapRight, ZOperand(_, (_, E))) => Failed
+    | (SwapRight, ZOperand(zoperand,
+                          (prefix, A(operator, S(operand, new_suffix)))
+                          )) => {
+                            let new_prefix = Seq.A(operator, S(operand, prefix));
+                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+                            Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
+                          }
 
     /* Zipper */
     | (_, ZOperand(zoperand, (E, E))) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -242,7 +242,6 @@ module Typ = {
 
     /* SwapLeft and SwapRight is handled at block level */
 
-    /* invalid swap actions */
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
     
@@ -2819,9 +2818,6 @@ module Exp = {
 
     /* Invalid actions */
     | (UpdateApPalette(_), ZOperator(_)) => Failed
-    | (SwapUp | SwapDown, ZOperator(_)) => Failed
-    | (SwapLeft, ZOperator(_))
-    | (SwapRight, ZOperator(_)) => Failed
 
     /* Movement handled at top level */
     | (
@@ -2934,7 +2930,11 @@ module Exp = {
       let new_zblock = ([new_line], new_zline, []);
       Succeeded(SynDone((new_zblock, ty, u_gen)));
 
-    /* SwapLeft and SwapRight */
+    /* Swap actions */
+    | (SwapUp | SwapDown, ZOperator(_))
+    | (SwapLeft, ZOperator(_))
+    | (SwapRight, ZOperator(_)) => Failed
+
     | (SwapLeft, ZOperand(CursorE(_), (E, _))) => Failed
     | (SwapLeft, ZOperand(CursorE(_) as zoperand, 
                           (A(operator, S(operand, new_prefix)), suffix)
@@ -3043,7 +3043,6 @@ module Exp = {
     /* Invalid actions at expression level */
     | (Construct(SLine), CursorE(OnText(_), _))
     | (Construct(SList), _) => Failed
-    | (SwapUp | SwapDown, CursorE(_) | LamZP(_) | LamZA(_) | CaseZA(_)) => Failed
     
     /* Movement handled at top level */
     | (
@@ -3379,8 +3378,10 @@ module Exp = {
       Succeeded(SynDone((new_ze, ty, u_gen)));
     | (Construct(SLine), CursorE(_)) => Failed
 
-    /* Invalid SwapLeft and SwapRight actions */
+    /* Invalid Swap actions */
+    | (SwapUp | SwapDown, CursorE(_) | LamZP(_) | LamZA(_) | CaseZA(_)) => Failed
     | (SwapLeft | SwapRight, CursorE(_)) => Failed
+
     /* Zipper Cases */
     | (_, ParenthesizedZ(zbody)) =>
       switch (syn_perform(ctx, a, (zbody, ty, u_gen))) {
@@ -3884,7 +3885,6 @@ module Exp = {
 
     /* Invalid actions */
     | (UpdateApPalette(_), ZOperator(_)) => Failed
-    | (SwapUp | SwapDown, ZOperator(_)) => Failed
 
     /* Movement handled at top level */
     | (
@@ -4033,7 +4033,8 @@ module Exp = {
       let new_zblock = ([new_line], new_zline, []);
       Succeeded(AnaDone((new_zblock, u_gen)));
 
-    /* SwapLeft and SwapRight actions */
+    /* Swap actions */
+    | (SwapUp | SwapDown, ZOperator(_))
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
 
@@ -4141,9 +4142,6 @@ module Exp = {
         ),
       ) =>
       Failed
-
-    /* Invalid swap actions */
-    | (SwapUp | SwapDown, CursorE(_) | LamZP(_) | LamZA(_) | CaseZA(_)) => Failed
 
     | (_, CursorE(cursor, operand))
         when !ZExp.is_valid_cursor_operand(cursor, operand) =>
@@ -4453,7 +4451,8 @@ module Exp = {
       Succeeded(AnaDone((new_ze, u_gen)));
     | (Construct(SLine), CursorE(_)) => Failed
 
-    /* Invalid SwapLeft and SwapRight actions */
+    /* Invalid Swap actions */
+    | (SwapUp | SwapDown, CursorE(_) | LamZP(_) | LamZA(_) | CaseZA(_)) => Failed
     | (SwapLeft | SwapRight, CursorE(_)) => Failed
 
     /* Zipper Cases */

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2499,7 +2499,7 @@ module Exp = {
     /* No construction handled at block level */
 
     /* SwapUp and SwapDown is handled at block level */
-    | SwapUp => 
+    | SwapUp when ZExp.is_cursorL(zline) => 
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
       | Some((rest, last)) => {
@@ -2507,7 +2507,7 @@ module Exp = {
           Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
         }
       }  
-    | SwapDown =>
+    | SwapDown when ZExp.is_cursorL(zline) =>
       switch (suffix) {
       | [] => Failed
       | [hd, ...tl] => {

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -1060,8 +1060,7 @@ module Pat = {
     | (UpdateApPalette(_), ZOperator(_)) => Failed
 
     /* Invalid swap actions */
-    | (SwapUp, _)
-    | (SwapDown, _) => Failed
+    | (SwapUp | SwapDown, _) => Failed
 
     /* Movement */
     | (
@@ -1135,20 +1134,20 @@ module Pat = {
       | Some(zp) => syn_perform(ctx, u_gen, a, zp)
       };
 
-    /* invalid swap actions */
+    /* SwapLeft and SwapRight actions */
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
     
-    | (SwapLeft, ZOperand(_, (E, _))) => Failed
-    | (SwapLeft, ZOperand(zoperand,
+    | (SwapLeft, ZOperand(CursorP(_), (E, _))) => Failed
+    | (SwapLeft, ZOperand(CursorP(_) as zoperand,
                           (A(operator, S(operand, new_prefix)), suffix)
                           )) => {
                             let new_suffix = Seq.A(operator, S(operand, suffix));
                             let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
                             Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq));
                           }
-    | (SwapRight, ZOperand(_, (_, E))) => Failed
-    | (SwapRight, ZOperand(zoperand,
+    | (SwapRight, ZOperand(CursorP(_), (_, E))) => Failed
+    | (SwapRight, ZOperand(CursorP(_) as zoperand,
                           (prefix, A(operator, S(operand, new_suffix)))
                           )) => {
                             let new_prefix = Seq.A(operator, S(operand, prefix));
@@ -1211,9 +1210,7 @@ module Pat = {
         Construct(SApPalette(_) | SList | SAsc | SLet | SLine | SLam | SCase) |
         UpdateApPalette(_) |
         SwapUp |
-        SwapDown |
-        SwapLeft |
-        SwapRight,
+        SwapDown,
         _,
       ) =>
       Failed
@@ -1370,6 +1367,9 @@ module Pat = {
           construct_operator(u_gen, operator, zoperand, (E, E));
         Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, zseq));
       }
+
+    /* Invalid SwapLeft and SwapRight actions */
+    | (SwapLeft | SwapRight, CursorP(_)) => Failed
 
     /* Zipper */
     | (_, ParenthesizedZ(zbody)) =>
@@ -1539,16 +1539,16 @@ module Pat = {
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
     
-    | (SwapLeft, ZOperand(_, (E, _))) => Failed
-    | (SwapLeft, ZOperand(zoperand,
+    | (SwapLeft, ZOperand(CursorP(_), (E, _))) => Failed
+    | (SwapLeft, ZOperand(CursorP(_) as zoperand,
                           (A(operator, S(operand, new_prefix)), suffix)
                           )) => {
                             let new_suffix = Seq.A(operator, S(operand, suffix));
                             let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
                             Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
                           }
-    | (SwapRight, ZOperand(_, (_, E))) => Failed
-    | (SwapRight, ZOperand(zoperand,
+    | (SwapRight, ZOperand(CursorP(_), (_, E))) => Failed
+    | (SwapRight, ZOperand(CursorP(_) as zoperand,
                           (prefix, A(operator, S(operand, new_suffix)))
                           )) => {
                             let new_prefix = Seq.A(operator, S(operand, prefix));
@@ -1616,9 +1616,7 @@ module Pat = {
         Construct(SApPalette(_) | SList | SAsc | SLet | SLine | SLam | SCase) |
         UpdateApPalette(_) |
         SwapUp |
-        SwapDown |
-        SwapLeft |
-        SwapRight,
+        SwapDown,
         _,
       ) =>
       Failed
@@ -1794,6 +1792,9 @@ module Pat = {
           construct_operator(u_gen, operator, zoperand, (E, E));
         Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, zseq, ty));
       }
+
+    /* Invalid SwapLeft and SwapRight actions */
+    | (SwapLeft | SwapRight, CursorP(_)) => Failed
 
     /* Zipper */
     | (_, ParenthesizedZ(zbody)) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -1190,7 +1190,7 @@ module Pat = {
         SwapUp |
         SwapDown |
         SwapLeft |
-        SwapRight
+        SwapRight,
         _,
       ) =>
       Failed

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2531,8 +2531,6 @@ module Exp = {
       /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
-      /** doesn't perform syn_fix_holes_z when second to last line
-       *  is EmptyLine to avoid generating a new hole */
       | ([last], CursorL(_, EmptyLine)) => 
         let new_zblock = (prefix @ [last], zline, []) |> ZExp.prune_empty_hole_lines;
         Succeeded(SynDone((new_zblock, ty, u_gen)));
@@ -3839,6 +3837,9 @@ module Exp = {
       /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
+      | ([last], CursorL(_, EmptyLine)) =>
+        let new_zblock = (prefix @ [last], zline, []) |> ZExp.prune_empty_hole_lines;
+        Succeeded(AnaDone(new_zblock, u_gen));
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2689,6 +2689,10 @@ module Exp = {
       };
     | (Construct(_) | UpdateApPalette(_), CursorL(_)) => Failed
 
+    /* Invalid swap actions */
+    | (SwapUp, _)
+    | (SwapDown, _) => Failed
+
     /* Zipper */
 
     | (_, ExpLineZ(zopseq)) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2692,6 +2692,8 @@ module Exp = {
     /* Invalid swap actions */
     | (SwapUp, _)
     | (SwapDown, _) => Failed
+    | (SwapLeft, CursorL(_))
+    | (SwapRight, CursorL(_)) => Failed
 
     /* Zipper */
 

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2531,9 +2531,6 @@ module Exp = {
       /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
-      | ([last], CursorL(_, EmptyLine)) => 
-        let new_zblock = (prefix @ [last], zline, []) |> ZExp.prune_empty_hole_lines;
-        Succeeded(SynDone((new_zblock, ty, u_gen)));
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(
@@ -3837,9 +3834,6 @@ module Exp = {
       /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
-      | ([last], CursorL(_, EmptyLine)) =>
-        let new_zblock = (prefix @ [last], zline, []) |> ZExp.prune_empty_hole_lines;
-        Succeeded(AnaDone(new_zblock, u_gen));
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3837,6 +3837,7 @@ module Exp = {
     | (SwapUp, _) when ZExp.line_can_be_swapped(zline) =>
       switch (ListUtil.split_last(prefix), suffix) {
       | (None, _) => Failed
+      /* handle the corner case when swapping the last line up where the second to last line is EmptyLine */
       | (Some((rest, EmptyLine)), []) =>
         let (new_hole, u_gen) = u_gen |> UHExp.new_EmptyHole;
         let new_zblock = (rest, zline, UHExp.Block.wrap(new_hole)) |> ZExp.prune_empty_hole_lines;

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3990,6 +3990,8 @@ module Exp = {
       Succeeded(AnaDone((new_zblock, u_gen)));
 
     /* SwapLeft and SwapRight actions */
+    | (SwapLeft, ZOperator(_))
+    | (SwapRight, ZOperator(_)) => Failed
 
     | (SwapLeft, ZOperand(_, (E, _))) => Failed
     | (SwapLeft, ZOperand(zoperand,

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3648,7 +3648,9 @@ module Exp = {
     | (Construct(_) | UpdateApPalette(_), CursorR(OnDelim(_), _)) => Failed
 
     /* Invalid swap actions */
-    | (SwapUp | SwapDown | SwapLeft | SwapRight, _) => Failed
+    | (SwapUp | SwapDown, _) => Failed
+    | (SwapLeft | SwapRight, CursorR(_)) => Failed
+
     /* Zipper */
     | (_, RuleZP(zp, clause)) =>
       switch (Pat.ana_perform(ctx, u_gen, a, zp, pat_ty)) {

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -292,7 +292,7 @@ module Typ = {
         Construct(
           SAsc | SLet | SLine | SLam | SListNil | SInj(_) | SCase |
           SApPalette(_),
-        ),
+        ) |
         SwapUp |
         SwapDown |
         SwapLeft |

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2417,7 +2417,7 @@ module Exp = {
       switch (suffix) {
       | [] => Failed
       | [hd, ...tl] => {
-          let new_zblock = (([hd] @ prefix, zline, tl));
+          let new_zblock = ((prefix @ [hd]), zline, tl);
           Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
         }
       }
@@ -3646,7 +3646,28 @@ module Exp = {
       }
 
     /* No construction handled at block level */
-
+    
+    /* SwapUp and SwapDown is handled at block level */
+    | SwapUp => 
+      switch (ListUtil.split_last(prefix)) {
+      | None => Failed
+      | Some(rest, last) => {
+          let new_zblock = (rest, zline, ([last] @ suffix));
+          Succeeded(
+            AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty))
+          )
+        }
+      }
+    | SwapDown =>
+      switch(suffix) {
+      | [] => Failed
+      | [hd, ...tl] => {
+          let new_zblock = ((prefix @ [hd]), zline, tl);
+          Succeeded(
+            AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty))
+          )
+        }
+      }
     /* Zipper */
     | _ =>
       switch (Statics.Exp.syn_lines(ctx, prefix)) {

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -43,7 +43,11 @@ type t =
   | UpdateApPalette(SpliceGenMonad.t(SerializedModel.t))
   | Delete
   | Backspace
-  | Construct(shape);
+  | Construct(shape)
+  | SwapLeft
+  | SwapRight
+  | SwapUp
+  | SwapDown;
 
 module Outcome = {
   type t('success) =
@@ -154,7 +158,11 @@ module Typ = {
     | Construct(_)
     | Delete
     | Backspace
-    | UpdateApPalette(_) =>
+    | UpdateApPalette(_) 
+    | SwapLeft
+    | SwapRight
+    | SwapUp
+    | SwapDown =>
       failwith(
         __LOC__
         ++ ": expected movement action, got "

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -262,6 +262,7 @@ module Typ = {
                             let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
                             Succeeded(mk_ZOpSeq(new_zseq));
                           }
+
     /* Zipper */
     | (_, ZOperand(zoperand, (prefix, suffix))) =>
       switch (perform_operand(a, zoperand)) {
@@ -1132,6 +1133,27 @@ module Pat = {
       | None => Failed
       | Some(zp) => syn_perform(ctx, u_gen, a, zp)
       };
+
+    /* invalid swap actions */
+    | (SwapLeft, ZOperator(_))
+    | (SwapRight, ZOperator(_)) => Failed
+    
+    | (SwapLeft, ZOperand(_, (E, _))) => Failed
+    | (SwapLeft, ZOperand(zoperand,
+                          (A(operator, S(operand, new_prefix)), suffix)
+                          )) => {
+                            let new_suffix = Seq.A(operator, S(operand, suffix));
+                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+                            Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq));
+                          }
+    | (SwapRight, ZOperand(_, (_, E))) => Failed
+    | (SwapRight, ZOperand(zoperand,
+                          (prefix, A(operator, S(operand, new_suffix)))
+                          )) => {
+                            let new_prefix = Seq.A(operator, S(operand, prefix));
+                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+                            Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq));
+                          }
 
     /* Zipper */
 

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -948,7 +948,11 @@ module Pat = {
     | Construct(_)
     | Delete
     | Backspace
-    | UpdateApPalette(_) =>
+    | UpdateApPalette(_)
+    | SwapUp
+    | SwapDown
+    | SwapLeft
+    | SwapRight =>
       failwith(
         __LOC__
         ++ ": expected movement action, got "
@@ -996,7 +1000,11 @@ module Pat = {
     | Construct(_)
     | Delete
     | Backspace
-    | UpdateApPalette(_) =>
+    | UpdateApPalette(_)
+    | SwapUp
+    | SwapDown
+    | SwapLeft
+    | SwapRight =>
       failwith(
         __LOC__
         ++ ": expected movement action, got "
@@ -1022,6 +1030,10 @@ module Pat = {
 
     /* Invalid actions */
     | (UpdateApPalette(_), ZOperator(_)) => Failed
+
+    /* Invalid swap actions */
+    | (SwapUp, _)
+    | (SwapDown, _) => Failed
 
     /* Movement */
     | (

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2531,6 +2531,10 @@ module Exp = {
       /* avoid swap down for the Let line if it is second to last */
       | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
         Failed
+      /* doesn't perform syn_fix_holes_z when second to last is EmptyLine to avoid generating a new hole */
+      | ([last], CursorL(_, EmptyLine)) => 
+        let new_zblock = (prefix @ [last], zline, []) |> ZExp.prune_empty_hole_lines;
+        Succeeded(SynDone(new_zblock, ty, u_gen));
       | ([hd, ...tl], _) =>
         let new_zblock = (prefix @ [hd], zline, tl) |> ZExp.prune_empty_hole_lines;
         Succeeded(

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -1591,7 +1591,11 @@ module Pat = {
     /* Invalid actions */
     | (
         Construct(SApPalette(_) | SList | SAsc | SLet | SLine | SLam | SCase) |
-        UpdateApPalette(_),
+        UpdateApPalette(_) |
+        SwapUp |
+        SwapDown |
+        SwapLeft |
+        SwapRight,
         _,
       ) =>
       Failed

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -158,7 +158,7 @@ module Typ = {
     | Construct(_)
     | Delete
     | Backspace
-    | UpdateApPalette(_) 
+    | UpdateApPalette(_)
     | SwapLeft
     | SwapRight
     | SwapUp
@@ -182,7 +182,7 @@ module Typ = {
           SAsc | SLet | SLine | SLam | SListNil | SInj(_) | SCase |
           SApPalette(_),
         ) |
-        SwapUp | 
+        SwapUp |
         SwapDown,
         _,
       )
@@ -244,23 +244,29 @@ module Typ = {
 
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
-    
+
     | (SwapLeft, ZOperand(CursorT(_), (E, _))) => Failed
-    | (SwapLeft, ZOperand(CursorT(_) as zoperand,
-                          (A(operator, S(operand, new_prefix)), suffix)
-                          )) => {
-                            let new_suffix = Seq.A(operator, S(operand, suffix));
-                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(mk_ZOpSeq(new_zseq));
-                          }
+    | (
+        SwapLeft,
+        ZOperand(
+          CursorT(_) as zoperand,
+          (A(operator, S(operand, new_prefix)), suffix),
+        ),
+      ) =>
+      let new_suffix = Seq.A(operator, S(operand, suffix));
+      let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+      Succeeded(mk_ZOpSeq(new_zseq));
     | (SwapRight, ZOperand(CursorT(_), (_, E))) => Failed
-    | (SwapRight, ZOperand(CursorT(_) as zoperand,
-                          (prefix, A(operator, S(operand, new_suffix)))
-                          )) => {
-                            let new_prefix = Seq.A(operator, S(operand, prefix));
-                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(mk_ZOpSeq(new_zseq));
-                          }
+    | (
+        SwapRight,
+        ZOperand(
+          CursorT(_) as zoperand,
+          (prefix, A(operator, S(operand, new_suffix))),
+        ),
+      ) =>
+      let new_prefix = Seq.A(operator, S(operand, prefix));
+      let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+      Succeeded(mk_ZOpSeq(new_zseq));
 
     /* Zipper */
     | (_, ZOperand(zoperand, (prefix, suffix))) =>
@@ -1136,23 +1142,29 @@ module Pat = {
     /* SwapLeft and SwapRight actions */
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
-    
+
     | (SwapLeft, ZOperand(CursorP(_), (E, _))) => Failed
-    | (SwapLeft, ZOperand(CursorP(_) as zoperand,
-                          (A(operator, S(operand, new_prefix)), suffix)
-                          )) => {
-                            let new_suffix = Seq.A(operator, S(operand, suffix));
-                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq));
-                          }
+    | (
+        SwapLeft,
+        ZOperand(
+          CursorP(_) as zoperand,
+          (A(operator, S(operand, new_prefix)), suffix),
+        ),
+      ) =>
+      let new_suffix = Seq.A(operator, S(operand, suffix));
+      let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+      Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq));
     | (SwapRight, ZOperand(CursorP(_), (_, E))) => Failed
-    | (SwapRight, ZOperand(CursorP(_) as zoperand,
-                          (prefix, A(operator, S(operand, new_suffix)))
-                          )) => {
-                            let new_prefix = Seq.A(operator, S(operand, prefix));
-                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq));
-                          }
+    | (
+        SwapRight,
+        ZOperand(
+          CursorP(_) as zoperand,
+          (prefix, A(operator, S(operand, new_suffix))),
+        ),
+      ) =>
+      let new_prefix = Seq.A(operator, S(operand, prefix));
+      let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+      Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq));
 
     /* Zipper */
 
@@ -1537,23 +1549,29 @@ module Pat = {
     /* invalid swap actions */
     | (SwapLeft, ZOperator(_))
     | (SwapRight, ZOperator(_)) => Failed
-    
+
     | (SwapLeft, ZOperand(CursorP(_), (E, _))) => Failed
-    | (SwapLeft, ZOperand(CursorP(_) as zoperand,
-                          (A(operator, S(operand, new_prefix)), suffix)
-                          )) => {
-                            let new_suffix = Seq.A(operator, S(operand, suffix));
-                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
-                          }
+    | (
+        SwapLeft,
+        ZOperand(
+          CursorP(_) as zoperand,
+          (A(operator, S(operand, new_prefix)), suffix),
+        ),
+      ) =>
+      let new_suffix = Seq.A(operator, S(operand, suffix));
+      let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+      Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
     | (SwapRight, ZOperand(CursorP(_), (_, E))) => Failed
-    | (SwapRight, ZOperand(CursorP(_) as zoperand,
-                          (prefix, A(operator, S(operand, new_suffix)))
-                          )) => {
-                            let new_prefix = Seq.A(operator, S(operand, prefix));
-                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
-                          }
+    | (
+        SwapRight,
+        ZOperand(
+          CursorP(_) as zoperand,
+          (prefix, A(operator, S(operand, new_suffix))),
+        ),
+      ) =>
+      let new_prefix = Seq.A(operator, S(operand, prefix));
+      let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+      Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
 
     /* Zipper */
     | (_, ZOperand(zoperand, (E, E))) =>
@@ -2498,25 +2516,28 @@ module Exp = {
     /* No construction handled at block level */
 
     /* SwapUp and SwapDown is handled at block level */
-    | SwapUp when ZExp.line_can_be_swapped(zline) => 
+    | SwapUp when ZExp.line_can_be_swapped(zline) =>
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
-      | Some((rest, last)) => {
-          let new_zblock = (rest, zline, ([last, ...suffix]));
-          Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
-        }
-      }  
+      | Some((rest, last)) =>
+        let new_zblock = (rest, zline, [last, ...suffix]);
+        Succeeded(
+          SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
+        );
+      }
     | SwapDown when ZExp.line_can_be_swapped(zline) =>
       switch (suffix, zline) {
       | ([], _) => Failed
       /* avoid swap down for the Let line if it is second to last */
-      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) => Failed
-      | ([hd, ...tl], _) => {
-          let new_zblock = ((prefix @ [hd]), zline, tl);
-          Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
-        }
+      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
+        Failed
+      | ([hd, ...tl], _) =>
+        let new_zblock = (prefix @ [hd], zline, tl);
+        Succeeded(
+          SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
+        );
       }
-    
+
     /* Zipper */
     | _ =>
       switch (Statics.Exp.syn_lines(ctx, prefix)) {
@@ -2938,21 +2959,27 @@ module Exp = {
     | (SwapRight, ZOperator(_)) => Failed
 
     | (SwapLeft, ZOperand(CursorE(_), (E, _))) => Failed
-    | (SwapLeft, ZOperand(CursorE(_) as zoperand, 
-                          (A(operator, S(operand, new_prefix)), suffix)
-                          )) => {
-                            let new_suffix = Seq.A(operator, S(operand, suffix));
-                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
-                          }
+    | (
+        SwapLeft,
+        ZOperand(
+          CursorE(_) as zoperand,
+          (A(operator, S(operand, new_prefix)), suffix),
+        ),
+      ) =>
+      let new_suffix = Seq.A(operator, S(operand, suffix));
+      let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+      Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
     | (SwapRight, ZOperand(CursorE(_), (_, E))) => Failed
-    | (SwapRight, ZOperand(CursorE(_) as zoperand, 
-                          (prefix, A(operator, S(operand, new_suffix)))
-                          )) => {
-                            let new_prefix = Seq.A(operator, S(operand, prefix));
-                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
-                          }
+    | (
+        SwapRight,
+        ZOperand(
+          CursorE(_) as zoperand,
+          (prefix, A(operator, S(operand, new_suffix))),
+        ),
+      ) =>
+      let new_prefix = Seq.A(operator, S(operand, prefix));
+      let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+      Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
 
     /* Zipper */
 
@@ -3045,7 +3072,7 @@ module Exp = {
     /* Invalid actions at expression level */
     | (Construct(SLine), CursorE(OnText(_), _))
     | (Construct(SList), _) => Failed
-    
+
     /* Movement handled at top level */
     | (
         MoveTo(_) | MoveToBefore(_) | MoveToPrevHole | MoveToNextHole | MoveLeft |
@@ -3381,7 +3408,8 @@ module Exp = {
     | (Construct(SLine), CursorE(_)) => Failed
 
     /* Invalid Swap actions */
-    | (SwapUp | SwapDown, CursorE(_) | LamZP(_) | LamZA(_) | CaseZA(_)) => Failed
+    | (SwapUp | SwapDown, CursorE(_) | LamZP(_) | LamZA(_) | CaseZA(_)) =>
+      Failed
     | (SwapLeft | SwapRight, CursorE(_)) => Failed
 
     /* Zipper Cases */
@@ -3654,18 +3682,16 @@ module Exp = {
     | (SwapUp, CursorR(_) | RuleZP(_)) =>
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
-      | Some((rest, last)) => {
-          let new_zrules = (rest, zrule, ([last, ...suffix]));
-          Succeeded((new_zrules, u_gen))
-        }
+      | Some((rest, last)) =>
+        let new_zrules = (rest, zrule, [last, ...suffix]);
+        Succeeded((new_zrules, u_gen));
       }
     | (SwapDown, CursorR(_) | RuleZP(_)) =>
       switch (suffix) {
       | [] => Failed
-      | [hd, ...tl] => {
-          let new_zrules = ((prefix @ [hd]), zrule, tl);
-          Succeeded((new_zrules, u_gen))
-        }
+      | [hd, ...tl] =>
+        let new_zrules = (prefix @ [hd], zrule, tl);
+        Succeeded((new_zrules, u_gen));
       }
 
     /* Zipper */
@@ -3791,29 +3817,28 @@ module Exp = {
       }
 
     /* No construction handled at block level */
-    
+
     /* SwapUp and SwapDown is handled at block level */
-    | (SwapUp, _) when ZExp.line_can_be_swapped(zline) => 
+    | (SwapUp, _) when ZExp.line_can_be_swapped(zline) =>
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
-      | Some((rest, last)) => {
-          let new_zblock = (rest, zline, ([last, ...suffix]));
-          Succeeded(
-            AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty))
-          )
-        }
+      | Some((rest, last)) =>
+        let new_zblock = (rest, zline, [last, ...suffix]);
+        Succeeded(
+          AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
+        );
       }
     | (SwapDown, _) when ZExp.line_can_be_swapped(zline) =>
-      switch(suffix, zline) {
+      switch (suffix, zline) {
       | ([], _) => Failed
       /* avoid swap down fot the Let line if it is second to last */
-      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) => Failed
-      | ([hd, ...tl], _) => {
-          let new_zblock = ((prefix @ [hd]), zline, tl);
-          Succeeded(
-            AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty))
-          )
-        }
+      | ([_], LetLineZP(_) | LetLineZA(_) | CursorL(_, LetLine(_))) =>
+        Failed
+      | ([hd, ...tl], _) =>
+        let new_zblock = (prefix @ [hd], zline, tl);
+        Succeeded(
+          AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
+        );
       }
     /* Zipper */
     | _ =>
@@ -4043,23 +4068,29 @@ module Exp = {
     | (SwapRight, ZOperator(_)) => Failed
 
     | (SwapLeft, ZOperand(CursorE(_), (E, _))) => Failed
-    | (SwapLeft, ZOperand(CursorE(_) as zoperand,
-                          (A(operator, S(operand, new_prefix)), suffix)
-                          )) => {
-                            let new_suffix = Seq.A(operator, S(operand, suffix));
-                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Outcome.Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty))
-                            |> wrap_in_AnaDone;
-                          }
+    | (
+        SwapLeft,
+        ZOperand(
+          CursorE(_) as zoperand,
+          (A(operator, S(operand, new_prefix)), suffix),
+        ),
+      ) =>
+      let new_suffix = Seq.A(operator, S(operand, suffix));
+      let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+      Outcome.Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty))
+      |> wrap_in_AnaDone;
     | (SwapRight, ZOperand(CursorE(_), (_, E))) => Failed
-    | (SwapRight, ZOperand(CursorE(_) as zoperand,
-                          (prefix, A(operator, S(operand, new_suffix)))
-                          )) => {
-                            let new_prefix = Seq.A(operator, S(operand, prefix));
-                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
-                            Outcome.Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty))
-                            |> wrap_in_AnaDone;
-                          }
+    | (
+        SwapRight,
+        ZOperand(
+          CursorE(_) as zoperand,
+          (prefix, A(operator, S(operand, new_suffix))),
+        ),
+      ) =>
+      let new_prefix = Seq.A(operator, S(operand, prefix));
+      let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
+      Outcome.Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty))
+      |> wrap_in_AnaDone;
 
     /* Zipper */
 
@@ -4456,7 +4487,8 @@ module Exp = {
     | (Construct(SLine), CursorE(_)) => Failed
 
     /* Invalid Swap actions */
-    | (SwapUp | SwapDown, CursorE(_) | LamZP(_) | LamZA(_) | CaseZA(_)) => Failed
+    | (SwapUp | SwapDown, CursorE(_) | LamZP(_) | LamZA(_) | CaseZA(_)) =>
+      Failed
     | (SwapLeft | SwapRight, CursorE(_)) => Failed
 
     /* Zipper Cases */

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2499,7 +2499,7 @@ module Exp = {
     /* No construction handled at block level */
 
     /* SwapUp and SwapDown is handled at block level */
-    | SwapUp when ZExp.is_cursorL(zline) => 
+    | SwapUp when ZExp.is_CursorL(zline) => 
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
       | Some((rest, last)) => {
@@ -2507,7 +2507,7 @@ module Exp = {
           Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
         }
       }  
-    | SwapDown when ZExp.is_cursorL(zline) =>
+    | SwapDown when ZExp.is_CursorL(zline) =>
       switch (suffix) {
       | [] => Failed
       | [hd, ...tl] => {

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2517,16 +2517,17 @@ module Exp = {
 
     /* SwapUp and SwapDown is handled at block level */
     | SwapUp when ZExp.line_can_be_swapped(zline) =>
-      switch (ListUtil.split_last(prefix), suffix) {
-      | (None, _) => Failed
+      switch (ListUtil.split_last(prefix), zline |> ZExp.erase_zline, suffix) {
+      | (None, _, _) => Failed
+      | (Some((_, LetLine(_))), ExpLine(OpSeq(_, S(EmptyHole(_), E))), []) => Failed
       /* handle the corner case when swapping the last line up where the second to last line is EmptyLine */
-      | (Some((rest, EmptyLine)), []) => 
+      | (Some((rest, EmptyLine)), _, []) => 
         let (new_hole, u_gen) = u_gen |> UHExp.new_EmptyHole;
         let new_zblock = (rest, zline, UHExp.Block.wrap(new_hole)) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
         );
-      | (Some((rest, last)), _) =>
+      | (Some((rest, last)), _, _) =>
         let new_zblock = (rest, zline, [last, ...suffix]) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
@@ -3835,16 +3836,17 @@ module Exp = {
 
     /* SwapUp and SwapDown is handled at block level */
     | (SwapUp, _) when ZExp.line_can_be_swapped(zline) =>
-      switch (ListUtil.split_last(prefix), suffix) {
-      | (None, _) => Failed
+      switch (ListUtil.split_last(prefix), zline |> ZExp.erase_zline, suffix) {
+      | (None, _, _) => Failed
+      | (Some((_, LetLine(_))), ExpLine(OpSeq(_, S(EmptyHole(_), E))), []) => Failed
       /* handle the corner case when swapping the last line up where the second to last line is EmptyLine */
-      | (Some((rest, EmptyLine)), []) =>
+      | (Some((rest, EmptyLine)), _, []) =>
         let (new_hole, u_gen) = u_gen |> UHExp.new_EmptyHole;
         let new_zblock = (rest, zline, UHExp.Block.wrap(new_hole)) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
         );
-      | (Some((rest, last)), _) =>
+      | (Some((rest, last)), _, _) =>
         let new_zblock = (rest, zline, [last, ...suffix]) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3653,7 +3653,7 @@ module Exp = {
       | None => Failed
       | Some((rest, last)) => {
           let new_zrules = (rest, zrule, ([last, ...suffix]));
-          Succeeded()
+          Succeeded((new_zrules, u_gen))
         }
       }
     | (SwapDown, CursorR(_) | RuleZP(_)) =>

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2417,7 +2417,7 @@ module Exp = {
       switch (suffix) {
       | [] => Failed
       | [hd, ...tl] => {
-          let new_zblock = ((prefix @ [hd]), zline, tl);
+          let new_zblock = (([hd] @ prefix, zline, tl));
           Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
         }
       }
@@ -3646,28 +3646,7 @@ module Exp = {
       }
 
     /* No construction handled at block level */
-    
-    /* SwapUp and SwapDown is handled at block level */
-    | SwapUp => 
-      switch (ListUtil.split_last(prefix)) {
-      | None => Failed
-      | Some(rest, last) => {
-          let new_zblock = (rest, zline, ([last] @ suffix));
-          Succeeded(
-            AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty))
-          )
-        }
-      }
-    | SwapDown =>
-      switch(suffix) {
-      | [] => Failed
-      | [hd, ...tl] => {
-          let new_zblock = ((prefix @ [hd]), zline, tl);
-          Succeeded(
-            AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty))
-          )
-        }
-      }
+
     /* Zipper */
     | _ =>
       switch (Statics.Exp.syn_lines(ctx, prefix)) {

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2841,16 +2841,16 @@ module Exp = {
     | (SwapLeft, ZOperand(zoperand, 
                           (A(operator, S(operand, new_prefix)), suffix)
                           )) => {
-                            let new_suffix = A(operator, S(operand, suffix));
-                            let new_zseq = ZOperand(zoperand, (new_prefix, new_suffix));
+                            let new_suffix = Seq.A(operator, S(operand, suffix));
+                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
                             Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
                           }
     | (SwapRight, ZOperand(_, (_, E))) => Failed
     | (SwapRight, ZOperand(zoperand, 
                           (prefix, A(operator, S(operand, new_suffix)))
                           )) => {
-                            let new_prefix = A(operator, S(operand, prefix));
-                            let new_zseq = ZOperand(zoperand, (new_prefix, new_suffix));
+                            let new_prefix = Seq.A(operator, S(operand, prefix));
+                            let new_zseq = ZSeq.ZOperand(zoperand, (new_prefix, new_suffix));
                             Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
                           }
 

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2409,7 +2409,7 @@ module Exp = {
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
       | Some((rest, last)) => {
-          let new_zblock = (rest, zline, ([last] @ suffix));
+          let new_zblock = (rest, zline, ([last, ...suffix]));
           Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
         }
       }  

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -4071,6 +4071,10 @@ module Exp = {
         ),
       ) =>
       Failed
+
+    /* Invalid swap actions */
+    | (SwapUp | SwapDown | SwapLeft | SwapRight, _) => Failed
+
     | (_, CursorE(cursor, operand))
         when !ZExp.is_valid_cursor_operand(cursor, operand) =>
       Failed

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2408,7 +2408,7 @@ module Exp = {
     | SwapUp => 
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
-      | Some(rest, last) => {
+      | Some((rest, last)) => {
           let new_zblock = (rest, zline, ([last] @ suffix));
           Succeeded(SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)))
         }
@@ -3648,17 +3648,17 @@ module Exp = {
     /* No construction handled at block level */
     
     /* SwapUp and SwapDown is handled at block level */
-    | SwapUp => 
+    | (SwapUp, _) => 
       switch (ListUtil.split_last(prefix)) {
       | None => Failed
-      | Some(rest, last) => {
+      | Some((rest, last)) => {
           let new_zblock = (rest, zline, ([last] @ suffix));
           Succeeded(
             AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty))
           )
         }
       }
-    | SwapDown =>
+    | (SwapDown, _) =>
       switch(suffix) {
       | [] => Failed
       | [hd, ...tl] => {

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -2517,9 +2517,16 @@ module Exp = {
 
     /* SwapUp and SwapDown is handled at block level */
     | SwapUp when ZExp.line_can_be_swapped(zline) =>
-      switch (ListUtil.split_last(prefix)) {
-      | None => Failed
-      | Some((rest, last)) =>
+      switch (ListUtil.split_last(prefix), suffix) {
+      | (None, _) => Failed
+      /* handle the corner case when swapping the last line up where the second to last line is EmptyLine */
+      | (Some((rest, EmptyLine)), []) => 
+        let (new_hole, u_gen) = u_gen |> UHExp.new_EmptyHole;
+        let new_zblock = (rest, zline, UHExp.Block.wrap(new_hole)) |> ZExp.prune_empty_hole_lines;
+        Succeeded(
+          SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
+        );
+      | (Some((rest, last)), _) =>
         let new_zblock = (rest, zline, [last, ...suffix]) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           SynDone(Statics.Exp.syn_fix_holes_z(ctx, u_gen, new_zblock)),
@@ -3828,9 +3835,15 @@ module Exp = {
 
     /* SwapUp and SwapDown is handled at block level */
     | (SwapUp, _) when ZExp.line_can_be_swapped(zline) =>
-      switch (ListUtil.split_last(prefix)) {
-      | None => Failed
-      | Some((rest, last)) =>
+      switch (ListUtil.split_last(prefix), suffix) {
+      | (None, _) => Failed
+      | (Some((rest, EmptyLine)), []) =>
+        let (new_hole, u_gen) = u_gen |> UHExp.new_EmptyHole;
+        let new_zblock = (rest, zline, UHExp.Block.wrap(new_hole)) |> ZExp.prune_empty_hole_lines;
+        Succeeded(
+          AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),
+        );
+      | (Some((rest, last)), _) =>
         let new_zblock = (rest, zline, [last, ...suffix]) |> ZExp.prune_empty_hole_lines;
         Succeeded(
           AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock, ty)),

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -3845,7 +3845,7 @@ module Exp = {
         let (new_hole, u_gen) = u_gen |> ZExp.new_EmptyHole;
         let new_zblock = (prefix @ [last], ZExp.ExpLineZ(ZOpSeq.wrap(new_hole)), []) |> ZExp.prune_empty_hole_lines;
         Succeeded(
-          SynDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock)),
+          AnaDone(Statics.Exp.ana_fix_holes_z(ctx, u_gen, new_zblock)),
         );
       }
       | ([hd, ...tl], _) =>

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -37,7 +37,7 @@ type operand_surround = Seq.operand_surround(UHExp.operand, UHExp.operator);
 type operator_surround = Seq.operator_surround(UHExp.operand, UHExp.operator);
 type zseq = ZSeq.t(UHExp.operand, UHExp.operator, zoperand, zoperator);
 
-let is_cusorL = (line: zline): bool =>
+let is_CursorL = (line: zline): bool =>
   switch (line) {
   | CursorL(_) => true
   | _ => false

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -40,8 +40,8 @@ type zseq = ZSeq.t(UHExp.operand, UHExp.operator, zoperand, zoperator);
 let line_can_be_swapped = (line: zline): bool =>
   switch (line) {
   | CursorL(_) 
-  | LetLineZP
-  | LetLineZA
+  | LetLineZP(_)
+  | LetLineZA(_)
   | ExpLineZ(_, ZOpertor(_)) 
   | ExpLineZ(_, ZOperand(CursorE(_), _))
   | ExpLineZ(_, ZOperand(LamZP(_), _))

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -48,7 +48,12 @@ let line_can_be_swapped = (line: zline): bool =>
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZA(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(CaseZA(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(ApPaletteZ(_), _))) => true
-  | _ => false
+  | LetLineZE(_)
+  | ExpLine(ZOpSeq(_, ZOperand(LamZE(_), _)))
+  | ExpLine(ZOpSeq(_, ZOperand(InjZ(_), _))) 
+  | ExpLine(ZOpSeq(_, ZOperand(CaseZE(_), _))) 
+  | ExpLine(ZOpSeq(_, ZOperand(CaseZR(_), _))
+  | ExpLine(ZOpSeq(_, ZOperand(ParenthesizedZ(_), _))) ) => false
   };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>
   switch (line) {

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -46,14 +46,14 @@ let line_can_be_swapped = (line: zline): bool =>
   | ExpLineZ(ZOpSeq(_, ZOperand(CursorE(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZP(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZA(_), _)))
-  | ExpLineZ(ZOpSeq(_, ZOperand(CaseZA(_), _)))
-  | ExpLineZ(ZOpSeq(_, ZOperand(ApPaletteZ(_), _))) => true
+  | ExpLineZ(ZOpSeq(_, ZOperand(CaseZA(_), _))) => true
   | LetLineZE(_)
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZE(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(InjZ(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(CaseZE(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(CaseZR(_), _)))
-  | ExpLineZ(ZOpSeq(_, ZOperand(ParenthesizedZ(_), _))) => false
+  | ExpLineZ(ZOpSeq(_, ZOperand(ParenthesizedZ(_), _)))
+  | ExpLineZ(ZOpSeq(_, ZOperand(ApPaletteZ(_), _)) => false
   };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>
   switch (line) {

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -53,7 +53,7 @@ let line_can_be_swapped = (line: zline): bool =>
   | ExpLineZ(ZOpSeq(_, ZOperand(CaseZE(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(CaseZR(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(ParenthesizedZ(_), _)))
-  | ExpLineZ(ZOpSeq(_, ZOperand(ApPaletteZ(_), _)) => false
+  | ExpLineZ(ZOpSeq(_, ZOperand(ApPaletteZ(_), _))) => false
   };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>
   switch (line) {

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -49,11 +49,11 @@ let line_can_be_swapped = (line: zline): bool =>
   | ExpLineZ(ZOpSeq(_, ZOperand(CaseZA(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(ApPaletteZ(_), _))) => true
   | LetLineZE(_)
-  | ExpLine(ZOpSeq(_, ZOperand(LamZE(_), _)))
-  | ExpLine(ZOpSeq(_, ZOperand(InjZ(_), _))) 
-  | ExpLine(ZOpSeq(_, ZOperand(CaseZE(_), _))) 
-  | ExpLine(ZOpSeq(_, ZOperand(CaseZR(_), _))
-  | ExpLine(ZOpSeq(_, ZOperand(ParenthesizedZ(_), _))) ) => false
+  | ExpLineZ(ZOpSeq(_, ZOperand(LamZE(_), _)))
+  | ExpLineZ(ZOpSeq(_, ZOperand(InjZ(_), _))) 
+  | ExpLineZ(ZOpSeq(_, ZOperand(CaseZE(_), _))) 
+  | ExpLineZ(ZOpSeq(_, ZOperand(CaseZR(_), _))
+  | ExpLineZ(ZOpSeq(_, ZOperand(ParenthesizedZ(_), _))) ) => false
   };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>
   switch (line) {

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -50,8 +50,8 @@ let line_can_be_swapped = (line: zline): bool =>
   | ExpLineZ(ZOpSeq(_, ZOperand(ApPaletteZ(_), _))) => true
   | LetLineZE(_)
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZE(_), _)))
-  | ExpLineZ(ZOpSeq(_, ZOperand(InjZ(_), _))) 
-  | ExpLineZ(ZOpSeq(_, ZOperand(CaseZE(_), _))) 
+  | ExpLineZ(ZOpSeq(_, ZOperand(InjZ(_), _)))
+  | ExpLineZ(ZOpSeq(_, ZOperand(CaseZE(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(CaseZR(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(ParenthesizedZ(_), _))) => false
   };

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -42,11 +42,11 @@ let line_can_be_swapped = (line: zline): bool =>
   | CursorL(_) 
   | LetLineZP(_)
   | LetLineZA(_)
-  | ExpLineZ(_, ZOpertor(_)) 
-  | ExpLineZ(_, ZOperand(CursorE(_), _))
-  | ExpLineZ(_, ZOperand(LamZP(_), _))
-  | ExpLineZ(_, ZOperand(LamZA(_), _))
-  | ExpLineZ(_, ZOperand(CaseZA(_), _))
+  | ExpLineZ(ZOpSeq(_, ZOpertor(_))) 
+  | ExpLineZ(ZOpSeq(_, ZOperand(CursorE(_), _)))
+  | ExpLineZ(ZOpSeq(_, ZOperand(LamZP(_), _)))
+  | ExpLineZ(ZOpSeq(_, ZOperand(LamZA(_), _)))
+  | ExpLineZ(ZOpSeq(_, ZOperand(CaseZA(_), _)))
   | ApPaletteZ(_) => true
   | _ => false
   };

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -39,7 +39,7 @@ type zseq = ZSeq.t(UHExp.operand, UHExp.operator, zoperand, zoperator);
 
 let is_cusorL = (line: zline): bool =>
   switch (line) {
-  | cursorL(_) => true
+  | CursorL(_) => true
   | _ => false
   };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -39,10 +39,10 @@ type zseq = ZSeq.t(UHExp.operand, UHExp.operator, zoperand, zoperator);
 
 let line_can_be_swapped = (line: zline): bool =>
   switch (line) {
-  | CursorL(_) 
+  | CursorL(_)
   | LetLineZP(_)
   | LetLineZA(_)
-  | ExpLineZ(ZOpSeq(_, ZOperator(_))) 
+  | ExpLineZ(ZOpSeq(_, ZOperator(_)))
   | ExpLineZ(ZOpSeq(_, ZOperand(CursorE(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZP(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZA(_), _)))

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -37,6 +37,11 @@ type operand_surround = Seq.operand_surround(UHExp.operand, UHExp.operator);
 type operator_surround = Seq.operator_surround(UHExp.operand, UHExp.operator);
 type zseq = ZSeq.t(UHExp.operand, UHExp.operator, zoperand, zoperator);
 
+let is_cusorL = (line: zline): bool =>
+  switch (line) {
+    cursorL(_) => true
+    _ => false
+  };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>
   switch (line) {
   | ExpLine(_) => []

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -47,7 +47,7 @@ let line_can_be_swapped = (line: zline): bool =>
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZP(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZA(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(CaseZA(_), _)))
-  | ApPaletteZ(_) => true
+  | ExpLineZ(ZOpSeq(_, ZOperand(ApPaletteZ(_), _))) => true
   | _ => false
   };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -52,8 +52,8 @@ let line_can_be_swapped = (line: zline): bool =>
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZE(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(InjZ(_), _))) 
   | ExpLineZ(ZOpSeq(_, ZOperand(CaseZE(_), _))) 
-  | ExpLineZ(ZOpSeq(_, ZOperand(CaseZR(_), _))
-  | ExpLineZ(ZOpSeq(_, ZOperand(ParenthesizedZ(_), _))) ) => false
+  | ExpLineZ(ZOpSeq(_, ZOperand(CaseZR(_), _)))
+  | ExpLineZ(ZOpSeq(_, ZOperand(ParenthesizedZ(_), _))) => false
   };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>
   switch (line) {

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -42,7 +42,7 @@ let line_can_be_swapped = (line: zline): bool =>
   | CursorL(_) 
   | LetLineZP(_)
   | LetLineZA(_)
-  | ExpLineZ(ZOpSeq(_, ZOpertor(_))) 
+  | ExpLineZ(ZOpSeq(_, ZOperator(_))) 
   | ExpLineZ(ZOpSeq(_, ZOperand(CursorE(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZP(_), _)))
   | ExpLineZ(ZOpSeq(_, ZOperand(LamZA(_), _)))

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -37,9 +37,10 @@ type operand_surround = Seq.operand_surround(UHExp.operand, UHExp.operator);
 type operator_surround = Seq.operator_surround(UHExp.operand, UHExp.operator);
 type zseq = ZSeq.t(UHExp.operand, UHExp.operator, zoperand, zoperator);
 
-let is_CursorL = (line: zline): bool =>
+let line_can_be_swapped = (line: zline): bool =>
   switch (line) {
-  | CursorL(_) => true
+  | CursorL(_) 
+  | ExpLineZ(_) => true
   | _ => false
   };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -39,8 +39,8 @@ type zseq = ZSeq.t(UHExp.operand, UHExp.operator, zoperand, zoperator);
 
 let is_cusorL = (line: zline): bool =>
   switch (line) {
-    cursorL(_) => true
-    _ => false
+  | cursorL(_) => true
+  | _ => false
   };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>
   switch (line) {

--- a/src/hazelcore/semantics/ZExp.re
+++ b/src/hazelcore/semantics/ZExp.re
@@ -40,7 +40,14 @@ type zseq = ZSeq.t(UHExp.operand, UHExp.operator, zoperand, zoperator);
 let line_can_be_swapped = (line: zline): bool =>
   switch (line) {
   | CursorL(_) 
-  | ExpLineZ(_) => true
+  | LetLineZP
+  | LetLineZA
+  | ExpLineZ(_, ZOpertor(_)) 
+  | ExpLineZ(_, ZOperand(CursorE(_), _))
+  | ExpLineZ(_, ZOperand(LamZP(_), _))
+  | ExpLineZ(_, ZOperand(LamZA(_), _))
+  | ExpLineZ(_, ZOperand(CaseZA(_), _))
+  | ApPaletteZ(_) => true
   | _ => false
   };
 let valid_cursors_line = (line: UHExp.line): list(CursorPosition.t) =>

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -420,10 +420,10 @@ module KeyCombo = {
     let alt_F = alt(Key.the_key("F"));
     let ctrl_z = ctrl(Key.the_key("z"));
     let ctrl_shift_z = ctrl_shift(Key.the_key("Z"))
-    let ctrl_shift_left = ctrl_shift(Key.the_key("ArrowLeft"));
-    let ctrl_shift_right = ctrl_shift(Key.the_key("ArrowRight"));
-    let ctrl_shift_up = ctrl_shift(Key.the_key("ArrowUp"));
-    let ctrl_shift_down = ctrl_shift(Key.the_key("ArrowDown"));
+    let ctrl_shift_left = ctrl_shift(Key.the_code("ArrowLeft"));
+    let ctrl_shift_right = ctrl_shift(Key.the_code("ArrowRight"));
+    let ctrl_shift_up = ctrl_shift(Key.the_code("ArrowUp"));
+    let ctrl_shift_down = ctrl_shift(Key.the_code("ArrowDown"));
   };
 
   [@deriving sexp]

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -454,7 +454,11 @@ module KeyCombo = {
     | Alt_C
     | Pound
     | Ctrl_Z
-    | Ctrl_Shift_Z;
+    | Ctrl_Shift_Z
+    | Alt_W
+    | Alt_S
+    | Alt_A
+    | Alt_D;
 
   let get_details =
     fun
@@ -484,7 +488,11 @@ module KeyCombo = {
     | Alt_R => Details.alt_R
     | Alt_C => Details.alt_C
     | Ctrl_Z => Details.ctrl_z
-    | Ctrl_Shift_Z => Details.ctrl_shift_z;
+    | Ctrl_Shift_Z => Details.ctrl_shift_z
+    | Alt_W => Details.alt_W
+    | Alt_S => Details.alt_S
+    | Alt_A => Details.alt_A
+    | Alt_D => Details.alt_D;
 
   let of_evt = (evt: Js.t(Dom_html.keyboardEvent)): option(t) => {
     let evt_matches = details => Details.matches(details, evt);

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -613,24 +613,24 @@ let single_key_string: single_key => string =
 
 let is_movement_key: Js.t(Dom_html.keyboardEvent) => bool =
   evt => {
-    switch (KeyCombo.of_evt(evt)) {
-    | Some(Ctrl_Alt_Up | Ctrl_Alt_Down | Ctrl_Alt_Left | Ctrl_Alt_Right) => false
-    | Some(_)
-    | None => {
-      let key = get_key(evt);
-      switch (key) {
-      | "ArrowLeft"
-      | "ArrowRight"
-      | "ArrowUp"
-      | "ArrowDown"
-      | "PageUp"
-      | "PageDown"
-      | "Home"
-      | "End" => true
-      | _ => false
-      };
+    let key = get_key(evt);
+    switch (key) {
+    | "ArrowLeft"
+    | "ArrowRight"
+    | "ArrowUp"
+    | "ArrowDown" => {
+      switch (KeyCombo.of_evt(evt)) {
+      | Some(Ctrl_Alt_Up | Ctrl_Alt_Down | Ctrl_Alt_Left | Ctrl_Alt_Down) => false
+      | Some(_)
+      | None => true
       }
     }
+    | "PageUp"
+    | "PageDown"
+    | "Home"
+    | "End" => true
+    | _ => false
+    };
   };
 
 type div_element = Js.t(Dom_html.divElement);

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -620,7 +620,7 @@ let is_movement_key: Js.t(Dom_html.keyboardEvent) => bool =
     | "ArrowUp"
     | "ArrowDown" => {
       switch (KeyCombo.of_evt(evt)) {
-      | Some(Ctrl_Alt_Up | Ctrl_Alt_Down | Ctrl_Alt_Left | Ctrl_Alt_Down) => false
+      | Some(Ctrl_Alt_Up | Ctrl_Alt_Down | Ctrl_Alt_Left | Ctrl_Alt_Right) => false
       | Some(_)
       | None => true
       }

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -419,11 +419,11 @@ module KeyCombo = {
     let alt_T = alt(Key.the_key("T"));
     let alt_F = alt(Key.the_key("F"));
     let ctrl_z = ctrl(Key.the_key("z"));
-    let ctrl_shift_z = ctrl_shift(Key.the_key("Z"));
-    let alt_W = alt(Key.the_key("w"));
-    let alt_S = alt(Key.the_key("s"));
-    let alt_A = alt(Key.the_key("a"));
-    let alt_D = alt(Key.the_key("d"));
+    let ctrl_shift_z = ctrl_shift(Key.the_key("Z"))
+    let ctrl_shift_left = ctrl_shift(Key.the_key("ArrowLeft"));
+    let ctrl_shift_right = ctrl_shift(Key.the_key("ArrowRight"));
+    let ctrl_shift_up = ctrl_shift(Key.the_key("ArrowUp"));
+    let ctrl_shift_down = ctrl_shift(Key.the_key("ArrowDown"));;
   };
 
   [@deriving sexp]
@@ -455,10 +455,10 @@ module KeyCombo = {
     | Pound
     | Ctrl_Z
     | Ctrl_Shift_Z
-    | Alt_W
-    | Alt_S
-    | Alt_A
-    | Alt_D;
+    | Ctrl_Shift_Left
+    | Ctrl_Shift_Right
+    | Ctrl_Shift_Up
+    | Ctrl_Shift_Down;
 
   let get_details =
     fun
@@ -489,10 +489,10 @@ module KeyCombo = {
     | Alt_C => Details.alt_C
     | Ctrl_Z => Details.ctrl_z
     | Ctrl_Shift_Z => Details.ctrl_shift_z
-    | Alt_W => Details.alt_W
-    | Alt_S => Details.alt_S
-    | Alt_A => Details.alt_A
-    | Alt_D => Details.alt_D;
+    | Ctrl_Shift_Left => Details.ctrl_shift_left
+    | Ctrl_Shift_Right => Details.ctrl_shift_right
+    | Ctrl_Shift_Up => Details.ctrl_shift_up
+    | Ctrl_Shift_Down => Details.ctrl_shift_down;
 
   let of_evt = (evt: Js.t(Dom_html.keyboardEvent)): option(t) => {
     let evt_matches = details => Details.matches(details, evt);

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -424,6 +424,7 @@ module KeyCombo = {
     let ctrl_shift_right = ctrl_shift(Key.the_code("ArrowRight"));
     let ctrl_shift_up = ctrl_shift(Key.the_code("ArrowUp"));
     let ctrl_shift_down = ctrl_shift(Key.the_code("ArrowDown"));
+    let ctrl_shift_l = ctrl_shift(Key.the_key("l"));
   };
 
   [@deriving sexp]
@@ -458,7 +459,8 @@ module KeyCombo = {
     | Ctrl_Shift_Left
     | Ctrl_Shift_Right
     | Ctrl_Shift_Up
-    | Ctrl_Shift_Down;
+    | Ctrl_Shift_Down
+    | Ctrl_Shift_L;
 
   let get_details =
     fun
@@ -492,7 +494,8 @@ module KeyCombo = {
     | Ctrl_Shift_Left => Details.ctrl_shift_left
     | Ctrl_Shift_Right => Details.ctrl_shift_right
     | Ctrl_Shift_Up => Details.ctrl_shift_up
-    | Ctrl_Shift_Down => Details.ctrl_shift_down;
+    | Ctrl_Shift_Down => Details.ctrl_shift_down
+    | Ctrl_Shift_L => Details.ctrl_shift_l;
 
   let of_evt = (evt: Js.t(Dom_html.keyboardEvent)): option(t) => {
     let evt_matches = details => Details.matches(details, evt);
@@ -506,8 +509,8 @@ module KeyCombo = {
       Some(Ctrl_Shift_Right);
     } else if (evt_matches(Details.ctrl_shift_up)) {
       Some(Ctrl_Shift_Up);
-    } else if (evt_matches(Details.ctrl_shift_down)) {
-      Some(Ctrl_Shift_Down);
+    } else if (evt_matches(Details.ctrl_shift_l)) {
+      Some(Ctrl_Shift_L);
     } else if (evt_matches(Details.ctrl_shift_z)) {
       Some(Ctrl_Shift_Z);
     } else if (evt_matches(Details.escape)) {

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -613,18 +613,24 @@ let single_key_string: single_key => string =
 
 let is_movement_key: Js.t(Dom_html.keyboardEvent) => bool =
   evt => {
-    let key = get_key(evt);
-    switch (key) {
-    | "ArrowLeft"
-    | "ArrowRight"
-    | "ArrowUp"
-    | "ArrowDown"
-    | "PageUp"
-    | "PageDown"
-    | "Home"
-    | "End" => true
-    | _ => false
-    };
+    switch (KeyCombo.of_evt(evt)) {
+    | Some(Ctrl_Alt_Up | Ctrl_Alt_Down | Ctrl_Alt_Left | Ctrl_Alt_Right) => false
+    | Some(_)
+    | None => {
+      let key = get_key(evt);
+      switch (key) {
+      | "ArrowLeft"
+      | "ArrowRight"
+      | "ArrowUp"
+      | "ArrowDown"
+      | "PageUp"
+      | "PageDown"
+      | "Home"
+      | "End" => true
+      | _ => false
+      };
+      }
+    }
   };
 
 type div_element = Js.t(Dom_html.divElement);

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -420,6 +420,10 @@ module KeyCombo = {
     let alt_F = alt(Key.the_key("F"));
     let ctrl_z = ctrl(Key.the_key("z"));
     let ctrl_shift_z = ctrl_shift(Key.the_key("Z"));
+    let alt_W = alt(Key.the_key("w"));
+    let alt_S = alt(Key.the_key("s"));
+    let alt_A = alt(Key.the_key("a"));
+    let alt_D = alt(Key.the_key("d"));
   };
 
   [@deriving sexp]

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -421,12 +421,11 @@ module KeyCombo = {
     let alt_T = alt(Key.the_key("T"));
     let alt_F = alt(Key.the_key("F"));
     let ctrl_z = ctrl(Key.the_key("z"));
-    let ctrl_shift_z = ctrl_shift(Key.the_key("Z"))
-    let ctrl_shift_left = ctrl_shift(Key.the_code("ArrowLeft"));
-    let ctrl_shift_right = ctrl_shift(Key.the_code("ArrowRight"));
-    let ctrl_shift_up = ctrl_shift(Key.the_code("ArrowUp"));
-    let ctrl_shift_down = ctrl_shift(Key.the_code("ArrowDown"));
-    let ctrl_shift_l = ctrl_alt(Key.the_key("l"));
+    let ctrl_shift_z = ctrl_shift(Key.the_key("Z"));
+    let ctrl_alt_i = ctrl_alt(Key.the_key("i"));
+    let ctrl_alt_k = ctrl_alt(Key.the_key("k"));
+    let ctrl_alt_j = ctrl_alt(Key.the_key("j"));
+    let ctrl_alt_l = ctrl_alt(Key.the_key("l"));
   };
 
   [@deriving sexp]
@@ -458,11 +457,10 @@ module KeyCombo = {
     | Pound
     | Ctrl_Z
     | Ctrl_Shift_Z
-    | Ctrl_Shift_Left
-    | Ctrl_Shift_Right
-    | Ctrl_Shift_Up
-    | Ctrl_Shift_Down
-    | Ctrl_Shift_L;
+    | Ctrl_Alt_I
+    | Ctrl_Alt_K
+    | Ctrl_Alt_J
+    | Ctrl_Alt_L;
 
   let get_details =
     fun
@@ -493,11 +491,10 @@ module KeyCombo = {
     | Alt_C => Details.alt_C
     | Ctrl_Z => Details.ctrl_z
     | Ctrl_Shift_Z => Details.ctrl_shift_z
-    | Ctrl_Shift_Left => Details.ctrl_shift_left
-    | Ctrl_Shift_Right => Details.ctrl_shift_right
-    | Ctrl_Shift_Up => Details.ctrl_shift_up
-    | Ctrl_Shift_Down => Details.ctrl_shift_down
-    | Ctrl_Shift_L => Details.ctrl_shift_l;
+    | Ctrl_Alt_I => Details.ctrl_alt_i
+    | Ctrl_Alt_K => Details.ctrl_alt_k
+    | Ctrl_Alt_J => Details.ctrl_alt_j
+    | Ctrl_Alt_L => Details.ctrl_alt_l;
 
   let of_evt = (evt: Js.t(Dom_html.keyboardEvent)): option(t) => {
     let evt_matches = details => Details.matches(details, evt);
@@ -505,14 +502,6 @@ module KeyCombo = {
       Some(Pound);
     } else if (evt_matches(Details.ctrl_z)) {
       Some(Ctrl_Z);
-    } else if (evt_matches(Details.ctrl_shift_left)) {
-      Some(Ctrl_Shift_Left);
-    } else if (evt_matches(Details.ctrl_shift_right)) {
-      Some(Ctrl_Shift_Right);
-    } else if (evt_matches(Details.ctrl_shift_up)) {
-      Some(Ctrl_Shift_Up);
-    } else if (evt_matches(Details.ctrl_shift_l)) {
-      Some(Ctrl_Shift_L);
     } else if (evt_matches(Details.ctrl_shift_z)) {
       Some(Ctrl_Shift_Z);
     } else if (evt_matches(Details.escape)) {
@@ -563,6 +552,14 @@ module KeyCombo = {
       Some(Alt_R);
     } else if (evt_matches(Details.alt_C)) {
       Some(Alt_C);
+    } else if (evt_matches(Details.ctrl_alt_i)) {
+      Some(Ctrl_Alt_I);
+    } else if (evt_matches(Details.ctrl_alt_k)) {
+      Some(Ctrl_Alt_K);
+    } else if (evt_matches(Details.ctrl_alt_j)) {
+      Some(Ctrl_Alt_J);
+    } else if (evt_matches(Details.ctrl_alt_l)) {
+      Some(Ctrl_Alt_L);
     } else {
       None;
     };

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -424,7 +424,7 @@ module KeyCombo = {
     let ctrl_shift_z = ctrl_shift(Key.the_key("Z"));
     let ctrl_alt_i = ctrl_alt(Key.the_key("i"));
     let ctrl_alt_k = ctrl_alt(Key.the_key("k"));
-    let ctrl_alt_j = ctrl_alt(Key.the_key("j"));
+    let ctrl_alt_j = ctrl_alt(Key.the_key("ArrowLeft"));
     let ctrl_alt_l = ctrl_alt(Key.the_key("l"));
   };
 

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -423,7 +423,7 @@ module KeyCombo = {
     let ctrl_shift_left = ctrl_shift(Key.the_key("ArrowLeft"));
     let ctrl_shift_right = ctrl_shift(Key.the_key("ArrowRight"));
     let ctrl_shift_up = ctrl_shift(Key.the_key("ArrowUp"));
-    let ctrl_shift_down = ctrl_shift(Key.the_key("ArrowDown"));;
+    let ctrl_shift_down = ctrl_shift(Key.the_key("ArrowDown"));
   };
 
   [@deriving sexp]

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -500,6 +500,14 @@ module KeyCombo = {
       Some(Pound);
     } else if (evt_matches(Details.ctrl_z)) {
       Some(Ctrl_Z);
+    } else if (evt_matches(Details.ctrl_shift_left)) {
+      Some(Ctrl_Shift_Left);
+    } else if (evt_matches(Details.ctrl_shift_right)) {
+      Some(Ctrl_Shift_Right);
+    } else if (evt_matches(Details.ctrl_shift_up)) {
+      Some(Ctrl_Shift_Up);
+    } else if (evt_matches(Details.ctrl_shift_down)) {
+      Some(Ctrl_Shift_Down);
     } else if (evt_matches(Details.ctrl_shift_z)) {
       Some(Ctrl_Shift_Z);
     } else if (evt_matches(Details.escape)) {

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -422,10 +422,10 @@ module KeyCombo = {
     let alt_F = alt(Key.the_key("F"));
     let ctrl_z = ctrl(Key.the_key("z"));
     let ctrl_shift_z = ctrl_shift(Key.the_key("Z"));
-    let ctrl_alt_i = ctrl_alt(Key.the_key("i"));
-    let ctrl_alt_k = ctrl_alt(Key.the_key("k"));
-    let ctrl_alt_j = ctrl_alt(Key.the_key("ArrowLeft"));
-    let ctrl_alt_l = ctrl_alt(Key.the_key("l"));
+    let ctrl_alt_up = ctrl_alt(Key.the_key("ArrowUp"));
+    let ctrl_alt_down = ctrl_alt(Key.the_key("ArrowDown"));
+    let ctrl_alt_left = ctrl_alt(Key.the_key("ArrowLeft"));
+    let ctrl_alt_right = ctrl_alt(Key.the_key("ArrowRight"));
   };
 
   [@deriving sexp]
@@ -457,10 +457,10 @@ module KeyCombo = {
     | Pound
     | Ctrl_Z
     | Ctrl_Shift_Z
-    | Ctrl_Alt_I
-    | Ctrl_Alt_K
-    | Ctrl_Alt_J
-    | Ctrl_Alt_L;
+    | Ctrl_Alt_Up
+    | Ctrl_Alt_Down
+    | Ctrl_Alt_Left
+    | Ctrl_Alt_Right;
 
   let get_details =
     fun
@@ -491,10 +491,10 @@ module KeyCombo = {
     | Alt_C => Details.alt_C
     | Ctrl_Z => Details.ctrl_z
     | Ctrl_Shift_Z => Details.ctrl_shift_z
-    | Ctrl_Alt_I => Details.ctrl_alt_i
-    | Ctrl_Alt_K => Details.ctrl_alt_k
-    | Ctrl_Alt_J => Details.ctrl_alt_j
-    | Ctrl_Alt_L => Details.ctrl_alt_l;
+    | Ctrl_Alt_Up => Details.ctrl_alt_up
+    | Ctrl_Alt_Down => Details.ctrl_alt_down
+    | Ctrl_Alt_Left => Details.ctrl_alt_left
+    | Ctrl_Alt_Right => Details.ctrl_alt_right;
 
   let of_evt = (evt: Js.t(Dom_html.keyboardEvent)): option(t) => {
     let evt_matches = details => Details.matches(details, evt);
@@ -552,14 +552,14 @@ module KeyCombo = {
       Some(Alt_R);
     } else if (evt_matches(Details.alt_C)) {
       Some(Alt_C);
-    } else if (evt_matches(Details.ctrl_alt_i)) {
-      Some(Ctrl_Alt_I);
-    } else if (evt_matches(Details.ctrl_alt_k)) {
-      Some(Ctrl_Alt_K);
-    } else if (evt_matches(Details.ctrl_alt_j)) {
-      Some(Ctrl_Alt_J);
-    } else if (evt_matches(Details.ctrl_alt_l)) {
-      Some(Ctrl_Alt_L);
+    } else if (evt_matches(Details.ctrl_alt_up)) {
+      Some(Ctrl_Alt_Up);
+    } else if (evt_matches(Details.ctrl_alt_down)) {
+      Some(Ctrl_Alt_Down);
+    } else if (evt_matches(Details.ctrl_alt_left)) {
+      Some(Ctrl_Alt_Left);
+    } else if (evt_matches(Details.ctrl_alt_right)) {
+      Some(Ctrl_Alt_Right);
     } else {
       None;
     };

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -290,6 +290,7 @@ module ModKeys = {
   let alt = {c: NotHeld, s: Any, a: Held, m: NotHeld};
   let no_ctrl_alt_meta = {c: NotHeld, s: Any, a: NotHeld, m: NotHeld};
   let ctrl_shift = {c: Held, s: Held, a: NotHeld, m: NotHeld};
+  let ctrl_alt = {c: Held, s: NotHeld, a: Held, m: NotHeld};
 
   let req_matches = (req, mk, evt) =>
     switch (req) {
@@ -375,6 +376,7 @@ module KeyCombo = {
     let ctrl = key => {mod_keys: ModKeys.ctrl, key};
     let alt = key => {mod_keys: ModKeys.alt, key};
     let ctrl_shift = key => {mod_keys: ModKeys.ctrl_shift, key};
+    let ctrl_alt = key => {mod_keys: ModKeys.ctrl_alt, key};
 
     let matches = (kc, evt: Js.t(Dom_html.keyboardEvent)) =>
       ModKeys.matches(kc.mod_keys, evt) && Key.matches(kc.key, evt);
@@ -424,7 +426,7 @@ module KeyCombo = {
     let ctrl_shift_right = ctrl_shift(Key.the_code("ArrowRight"));
     let ctrl_shift_up = ctrl_shift(Key.the_code("ArrowUp"));
     let ctrl_shift_down = ctrl_shift(Key.the_code("ArrowDown"));
-    let ctrl_shift_l = ctrl_shift(Key.the_key("l"));
+    let ctrl_shift_l = ctrl_alt(Key.the_key("l"));
   };
 
   [@deriving sexp]

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -618,13 +618,13 @@ let is_movement_key: Js.t(Dom_html.keyboardEvent) => bool =
     | "ArrowLeft"
     | "ArrowRight"
     | "ArrowUp"
-    | "ArrowDown" => {
+    | "ArrowDown" =>
       switch (KeyCombo.of_evt(evt)) {
-      | Some(Ctrl_Alt_Up | Ctrl_Alt_Down | Ctrl_Alt_Left | Ctrl_Alt_Right) => false
+      | Some(Ctrl_Alt_Up | Ctrl_Alt_Down | Ctrl_Alt_Left | Ctrl_Alt_Right) =>
+        false
       | Some(_)
       | None => true
       }
-    }
     | "PageUp"
     | "PageDown"
     | "Home"

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -44,7 +44,7 @@ let kc_actions: Hashtbl.t(KeyCombo.t, CursorInfo.t => Action.t) =
     (Alt_C, _ => Action.Construct(SCase)),
     (Ctrl_Shift_Up, _ => Action.SwapUp),
     (Ctrl_Shift_Down, _ => Action.SwapDown),
-    (Ctrl_Shift_Left, _ => Action.SwapLeft),
+    (Ctrl_Shift_L, _ => Action.SwapLeft),
     (Ctrl_Shift_Right, _ => Action.SwapRight),
   ]
   |> List.to_seq
@@ -73,7 +73,7 @@ let view =
           } else {
             switch (KeyCombo.of_evt(evt)) {
             | Some(Ctrl_Z) => prevent_stop_inject(Update.Action.Undo)
-            | Some(Ctrl_Shift_L) => prevent_stop_inject(Update.Action.Redo)
+            | Some(Ctrl_Shift_Z) => prevent_stop_inject(Update.Action.Redo)
             | Some(kc) =>
               prevent_stop_inject(
                 Update.Action.EditAction(

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -42,10 +42,10 @@ let kc_actions: Hashtbl.t(KeyCombo.t, CursorInfo.t => Action.t) =
     (Alt_L, _ => Action.Construct(SInj(L))),
     (Alt_R, _ => Action.Construct(SInj(R))),
     (Alt_C, _ => Action.Construct(SCase)),
-    (Ctrl_Alt_I, _ => Action.SwapUp),
-    (Ctrl_Alt_K, _ => Action.SwapDown),
-    (Ctrl_Alt_J, _ => Action.SwapLeft),
-    (Ctrl_Alt_L, _ => Action.SwapRight),
+    (Ctrl_Alt_Up, _ => Action.SwapUp),
+    (Ctrl_Alt_Down, _ => Action.SwapDown),
+    (Ctrl_Alt_Left, _ => Action.SwapLeft),
+    (Ctrl_Alt_Right, _ => Action.SwapRight),
   ]
   |> List.to_seq
   |> Hashtbl.of_seq;
@@ -70,7 +70,8 @@ let view =
             ]);
           if (JSUtil.is_movement_key(evt)) {
             switch (KeyCombo.of_evt(evt)) {
-            | Some(Ctrl_Alt_J) => prevent_stop_inject(
+            | Some(Ctrl_Alt_Up | Ctrl_Alt_Down 
+                  | Ctrl_Alt_Left | Ctrl_Alt_Right as kc) => prevent_stop_inject(
                 Update.Action.EditAction(
                   Hashtbl.find(
                     kc_actions,

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -69,7 +69,18 @@ let view =
               inject(a),
             ]);
           if (JSUtil.is_movement_key(evt)) {
-            Event.Many([]);
+            switch (KeyCombo.of_evt(evt)) {
+            | Some(Ctrl_Alt_J) => prevent_stop_inject(
+                Update.Action.EditAction(
+                  Hashtbl.find(
+                    kc_actions,
+                    kc,
+                    program |> Program.get_cursor_info,
+                  ),
+                ),
+              )
+            | _ => Event.Many([]);
+            };
           } else {
             switch (KeyCombo.of_evt(evt)) {
             | Some(Ctrl_Z) => prevent_stop_inject(Update.Action.Undo)

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -42,10 +42,10 @@ let kc_actions: Hashtbl.t(KeyCombo.t, CursorInfo.t => Action.t) =
     (Alt_L, _ => Action.Construct(SInj(L))),
     (Alt_R, _ => Action.Construct(SInj(R))),
     (Alt_C, _ => Action.Construct(SCase)),
-    (Alt_W, _ => Action.SwapUp),
-    (Alt_S, _ => Action.SwapDown),
-    (Alt_A, _ => Action.SwapLeft),
-    (Alt_D, _ => Action.SwapRight),
+    (Ctrl_Shift_Up, _ => Action.SwapUp),
+    (Ctrl_Shift_Down, _ => Action.SwapDown),
+    (Ctrl_Shift_Left, _ => Action.SwapLeft),
+    (Ctrl_Shift_Right, _ => Action.SwapRight),
   ]
   |> List.to_seq
   |> Hashtbl.of_seq;

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -70,8 +70,8 @@ let view =
             ]);
           if (JSUtil.is_movement_key(evt)) {
             switch (KeyCombo.of_evt(evt)) {
-            | Some(Ctrl_Alt_Up | Ctrl_Alt_Down 
-                  | Ctrl_Alt_Left | Ctrl_Alt_Right as kc) => prevent_stop_inject(
+            | Some(Ctrl_Alt_Up as kc | Ctrl_Alt_Down as kc | 
+                    Ctrl_Alt_Left as kc | Ctrl_Alt_Right as kc) => prevent_stop_inject(
                 Update.Action.EditAction(
                   Hashtbl.find(
                     kc_actions,

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -73,7 +73,7 @@ let view =
           } else {
             switch (KeyCombo.of_evt(evt)) {
             | Some(Ctrl_Z) => prevent_stop_inject(Update.Action.Undo)
-            | Some(Ctrl_Shift_Z) => prevent_stop_inject(Update.Action.Redo)
+            | Some(Ctrl_Shift_L) => prevent_stop_inject(Update.Action.Redo)
             | Some(kc) =>
               prevent_stop_inject(
                 Update.Action.EditAction(

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -69,22 +69,7 @@ let view =
               inject(a),
             ]);
           if (JSUtil.is_movement_key(evt)) {
-            switch (KeyCombo.of_evt(evt)) {
-            | Some(
-                Ctrl_Alt_Up as kc | Ctrl_Alt_Down as kc | Ctrl_Alt_Left as kc |
-                Ctrl_Alt_Right as kc,
-              ) =>
-              prevent_stop_inject(
-                Update.Action.EditAction(
-                  Hashtbl.find(
-                    kc_actions,
-                    kc,
-                    program |> Program.get_cursor_info,
-                  ),
-                ),
-              )
-            | _ => Event.Many([])
-            };
+            Event.Many([]);
           } else {
             switch (KeyCombo.of_evt(evt)) {
             | Some(Ctrl_Z) => prevent_stop_inject(Update.Action.Undo)

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -42,10 +42,10 @@ let kc_actions: Hashtbl.t(KeyCombo.t, CursorInfo.t => Action.t) =
     (Alt_L, _ => Action.Construct(SInj(L))),
     (Alt_R, _ => Action.Construct(SInj(R))),
     (Alt_C, _ => Action.Construct(SCase)),
-    (Ctrl_Shift_Up, _ => Action.SwapUp),
-    (Ctrl_Shift_Down, _ => Action.SwapDown),
-    (Ctrl_Shift_L, _ => Action.SwapLeft),
-    (Ctrl_Shift_Right, _ => Action.SwapRight),
+    (Ctrl_Alt_I, _ => Action.SwapUp),
+    (Ctrl_Alt_K, _ => Action.SwapDown),
+    (Ctrl_Alt_J, _ => Action.SwapLeft),
+    (Ctrl_Alt_L, _ => Action.SwapRight),
   ]
   |> List.to_seq
   |> Hashtbl.of_seq;

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -70,8 +70,11 @@ let view =
             ]);
           if (JSUtil.is_movement_key(evt)) {
             switch (KeyCombo.of_evt(evt)) {
-            | Some(Ctrl_Alt_Up as kc | Ctrl_Alt_Down as kc | 
-                    Ctrl_Alt_Left as kc | Ctrl_Alt_Right as kc) => prevent_stop_inject(
+            | Some(
+                Ctrl_Alt_Up as kc | Ctrl_Alt_Down as kc | Ctrl_Alt_Left as kc |
+                Ctrl_Alt_Right as kc,
+              ) =>
+              prevent_stop_inject(
                 Update.Action.EditAction(
                   Hashtbl.find(
                     kc_actions,
@@ -80,7 +83,7 @@ let view =
                   ),
                 ),
               )
-            | _ => Event.Many([]);
+            | _ => Event.Many([])
             };
           } else {
             switch (KeyCombo.of_evt(evt)) {

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -42,6 +42,10 @@ let kc_actions: Hashtbl.t(KeyCombo.t, CursorInfo.t => Action.t) =
     (Alt_L, _ => Action.Construct(SInj(L))),
     (Alt_R, _ => Action.Construct(SInj(R))),
     (Alt_C, _ => Action.Construct(SCase)),
+    (Alt_W, _ => Action.SwapUp),
+    (Alt_S, _ => Action.SwapDown),
+    (Alt_A, _ => Action.SwapLeft),
+    (Alt_D, _ => Action.SwapRight),
   ]
   |> List.to_seq
   |> Hashtbl.of_seq;

--- a/src/hazelweb/model/UndoHistory.re
+++ b/src/hazelweb/model/UndoHistory.re
@@ -32,7 +32,7 @@ let undoable_action = (action: Action.t): bool => {
   | UpdateApPalette(_)
   | Delete
   | Backspace
-  | Construct(_) 
+  | Construct(_)
   | SwapUp
   | SwapDown
   | SwapLeft

--- a/src/hazelweb/model/UndoHistory.re
+++ b/src/hazelweb/model/UndoHistory.re
@@ -32,7 +32,11 @@ let undoable_action = (action: Action.t): bool => {
   | UpdateApPalette(_)
   | Delete
   | Backspace
-  | Construct(_) => true
+  | Construct(_) 
+  | SwapUp
+  | SwapDown
+  | SwapLeft
+  | SwapRight => true
   | MoveTo(_)
   | MoveToBefore(_)
   | MoveLeft


### PR DESCRIPTION
1. **Action.re**: add SwapUp, SwapDown, SwapLeft and SwapRight to Action.t and handle these actions in 
             module Typ, Pat and Exp and the code is placed after the construct action but before the zipper case.

2. **ZExp.re**: add a function called "line_can_be_swapped" which is used in Action.Exp.syn_perform_block and Action.Exp.ana_perform_block to determine if the line can be swapped at the block level.

3. **JSUtil.re**: add new function "ctrl_alt" to indicate the mod key status and add four key combinations which are ctrl_alt_[up, down, left, right]

4. **Cell.re**: use ctrl_alt_[up, down, left, right] to indicate Swap[Up, Down, Left, Right] actions and add  a few lines to the "view" function to let the key combination with arrows are handled

5. **UndoHistory.re**: add four swap actions as undoable actions