### PR TITLE
Add option to explicitly renumber holes using Ctrl+#

### DIFF
--- a/src/hazelcore/Action.re
+++ b/src/hazelcore/Action.re
@@ -48,4 +48,5 @@ type t =
   | SwapRight
   | SwapUp
   | SwapDown
+  | RenumberHoles
   | Init;

--- a/src/hazelcore/Action_Pat.re
+++ b/src/hazelcore/Action_Pat.re
@@ -306,6 +306,7 @@ let rec syn_move =
   | SwapDown
   | SwapLeft
   | SwapRight
+  | RenumberHoles
   | Init =>
     failwith(
       __LOC__
@@ -370,6 +371,7 @@ let rec ana_move =
   | SwapDown
   | SwapLeft
   | SwapRight
+  | RenumberHoles
   | Init =>
     failwith(
       __LOC__
@@ -540,6 +542,15 @@ and syn_perform_opseq =
         Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq));
       }
     };
+  | (RenumberHoles, _) =>
+    let (zopseq, ty, ctx, u_gen) =
+      Statics_Pat.syn_fix_holes_zopseq(
+        ctx,
+        u_gen,
+        ~renumber_empty_holes=true,
+        zopseq,
+      );
+    Succeeded((zopseq, ty, ctx, u_gen));
   | (Init, _) => failwith("Init action should not be performed.")
   }
 and syn_perform_operand =
@@ -779,6 +790,15 @@ and syn_perform_operand =
         };
       Succeeded((zp, ty, ctx, u_gen));
     }
+  | (RenumberHoles, _) =>
+    let (new_zoperand, ty, ctx, u_gen) =
+      Statics_Pat.syn_fix_holes_zoperand(
+        ctx,
+        u_gen,
+        ~renumber_empty_holes=true,
+        zoperand,
+      );
+    Succeeded((ZOpSeq.wrap(new_zoperand), ty, ctx, u_gen));
   | (Init, _) => failwith("Init action should not be performed.")
   };
 }
@@ -964,6 +984,8 @@ and ana_perform_opseq =
         Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
       }
     };
+  | (RenumberHoles, _) =>
+    Succeeded(Statics_Pat.ana_fix_holes_zopseq(ctx, u_gen, zopseq, ty))
   | (Init, _) => failwith("Init action should not be performed.")
   }
 and ana_perform_operand =
@@ -1268,5 +1290,15 @@ and ana_perform_operand =
         Succeeded((zp, ctx, u_gen));
       }
     }
+  | (RenumberHoles, _) =>
+    let (new_zoperand, ctx, u_gen) =
+      Statics_Pat.ana_fix_holes_zoperand(
+        ctx,
+        u_gen,
+        ~renumber_empty_holes=true,
+        zoperand,
+        ty,
+      );
+    Succeeded((ZOpSeq.wrap(new_zoperand), ctx, u_gen));
   | (Init, _) => failwith("Init action should not be performed.")
   };

--- a/src/hazelcore/Action_Typ.re
+++ b/src/hazelcore/Action_Typ.re
@@ -91,6 +91,7 @@ let rec move = (a: Action.t, zty: ZTyp.t): ActionOutcome.t(ZTyp.t) =>
   | SwapRight
   | SwapUp
   | SwapDown
+  | RenumberHoles
   | Init =>
     failwith(
       __LOC__
@@ -217,6 +218,8 @@ and perform_opseq =
         );
       }
     }
+  | (RenumberHoles, _) =>
+    failwith("Renumbering action should not be performed.")
   | (Init, _) => failwith("Init action should not be performed.")
   }
 and perform_operand =
@@ -327,5 +330,7 @@ and perform_operand =
       perform_operand(Action_common.escape(side), zoperand)
     | Succeeded(zbody) => Succeeded(ZOpSeq.wrap(ZTyp.ListZ(zbody)))
     }
+  | (RenumberHoles, _) =>
+    failwith("Renumbering action should not be performed.")
   | (Init, _) => failwith("Init action should not be performed.")
   };

--- a/src/hazelcore/Statics_Exp.rei
+++ b/src/hazelcore/Statics_Exp.rei
@@ -129,3 +129,46 @@ let fix_and_renumber_holes:
   (Contexts.t, UHExp.t) => (UHExp.t, HTyp.t, MetaVarGen.t);
 
 let fix_and_renumber_holes_z: (Contexts.t, ZExp.t) => Statics.edit_state;
