### PR TITLE
Smyth sketch-sensitive

### DIFF
--- a/src/hazelcore/Shmyth.re
+++ b/src/hazelcore/Shmyth.re
@@ -891,8 +891,8 @@ let solve_all = (e: UHExp.t): option(hole_fillings) => {
     |> List.map(hole_filling =>
          hole_filling
          |> List.map(((u, smexp)) => {
-              print_endline("smyth:");
-              print_endline(Smyth.Pretty.exp(smexp));
+              // print_endline("smyth:");
+              // print_endline(Smyth.Pretty.exp(smexp));
               let+ e = smexp_to_uhexp(smexp);
               // print_endline("hazel:");
               // print_endline(Serialization.string_of_exp(e));

--- a/src/hazelweb/model/Model.re
+++ b/src/hazelweb/model/Model.re
@@ -69,7 +69,7 @@ let init = (): t => {
     selected_instances,
     undo_history,
     left_sidebar_open: false,
-    right_sidebar_open: true,
+    right_sidebar_open: false,
     font_metrics:
       FontMetrics.{
         // to be set on display

--- a/src/hazelweb/model/Settings.re
+++ b/src/hazelweb/model/Settings.re
@@ -127,7 +127,7 @@ module CursorInspector = {
   };
 
   let init = {
-    visible: true,
+    visible: false,
     show_expanded: false,
     term_novice_message_mode: false,
     type_novice_message_mode: false,

--- a/src/smyth/smyth/branch.ml
+++ b/src/smyth/smyth/branch.ml
@@ -45,7 +45,7 @@ let distribute (delta : hole_ctx) (sigma : datatype_ctx) (hf : hole_filling)
       Nondet.none
 
 let branch max_scrutinee_size delta sigma hf
-    ((gamma, goal_type, goal_dec), worlds) =
+    ((gamma, goal_type, goal_dec, term_kind), worlds) =
   let open Nondet.Syntax in
   let* _ = Nondet.guard (Option.is_none goal_dec) in
   let filtered_worlds = filter worlds in
@@ -61,7 +61,9 @@ let branch max_scrutinee_size delta sigma hf
     Term_gen.up_to_e sigma max_scrutinee_size
       ( gamma
       , TData (data_name, List.map (fun _ -> Type.wildcard) datatype_params)
-      , None )
+      , None
+      , term_kind )
+    (* TODO: should this be E? *)
   in
   let* datatype_args =
     Type.infer sigma gamma scrutinee
@@ -119,7 +121,8 @@ let branch max_scrutinee_size delta sigma hf
                      (arg_name, (arg_type, arg_bind_spec))
                      gamma
                  , goal_type
-                 , None )
+                 , None
+                 , term_kind )
                , distributed_worlds ) )
            in
            let branch = (ctor_name, (PVar arg_name, EHole hole_name)) in

--- a/src/smyth/smyth/branch.ml
+++ b/src/smyth/smyth/branch.ml
@@ -45,7 +45,7 @@ let distribute (delta : hole_ctx) (sigma : datatype_ctx) (hf : hole_filling)
       Nondet.none
 
 let branch max_scrutinee_size delta sigma hf
-    ((gamma, goal_type, goal_dec, term_kind), worlds) =
+    ({gamma; goal_type; goal_dec; term_kind}, worlds) =
   let open Nondet.Syntax in
   let* _ = Nondet.guard (Option.is_none goal_dec) in
   let filtered_worlds = filter worlds in
@@ -59,10 +59,11 @@ let branch max_scrutinee_size delta sigma hf
   in
   let* scrutinee =
     Term_gen.up_to_e sigma max_scrutinee_size
-      ( gamma
-      , TData (data_name, List.map (fun _ -> Type.wildcard) datatype_params)
-      , None
-      , term_kind )
+      { gamma
+      ; goal_type=
+          TData (data_name, List.map (fun _ -> Type.wildcard) datatype_params)
+      ; goal_dec= None
+      ; term_kind }
     (* TODO: should this be E? *)
   in
   let* datatype_args =
@@ -117,12 +118,13 @@ let branch max_scrutinee_size delta sigma hf
            let hole_name = Fresh.gen_hole () in
            let goal =
              ( hole_name
-             , ( ( Type_ctx.add_type
-                     (arg_name, (arg_type, arg_bind_spec))
-                     gamma
-                 , goal_type
-                 , None
-                 , term_kind )
+             , ( { gamma=
+                     Type_ctx.add_type
+                       (arg_name, (arg_type, arg_bind_spec))
+                       gamma
+                 ; goal_type
+                 ; goal_dec= None
+                 ; term_kind }
                , distributed_worlds ) )
            in
            let branch = (ctor_name, (PVar arg_name, EHole hole_name)) in

--- a/src/smyth/smyth/branch.ml
+++ b/src/smyth/smyth/branch.ml
@@ -45,11 +45,11 @@ let distribute (delta : hole_ctx) (sigma : datatype_ctx) (hf : hole_filling)
       Nondet.none
 
 let branch max_scrutinee_size delta sigma hf
-    (({gamma; goal_dec; _} as gen_goal), worlds) =
+    (({gamma; idents; goal_dec; _} as gen_goal), worlds) =
   let open Nondet.Syntax in
   let* _ = Nondet.guard (Option.is_none goal_dec) in
   let filtered_worlds = filter worlds in
-  let arg_name = Term_gen.fresh_ident gamma Term_gen.match_char in
+  let arg_name = Term_gen.fresh_ident idents Term_gen.match_char in
   let* data_name, (datatype_params, data_ctors) = Nondet.from_list sigma in
   let ctor_names = List.map fst data_ctors in
   let ctor_info : (string * typ) Ctor_map.t =

--- a/src/smyth/smyth/endpoint.ml
+++ b/src/smyth/smyth/endpoint.ml
@@ -34,10 +34,11 @@ let solve_program : Desugar.program -> solve_result response =
   match Type.check sigma Type_ctx.empty exp (Lang.TTuple []) with
   | Error e -> Error (TypeError e)
   | Ok delta -> (
-    (* delta should contain synthesis_ctx *)
     match Eval.eval Env.empty exp with
     | Error e -> Error (EvalError e)
     | Ok (_, assertions) ->
+        (* assertions |> List.iter (fun (res, value) -> print_endline
+           (Pretty.res res ^ " === " ^ Pretty.value value)) ; *)
         let () = Term_gen.clear_cache () in
         let () =
           delta |> List.map fst |> List2.maximum |> Option2.with_default 0

--- a/src/smyth/smyth/endpoint.ml
+++ b/src/smyth/smyth/endpoint.ml
@@ -34,6 +34,7 @@ let solve_program : Desugar.program -> solve_result response =
   match Type.check sigma Type_ctx.empty exp (Lang.TTuple []) with
   | Error e -> Error (TypeError e)
   | Ok delta -> (
+    (* delta should contain synthesis_ctx *)
     match Eval.eval Env.empty exp with
     | Error e -> Error (EvalError e)
     | Ok (_, assertions) ->

--- a/src/smyth/smyth/fill.ml
+++ b/src/smyth/smyth/fill.ml
@@ -1,6 +1,11 @@
 open Lang
 open Nondet.Syntax
 
+(* NOTE: [refine] only works if all constraints agree, so excess constraints
+   can hamper it. In Myth, this means that [branch] should take over and
+   distribute the constraints which don't agree over different branches. In
+   Smyth, however, we might have branched by hand, without removing the
+   irrelevant constraints. *)
 let refine_or_branch params delta sigma hf (hole_name, synthesis_goal) =
   let* additional_depth, ((exp, subgoals), choice_constraints) =
     (* Note: Try to branch FIRST! This results in more idiomatic solutions. *)
@@ -49,6 +54,7 @@ let guess_and_check params delta sigma hf
     Term_gen.up_to sigma params.max_term_size {gen_goal with term_kind= E}
     (* TODO: remove term_kind=E? *)
   in
+  (* print_endline ("guess: " ^ Pretty.exp exp) ; *)
   let binding = Hole_map.singleton hole_name exp in
   let* extended_hf =
     Nondet.lift_option @@ Constraints.merge_solved [binding; hf]

--- a/src/smyth/smyth/fill.ml
+++ b/src/smyth/smyth/fill.ml
@@ -45,7 +45,9 @@ let guess_and_check params delta sigma hf
   let* _ = Nondet.guard (Type.is_base goal_type) in
   let* exp =
     Timer.Multi.accumulate Timer.Multi.Guess
-    @@ fun () -> Term_gen.up_to_e sigma params.max_term_size gen_goal
+    @@ fun () ->
+    Term_gen.up_to sigma params.max_term_size {gen_goal with term_kind= E}
+    (* TODO: remove term_kind=E? *)
   in
   let binding = Hole_map.singleton hole_name exp in
   let* extended_hf =

--- a/src/smyth/smyth/fill.ml
+++ b/src/smyth/smyth/fill.ml
@@ -50,8 +50,7 @@ let guess_and_check params delta sigma hf
   let* _ = Nondet.guard (Type.is_base goal_type) in
   let* exp =
     Timer.Multi.accumulate Timer.Multi.Guess
-    @@ fun () ->
-    Term_gen.up_to sigma params.max_term_size {gen_goal with term_kind= E}
+    @@ fun () -> Term_gen.up_to sigma params.max_term_size gen_goal
     (* TODO: remove term_kind=E? *)
   in
   (* print_endline ("guess: " ^ Pretty.exp exp) ; *)

--- a/src/smyth/smyth/fill.ml
+++ b/src/smyth/smyth/fill.ml
@@ -21,7 +21,7 @@ let refine_or_branch params delta sigma hf (hole_name, synthesis_goal) =
   let delta' =
     List.map
       ( Pair2.map_snd
-      @@ fun ((gamma, goal_type, goal_dec, term_kind), _) ->
+      @@ fun ({gamma; goal_type; goal_dec; term_kind}, _) ->
       (gamma, goal_type, goal_dec, term_kind, match_depth) )
       subgoals
   in
@@ -40,7 +40,7 @@ let refine_or_branch params delta sigma hf (hole_name, synthesis_goal) =
   (final_constraints, delta')
 
 let guess_and_check params delta sigma hf
-    (hole_name, (((_, goal_type, _, _) as gen_goal), worlds)) =
+    (hole_name, (({goal_type; _} as gen_goal), worlds)) =
   (* Only guess if we have not exhausted all time allotted for guessing *)
   let* _ = Nondet.guard (Timer.Multi.check Timer.Multi.Guess) in
   (* Only guess at base types *)
@@ -63,8 +63,7 @@ let guess_and_check params delta sigma hf
   in
   (merged_constraints, [])
 
-let defer _params _delta _sigma _hf
-    (hole_name, ((_, goal_type, _, _), worlds)) =
+let defer _params _delta _sigma _hf (hole_name, ({goal_type; _}, worlds)) =
   if
     (not (Type.equal goal_type (TTuple [])))
     && List.length worlds > 0

--- a/src/smyth/smyth/fill.ml
+++ b/src/smyth/smyth/fill.ml
@@ -14,15 +14,15 @@ let refine_or_branch params delta sigma hf (hole_name, synthesis_goal) =
         @@ Nondet.lift_option
         @@ Refine.refine delta sigma synthesis_goal ]
   in
-  let* _, _, _, parent_depth =
+  let* _, _, _, _, parent_depth =
     Nondet.lift_option @@ List.assoc_opt hole_name delta
   in
   let match_depth = parent_depth + additional_depth in
   let delta' =
     List.map
       ( Pair2.map_snd
-      @@ fun ((gamma, goal_type, goal_dec), _) ->
-      (gamma, goal_type, goal_dec, match_depth) )
+      @@ fun ((gamma, goal_type, goal_dec, term_kind), _) ->
+      (gamma, goal_type, goal_dec, term_kind, match_depth) )
       subgoals
   in
   let solved_constraints = Hole_map.singleton hole_name exp in
@@ -40,7 +40,7 @@ let refine_or_branch params delta sigma hf (hole_name, synthesis_goal) =
   (final_constraints, delta')
 
 let guess_and_check params delta sigma hf
-    (hole_name, (((_, goal_type, _) as gen_goal), worlds)) =
+    (hole_name, (((_, goal_type, _, _) as gen_goal), worlds)) =
   (* Only guess if we have not exhausted all time allotted for guessing *)
   let* _ = Nondet.guard (Timer.Multi.check Timer.Multi.Guess) in
   (* Only guess at base types *)
@@ -63,8 +63,8 @@ let guess_and_check params delta sigma hf
   in
   (merged_constraints, [])
 
-let defer _params _delta _sigma _hf (hole_name, ((_, goal_type, _), worlds))
-    =
+let defer _params _delta _sigma _hf
+    (hole_name, ((_, goal_type, _, _), worlds)) =
   if
     (not (Type.equal goal_type (TTuple [])))
     && List.length worlds > 0

--- a/src/smyth/smyth/fill.ml
+++ b/src/smyth/smyth/fill.ml
@@ -14,15 +14,13 @@ let refine_or_branch params delta sigma hf (hole_name, synthesis_goal) =
         @@ Nondet.lift_option
         @@ Refine.refine delta sigma synthesis_goal ]
   in
-  let* _, _, _, _, parent_depth =
+  let* _, parent_depth =
     Nondet.lift_option @@ List.assoc_opt hole_name delta
   in
   let match_depth = parent_depth + additional_depth in
   let delta' =
     List.map
-      ( Pair2.map_snd
-      @@ fun ({gamma; goal_type; goal_dec; term_kind}, _) ->
-      (gamma, goal_type, goal_dec, term_kind, match_depth) )
+      (Pair2.map_snd @@ fun (gen_goal, _) -> (gen_goal, match_depth))
       subgoals
   in
   let solved_constraints = Hole_map.singleton hole_name exp in

--- a/src/smyth/smyth/lang.ml
+++ b/src/smyth/smyth/lang.ml
@@ -122,15 +122,20 @@ type datatype_ctx = (string * (string list * (string * typ) list)) list
 (** Term kinds. *)
 type term_kind = E | I
 
-(* TODO: refactor hole_ctx to be defined in terms of gen_goal *)
 (* TODO: should match_depth be in there too? *)
+
+(** Term generation ("guessing") goals. *)
+type gen_goal =
+  { gamma: type_ctx
+  ; goal_type: typ
+  ; goal_dec: string option
+  ; term_kind: term_kind }
 
 (** Hole contexts:
     [(hole name, type context, typ, decrease requirement, match depth)]. The
     "decrease requirement", if present, is a function that expressions must
     be decreasing on to fill the hole in question. *)
-type hole_ctx =
-  (hole_name * (type_ctx * typ * string option * term_kind * int)) list
+type hole_ctx = (hole_name * (gen_goal * int)) list
 
 (** "Simple" values. *)
 type value =
@@ -166,18 +171,6 @@ type resumption_assertion = res * value
 
 (** Multiple resumption assertions. *)
 type resumption_assertions = resumption_assertion list
-
-(* TODO: make gen_goal a record type so that it can be modified easier *)
-
-(** Term generation ("guessing") goals. *)
-
-(* type gen_goal = type_ctx * typ * string option * term_kind *)
-
-type gen_goal =
-  { gamma: type_ctx
-  ; goal_type: typ
-  ; goal_dec: string option
-  ; term_kind: term_kind }
 
 (** Basic synthesis goals. *)
 type synthesis_goal = gen_goal * worlds

--- a/src/smyth/smyth/lang.ml
+++ b/src/smyth/smyth/lang.ml
@@ -122,6 +122,9 @@ type datatype_ctx = (string * (string list * (string * typ) list)) list
 (** Term kinds. *)
 type term_kind = E | I
 
+(* TODO: refactor hole_ctx to be defined in terms of gen_goal *)
+(* TODO: should match_depth be in there too? *)
+
 (** Hole contexts:
     [(hole name, type context, typ, decrease requirement, match depth)]. The
     "decrease requirement", if present, is a function that expressions must
@@ -164,8 +167,17 @@ type resumption_assertion = res * value
 (** Multiple resumption assertions. *)
 type resumption_assertions = resumption_assertion list
 
+(* TODO: make gen_goal a record type so that it can be modified easier *)
+
 (** Term generation ("guessing") goals. *)
-type gen_goal = type_ctx * typ * string option * term_kind
+
+(* type gen_goal = type_ctx * typ * string option * term_kind *)
+
+type gen_goal =
+  { gamma: type_ctx
+  ; goal_type: typ
+  ; goal_dec: string option
+  ; term_kind: term_kind }
 
 (** Basic synthesis goals. *)
 type synthesis_goal = gen_goal * worlds

--- a/src/smyth/smyth/lang.ml
+++ b/src/smyth/smyth/lang.ml
@@ -127,6 +127,7 @@ type term_kind = E | I
 (** Term generation ("guessing") goals. *)
 type gen_goal =
   { gamma: type_ctx
+  ; idents: string list
   ; goal_type: typ
   ; goal_dec: string option
   ; term_kind: term_kind }

--- a/src/smyth/smyth/lang.ml
+++ b/src/smyth/smyth/lang.ml
@@ -119,11 +119,15 @@ type type_ctx = type_binding list * poly_binding list
 type datatype_ctx = (string * (string list * (string * typ) list)) list
 [@@deriving sexp]
 
+(** Term kinds. *)
+type term_kind = E | I
+
 (** Hole contexts:
     [(hole name, type context, typ, decrease requirement, match depth)]. The
     "decrease requirement", if present, is a function that expressions must
     be decreasing on to fill the hole in question. *)
-type hole_ctx = (hole_name * (type_ctx * typ * string option * int)) list
+type hole_ctx =
+  (hole_name * (type_ctx * typ * string option * term_kind * int)) list
 
 (** "Simple" values. *)
 type value =
@@ -161,7 +165,7 @@ type resumption_assertion = res * value
 type resumption_assertions = resumption_assertion list
 
 (** Term generation ("guessing") goals. *)
-type gen_goal = type_ctx * typ * string option
+type gen_goal = type_ctx * typ * string option * term_kind
 
 (** Basic synthesis goals. *)
 type synthesis_goal = gen_goal * worlds

--- a/src/smyth/smyth/refine.ml
+++ b/src/smyth/smyth/refine.ml
@@ -3,7 +3,7 @@ open Lang
 let filter (ws : worlds) : worlds =
   List.filter (fun (_env, ex) -> ex <> ExTop) ws
 
-let refine _delta sigma ((gamma, goal_type, goal_dec), worlds) =
+let refine _delta sigma ((gamma, goal_type, goal_dec, term_kind), worlds) =
   let open Option2.Syntax in
   let* _ = Option2.guard (Option.is_none goal_dec) in
   let filtered_worlds = filter worlds in
@@ -39,7 +39,8 @@ let refine _delta sigma ((gamma, goal_type, goal_dec), worlds) =
                 ; (x_name, (tau1, Arg f_name)) ]
                 gamma
             , tau2
-            , None )
+            , None
+            , term_kind )
           , refined_worlds ) )
       in
       let exp =
