### PR TITLE
change dune to use js_of_ocaml-ppx rather than js_of_ocaml.ppx

### DIFF
--- a/src/hazelweb/dune
+++ b/src/hazelweb/dune
@@ -15,7 +15,7 @@
   (flags
    (:include js-of-ocaml-flags-%{profile})))
  (preprocess
-  (pps js_of_ocaml.ppx ppx_let ppx_sexp_conv)))
+  (pps js_of_ocaml-ppx ppx_let ppx_sexp_conv)))
 
 (executable
  (name main)
@@ -26,7 +26,7 @@
   (flags
    (:include js-of-ocaml-flags-%{profile})))
  (preprocess
-  (pps js_of_ocaml.ppx ppx_let ppx_sexp_conv)))
+  (pps js_of_ocaml-ppx ppx_let ppx_sexp_conv)))
 
 (rule
  (write-file js-of-ocaml-flags-dev "(:standard --debuginfo --noinline)"))


### PR DESCRIPTION
On a fresh install of opam with OCaml 4.08.1 switch and `make deps` (on Linux), I get the following error on `make`:

```
dune build @src/fmt --auto-promote || true
dune build src --profile dev
File "src/hazelweb/dune", line 18, characters 7-22:
18 |   (pps js_of_ocaml.ppx ppx_let ppx_sexp_conv)))
            ^^^^^^^^^^^^^^^
Error: Library "js_of_ocaml.ppx" not found.
Hint: try: dune external-lib-deps --missing --profile dev src
File "src/hazelweb/dune", line 29, characters 7-22:
29 |   (pps js_of_ocaml.ppx ppx_let ppx_sexp_conv)))
            ^^^^^^^^^^^^^^^
Error: Library "js_of_ocaml.ppx" not found.
Hint: try: dune external-lib-deps --missing --profile dev src
make: *** [Makefile:12: dev] Error 1
```

This is fixed by this pull request. Need to make sure this isn't breaking anything.