### PR TITLE
Refactor KeyComboAction.get to use a switch expression instead of a hashtable

### DIFF
--- a/src/hazelweb/gui/ActionPanel.re
+++ b/src/hazelweb/gui/ActionPanel.re
@@ -165,8 +165,20 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject, is_mac) => {
     sub_panel(title, children);
   };
 
+  let action_of_combo = combo =>
+    switch (KeyComboAction.get_model_action(cursor_info, combo, is_mac)) {
+    | Some(EditAction(action)) => action
+    | _ =>
+      failwith(
+        __LOC__
+        ++ ": "
+        ++ (combo |> HazelKeyCombos.get_details |> KeyCombo.name)
+        ++ " does not correspond to an EditAction in KeyComboAction.get_model_action",
+      )
+    };
+
   let combo_element = (is_allowed_action, combo, description) => {
-    let action = KeyComboAction.get_action(cursor_info, combo, is_mac);
+    let action = action_of_combo(combo);
     action_button(
       is_allowed_action,
       inject,
@@ -204,7 +216,7 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject, is_mac) => {
     let actions =
       List.map(
         combo => {
-          let action = KeyComboAction.get_action(cursor_info, combo, is_mac);
+          let action = action_of_combo(combo);
           (HazelKeyCombos.get_details(combo), action);
         },
         combos,
@@ -214,7 +226,7 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject, is_mac) => {
   };
 
   let keyboard_button = combo => {
-    let action = KeyComboAction.get_action(cursor_info, combo, is_mac);
+    let action = action_of_combo(combo);
     let combo = HazelKeyCombos.get_details(combo);
     keyboard_button(is_action_allowed, ~inject, ~combo, ~action);
   };

--- a/src/hazelweb/gui/ActionPanel.re
+++ b/src/hazelweb/gui/ActionPanel.re
@@ -166,7 +166,7 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject) => {
   };
 
   let combo_element = (is_allowed_action, combo, description) => {
-    let action = KeyComboAction.get(cursor_info, combo);
+    let action = KeyComboAction.get_action(cursor_info, combo);
     action_button(
       is_allowed_action,
       inject,
@@ -204,7 +204,7 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject) => {
     let actions =
       List.map(
         combo => {
-          let action = KeyComboAction.get(cursor_info, combo);
+          let action = KeyComboAction.get_action(cursor_info, combo);
           (HazelKeyCombos.get_details(combo), action);
         },
         combos,
@@ -214,7 +214,7 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject) => {
   };
 
   let keyboard_button = combo => {
-    let action = KeyComboAction.get(cursor_info, combo);
+    let action = KeyComboAction.get_action(cursor_info, combo);
     let combo = HazelKeyCombos.get_details(combo);
     keyboard_button(is_action_allowed, ~inject, ~combo, ~action);
   };

--- a/src/hazelweb/gui/ActionPanel.re
+++ b/src/hazelweb/gui/ActionPanel.re
@@ -157,7 +157,7 @@ let action_list =
   );
 };
 
-let generate_panel_body = (is_action_allowed, cursor_info, inject) => {
+let generate_panel_body = (is_action_allowed, cursor_info, inject, is_mac) => {
   let text = Node.text;
   let simple = desc => [Node.text(desc)];
 
@@ -166,7 +166,7 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject) => {
   };
 
   let combo_element = (is_allowed_action, combo, description) => {
-    let action = KeyComboAction.get_action(cursor_info, combo);
+    let action = KeyComboAction.get_action(cursor_info, combo, is_mac);
     action_button(
       is_allowed_action,
       inject,
@@ -204,7 +204,7 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject) => {
     let actions =
       List.map(
         combo => {
-          let action = KeyComboAction.get_action(cursor_info, combo);
+          let action = KeyComboAction.get_action(cursor_info, combo, is_mac);
           (HazelKeyCombos.get_details(combo), action);
         },
         combos,
@@ -214,7 +214,7 @@ let generate_panel_body = (is_action_allowed, cursor_info, inject) => {
   };
 
   let keyboard_button = combo => {
-    let action = KeyComboAction.get_action(cursor_info, combo);
+    let action = KeyComboAction.get_action(cursor_info, combo, is_mac);
     let combo = HazelKeyCombos.get_details(combo);
     keyboard_button(is_action_allowed, ~inject, ~combo, ~action);
   };
@@ -432,7 +432,8 @@ let view = (~inject: ModelAction.t => Event.t, model: Model.t) => {
     };
   };
 
-  let body = generate_panel_body(is_action_allowed, cursor_info, inject);
+  let body =
+    generate_panel_body(is_action_allowed, cursor_info, inject, model.is_mac);
 
   action_panel(body);
 };

--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -1,5 +1,5 @@
 let get_model_action =
-    (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t, is_mac: bool)
+    (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t, is_mac: option(bool))
     : option(ModelAction.t) =>
   switch (kc, cursor_info, is_mac) {
   | (Escape, _, _) => None
@@ -35,24 +35,27 @@ let get_model_action =
   | (Alt_R, _, _) => Some(EditAction(Construct(SInj(R))))
   | (Alt_C, _, _) => Some(EditAction(Construct(SCase)))
   | (Pound, _, _) => Some(EditAction(Construct(SCommentLine)))
-  | (Ctrl_Z, _, true) => None
-  | (Ctrl_Z, _, false) => Some(Undo)
-  | (Ctrl_Shift_Z, _, true) => None
-  | (Ctrl_Shift_Z, _, false) => Some(Redo)
+  | (Ctrl_Z, _, Some(true)) => None
+  | (Ctrl_Z, _, Some(false)) => Some(Undo)
+  | (Ctrl_Z, _, None) => None
+  | (Ctrl_Shift_Z, _, Some(true)) => None
+  | (Ctrl_Shift_Z, _, Some(false)) => Some(Redo)
+  | (Ctrl_Shift_Z, _, None) => None
   | (Ctrl_Alt_I, _, _) => Some(EditAction(SwapUp))
   | (Ctrl_Alt_K, _, _) => Some(EditAction(SwapDown))
   | (Ctrl_Alt_J, _, _) => Some(EditAction(SwapLeft))
   | (Ctrl_Alt_L, _, _) => Some(EditAction(SwapRight))
-  | (Meta_Z, _, true) => Some(Undo)
-  | (Meta_Z, _, false) => None
-  | (Meta_Shift_Z, _, true) => Some(Redo)
-  | (Meta_Shift_Z, _, false) => None
+  | (Meta_Z, _, Some(true)) => Some(Undo)
+  | (Meta_Z, _, Some(false)) => None
+  | (Meta_Z, _, None) => None
+  | (Meta_Shift_Z, _, Some(true)) => Some(Redo)
+  | (Meta_Shift_Z, _, Some(false)) => None
+  | (Meta_Shift_Z, _, None) => None
   };
 
 let get_action =
     (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t): option(Action.t) =>
-  // is_mac shouldn't matter here, so we'll just have it be false
-  switch (get_model_action(cursor_info, kc, false)) {
+  switch (get_model_action(cursor_info, kc, None)) {
   | Some(EditAction(action)) => Some(action)
   | _ => None
   };

--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -50,9 +50,9 @@ let get_model_action =
   };
 
 let get_action =
-    (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t): option(Action.t) =>
-  // is_mac shouldn't matter here, so we'll just have it be false
-  switch (get_model_action(cursor_info, kc, false)) {
+    (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t, is_mac: bool)
+    : option(Action.t) =>
+  switch (get_model_action(cursor_info, kc, is_mac)) {
   | Some(EditAction(action)) => Some(action)
   | _ => None
   };

--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -1,42 +1,50 @@
-let get = (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t): option(Action.t) =>
-  switch (kc, cursor_info) {
-  | (Escape, _) => None
-  | (Backspace, _) => Some(Backspace)
-  | (Delete, _) => Some(Delete)
-  | (ShiftTab, _) => Some(MoveToPrevHole)
-  | (Tab, _) => Some(MoveToNextHole)
-  | (GT, {CursorInfo.typed: OnType, _}) => Some(Construct(SOp(SArrow)))
-  | (GT, _) => Some(Construct(SOp(SGreaterThan)))
-  | (Ampersand, _) => Some(Construct(SOp(SAnd)))
-  | (VBar, _) => Some(Construct(SOp(SOr)))
-  | (LeftParen, _) => Some(Construct(SParenthesized))
-  | (Colon, _) => Some(Construct(SAnn))
-  | (Equals, _) => Some(Construct(SOp(SEquals)))
-  | (Enter, _) => Some(Construct(SLine))
-  | (Shift_Enter, _) => Some(Construct(SCommentLine))
-  | (Backslash, _) => Some(Construct(SLam))
-  | (Plus, _) => Some(Construct(SOp(SPlus)))
-  | (Minus, _) => Some(Construct(SOp(SMinus)))
-  | (Asterisk, _) => Some(Construct(SOp(STimes)))
-  | (Slash, _) => Some(Construct(SOp(SDivide)))
-  | (LT, _) => Some(Construct(SOp(SLessThan)))
-  | (Space, {CursorInfo.cursor_term: Line(_, CommentLine(_)), _}) =>
-    Some(Construct(SChar(" ")))
-  | (Space, _) => Some(Construct(SOp(SSpace)))
-  | (Comma, _) => Some(Construct(SOp(SComma)))
-  | (LeftBracket, {CursorInfo.typed: OnType, _}) => Some(Construct(SList))
-  | (LeftBracket, _) => Some(Construct(SListNil))
-  | (Semicolon, _) => Some(Construct(SOp(SCons)))
-  | (Alt_L, _) => Some(Construct(SInj(L)))
-  | (Alt_R, _) => Some(Construct(SInj(R)))
-  | (Alt_C, _) => Some(Construct(SCase))
-  | (Pound, _) => Some(Construct(SCommentLine))
-  | (Ctrl_Z, _) => None
-  | (Ctrl_Shift_Z, _) => None
-  | (Ctrl_Alt_I, _) => Some(SwapUp)
-  | (Ctrl_Alt_K, _) => Some(SwapDown)
-  | (Ctrl_Alt_J, _) => Some(SwapLeft)
-  | (Ctrl_Alt_L, _) => Some(SwapRight)
-  | (Meta_Z, _) => None
-  | (Meta_Shift_Z, _) => None
+let get =
+    (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t, is_mac: bool)
+    : option(ModelAction.t) =>
+  switch (kc, cursor_info, is_mac) {
+  | (Escape, _, _) => None
+  | (Backspace, _, _) => Some(EditAction(Backspace))
+  | (Delete, _, _) => Some(EditAction(Delete))
+  | (ShiftTab, _, _) => Some(EditAction(MoveToPrevHole))
+  | (Tab, _, _) => Some(EditAction(MoveToNextHole))
+  | (GT, {CursorInfo.typed: OnType, _}, _) =>
+    Some(EditAction(Construct(SOp(SArrow))))
+  | (GT, _, _) => Some(EditAction(Construct(SOp(SGreaterThan))))
+  | (Ampersand, _, _) => Some(EditAction(Construct(SOp(SAnd))))
+  | (VBar, _, _) => Some(EditAction(Construct(SOp(SOr))))
+  | (LeftParen, _, _) => Some(EditAction(Construct(SParenthesized)))
+  | (Colon, _, _) => Some(EditAction(Construct(SAnn)))
+  | (Equals, _, _) => Some(EditAction(Construct(SOp(SEquals))))
+  | (Enter, _, _) => Some(EditAction(Construct(SLine)))
+  | (Shift_Enter, _, _) => Some(EditAction(Construct(SCommentLine)))
+  | (Backslash, _, _) => Some(EditAction(Construct(SLam)))
+  | (Plus, _, _) => Some(EditAction(Construct(SOp(SPlus))))
+  | (Minus, _, _) => Some(EditAction(Construct(SOp(SMinus))))
+  | (Asterisk, _, _) => Some(EditAction(Construct(SOp(STimes))))
+  | (Slash, _, _) => Some(EditAction(Construct(SOp(SDivide))))
+  | (LT, _, _) => Some(EditAction(Construct(SOp(SLessThan))))
+  | (Space, {CursorInfo.cursor_term: Line(_, CommentLine(_)), _}, _) =>
+    Some(EditAction(Construct(SChar(" "))))
+  | (Space, _, _) => Some(EditAction(Construct(SOp(SSpace))))
+  | (Comma, _, _) => Some(EditAction(Construct(SOp(SComma))))
+  | (LeftBracket, {CursorInfo.typed: OnType, _}, _) =>
+    Some(EditAction(Construct(SList)))
+  | (LeftBracket, _, _) => Some(EditAction(Construct(SListNil)))
+  | (Semicolon, _, _) => Some(EditAction(Construct(SOp(SCons))))
+  | (Alt_L, _, _) => Some(EditAction(Construct(SInj(L))))
+  | (Alt_R, _, _) => Some(EditAction(Construct(SInj(R))))
+  | (Alt_C, _, _) => Some(EditAction(Construct(SCase)))
+  | (Pound, _, _) => Some(EditAction(Construct(SCommentLine)))
+  | (Ctrl_Z, _, true) => None
+  | (Ctrl_Z, _, false) => Some(Undo)
+  | (Ctrl_Shift_Z, _, true) => None
+  | (Ctrl_Shift_Z, _, false) => Some(Redo)
+  | (Ctrl_Alt_I, _, _) => Some(EditAction(SwapUp))
+  | (Ctrl_Alt_K, _, _) => Some(EditAction(SwapDown))
+  | (Ctrl_Alt_J, _, _) => Some(EditAction(SwapLeft))
+  | (Ctrl_Alt_L, _, _) => Some(EditAction(SwapRight))
+  | (Meta_Z, _, true) => Some(Undo)
+  | (Meta_Z, _, false) => None
+  | (Meta_Shift_Z, _, true) => Some(Redo)
+  | (Meta_Shift_Z, _, false) => None
   };

--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -1,4 +1,4 @@
-let get =
+let get_model_action =
     (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t, is_mac: bool)
     : option(ModelAction.t) =>
   switch (kc, cursor_info, is_mac) {
@@ -47,4 +47,12 @@ let get =
   | (Meta_Z, _, false) => None
   | (Meta_Shift_Z, _, true) => Some(Redo)
   | (Meta_Shift_Z, _, false) => None
+  };
+
+let get_action =
+    (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t): option(Action.t) =>
+  // is_mac shouldn't matter here, so we'll just have it be false
+  switch (get_model_action(cursor_info, kc, false)) {
+  | Some(EditAction(action)) => Some(action)
+  | _ => None
   };

--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -1,56 +1,54 @@
-let table: Hashtbl.t(HazelKeyCombos.t, CursorInfo.t => Action.t) =
-  [
-    (HazelKeyCombos.Backspace, _ => Action.Backspace),
-    (Delete, _ => Delete),
-    (ShiftTab, _ => MoveToPrevHole),
-    (Tab, _ => MoveToNextHole),
-    (
-      GT,
-      fun
-      | {CursorInfo.typed: OnType, _} => Construct(SOp(SArrow))
-      | _ => Construct(SOp(SGreaterThan)),
-    ),
-    (Ampersand, _ => Construct(SOp(SAnd))),
-    (VBar, _ => Construct(SOp(SOr))),
-    (LeftParen, _ => Construct(SParenthesized)),
-    (Colon, _ => Construct(SAnn)),
-    (Equals, _ => Construct(SOp(SEquals))),
-    (Enter, _ => Construct(SLine)),
-    (Backslash, _ => Construct(SLam)),
-    (Plus, _ => Construct(SOp(SPlus))),
-    (Minus, _ => Construct(SOp(SMinus))),
-    (Asterisk, _ => Construct(SOp(STimes))),
-    (Slash, _ => Construct(SOp(SDivide))),
-    (LT, _ => Construct(SOp(SLessThan))),
-    (
-      Space,
-      fun
-      | {CursorInfo.cursor_term: Line(_, CommentLine(_)), _} =>
-        Construct(SChar(" "))
-      | _ => Construct(SOp(SSpace)),
-    ),
-    (Comma, _ => Construct(SOp(SComma))),
-    (
-      LeftBracket,
-      fun
-      | {CursorInfo.typed: OnType, _} => Construct(SList)
-      | _ => Construct(SListNil),
-    ),
-    (Semicolon, _ => Construct(SOp(SCons))),
-    (Alt_L, _ => Construct(SInj(L))),
-    (Alt_R, _ => Construct(SInj(R))),
-    (Alt_C, _ => Construct(SCase)),
-    (Pound, _ => Construct(SCommentLine)),
-    (Shift_Enter, _ => Construct(SCommentLine)),
-    (Ctrl_Alt_I, _ => SwapUp),
-    (Ctrl_Alt_K, _ => SwapDown),
-    (Ctrl_Alt_J, _ => SwapLeft),
-    (Ctrl_Alt_L, _ => SwapRight),
-  ]
-  |> List.to_seq
-  |> Hashtbl.of_seq;
-
 let get = (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t): Action.t => {
-  let action_of_ci = Hashtbl.find(table, kc);
+  let action_of_ci: CursorInfo.t => Action.t =
+    switch (kc) {
+    | Escape => raise(Not_found)
+    | Backspace => (_ => Backspace)
+    | Delete => (_ => Delete)
+    | ShiftTab => (_ => MoveToPrevHole)
+    | Tab => (_ => MoveToNextHole)
+    | GT => (
+        fun
+        | {CursorInfo.typed: OnType, _} => Construct(SOp(SArrow))
+        | _ => Construct(SOp(SGreaterThan))
+      )
+    | Ampersand => (_ => Construct(SOp(SAnd)))
+    | VBar => (_ => Construct(SOp(SOr)))
+    | LeftParen => (_ => Construct(SParenthesized))
+    | Colon => (_ => Construct(SAnn))
+    | Equals => (_ => Construct(SOp(SEquals)))
+    | Enter => (_ => Construct(SLine))
+    | Shift_Enter => (_ => Construct(SCommentLine))
+    | Backslash => (_ => Construct(SLam))
+    | Plus => (_ => Construct(SOp(SPlus)))
+    | Minus => (_ => Construct(SOp(SMinus)))
+    | Asterisk => (_ => Construct(SOp(STimes)))
+    | Slash => (_ => Construct(SOp(SDivide)))
+    | LT => (_ => Construct(SOp(SLessThan)))
+    | Space => (
+        fun
+        | {CursorInfo.cursor_term: Line(_, CommentLine(_)), _} =>
+          Construct(SChar(" "))
+        | _ => Construct(SOp(SSpace))
+      )
+    | Comma => (_ => Construct(SOp(SComma)))
+    | LeftBracket => (
+        fun
+        | {CursorInfo.typed: OnType, _} => Construct(SList)
+        | _ => Construct(SListNil)
+      )
+    | Semicolon => (_ => Construct(SOp(SCons)))
+    | Alt_L => (_ => Construct(SInj(L)))
+    | Alt_R => (_ => Construct(SInj(R)))
+    | Alt_C => (_ => Construct(SCase))
+    | Pound => (_ => Construct(SCommentLine))
+    | Ctrl_Z => raise(Not_found)
+    | Ctrl_Shift_Z => raise(Not_found)
+    | Ctrl_Alt_I => (_ => SwapUp)
+    | Ctrl_Alt_K => (_ => SwapDown)
+    | Ctrl_Alt_J => (_ => SwapLeft)
+    | Ctrl_Alt_L => (_ => SwapRight)
+    | Meta_Z => raise(Not_found)
+    | Meta_Shift_Z => raise(Not_found)
+    };
   action_of_ci(cursor_info);
 };

--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -1,54 +1,42 @@
-let get = (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t): Action.t => {
-  let action_of_ci: CursorInfo.t => Action.t =
-    switch (kc) {
-    | Escape => raise(Not_found)
-    | Backspace => (_ => Backspace)
-    | Delete => (_ => Delete)
-    | ShiftTab => (_ => MoveToPrevHole)
-    | Tab => (_ => MoveToNextHole)
-    | GT => (
-        fun
-        | {CursorInfo.typed: OnType, _} => Construct(SOp(SArrow))
-        | _ => Construct(SOp(SGreaterThan))
-      )
-    | Ampersand => (_ => Construct(SOp(SAnd)))
-    | VBar => (_ => Construct(SOp(SOr)))
-    | LeftParen => (_ => Construct(SParenthesized))
-    | Colon => (_ => Construct(SAnn))
-    | Equals => (_ => Construct(SOp(SEquals)))
-    | Enter => (_ => Construct(SLine))
-    | Shift_Enter => (_ => Construct(SCommentLine))
-    | Backslash => (_ => Construct(SLam))
-    | Plus => (_ => Construct(SOp(SPlus)))
-    | Minus => (_ => Construct(SOp(SMinus)))
-    | Asterisk => (_ => Construct(SOp(STimes)))
-    | Slash => (_ => Construct(SOp(SDivide)))
-    | LT => (_ => Construct(SOp(SLessThan)))
-    | Space => (
-        fun
-        | {CursorInfo.cursor_term: Line(_, CommentLine(_)), _} =>
-          Construct(SChar(" "))
-        | _ => Construct(SOp(SSpace))
-      )
-    | Comma => (_ => Construct(SOp(SComma)))
-    | LeftBracket => (
-        fun
-        | {CursorInfo.typed: OnType, _} => Construct(SList)
-        | _ => Construct(SListNil)
-      )
-    | Semicolon => (_ => Construct(SOp(SCons)))
-    | Alt_L => (_ => Construct(SInj(L)))
-    | Alt_R => (_ => Construct(SInj(R)))
-    | Alt_C => (_ => Construct(SCase))
-    | Pound => (_ => Construct(SCommentLine))
-    | Ctrl_Z => raise(Not_found)
-    | Ctrl_Shift_Z => raise(Not_found)
-    | Ctrl_Alt_I => (_ => SwapUp)
-    | Ctrl_Alt_K => (_ => SwapDown)
-    | Ctrl_Alt_J => (_ => SwapLeft)
-    | Ctrl_Alt_L => (_ => SwapRight)
-    | Meta_Z => raise(Not_found)
-    | Meta_Shift_Z => raise(Not_found)
-    };
-  action_of_ci(cursor_info);
-};
+let get = (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t): option(Action.t) =>
+  switch (kc, cursor_info) {
+  | (Escape, _) => None
+  | (Backspace, _) => Some(Backspace)
+  | (Delete, _) => Some(Delete)
+  | (ShiftTab, _) => Some(MoveToPrevHole)
+  | (Tab, _) => Some(MoveToNextHole)
+  | (GT, {CursorInfo.typed: OnType, _}) => Some(Construct(SOp(SArrow)))
+  | (GT, _) => Some(Construct(SOp(SGreaterThan)))
+  | (Ampersand, _) => Some(Construct(SOp(SAnd)))
+  | (VBar, _) => Some(Construct(SOp(SOr)))
+  | (LeftParen, _) => Some(Construct(SParenthesized))
+  | (Colon, _) => Some(Construct(SAnn))
+  | (Equals, _) => Some(Construct(SOp(SEquals)))
+  | (Enter, _) => Some(Construct(SLine))
+  | (Shift_Enter, _) => Some(Construct(SCommentLine))
+  | (Backslash, _) => Some(Construct(SLam))
+  | (Plus, _) => Some(Construct(SOp(SPlus)))
+  | (Minus, _) => Some(Construct(SOp(SMinus)))
+  | (Asterisk, _) => Some(Construct(SOp(STimes)))
+  | (Slash, _) => Some(Construct(SOp(SDivide)))
+  | (LT, _) => Some(Construct(SOp(SLessThan)))
+  | (Space, {CursorInfo.cursor_term: Line(_, CommentLine(_)), _}) =>
+    Some(Construct(SChar(" ")))
+  | (Space, _) => Some(Construct(SOp(SSpace)))
+  | (Comma, _) => Some(Construct(SOp(SComma)))
+  | (LeftBracket, {CursorInfo.typed: OnType, _}) => Some(Construct(SList))
+  | (LeftBracket, _) => Some(Construct(SListNil))
+  | (Semicolon, _) => Some(Construct(SOp(SCons)))
+  | (Alt_L, _) => Some(Construct(SInj(L)))
+  | (Alt_R, _) => Some(Construct(SInj(R)))
+  | (Alt_C, _) => Some(Construct(SCase))
+  | (Pound, _) => Some(Construct(SCommentLine))
+  | (Ctrl_Z, _) => None
+  | (Ctrl_Shift_Z, _) => None
+  | (Ctrl_Alt_I, _) => Some(SwapUp)
+  | (Ctrl_Alt_K, _) => Some(SwapDown)
+  | (Ctrl_Alt_J, _) => Some(SwapLeft)
+  | (Ctrl_Alt_L, _) => Some(SwapRight)
+  | (Meta_Z, _) => None
+  | (Meta_Shift_Z, _) => None
+  };

--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -1,5 +1,5 @@
 let get_model_action =
-    (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t, is_mac: option(bool))
+    (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t, is_mac: bool)
     : option(ModelAction.t) =>
   switch (kc, cursor_info, is_mac) {
   | (Escape, _, _) => None
@@ -35,27 +35,24 @@ let get_model_action =
   | (Alt_R, _, _) => Some(EditAction(Construct(SInj(R))))
   | (Alt_C, _, _) => Some(EditAction(Construct(SCase)))
   | (Pound, _, _) => Some(EditAction(Construct(SCommentLine)))
-  | (Ctrl_Z, _, Some(true)) => None
-  | (Ctrl_Z, _, Some(false)) => Some(Undo)
-  | (Ctrl_Z, _, None) => None
-  | (Ctrl_Shift_Z, _, Some(true)) => None
-  | (Ctrl_Shift_Z, _, Some(false)) => Some(Redo)
-  | (Ctrl_Shift_Z, _, None) => None
+  | (Ctrl_Z, _, true) => None
+  | (Ctrl_Z, _, false) => Some(Undo)
+  | (Ctrl_Shift_Z, _, true) => None
+  | (Ctrl_Shift_Z, _, false) => Some(Redo)
   | (Ctrl_Alt_I, _, _) => Some(EditAction(SwapUp))
   | (Ctrl_Alt_K, _, _) => Some(EditAction(SwapDown))
   | (Ctrl_Alt_J, _, _) => Some(EditAction(SwapLeft))
   | (Ctrl_Alt_L, _, _) => Some(EditAction(SwapRight))
-  | (Meta_Z, _, Some(true)) => Some(Undo)
-  | (Meta_Z, _, Some(false)) => None
-  | (Meta_Z, _, None) => None
-  | (Meta_Shift_Z, _, Some(true)) => Some(Redo)
-  | (Meta_Shift_Z, _, Some(false)) => None
-  | (Meta_Shift_Z, _, None) => None
+  | (Meta_Z, _, true) => Some(Undo)
+  | (Meta_Z, _, false) => None
+  | (Meta_Shift_Z, _, true) => Some(Redo)
+  | (Meta_Shift_Z, _, false) => None
   };
 
 let get_action =
     (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t): option(Action.t) =>
-  switch (get_model_action(cursor_info, kc, None)) {
+  // is_mac shouldn't matter here, so we'll just have it be false
+  switch (get_model_action(cursor_info, kc, false)) {
   | Some(EditAction(action)) => Some(action)
   | _ => None
   };

--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -57,11 +57,3 @@ let get_model_action =
   | Meta_Shift_Z => None
   };
 };
-
-let get_action =
-    (cursor_info: CursorInfo.t, kc: HazelKeyCombos.t, is_mac: bool)
-    : option(Action.t) =>
-  switch (get_model_action(cursor_info, kc, is_mac)) {
-  | Some(EditAction(action)) => Some(action)
-  | _ => None
-  };

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -117,7 +117,16 @@ let key_handlers =
         | Some(model_action) => prevent_stop_inject(model_action)
         | None => Event.Ignore
         }
-      | None => Event.Ignore
+      | None =>
+        switch (JSUtil.is_single_key(evt)) {
+        | None => Event.Ignore
+        | Some(single_key) =>
+          prevent_stop_inject(
+            ModelAction.EditAction(
+              Construct(SChar(JSUtil.single_key_string(single_key))),
+            ),
+          )
+        }
       }
     ),
   ];

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -111,21 +111,23 @@ let key_handlers =
   [
     Attr.on_keypress(_ => Event.Prevent_default),
     Attr.on_keydown(evt => {
-      let model_action: option(ModelAction.t) =
-        switch (MoveKey.of_key(Key.get_key(evt))) {
-        | Some(move_key) => Some(MoveAction(Key(move_key)))
-        | None =>
-          switch (HazelKeyCombos.of_evt(evt)) {
-          | Some(kc) =>
-            KeyComboAction.get_model_action(cursor_info, kc, is_mac)
-          | None =>
-            open OptUtil.Syntax;
-            let+ single_key = JSUtil.is_single_key(evt);
-            ModelAction.EditAction(
+      let model_action: option(ModelAction.t) = {
+        let move_key = MoveKey.of_key(Key.get_key(evt));
+        let key_combo = HazelKeyCombos.of_evt(evt);
+        let single_key = JSUtil.is_single_key(evt);
+        switch (move_key, key_combo, single_key) {
+        | (Some(move_key), _, _) => Some(MoveAction(Key(move_key)))
+        | (_, Some(key_combo), _) =>
+          KeyComboAction.get_model_action(cursor_info, key_combo, is_mac)
+        | (_, _, Some(single_key)) =>
+          Some(
+            EditAction(
               Construct(SChar(JSUtil.single_key_string(single_key))),
-            );
-          }
+            ),
+          )
+        | (None, None, None) => None
         };
+      };
       switch (model_action) {
       | Some(model_action) => prevent_stop_inject(model_action)
       | None => Event.Ignore

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -110,37 +110,16 @@ let key_handlers =
     Event.Many([Event.Prevent_default, Event.Stop_propagation, inject(a)]);
   [
     Attr.on_keypress(_ => Event.Prevent_default),
-    Attr.on_keydown(evt => {
-      switch (MoveKey.of_key(Key.get_key(evt))) {
-      | Some(move_key) =>
-        prevent_stop_inject(ModelAction.MoveAction(Key(move_key)))
-      | None =>
-        switch (HazelKeyCombos.of_evt(evt)) {
-        | Some(kc) =>
-          switch (KeyComboAction.get(cursor_info, kc)) {
-          | Some(kca) => prevent_stop_inject(ModelAction.EditAction(kca))
-          | None =>
-            switch (kc, is_mac) {
-            | (Ctrl_Z, false)
-            | (Meta_Z, true) => prevent_stop_inject(ModelAction.Undo)
-            | (Ctrl_Shift_Z, false)
-            | (Meta_Shift_Z, true) => prevent_stop_inject(ModelAction.Redo)
-            | _ => Event.Ignore
-            }
-          }
-        | None =>
-          switch (JSUtil.is_single_key(evt)) {
-          | None => Event.Ignore
-          | Some(single_key) =>
-            prevent_stop_inject(
-              ModelAction.EditAction(
-                Construct(SChar(JSUtil.single_key_string(single_key))),
-              ),
-            )
-          }
+    Attr.on_keydown(evt =>
+      switch (HazelKeyCombos.of_evt(evt)) {
+      | Some(kc) =>
+        switch (KeyComboAction.get(cursor_info, kc, is_mac)) {
+        | Some(model_action) => prevent_stop_inject(model_action)
+        | None => Event.Ignore
         }
+      | None => Event.Ignore
       }
-    }),
+    ),
   ];
 };
 

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -120,31 +120,11 @@ let key_handlers =
           switch (KeyComboAction.get(cursor_info, kc)) {
           | Some(kca) => prevent_stop_inject(ModelAction.EditAction(kca))
           | None =>
-            switch (kc) {
-            | Ctrl_Z =>
-              if (is_mac) {
-                Event.Ignore;
-              } else {
-                prevent_stop_inject(ModelAction.Undo);
-              }
-            | Meta_Z =>
-              if (is_mac) {
-                prevent_stop_inject(ModelAction.Undo);
-              } else {
-                Event.Ignore;
-              }
-            | Ctrl_Shift_Z =>
-              if (is_mac) {
-                Event.Ignore;
-              } else {
-                prevent_stop_inject(ModelAction.Redo);
-              }
-            | Meta_Shift_Z =>
-              if (is_mac) {
-                prevent_stop_inject(ModelAction.Redo);
-              } else {
-                Event.Ignore;
-              }
+            switch (kc, is_mac) {
+            | (Ctrl_Z, false)
+            | (Meta_Z, true) => prevent_stop_inject(ModelAction.Undo)
+            | (Ctrl_Shift_Z, false)
+            | (Meta_Shift_Z, true) => prevent_stop_inject(ModelAction.Redo)
             | _ => Event.Ignore
             }
           }

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -118,11 +118,7 @@ let key_handlers =
         switch (move_key, key_combo, single_key) {
         | (Some(move_key), _, _) => Some(MoveAction(Key(move_key)))
         | (_, Some(key_combo), _) =>
-          KeyComboAction.get_model_action(
-            cursor_info,
-            key_combo,
-            Some(is_mac),
-          )
+          KeyComboAction.get_model_action(cursor_info, key_combo, is_mac)
         | (_, _, Some(single_key)) =>
           Some(
             EditAction(

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -111,21 +111,26 @@ let key_handlers =
   [
     Attr.on_keypress(_ => Event.Prevent_default),
     Attr.on_keydown(evt =>
-      switch (HazelKeyCombos.of_evt(evt)) {
-      | Some(kc) =>
-        switch (KeyComboAction.get_model_action(cursor_info, kc, is_mac)) {
-        | Some(model_action) => prevent_stop_inject(model_action)
-        | None => Event.Ignore
-        }
+      switch (MoveKey.of_key(Key.get_key(evt))) {
+      | Some(move_key) =>
+        prevent_stop_inject(ModelAction.MoveAction(Key(move_key)))
       | None =>
-        switch (JSUtil.is_single_key(evt)) {
-        | None => Event.Ignore
-        | Some(single_key) =>
-          prevent_stop_inject(
-            ModelAction.EditAction(
-              Construct(SChar(JSUtil.single_key_string(single_key))),
-            ),
-          )
+        switch (HazelKeyCombos.of_evt(evt)) {
+        | Some(kc) =>
+          switch (KeyComboAction.get_model_action(cursor_info, kc, is_mac)) {
+          | Some(model_action) => prevent_stop_inject(model_action)
+          | None => Event.Ignore
+          }
+        | None =>
+          switch (JSUtil.is_single_key(evt)) {
+          | Some(single_key) =>
+            prevent_stop_inject(
+              ModelAction.EditAction(
+                Construct(SChar(JSUtil.single_key_string(single_key))),
+              ),
+            )
+          | None => Event.Ignore
+          }
         }
       }
     ),

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -113,7 +113,7 @@ let key_handlers =
     Attr.on_keydown(evt =>
       switch (HazelKeyCombos.of_evt(evt)) {
       | Some(kc) =>
-        switch (KeyComboAction.get(cursor_info, kc, is_mac)) {
+        switch (KeyComboAction.get_model_action(cursor_info, kc, is_mac)) {
         | Some(model_action) => prevent_stop_inject(model_action)
         | None => Event.Ignore
         }

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -141,9 +141,11 @@ let key_handlers =
             Event.Ignore;
           }
         | Some(kc) =>
-          prevent_stop_inject(
-            ModelAction.EditAction(KeyComboAction.get(cursor_info, kc)),
-          )
+          switch (KeyComboAction.get(cursor_info, kc)) {
+          | Some(action) =>
+            prevent_stop_inject(ModelAction.EditAction(action))
+          | None => Event.Ignore
+          }
         | None =>
           switch (JSUtil.is_single_key(evt)) {
           | None => Event.Ignore

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -118,7 +118,11 @@ let key_handlers =
         switch (move_key, key_combo, single_key) {
         | (Some(move_key), _, _) => Some(MoveAction(Key(move_key)))
         | (_, Some(key_combo), _) =>
-          KeyComboAction.get_model_action(cursor_info, key_combo, is_mac)
+          KeyComboAction.get_model_action(
+            cursor_info,
+            key_combo,
+            Some(is_mac),
+          )
         | (_, _, Some(single_key)) =>
           Some(
             EditAction(

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -116,35 +116,37 @@ let key_handlers =
         prevent_stop_inject(ModelAction.MoveAction(Key(move_key)))
       | None =>
         switch (HazelKeyCombos.of_evt(evt)) {
-        | Some(Ctrl_Z) =>
-          if (is_mac) {
-            Event.Ignore;
-          } else {
-            prevent_stop_inject(ModelAction.Undo);
-          }
-        | Some(Meta_Z) =>
-          if (is_mac) {
-            prevent_stop_inject(ModelAction.Undo);
-          } else {
-            Event.Ignore;
-          }
-        | Some(Ctrl_Shift_Z) =>
-          if (is_mac) {
-            Event.Ignore;
-          } else {
-            prevent_stop_inject(ModelAction.Redo);
-          }
-        | Some(Meta_Shift_Z) =>
-          if (is_mac) {
-            prevent_stop_inject(ModelAction.Redo);
-          } else {
-            Event.Ignore;
-          }
         | Some(kc) =>
           switch (KeyComboAction.get(cursor_info, kc)) {
-          | Some(action) =>
-            prevent_stop_inject(ModelAction.EditAction(action))
-          | None => Event.Ignore
+          | Some(kca) => prevent_stop_inject(ModelAction.EditAction(kca))
+          | None =>
+            switch (kc) {
+            | Ctrl_Z =>
+              if (is_mac) {
+                Event.Ignore;
+              } else {
+                prevent_stop_inject(ModelAction.Undo);
+              }
+            | Meta_Z =>
+              if (is_mac) {
+                prevent_stop_inject(ModelAction.Undo);
+              } else {
+                Event.Ignore;
+              }
+            | Ctrl_Shift_Z =>
+              if (is_mac) {
+                Event.Ignore;
+              } else {
+                prevent_stop_inject(ModelAction.Redo);
+              }
+            | Meta_Shift_Z =>
+              if (is_mac) {
+                prevent_stop_inject(ModelAction.Redo);
+              } else {
+                Event.Ignore;
+              }
+            | _ => Event.Ignore
+            }
           }
         | None =>
           switch (JSUtil.is_single_key(evt)) {


### PR DESCRIPTION
Previously, `KeyComboAction.get` used a static hashtable to emulate the behavior of a switch expression. As far as I can tell, this has no particular advantages, and it means that the exhausiveness checker won't work on it.

There were some constructors of `HazelKeyCombos.t` that weren't in the original hashtable. Since a switch expression requires exhaustiveness, I had these inputs raise the exception `Not_found`, since that's identical behavior to what the hashtable lookup would have done. If anyone has a better idea of what to do in these cases, let me know.