### PR TITLE
Fix issues with inconsistent branches on a case 

### DIFF
--- a/src/hazelcore/CursorInfo_Exp.re
+++ b/src/hazelcore/CursorInfo_Exp.re
@@ -160,7 +160,7 @@ and get_outer_zrules_from_zrule =
 
 let rec cursor_on_outer_expr:
   ZExp.zoperand =>
-  option((ErrStatus.t, VarErrStatus.t, option(CaseErrStatus.t))) =
+  option((ErrStatus.t, VarErrStatus.t, option(list(HTyp.t)))) =
   fun
   | CursorE(_, operand) => {
       let err = operand |> UHExp.get_err_status_operand;
@@ -172,8 +172,7 @@ let rec cursor_on_outer_expr:
       /* Only pull out the case error status if it is the special form */
       let cerr =
         switch (operand) {
-        | Case(InconsistentBranches(types, u), _, _) =>
-          Some(CaseErrStatus.InconsistentBranches(types, u))
+        | Case(InconsistentBranches(types, _), _, _) => Some(types)
         | _ => None
         };
       Some((err, verr, cerr));
@@ -449,9 +448,8 @@ and syn_cursor_info_skel =
           Some(mk(SynFreeArrow(Arrow(Hole, Hole))))
         | Some((_, InVarHole(Keyword(k), _), _)) =>
           Some(mk(SynKeywordArrow(Arrow(Hole, Hole), k)))
-        | Some((_, _, Some(InconsistentBranches(rule_types, _)))) =>
+        | Some((_, _, Some(rule_types))) =>
           Some(mk(SynInconsistentBranchesArrow(rule_types, steps @ [n])))
-        | Some((_, _, Some(StandardErrStatus(_)))) => None // This should be handled at a higher level...
         | Some((NotInHole, NotInVarHole, None)) =>
           let operand_nih =
             zoperand

--- a/src/hazelcore/CursorInfo_Exp.re
+++ b/src/hazelcore/CursorInfo_Exp.re
@@ -158,29 +158,27 @@ and get_outer_zrules_from_zrule =
   };
 };
 
