### PR TITLE
update VS Code instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ that you know the OCaml syntax for.
 Most of our team uses VisualStudio Code to write code.  If you use VS Code, here
 are a few extensions that might be helpful.
 
-- This extension provides full support for editing ReasonML source code and relevant tools:
+- This extension provides full support for editing ReasonML source code and
+  relevant tools:
 
   - [ocaml-platform](https://github.com/ocamllabs/vscode-ocaml-platform)
 
@@ -71,6 +72,16 @@ are a few extensions that might be helpful.
   - [Bracket Pair Colorizer 2](https://marketplace.visualstudio.com/items?itemName=coenraads.bracket-pair-colorizer-2)
   - [Indenticator](https://marketplace.visualstudio.com/items?itemName=sirtori.indenticator)
   - [indent-rainbow](https://marketplace.visualstudio.com/items?itemName=oderwat.indent-rainbow)
+
+In addition to these extensions, enabling the breadcrumbs bar can make
+navigating a large code base easier. There are multiple ways to make the
+breadcrumbs bar visible:
+
+- Click **View** / **Show Breadcrumbs** from the menu bar.
+- Press `Ctrl+Shift+P` (macOS: `Cmd+Shift+P`), start typing `breadcrumbs`, and
+  select `View: Toggle Breadcrumbs` from the dropdown menu to toggle breadcrumbs
+  on and off.
+- Press `Ctrl+Shift+.` to start breadcrumbs navigation.
 
 ### Build System Details
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,9 @@ that you know the OCaml syntax for.
 Most of our team uses VisualStudio Code to write code.  If you use VS Code, here
 are a few extensions that might be helpful.
 
-- These extensions provide support for editing ReasonML and Dune source code:
+- This extension provides full support for editing ReasonML source code and relevant tools:
 
-  - [reason-vscode](https://marketplace.visualstudio.com/items?itemName=jaredly.reason-vscode)
-  - [Dune](https://marketplace.visualstudio.com/items?itemName=maelvalais.dune)
+  - [ocaml-platform](https://github.com/ocamllabs/vscode-ocaml-platform)
 
 - Due to Reason's poor parse errors, unbalanced parentheses can be difficult
   to find.  The following extensions help with that.


### PR DESCRIPTION
Switches the VS Code recommended extension for ReasonML to ocaml-platform, and adds instructions for enabling breadcrumbs.