### PR TITLE
Turn off user-select on UI elements 

### DIFF
--- a/src/hazelweb/gui/ActionPanel.re
+++ b/src/hazelweb/gui/ActionPanel.re
@@ -4,7 +4,7 @@ let action_panel = (children: list(Vdom.Node.t)): Vdom.Node.t => {
   open Vdom;
   let panel_title =
     Node.div(
-      [Attr.classes(["panel-title-bar", "title-bar"])],
+      [Attr.classes(["panel-title-bar", "title-bar", "noselect"])],
       [Node.text("Edit Actions")],
     );
 
@@ -44,8 +44,8 @@ let info_button = (can_perform, lbl) =>
       [
         Attr.classes(
           can_perform
-            ? ["action-panel-entry", "action-enabled"]
-            : ["action-panel-entry", "action-disabled"],
+            ? ["action-panel-entry", "action-enabled", "noselect"]
+            : ["action-panel-entry", "action-disabled", "noselect"],
         ),
       ],
       [action_label(lbl)],
@@ -75,8 +75,8 @@ let action_button =
       [
         Attr.classes(
           can_perform
-            ? ["action-panel-entry", "action-enabled"]
-            : ["action-panel-entry", "action-disabled"],
+            ? ["action-panel-entry", "action-enabled", "noselect"]
+            : ["action-panel-entry", "action-disabled", "noselect"],
         ),
         Attr.on_click(_ => inject(ModelAction.EditAction(a))),
         Attr.on_keydown(evt =>
@@ -170,7 +170,7 @@ let action_list =
   let items = List.map(item, actions);
   Vdom.(
     Node.div(
-      [Attr.classes(["action-panel-entry"]), display_flex],
+      [Attr.classes(["action-panel-entry", "noselect"]), display_flex],
       [label, ...items],
     )
   );
@@ -247,7 +247,7 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject) => {
   let spaced_line = children => {
     Vdom.Node.div(
       Vdom.Attr.[
-        classes(["action-panel-entry"]),
+        classes(["action-panel-entry", "noselect"]),
         style(
           Css_gen.(
             create(~field="display", ~value="flex")

--- a/src/hazelweb/gui/OptionsPanel.re
+++ b/src/hazelweb/gui/OptionsPanel.re
@@ -14,7 +14,10 @@ let labeled_checkbox =
   let checkbox_id = id ++ "_checkbox";
   Vdom.(
     Node.div(
-      [Attr.id(id), Attr.classes(["labeled-checkbox", ...classes])],
+      [
+        Attr.id(id),
+        Attr.classes(["labeled-checkbox", "noselect", ...classes]),
+      ],
       [
         Node.input(
           [

--- a/src/hazelweb/gui/Panel.re
+++ b/src/hazelweb/gui/Panel.re
@@ -3,10 +3,15 @@ module Vdom = Virtual_dom.Vdom;
 let view_of_main_title_bar = (title_text: string) =>
   Vdom.(
     Node.div(
-      [Attr.classes(["title-bar", "panel-title-bar"])],
+      [Attr.classes(["title-bar", "panel-title-bar", "noselect"])],
       [Node.text(title_text)],
     )
   );
 
 let view_of_other_title_bar = (title_text: string) =>
-  Vdom.(Node.div([Attr.classes(["title-bar"])], [Node.text(title_text)]));
+  Vdom.(
+    Node.div(
+      [Attr.classes(["title-bar", "noselect"])],
+      [Node.text(title_text)],
+    )
+  );

--- a/src/hazelweb/gui/UndoHistoryPanel.re
+++ b/src/hazelweb/gui/UndoHistoryPanel.re
@@ -493,7 +493,13 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
               ),
               Attr.create("title", "Collapse Group"),
             ],
-            [Icons.down_arrow(["entry-tab-icon", "history-tab-icon"])],
+            [
+              Icons.down_arrow([
+                "entry-tab-icon",
+                "history-tab-icon",
+                "noselect",
+              ]),
+            ],
           )
         );
       } else {
@@ -510,7 +516,13 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
               ),
               Attr.create("title", "Expand Group"),
             ],
-            [Icons.left_arrow(["entry-tab-icon", "history-tab-icon"])],
+            [
+              Icons.left_arrow([
+                "entry-tab-icon",
+                "history-tab-icon",
+                "noselect",
+              ]),
+            ],
           )
         );
       };
@@ -642,7 +654,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
                 Attr.id("cur-selected-entry"),
                 Attr.create("group_id", string_of_int(group_id)),
                 Attr.create("elt_id", string_of_int(elt_id)),
-                Attr.classes(["history-entry"]),
+                Attr.classes(["history-entry", "noselect"]),
                 Attr.on_click(_ =>
                   Vdom.Event.Many([
                     inject(
@@ -692,7 +704,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
               [
                 Attr.create("group_id", string_of_int(group_id)),
                 Attr.create("elt_id", string_of_int(elt_id)),
-                Attr.classes(["history-entry"]),
+                Attr.classes(["history-entry", "noselect"]),
                 Attr.on_click(_ =>
                   Vdom.Event.Many([
                     inject(
@@ -804,7 +816,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
               [
                 Attr.create("group_id", string_of_int(group_id)),
                 Attr.create("elt_id", string_of_int(elt_id)),
-                Attr.classes(["history-entry"]),
+                Attr.classes(["history-entry", "noselect"]),
                 Attr.id("cur-selected-entry"),
                 Attr.on_click(_ =>
                   Vdom.Event.Many([
@@ -855,7 +867,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
               [
                 Attr.create("group_id", string_of_int(group_id)),
                 Attr.create("elt_id", string_of_int(elt_id)),
-                Attr.classes(["history-entry"]),
+                Attr.classes(["history-entry", "noselect"]),
                 Attr.on_click(_ =>
                   Vdom.Event.Many([
                     inject(
@@ -1005,7 +1017,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
             ),
             Attr.create("title", title),
           ],
-        [Icons.undo(["redo-undo-icon"])],
+        [Icons.undo(["redo-undo-icon", "noselect"])],
       )
     );
   };
@@ -1031,7 +1043,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
             ),
             Attr.create("title", title),
           ],
-        [Icons.undo(["redo-undo-icon", "horizontal-flip"])],
+        [Icons.undo(["redo-undo-icon", "horizontal-flip", "noselect"])],
       )
     );
   };
@@ -1050,7 +1062,13 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
             ),
             Attr.create("title", "Collapse Groups"),
           ],
-          [Icons.down_arrow(["all-history-tab-icon", "history-tab-icon"])],
+          [
+            Icons.down_arrow([
+              "all-history-tab-icon",
+              "history-tab-icon",
+              "noselect",
+            ]),
+          ],
         )
       );
     } else {
@@ -1066,7 +1084,13 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
             ),
             Attr.create("title", "Expand Groups"),
           ],
-          [Icons.left_arrow(["all-history-tab-icon", "history-tab-icon"])],
+          [
+            Icons.left_arrow([
+              "all-history-tab-icon",
+              "history-tab-icon",
+              "noselect",
+            ]),
+          ],
         )
       );
     };


### PR DESCRIPTION
Sometimes double-clicking on UI elements will cause the text inside to be selected. Use the CSS user-select property to disable this for UI elements containing text.

Simply add the existing `noselect` class to elements.