+
+let ana_fix_holes_zoperand:
+  (
+    Contexts.t,
+    MetaVarGen.t,
+    ~renumber_empty_holes: bool=?,
+    ZExp.zoperand,
+    HTyp.t
+  ) =>
+  (ZExp.zoperand, MetaVarGen.t);
+
+let ana_fix_holes_zopseq:
+  (
+    Contexts.t,
+    MetaVarGen.t,
+    ~renumber_empty_holes: bool=?,
+    ZExp.zopseq,
+    HTyp.t
+  ) =>
+  (ZExp.zopseq, MetaVarGen.t);
+
+let ana_fix_holes_zrules:
+  (
+    Contexts.t,
+    MetaVarGen.t,
+    ~renumber_empty_holes: bool=?,
+    ZExp.zrules,
+    HTyp.t,
+    HTyp.t
+  ) =>
+  (ZExp.zrules, MetaVarGen.t);
+
+let syn_fix_holes_zoperand:
+  (Contexts.t, MetaVarGen.t, ~renumber_empty_holes: bool=?, ZExp.zoperand) =>
+  (ZExp.zoperand, HTyp.t, MetaVarGen.t);
+
+let syn_fix_holes_zopseq:
+  (Contexts.t, MetaVarGen.t, ~renumber_empty_holes: bool=?, ZExp.zopseq) =>
+  (ZExp.zopseq, HTyp.t, MetaVarGen.t);
+
+let syn_fix_holes_zline:
+  (Contexts.t, MetaVarGen.t, ~renumber_empty_holes: bool=?, ZExp.zline) =>
+  (ZExp.zline, Contexts.t, MetaVarGen.t);

--- a/src/hazelcore/Statics_Pat.rei
+++ b/src/hazelcore/Statics_Pat.rei
@@ -64,3 +64,31 @@ let syn_fix_holes_z:
 let ana_fix_holes_z:
   (Contexts.t, MetaVarGen.t, ZPat.t, HTyp.t) =>
   (ZPat.t, Contexts.t, MetaVarGen.t);
+
+let ana_fix_holes_zoperand:
+  (
+    Contexts.t,
+    MetaVarGen.t,
+    ~renumber_empty_holes: bool=?,
+    ZPat.zoperand,
+    HTyp.t
+  ) =>
+  (ZPat.zoperand, Contexts.t, MetaVarGen.t);
+
+let ana_fix_holes_zopseq:
+  (
+    Contexts.t,
+    MetaVarGen.t,
+    ~renumber_empty_holes: bool=?,
+    ZPat.zopseq,
+    HTyp.t
+  ) =>
+  (ZPat.zopseq, Contexts.t, MetaVarGen.t);
+
+let syn_fix_holes_zopseq:
+  (Contexts.t, MetaVarGen.t, ~renumber_empty_holes: bool=?, ZPat.zopseq) =>
+  (ZPat.zopseq, HTyp.t, Contexts.t, MetaVarGen.t);
+
+let syn_fix_holes_zoperand:
+  (Contexts.t, MetaVarGen.t, ~renumber_empty_holes: bool=?, ZPat.zoperand) =>
+  (ZPat.zoperand, HTyp.t, Contexts.t, MetaVarGen.t);

--- a/src/hazelweb/gui/ActionPanel.re
+++ b/src/hazelweb/gui/ActionPanel.re
@@ -417,6 +417,10 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject) => {
         combo(Enter, simple("Add new rule")),
       ],
     ),
+    section(
+      "Renumber Holes",
+      [combo(Ctrl_Pound, simple("Renumber holes"))],
+    ),
   ];
 };
 
@@ -492,5 +496,6 @@ let _check_actions = (a: Action.t) =>
   | Construct(SApPalette(_)) => failwith("Unimplemented")
   | UpdateApPalette(_) => failwith("Unimplemented")
   | MoveTo(_) => Added
+  | RenumberHoles => Added
   | Init => Added
   };

--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -36,16 +36,17 @@ let table: Hashtbl.t(HazelKeyCombos.t, CursorInfo.t => Action.t) =
       | {CursorInfo.typed: OnType, _} => Construct(SList)
       | _ => Construct(SListNil),
     ),
-    (Semicolon, _ => Construct(SOp(SCons))),
-    (Alt_L, _ => Construct(SInj(L))),
-    (Alt_R, _ => Construct(SInj(R))),
-    (Alt_C, _ => Construct(SCase)),
-    (Pound, _ => Construct(SCommentLine)),
-    (Shift_Enter, _ => Construct(SCommentLine)),
-    (Ctrl_Alt_I, _ => SwapUp),
-    (Ctrl_Alt_K, _ => SwapDown),
-    (Ctrl_Alt_J, _ => SwapLeft),
-    (Ctrl_Alt_L, _ => SwapRight),
+    (Semicolon, _ => Action.Construct(SOp(SCons))),
+    (Alt_L, _ => Action.Construct(SInj(L))),
+    (Alt_R, _ => Action.Construct(SInj(R))),
+    (Alt_C, _ => Action.Construct(SCase)),
+    (Pound, _ => Action.Construct(SCommentLine)),
+    (Shift_Enter, _ => Action.Construct(SCommentLine)),
+    (Ctrl_Alt_I, _ => Action.SwapUp),
+    (Ctrl_Alt_K, _ => Action.SwapDown),
+    (Ctrl_Alt_J, _ => Action.SwapLeft),
+    (Ctrl_Alt_L, _ => Action.SwapRight),
+    (Ctrl_Pound, _ => Action.RenumberHoles),
   ]
   |> List.to_seq
   |> Hashtbl.of_seq;

