### PR TITLE
Shmyth feedback

### DIFF
--- a/src/hazelcore/Action.re
+++ b/src/hazelcore/Action.re
@@ -25,6 +25,7 @@ type shape =
   | SChar(string)
   | SAsc
   | SLam
+  | SExpand
   | SListNil
   | SInj(InjSide.t)
   | SLet

--- a/src/hazelcore/Action_Pat.re
+++ b/src/hazelcore/Action_Pat.re
@@ -590,7 +590,7 @@ and syn_perform_operand =
   /* Invalid actions */
   | (
       Construct(
-        SApPalette(_) | SList | SAsc | SLet | SLine | SLam | SCase |
+        SApPalette(_) | SList | SAsc | SLet | SLine | SLam | SExpand | SCase |
         SCommentLine,
       ) |
       UpdateApPalette(_) |
@@ -1024,7 +1024,7 @@ and ana_perform_operand =
   /* Invalid actions */
   | (
       Construct(
-        SApPalette(_) | SList | SAsc | SLet | SLine | SLam | SCase |
+        SApPalette(_) | SList | SAsc | SLet | SLine | SLam | SExpand | SCase |
         SCommentLine,
       ) |
       UpdateApPalette(_) |

--- a/src/hazelcore/Action_Typ.re
+++ b/src/hazelcore/Action_Typ.re
@@ -110,7 +110,8 @@ and perform_opseq =
   | (
       UpdateApPalette(_) |
       Construct(
-        SAsc | SLet | SLine | SLam | SListNil | SInj(_) | SCase | SApPalette(_),
+        SAsc | SLet | SLine | SLam | SExpand | SListNil | SInj(_) | SCase |
+        SApPalette(_),
       ) |
       SwapUp |
       SwapDown |
@@ -228,7 +229,8 @@ and perform_operand =
   | (
       UpdateApPalette(_) |
       Construct(
-        SAsc | SLet | SLine | SLam | SListNil | SInj(_) | SCase | SApPalette(_) |
+        SAsc | SLet | SLine | SLam | SExpand | SListNil | SInj(_) | SCase |
+        SApPalette(_) |
         SCommentLine,
       ) |
       SwapUp |

--- a/src/hazelcore/Action_common.re
+++ b/src/hazelcore/Action_common.re
@@ -7,6 +7,7 @@ let shape_to_string = (shape: shape): string => {
   | SChar(str) => str
   | SAsc => "type annotation"
   | SLam => "function"
+  | SExpand => "eta expansion"
   | SListNil => "empty list"
   | SInj(side) =>
     switch (side) {

--- a/src/hazelcore/Shmyth.re
+++ b/src/hazelcore/Shmyth.re
@@ -424,6 +424,7 @@ and smexp_list_to_opseq: Smyth.Lang.exp => option(UHExp.opseq) =
         UHExp.mk_OpSeq(Seq.seq_op_seq(hz_hd, Operators_Exp.Cons, hz_tl)),
       );
     }
+  | ECtor("Cons", _, EVar(x)) => Some(OpSeq.wrap(UHExp.var(x)))
   | ECtor(name, _, _e) => {
       Format.printf("bad list constructor: %s%!", name);
       Format.printf(
@@ -493,7 +494,22 @@ and smexp_branch_to_uhexp_rule =
           Seq.wrap(UHPat.var(x ++ "_tl")),
         ),
       ),
-      clause,
+      [
+        UHExp.letline(
+          OpSeq.wrap(UHPat.var(x)),
+          [
+            ExpLine(
+              UHExp.mk_OpSeq(
+                Seq.mk(
+                  UHExp.var(x ++ "_hd"),
+                  [(Operators_Exp.Comma, UHExp.var(x ++ "_tl"))],
+                ),
+              ),
+            ),
+          ],
+        ),
+        ...clause,
+      ],
     )
   | _ => assert(false)
   };

--- a/src/hazelcore/Shmyth.re
+++ b/src/hazelcore/Shmyth.re
@@ -891,7 +891,11 @@ let solve_all = (e: UHExp.t): option(hole_fillings) => {
     |> List.map(hole_filling =>
          hole_filling
          |> List.map(((u, smexp)) => {
+              print_endline("smyth:");
+              print_endline(Smyth.Pretty.exp(smexp));
               let+ e = smexp_to_uhexp(smexp);
+              // print_endline("hazel:");
+              // print_endline(Serialization.string_of_exp(e));
               (u, e);
             })
          |> OptUtil.sequence

--- a/src/hazelcore/Shmyth.re
+++ b/src/hazelcore/Shmyth.re
@@ -572,7 +572,7 @@ and smexp_to_uhexp_opseq: Smyth.Lang.exp => option(UHExp.opseq) =
       let p = {
         let operands =
           ListUtil.range(n)
-          |> List.map(j => j == i ? UHPat.var(x) : UHPat.wild())
+          |> List.map(j => 1 + j == i ? UHPat.var(x) : UHPat.wild())
           |> List.map(Seq.wrap);
         switch (operands) {
         | [] => assert(false)

--- a/src/hazelcore/Shmyth.re
+++ b/src/hazelcore/Shmyth.re
@@ -424,8 +424,12 @@ and smexp_list_to_opseq: Smyth.Lang.exp => option(UHExp.opseq) =
         UHExp.mk_OpSeq(Seq.seq_op_seq(hz_hd, Operators_Exp.Cons, hz_tl)),
       );
     }
-  | ECtor(name, _, _) => {
+  | ECtor(name, _, _e) => {
       Format.printf("bad list constructor: %s%!", name);
+      Format.printf(
+        "argument: %s%!",
+        Sexplib.Sexp.to_string_hum(Smyth.Lang.sexp_of_exp(_e)),
+      );
       assert(false);
     }
   | exp => smexp_to_uhexp_opseq(exp)

--- a/src/hazelweb/ModelAction.re
+++ b/src/hazelweb/ModelAction.re
@@ -29,6 +29,7 @@ type t =
   | NextCard
   | PrevCard
   | SynthesizeHole(MetaVar.t)
+  | SynthesizeAll
   | ScrollFilling(bool)
   | AcceptFilling
   | StepInFilling

--- a/src/hazelweb/ModelAction.re
+++ b/src/hazelweb/ModelAction.re
@@ -30,6 +30,7 @@ type t =
   | PrevCard
   | SynthesizeHole(MetaVar.t)
   | SynthesizeAll
+  | EtaExpandAll
   | ScrollFilling(bool)
   | AcceptFilling
   | StepInFilling

--- a/src/hazelweb/Update.re
+++ b/src/hazelweb/Update.re
@@ -66,6 +66,7 @@ let log_action = (action: ModelAction.t, _: State.t): unit => {
   | UpdateFontMetrics(_)
   | UpdateIsMac(_)
   | SynthesizeHole(_)
+  | SynthesizeAll
   | ScrollFilling(_)
   | AcceptFilling
   | StepInFilling
@@ -133,10 +134,11 @@ let apply_action =
       | PrevCard => Model.prev_card(model)
       | SynthesizeHole(u) =>
         Model.map_program(Program.begin_synthesizing(u), model)
+      | SynthesizeAll => Model.map_program(Program.accept_all, model)
       | ScrollFilling(up) =>
         Model.map_program(Program.scroll_synthesized_selection(up), model)
-      | AcceptFilling => Model.map_program(Program.accept_synthesized, model)
       | StepInFilling => Model.map_program(Program.step_in_synthesized, model)
+      | AcceptFilling => Model.map_program(Program.accept_synthesized, model)
       | StepOutFilling =>
         Model.map_program(Program.step_out_synthesized, model)
       | NextSynthesisHole =>

--- a/src/hazelweb/Update.re
+++ b/src/hazelweb/Update.re
@@ -67,6 +67,7 @@ let log_action = (action: ModelAction.t, _: State.t): unit => {
   | UpdateIsMac(_)
   | SynthesizeHole(_)
   | SynthesizeAll
+  | EtaExpandAll
   | ScrollFilling(_)
   | AcceptFilling
   | StepInFilling
@@ -135,6 +136,7 @@ let apply_action =
       | SynthesizeHole(u) =>
         Model.map_program(Program.begin_synthesizing(u), model)
       | SynthesizeAll => Model.map_program(Program.accept_all, model)
+      | EtaExpandAll => Model.map_program(Program.eta_expand_all, model)
       | ScrollFilling(up) =>
         Model.map_program(Program.scroll_synthesized_selection(up), model)
       | StepInFilling => Model.map_program(Program.step_in_synthesized, model)

--- a/src/hazelweb/gui/ActionPanel.re
+++ b/src/hazelweb/gui/ActionPanel.re
@@ -466,6 +466,7 @@ let _check_actions = (a: Action.t) =>
   | Construct(SLine) => Added
   | Construct(SCommentLine) => Added
   | Construct(SLam) => Added
+  | Construct(SExpand) => Added
   | Construct(SOp(SPlus)) => Added
   | Construct(SOp(SMinus)) => Added
   | Construct(SOp(STimes)) => Added

--- a/src/hazelweb/gui/Examples.re
+++ b/src/hazelweb/gui/Examples.re
@@ -883,6 +883,38 @@ let sort_template: UHExp.t = [
     ),
   ),
 ];
+let sort_degenerate: UHExp.t = [
+  lte,
+  insert,
+  LetLine(
+    OpSeq.wrap(UHPat.var("test")),
+    Some(UHTyp.contract(List(Int))),
+    [
+      ExpLine(
+        shmyth_app(
+          "insert",
+          [
+            UHExp.intlit("2"),
+            shmyth_parens(
+              shmyth_app(
+                "insert",
+                [UHExp.intlit("1"), UHExp.EmptyHole(0)],
+              ),
+            ),
+          ],
+        ),
+      ),
+    ],
+  ),
+  mk_app_equality_assert(
+    3,
+    "test",
+    [],
+    shmyth_parens(
+      shmyth_cons(UHExp.intlit("1"), [UHExp.intlit("2"), UHExp.listnil()]),
+    ),
+  ),
+];
 
 let append_template: UHExp.t = [
   shmyth_let(
@@ -1401,6 +1433,7 @@ let examples =
     |> add("add_template", addition_template)
     |> add("length_template", length_template)
     |> add("sort_template", sort_template)
+    |> add("sort_degenerate", sort_degenerate)
     |> add("max_template", max_template)
     |> add("odd_template", odd_template)
     |> add("mult_template", mult_template)

--- a/src/hazelweb/gui/Examples.re
+++ b/src/hazelweb/gui/Examples.re
@@ -920,6 +920,45 @@ let sort_degenerate: UHExp.t = [
     ),
   ),
 ];
+let mistyped_uneval: UHExp.t = [
+  LetLine(
+    OpSeq.wrap(UHPat.var("foo")),
+    Some(
+      Operators_Typ.(
+        UHTyp.(
+          Seq.mk(
+            Parenthesized(
+              Seq.mk(
+                Int,
+                [
+                  (Arrow, List(OpSeq.wrap(Int))),
+                  (Arrow, List(OpSeq.wrap(Int))),
+                ],
+              )
+              |> mk_OpSeq,
+            ),
+            [(Arrow, List(OpSeq.wrap(Int)))],
+          )
+          |> mk_OpSeq
+        )
+      ),
+    ),
+    [
+      ExpLine(
+        shmyth_lam(
+          "f",
+          shmyth_app("f", [UHExp.intlit("0"), UHExp.listnil()]),
+        ),
+      ),
+    ],
+  ),
+  LetLine(
+    OpSeq.wrap(UHPat.var("bar")),
+    Some(UHTyp.contract(Arrow(List(Int), List(Int)))),
+    [ExpLine(OpSeq.wrap(UHExp.EmptyHole(0)))],
+  ),
+  mk_app_equality_assert(3, "bar", [UHExp.listnil()], UHExp.listnil()),
+];
 
 let append_template: UHExp.t = [
   shmyth_let(
@@ -1439,6 +1478,7 @@ let examples =
     |> add("length_template", length_template)
     |> add("sort_template", sort_template)
     |> add("sort_degenerate", sort_degenerate)
+    |> add("mistyped_uneval", mistyped_uneval)
     |> add("max_template", max_template)
     |> add("odd_template", odd_template)
     |> add("mult_template", mult_template)

--- a/src/hazelweb/gui/Examples.re
+++ b/src/hazelweb/gui/Examples.re
@@ -838,6 +838,11 @@ let sort_template: UHExp.t = [
   lte,
   insert,
   LetLine(
+    OpSeq.wrap(UHPat.var("nil")),
+    Some(UHTyp.contract(List(Int))),
+    [ExpLine(OpSeq.wrap(UHExp.listnil()))],
+  ),
+  LetLine(
     OpSeq.wrap(UHPat.var("sort")),
     Some(UHTyp.contract(Arrow(List(Int), List(Int)))),
     [ExpLine(OpSeq.wrap(UHExp.EmptyHole(0)))],

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -50,6 +50,10 @@ let examples_select = (~inject: ModelAction.t => Vdom.Event.t) =>
           [Node.text("sort template")],
         ),
         Node.option(
+          [Attr.value("sort_degenerate")],
+          [Node.text("sort degenerate")],
+        ),
+        Node.option(
           [Attr.value("max_template")],
           [Node.text("max template")],
         ),

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -272,16 +272,16 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
                       ),
                       Node.button(
                         [
-                          Attr.on_click(_ => {
-                            let program = Model.get_program(model);
-                            let (ze, _, _) = program.edit_state;
-                            let holes_z = CursorPath_Exp.holes_z(ze, []);
-                            switch (holes_z.hole_selected) {
-                            | Some({sort: ExpHole(u, Empty), _}) =>
-                              inject(ModelAction.SynthesizeHole(u))
-                            | _ => Event.Many([])
-                            };
-                          }),
+                          Attr.on_click(_ =>
+                            inject(ModelAction.SynthesizeAll)
+                          ),
+                          // let program = Model.get_program(model);
+                          // let (ze, _, _) = program.edit_state;
+                          // let holes_z = CursorPath_Exp.holes_z(ze, []);
+                          // switch (holes_z.hole_selected) {
+                          // | Some({sort: ExpHole(u, Empty), _}) =>
+                          //   inject(ModelAction.SynthesizeHole(u))
+                          // | _ => Event.Many([])
                         ],
                         [Node.text("Shmythesize")],
                       ),

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -284,6 +284,12 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
                       ),
                       Node.button(
                         [
+                          Attr.on_click(_ => inject(ModelAction.EtaExpandAll)),
+                        ],
+                        [Node.text("Eta-expand")],
+                      ),
+                      Node.button(
+                        [
                           Attr.on_click(_ =>
                             inject(ModelAction.SynthesizeAll)
                           ),

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -54,6 +54,10 @@ let examples_select = (~inject: ModelAction.t => Vdom.Event.t) =>
           [Node.text("sort degenerate")],
         ),
         Node.option(
+          [Attr.value("mistyped_uneval")],
+          [Node.text("mistyped uneval")],
+        ),
+        Node.option(
           [Attr.value("max_template")],
           [Node.text("max template")],
         ),

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -42,6 +42,10 @@ let examples_select = (~inject: ModelAction.t => Vdom.Event.t) =>
           [Node.text("add template")],
         ),
         Node.option(
+          [Attr.value("length_template")],
+          [Node.text("length template")],
+        ),
+        Node.option(
           [Attr.value("max_template")],
           [Node.text("max template")],
         ),

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -275,13 +275,6 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
                           Attr.on_click(_ =>
                             inject(ModelAction.SynthesizeAll)
                           ),
-                          // let program = Model.get_program(model);
-                          // let (ze, _, _) = program.edit_state;
-                          // let holes_z = CursorPath_Exp.holes_z(ze, []);
-                          // switch (holes_z.hole_selected) {
-                          // | Some({sort: ExpHole(u, Empty), _}) =>
-                          //   inject(ModelAction.SynthesizeHole(u))
-                          // | _ => Event.Many([])
                         ],
                         [Node.text("Shmythesize")],
                       ),

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -46,6 +46,10 @@ let examples_select = (~inject: ModelAction.t => Vdom.Event.t) =>
           [Node.text("length template")],
         ),
         Node.option(
+          [Attr.value("sort_template")],
+          [Node.text("sort template")],
+        ),
+        Node.option(
           [Attr.value("max_template")],
           [Node.text("max template")],
         ),

--- a/src/hazelweb/gui/UndoHistoryPanel.re
+++ b/src/hazelweb/gui/UndoHistoryPanel.re
@@ -318,6 +318,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
           [code_keywords_view("case"), indicate_words_view(" expression")],
         )
       )
+    | SExpand
     | SList
     | SListNil
     | SLine
@@ -375,6 +376,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
           )
         )
       | SLam => indicate_words_view("construct function")
