### PR TITLE
Fixes #357 Add padding to left sidebar to match right side bar body

### DIFF
--- a/src/hazelweb/Hazel.re
+++ b/src/hazelweb/Hazel.re
@@ -5,7 +5,6 @@
  * See <https://github.com/janestreet/incr_dom/tree/master/example/text_input>
  * for an example-driven overview.
  */
-
 module Js = Js_of_ocaml.Js;
 module Dom = Js_of_ocaml.Dom;
 module Dom_html = Js_of_ocaml.Dom_html;

--- a/src/hazelweb/www/style.css
+++ b/src/hazelweb/www/style.css
@@ -227,6 +227,7 @@ html, body {
 
 #slidable-left-bar-body {
   direction: rtl;
+  padding-left: 7px;
 }
 
 #slidable-right-bar-body {


### PR DESCRIPTION
The right side bar has some padding on the far right edge. The left
side bar does not. This commit adds the same padding to the left bar.

![Screen Shot 2020-06-23 at 21 21 24](https://user-images.githubusercontent.com/1189464/85500038-999b4380-b597-11ea-8c6a-f24084cb90b8.png)