@@ -62,7 +63,8 @@ let refine _delta sigma ((gamma, goal_type, goal_dec), worlds) =
         let new_goals =
           List.map2
             (fun tau refined_worlds ->
-              (Fresh.gen_hole (), ((gamma, tau, None), refined_worlds)))
+              ( Fresh.gen_hole ()
+              , ((gamma, tau, None, term_kind), refined_worlds) ))
             taus refined_worldss
         in
         let exp =
@@ -94,7 +96,7 @@ let refine _delta sigma ((gamma, goal_type, goal_dec), worlds) =
       in
       let hole_name = Fresh.gen_hole () in
       let new_goal =
-        (hole_name, ((gamma, arg_type, None), refined_worlds))
+        (hole_name, ((gamma, arg_type, None, term_kind), refined_worlds))
       in
       let exp = ECtor (ctor_name, datatype_args, EHole hole_name) in
       (exp, [new_goal])

--- a/src/smyth/smyth/refine.ml
+++ b/src/smyth/smyth/refine.ml
@@ -4,7 +4,7 @@ let filter (ws : worlds) : worlds =
   List.filter (fun (_env, ex) -> ex <> ExTop) ws
 
 let refine _delta sigma
-    (({gamma; goal_type; goal_dec; _} as gen_goal), worlds) =
+    (({gamma; idents; goal_type; goal_dec; _} as gen_goal), worlds) =
   let open Option2.Syntax in
   let* _ = Option2.guard (Option.is_none goal_dec) in
   let filtered_worlds = filter worlds in