-let rec cursor_on_outer_expr:
-  ZExp.zoperand =>
-  option((ErrStatus.t, VarErrStatus.t, option(list(HTyp.t)))) =
+type err_status_result =
+  | StandardErr(ErrStatus.t)
+  | VarErr(VarErrStatus.HoleReason.t)
+  | InconsistentBranchesErr(list(HTyp.t));
+
+let rec cursor_on_outer_expr: ZExp.zoperand => option(err_status_result) =
   fun
   | CursorE(_, operand) => {
-      let err = operand |> UHExp.get_err_status_operand;
-      let verr =
+      let err_status =
         switch (operand) {
-        | Var(_, verr, _) => verr
-        | _ => NotInVarHole
+        | Var(_, InVarHole(reason, _), _) => VarErr(reason)
+        | Case(InconsistentBranches(types, _), _, _) =>
+          InconsistentBranchesErr(types)
+        | _ => StandardErr(UHExp.get_err_status_operand(operand))
         };
-      /* Only pull out the case error status if it is the special form */
-      let cerr =
-        switch (operand) {
-        | Case(InconsistentBranches(types, _), _, _) => Some(types)
-        | _ => None
-        };
-      Some((err, verr, cerr));
+      Some(err_status);
     }
   | ParenthesizedZ(([], ExpLineZ(ZOpSeq(skel, zseq)), [])) =>
     if (ZOpSeq.skel_is_rooted_at_cursor(skel, zseq)) {
       switch (skel, zseq) {
-      | (BinOp(err, _, _, _), _) => Some((err, NotInVarHole, None))
+      | (BinOp(err, _, _, _), _) => Some(StandardErr(err))
       | (_, ZOperand(zoperand, _)) => cursor_on_outer_expr(zoperand)
       | _ => None
       };
@@ -436,21 +434,20 @@ and syn_cursor_info_skel =
           CursorInfo_common.mk(typed, ctx, extract_from_zexp_zseq(zseq));
         switch (cursor_on_outer_expr(zoperand)) {
         | None => syn_cursor_info_zoperand(~steps=steps @ [n], ctx, zoperand)
-        | Some((InHole(WrongLength, _), _, _)) => None
-        | Some((InHole(TypeInconsistent, _), _, _)) =>
+        | Some(StandardErr(InHole(WrongLength, _))) => None
+        | Some(StandardErr(InHole(TypeInconsistent, _))) =>
           let operand_nih =
             zoperand
             |> ZExp.erase_zoperand
             |> UHExp.set_err_status_operand(NotInHole);
           Statics_Exp.syn_operand(ctx, operand_nih)
           |> OptUtil.map(ty => mk(SynErrorArrow(Arrow(Hole, Hole), ty)));
-        | Some((_, InVarHole(Free, _), _)) =>
-          Some(mk(SynFreeArrow(Arrow(Hole, Hole))))
-        | Some((_, InVarHole(Keyword(k), _), _)) =>
+        | Some(VarErr(Free)) => Some(mk(SynFreeArrow(Arrow(Hole, Hole))))
+        | Some(VarErr(Keyword(k))) =>
           Some(mk(SynKeywordArrow(Arrow(Hole, Hole), k)))
-        | Some((_, _, Some(rule_types))) =>
+        | Some(InconsistentBranchesErr(rule_types)) =>
           Some(mk(SynInconsistentBranchesArrow(rule_types, steps @ [n])))
-        | Some((NotInHole, NotInVarHole, None)) =>
+        | Some(StandardErr(NotInHole)) =>
           let operand_nih =
             zoperand
             |> ZExp.erase_zoperand

--- a/src/hazelcore/CursorInfo_common.re
+++ b/src/hazelcore/CursorInfo_common.re
@@ -52,6 +52,9 @@ type typed =
   | SynFreeArrow(HTyp.t)
   // cursor is on a keyword in the function position of an ap
   | SynKeywordArrow(HTyp.t, ExpandingKeyword.t)
+  // cursor is on a case with inconsistent branch types
+  // in the function position of an ap
+  | SynInconsistentBranchesArrow(list(HTyp.t), CursorPath_common.steps)
   // none of the above, cursor is on a free variable
   | SynFree
   // cursor is on a keyword

--- a/src/hazelcore/Statics_Exp.re
+++ b/src/hazelcore/Statics_Exp.re
@@ -371,11 +371,6 @@ and ana_operand =
     | None => None
     | Some(_) => Some() /* this is a consequence of subsumption and hole universality */
     };
-  | Case(InconsistentBranches(_, _), _, _) =>
-    switch (syn_operand(ctx, operand)) {
-    | None => None
-    | Some(_) => Some() /* this is a consequence of subsumption and hole universality */
-    }
   | Var(InHole(WrongLength, _), _, _)
   | IntLit(InHole(WrongLength, _), _)
   | FloatLit(InHole(WrongLength, _), _)
@@ -386,6 +381,7 @@ and ana_operand =
   | Case(StandardErrStatus(InHole(WrongLength, _)), _, _)
   | ApPalette(InHole(WrongLength, _), _, _, _) =>
     ty |> HTyp.get_prod_elements |> List.length > 1 ? Some() : None
+  | Case(InconsistentBranches(_, _), _, _) => None
   /* not in hole */
   | ListNil(NotInHole) =>
     switch (HTyp.matched_list(ty)) {

--- a/src/hazelcore/Statics_Exp.re
+++ b/src/hazelcore/Statics_Exp.re
@@ -369,6 +369,11 @@ and ana_operand =
     | None => None
     | Some(_) => Some() /* this is a consequence of subsumption and hole universality */
     };
+  | Case(InconsistentBranches(_, _), _, _) =>
+    switch (syn_operand(ctx, operand)) {
+    | None => None
+    | Some(_) => Some() /* this is a consequence of subsumption and hole universality */
+    }
   | Var(InHole(WrongLength, _), _, _)
   | IntLit(InHole(WrongLength, _), _)
   | FloatLit(InHole(WrongLength, _), _)
@@ -376,11 +381,7 @@ and ana_operand =
   | ListNil(InHole(WrongLength, _))
   | Lam(InHole(WrongLength, _), _, _, _)
   | Inj(InHole(WrongLength, _), _, _)
-  | Case(
-      StandardErrStatus(InHole(WrongLength, _)) | InconsistentBranches(_, _),
-      _,
-      _,
-    )
+  | Case(StandardErrStatus(InHole(WrongLength, _)), _, _)
   | ApPalette(InHole(WrongLength, _), _, _, _) =>
     ty |> HTyp.get_prod_elements |> List.length > 1 ? Some() : None
   /* not in hole */

--- a/src/hazelcore/UHExp.re
+++ b/src/hazelcore/UHExp.re
@@ -199,7 +199,7 @@ and get_err_status_operand =
   | Inj(err, _, _)
   | Case(StandardErrStatus(err), _, _)
   | ApPalette(err, _, _, _) => err
-  | Case(InconsistentBranches(_), _, _) => NotInHole /* TODO: What to do here...? */
+  | Case(InconsistentBranches(_), _, _) => NotInHole
   | Parenthesized(e) => get_err_status(e);
 
 /* put e in the specified hole */

--- a/src/hazelcore/UsageAnalysis.re
+++ b/src/hazelcore/UsageAnalysis.re
@@ -71,13 +71,17 @@ and find_uses_operand = (~steps, x: Var.t, operand: UHExp.operand): uses_list =>
   | ListNil(_)
   | Lam(InHole(_), _, _, _)
   | Inj(InHole(_), _, _)
-  | Case(StandardErrStatus(InHole(_)) | InconsistentBranches(_), _, _)
+  | Case(StandardErrStatus(InHole(_)), _, _)
   | ApPalette(_) => []
   | Var(_, NotInVarHole, y) => x == y ? [steps] : []
   | Lam(NotInHole, p, _, body) =>
     binds_var(x, p) ? [] : find_uses(~steps=steps @ [2], x, body)
   | Inj(NotInHole, _, body) => find_uses(~steps=steps @ [0], x, body)
-  | Case(StandardErrStatus(NotInHole), scrut, rules) =>
+  | Case(
+      StandardErrStatus(NotInHole) | InconsistentBranches(_),
+      scrut,
+      rules,
+    ) =>
     let scrut_uses = find_uses(~steps=steps @ [0], x, scrut);
     let rules_uses =
       rules

--- a/src/hazelcore/dynamics/DHExp.re
+++ b/src/hazelcore/dynamics/DHExp.re
@@ -157,7 +157,6 @@ type t =
   | Inj(HTyp.t, InjSide.t, t)
   | Pair(t, t)
   | Triv
-  /* TODO: Is this the right way to handle things? */
   | ConsistentCase(case)
   | InconsistentBranches(MetaVar.t, MetaVarInst.t, VarMap.t_(t), case)
   | Cast(t, HTyp.t, HTyp.t)

--- a/src/hazelcore/dynamics/DHExp.rei
+++ b/src/hazelcore/dynamics/DHExp.rei
@@ -70,7 +70,6 @@ type t =
   | Inj(HTyp.t, InjSide.t, t)
   | Pair(t, t)
   | Triv
-  /* TODO: Is this the right way to handle things? */
   | ConsistentCase(case)
   | InconsistentBranches(MetaVar.t, MetaVarInst.t, VarMap.t_(t), case)
   | Cast(t, HTyp.t, HTyp.t)

--- a/src/hazelcore/dynamics/Elaborator_Exp.re
+++ b/src/hazelcore/dynamics/Elaborator_Exp.re
@@ -1132,7 +1132,7 @@ and ana_elab_operand =
   | Lam(InHole(WrongLength, _), _, _, _)
   | Inj(InHole(WrongLength, _), _, _)
   | Case(StandardErrStatus(InHole(WrongLength, _)), _, _)
-  | ApPalette(InHole(WrongLength, _), _, _, _) => DoesNotElaborate
+  | ApPalette(InHole(WrongLength, _), _, _, _) => DoesNotElaborate /* not in hole */
   | Case(InconsistentBranches(rule_types, u), scrut, rules) =>
     switch (syn_elab(ctx, delta, scrut)) {
     | DoesNotElaborate => DoesNotElaborate

--- a/src/hazelcore/layout/DHDoc_Exp.re
+++ b/src/hazelcore/layout/DHDoc_Exp.re
@@ -46,7 +46,7 @@ let rec precedence = (~show_casts: bool, d: DHExp.t) => {
   | Let(_)
   | FixF(_)
   | ConsistentCase(_)
-  | InconsistentBranches(_) => DHDoc_common.precedence_max /* TODO: is this right */
+  | InconsistentBranches(_) => DHDoc_common.precedence_max
   | BinBoolOp(op, _, _) => precedence_bin_bool_op(op)
   | BinIntOp(op, _, _) => precedence_bin_int_op(op)
   | BinFloatOp(op, _, _) => precedence_bin_float_op(op)

--- a/src/hazelweb/gui/CursorInspector.re
+++ b/src/hazelweb/gui/CursorInspector.re
@@ -266,6 +266,11 @@ let view =
       let ind2 =
         got_inconsistent_branches_indicator(rule_types, path_to_case);
       (ind1, ind2, TypeInconsistency);
+    | SynInconsistentBranchesArrow(rule_types, path_to_case) =>
+      let ind1 = expected_msg_indicator("function type");
+      let ind2 =
+        got_inconsistent_branches_indicator(rule_types, path_to_case);
+      (ind1, ind2, TypeInconsistency);
     | OnType =>
       let ind1 = expected_a_type_indicator;
       let ind2 = got_a_type_indicator;


### PR DESCRIPTION
- Handle inconsistent branches when the case is in the function position of an application (previously, this would stop Hazel)
- Remove some left-over TODOs 
- Fix issue with usage analysis and case with inconsistent branches (wasn't highlighting uses in a case that had inconsistent branches)