### PR TITLE
Invalid var

### DIFF
--- a/src/hazelcore/layout/DHDoc.re
+++ b/src/hazelcore/layout/DHDoc.re
@@ -127,6 +127,7 @@ module Pat = {
     | NonEmptyHole(_)
     | Wild
     | Keyword(_)
+    | InvalidVar(_)
     | Var(_)
     | IntLit(_)
     | FloatLit(_)
@@ -155,6 +156,7 @@ module Pat = {
       | NonEmptyHole(reason, u, i, dp) =>
         mk'(dp) |> Doc.annot(DHAnnot.NonEmptyHole(reason, (u, i)))
       | Keyword(u, i, k) => mk_Keyword(u, i, k)
+      | InvalidVar(_, _, _) => failwith("unimplemented")
       | Var(x) => Doc.text(x)
       | Wild => Delim.wild
       | Triv => Delim.triv
@@ -204,6 +206,7 @@ module Exp = {
     switch (d) {
     | BoundVar(_)
     | FreeVar(_)
+    | InvalidVar(_, _, _)
     | Keyword(_)
     | BoolLit(_)
     | IntLit(_)
@@ -309,6 +312,7 @@ module Exp = {
         | Keyword(u, i, _sigma, k) => mk_Keyword(u, i, k)
         | FreeVar(u, i, _sigma, x) =>
           text(x) |> annot(DHAnnot.VarHole(Free, (u, i)))
+        | InvalidVar(_, _, _) => failwith("unimplemented")
         | BoundVar(x) => text(x)
         | Triv => Delim.triv
         | BoolLit(b) => mk_BoolLit(b)

--- a/src/hazelcore/layout/DHDoc.re
+++ b/src/hazelcore/layout/DHDoc.re
@@ -95,6 +95,9 @@ let mk_Keyword = (u, i, k) =>
   Doc.text(ExpandingKeyword.to_string(k))
   |> Doc.annot(DHAnnot.VarHole(Keyword(k), (u, i)));
 
+let mk_Invalid = (u, i, s) =>
+  Doc.text(s) |> Doc.annot(DHAnnot.VarHole(Invalid, (u, i)));
+
 let mk_IntLit = n => Doc.text(string_of_int(n));
 
 let mk_FloatLit = f => Doc.text(string_of_float(f));
@@ -156,7 +159,7 @@ module Pat = {
       | NonEmptyHole(reason, u, i, dp) =>
         mk'(dp) |> Doc.annot(DHAnnot.NonEmptyHole(reason, (u, i)))
       | Keyword(u, i, k) => mk_Keyword(u, i, k)
-      | InvalidVar(_, _, _) => failwith("unimplemented")
+      | InvalidVar(u, i, s) => mk_Invalid(u, i, s)
       | Var(x) => Doc.text(x)
       | Wild => Delim.wild
       | Triv => Delim.triv
@@ -312,7 +315,7 @@ module Exp = {
         | Keyword(u, i, _sigma, k) => mk_Keyword(u, i, k)
         | FreeVar(u, i, _sigma, x) =>
           text(x) |> annot(DHAnnot.VarHole(Free, (u, i)))
-        | InvalidVar(_, _, _) => failwith("unimplemented")
+        | InvalidVar(u, i, s) => mk_Invalid(u, i, s)
         | BoundVar(x) => text(x)
         | Triv => Delim.triv
         | BoolLit(b) => mk_BoolLit(b)

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -752,7 +752,10 @@ module Pat = {
         let (zhole, u_gen) = u_gen |> ZPat.new_EmptyHole;
         Succeeded((ZOpSeq.wrap(zhole), HTyp.Hole, ctx, u_gen));
       } else {
-        Failed;
+        let (u, u_gen) = u_gen |> MetaVarGen.next;
+        let var = UHPat.var(~var_err=InVarHole(Invalid, u), text);
+        let zp = ZOpSeq.wrap(ZPat.CursorP(text_cursor, var));
+        Succeeded((zp, HTyp.Hole, ctx, u_gen));
       }
     | Underscore =>
       let zp = ZOpSeq.wrap(ZPat.CursorP(OnDelim(0, After), UHPat.wild()));
@@ -803,7 +806,10 @@ module Pat = {
         let (zhole, u_gen) = u_gen |> ZPat.new_EmptyHole;
         Succeeded((ZOpSeq.wrap(zhole), ctx, u_gen));
       } else {
-        Failed;
+        let (u, u_gen) = u_gen |> MetaVarGen.next;
+        let var = UHPat.var(~var_err=InVarHole(Invalid, u), text);
+        let zp = ZOpSeq.wrap(ZPat.CursorP(text_cursor, var));
+        Succeeded((zp, ctx, u_gen));
       }
     | Underscore =>
       let zp = ZOpSeq.wrap(ZPat.CursorP(OnDelim(0, After), UHPat.wild()));
@@ -2184,7 +2190,10 @@ module Exp = {
         let (zhole, u_gen) = u_gen |> ZExp.new_EmptyHole;
         Succeeded(SynDone((ZExp.ZBlock.wrap(zhole), HTyp.Hole, u_gen)));
       } else {
-        Failed;
+        let (u, u_gen) = u_gen |> MetaVarGen.next;
+        let var = UHExp.var(~var_err=InVarHole(Invalid, u), text);
+        let ze = ZExp.ZBlock.wrap(CursorE(text_cursor, var));
+        Succeeded(SynDone((ze, HTyp.Hole, u_gen)));
       }
     | IntLit(n) =>
       let ze = ZExp.ZBlock.wrap(CursorE(text_cursor, UHExp.intlit(n)));
@@ -2245,7 +2254,10 @@ module Exp = {
         let (zhole, u_gen) = u_gen |> ZExp.new_EmptyHole;
         Succeeded(AnaDone((ZExp.ZBlock.wrap(zhole), u_gen)));
       } else {
-        Failed;
+        let (u, u_gen) = u_gen |> MetaVarGen.next;
+        let var = UHExp.var(~var_err=InVarHole(Invalid, u), text);
+        let ze = ZExp.ZBlock.wrap(CursorE(text_cursor, var));
+        Succeeded(AnaDone((ze, u_gen)));
       }
     | ExpandingKeyword(k) =>
       let (u, u_gen) = u_gen |> MetaVarGen.next;

--- a/src/hazelcore/semantics/CursorInfo.re
+++ b/src/hazelcore/semantics/CursorInfo.re
@@ -679,6 +679,7 @@ module Exp = {
             Some(mk(SynFreeArrow(Arrow(Hole, Hole))))
           | Some((_, InVarHole(Keyword(k), _))) =>
             Some(mk(SynKeywordArrow(Arrow(Hole, Hole), k)))
+          | Some((_, InVarHole(Invalid, _))) => failwith("unimplemented")
           | Some((NotInHole, NotInVarHole)) =>
             switch (
               Statics.Exp.syn_operand(ctx, zoperand |> ZExp.erase_zoperand)
@@ -737,6 +738,8 @@ module Exp = {
     | CursorE(_, Var(_, InVarHole(Keyword(k), _), _)) =>
       Some(mk(SynKeyword(k), ctx))
     | CursorE(_, Var(_, InVarHole(Free, _), _)) => Some(mk(SynFree, ctx))
+    | CursorE(_, Var(_, InVarHole(Invalid, _), _)) =>
+      failwith("unimplemented")
     | CursorE(_, e) =>
       switch (Statics.Exp.syn_operand(ctx, e)) {
       | None => None
@@ -962,6 +965,7 @@ module Exp = {
       | Var(_, InVarHole(Keyword(k), _), _) =>
         Some(mk(AnaKeyword(ty, k), ctx))
       | Var(_, InVarHole(Free, _), _) => Some(mk(AnaFree(ty), ctx))
+      | Var(_, InVarHole(Invalid, _), _) => failwith("unimplemented")
       | Var(InHole(TypeInconsistent, _), _, _)
       | IntLit(InHole(TypeInconsistent, _), _)
       | FloatLit(InHole(TypeInconsistent, _), _)

--- a/src/hazelcore/semantics/CursorInfo.re
+++ b/src/hazelcore/semantics/CursorInfo.re
@@ -685,7 +685,8 @@ module Exp = {
             Some(mk(SynFreeArrow(Arrow(Hole, Hole))))
           | Some((_, InVarHole(Keyword(k), _))) =>
             Some(mk(SynKeywordArrow(Arrow(Hole, Hole), k)))
-          | Some((_, InVarHole(Invalid, _))) => failwith("unimplemented")
+          | Some((_, InVarHole(Invalid, _))) =>
+            Some(mk(SynInvalidArrow(Arrow(Hole, Hole))))
           | Some((NotInHole, NotInVarHole)) =>
             switch (
               Statics.Exp.syn_operand(ctx, zoperand |> ZExp.erase_zoperand)
@@ -745,7 +746,7 @@ module Exp = {
       Some(mk(SynKeyword(k), ctx))
     | CursorE(_, Var(_, InVarHole(Free, _), _)) => Some(mk(SynFree, ctx))
     | CursorE(_, Var(_, InVarHole(Invalid, _), _)) =>
-      failwith("unimplemented")
+      Some(mk(SynInvalid, ctx))
     | CursorE(_, e) =>
       switch (Statics.Exp.syn_operand(ctx, e)) {
       | None => None
@@ -971,7 +972,7 @@ module Exp = {
       | Var(_, InVarHole(Keyword(k), _), _) =>
         Some(mk(AnaKeyword(ty, k), ctx))
       | Var(_, InVarHole(Free, _), _) => Some(mk(AnaFree(ty), ctx))
-      | Var(_, InVarHole(Invalid, _), _) => failwith("unimplemented")
+      | Var(_, InVarHole(Invalid, _), _) => Some(mk(AnaInvalid(ty), ctx))
       | Var(InHole(TypeInconsistent, _), _, _)
       | IntLit(InHole(TypeInconsistent, _), _)
       | FloatLit(InHole(TypeInconsistent, _), _)

--- a/src/hazelcore/semantics/CursorInfo.re
+++ b/src/hazelcore/semantics/CursorInfo.re
@@ -19,6 +19,8 @@ type typed =
       )
   // cursor is on a free variable
   | AnaFree(HTyp.t)
+  // cursor is on an invalid variable
+  | AnaInvalid(HTyp.t)
   // cursor is on a keyword
   | AnaKeyword(HTyp.t, ExpandingKeyword.t)
   // none of the above and didn't go through subsumption
@@ -45,6 +47,10 @@ type typed =
   | SynFreeArrow(HTyp.t)
   // cursor is on a keyword in the function position of an ap
   | SynKeywordArrow(HTyp.t, ExpandingKeyword.t)
+  // cursor is on an invalid variable in the fuction position of an ap
+  | SynInvalidArrow(HTyp.t)
+  // cursor is on an invalid variable
+  | SynInvalid
   // none of the above, cursor is on a free variable
   | SynFree
   // cursor is on a keyword

--- a/src/hazelcore/semantics/Statics.re
+++ b/src/hazelcore/semantics/Statics.re
@@ -104,6 +104,7 @@ module Pat = {
     | Wild(NotInHole) => Some((Hole, ctx))
     | Var(NotInHole, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(NotInHole, InVarHole(Keyword(_), _), _) => Some((Hole, ctx))
+    | Var(NotInHole, InVarHole(Invalid, _), _) => failwith("unimplemented")
     | Var(NotInHole, NotInVarHole, x) =>
       Var.check_valid(
         x,
@@ -208,6 +209,7 @@ module Pat = {
     /* not in hole */
     | Var(NotInHole, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(NotInHole, InVarHole(Keyword(_), _), _) => Some(ctx)
+    | Var(NotInHole, InVarHole(Invalid, _), _) => failwith("unimplemented")
     | Var(NotInHole, NotInVarHole, x) =>
       Var.check_valid(x, Some(Contexts.extend_gamma(ctx, (x, ty))))
     | Wild(NotInHole) => Some(ctx)
@@ -455,6 +457,7 @@ module Pat = {
     | Wild(_) => (operand_nih, Hole, ctx, u_gen)
     | Var(_, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(_, InVarHole(Keyword(_), _), _) => (operand_nih, Hole, ctx, u_gen)
+    | Var(_, InVarHole(Invalid, _), _) => failwith("unimplemented")
     | Var(_, NotInVarHole, x) =>
       let ctx = Contexts.extend_gamma(ctx, (x, Hole));
       (operand_nih, Hole, ctx, u_gen);
@@ -722,6 +725,7 @@ module Pat = {
     | Wild(_) => (operand_nih, ctx, u_gen)
     | Var(_, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(_, InVarHole(Keyword(_), _), _) => (operand_nih, ctx, u_gen)
+    | Var(_, InVarHole(Invalid, _), _) => failwith("unimplemented")
     | Var(_, NotInVarHole, x) =>
       let ctx = Contexts.extend_gamma(ctx, (x, ty));
       (operand_nih, ctx, u_gen);

--- a/src/hazelcore/semantics/Statics.re
+++ b/src/hazelcore/semantics/Statics.re
@@ -104,7 +104,7 @@ module Pat = {
     | Wild(NotInHole) => Some((Hole, ctx))
     | Var(NotInHole, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(NotInHole, InVarHole(Keyword(_), _), _) => Some((Hole, ctx))
-    | Var(NotInHole, InVarHole(Invalid, _), _) => failwith("unimplemented")
+    | Var(NotInHole, InVarHole(Invalid, _), _) => Some((Hole, ctx))
     | Var(NotInHole, NotInVarHole, x) =>
       Var.check_valid(
         x,
@@ -209,7 +209,7 @@ module Pat = {
     /* not in hole */
     | Var(NotInHole, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(NotInHole, InVarHole(Keyword(_), _), _) => Some(ctx)
-    | Var(NotInHole, InVarHole(Invalid, _), _) => failwith("unimplemented")
+    | Var(NotInHole, InVarHole(Invalid, _), _) => Some(ctx)
     | Var(NotInHole, NotInVarHole, x) =>
       Var.check_valid(x, Some(Contexts.extend_gamma(ctx, (x, ty))))
     | Wild(NotInHole) => Some(ctx)
@@ -457,7 +457,7 @@ module Pat = {
     | Wild(_) => (operand_nih, Hole, ctx, u_gen)
     | Var(_, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(_, InVarHole(Keyword(_), _), _) => (operand_nih, Hole, ctx, u_gen)
-    | Var(_, InVarHole(Invalid, _), _) => failwith("unimplemented")
+    | Var(_, InVarHole(Invalid, _), _) => (operand_nih, Hole, ctx, u_gen)
     | Var(_, NotInVarHole, x) =>
       let ctx = Contexts.extend_gamma(ctx, (x, Hole));
       (operand_nih, Hole, ctx, u_gen);
@@ -725,7 +725,7 @@ module Pat = {
     | Wild(_) => (operand_nih, ctx, u_gen)
     | Var(_, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(_, InVarHole(Keyword(_), _), _) => (operand_nih, ctx, u_gen)
-    | Var(_, InVarHole(Invalid, _), _) => failwith("unimplemented")
+    | Var(_, InVarHole(Invalid, _), _) => (operand_nih, ctx, u_gen)
     | Var(_, NotInVarHole, x) =>
       let ctx = Contexts.extend_gamma(ctx, (x, ty));
       (operand_nih, ctx, u_gen);

--- a/src/hazelcore/semantics/TextShape.re
+++ b/src/hazelcore/semantics/TextShape.re
@@ -7,7 +7,8 @@ type t =
   | FloatLit(string)
   | BoolLit(bool)
   | ExpandingKeyword(ExpandingKeyword.t)
-  | Var(Var.t);
+  | Var(Var.t)
+  | InvalidVar(string);
 
 /* Eventually replace Ocaml's ___of_string_opt with our own rules */
 /* Ocaml accepts _1 as a float */
@@ -18,24 +19,23 @@ let hazel_float_of_string_opt = (s: string): option(float) =>
     float_of_string_opt(s);
   };
 
-let of_text = (text: string): option(t) => {
+let of_text = (text: string): t =>
   switch (
     int_of_string_opt(text),
     hazel_float_of_string_opt(text),
     bool_of_string_opt(text),
     ExpandingKeyword.mk(text),
   ) {
-  | (Some(_), _, _, _) => Some(IntLit(text))
-  | (_, Some(_), _, _) => Some(FloatLit(text))
-  | (_, _, Some(b), _) => Some(BoolLit(b))
-  | (_, _, _, Some(k)) => Some(ExpandingKeyword(k))
+  | (Some(_), _, _, _) => IntLit(text)
+  | (_, Some(_), _, _) => FloatLit(text)
+  | (_, _, Some(b), _) => BoolLit(b)
+  | (_, _, _, Some(k)) => ExpandingKeyword(k)
   | (None, None, None, None) =>
     if (text |> String.equal("_")) {
-      Some(Underscore);
+      Underscore;
     } else if (text |> Var.is_valid) {
-      Some(Var(text));
+      Var(text);
     } else {
-      None;
+      InvalidVar(text);
     }
   };
-};

--- a/src/hazelcore/semantics/UHExp.re
+++ b/src/hazelcore/semantics/UHExp.re
@@ -292,7 +292,9 @@ let text_operand =
       var(~var_err=InVarHole(Free, u), kw |> ExpandingKeyword.to_string),
       u_gen,
     );
-  | InvalidVar(_) => failwith("unimplemented")
+  | InvalidVar(x) =>
+    let (u, u_gen) = u_gen |> MetaVarGen.next;
+    (var(~var_err=InVarHole(Invalid, u), x), u_gen);
   };
 
 let associate = (seq: seq) => {

--- a/src/hazelcore/semantics/UHExp.re
+++ b/src/hazelcore/semantics/UHExp.re
@@ -292,6 +292,7 @@ let text_operand =
       var(~var_err=InVarHole(Free, u), kw |> ExpandingKeyword.to_string),
       u_gen,
     );
+  | InvalidVar(_) => failwith("unimplemented")
   };
 
 let associate = (seq: seq) => {

--- a/src/hazelcore/semantics/UHPat.re
+++ b/src/hazelcore/semantics/UHPat.re
@@ -155,7 +155,9 @@ let text_operand =
       var(~var_err=InVarHole(Free, u), kw |> ExpandingKeyword.to_string),
       u_gen,
     );
-  | InvalidVar(_) => failwith("unimplemented")
+  | InvalidVar(x) =>
+    let (u, u_gen) = u_gen |> MetaVarGen.next;
+    (var(~var_err=InVarHole(Invalid, u), x), u_gen);
   };
 
 let associate = (seq: seq) => {

--- a/src/hazelcore/semantics/UHPat.re
+++ b/src/hazelcore/semantics/UHPat.re
@@ -155,6 +155,7 @@ let text_operand =
       var(~var_err=InVarHole(Free, u), kw |> ExpandingKeyword.to_string),
       u_gen,
     );
+  | InvalidVar(_) => failwith("unimplemented")
   };
 
 let associate = (seq: seq) => {

--- a/src/hazelcore/semantics/VarErrStatus.re
+++ b/src/hazelcore/semantics/VarErrStatus.re
@@ -4,7 +4,8 @@ module HoleReason = {
   [@deriving sexp]
   type t =
     | Free
-    | Keyword(ExpandingKeyword.t);
+    | Keyword(ExpandingKeyword.t)
+    | Invalid;
 };
 
 /* Variable: var_err */

--- a/src/hazelcore/semantics/dynamics/DHExp.re
+++ b/src/hazelcore/semantics/dynamics/DHExp.re
@@ -97,6 +97,7 @@ type t =
   // TODO rename to ExpandingKeyword
   | Keyword(MetaVar.t, MetaVarInst.t, VarMap.t_(t), ExpandingKeyword.t)
   | FreeVar(MetaVar.t, MetaVarInst.t, VarMap.t_(t), Var.t)
+  | InvalidVar(MetaVar.t, MetaVarInst.t, string)
   | BoundVar(Var.t)
   | Let(DHPat.t, t, t)
   | FixF(Var.t, HTyp.t, t)
@@ -126,6 +127,7 @@ let constructor_string = (d: t): string =>
   | NonEmptyHole(_, _, _, _, _) => "NonEmptyHole"
   | Keyword(_, _, _, _) => "Keyword"
   | FreeVar(_, _, _, _) => "FreeVar"
+  | InvalidVar(_, _, _) => "InvalidVar"
   | BoundVar(_) => "BoundVar"
   | Let(_, _, _) => "Let"
   | FixF(_, _, _) => "FixF"

--- a/src/hazelcore/semantics/dynamics/DHPat.re
+++ b/src/hazelcore/semantics/dynamics/DHPat.re
@@ -7,6 +7,7 @@ type t =
   | Wild
   // TODO rename to ExpandingKeyword
   | Keyword(MetaVar.t, MetaVarInst.t, ExpandingKeyword.t)
+  | InvalidVar(MetaVar.t, MetaVarInst.t, string)
   | Var(Var.t)
   | IntLit(int)
   | FloatLit(float)
@@ -32,6 +33,7 @@ let rec binds_var = (x: Var.t, dp: t): bool =>
   | EmptyHole(_, _)
   | NonEmptyHole(_, _, _, _)
   | Wild
+  | InvalidVar(_, _, _)
   | IntLit(_)
   | FloatLit(_)
   | BoolLit(_)

--- a/src/hazelcore/semantics/dynamics/Dynamics.re
+++ b/src/hazelcore/semantics/dynamics/Dynamics.re
@@ -144,7 +144,8 @@ module Pat = {
     | Var(NotInHole, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(NotInHole, InVarHole(Keyword(k), u), _) =>
       Expands(Keyword(u, 0, k), Hole, ctx, delta)
-    | Var(NotInHole, InVarHole(Invalid, _), _) => failwith("unimplemented")
+    | Var(NotInHole, InVarHole(Invalid, u), x) =>
+      Expands(InvalidVar(u, 0, x), Hole, ctx, delta)
     | Var(NotInHole, NotInVarHole, x) =>
       let ctx = Contexts.extend_gamma(ctx, (x, Hole));
       Expands(Var(x), Hole, ctx, delta);
@@ -366,7 +367,8 @@ module Pat = {
     | Var(NotInHole, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(NotInHole, InVarHole(Keyword(k), u), _) =>
       Expands(Keyword(u, 0, k), ty, ctx, delta)
-    | Var(NotInHole, InVarHole(Invalid, _), _) => failwith("unimplemented")
+    | Var(NotInHole, InVarHole(Invalid, u), x) =>
+      Expands(InvalidVar(u, 0, x), ty, ctx, delta)
     | Var(NotInHole, NotInVarHole, x) =>
       let ctx = Contexts.extend_gamma(ctx, (x, ty));
       Expands(Var(x), ty, ctx, delta);
@@ -454,7 +456,7 @@ module Exp = {
         d2;
       }
     | FreeVar(_) => d2
-    | InvalidVar(_, _, _) => failwith("unimplemented")
+    | InvalidVar(_, _, _) => d2
     | Keyword(_) => d2
     | Let(dp, d3, d4) =>
       let d3 = subst_var(d1, x, d3);
@@ -577,7 +579,7 @@ module Exp = {
     | (NonEmptyHole(_, _, _, _), _) => Indet
     | (Wild, _) => Matches(Environment.empty)
     | (Keyword(_, _, _), _) => DoesNotMatch
-    | (InvalidVar(_, _, _), _) => failwith("unimplemented")
+    | (InvalidVar(_, _, _), _) => Indet
     | (Var(x), _) =>
       let env = Environment.extend(Environment.empty, (x, d));
       Matches(env);
@@ -585,7 +587,7 @@ module Exp = {
     | (_, NonEmptyHole(_, _, _, _, _)) => Indet
     | (_, FailedCast(_, _, _)) => Indet
     | (_, FreeVar(_, _, _, _)) => Indet
-    | (_, InvalidVar(_, _, _)) => failwith("unimplemented")
+    | (_, InvalidVar(_, _, _)) => Indet
     | (_, Let(_, _, _)) => Indet
     | (_, FixF(_, _, _)) => DoesNotMatch
     | (_, Lam(_, _, _)) => DoesNotMatch
@@ -717,7 +719,7 @@ module Exp = {
     | Cast(_, _, _) => DoesNotMatch
     | BoundVar(_) => DoesNotMatch
     | FreeVar(_, _, _, _) => Indet
-    | InvalidVar(_, _, _) => failwith("unimplemented")
+    | InvalidVar(_, _, _) => Indet
     | Keyword(_, _, _, _) => Indet
     | Let(_, _, _) => Indet
     | FixF(_, _, _) => DoesNotMatch
@@ -776,7 +778,7 @@ module Exp = {
     | Cast(_, _, _) => DoesNotMatch
     | BoundVar(_) => DoesNotMatch
     | FreeVar(_, _, _, _) => Indet
-    | InvalidVar(_, _, _) => failwith("unimplemented")
+    | InvalidVar(_, _, _) => Indet
     | Keyword(_, _, _, _) => Indet
     | Let(_, _, _) => Indet
     | FixF(_, _, _) => DoesNotMatch
@@ -833,7 +835,7 @@ module Exp = {
     | Cast(_, _, _) => DoesNotMatch
     | BoundVar(_) => DoesNotMatch
     | FreeVar(_, _, _, _) => Indet
-    | InvalidVar(_, _, _) => failwith("unimplemented")
+    | InvalidVar(_, _, _) => Indet
     | Keyword(_, _, _, _) => Indet
     | Let(_, _, _) => Indet
     | FixF(_, _, _) => DoesNotMatch
@@ -1185,7 +1187,7 @@ module Exp = {
         switch (reason) {
         | Free => DHExp.FreeVar(u, 0, sigma, x)
         | Keyword(k) => DHExp.Keyword(u, 0, sigma, k)
-        | Invalid => failwith("unimplemented")
+        | Invalid => DHExp.InvalidVar(u, 0, x)
         };
       Expands(d, Hole, delta);
     | IntLit(NotInHole, n) =>
@@ -1502,7 +1504,7 @@ module Exp = {
         switch (reason) {
         | Free => FreeVar(u, 0, sigma, x)
         | Keyword(k) => Keyword(u, 0, sigma, k)
-        | Invalid => failwith("unimplemented")
+        | Invalid => InvalidVar(u, 0, x)
         };
       Expands(d, ty, delta);
     | Parenthesized(body) => ana_expand(ctx, delta, body, ty)
@@ -2129,7 +2131,7 @@ module Evaluator = {
       }
     | FreeVar(_) => Indet(d)
     | Keyword(_) => Indet(d)
-    | InvalidVar(_, _, _) => failwith("unimplemented")
+    | InvalidVar(_, _, _) => Indet(d)
     | Cast(d1, ty, ty') =>
       switch (evaluate(d1)) {
       | InvalidInput(msg) => InvalidInput(msg)

--- a/src/hazelcore/semantics/dynamics/Dynamics.re
+++ b/src/hazelcore/semantics/dynamics/Dynamics.re
@@ -144,6 +144,7 @@ module Pat = {
     | Var(NotInHole, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(NotInHole, InVarHole(Keyword(k), u), _) =>
       Expands(Keyword(u, 0, k), Hole, ctx, delta)
+    | Var(NotInHole, InVarHole(Invalid, _), _) => failwith("unimplemented")
     | Var(NotInHole, NotInVarHole, x) =>
       let ctx = Contexts.extend_gamma(ctx, (x, Hole));
       Expands(Var(x), Hole, ctx, delta);
@@ -365,6 +366,7 @@ module Pat = {
     | Var(NotInHole, InVarHole(Free, _), _) => raise(UHPat.FreeVarInPat)
     | Var(NotInHole, InVarHole(Keyword(k), u), _) =>
       Expands(Keyword(u, 0, k), ty, ctx, delta)
+    | Var(NotInHole, InVarHole(Invalid, _), _) => failwith("unimplemented")
     | Var(NotInHole, NotInVarHole, x) =>
       let ctx = Contexts.extend_gamma(ctx, (x, ty));
       Expands(Var(x), ty, ctx, delta);
@@ -1176,6 +1178,7 @@ module Exp = {
         switch (reason) {
         | Free => DHExp.FreeVar(u, 0, sigma, x)
         | Keyword(k) => DHExp.Keyword(u, 0, sigma, k)
+        | Invalid => failwith("unimplemented")
         };
       Expands(d, Hole, delta);
     | IntLit(NotInHole, n) =>
@@ -1492,6 +1495,7 @@ module Exp = {
         switch (reason) {
         | Free => FreeVar(u, 0, sigma, x)
         | Keyword(k) => Keyword(u, 0, sigma, k)
+        | Invalid => failwith("unimplemented")
         };
       Expands(d, ty, delta);
     | Parenthesized(body) => ana_expand(ctx, delta, body, ty)

--- a/src/hazelcore/semantics/dynamics/Dynamics.re
+++ b/src/hazelcore/semantics/dynamics/Dynamics.re
@@ -406,6 +406,7 @@ module Pat = {
     | Var(_)
     | IntLit(_)
     | FloatLit(_)
+    | InvalidVar(_, _, _)
     | BoolLit(_)
     | ListNil
     | Triv => (dp, hii)
@@ -453,6 +454,7 @@ module Exp = {
         d2;
       }
     | FreeVar(_) => d2
+    | InvalidVar(_, _, _) => failwith("unimplemented")
     | Keyword(_) => d2
     | Let(dp, d3, d4) =>
       let d3 = subst_var(d1, x, d3);
@@ -575,6 +577,7 @@ module Exp = {
     | (NonEmptyHole(_, _, _, _), _) => Indet
     | (Wild, _) => Matches(Environment.empty)
     | (Keyword(_, _, _), _) => DoesNotMatch
+    | (InvalidVar(_, _, _), _) => failwith("unimplemented")
     | (Var(x), _) =>
       let env = Environment.extend(Environment.empty, (x, d));
       Matches(env);
@@ -582,6 +585,7 @@ module Exp = {
     | (_, NonEmptyHole(_, _, _, _, _)) => Indet
     | (_, FailedCast(_, _, _)) => Indet
     | (_, FreeVar(_, _, _, _)) => Indet
+    | (_, InvalidVar(_, _, _)) => failwith("unimplemented")
     | (_, Let(_, _, _)) => Indet
     | (_, FixF(_, _, _)) => DoesNotMatch
     | (_, Lam(_, _, _)) => DoesNotMatch
@@ -713,6 +717,7 @@ module Exp = {
     | Cast(_, _, _) => DoesNotMatch
     | BoundVar(_) => DoesNotMatch
     | FreeVar(_, _, _, _) => Indet
+    | InvalidVar(_, _, _) => failwith("unimplemented")
     | Keyword(_, _, _, _) => Indet
     | Let(_, _, _) => Indet
     | FixF(_, _, _) => DoesNotMatch
@@ -771,6 +776,7 @@ module Exp = {
     | Cast(_, _, _) => DoesNotMatch
     | BoundVar(_) => DoesNotMatch
     | FreeVar(_, _, _, _) => Indet
+    | InvalidVar(_, _, _) => failwith("unimplemented")
     | Keyword(_, _, _, _) => Indet
     | Let(_, _, _) => Indet
     | FixF(_, _, _) => DoesNotMatch
@@ -827,6 +833,7 @@ module Exp = {
     | Cast(_, _, _) => DoesNotMatch
     | BoundVar(_) => DoesNotMatch
     | FreeVar(_, _, _, _) => Indet
+    | InvalidVar(_, _, _) => failwith("unimplemented")
     | Keyword(_, _, _, _) => Indet
     | Let(_, _, _) => Indet
     | FixF(_, _, _) => DoesNotMatch
@@ -1642,6 +1649,7 @@ module Exp = {
           : (DHExp.t, HoleInstanceInfo.t) =>
     switch (d) {
     | BoundVar(_)
+    | InvalidVar(_, _, _)
     | BoolLit(_)
     | IntLit(_)
     | FloatLit(_)
@@ -1738,6 +1746,7 @@ module Exp = {
           : (DHExp.t, HoleInstanceInfo.t) =>
     switch (d) {
     | BoundVar(_)
+    | InvalidVar(_, _, _)
     | BoolLit(_)
     | IntLit(_)
     | FloatLit(_)
@@ -2120,6 +2129,7 @@ module Evaluator = {
       }
     | FreeVar(_) => Indet(d)
     | Keyword(_) => Indet(d)
+    | InvalidVar(_, _, _) => failwith("unimplemented")
     | Cast(d1, ty, ty') =>
       switch (evaluate(d1)) {
       | InvalidInput(msg) => InvalidInput(msg)

--- a/src/hazelweb/gui/CursorInspector.re
+++ b/src/hazelweb/gui/CursorInspector.re
@@ -125,6 +125,7 @@ let view = (model: Model.t): Vdom.Node.t => {
           special_msg_bar(got_msg),
         );
       (ind1, ind2, TypeInconsistency);
+    | AnaInvalid(_) => failwith("unimplemented")
     | AnaFree(expected_ty) =>
       let ind1 = expected_ty_indicator(expected_ty);
       let ind2 = got_free_indicator;
@@ -144,6 +145,7 @@ let view = (model: Model.t): Vdom.Node.t => {
       let ind1 = expected_any_indicator;
       let ind2 = got_ty_indicator(ty);
       (ind1, ind2, OK);
+    | SynInvalid => failwith("unimplemented")
     | SynFree =>
       let ind1 = expected_any_indicator;
       let ind2 = got_free_indicator;
@@ -176,6 +178,7 @@ let view = (model: Model.t): Vdom.Node.t => {
           matched_ty_bar(HTyp.Hole, matched_ty),
         );
       (ind1, ind2, BindingError);
+    | SynInvalidArrow(_) => failwith("unimplemented")
     | SynFreeArrow(matched_ty) =>
       let ind1 = expected_msg_indicator("function type");
       let ind2 =

--- a/src/hazelweb/gui/CursorInspector.re
+++ b/src/hazelweb/gui/CursorInspector.re
@@ -83,6 +83,9 @@ let view = (model: Model.t): Vdom.Node.t => {
   let got_free_indicator =
     got_indicator("Got a free variable", typebar(HTyp.Hole));
 
+  let got_invalid_indicator =
+    got_indicator("Got an invalid variable", typebar(HTyp.Hole));
+
   let got_consistent_indicator = got_ty =>
     got_indicator("Got consistent type", typebar(got_ty));
   let got_a_type_indicator = got_indicator("Got", special_msg_bar("a type"));
@@ -125,7 +128,10 @@ let view = (model: Model.t): Vdom.Node.t => {
           special_msg_bar(got_msg),
         );
       (ind1, ind2, TypeInconsistency);
-    | AnaInvalid(_) => failwith("unimplemented")
+    | AnaInvalid(expected_ty) =>
+      let ind1 = expected_ty_indicator(expected_ty);
+      let ind2 = got_invalid_indicator;
+      (ind1, ind2, BindingError);
     | AnaFree(expected_ty) =>
       let ind1 = expected_ty_indicator(expected_ty);
       let ind2 = got_free_indicator;
@@ -145,7 +151,10 @@ let view = (model: Model.t): Vdom.Node.t => {
       let ind1 = expected_any_indicator;
       let ind2 = got_ty_indicator(ty);
       (ind1, ind2, OK);
-    | SynInvalid => failwith("unimplemented")
+    | SynInvalid =>
+      let ind1 = expected_any_indicator;
+      let ind2 = got_invalid_indicator;
+      (ind1, ind2, BindingError);
     | SynFree =>
       let ind1 = expected_any_indicator;
       let ind2 = got_free_indicator;
@@ -178,7 +187,14 @@ let view = (model: Model.t): Vdom.Node.t => {
           matched_ty_bar(HTyp.Hole, matched_ty),
         );
       (ind1, ind2, BindingError);
-    | SynInvalidArrow(_) => failwith("unimplemented")
+    | SynInvalidArrow(matched_ty) =>
+      let ind1 = expected_msg_indicator("function type");
+      let ind2 =
+        got_indicator(
+          "Got an invalid variable ▶ matched to",
+          matched_ty_bar(HTyp.Hole, matched_ty),
+        );
+      (ind1, ind2, BindingError);
     | SynFreeArrow(matched_ty) =>
       let ind1 = expected_msg_indicator("function type");
       let ind2 =


### PR DESCRIPTION
Implement InvalidVars, as a fall-through return of `TextShape.of_text`.
Refactors uses of `TextShape.of_text` as it is no longer an option type.

Marks expressions such as '1a' (or anything that doesn't match any current TextShape criteria) as an "Invalid Variable".