@@ -12,9 +12,9 @@ let refine _delta sigma
   (* Refine-Fix *)
   | TArr (tau1, tau2) ->
       let hole_name = Fresh.gen_hole () in
-      let f_name = Term_gen.fresh_ident gamma Term_gen.function_char in
+      let f_name = Term_gen.fresh_ident idents Term_gen.function_char in
       (* print_endline ("generated function name " ^ f_name) ; *)
-      let x_name = Term_gen.fresh_ident gamma Term_gen.variable_char in
+      let x_name = Term_gen.fresh_ident idents Term_gen.variable_char in
       let+ refined_worlds =
         filtered_worlds
         |> List.map (fun (env, io_ex) ->
@@ -43,6 +43,7 @@ let refine _delta sigma
                   ; (x_name, (tau1, Arg f_name)) ]
                   gamma
                 (* TODO: should we set dec=None? *)
+            ; idents= idents @ [f_name; x_name]
             ; goal_type= tau2 }
           , refined_worlds ) )
       in

--- a/src/smyth/smyth/refine.ml
+++ b/src/smyth/smyth/refine.ml
@@ -13,6 +13,7 @@ let refine _delta sigma
   | TArr (tau1, tau2) ->
       let hole_name = Fresh.gen_hole () in
       let f_name = Term_gen.fresh_ident gamma Term_gen.function_char in
