### PR TITLE
Fixed being unable to construct float op in definition of let when type ascription isn't Float

### DIFF
--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -4165,9 +4165,7 @@ module Exp = {
       | Some(op) =>
         let new_zoperator = (pos, op);
         let new_zseq = ZSeq.ZOperator(new_zoperator, seq);
-        Succeeded(
-          AnaDone(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, Float)),
-        );
+        Succeeded(AnaDone(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty)));
       | None => Failed
       };
 


### PR DESCRIPTION
**fixed issue #234** 
- Fixed the issue in the Float Op construction case of Action.Exp.ana_perform_operand where Float was used as ascription type instead of the given type.