### PR TITLE
division operator for Int and Float types

### DIFF
--- a/src/hazelcore/Operators.re
+++ b/src/hazelcore/Operators.re
@@ -55,6 +55,7 @@ module Exp = {
     | FPlus
     | FMinus
     | FTimes
+    | FDivide
     | LessThan
     | GreaterThan
     | Equals
@@ -76,6 +77,7 @@ module Exp = {
     | FPlus => "+."
     | FMinus => "-."
     | FTimes => "*."
+    | FDivide => "/."
     | LessThan => "<"
     | GreaterThan => ">"
     | Equals => "=="

--- a/src/hazelcore/Operators.re
+++ b/src/hazelcore/Operators.re
@@ -51,6 +51,7 @@ module Exp = {
     | Plus
     | Minus
     | Times
+    | Divide
     | FPlus
     | FMinus
     | FTimes
@@ -71,6 +72,7 @@ module Exp = {
     | Plus => "+"
     | Minus => "-"
     | Times => "*"
+    | Divide => "/"
     | FPlus => "+."
     | FMinus => "-."
     | FTimes => "*."

--- a/src/hazelcore/SkelExprLexer.mll
+++ b/src/hazelcore/SkelExprLexer.mll
@@ -12,6 +12,7 @@ rule read =
   | "+" { PLUS }
   | "-" { MINUS }
   | "*" { TIMES }
+  | "/" { DIVIDE }
   | "+." { FPLUS }
   | "-." { FMINUS }
   | "*." { FTIMES }

--- a/src/hazelcore/SkelExprLexer.mll
+++ b/src/hazelcore/SkelExprLexer.mll
@@ -16,6 +16,7 @@ rule read =
   | "+." { FPLUS }
   | "-." { FMINUS }
   | "*." { FTIMES }
+  | "/." { FDIVIDE }
   | "_" { SPACEOP }
   | "," { COMMA }
   | "::" { CONS }

--- a/src/hazelcore/SkelExprParser.mly
+++ b/src/hazelcore/SkelExprParser.mly
@@ -20,6 +20,7 @@
 %token PLUS
 %token MINUS
 %token TIMES
+%token DIVIDE
 %token FPLUS
 %token FMINUS
 %token FTIMES
@@ -39,6 +40,7 @@
 %left PLUS
 %left MINUS
 %left TIMES
+%left DIVIDE
 %left FPLUS
 %left FMINUS
 %left FTIMES
@@ -131,6 +133,11 @@ expr:
     Skel.BinOp(
       NotInHole,
       Operators.Exp.Times,
+      e1, e2) }
+  | e1 = expr; DIVIDE; e2 = expr {
+    Skel.BinOp(
+      NotInHole,
+      Operators.Exp.Divide,
       e1, e2) }
   | e1 = expr; FTIMES; e2 = expr {
     Skel.BinOp(

--- a/src/hazelcore/SkelExprParser.mly
+++ b/src/hazelcore/SkelExprParser.mly
@@ -24,6 +24,7 @@
 %token FPLUS
 %token FMINUS
 %token FTIMES
+%token FDIVIDE
 %token SPACEOP
 %token EOF
 
@@ -44,6 +45,7 @@
 %left FPLUS
 %left FMINUS
 %left FTIMES
+%left FDIVIDE
 %left SPACEOP
 
 %start <Operators.Exp.t Skel.t> skel_expr
@@ -143,6 +145,11 @@ expr:
     Skel.BinOp(
       NotInHole,
       Operators.Exp.FTimes,
+      e1, e2) }
+  | e1 = expr; FDIVIDE; e2 = expr {
+    Skel.BinOp(
+      NotInHole,
+      Operators.Exp.FDivide,
       e1, e2) }
   | e1 = expr; SPACEOP; e2 = expr {
     Skel.BinOp(

--- a/src/hazelcore/layout/DHAnnot.re
+++ b/src/hazelcore/layout/DHAnnot.re
@@ -11,4 +11,5 @@ type t =
   | InconsistentBranches(HoleInstance.t)
   | FailedCastDelim
   | FailedCastDecoration
-  | CastDecoration;
+  | CastDecoration
+  | DivideByZero;

--- a/src/hazelcore/layout/DHDoc.re
+++ b/src/hazelcore/layout/DHDoc.re
@@ -195,6 +195,7 @@ module Exp = {
   let precedence_bin_float_op = (bfo: DHExp.BinFloatOp.t) =>
     switch (bfo) {
     | FTimes => precedence_Times
+    | FDivide => precedence_Divide
     | FPlus => precedence_Plus
     | FMinus => precedence_Minus
     | FEquals => precedence_Equals
@@ -250,6 +251,7 @@ module Exp = {
       | FMinus => "-."
       | FPlus => "+."
       | FTimes => "*."
+      | FDivide => "/."
       | FLessThan => "<."
       | FGreaterThan => ">."
       | FEquals => "==."

--- a/src/hazelcore/layout/DHDoc.re
+++ b/src/hazelcore/layout/DHDoc.re
@@ -8,6 +8,7 @@ type formattable_child = (~enforce_inline: bool) => t;
 let precedence_const = 0;
 let precedence_Ap = 1;
 let precedence_Times = 2;
+let precedence_Divide = 2;
 let precedence_Plus = 3;
 let precedence_Minus = 3;
 let precedence_Cons = 4;
@@ -184,6 +185,7 @@ module Exp = {
   let precedence_bin_int_op = (bio: DHExp.BinIntOp.t) =>
     switch (bio) {
     | Times => precedence_Times
+    | Divide => precedence_Divide
     | Plus => precedence_Plus
     | Minus => precedence_Minus
     | Equals => precedence_Equals
@@ -235,6 +237,7 @@ module Exp = {
       | Minus => "-"
       | Plus => "+"
       | Times => "*"
+      | Divide => "/"
       | LessThan => "<"
       | GreaterThan => ">"
       | Equals => "=="

--- a/src/hazelcore/layout/DHDoc.re
+++ b/src/hazelcore/layout/DHDoc.re
@@ -99,9 +99,11 @@ let mk_Keyword = (u, i, k) =>
 let mk_IntLit = n => Doc.text(string_of_int(n));
 
 let mk_FloatLit = (f: float) =>
-  switch (Float.is_infinite(f), Float.is_nan(f)) {
-  | (true, _) => Doc.text("Inf")
-  | (_, true) => Doc.text("NaN")
+  switch (f < 0., Float.is_infinite(f), Float.is_nan(f)) {
+  | (false, true, _) => Doc.text("Inf")
+  /* TODO: NegInf is temporarily introduced until unary minus is introduced to Hazel */
+  | (true, true, _) => Doc.text("NegInf")
+  | (_, _, true) => Doc.text("NaN")
   | _ => Doc.text(string_of_float(f))
   };
 

--- a/src/hazelcore/layout/DHDoc.re
+++ b/src/hazelcore/layout/DHDoc.re
@@ -98,7 +98,12 @@ let mk_Keyword = (u, i, k) =>
 
 let mk_IntLit = n => Doc.text(string_of_int(n));
 
-let mk_FloatLit = f => Doc.text(string_of_float(f));
+let mk_FloatLit = (f: float) =>
+  switch (Float.is_infinite(f), Float.is_nan(f)) {
+  | (true, _) => Doc.text("Inf")
+  | (_, true) => Doc.text("NaN")
+  | _ => Doc.text(string_of_float(f))
+  };
 
 let mk_BoolLit = b => Doc.text(string_of_bool(b));
 

--- a/src/hazelcore/layout/DHDoc.re
+++ b/src/hazelcore/layout/DHDoc.re
@@ -221,6 +221,7 @@ module Exp = {
     | EmptyHole(_)
     | Triv
     | FailedCast(_)
+    | InvalidOperation(_)
     | Lam(_) => precedence_const
     | Cast(d1, _, _) => show_casts ? precedence_const : precedence'(d1)
     | Let(_)
@@ -434,6 +435,16 @@ module Exp = {
           hcats([d_doc, cast_decoration]);
         | FailedCast(_d, _ty1, _ty2) =>
           failwith("unexpected FailedCast without inner cast")
+        | InvalidOperation(operation) =>
+          switch (operation) {
+          | DivideByZero(BinIntOp(Divide, _, IntLit(0)) as expr) =>
+            let (d_doc, _) = go'(expr);
+            let decoration =
+              Doc.text("Error: Divide by Zero")
+              |> annot(DHAnnot.DivideByZero);
+            hcats([d_doc, decoration]);
+          | _ => failwith("impossible")
+          }
         /*
          let (d_doc, d_cast) as dcast_doc = go'(d);
          let cast_decoration =

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -6,6 +6,7 @@ type operator_shape =
   | SMinus
   | SPlus
   | STimes
+  | SDivide
   | SLessThan
   | SGreaterThan
   | SEquals
@@ -75,6 +76,7 @@ module Typ = {
     | SMinus
     | SPlus
     | STimes
+    | SDivide
     | SAnd
     | SOr
     | SLessThan
@@ -689,6 +691,7 @@ module Pat = {
     | SMinus
     | SPlus
     | STimes
+    | SDivide
     | SLessThan
     | SGreaterThan
     | SEquals
@@ -1887,6 +1890,7 @@ module Exp = {
     | SPlus => Some(Plus)
     | SMinus => Some(Minus)
     | STimes => Some(Times)
+    | SDivide => Some(Divide)
     | SLessThan => Some(LessThan)
     | SGreaterThan => Some(GreaterThan)
     | SEquals => Some(Equals)
@@ -1904,6 +1908,7 @@ module Exp = {
     | Minus => Some(SMinus)
     | Plus => Some(SPlus)
     | Times => Some(STimes)
+    | Divide => Some(SDivide)
     | LessThan => Some(SLessThan)
     | GreaterThan => Some(SGreaterThan)
     | Equals => Some(SEquals)

--- a/src/hazelcore/semantics/Action.re
+++ b/src/hazelcore/semantics/Action.re
@@ -1920,6 +1920,7 @@ module Exp = {
     | FPlus
     | FMinus
     | FTimes
+    | FDivide
     | FLessThan
     | FGreaterThan
     | FEquals => None
@@ -2945,7 +2946,10 @@ module Exp = {
         ZOperator(
           (
             OnOp(After) as pos,
-            (FPlus | FMinus | FTimes | FLessThan | FGreaterThan | FEquals) as oper,
+            (
+              FPlus | FMinus | FTimes | FDivide | FLessThan | FGreaterThan |
+              FEquals
+            ) as oper,
           ),
           seq,
         ),
@@ -2955,6 +2959,7 @@ module Exp = {
         | Operators.Exp.FPlus => Some(Operators.Exp.Plus)
         | Operators.Exp.FMinus => Some(Operators.Exp.Minus)
         | Operators.Exp.FTimes => Some(Operators.Exp.Times)
+        | Operators.Exp.FDivide => Some(Operators.Exp.Divide)
         | Operators.Exp.FLessThan => Some(Operators.Exp.LessThan)
         | Operators.Exp.FGreaterThan => Some(Operators.Exp.GreaterThan)
         | Operators.Exp.FEquals => Some(Operators.Exp.Equals)
@@ -3018,6 +3023,7 @@ module Exp = {
         | Operators.Exp.Plus => Some(Operators.Exp.FPlus)
         | Operators.Exp.Minus => Some(Operators.Exp.FMinus)
         | Operators.Exp.Times => Some(Operators.Exp.FTimes)
+        | Operators.Exp.Divide => Some(Operators.Exp.FDivide)
         | Operators.Exp.LessThan => Some(Operators.Exp.FLessThan)
         | Operators.Exp.GreaterThan => Some(Operators.Exp.FGreaterThan)
         | Operators.Exp.Equals => Some(Operators.Exp.FEquals)
@@ -4105,7 +4111,10 @@ module Exp = {
         ZOperator(
           (
             OnOp(After) as pos,
-            (FPlus | FMinus | FTimes | FLessThan | FGreaterThan | FEquals) as oper,
+            (
+              FPlus | FMinus | FTimes | FDivide | FLessThan | FGreaterThan |
+              FEquals
+            ) as oper,
           ),
           seq,
         ),
@@ -4115,6 +4124,7 @@ module Exp = {
         | Operators.Exp.FPlus => Some(Operators.Exp.Plus)
         | Operators.Exp.FMinus => Some(Operators.Exp.Minus)
         | Operators.Exp.FTimes => Some(Operators.Exp.Times)
+        | Operators.Exp.FDivide => Some(Operators.Exp.Divide)
         | Operators.Exp.FLessThan => Some(Operators.Exp.LessThan)
         | Operators.Exp.FGreaterThan => Some(Operators.Exp.GreaterThan)
         | Operators.Exp.FEquals => Some(Operators.Exp.Equals)
@@ -4187,6 +4197,7 @@ module Exp = {
         | Operators.Exp.Plus => Some(Operators.Exp.FPlus)
         | Operators.Exp.Minus => Some(Operators.Exp.FMinus)
         | Operators.Exp.Times => Some(Operators.Exp.FTimes)
+        | Operators.Exp.Divide => Some(Operators.Exp.FDivide)
         | Operators.Exp.LessThan => Some(Operators.Exp.FLessThan)
         | Operators.Exp.GreaterThan => Some(Operators.Exp.FGreaterThan)
         | Operators.Exp.Equals => Some(Operators.Exp.FEquals)

--- a/src/hazelcore/semantics/CursorInfo.re
+++ b/src/hazelcore/semantics/CursorInfo.re
@@ -633,7 +633,7 @@ module Exp = {
         )
       | BinOp(
           _,
-          Minus | Plus | Times | LessThan | GreaterThan | Equals,
+          Minus | Plus | Times | Divide | LessThan | GreaterThan | Equals,
           skel1,
           skel2,
         ) =>
@@ -931,7 +931,7 @@ module Exp = {
         }
       | BinOp(
           _,
-          Plus | Minus | Times | FPlus | FMinus | FTimes | LessThan |
+          Plus | Minus | Times | Divide | FPlus | FMinus | FTimes | LessThan |
           GreaterThan |
           Equals |
           FLessThan |

--- a/src/hazelcore/semantics/CursorInfo.re
+++ b/src/hazelcore/semantics/CursorInfo.re
@@ -643,7 +643,8 @@ module Exp = {
         }
       | BinOp(
           _,
-          FMinus | FPlus | FTimes | FLessThan | FGreaterThan | FEquals,
+          FMinus | FPlus | FTimes | FDivide | FLessThan | FGreaterThan |
+          FEquals,
           skel1,
           skel2,
         ) =>
@@ -931,7 +932,8 @@ module Exp = {
         }
       | BinOp(
           _,
-          Plus | Minus | Times | Divide | FPlus | FMinus | FTimes | LessThan |
+          Plus | Minus | Times | Divide | FPlus | FMinus | FTimes | FDivide |
+          LessThan |
           GreaterThan |
           Equals |
           FLessThan |

--- a/src/hazelcore/semantics/Statics.re
+++ b/src/hazelcore/semantics/Statics.re
@@ -877,7 +877,7 @@ module Exp = {
       | Some(_) =>
         ana_skel(ctx, skel2, seq, Int) |> OptUtil.map(_ => HTyp.Int)
       }
-    | BinOp(NotInHole, FMinus | FPlus | FTimes, skel1, skel2) =>
+    | BinOp(NotInHole, FMinus | FPlus | FTimes | FDivide, skel1, skel2) =>
       switch (ana_skel(ctx, skel1, seq, HTyp.Float)) {
       | None => None
       | Some(_) =>
@@ -1073,6 +1073,7 @@ module Exp = {
     | BinOp(
         NotInHole,
         And | Or | Minus | Plus | Times | Divide | FMinus | FPlus | FTimes |
+        FDivide |
         LessThan |
         GreaterThan |
         Equals |
@@ -1266,7 +1267,7 @@ module Exp = {
           ? ana_go(skel1, Int) : ana_go(skel2, Int)
       | BinOp(
           NotInHole,
-          FPlus | FMinus | FTimes | FLessThan | FGreaterThan,
+          FPlus | FMinus | FTimes | FDivide | FLessThan | FGreaterThan,
           skel1,
           skel2,
         ) =>
@@ -1352,6 +1353,7 @@ module Exp = {
       | BinOp(
           NotInHole,
           And | Or | Minus | Plus | Times | Divide | FMinus | FPlus | FTimes |
+          FDivide |
           LessThan |
           GreaterThan |
           Equals |
@@ -1508,7 +1510,7 @@ module Exp = {
           HTyp.Int,
         );
       (BinOp(NotInHole, op, skel1, skel2), seq, Int, u_gen);
-    | BinOp(_, (FMinus | FPlus | FTimes) as op, skel1, skel2) =>
+    | BinOp(_, (FMinus | FPlus | FTimes | FDivide) as op, skel1, skel2) =>
       let (skel1, seq, u_gen) =
         ana_fix_holes_skel(
           ctx,
@@ -2048,6 +2050,7 @@ module Exp = {
     | BinOp(
         _,
         And | Or | Minus | Plus | Times | Divide | FMinus | FPlus | FTimes |
+        FDivide |
         LessThan |
         GreaterThan |
         Equals |

--- a/src/hazelcore/semantics/Statics.re
+++ b/src/hazelcore/semantics/Statics.re
@@ -871,7 +871,7 @@ module Exp = {
     | BinOp(InHole(_), op, skel1, skel2) =>
       let skel_not_in_hole = Skel.BinOp(NotInHole, op, skel1, skel2);
       syn_skel(ctx, skel_not_in_hole, seq) |> OptUtil.map(_ => HTyp.Hole);
-    | BinOp(NotInHole, Minus | Plus | Times, skel1, skel2) =>
+    | BinOp(NotInHole, Minus | Plus | Times | Divide, skel1, skel2) =>
       switch (ana_skel(ctx, skel1, seq, HTyp.Int)) {
       | None => None
       | Some(_) =>
@@ -1072,7 +1072,8 @@ module Exp = {
     | BinOp(InHole(TypeInconsistent, _), _, _, _)
     | BinOp(
         NotInHole,
-        And | Or | Minus | Plus | Times | FMinus | FPlus | FTimes | LessThan |
+        And | Or | Minus | Plus | Times | Divide | FMinus | FPlus | FTimes |
+        LessThan |
         GreaterThan |
         Equals |
         FLessThan |
@@ -1257,7 +1258,7 @@ module Exp = {
         }
       | BinOp(
           NotInHole,
-          Plus | Minus | Times | LessThan | GreaterThan,
+          Plus | Minus | Times | Divide | LessThan | GreaterThan,
           skel1,
           skel2,
         ) =>
@@ -1350,7 +1351,8 @@ module Exp = {
         }
       | BinOp(
           NotInHole,
-          And | Or | Minus | Plus | Times | FMinus | FPlus | FTimes | LessThan |
+          And | Or | Minus | Plus | Times | Divide | FMinus | FPlus | FTimes |
+          LessThan |
           GreaterThan |
           Equals |
           FLessThan |
@@ -1486,7 +1488,7 @@ module Exp = {
         syn_fix_holes_operand(ctx, u_gen, ~renumber_empty_holes, en);
       let seq = seq |> Seq.update_nth_operand(n, en);
       (skel, seq, ty, u_gen);
-    | BinOp(_, (Minus | Plus | Times) as op, skel1, skel2) =>
+    | BinOp(_, (Minus | Plus | Times | Divide) as op, skel1, skel2) =>
       let (skel1, seq, u_gen) =
         ana_fix_holes_skel(
           ctx,
@@ -2045,7 +2047,8 @@ module Exp = {
       }
     | BinOp(
         _,
-        And | Or | Minus | Plus | Times | FMinus | FPlus | FTimes | LessThan |
+        And | Or | Minus | Plus | Times | Divide | FMinus | FPlus | FTimes |
+        LessThan |
         GreaterThan |
         Equals |
         FLessThan |

--- a/src/hazelcore/semantics/TextShape.re
+++ b/src/hazelcore/semantics/TextShape.re
@@ -18,6 +18,8 @@ let hazel_float_of_string_opt = (s: string): option(float) =>
     switch (s, String.lowercase_ascii(s)) {
     | ("NaN", _) => Some(nan)
     | ("Inf", _) => Some(infinity)
+    /* TODO: NegInf is temporarily introduced until unary minus is introduced to Hazel */
+    | ("NegInf", _) => Some(neg_infinity)
     | (_, "nan")
     | (_, "inf")
     | (_, "infinity") => None

--- a/src/hazelcore/semantics/TextShape.re
+++ b/src/hazelcore/semantics/TextShape.re
@@ -15,7 +15,14 @@ let hazel_float_of_string_opt = (s: string): option(float) =>
   if (String.length(s) > 0 && s.[0] == '_') {
     None;
   } else {
-    float_of_string_opt(s);
+    switch (s, String.lowercase_ascii(s)) {
+    | ("NaN", _) => Some(nan)
+    | ("Inf", _) => Some(infinity)
+    | (_, "nan")
+    | (_, "inf")
+    | (_, "infinity") => None
+    | _ => float_of_string_opt(s)
+    };
   };
 
 let of_text = (text: string): option(t) => {

--- a/src/hazelcore/semantics/Var.re
+++ b/src/hazelcore/semantics/Var.re
@@ -7,7 +7,7 @@ let eq = String.equal;
 
 let length = String.length;
 
-let valid_regex = Re.Str.regexp("^[_a-z][_a-zA-Z0-9']*$");
+let valid_regex = Re.Str.regexp("^[_a-zA-Z][_a-zA-Z0-9']*$");
 let is_valid = s => Re.Str.string_match(valid_regex, s, 0);
 
 /* helper function for guarding options with is_valid */

--- a/src/hazelcore/semantics/dynamics/DHExp.re
+++ b/src/hazelcore/semantics/dynamics/DHExp.re
@@ -127,10 +127,13 @@ type t =
   | InconsistentBranches(MetaVar.t, MetaVarInst.t, VarMap.t_(t), case)
   | Cast(t, HTyp.t, HTyp.t)
   | FailedCast(t, HTyp.t, HTyp.t)
+  | InvalidOperation(operation)
 and case =
   | Case(t, list(rule), int)
 and rule =
-  | Rule(DHPat.t, t);
+  | Rule(DHPat.t, t)
+and operation =
+  | DivideByZero(t);
 
 let constructor_string = (d: t): string =>
   switch (d) {
@@ -159,6 +162,7 @@ let constructor_string = (d: t): string =>
   | InconsistentBranches(_, _, _, _) => "InconsistentBranches"
   | Cast(_, _, _) => "Cast"
   | FailedCast(_, _, _) => "FailedCast"
+  | InvalidOperation(_) => "InvalidOperation"
   };
 
 let rec make_tuple: list(t) => t =

--- a/src/hazelcore/semantics/dynamics/DHExp.re
+++ b/src/hazelcore/semantics/dynamics/DHExp.re
@@ -23,6 +23,7 @@ module BinIntOp = {
     | FPlus
     | FMinus
     | FTimes
+    | FDivide
     | FLessThan
     | FGreaterThan
     | FEquals
@@ -51,6 +52,7 @@ module BinFloatOp = {
     | FPlus
     | FMinus
     | FTimes
+    | FDivide
     | FLessThan
     | FGreaterThan
     | FEquals;
@@ -60,6 +62,7 @@ module BinFloatOp = {
     | FPlus => Some((FPlus, Float))
     | FMinus => Some((FMinus, Float))
     | FTimes => Some((FTimes, Float))
+    | FDivide => Some((FDivide, Float))
     | FLessThan => Some((FLessThan, Bool))
     | FGreaterThan => Some((FGreaterThan, Bool))
     | FEquals => Some((FEquals, Bool))
@@ -82,6 +85,7 @@ module BinFloatOp = {
     | FPlus => FPlus
     | FMinus => FMinus
     | FTimes => FTimes
+    | FDivide => FDivide
     | FLessThan => FLessThan
     | FGreaterThan => FGreaterThan
     | FEquals => FEquals

--- a/src/hazelcore/semantics/dynamics/DHExp.re
+++ b/src/hazelcore/semantics/dynamics/DHExp.re
@@ -6,6 +6,7 @@ module BinIntOp = {
     | Minus
     | Plus
     | Times
+    | Divide
     | LessThan
     | GreaterThan
     | Equals;
@@ -15,6 +16,7 @@ module BinIntOp = {
     | Minus => Some((Minus, Int))
     | Plus => Some((Plus, Int))
     | Times => Some((Times, Int))
+    | Divide => Some((Divide, Int))
     | LessThan => Some((LessThan, Bool))
     | GreaterThan => Some((GreaterThan, Bool))
     | Equals => Some((Equals, Bool))
@@ -36,6 +38,7 @@ module BinIntOp = {
     | Minus => Minus
     | Plus => Plus
     | Times => Times
+    | Divide => Divide
     | LessThan => LessThan
     | GreaterThan => GreaterThan
     | Equals => Equals
@@ -63,6 +66,7 @@ module BinFloatOp = {
     | Plus
     | Minus
     | Times
+    | Divide
     | LessThan
     | GreaterThan
     | Equals

--- a/src/hazelcore/semantics/dynamics/Dynamics.re
+++ b/src/hazelcore/semantics/dynamics/Dynamics.re
@@ -153,7 +153,7 @@ module Pat = {
       | None => DoesNotExpand
       }
     | FloatLit(NotInHole, f) =>
-      switch (float_of_string_opt(f)) {
+      switch (TextShape.hazel_float_of_string_opt(f)) {
       | Some(f) => Expands(FloatLit(f), Float, ctx, delta)
       | None => DoesNotExpand
       }
@@ -1242,7 +1242,7 @@ module Exp = {
       | None => DoesNotExpand
       }
     | FloatLit(NotInHole, f) =>
-      switch (float_of_string_opt(f)) {
+      switch (TextShape.hazel_float_of_string_opt(f)) {
       | Some(f) => Expands(FloatLit(f), Float, delta)
       | None => DoesNotExpand
       }

--- a/src/hazelcore/semantics/dynamics/Dynamics.re
+++ b/src/hazelcore/semantics/dynamics/Dynamics.re
@@ -1897,6 +1897,7 @@ module Evaluator = {
      6 = Cast BV Hole Ground
      7 = boxed value not a float literal 1
      8 = boxed value not a float literal 2
+     9 = integer divide by zero error
    */
 
   [@deriving sexp]
@@ -1937,7 +1938,10 @@ module Evaluator = {
     | Minus => Some(IntLit(n1 - n2))
     | Plus => Some(IntLit(n1 + n2))
     | Times => Some(IntLit(n1 * n2))
-    | Divide => Some(IntLit(n1 / n2))
+    | Divide =>
+      /* TODO: this is a temporary fix to show the error until there is a proper way to represent errors */
+      n2 == 0
+        ? Some(BoundVar("divide by zero error")) : Some(IntLit(n1 / n2))
     | LessThan => Some(BoolLit(n1 < n2))
     | GreaterThan => Some(BoolLit(n1 > n2))
     | Equals => Some(BoolLit(n1 == n2))

--- a/src/hazelcore/semantics/dynamics/Dynamics.re
+++ b/src/hazelcore/semantics/dynamics/Dynamics.re
@@ -1057,7 +1057,7 @@ module Exp = {
           Expands(d, ty, delta);
         };
       }
-    | BinOp(NotInHole, (Plus | Minus | Times) as op, skel1, skel2)
+    | BinOp(NotInHole, (Plus | Minus | Times | Divide) as op, skel1, skel2)
     | BinOp(NotInHole, (LessThan | GreaterThan | Equals) as op, skel1, skel2) =>
       switch (ana_expand_skel(ctx, delta, skel1, seq, Int)) {
       | ExpandResult.DoesNotExpand => ExpandResult.DoesNotExpand
@@ -1421,7 +1421,8 @@ module Exp = {
       }
     | BinOp(
         _,
-        Plus | Minus | Times | FPlus | FMinus | FTimes | LessThan | GreaterThan |
+        Plus | Minus | Times | Divide | FPlus | FMinus | FTimes | LessThan |
+        GreaterThan |
         Equals |
         FLessThan |
         FGreaterThan |
@@ -1930,6 +1931,7 @@ module Evaluator = {
     | Minus => Some(IntLit(n1 - n2))
     | Plus => Some(IntLit(n1 + n2))
     | Times => Some(IntLit(n1 * n2))
+    | Divide => Some(IntLit(n1 / n2))
     | LessThan => Some(BoolLit(n1 < n2))
     | GreaterThan => Some(BoolLit(n1 > n2))
     | Equals => Some(BoolLit(n1 == n2))

--- a/src/hazelcore/semantics/dynamics/Dynamics.re
+++ b/src/hazelcore/semantics/dynamics/Dynamics.re
@@ -1075,7 +1075,12 @@ module Exp = {
           };
         }
       }
-    | BinOp(NotInHole, (FPlus | FMinus | FTimes) as op, skel1, skel2)
+    | BinOp(
+        NotInHole,
+        (FPlus | FMinus | FTimes | FDivide) as op,
+        skel1,
+        skel2,
+      )
     | BinOp(
         NotInHole,
         (FLessThan | FGreaterThan | FEquals) as op,
@@ -1421,7 +1426,8 @@ module Exp = {
       }
     | BinOp(
         _,
-        Plus | Minus | Times | Divide | FPlus | FMinus | FTimes | LessThan |
+        Plus | Minus | Times | Divide | FPlus | FMinus | FTimes | FDivide |
+        LessThan |
         GreaterThan |
         Equals |
         FLessThan |
@@ -1944,6 +1950,7 @@ module Evaluator = {
     | FPlus => Some(FloatLit(f1 +. f2))
     | FMinus => Some(FloatLit(f1 -. f2))
     | FTimes => Some(FloatLit(f1 *. f2))
+    | FDivide => Some(FloatLit(f1 /. f2))
     | FLessThan => Some(BoolLit(f1 < f2))
     | FGreaterThan => Some(BoolLit(f1 > f2))
     | FEquals => Some(BoolLit(f1 == f2))

--- a/src/hazelcore/semantics/dynamics/Dynamics.re
+++ b/src/hazelcore/semantics/dynamics/Dynamics.re
@@ -534,6 +534,12 @@ module Exp = {
     | FailedCast(d, ty1, ty2) =>
       let d' = subst_var(d1, x, d);
       FailedCast(d', ty1, ty2);
+    | InvalidOperation(op) =>
+      switch (op) {
+      | DivideByZero(d) =>
+        let d' = subst_var(d1, x, d);
+        InvalidOperation(DivideByZero(d'));
+      }
     }
   and subst_var_rules =
       (d1: DHExp.t, x: Var.t, rules: list(DHExp.rule)): list(DHExp.rule) =>
@@ -584,6 +590,7 @@ module Exp = {
     | (_, EmptyHole(_, _, _)) => Indet
     | (_, NonEmptyHole(_, _, _, _, _)) => Indet
     | (_, FailedCast(_, _, _)) => Indet
+    | (_, InvalidOperation(_)) => Indet
     | (_, FreeVar(_, _, _, _)) => Indet
     | (_, Let(_, _, _)) => Indet
     | (_, FixF(_, _, _)) => DoesNotMatch
@@ -737,6 +744,7 @@ module Exp = {
     | EmptyHole(_, _, _) => Indet
     | NonEmptyHole(_, _, _, _, _) => Indet
     | FailedCast(_, _, _) => Indet
+    | InvalidOperation(_) => Indet
     }
   and matches_cast_Pair =
       (
@@ -796,6 +804,7 @@ module Exp = {
     | EmptyHole(_, _, _) => Indet
     | NonEmptyHole(_, _, _, _, _) => Indet
     | FailedCast(_, _, _) => Indet
+    | InvalidOperation(_) => Indet
     }
   and matches_cast_Cons =
       (
@@ -853,6 +862,7 @@ module Exp = {
     | EmptyHole(_, _, _) => Indet
     | NonEmptyHole(_, _, _, _, _) => Indet
     | FailedCast(_, _, _) => Indet
+    | InvalidOperation(_) => Indet
     };
 
   type expand_result_lines =
@@ -1809,6 +1819,12 @@ module Exp = {
     | FailedCast(d1, ty1, ty2) =>
       let (d1, hii) = renumber_result_only(path, hii, d1);
       (FailedCast(d1, ty1, ty2), hii);
+    | InvalidOperation(op) =>
+      switch (op) {
+      | DivideByZero(d) =>
+        let (d, hii) = renumber_result_only(path, hii, d);
+        (InvalidOperation(DivideByZero(d)), hii);
+      }
     }
   and renumber_result_only_rules =
       (
@@ -1915,6 +1931,12 @@ module Exp = {
     | FailedCast(d1, ty1, ty2) =>
       let (d1, hii) = renumber_sigmas_only(path, hii, d1);
       (FailedCast(d1, ty1, ty2), hii);
+    | InvalidOperation(op) =>
+      switch (op) {
+      | DivideByZero(d) =>
+        let (d, hii) = renumber_sigmas_only(path, hii, d);
+        (InvalidOperation(DivideByZero(d)), hii);
+      }
     }
   and renumber_sigmas_only_rules =
       (
@@ -2038,10 +2060,7 @@ module Evaluator = {
     | Minus => Some(IntLit(n1 - n2))
     | Plus => Some(IntLit(n1 + n2))
     | Times => Some(IntLit(n1 * n2))
-    | Divide =>
-      /* TODO: this is a temporary fix to show the error until there is a proper way to represent errors */
-      n2 == 0
-        ? Some(BoundVar("divide by zero error")) : Some(IntLit(n1 / n2))
+    | Divide => Some(IntLit(n1 / n2))
     | LessThan => Some(BoolLit(n1 < n2))
     | GreaterThan => Some(BoolLit(n1 > n2))
     | Equals => Some(BoolLit(n1 == n2))
@@ -2158,9 +2177,18 @@ module Evaluator = {
         switch (evaluate(d2)) {
         | InvalidInput(msg) => InvalidInput(msg)
         | BoxedValue(IntLit(n2)) =>
-          switch (eval_bin_int_op(op, n1, n2)) {
-          | Some(out) => BoxedValue(out)
-          | None => InvalidInput(5)
+          switch (op, n1, n2) {
+          | (Divide, _, 0) =>
+            Indet(
+              InvalidOperation(
+                DivideByZero(BinIntOp(op, IntLit(n1), IntLit(n2))),
+              ),
+            )
+          | _ =>
+            switch (eval_bin_int_op(op, n1, n2)) {
+            | Some(out) => BoxedValue(out)
+            | None => InvalidInput(5)
+            }
           }
         | BoxedValue(_) => InvalidInput(3)
         | Indet(d2') => Indet(BinIntOp(op, d1', d2'))
@@ -2324,6 +2352,15 @@ module Evaluator = {
       | InvalidInput(msg) => InvalidInput(msg)
       | BoxedValue(d1')
       | Indet(d1') => Indet(FailedCast(d1', ty, ty'))
+      }
+    | InvalidOperation(op) =>
+      switch (op) {
+      | DivideByZero(d) =>
+        switch (evaluate(d)) {
+        | InvalidInput(msg) => InvalidInput(msg)
+        | BoxedValue(d')
+        | Indet(d') => Indet(InvalidOperation(DivideByZero(d')))
+        }
       }
     }
   and evaluate_case =

--- a/src/hazelcore/semantics/dynamics/Dynamics.re
+++ b/src/hazelcore/semantics/dynamics/Dynamics.re
@@ -1998,7 +1998,6 @@ module Evaluator = {
      6 = Cast BV Hole Ground
      7 = boxed value not a float literal 1
      8 = boxed value not a float literal 2
-     9 = integer divide by zero error
    */
 
   [@deriving sexp]

--- a/src/hazelweb/JSUtil.re
+++ b/src/hazelweb/JSUtil.re
@@ -416,6 +416,7 @@ module KeyCombo = {
     let plus = no_ctrl_alt_meta(Key.the_key("+"));
     let minus = no_ctrl_alt_meta(Key.the_key("-"));
     let asterisk = no_ctrl_alt_meta(Key.the_key("*"));
+    let slash = no_ctrl_alt_meta(Key.the_key("/"));
     let semicolon = no_ctrl_alt_meta(Key.the_key(";"));
     let comma = no_ctrl_alt_meta(Key.the_key(","));
     let vbar = no_ctrl_alt_meta(Key.the_key("|"));
@@ -455,6 +456,7 @@ module KeyCombo = {
     | Plus
     | Minus
     | Asterisk
+    | Slash
     | LT
     | Space
     | Comma
@@ -490,6 +492,7 @@ module KeyCombo = {
     | Plus => Details.plus
     | Minus => Details.minus
     | Asterisk => Details.asterisk
+    | Slash => Details.slash
     | LT => Details.lt
     | Space => Details.space
     | Comma => Details.comma
@@ -545,6 +548,8 @@ module KeyCombo = {
       Some(Minus);
     } else if (evt_matches(Details.asterisk)) {
       Some(Asterisk);
+    } else if (evt_matches(Details.slash)) {
+      Some(Slash);
     } else if (evt_matches(Details.lt)) {
       Some(LT);
     } else if (evt_matches(Details.space)) {

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -30,6 +30,7 @@ let kc_actions: Hashtbl.t(KeyCombo.t, CursorInfo.t => Action.t) =
     (Plus, _ => Action.Construct(SOp(SPlus))),
     (Minus, _ => Action.Construct(SOp(SMinus))),
     (Asterisk, _ => Action.Construct(SOp(STimes))),
+    (Slash, _ => Action.Construct(SOp(SDivide))),
     (LT, _ => Action.Construct(SOp(SLessThan))),
     (Space, _ => Action.Construct(SOp(SSpace))),
     (Comma, _ => Action.Construct(SOp(SComma))),

--- a/src/hazelweb/gui/DHCode.re
+++ b/src/hazelweb/gui/DHCode.re
@@ -47,6 +47,9 @@ let view_of_layout = (~inject, l: DHLayout.t): Vdom.Node.t => {
     | Annot(CastDecoration, l) => [
         Node.div([Attr.classes(["CastDecoration"])], go(l)),
       ]
+    | Annot(DivideByZero, l) => [
+        Node.span([Attr.classes(["DivideByZero"])], go(l)),
+      ]
     };
   Node.div([Attr.classes(["code", "DHCode"])], go(l));
 };

--- a/src/hazelweb/layout/UHDoc.re
+++ b/src/hazelweb/layout/UHDoc.re
@@ -697,14 +697,15 @@ module Exp = {
   let inline_padding_of_operator: UHExp.operator => (t, t) =
     fun
     | Space
-    | Times
-    | Divide
-    | FTimes
     | Cons => (empty_, empty_)
     | Plus
     | Minus
     | FPlus
     | FMinus
+    | Times
+    | Divide
+    | FTimes
+    | FDivide
     | LessThan
     | GreaterThan
     | Equals

--- a/src/hazelweb/layout/UHDoc.re
+++ b/src/hazelweb/layout/UHDoc.re
@@ -698,6 +698,7 @@ module Exp = {
     fun
     | Space
     | Times
+    | Divide
     | FTimes
     | Cons => (empty_, empty_)
     | Plus

--- a/src/hazelweb/www/style.css
+++ b/src/hazelweb/www/style.css
@@ -764,7 +764,8 @@ h1 {
   line-height: var(--code-line-height);
 }
 .DHCode .CastDecoration,
-.DHCode .FailedCastDecoration {
+.DHCode .FailedCastDecoration,
+.DHCode .DivideByZero {
   display: inline-block;
   position: relative;
   font-size: 75%;
@@ -777,6 +778,10 @@ h1 {
   background-color: rgba(150, 0, 255, 0.2);
 }
 .DHCode .FailedCastDecoration {
+  background-color: rgba(255, 0, 0, 0.2);
+}
+
+.DHCode .DivideByZero {
   background-color: rgba(255, 0, 0, 0.2);
 }
 


### PR DESCRIPTION
**Division Operator is introduced for Int and Float Types**

- `Int` type will have a `/` operator that behaves the same way as Ocaml's division operator
- `/` will throw an `divide by zero error` as an `InvalidOperation`, a generalized way of throwing run-time errors that was made with @annie-anna 
- `Float` type will have a `/.` operator that behaves the same way it does in Ocaml.
- `NaN` and `Inf` constants were introduced for `Float` type, and all other variations of it from Ocaml were disabled to be treated as a variable
- `NegInf` constant was introduced for `Float` type temporarily until unary minus is introduced
- Variables can now start with an uppercase letter
- Fixed issue #264 