+      (* print_endline ("generated function name " ^ f_name) ; *)
       let x_name = Term_gen.fresh_ident gamma Term_gen.variable_char in
       let+ refined_worlds =
         filtered_worlds
@@ -48,6 +49,7 @@ let refine _delta sigma
       let exp =
         EFix (Some f_name, PatParam (PVar x_name), EHole hole_name)
       in
+      (* print_endline ("refine: " ^ Pretty.exp exp) ; *)
       (exp, [new_goal])
   (* Refine-Tuple *)
   | TTuple taus ->

--- a/src/smyth/smyth/solve.ml
+++ b/src/smyth/smyth/solve.ml
@@ -40,14 +40,14 @@ let rec iter_solve params delta sigma (hf, us_all) =
       current_solution_count := !current_solution_count + 1 ;
       Nondet.pure (hf, delta)
   | Some ((hole_name, worlds), us) ->
-      let* gamma, goal_type, goal_dec, term_kind, match_depth =
+      let* gen_goal, match_depth =
         Nondet.lift_option @@ List.assoc_opt hole_name delta
       in
       let* k_new, delta_new =
         Fill.fill
           {params with max_match_depth= params.max_match_depth - match_depth}
           delta sigma hf
-          (hole_name, ({gamma; goal_type; goal_dec; term_kind}, worlds))
+          (hole_name, (gen_goal, worlds))
       in
       let delta_merged = delta_new @ delta in
       let* k_merged =