--- a/src/hazelweb/keyboard/HazelKeyCombos.re
+++ b/src/hazelweb/keyboard/HazelKeyCombos.re
@@ -37,7 +37,8 @@ type t =
   | Ctrl_Alt_J
   | Ctrl_Alt_L
   | Meta_Z
-  | Meta_Shift_Z;
+  | Meta_Shift_Z
+  | Ctrl_Pound;
 
 let get_details =
   fun
@@ -75,7 +76,8 @@ let get_details =
   | Ctrl_Alt_J => KeyCombo.ctrl_alt_j
   | Ctrl_Alt_L => KeyCombo.ctrl_alt_l
   | Meta_Z => KeyCombo.meta_z
-  | Meta_Shift_Z => KeyCombo.meta_shift_z;
+  | Meta_Shift_Z => KeyCombo.meta_shift_z
+  | Ctrl_Pound => KeyCombo.ctrl_pound;
 
 let of_evt = (evt: Js.t(Dom_html.keyboardEvent)): option(t) => {
   let evt_matches = details => KeyCombo.matches(details, evt);
@@ -149,6 +151,8 @@ let of_evt = (evt: Js.t(Dom_html.keyboardEvent)): option(t) => {
     Some(Ctrl_Alt_J);
   } else if (evt_matches(KeyCombo.ctrl_alt_l)) {
     Some(Ctrl_Alt_L);
+  } else if (evt_matches(KeyCombo.ctrl_pound)) {
+    Some(Ctrl_Pound);
   } else {
     None;
   };

--- a/src/hazelweb/keyboard/HazelKeyCombos.rei
+++ b/src/hazelweb/keyboard/HazelKeyCombos.rei
@@ -37,7 +37,8 @@ type t =
   | Ctrl_Alt_J
   | Ctrl_Alt_L
   | Meta_Z
-  | Meta_Shift_Z;
+  | Meta_Shift_Z
+  | Ctrl_Pound;
 
 let get_details: t => KeyCombo.t;
 

--- a/src/hazelweb/keyboard/KeyCombo.re
+++ b/src/hazelweb/keyboard/KeyCombo.re
@@ -61,3 +61,4 @@ let ctrl_alt_j = ctrl_alt(Key.the_key("j"));
 let ctrl_alt_l = ctrl_alt(Key.the_key("l"));
 let meta_z = ctrl(Key.the_key("z"));
 let meta_shift_z = ctrl_shift(Key.the_key("Z"));
+let ctrl_pound = ctrl_shift(Key.the_key("#"));

--- a/src/hazelweb/keyboard/KeyCombo.rei
+++ b/src/hazelweb/keyboard/KeyCombo.rei
@@ -46,3 +46,4 @@ let ctrl_alt_j: t;
 let ctrl_alt_l: t;
 let meta_z: t;
 let meta_shift_z: t;
+let ctrl_pound: t;

--- a/src/hazelweb/layout/UHDoc_common.re
+++ b/src/hazelweb/layout/UHDoc_common.re
@@ -25,7 +25,7 @@ let memoize =
           };
         let _ = WeakMap.set(table, k, m);
         v;
-      | Some((m: memoization_value('v))) =>
+      | Some(m: memoization_value('v)) =>
         if (enforce_inline) {
           switch (m.inline_true) {
           | Some(v) => v

--- a/src/hazelweb/model/UndoHistory.re
+++ b/src/hazelweb/model/UndoHistory.re
@@ -649,6 +649,7 @@ let get_new_action_group =
     | MoveRight
     | MoveToNextHole
     | MoveToPrevHole
+    | RenumberHoles
     | Init => None
     | UpdateApPalette(_) =>
       failwith("ApPalette is not implemented in undo_history")


### PR DESCRIPTION
This PR addresses the following issue: 
https://github.com/hazelgrove/hazel/issues/41

Since hole numbers can become extremely large, users should be allowed to renumber them explicitly. To enable users to do so, I have introduced a new action called "RenumberHoles" and mapped it to the (Ctrl+#) key combination.

Tested by creating expressions with holes, pressing Ctrl+#, and ensuring that the hole numbers start from 1 again.