### PR TITLE
Fixed comma issue when analyzing against non-tuple type

### DIFF
--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -4196,8 +4196,8 @@ module Exp = {
           // safe because pattern guard
           ty |> HTyp.get_prod_elements |> List.hd,
         );
-      let (new_zopseq, u_gen) = complete_tuple(u_gen, opseq, ty);
-      Succeeded(AnaDone((ZExp.ZBlock.wrap'(new_zopseq), u_gen)));
+      let (ZOpSeq(_, new_zseq), u_gen) = complete_tuple(u_gen, opseq, ty);
+      Succeeded(AnaDone(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty)));
     | (
         Construct(SParenthesized),
         ZOperand(CursorE(_, EmptyHole(_)), (E, E)),

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -4165,9 +4165,7 @@ module Exp = {
       | Some(op) =>
         let new_zoperator = (pos, op);
         let new_zseq = ZSeq.ZOperator(new_zoperator, seq);
-        Succeeded(
-          AnaDone(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, Float)),
-        );
+        Succeeded(AnaDone(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty)));
       | None => Failed
       };
 


### PR DESCRIPTION
**fixed issue #240** 

- called `mk_and_ana_fix_ZOpSeq` on the `zseq` returned by the complete tuple function in `Action.Exp.ana_perform_opseq`