@@ -74,7 +74,7 @@ let rec iter_solve_once_list holes params delta sigma (hf, us_all)
         current_solution_count := !current_solution_count + 1 ;
         Nondet.pure (hf, delta, us_all_init)
     | Some ((hole_name, worlds), us) ->
-        let* gamma, goal_type, goal_dec, term_kind, match_depth =
+        let* gen_goal, match_depth =
           Nondet.lift_option @@ List.assoc_opt hole_name delta
         in
         let* k_new, delta_new =
@@ -82,7 +82,7 @@ let rec iter_solve_once_list holes params delta sigma (hf, us_all)
             { params with
               max_match_depth= params.max_match_depth - match_depth }
             delta sigma hf
-            (hole_name, ({gamma; goal_type; goal_dec; term_kind}, worlds))
+            (hole_name, (gen_goal, worlds))
         in
         let delta_merged = delta_new @ delta in
         let* k_merged =
@@ -98,14 +98,14 @@ let _iter_solve_once hole_name params delta sigma (hf, us_all) =
   match Constraints.delete hole_name us_all with
   | None -> failwith __LOC__
   | Some ((_, worlds), us) ->
-      let* gamma, goal_type, goal_dec, term_kind, match_depth =
+      let* gen_goal, match_depth =
         Nondet.lift_option @@ List.assoc_opt hole_name delta
       in
       let* k_new, delta_new =
         Fill.fill
           {params with max_match_depth= params.max_match_depth - match_depth}
           delta sigma hf
-          (hole_name, ({gamma; goal_type; goal_dec; term_kind}, worlds))
+          (hole_name, (gen_goal, worlds))
       in
       let delta_merged = delta_new @ delta in
       let* hf', _ =

--- a/src/smyth/smyth/solve.ml
+++ b/src/smyth/smyth/solve.ml
@@ -40,14 +40,14 @@ let rec iter_solve params delta sigma (hf, us_all) =
       current_solution_count := !current_solution_count + 1 ;
       Nondet.pure (hf, delta)
   | Some ((hole_name, worlds), us) ->
-      let* gamma, typ, dec, term_kind, match_depth =
+      let* gamma, goal_type, goal_dec, term_kind, match_depth =
         Nondet.lift_option @@ List.assoc_opt hole_name delta
       in
       let* k_new, delta_new =
         Fill.fill
           {params with max_match_depth= params.max_match_depth - match_depth}
           delta sigma hf
-          (hole_name, ((gamma, typ, dec, term_kind), worlds))
+          (hole_name, ({gamma; goal_type; goal_dec; term_kind}, worlds))
       in
       let delta_merged = delta_new @ delta in
       let* k_merged =
@@ -74,7 +74,7 @@ let rec iter_solve_once_list holes params delta sigma (hf, us_all)
         current_solution_count := !current_solution_count + 1 ;
         Nondet.pure (hf, delta, us_all_init)
     | Some ((hole_name, worlds), us) ->
