### PR TITLE
Delayed indet

### DIFF
--- a/src/hazelcore/dynamics/Elaborator_Exp.re
+++ b/src/hazelcore/dynamics/Elaborator_Exp.re
@@ -194,7 +194,7 @@ let rec matches = (dp: DHPat.t, d: DHExp.t): match_result =>
   | (Pair(dp1, dp2), Pair(d1, d2)) =>
     switch (matches(dp1, d1)) {
     | DoesNotMatch => DoesNotMatch
-    | Indet => 
+    | Indet =>
       switch (matches(dp2, d2)) {
       | DoesNotMatch => DoesNotMatch
       | Indet
@@ -233,7 +233,7 @@ let rec matches = (dp: DHPat.t, d: DHExp.t): match_result =>
   | (Cons(dp1, dp2), Cons(d1, d2)) =>
     switch (matches(dp1, d1)) {
     | DoesNotMatch => DoesNotMatch
-    | Indet => 
+    | Indet =>
       switch (matches(dp2, d2)) {
       | DoesNotMatch => DoesNotMatch
       | Indet
@@ -323,7 +323,12 @@ and matches_cast_Pair =
   | Pair(d1, d2) =>
     switch (matches(dp1, DHExp.apply_casts(d1, left_casts))) {
     | DoesNotMatch => DoesNotMatch
-    | Indet => Indet
+    | Indet =>
+      switch (matches(dp2, DHExp.apply_casts(d2, right_casts))) {
+      | DoesNotMatch => DoesNotMatch
+      | Indet
+      | Matches(_) => Indet
+      }
     | Matches(env1) =>
       switch (matches(dp2, DHExp.apply_casts(d2, right_casts))) {
       | DoesNotMatch => DoesNotMatch
@@ -382,7 +387,20 @@ and matches_cast_Cons =
   | Cons(d1, d2) =>
     switch (matches(dp1, DHExp.apply_casts(d1, elt_casts))) {
     | DoesNotMatch => DoesNotMatch
-    | Indet => Indet
+    | Indet =>
+      let list_casts =
+        List.map(
+          (c: (HTyp.t, HTyp.t)) => {
+            let (ty1, ty2) = c;
+            (HTyp.List(ty1), HTyp.List(ty2));
+          },
+          elt_casts,
+        );
+      switch (matches(dp2, DHExp.apply_casts(d2, list_casts))) {
+      | DoesNotMatch => DoesNotMatch
+      | Indet
+      | Matches(_) => Indet
+      };
     | Matches(env1) =>
       let list_casts =
         List.map(

--- a/src/hazelcore/dynamics/Elaborator_Exp.re
+++ b/src/hazelcore/dynamics/Elaborator_Exp.re
@@ -194,7 +194,12 @@ let rec matches = (dp: DHPat.t, d: DHExp.t): match_result =>
   | (Pair(dp1, dp2), Pair(d1, d2)) =>
     switch (matches(dp1, d1)) {
     | DoesNotMatch => DoesNotMatch
-    | Indet => Indet
+    | Indet => 
+      switch (matches(dp2, d2)) {
+      | DoesNotMatch => DoesNotMatch
+      | Indet
+      | Matches(_) => Indet
+      }
     | Matches(env1) =>
       switch (matches(dp2, d2)) {
       | DoesNotMatch => DoesNotMatch
@@ -228,7 +233,12 @@ let rec matches = (dp: DHPat.t, d: DHExp.t): match_result =>
   | (Cons(dp1, dp2), Cons(d1, d2)) =>
     switch (matches(dp1, d1)) {
     | DoesNotMatch => DoesNotMatch
-    | Indet => Indet
+    | Indet => 
+      switch (matches(dp2, d2)) {
+      | DoesNotMatch => DoesNotMatch
+      | Indet
+      | Matches(_) => Indet
+      }
     | Matches(env1) =>
       switch (matches(dp2, d2)) {
       | DoesNotMatch => DoesNotMatch


### PR DESCRIPTION
This PR is used to fix the small bug in Elaborator_Exp.matches function that `Indet` is returned without looking at later patterns.