### PR TITLE
fix hole ordering bug

### DIFF
--- a/src/hazelcore/CursorPath_Exp.re
+++ b/src/hazelcore/CursorPath_Exp.re
@@ -608,8 +608,8 @@ and holes_zoperand =
   | CursorE(OnDelim(k, _), Parenthesized(body)) =>
     let body_holes = holes(body, [0, ...rev_steps], []);
     switch (k) {
-    | 0 => CursorPath_common.mk_zholes(~holes_before=body_holes, ())
-    | 1 => CursorPath_common.mk_zholes(~holes_after=body_holes, ())
+    | 0 => CursorPath_common.mk_zholes(~holes_after=body_holes, ())
+    | 1 => CursorPath_common.mk_zholes(~holes_before=body_holes, ())
     | _ => CursorPath_common.no_holes
     };
   | CursorE(OnDelim(k, _), Inj(err, _, body)) =>


### PR DESCRIPTION
Fixed bug in CursorE(OnDelim(k,_), Parenthesized(body)) case so that holes_after DelimIndex 0 is body_holes and holes_before DelimIndex 1 is body_holes