### PR TITLE
Fix #390 For the options panel use <details><summary>...

### DIFF
--- a/src/hazelweb/gui/OptionsPanel.re
+++ b/src/hazelweb/gui/OptionsPanel.re
@@ -42,6 +42,9 @@ let labeled_checkbox =
   );
 };
 
+let details = Vdom.Node.create("details");
+let summary = Vdom.Node.create("summary");
+
 let view =
     (~inject: ModelAction.t => Vdom.Event.t, model: Model.t): Vdom.Node.t => {
   let compute_results_checkbox =
@@ -168,5 +171,8 @@ let view =
         ],
       )
     );
-  compute_results_checkbox;
+  details(
+    [],
+    [summary([], [Vdom.Node.text("Options")]), compute_results_checkbox],
+  );
 };


### PR DESCRIPTION
Simple change to wrap the Options Panel in a details + summary
element.

![Selection_006](https://user-images.githubusercontent.com/1189464/87508435-3cd5fa80-c624-11ea-94cf-b62e6b7f9baf.png)
![Selection_007](https://user-images.githubusercontent.com/1189464/87508444-42334500-c624-11ea-8673-aa1999471344.png)