-        let* gamma, typ, dec, term_kind, match_depth =
+        let* gamma, goal_type, goal_dec, term_kind, match_depth =
           Nondet.lift_option @@ List.assoc_opt hole_name delta
         in
         let* k_new, delta_new =
@@ -82,7 +82,7 @@ let rec iter_solve_once_list holes params delta sigma (hf, us_all)
             { params with
               max_match_depth= params.max_match_depth - match_depth }
             delta sigma hf
-            (hole_name, ((gamma, typ, dec, term_kind), worlds))
+            (hole_name, ({gamma; goal_type; goal_dec; term_kind}, worlds))
         in
         let delta_merged = delta_new @ delta in
         let* k_merged =
@@ -98,14 +98,14 @@ let _iter_solve_once hole_name params delta sigma (hf, us_all) =
   match Constraints.delete hole_name us_all with
   | None -> failwith __LOC__
   | Some ((_, worlds), us) ->
-      let* gamma, typ, dec, term_kind, match_depth =
+      let* gamma, goal_type, goal_dec, term_kind, match_depth =
         Nondet.lift_option @@ List.assoc_opt hole_name delta
       in
       let* k_new, delta_new =
         Fill.fill
           {params with max_match_depth= params.max_match_depth - match_depth}
           delta sigma hf
-          (hole_name, ((gamma, typ, dec, term_kind), worlds))
+          (hole_name, ({gamma; goal_type; goal_dec; term_kind}, worlds))
       in
       let delta_merged = delta_new @ delta in
       let* hf', _ =

--- a/src/smyth/smyth/solve.ml
+++ b/src/smyth/smyth/solve.ml
@@ -40,14 +40,14 @@ let rec iter_solve params delta sigma (hf, us_all) =
       current_solution_count := !current_solution_count + 1 ;
       Nondet.pure (hf, delta)
   | Some ((hole_name, worlds), us) ->
-      let* gamma, typ, dec, match_depth =
+      let* gamma, typ, dec, term_kind, match_depth =
         Nondet.lift_option @@ List.assoc_opt hole_name delta
       in
       let* k_new, delta_new =
         Fill.fill
           {params with max_match_depth= params.max_match_depth - match_depth}
           delta sigma hf
-          (hole_name, ((gamma, typ, dec), worlds))
+          (hole_name, ((gamma, typ, dec, term_kind), worlds))
       in
       let delta_merged = delta_new @ delta in
       let* k_merged =
@@ -74,7 +74,7 @@ let rec iter_solve_once_list holes params delta sigma (hf, us_all)
         current_solution_count := !current_solution_count + 1 ;
         Nondet.pure (hf, delta, us_all_init)
     | Some ((hole_name, worlds), us) ->
-        let* gamma, typ, dec, match_depth =
+        let* gamma, typ, dec, term_kind, match_depth =
           Nondet.lift_option @@ List.assoc_opt hole_name delta
         in
         let* k_new, delta_new =
@@ -82,7 +82,7 @@ let rec iter_solve_once_list holes params delta sigma (hf, us_all)
             { params with
               max_match_depth= params.max_match_depth - match_depth }
             delta sigma hf
-            (hole_name, ((gamma, typ, dec), worlds))
+            (hole_name, ((gamma, typ, dec, term_kind), worlds))
         in
         let delta_merged = delta_new @ delta in
         let* k_merged =
@@ -98,14 +98,14 @@ let _iter_solve_once hole_name params delta sigma (hf, us_all) =
   match Constraints.delete hole_name us_all with
   | None -> failwith __LOC__
   | Some ((_, worlds), us) ->
-      let* gamma, typ, dec, match_depth =
+      let* gamma, typ, dec, term_kind, match_depth =
         Nondet.lift_option @@ List.assoc_opt hole_name delta
       in
       let* k_new, delta_new =
         Fill.fill
           {params with max_match_depth= params.max_match_depth - match_depth}
           delta sigma hf
-          (hole_name, ((gamma, typ, dec), worlds))
+          (hole_name, ((gamma, typ, dec, term_kind), worlds))
       in
       let delta_merged = delta_new @ delta in
       let* hf', _ =

--- a/src/smyth/smyth/solve.mli
+++ b/src/smyth/smyth/solve.mli
@@ -17,10 +17,7 @@ val solve_once :
   -> hole_ctx
   -> datatype_ctx
   -> (hole_filling * worlds hole_map) Nondet.t
-  -> ( hole_filling
-     * (hole_name * (type_ctx * typ * string option * int)) list
-     * worlds hole_map )
-     Nondet.t
+  -> (hole_filling * hole_ctx * worlds hole_map) Nondet.t
 (** [solve_once hole_name delta sigma possible_ks] tries to incrementally
     solve the constraint in [possible_ks] bound to [hole_name]. As soon as
     [solve_once] finds a solution to the named element of [possible_ks], it

--- a/src/smyth/smyth/term_gen.ml
+++ b/src/smyth/smyth/term_gen.ml
@@ -283,6 +283,9 @@ and rel_gen_e (sigma : datatype_ctx) (term_size : int)
       let* specialized_type, specialized_exp =
         instantiations sigma gamma rel_name rel_type
       in
+      let* _ =
+        Nondet.guard (match rel_bind_spec with Rec _ -> false | _ -> true)
+      in
       if
         Type.matches goal_type specialized_type
         && Type.matches_dec goal_dec rel_bind_spec

--- a/src/smyth/smyth/term_gen.ml
+++ b/src/smyth/smyth/term_gen.ml
@@ -504,12 +504,8 @@ and gen (gen_input : gen_input) : exp Nondet.t =
 let clear_cache _ = Hashtbl.reset gen_cache
 
 (* TODO: make this just up_to, because the gen_goal determines i/e *)
-let up_to_e sigma max_size goal =
+let up_to sigma max_size goal =
   List2.range ~low:1 ~high:max_size
   |> List.map (fun term_size ->
-         gen
-           { sigma
-           ; rel_binding= None
-           ; term_size
-           ; goal= {goal with term_kind= E} })
+         gen {sigma; rel_binding= None; term_size; goal})
   |> Nondet.union

