### PR TITLE
Fix cursor positioning around empty holes

### DIFF
--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -117,20 +117,33 @@ let view =
             let full_space = font_width *. float_of_int(len);
             let shrunk_space = full_space *. font_shrink;
             let per_side_padding = (full_space -. shrunk_space) /. 2.0;
-            let padding =
-              Css_gen.padding(
-                ~left=`Px(int_of_float(per_side_padding)),
-                ~right=`Px(int_of_float(per_side_padding)),
-                (),
-              );
-            let font_size =
-              Css_gen.font_size(
-                `Percent(
-                  Core_kernel.Percent.of_percentage(font_shrink *. 100.0),
-                ),
-              );
+            /*let padding =
+                Css_gen.padding(
+                  ~left=`Px(int_of_float(per_side_padding)),
+                  ~right=`Px(int_of_float(per_side_padding)),
+                  (),
+                );
+              let font_size =
+                Css_gen.font_size(
+                  `Percent(
+                    Core_kernel.Percent.of_percentage(font_shrink *. 100.0),
+                  ),
+                );
+              let styling =
+                Vdom.Attr.style(Css_gen.combine(padding, font_size));*/
             let styling =
-              Vdom.Attr.style(Css_gen.combine(padding, font_size));
+              Vdom.Attr.create(
+                "style",
+                "padding-right: "
+                ++ string_of_float(per_side_padding)
+                ++ "0px; "
+                ++ "padding-left: "
+                ++ string_of_float(per_side_padding)
+                ++ "0px; "
+                ++ "font-size: "
+                ++ string_of_int(int_of_float(font_shrink *. 100.0))
+                ++ "%;",
+              );
             [Node.span([styling, Attr.classes(["HoleLabel"])], go(l))];
           }
         | Annot(UserNewline, l) => [

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -52,11 +52,14 @@ let has_child_clss = (has_child: bool) =>
 
 let caret_from_pos = (x: float, y: float): Vdom.Node.t => {
   let pos_attr =
-    Vdom.Attr.style(
-      Css_gen.combine(
-        Css_gen.left(`Px(int_of_float(x))),
-        Css_gen.top(`Px(int_of_float(y))),
-      ),
+    Vdom.Attr.create(
+      "style",
+      "left: "
+      ++ string_of_float(x)
+      ++ "0px; "
+      ++ "top: "
+      ++ string_of_float(y)
+      ++ "0px;",
     );
   Vdom.Node.span(
     [Vdom.Attr.id("caret"), pos_attr, Vdom.Attr.classes(["blink"])],
@@ -117,21 +120,15 @@ let view =
             let full_space = font_width *. float_of_int(len);
             let shrunk_space = full_space *. font_shrink;
             let per_side_padding = (full_space -. shrunk_space) /. 2.0;
-            /*let padding =
-                Css_gen.padding(
-                  ~left=`Px(int_of_float(per_side_padding)),
-                  ~right=`Px(int_of_float(per_side_padding)),
-                  (),
-                );
-              let font_size =
+            let font_size =
+              Vdom.Attr.style(
                 Css_gen.font_size(
                   `Percent(
                     Core_kernel.Percent.of_percentage(font_shrink *. 100.0),
                   ),
-                );
-              let styling =
-                Vdom.Attr.style(Css_gen.combine(padding, font_size));*/
-            let styling =
+                ),
+              );
+            let padding =
               Vdom.Attr.create(
                 "style",
                 "padding-right: "
@@ -139,12 +136,14 @@ let view =
                 ++ "0px; "
                 ++ "padding-left: "
                 ++ string_of_float(per_side_padding)
-                ++ "0px; "
-                ++ "font-size: "
-                ++ string_of_int(int_of_float(font_shrink *. 100.0))
-                ++ "%;",
+                ++ "0px;",
               );
-            [Node.span([styling, Attr.classes(["HoleLabel"])], go(l))];
+            [
+              Node.span(
+                [font_size, padding, Attr.classes(["HoleLabel"])],
+                go(l),
+              ),
+            ];
           }
         | Annot(UserNewline, l) => [
             Node.span([Attr.classes(["UserNewline"])], go(l)),

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -52,14 +52,11 @@ let has_child_clss = (has_child: bool) =>
 
 let caret_from_pos = (x: float, y: float): Vdom.Node.t => {
   let pos_attr =
-    Vdom.Attr.create(
-      "style",
-      "left: "
-      ++ string_of_float(x)
-      ++ "0px; "
-      ++ "top: "
-      ++ string_of_float(y)
-      ++ "0px;",
+    Vdom.Attr.style(
+      Css_gen.combine(
+        Css_gen.left(`Px(int_of_float(Float.round(x)))),
+        Css_gen.top(`Px(int_of_float(Float.round(y)))),
+      ),
     );
   Vdom.Node.span(
     [Vdom.Attr.id("caret"), pos_attr, Vdom.Attr.classes(["blink"])],
@@ -116,34 +113,11 @@ let view =
 
         | Annot(HoleLabel({len}), l) => {
             let font_width = font_metrics.col_width;
-            let font_shrink = 0.65;
             let full_space = font_width *. float_of_int(len);
-            let shrunk_space = full_space *. font_shrink;
-            let per_side_padding = (full_space -. shrunk_space) /. 2.0;
-            let font_size =
-              Vdom.Attr.style(
-                Css_gen.font_size(
-                  `Percent(
-                    Core_kernel.Percent.of_percentage(font_shrink *. 100.0),
-                  ),
-                ),
-              );
-            let padding =
-              Vdom.Attr.create(
-                "style",
-                "padding-right: "
-                ++ string_of_float(per_side_padding)
-                ++ "0px; "
-                ++ "padding-left: "
-                ++ string_of_float(per_side_padding)
-                ++ "0px;",
-              );
-            [
-              Node.span(
-                [font_size, padding, Attr.classes(["HoleLabel"])],
-                go(l),
-              ),
-            ];
+            let width =
+              Css_gen.width(`Px(int_of_float(Float.round(full_space))));
+            let styling = Vdom.Attr.style(width);
+            [Node.span([styling, Attr.classes(["HoleLabel"])], go(l))];
           }
         | Annot(UserNewline, l) => [
             Node.span([Attr.classes(["UserNewline"])], go(l)),

--- a/src/hazelweb/www/style.css
+++ b/src/hazelweb/www/style.css
@@ -12,7 +12,7 @@
   --page-padding: 15px;
 
   --code-font-family: "Fira Code", monospace;
-  --code-font-size: 16.25px;
+  --code-font-size: 16px;
   --code-line-height: 1.5;
   --closed-child-line-height: 1.25;
 

--- a/src/hazelweb/www/style.css
+++ b/src/hazelweb/www/style.css
@@ -12,7 +12,7 @@
   --page-padding: 15px;
 
   --code-font-family: "Fira Code", monospace;
-  --code-font-size: 14pt;
+  --code-font-size: 16.25px;
   --code-line-height: 1.5;
   --closed-child-line-height: 1.25;
 
@@ -1315,14 +1315,16 @@ h1 {
 }
 
 .HoleLabel {
-  vertical-align: text-bottom;
   font-size: 65%;
   color: #BBB;
+  display: inline-block;
+  text-align: center;
+  /* border-bottom: 1px solid var(--empty-hole-color); */
+  /* line-height: initial; */
+}
+.DHCode .HoleLabel {
   padding-left: 2px;
   padding-right: 2px;
-  /* border-bottom: 1px solid var(--empty-hole-color); */
-  margin-bottom: -3px;
-  /* line-height: initial; */
 }
 .DHCode .CastDecoration .HoleLabel,
 .DHCode .FailedCastDecoration .HoleLabel {


### PR DESCRIPTION
Don't round pixels for cursor positioning and padding around empty holes.
fixes #313 

@dmoon1221 Using Css_gen only allows ints for pixels and the rounding is causing issues https://ocaml.janestreet.com/ocaml-core/latest/doc/virtual_dom/Css_gen/Length/index.html. 
Potentially we could still use Css_gen if we convert to pt I think, but I believe you would need to grab the dpi to do this correctly.