### PR TITLE
Enrich monad implementation for more reuse

### DIFF
--- a/src/hazelcore/ActionOutcome.re
+++ b/src/hazelcore/ActionOutcome.re
@@ -1,28 +1,5 @@
-module T = {
-  [@deriving sexp]
-  type t('success) =
-    | Succeeded('success)
-    | CursorEscaped(Side.t)
-    | Failed;
-
-  let map =
-    `Custom(
-      (x, f) =>
-        switch (x) {
-        | Succeeded(a) => Succeeded(f(a))
-        | CursorEscaped(s) => CursorEscaped(s)
-        | Failed => Failed
-        },
-    );
-
-  let bind = (x, f) =>
-    switch (x) {
-    | Succeeded(a) => f(a)
-    | CursorEscaped(s) => CursorEscaped(s)
-    | Failed => Failed
-    };
-
-  let return = a => Succeeded(a);
-};
-include T;
-include Monads.Make(T);
+[@deriving sexp]
+type t('success) =
+  | Succeeded('success)
+  | CursorEscaped(Side.t)
+  | Failed;

--- a/src/hazelcore/ActionOutcome.re
+++ b/src/hazelcore/ActionOutcome.re
@@ -1,4 +1,28 @@
-type t('success) =
-  | Succeeded('success)
-  | CursorEscaped(Side.t)
-  | Failed;
+module T = {
+  [@deriving sexp]
+  type t('success) =
+    | Succeeded('success)
+    | CursorEscaped(Side.t)
+    | Failed;
+
+  let map =
+    `Custom(
+      (x, f) =>
+        switch (x) {
+        | Succeeded(a) => Succeeded(f(a))
+        | CursorEscaped(s) => CursorEscaped(s)
+        | Failed => Failed
+        },
+    );
+
+  let bind = (x, f) =>
+    switch (x) {
+    | Succeeded(a) => f(a)
+    | CursorEscaped(s) => CursorEscaped(s)
+    | Failed => Failed
+    };
+
+  let return = a => Succeeded(a);
+};
+include T;
+include Monads.Make(T);

--- a/src/hazelcore/ActionOutcome.rei
+++ b/src/hazelcore/ActionOutcome.rei
@@ -3,5 +3,3 @@ type t('success) =
   | Succeeded('success)
   | CursorEscaped(Side.t)
   | Failed;
-
-include Monads.MONAD with type t('a) := t('a);

--- a/src/hazelcore/ActionOutcome.rei
+++ b/src/hazelcore/ActionOutcome.rei
@@ -1,4 +1,7 @@
+[@deriving sexp]
 type t('success) =
   | Succeeded('success)
   | CursorEscaped(Side.t)
   | Failed;
+
+include Monads.MONAD with type t('a) := t('a);

--- a/src/hazelcore/Monads.re
+++ b/src/hazelcore/Monads.re
@@ -7,7 +7,6 @@
    In any case, that's a good reference. */
 
 module type MONAD_BASIC = {
-  [@deriving sexp]
   type t('a);
   let return: 'a => t('a);
   let bind: (t('a), 'a => t('b)) => t('b);

--- a/src/hazelcore/Monads.re
+++ b/src/hazelcore/Monads.re
@@ -6,9 +6,39 @@
 
    In any case, that's a good reference. */
 
-module type MONAD = {
+module type MONAD_BASIC = {
   [@deriving sexp]
   type t('a);
   let return: 'a => t('a);
   let bind: (t('a), 'a => t('b)) => t('b);
+  let map: [ | `Define_using_bind | `Custom((t('a), 'a => 'b) => t('b))];
+};
+
+module type MONAD = {
+  include MONAD_BASIC;
+  let map: (t('a), 'a => 'b) => t('b);
+  let zip: (t('a), t('b)) => t(('a, 'b));
+  module Syntax: {
+    let ( let* ): (t('a), 'a => t('b)) => t('b);
+    let (let+): (t('a), 'a => 'b) => t('b);
+    let (and+): (t('a), t('b)) => t(('a, 'b));
+  };
+};
+
+module Make = (M: MONAD_BASIC) => {
+  include M;
+
+  let map = (x, f) =>
+    switch (M.map) {
+    | `Define_using_bind => bind(x, a => M.return(f(a)))
+    | `Custom(mapper) => mapper(x, f)
+    };
+
+  let zip = (x, y) => bind(x, a => bind(y, b => M.return((a, b))));
+
+  module Syntax = {
+    let ( let* ) = bind;
+    let (let+) = map;
+    let (and+) = zip;
+  };
 };

--- a/src/hazelcore/Monads.re
+++ b/src/hazelcore/Monads.re
@@ -6,11 +6,17 @@
 
    In any case, that's a good reference. */
 
+module MapDefinition = {
+  type t('custom) =
+    | Define_using_bind
+    | Custom('custom);
+};
+
 module type MONAD_BASIC = {
   type t('a);
   let return: 'a => t('a);
   let bind: (t('a), 'a => t('b)) => t('b);
-  let map: [ | `Define_using_bind | `Custom((t('a), 'a => 'b) => t('b))];
+  let map: MapDefinition.t((t('a), 'a => 'b) => t('b));
 };
 
 module type MONAD = {
@@ -29,8 +35,8 @@ module Make = (M: MONAD_BASIC) => {
 
   let map = (x, f) =>
     switch (M.map) {
-    | `Define_using_bind => bind(x, a => M.return(f(a)))
-    | `Custom(mapper) => mapper(x, f)
+    | Define_using_bind => bind(x, a => M.return(f(a)))
+    | Custom(mapper) => mapper(x, f)
     };
 
   let zip = (x, y) => bind(x, a => bind(y, b => M.return((a, b))));

--- a/src/hazelcore/Monads.rei
+++ b/src/hazelcore/Monads.rei
@@ -1,11 +1,17 @@
 /* Inspired by Jane Street's Monad:
  * https://ocaml.janestreet.com/ocaml-core/v0.13/doc/base/Base__/Monad_intf/index.html */
 
+module MapDefinition: {
+  type t('custom) =
+    | Define_using_bind
+    | Custom('custom);
+};
+
 module type MONAD_BASIC = {
   type t('a);
   let return: 'a => t('a);
   let bind: (t('a), 'a => t('b)) => t('b);
-  let map: [ | `Define_using_bind | `Custom((t('a), 'a => 'b) => t('b))];
+  let map: MapDefinition.t((t('a), 'a => 'b) => t('b));
 };
 
 // Use `includ Monads.Make` with a MONAD_BASIC to get a MONAD

--- a/src/hazelcore/Monads.rei
+++ b/src/hazelcore/Monads.rei
@@ -2,7 +2,6 @@
  * https://ocaml.janestreet.com/ocaml-core/v0.13/doc/base/Base__/Monad_intf/index.html */
 
 module type MONAD_BASIC = {
-  [@deriving sexp]
   type t('a);
   let return: 'a => t('a);
   let bind: (t('a), 'a => t('b)) => t('b);

--- a/src/hazelcore/palettes/SpliceGenMonad.re
+++ b/src/hazelcore/palettes/SpliceGenMonad.re
@@ -1,10 +1,15 @@
-[@deriving sexp]
-type t('a) = SpliceInfo.t(UHExp.t) => ('a, SpliceInfo.t(UHExp.t));
-let return = (x, psi) => (x, psi);
-let bind = (cmd, f, psi) => {
-  let (a, psi') = cmd(psi);
-  f(a, psi');
+module T = {
+  [@deriving sexp]
+  type t('a) = SpliceInfo.t(UHExp.t) => ('a, SpliceInfo.t(UHExp.t));
+  let return = (x, psi) => (x, psi);
+  let bind = (cmd, f, psi) => {
+    let (a, psi') = cmd(psi);
+    f(a, psi');
+  };
+  let map = `Define_using_bind;
 };
+include T;
+include Monads.Make(T);
 
 let exec = (cmd, psi, u_gen) => {
   let (a, psi) = cmd(psi);

--- a/src/hazelcore/palettes/SpliceGenMonad.re
+++ b/src/hazelcore/palettes/SpliceGenMonad.re
@@ -6,7 +6,7 @@ module T = {
     let (a, psi') = cmd(psi);
     f(a, psi');
   };
-  let map = `Define_using_bind;
+  let map = Monads.MapDefinition.Define_using_bind;
 };
 include T;
 include Monads.Make(T);

--- a/src/hazelcore/palettes/SpliceGenMonad.rei
+++ b/src/hazelcore/palettes/SpliceGenMonad.rei
@@ -1,4 +1,7 @@
-include Monads.MONAD;
+[@deriving sexp]
+type t('a);
+
+include Monads.MONAD with type t('a) := t('a);
 
 let exec:
   (t('a), SpliceInfo.t(UHExp.t), MetaVarGen.t) =>

--- a/src/hazelcore/util/OptUtil.re
+++ b/src/hazelcore/util/OptUtil.re
@@ -3,7 +3,7 @@ open Sexplib.Conv;
 module T = {
   [@deriving sexp]
   type t('a) = option('a);
-  let map = `Custom((x, f) => Option.map(f, x));
+  let map = Monads.MapDefinition.Custom((x, f) => Option.map(f, x));
   let bind = Option.bind;
   let return = x => Some(x);
 };

--- a/src/hazelcore/util/OptUtil.re
+++ b/src/hazelcore/util/OptUtil.re
@@ -1,3 +1,13 @@
+open Sexplib.Conv;
+
+include Monads.Make({
+  [@deriving sexp]
+  type t('a) = option('a);
+  let map = `Custom((x, f) => Option.map(f, x));
+  let bind = Option.bind;
+  let return = x => Some(x);
+});
+
 let map2 =
     (f: ('a, 'b) => 'c, opt1: option('a), opt2: option('b)): option('c) =>
   switch (opt1, opt2) {
@@ -14,15 +24,3 @@ let get = (if_absent: unit => 'a, opt: option('a)): 'a =>
 
 let sequence = (l: list(option('a))): option(list('a)) =>
   List.fold_right(map2((x, xs) => [x, ...xs]), l, Some([]));
-
-let product = (o1, o2) =>
-  switch (o1, o2) {
-  | (Some(x), Some(y)) => Some((x, y))
-  | _ => None
-  };
-
-module Syntax = {
-  let ( let* ) = Option.bind;
-  let (let+) = (o, f) => Option.map(f, o);
-  let (and+) = product;
-};

--- a/src/hazelcore/util/OptUtil.re
+++ b/src/hazelcore/util/OptUtil.re
@@ -1,12 +1,14 @@
 open Sexplib.Conv;
 
-include Monads.Make({
+module T = {
   [@deriving sexp]
   type t('a) = option('a);
   let map = `Custom((x, f) => Option.map(f, x));
   let bind = Option.bind;
   let return = x => Some(x);
-});
+};
+include T;
+include Monads.Make(T);
 
 let map2 =
     (f: ('a, 'b) => 'c, opt1: option('a), opt2: option('b)): option('c) =>

--- a/src/hazelcore/util/OptUtil.rei
+++ b/src/hazelcore/util/OptUtil.rei
@@ -1,11 +1,7 @@
+include Monads.MONAD with type t('a) := option('a);
+
 let map2: (('a, 'b) => 'c, option('a), option('b)) => option('c);
 
 let get: (unit => 'a, option('a)) => 'a;
 
 let sequence: list(option('a)) => option(list('a));
-
-module Syntax: {
-  let ( let* ): (option('a), 'a => option('b)) => option('b);
-  let (let+): (option('a), 'a => 'b) => option('b);
-  let (and+): (option('a), option('b)) => option(('a, 'b));
-};


### PR DESCRIPTION
I converted existing monads and added one for ActionOutcome. This
formation is similar to the one used in Jane Street's Base library.

The Make functor derives everything you'd want (syntax, extra
functions) based on a basic monad definition.