--- a/src/smyth/smyth/term_gen.mli
+++ b/src/smyth/smyth/term_gen.mli
@@ -12,7 +12,7 @@
 
 open Lang
 
-val fresh_ident : type_ctx -> char -> string
+val fresh_ident : string list -> char -> string
 (** [fresh_ident gamma c] returns an identifier starting with the character
     [c] that does not appear in the type context [gamma] *)
 

--- a/src/smyth/smyth/term_gen.mli
+++ b/src/smyth/smyth/term_gen.mli
@@ -31,6 +31,6 @@ val clear_cache : unit -> unit
     [clear_cache] once synthesis is fully complete for a problem, and not any
     sooner or later! *)
 
-val up_to_e : datatype_ctx -> int -> gen_goal -> exp Nondet.t
-(** [up_to_e sigma n goal] nondeterministically generates elimination forms
-    at a goal [goal] up to (and including) AST size [n]. *)
+val up_to : datatype_ctx -> int -> gen_goal -> exp Nondet.t
+(** [up_to_e sigma n goal] nondeterministically generates terms at a goal
+    [goal] up to (and including) AST size [n]. *)

--- a/src/smyth/smyth/type.ml
+++ b/src/smyth/smyth/type.ml
@@ -283,10 +283,10 @@ let rec check' :
   | EHole name ->
       Ok
         [ ( name
-          , ( gamma
-            , tau
-            , state.function_decrease_requirement
-            , state.term_kind
+          , ( { gamma
+              ; goal_type= tau
+              ; goal_dec= state.function_decrease_requirement
+              ; term_kind= state.term_kind }
             , state.match_depth ) ) ]
   (* Nonstandard, but useful for let-bindings *)
   | EApp (_, head, EAExp (ETypeAnnotation (arg, arg_type))) ->

--- a/src/smyth/smyth/type.ml
+++ b/src/smyth/smyth/type.ml
@@ -163,8 +163,6 @@ let ctor_info :
 
 type state =
   { function_decrease_requirement: string option (* TODO: currently unused *)
-  ; term_kind: term_kind
-        (* TODO: we should know whether an expression is in E- or I-form *)
   ; match_depth: int
   ; arg_of: string option }
 
@@ -286,8 +284,10 @@ let rec check' :
           , ( { gamma
               ; idents= Type_ctx.names gamma
               ; goal_type= tau
-              ; goal_dec= state.function_decrease_requirement
-              ; term_kind= state.term_kind }
+              ; goal_dec=
+                  state.function_decrease_requirement
+                  (* TODO: figure out, if ever, we want term_kind=E *)
+              ; term_kind= I }
             , state.match_depth ) ) ]
   (* Nonstandard, but useful for let-bindings *)
   | EApp (_, head, EAExp (ETypeAnnotation (arg, arg_type))) ->
@@ -375,15 +375,7 @@ and infer' :
       (tau', delta)
 
 let check =
-  check'
-    { function_decrease_requirement= None
-    ; term_kind= I
-    ; match_depth= 0
-    ; arg_of= None }
+  check' {function_decrease_requirement= None; match_depth= 0; arg_of= None}
 
 let infer =
-  infer'
-    { function_decrease_requirement= None
-    ; term_kind= I
-    ; match_depth= 0
-    ; arg_of= None }
+  infer' {function_decrease_requirement= None; match_depth= 0; arg_of= None}

--- a/src/smyth/smyth/type.ml
+++ b/src/smyth/smyth/type.ml
@@ -163,6 +163,8 @@ let ctor_info :
 
 type state =
   { function_decrease_requirement: string option (* TODO: currently unused *)
+  ; term_kind: term_kind
+        (* TODO: we should know whether an expression is in E- or I-form *)
   ; match_depth: int
   ; arg_of: string option }
 
@@ -284,6 +286,7 @@ let rec check' :
           , ( gamma
             , tau
             , state.function_decrease_requirement
+            , state.term_kind
             , state.match_depth ) ) ]
   (* Nonstandard, but useful for let-bindings *)
   | EApp (_, head, EAExp (ETypeAnnotation (arg, arg_type))) ->