+      | SExpand => indicate_words_view("eta-expand")
       | _ =>
         Vdom.(
           Node.span(
@@ -451,6 +453,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
       | SLet
       | SCase
       | SLam
+      | SExpand
       | SAsc => Some(Exp)
       | _ =>
         Some(

--- a/src/hazelweb/model/Program.re
+++ b/src/hazelweb/model/Program.re
@@ -356,3 +356,12 @@ let accept_synthesized = program =>
     let edit_state = (ZExp.place_before(e), ty, id_gen);
     {...program, edit_state, is_focused: false, synthesizing: None};
   };
+
+let accept_all = program =>
+  switch (Synthesizing.synthesize_all(get_uhexp(program))) {
+  | None => program
+  | Some(syn) =>
+    let (_, ty, id) = program.edit_state;
+    let edit_state = (ZExp.place_before(syn), ty, id);
+    {...program, edit_state, is_focused: false, synthesizing: None};
+  };

--- a/src/hazelweb/model/Program.re
+++ b/src/hazelweb/model/Program.re
@@ -361,7 +361,14 @@ let accept_all = program =>
   switch (Synthesizing.synthesize_all(get_uhexp(program))) {
   | None => program
   | Some(syn) =>
-    let (_, ty, id) = program.edit_state;
-    let edit_state = (ZExp.place_before(syn), ty, id);
+    let id_gen = get_id_gen(program);
+    let (e, ty, id_gen) =
+      Statics_Exp.syn_fix_holes(
+        Contexts.empty,
+        id_gen,
+        ~renumber_empty_holes=true,
+        syn,
+      );
+    let edit_state = (ZExp.place_before(e), ty, id_gen);
     {...program, edit_state, is_focused: false, synthesizing: None};
   };

--- a/src/hazelweb/model/Program.re
+++ b/src/hazelweb/model/Program.re
@@ -383,7 +383,9 @@ let eta_expand_all = program => {
   );
 };
 let accept_all = program =>
-  switch (Synthesizing.synthesize_all(get_uhexp(eta_expand_all(program)))) {
+  // NOTE: turned off eta-expansion to experiment with mistyped uneval warning
+  // switch (Synthesizing.synthesize_all(get_uhexp(eta_expand_all(program)))) {
+  switch (Synthesizing.synthesize_all(get_uhexp(program))) {
   | None =>
     print_endline("Not on track");
     program;

--- a/src/hazelweb/model/Program.re
+++ b/src/hazelweb/model/Program.re
@@ -370,7 +370,7 @@ let eta_expand_all = program => {
     |> List.filter_map(info =>
          CursorPath.(
            switch (info.sort) {
-           | CursorPath.ExpHole(u, Empty) => Some(u)
+           | ExpHole(u, Empty) => Some(u)
            | _ => None
            }
          )

--- a/src/hazelweb/model/Program.rei
+++ b/src/hazelweb/model/Program.rei
@@ -86,3 +86,4 @@ let step_in_synthesized: t => t;
 let step_out_synthesized: t => t;
 let scroll_synthesized_selection: (bool, t) => t;
 let accept_synthesized: t => t;
+let accept_all: t => t;

--- a/src/hazelweb/model/Program.rei
+++ b/src/hazelweb/model/Program.rei
@@ -87,3 +87,4 @@ let step_out_synthesized: t => t;
 let scroll_synthesized_selection: (bool, t) => t;
 let accept_synthesized: t => t;
 let accept_all: t => t;
+let eta_expand_all: t => t;

--- a/src/hazelweb/model/Synthesizing.re
+++ b/src/hazelweb/model/Synthesizing.re
@@ -345,3 +345,17 @@ let step_out = (e: UHExp.t, (steps, z): t): option(t) => {
   let+ z = go(~rev_sketch=[(e, F(HoleMap.empty), steps)], z);
   (steps, z);
 };
+
+let synthesize_all = (e: UHExp.t) => {
+  switch (Shmyth.solve_all(e)) {
+  | Some([results, ..._]) =>
+    Some(
+      List.fold_right(
+        ((hole, filling), expr) => UHExp.fill_hole(hole, filling, expr),
+        results,
+        e,
+      ),
+    )
+  | _ => None
+  };
+};

--- a/src/hazelweb/model/UndoHistory.re
+++ b/src/hazelweb/model/UndoHistory.re
@@ -499,6 +499,7 @@ let get_new_action_group =
       | SList
       | SAsc
       | SLam
+      | SExpand
       | SListNil
       | SInj(_)
       | SLet

--- a/src/smyth/smyth/pretty.mli
+++ b/src/smyth/smyth/pretty.mli
@@ -10,3 +10,9 @@ val typ : typ -> string
 
 val exp : exp -> string
 (** Pretty-prints an expression. *)
+
+val res : res -> string
+(** Pretty-prints a result. *)
+
+val value : value -> string
+(** Pretty-prints a value. *)

--- a/src/smyth/smyth/term_gen.ml
+++ b/src/smyth/smyth/term_gen.ml
@@ -272,7 +272,7 @@ and rel_gen_e_app (sigma : datatype_ctx) (term_size : int)
          ; app_combine head_solution_nd rel_arg_solution_nd
            (* HACK: disallow rel_binding to be used in both the function and
               its argument, so that foldr is not used too much *)
-           (* app_combine rel_head_solution_nd rel_arg_solution_nd*) ]
+         ; app_combine rel_head_solution_nd rel_arg_solution_nd ]
   | _ ->
       Log.warn
         ( "integer partition is incorrect size (is "

--- a/src/smyth/smyth/term_gen.ml
+++ b/src/smyth/smyth/term_gen.ml
@@ -270,7 +270,9 @@ and rel_gen_e_app (sigma : datatype_ctx) (term_size : int)
       Nondet.union
       @@ [ app_combine rel_head_solution_nd arg_solution_nd
          ; app_combine head_solution_nd rel_arg_solution_nd
-         ; app_combine rel_head_solution_nd rel_arg_solution_nd ]
+           (* HACK: disallow rel_binding to be used in both the function and
+              its argument, so that foldr is not used too much *)
+           (* app_combine rel_head_solution_nd rel_arg_solution_nd*) ]
   | _ ->
       Log.warn
         ( "integer partition is incorrect size (is "


### PR DESCRIPTION
Add functionality for synthesis-based feedback, based on the HATRA 2020 paper [Model-Driven Synthesis for Programming Tutors](https://arxiv.org/abs/2011.07510).

Planned features:

- [x] Instant synthesis (rather than the current incremental synthesis)
- [ ] Prelude (related to modules? possibly just hidden let-bindings)
- [ ] Annotations on bindings with information for the synthesis (such as weights/maximum nr. of uses)
- [ ] Adapt the synthesis to take these annotations in mind
- [ ] Model solutions
- [ ] Better/more feedback from smyth when and how synthesis fails

Use model solutions to automatically derive:

- [ ] A prelude with possible annotations
- [ ] A set of assertions
- [ ] Relevant synthesis parameters