@@ -371,7 +374,15 @@ and infer' :
       (tau', delta)
 
 let check =
-  check' {function_decrease_requirement= None; match_depth= 0; arg_of= None}
+  check'
+    { function_decrease_requirement= None
+    ; term_kind= I
+    ; match_depth= 0
+    ; arg_of= None }
 
 let infer =
-  infer' {function_decrease_requirement= None; match_depth= 0; arg_of= None}
+  infer'
+    { function_decrease_requirement= None
+    ; term_kind= I
+    ; match_depth= 0
+    ; arg_of= None }

--- a/src/smyth/smyth/type.ml
+++ b/src/smyth/smyth/type.ml
@@ -284,6 +284,7 @@ let rec check' :
       Ok
         [ ( name
           , ( { gamma
+              ; idents= Type_ctx.names gamma
               ; goal_type= tau
               ; goal_dec= state.function_decrease_requirement
               ; term_kind= state.term_kind }

--- a/src/smyth/smyth/uneval.ml
+++ b/src/smyth/smyth/uneval.ml
@@ -34,12 +34,12 @@ module FuelLimited = struct
     let guesses (delta : hole_ctx) (sigma : datatype_ctx) (res : res) :
         hole_filling Nondet.t =
       let* hole_name = Nondet.lift_option @@ blocking_hole res in
-      let* gamma, goal_type, goal_dec, term_kind, _ =
+      let* gen_goal, _ =
         Nondet.lift_option @@ List.assoc_opt hole_name delta
       in
       Nondet.map
         (Hole_map.singleton hole_name)
-        (Term_gen.up_to_e sigma 1 {gamma; goal_type; goal_dec; term_kind})
+        (Term_gen.up_to_e sigma 1 gen_goal)
     in
     let* _ = Nondet.guard (fuel > 0) in
     match (res, ex) with

--- a/src/smyth/smyth/uneval.ml
+++ b/src/smyth/smyth/uneval.ml
@@ -39,7 +39,8 @@ module FuelLimited = struct
       in
       Nondet.map
         (Hole_map.singleton hole_name)
-        (Term_gen.up_to_e sigma 1 gen_goal)
+        (Term_gen.up_to sigma 1 {gen_goal with term_kind= E})
+      (* TODO: can we remove term_kind=E? *)
     in
     let* _ = Nondet.guard (fuel > 0) in
     match (res, ex) with

--- a/src/smyth/smyth/uneval.ml
+++ b/src/smyth/smyth/uneval.ml
@@ -34,12 +34,12 @@ module FuelLimited = struct
     let guesses (delta : hole_ctx) (sigma : datatype_ctx) (res : res) :
         hole_filling Nondet.t =
       let* hole_name = Nondet.lift_option @@ blocking_hole res in
-      let* gamma, tau, dec, _ =
+      let* gamma, tau, dec, term_kind, _ =
         Nondet.lift_option @@ List.assoc_opt hole_name delta
       in
       Nondet.map
         (Hole_map.singleton hole_name)
-        (Term_gen.up_to_e sigma 1 (gamma, tau, dec))
+        (Term_gen.up_to_e sigma 1 (gamma, tau, dec, term_kind))
     in
     let* _ = Nondet.guard (fuel > 0) in
     match (res, ex) with

--- a/src/smyth/smyth/uneval.ml
+++ b/src/smyth/smyth/uneval.ml
@@ -121,6 +121,7 @@ module FuelLimited = struct
         uneval fuel delta sigma hf arg (ExCtor (name, ex))
     | _ ->
         Log.warn "Mistyped uneval" ;
+        (* print_endline ("mistyped: " ^ Pretty.res res) ; *)
         Nondet.none
 
   and simplify_assertions fuel delta sigma rcs =

--- a/src/smyth/smyth/uneval.ml
+++ b/src/smyth/smyth/uneval.ml
@@ -34,12 +34,12 @@ module FuelLimited = struct
     let guesses (delta : hole_ctx) (sigma : datatype_ctx) (res : res) :
         hole_filling Nondet.t =
       let* hole_name = Nondet.lift_option @@ blocking_hole res in
-      let* gamma, tau, dec, term_kind, _ =
+      let* gamma, goal_type, goal_dec, term_kind, _ =
         Nondet.lift_option @@ List.assoc_opt hole_name delta
       in
       Nondet.map
         (Hole_map.singleton hole_name)
-        (Term_gen.up_to_e sigma 1 (gamma, tau, dec, term_kind))
+        (Term_gen.up_to_e sigma 1 {gamma; goal_type; goal_dec; term_kind})
     in
     let* _ = Nondet.guard (fuel > 0) in
     match (res, ex) with

--- a/src/smyth/smyth/uneval.ml
+++ b/src/smyth/smyth/uneval.ml
@@ -39,8 +39,9 @@ module FuelLimited = struct
       in
       Nondet.map
         (Hole_map.singleton hole_name)
-        (Term_gen.up_to sigma 1 {gen_goal with term_kind= E})
-      (* TODO: can we remove term_kind=E? *)
+        (Term_gen.up_to sigma 2 gen_goal)
+      (* TODO: what size is reasonable? >=2 is needed for generating nullary
+         constructors *)
     in
     let* _ = Nondet.guard (fuel > 0) in
     match (res, ex) with


### PR DESCRIPTION
Currently, smyth is not entirely sketch-sensitive: the synthesizer keeps track of some state, which is not entirely recoverable from a sketch. This means that, even though a sketch is an intermediate step towards a solution, the synthesizer might not find that solution when starting from that sketch, because it lacks the relevant state.
A solution to this problem is to use the same state during type checking and store it in the holes so that its available to the synthesizer.

Ideally, the synthesizer should be monotone in the sense that adding more relevant information should not hamper the synthesis. It is not clear whether this is possible or general. More assertions could lead to timeouts and some intermediate states are nonsensical (e.g. `?? ??`).