### PR TITLE
Examples cardstack + cardstack UI refresh

### DIFF
--- a/src/hazelweb/ModelAction.re
+++ b/src/hazelweb/ModelAction.re
@@ -36,7 +36,6 @@ type t =
   | Redo
   | Undo
   | ShiftHistory(shift_history_info)
-  | ShiftWhenScroll
   | ToggleHistoryGroup(group_id)
   | ToggleHiddenHistoryAll
   | TogglePreviewOnHover

--- a/src/hazelweb/ModelAction.re
+++ b/src/hazelweb/ModelAction.re
@@ -24,7 +24,7 @@ type t =
   | MoveAction(move_input)
   | ToggleLeftSidebar
   | ToggleRightSidebar
-  | LoadExample(Examples.id)
+  | LoadExample(int)
   | LoadCardstack(int)
   | NextCard
   | PrevCard
@@ -42,4 +42,5 @@ type t =
   | ToggleHiddenHistoryAll
   | TogglePreviewOnHover
   | UpdateFontMetrics(FontMetrics.t)
-  | UpdateIsMac(bool);
+  | UpdateIsMac(bool)
+  | SerializeToConsole;

--- a/src/hazelweb/ModelAction.re
+++ b/src/hazelweb/ModelAction.re
@@ -31,7 +31,6 @@ type t =
   | UpdateSettings(Settings.update)
   | SelectHoleInstance(HoleInstance.t)
   | SelectCaseBranch(CursorPath.steps, int)
-  | InvalidVar(string)
   | FocusCell
   | BlurCell
   | Redo

--- a/src/hazelweb/ModelAction.re
+++ b/src/hazelweb/ModelAction.re
@@ -24,7 +24,7 @@ type t =
   | MoveAction(move_input)
   | ToggleLeftSidebar
   | ToggleRightSidebar
-  | LoadExample(int)
+  | LoadCard(int)
   | LoadCardstack(int)
   | NextCard
   | PrevCard

--- a/src/hazelweb/Update.re
+++ b/src/hazelweb/Update.re
@@ -64,7 +64,8 @@ let log_action = (action: ModelAction.t, _: State.t): unit => {
   | ToggleHiddenHistoryAll
   | TogglePreviewOnHover
   | UpdateFontMetrics(_)
-  | UpdateIsMac(_) =>
+  | UpdateIsMac(_)
+  | SerializeToConsole =>
     Logger.append(
       Sexp.to_string(
         sexp_of_timestamped_action(mk_timestamped_action(action)),
@@ -120,7 +121,7 @@ let apply_action =
       | MoveAction(Click(row_col)) => model |> Model.move_via_click(row_col)
       | ToggleLeftSidebar => Model.toggle_left_sidebar(model)
       | ToggleRightSidebar => Model.toggle_right_sidebar(model)
-      | LoadExample(id) => Model.load_example(model, Examples.get(id))
+      | LoadExample(n) => Model.nth_card(n, model)
       | LoadCardstack(idx) => Model.load_cardstack(model, idx)
       | NextCard => Model.next_card(model)
       | PrevCard => Model.prev_card(model)
@@ -203,6 +204,10 @@ let apply_action =
           ...model,
           settings: Settings.apply_update(u, model.settings),
         }
+      | SerializeToConsole =>
+        let e = model |> Model.get_program |> Program.get_uhexp;
+        JSUtil.log(Js.string(Serialization.string_of_exp(e)));
+        model;
       };
     },
   );

--- a/src/hazelweb/Update.re
+++ b/src/hazelweb/Update.re
@@ -53,7 +53,6 @@ let log_action = (action: ModelAction.t, _: State.t): unit => {
   | UpdateSettings(_)
   | SelectHoleInstance(_)
   | SelectCaseBranch(_)
-  | InvalidVar(_)
   | FocusCell
   | BlurCell
   | Undo
@@ -128,7 +127,6 @@ let apply_action =
       | SelectHoleInstance(inst) => model |> Model.select_hole_instance(inst)
       | SelectCaseBranch(path_to_case, branch_index) =>
         Model.select_case_branch(path_to_case, branch_index, model)
-      | InvalidVar(_) => model
       | FocusCell => model |> Model.focus_cell
       | BlurCell => model |> Model.blur_cell
       | Undo =>

--- a/src/hazelweb/Update.re
+++ b/src/hazelweb/Update.re
@@ -58,7 +58,6 @@ let log_action = (action: ModelAction.t, _: State.t): unit => {
   | Undo
   | Redo
   | ShiftHistory(_)
-  | ShiftWhenScroll
   | ToggleHistoryGroup(_)
   | ToggleHiddenHistoryAll
   | TogglePreviewOnHover
@@ -151,7 +150,6 @@ let apply_action =
                shift_history_info.call_by_mouseenter,
              );
         Model.load_undo_history(model, new_history, ~is_after_move=false);
-      | ShiftWhenScroll => model
       | ToggleHistoryGroup(toggle_group_id) =>
         let (suc_groups, _, _) = model.undo_history.groups;
         let cur_group_id = List.length(suc_groups);

--- a/src/hazelweb/Update.re
+++ b/src/hazelweb/Update.re
@@ -46,7 +46,7 @@ let log_action = (action: ModelAction.t, _: State.t): unit => {
   | MoveAction(_)
   | ToggleLeftSidebar
   | ToggleRightSidebar
-  | LoadExample(_)
+  | LoadCard(_)
   | LoadCardstack(_)
   | NextCard
   | PrevCard
@@ -121,7 +121,7 @@ let apply_action =
       | MoveAction(Click(row_col)) => model |> Model.move_via_click(row_col)
       | ToggleLeftSidebar => Model.toggle_left_sidebar(model)
       | ToggleRightSidebar => Model.toggle_right_sidebar(model)
-      | LoadExample(n) => Model.nth_card(n, model)
+      | LoadCard(n) => Model.nth_card(n, model)
       | LoadCardstack(idx) => Model.load_cardstack(model, idx)
       | NextCard => Model.next_card(model)
       | PrevCard => Model.prev_card(model)
@@ -205,8 +205,12 @@ let apply_action =
           settings: Settings.apply_update(u, model.settings),
         }
       | SerializeToConsole =>
-        let e = model |> Model.get_program |> Program.get_uhexp;
-        JSUtil.log(Js.string(Serialization.string_of_exp(e)));
+        model
+        |> Model.get_program
+        |> Program.get_uhexp
+        |> Serialization.string_of_exp
+        |> Js.string
+        |> JSUtil.log;
         model;
       };
     },

--- a/src/hazelweb/cardstacks/CardInfo.re
+++ b/src/hazelweb/cardstacks/CardInfo.re
@@ -1,7 +1,9 @@
 module Vdom = Virtual_dom.Vdom;
+open Sexplib.Std;
 
 [@deriving sexp]
 type t = {
+  name: string,
   caption: [@sexp.opaque] Vdom.Node.t,
   init_zexp: ZExp.t,
 };

--- a/src/hazelweb/cardstacks/Cardstack.re
+++ b/src/hazelweb/cardstacks/Cardstack.re
@@ -36,19 +36,9 @@ let has_next = (cardstack: t): bool => {
   !ListUtil.is_empty(suffix);
 };
 
-let prev_card = (cardstack: t): t => {
+let map = (f, cardstack: t): t => {
   let width = get_program(cardstack).width;
-  switch (cardstack.zcards |> ZList.map_z(ZCard.erase) |> ZList.shift_prev) {
-  | None => cardstack
-  | Some(shifted) => {
-      ...cardstack,
-      zcards: shifted |> ZList.map_z(ZCard.mk(~width)),
-    }
-  };
-};
-let next_card = (cardstack: t): t => {
-  let width = get_program(cardstack).width;
-  switch (cardstack.zcards |> ZList.map_z(ZCard.erase) |> ZList.shift_next) {
+  switch (cardstack.zcards |> ZList.map_z(ZCard.erase) |> f) {
   | None => cardstack
   | Some(shifted) => {
       ...cardstack,
@@ -57,13 +47,6 @@ let next_card = (cardstack: t): t => {
   };
 };
 
-let nth_card = (n: int, cardstack: t): t => {
-  let width = get_program(cardstack).width;
-  switch (cardstack.zcards |> ZList.map_z(ZCard.erase) |> ZList.shift_to(n)) {
-  | None => cardstack
-  | Some(shifted) => {
-      ...cardstack,
-      zcards: shifted |> ZList.map_z(ZCard.mk(~width)),
-    }
-  };
-};
+let prev_card = map(ZList.shift_prev);
+let next_card = map(ZList.shift_next);
+let nth_card = n => map(ZList.shift_to(n));

--- a/src/hazelweb/cardstacks/Cardstack.re
+++ b/src/hazelweb/cardstacks/Cardstack.re
@@ -56,3 +56,14 @@ let next_card = (cardstack: t): t => {
     }
   };
 };
+
+let nth_card = (n: int, cardstack: t): t => {
+  let width = get_program(cardstack).width;
+  switch (cardstack.zcards |> ZList.map_z(ZCard.erase) |> ZList.shift_to(n)) {
+  | None => cardstack
+  | Some(shifted) => {
+      ...cardstack,
+      zcards: shifted |> ZList.map_z(ZCard.mk(~width)),
+    }
+  };
+};

--- a/src/hazelweb/cardstacks/builtins/Examples.re
+++ b/src/hazelweb/cardstacks/builtins/Examples.re
@@ -1,6 +1,3 @@
-module StringMap = Map.Make(String);
-open Sexplib.Std;
-
 let just_hole: UHExp.t = UHExp.Block.wrap(EmptyHole(0));
 
 let holey_lambda: UHExp.t = {
@@ -356,19 +353,32 @@ let rec qsort_n = (n: int): UHExp.t =>
     ];
   };
 
-[@deriving sexp]
-type id = string;
-let examples =
-  StringMap.(
-    empty
-    |> add("just_hole", just_hole)
-    |> add("holey_lambda", holey_lambda)
-    |> add("let_line", let_line)
-    |> add("map_example", map_example)
-    |> add("qsort_example", qsort_example)
-    |> add("qsort_example_3", qsort_n(3))
-    |> add("qsort_example_10", qsort_n(10))
-    |> add("qsort_example_30", qsort_n(30))
-    |> add("qsort_example_100", qsort_n(100))
-  );
-let get = id => StringMap.find(id, examples);
+let examples = [
+  ("hole", just_hole),
+  ("lambda", holey_lambda),
+  ("let", let_line),
+  ("map", map_example),
+  ("quicksort", qsort_example),
+];
+
+let example_to_card = ((name: string, e: UHExp.t)): CardInfo.t => {
+  name,
+  caption: Virtual_dom.Vdom.Node.div([], []),
+  init_zexp: ZExp.place_before(e),
+};
+
+let cardstack: CardstackInfo.t = {
+  title: "examples",
+  cards: List.map(example_to_card, examples),
+};
+
+let tests = [
+  ("quicksort x1", qsort_n(1)),
+  ("quicksort x10", qsort_n(10)),
+  ("quicksort x100", qsort_n(100)),
+];
+
+let teststack: CardstackInfo.t = {
+  title: "tests",
+  cards: List.map(example_to_card, tests),
+};

--- a/src/hazelweb/cardstacks/builtins/TutorialCards.re
+++ b/src/hazelweb/cardstacks/builtins/TutorialCards.re
@@ -43,6 +43,7 @@ let intro_init_zexp =
  };
  */
 let intro_card: CardInfo.t = {
+  name: "intro",
   caption: div([], []),
   init_zexp: intro_init_zexp,
 };

--- a/src/hazelweb/gui/ActionMenu.re
+++ b/src/hazelweb/gui/ActionMenu.re
@@ -1,0 +1,47 @@
+open Virtual_dom.Vdom;
+open Node;
+
+type menu_entry = {
+  id: string,
+  label: string,
+  shortcut: option(string),
+  action: ModelAction.t,
+};
+
+let menu_entries: list(menu_entry) = [
+  {
+    id: "serialize-to-console",
+    label: "Serialize to console",
+    shortcut: Some("Ctrl-S"),
+    action: ModelAction.SerializeToConsole,
+  },
+];
+
+let dropdown_option = (~inject, {id, label, shortcut, action}: menu_entry) => {
+  let shortcut_view =
+    switch (shortcut) {
+    | None => []
+    | Some(s) => [div([Attr.classes(["shortcut"])], [text(s)])]
+    };
+  li(
+    [Attr.id(id), Attr.on_click(_ => inject(action))],
+    [text(label)] @ shortcut_view,
+  );
+};
+
+let dropdown_options = (~inject) =>
+  List.map(dropdown_option(~inject), menu_entries);
+
+let dropdown = (~inject: ModelAction.t => Ui_event.t, ~model as _: Model.t) => {
+  create(
+    "details",
+    [],
+    [
+      create("summary", [], [text("☰")]),
+      ul([Attr.classes(["dropdown-content"])], dropdown_options(~inject)),
+    ],
+  );
+};
+
+let view = (~inject: ModelAction.t => Ui_event.t, ~model: Model.t) =>
+  div([Attr.classes(["dropdown"])], [dropdown(~inject, ~model)]);

--- a/src/hazelweb/gui/ActionMenu.re
+++ b/src/hazelweb/gui/ActionMenu.re
@@ -2,7 +2,6 @@ open Virtual_dom.Vdom;
 open Node;
 
 type menu_entry = {
-  id: string,
   label: string,
   shortcut: option(string),
   action: ModelAction.t,
@@ -10,23 +9,21 @@ type menu_entry = {
 
 let menu_entries: list(menu_entry) = [
   {
-    id: "serialize-to-console",
     label: "Serialize to console",
     shortcut: Some("Ctrl-S"),
-    action: ModelAction.SerializeToConsole,
+    action: SerializeToConsole,
   },
+  {label: "Toggle left sidebar", shortcut: None, action: ToggleLeftSidebar},
+  {label: "Toggle right sidebar", shortcut: None, action: ToggleRightSidebar},
 ];
 
-let dropdown_option = (~inject, {id, label, shortcut, action}: menu_entry) => {
+let dropdown_option = (~inject, {label, shortcut, action}: menu_entry) => {
   let shortcut_view =
     switch (shortcut) {
     | None => []
     | Some(s) => [div([Attr.classes(["shortcut"])], [text(s)])]
     };
-  li(
-    [Attr.id(id), Attr.on_click(_ => inject(action))],
-    [text(label)] @ shortcut_view,
-  );
+  li([Attr.on_click(_ => inject(action))], [text(label)] @ shortcut_view);
 };
 
 let dropdown_options = (~inject) =>

--- a/src/hazelweb/gui/CardsPanel.re
+++ b/src/hazelweb/gui/CardsPanel.re
@@ -1,86 +1,63 @@
 open Virtual_dom.Vdom;
 open Node;
 
-let card_to_option = (id, {name, _}: CardInfo.t): Node.t =>
+let card_option_view = (id: int, {name, _}: CardInfo.t): Node.t =>
   option([Attr.value(string_of_int(id))], [text(name)]);
 
 let card_select =
-    (
-      ~inject: ModelAction.t => Event.t,
-      cardstacks,
-      cardstack_info: list(CardstackInfo.t),
-    ) => {
-  let cards =
-    switch (cardstacks |> ZList.prefix_length |> List.nth_opt(cardstack_info)) {
-    | None => []
-    | Some({cards, _}) => cards
-    };
-  Node.select(
-    [
-      Attr.on_change((_, id) =>
-        inject(ModelAction.LoadCard(int_of_string(id)))
-      ),
-    ],
-    List.mapi(card_to_option, cards),
+    (~inject: ModelAction.t => Event.t, cards_info: list(CardInfo.t)) => {
+  let load_card = (_, id) =>
+    inject(ModelAction.LoadCard(int_of_string(id)));
+  select(
+    [Attr.on_change(load_card)],
+    List.mapi(card_option_view, cards_info),
   );
 };
 
-let cardstacks_select =
-    (~inject: ModelAction.t => Event.t, cardstacks: list(CardstackInfo.t)) => {
-  let cardstack_options =
-    List.mapi(
-      (i, cardstack: CardstackInfo.t) => {
-        let example_idx = string_of_int(i);
-        Node.option(
-          [Attr.value(example_idx)],
-          [Node.text(cardstack.title)],
-        );
-      },
-      cardstacks,
-    );
-  Node.select(
-    [
-      Attr.on_change((_, example_idx) =>
-        inject(ModelAction.LoadCardstack(int_of_string(example_idx)))
-      ),
-    ],
-    cardstack_options,
+let cardstack_option_view = (id: int, cardstack: CardstackInfo.t): Node.t =>
+  option([Attr.value(string_of_int(id))], [text(cardstack.title)]);
+
+let cardstack_select = (~inject: ModelAction.t => Event.t) => {
+  let load_cardstack = (_, id) =>
+    inject(ModelAction.LoadCardstack(int_of_string(id)));
+  select(
+    [Attr.on_change(load_cardstack)],
+    List.mapi(cardstack_option_view, Model.cardstack_info),
   );
 };
 
-let prev_card_button = (~inject, cardstack) => {
-  let show_prev = Cardstack.has_prev(cardstack) ? [] : [Attr.disabled];
-  Node.button(
+let prev_card_button = (~inject, cardstack): Node.t => {
+  let disabled = Cardstack.has_prev(cardstack) ? [] : [Attr.disabled];
+  button(
     [
       Attr.id("cardstack-prev-button"),
       Attr.on_click(_ => inject(ModelAction.PrevCard)),
-      ...show_prev,
+      ...disabled,
     ],
-    [Node.text("<")],
+    [text("<")],
   );
 };
 
-let next_card_button = (~inject, cardstack) => {
-  let show_next = Cardstack.has_next(cardstack) ? [] : [Attr.disabled];
-  Node.button(
+let next_card_button = (~inject, cardstack): Node.t => {
+  let disabled = Cardstack.has_next(cardstack) ? [] : [Attr.disabled];
+  button(
     [
       Attr.id("cardstack-next-button"),
       Attr.on_click(_ => inject(ModelAction.NextCard)),
-      ...show_next,
+      ...disabled,
     ],
-    [Node.text(">")],
+    [text(">")],
   );
 };
 
 let view = (~inject: ModelAction.t => Ui_event.t, ~model: Model.t) => {
-  let cardstack_info = Model.cardstack_info;
   let cardstack = Model.get_cardstack(model);
-  let cardstacks = model.cardstacks;
+  let cards_info = Model.get_cards_info(model);
   div(
     [Attr.id("card-controls")],
     [
-      cardstacks_select(~inject, cardstack_info),
-      card_select(~inject, cardstacks, cardstack_info),
+      cardstack_select(~inject),
+      card_select(~inject, cards_info),
       prev_card_button(~inject, cardstack),
       next_card_button(~inject, cardstack),
     ],

--- a/src/hazelweb/gui/CardsPanel.re
+++ b/src/hazelweb/gui/CardsPanel.re
@@ -1,0 +1,88 @@
+open Virtual_dom.Vdom;
+open Node;
+
+let card_to_option = (id, {name, _}: CardInfo.t): Node.t =>
+  option([Attr.value(string_of_int(id))], [text(name)]);
+
+let card_select =
+    (
+      ~inject: ModelAction.t => Event.t,
+      cardstacks,
+      cardstack_info: list(CardstackInfo.t),
+    ) => {
+  let cards =
+    switch (cardstacks |> ZList.prefix_length |> List.nth_opt(cardstack_info)) {
+    | None => []
+    | Some({cards, _}) => cards
+    };
+  Node.select(
+    [
+      Attr.on_change((_, id) =>
+        inject(ModelAction.LoadCard(int_of_string(id)))
+      ),
+    ],
+    List.mapi(card_to_option, cards),
+  );
+};
+
+let cardstacks_select =
+    (~inject: ModelAction.t => Event.t, cardstacks: list(CardstackInfo.t)) => {
+  let cardstack_options =
+    List.mapi(
+      (i, cardstack: CardstackInfo.t) => {
+        let example_idx = string_of_int(i);
+        Node.option(
+          [Attr.value(example_idx)],
+          [Node.text(cardstack.title)],
+        );
+      },
+      cardstacks,
+    );
+  Node.select(
+    [
+      Attr.on_change((_, example_idx) =>
+        inject(ModelAction.LoadCardstack(int_of_string(example_idx)))
+      ),
+    ],
+    cardstack_options,
+  );
+};
+
+let prev_card_button = (~inject, cardstack) => {
+  let show_prev = Cardstack.has_prev(cardstack) ? [] : [Attr.disabled];
+  Node.button(
+    [
+      Attr.id("cardstack-prev-button"),
+      Attr.on_click(_ => inject(ModelAction.PrevCard)),
+      ...show_prev,
+    ],
+    [Node.text("<")],
+  );
+};
+
+let next_card_button = (~inject, cardstack) => {
+  let show_next = Cardstack.has_next(cardstack) ? [] : [Attr.disabled];
+  Node.button(
+    [
+      Attr.id("cardstack-next-button"),
+      Attr.on_click(_ => inject(ModelAction.NextCard)),
+      ...show_next,
+    ],
+    [Node.text(">")],
+  );
+};
+
+let view = (~inject: ModelAction.t => Ui_event.t, ~model: Model.t) => {
+  let cardstack_info = Model.cardstack_info;
+  let cardstack = Model.get_cardstack(model);
+  let cardstacks = model.cardstacks;
+  div(
+    [Attr.id("card-controls")],
+    [
+      cardstacks_select(~inject, cardstack_info),
+      card_select(~inject, cardstacks, cardstack_info),
+      prev_card_button(~inject, cardstack),
+      next_card_button(~inject, cardstack),
+    ],
+  );
+};

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -13,9 +13,10 @@ let card_select =
       model: Model.t,
       cardstacks: list(CardstackInfo.t),
     ) => {
-  let n = ZList.prefix_length(model.cardstacks);
   let cards =
-    switch (List.nth_opt(cardstacks, n)) {
+    switch (
+      model.cardstacks |> ZList.prefix_length |> List.nth_opt(cardstacks)
+    ) {
     | None => []
     | Some({cards, _}) => cards
     };
@@ -23,7 +24,7 @@ let card_select =
     Node.select(
       [
         Attr.on_change((_, id) =>
-          inject(ModelAction.LoadExample(int_of_string(id)))
+          inject(ModelAction.LoadCard(int_of_string(id)))
         ),
       ],
       List.mapi(card_to_option, cards),

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -1,240 +1,126 @@
-module Js = Js_of_ocaml.Js;
-module Vdom = Virtual_dom.Vdom;
-
-let card_to_option = (id, {name, _}: CardInfo.t): Vdom.Node.t =>
-  Vdom.Node.option(
-    [Vdom.Attr.value(string_of_int(id))],
-    [Vdom.Node.text(name)],
+open Virtual_dom.Vdom;
+open Node;
+let logo_panel =
+  a(
+    [Attr.classes(["logo-text"]), Attr.href("https://hazel.org")],
+    [text("Hazel")],
   );
 
-let card_select =
-    (
-      ~inject: ModelAction.t => Vdom.Event.t,
-      model: Model.t,
-      cardstacks: list(CardstackInfo.t),
-    ) => {
-  let cards =
-    switch (
-      model.cardstacks |> ZList.prefix_length |> List.nth_opt(cardstacks)
-    ) {
-    | None => []
-    | Some({cards, _}) => cards
-    };
-  Vdom.(
-    Node.select(
-      [
-        Attr.on_change((_, id) =>
-          inject(ModelAction.LoadCard(int_of_string(id)))
-        ),
-      ],
-      List.mapi(card_to_option, cards),
-    )
-  );
-};
-
-let cardstacks_select =
-    (
-      ~inject: ModelAction.t => Vdom.Event.t,
-      cardstacks: list(CardstackInfo.t),
-    ) => {
-  let cardstack_options =
-    List.mapi(
-      (i, cardstack: CardstackInfo.t) => {
-        let example_idx = string_of_int(i);
-        Vdom.(
-          Node.option(
-            [Attr.value(example_idx)],
-            [Node.text(cardstack.title)],
-          )
-        );
-      },
-      cardstacks,
-    );
-  Vdom.(
-    Node.select(
-      [
-        Attr.on_change((_, example_idx) =>
-          inject(ModelAction.LoadCardstack(int_of_string(example_idx)))
-        ),
-      ],
-      cardstack_options,
-    )
-  );
-};
-
-let prev_card_button = (~inject, model: Model.t) => {
-  let cardstack = model |> Model.get_cardstack;
-  let show_prev = Cardstack.has_prev(cardstack) ? [] : [Vdom.Attr.disabled];
-  Vdom.(
-    Node.button(
-      [
-        Attr.id("cardstack-prev-button"),
-        Attr.on_click(_ => inject(ModelAction.PrevCard)),
-        ...show_prev,
-      ],
-      [Node.text("<")],
-    )
-  );
-};
-
-let next_card_button = (~inject, model: Model.t) => {
-  let cardstack = model |> Model.get_cardstack;
-  let show_next = Cardstack.has_next(cardstack) ? [] : [Vdom.Attr.disabled];
-  Vdom.(
-    Node.button(
-      [
-        Attr.id("cardstack-next-button"),
-        Attr.on_click(_ => inject(ModelAction.NextCard)),
-        ...show_next,
-      ],
-      [Node.text(">")],
-    )
-  );
-};
-
-let cards_panel = (~inject: ModelAction.t => Ui_event.t, ~model: Model.t) =>
-  Vdom.Node.div(
-    [Vdom.Attr.id("card-controls")],
+let top_bar = (~inject: ModelAction.t => Ui_event.t, ~model: Model.t) => {
+  div(
+    [Attr.classes(["top-bar"])],
     [
-      cardstacks_select(~inject, Model.cardstack_info),
-      card_select(~inject, model, Model.cardstack_info),
-      prev_card_button(~inject, model),
-      next_card_button(~inject, model),
+      logo_panel,
+      CardsPanel.view(~inject, ~model),
+      ActionMenu.view(~inject, ~model),
     ],
   );
+};
 
-let details = Vdom.Node.create("details");
-let summary = Vdom.Node.create("summary");
-
-let dropdown_options = (~inject) => [
-  Vdom.Node.li(
-    [
-      Vdom.Attr.id("serialize-to-console"),
-      Vdom.Attr.on_click(_ => inject(ModelAction.SerializeToConsole)),
-    ],
-    [Vdom.Node.text("Serialize to console")],
-  ),
-];
-
-let dropdown = (~inject: ModelAction.t => Ui_event.t, ~model as _: Model.t) => {
-  details(
+let cell_status_panel = (~settings: Settings.t, ~model: Model.t, ~inject) => {
+  let program = Model.get_program(model);
+  let selected_instance = Model.get_selected_hole_instance(model);
+  let (_, ty, _) = program.edit_state;
+  let result =
+    settings.evaluation.show_unevaluated_expansion
+      ? program |> Program.get_expansion
+      : program |> Program.get_result |> Result.get_dhexp;
+  div(
     [],
     [
-      summary([], [Vdom.Node.text("☰ Actions")]),
-      Vdom.Node.ul(
-        [Vdom.Attr.classes(["dropdown-content"])],
-        dropdown_options(~inject),
+      div(
+        [Attr.classes(["cell-status"])],
+        [
+          div(
+            [Attr.classes(["type-indicator"])],
+            [
+              div(
+                [Attr.classes(["type-label"])],
+                [text("Result of type: ")],
+              ),
+              div([Attr.classes(["htype-view"])], [HTypCode.view(ty)]),
+            ],
+          ),
+        ],
+      ),
+      div(
+        [Attr.classes(["result-view"])],
+        [
+          DHCode.view(
+            ~inject,
+            ~selected_instance,
+            ~settings=settings.evaluation,
+            ~width=80,
+            ~font_metrics=model.font_metrics,
+            result,
+          ),
+        ],
       ),
     ],
   );
 };
 
-let menu_panel = (~inject: ModelAction.t => Ui_event.t, ~model: Model.t) => {
-  Vdom.Node.div(
-    [Vdom.Attr.classes(["dropdown"])],
-    [dropdown(~inject, ~model)],
+let left_sidebar = (~inject: ModelAction.t => Event.t, ~model: Model.t) =>
+  Sidebar.left(~inject, ~is_open=model.left_sidebar_open, () =>
+    [ActionPanel.view(~inject, model)]
+  );
+
+let right_sidebar = (~inject: ModelAction.t => Event.t, ~model: Model.t) => {
+  let settings = model.settings;
+  let program = Model.get_program(model);
+  let selected_instance = Model.get_selected_hole_instance(model);
+  Sidebar.right(~inject, ~is_open=model.right_sidebar_open, () =>
+    [
+      CursorInspector.view(~inject, model),
+      ContextInspector.view(
+        ~inject,
+        ~selected_instance,
+        ~settings=settings.evaluation,
+        ~font_metrics=model.font_metrics,
+        program,
+      ),
+      UndoHistoryPanel.view(~inject, model),
+      SettingsPanel.view(~inject, settings),
+    ]
   );
 };
 
-let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
+let view = (~inject: ModelAction.t => Event.t, model: Model.t) => {
   let settings = model.settings;
   TimeUtil.measure_time(
     "Page.view",
     settings.performance.measure && settings.performance.page_view,
     () => {
-      open Vdom;
-      let card = model |> Model.get_card;
-      let program = model |> Model.get_program;
-      let selected_instance = model |> Model.get_selected_hole_instance;
+      let card_caption = Model.get_card(model).info.caption;
       let cell_status =
-        if (!settings.evaluation.evaluate) {
-          Node.div([], []);
-        } else {
-          Node.div(
-            [],
-            [
-              Node.div(
-                [Attr.classes(["cell-status"])],
-                [
-                  Node.div(
-                    [Attr.classes(["type-indicator"])],
-                    [
-                      Node.div(
-                        [Attr.classes(["type-label"])],
-                        [Node.text("Result of type: ")],
-                      ),
-                      Node.div(
-                        [Attr.classes(["htype-view"])],
-                        [
-                          {
-                            let (_, ty, _) = program.edit_state;
-                            HTypCode.view(ty);
-                          },
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-              Node.div(
-                [Attr.classes(["result-view"])],
-                [
-                  DHCode.view(
-                    ~inject,
-                    ~selected_instance,
-                    ~settings=settings.evaluation,
-                    ~width=80,
-                    ~font_metrics=model.font_metrics,
-                    settings.evaluation.show_unevaluated_expansion
-                      ? program |> Program.get_expansion
-                      : program |> Program.get_result |> Result.get_dhexp,
-                  ),
-                ],
-              ),
-            ],
-          );
-        };
-      Node.div(
+        !settings.evaluation.evaluate
+          ? div([], []) : cell_status_panel(~settings, ~model, ~inject);
+      div(
         [Attr.id("root")],
         [
-          Node.div(
-            [Attr.classes(["top-bar"])],
-            [
-              Node.a(
-                [
-                  Attr.classes(["logo-text"]),
-                  Attr.href("https://hazel.org"),
-                ],
-                [Node.text("Hazel")],
-              ),
-              menu_panel(~inject, ~model),
-              cards_panel(~inject, ~model),
-            ],
-          ),
-          Node.div(
+          top_bar(~inject, ~model),
+          div(
             [Attr.classes(["main-area"])],
             [
-              Sidebar.left(~inject, ~is_open=model.left_sidebar_open, () =>
-                [ActionPanel.view(~inject, model)]
-              ),
-              Node.div(
+              left_sidebar(~inject, ~model),
+              div(
                 [Attr.classes(["flex-wrapper"])],
                 [
-                  Node.div(
+                  div(
                     [Attr.id("page-area")],
                     [
-                      Node.div(
+                      div(
                         [Attr.classes(["page"])],
                         [
-                          Node.div(
+                          div(
                             [Attr.classes(["card-caption"])],
-                            [card.info.caption],
+                            [card_caption],
                           ),
                           Cell.view(~inject, model),
                           cell_status,
                         ],
                       ),
-                      Node.div(
+                      div(
                         [
                           Attr.style(
                             Css_gen.(
@@ -248,20 +134,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
                   ),
                 ],
               ),
-              Sidebar.right(~inject, ~is_open=model.right_sidebar_open, () =>
-                [
-                  CursorInspector.view(~inject, model),
-                  ContextInspector.view(
-                    ~inject,
-                    ~selected_instance,
-                    ~settings=settings.evaluation,
-                    ~font_metrics=model.font_metrics,
-                    program,
-                  ),
-                  UndoHistoryPanel.view(~inject, model),
-                  SettingsPanel.view(~inject, settings),
-                ]
-              ),
+              right_sidebar(~inject, ~model),
             ],
           ),
         ],

--- a/src/hazelweb/gui/UHCode.re
+++ b/src/hazelweb/gui/UHCode.re
@@ -116,6 +116,7 @@ let key_handlers =
         prevent_stop_inject(ModelAction.MoveAction(Key(move_key)))
       | None =>
         switch (HazelKeyCombos.of_evt(evt)) {
+        | Some(Ctrl_S) => prevent_stop_inject(ModelAction.SerializeToConsole)
         | Some(Ctrl_Z) =>
           if (is_mac) {
             Event.Ignore;

--- a/src/hazelweb/keyboard/HazelKeyCombos.re
+++ b/src/hazelweb/keyboard/HazelKeyCombos.re
@@ -31,6 +31,7 @@ type t =
   | Alt_C
   | Pound
   | Ctrl_Z
+  | Ctrl_S
   | Ctrl_Shift_Z
   | Ctrl_Alt_I
   | Ctrl_Alt_K
@@ -69,6 +70,7 @@ let get_details =
   | Alt_R => KeyCombo.alt_R
   | Alt_C => KeyCombo.alt_C
   | Ctrl_Z => KeyCombo.ctrl_z
+  | Ctrl_S => KeyCombo.ctrl_s
   | Ctrl_Shift_Z => KeyCombo.ctrl_shift_z
   | Ctrl_Alt_I => KeyCombo.ctrl_alt_i
   | Ctrl_Alt_K => KeyCombo.ctrl_alt_k
@@ -83,6 +85,8 @@ let of_evt = (evt: Js.t(Dom_html.keyboardEvent)): option(t) => {
     Some(Pound);
   } else if (evt_matches(KeyCombo.ctrl_z)) {
     Some(Ctrl_Z);
+  } else if (evt_matches(KeyCombo.ctrl_s)) {
+    Some(Ctrl_S);
   } else if (evt_matches(KeyCombo.ctrl_shift_z)) {
     Some(Ctrl_Shift_Z);
   } else if (evt_matches(KeyCombo.meta_z)) {

--- a/src/hazelweb/keyboard/HazelKeyCombos.rei
+++ b/src/hazelweb/keyboard/HazelKeyCombos.rei
@@ -31,6 +31,7 @@ type t =
   | Alt_C
   | Pound
   | Ctrl_Z
+  | Ctrl_S
   | Ctrl_Shift_Z
   | Ctrl_Alt_I
   | Ctrl_Alt_K

--- a/src/hazelweb/keyboard/KeyCombo.re
+++ b/src/hazelweb/keyboard/KeyCombo.re
@@ -54,6 +54,7 @@ let alt_C = alt(Key.the_key("c"));
 let alt_PageUp = alt(Key.the_key("PageUp"));
 let alt_PageDown = alt(Key.the_key("PageDown"));
 let ctrl_z = ctrl(Key.the_key("z"));
+let ctrl_s = ctrl(Key.the_key("s"));
 let ctrl_shift_z = ctrl_shift(Key.the_key("Z"));
 let ctrl_alt_i = ctrl_alt(Key.the_key("i"));
 let ctrl_alt_k = ctrl_alt(Key.the_key("k"));

--- a/src/hazelweb/keyboard/KeyCombo.rei
+++ b/src/hazelweb/keyboard/KeyCombo.rei
@@ -39,6 +39,7 @@ let alt_C: t;
 let alt_PageUp: t;
 let alt_PageDown: t;
 let ctrl_z: t;
+let ctrl_s: t;
 let ctrl_shift_z: t;
 let ctrl_alt_i: t;
 let ctrl_alt_k: t;

--- a/src/hazelweb/model/Model.re
+++ b/src/hazelweb/model/Model.re
@@ -14,7 +14,9 @@ type t = {
 let cutoff = (m1, m2) => m1 === m2;
 
 let cardstack_info = [
-  TutorialCards.cardstack,
+  Examples.cardstack,
+  Examples.teststack,
+  // TutorialCards.cardstack,
   // RCStudyCards.cardstack,
 ];
 
@@ -201,6 +203,12 @@ let next_card = model => {
   |> focus_cell;
 };
 
+let nth_card = (n, model) => {
+  model
+  |> map_cardstacks(ZCardstacks.map_z(Cardstack.nth_card(n)))
+  |> focus_cell;
+};
+
 let perform_edit_action = (a: Action.t, model: t): t => {
   TimeUtil.measure_time(
     "Model.perform_edit_action",
@@ -249,18 +257,6 @@ let toggle_right_sidebar = (model: t): t => {
   ...model,
   right_sidebar_open: !model.right_sidebar_open,
 };
-
-let load_example = (model: t, e: UHExp.t): t =>
-  model
-  |> put_program(
-       Program.mk(
-         ~width=model.cell_width,
-         Statics_Exp.fix_and_renumber_holes_z(
-           Contexts.empty,
-           ZExp.place_before(e),
-         ),
-       ),
-     );
 
 let load_cardstack = (model, idx) => {
   model |> map_cardstacks(ZCardstacks.load_cardstack(idx)) |> focus_cell;

--- a/src/hazelweb/model/Model.re
+++ b/src/hazelweb/model/Model.re
@@ -120,6 +120,14 @@ let map_cardstacks = (f: ZCardstacks.t => ZCardstacks.t, model: t): t => {
 let get_cardstack = model => model |> get_cardstacks |> ZCardstacks.get_z;
 let get_card = model => model |> get_cardstack |> Cardstack.get_z;
 
+let get_cards_info = (model: t): list(CardInfo.t) =>
+  switch (
+    model.cardstacks |> ZList.prefix_length |> List.nth_opt(cardstack_info)
+  ) {
+  | None => []
+  | Some(cardinfo) => cardinfo.cards
+  };
+
 let map_selected_instances =
     (f: UserSelectedInstances.t => UserSelectedInstances.t, model) => {
   ...model,

--- a/src/hazelweb/model/Model.rei
+++ b/src/hazelweb/model/Model.rei
@@ -51,6 +51,7 @@ let get_selected_hole_instance: t => option(HoleInstance.t);
 
 let prev_card: t => t;
 let next_card: t => t;
+let nth_card: (int, t) => t;
 
 let perform_edit_action: (Action.t, t) => t;
 
@@ -67,11 +68,6 @@ let select_case_branch: (CursorPath.steps, int, t) => t;
  */
 let toggle_left_sidebar: t => t;
 let toggle_right_sidebar: t => t;
-
-/**
- * Load an expression into the editor
- */
-let load_example: (t, UHExp.t) => t;
 
 /**
  * Load a selected cardstack into view

--- a/src/hazelweb/model/Model.rei
+++ b/src/hazelweb/model/Model.rei
@@ -32,6 +32,7 @@ let get_edit_state: t => Statics.edit_state;
 
 let get_card: t => ZCard.t;
 let get_cardstack: t => Cardstack.t;
+let get_cards_info: t => list(CardInfo.t);
 
 let get_cursor_info: t => CursorInfo.t;
 

--- a/src/hazelweb/www/style.css
+++ b/src/hazelweb/www/style.css
@@ -149,7 +149,7 @@ body {
   align-items: center;
   gap: 0.7em;
   font-size: 0.8em;
-  padding: 0.6em;
+  padding: 0.4em;
 }
 
 .dropdown ul li:hover {
@@ -182,8 +182,7 @@ body {
   min-inline-size: max-content;
   background-color: var(--title-bar-color);
   border-bottom-left-radius: 0.23em;
-  padding-left: 0.5em;
-  padding-right: 0.5em;
+  padding: 0.5em;
   z-index: 10001;
   filter: drop-shadow(0 0.2em 0.3em #2337);
 }

--- a/src/hazelweb/www/style.css
+++ b/src/hazelweb/www/style.css
@@ -113,7 +113,6 @@ body {
   justify-content: flex-start;
   gap: 1em;
   align-items: center;
-  border-bottom: solid #082903 3px;
 }
 
 .logo-text {
@@ -125,6 +124,7 @@ body {
 /* menu panel */
 
 .dropdown {
+  margin-left: auto;
   color:#239d60;
   display: inline-block;
   position: relative;
@@ -145,6 +145,9 @@ body {
 }
 
 .dropdown ul li {
+  display: flex;
+  align-items: center;
+  gap: 0.7em;
   font-size: 0.8em;
   padding: 0.6em;
 }
@@ -154,9 +157,17 @@ body {
   color: white;
 }
 
+.dropdown .shortcut {
+  font-size: 0.7em;
+  font-style: italic;
+  color:#7f8b85;
+}
+
 .dropdown summary {
+  text-shadow: 0 2px #020;
   list-style: none;
   cursor: pointer;
+  padding-left: 1.5em;
 }
 .dropdown summary::-webkit-details-marker {
   display: none;
@@ -166,12 +177,15 @@ body {
   font-size: 1em;
   font-weight: normal;
   position: absolute;
-  top: 1.4em;
+  right: -0.8em;
+  top: 1.7em;
   min-inline-size: max-content;
   background-color: var(--title-bar-color);
-  border-radius: 0.23em;
-  box-shadow: 0 3px #082903;
+  border-bottom-left-radius: 0.23em;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
   z-index: 10001;
+  filter: drop-shadow(0 0.2em 0.3em #2337);
 }
 
 .dropdown details[open] summary::before {
@@ -200,7 +214,7 @@ body {
   border-width: 0;
   height: 1.3rem;
   border-radius: 0.3em;
-  box-shadow: 0 3px #000;
+  box-shadow: 0 3px #020;
 }
 
 #card-controls select:hover, #card-controls button:hover {

--- a/src/hazelweb/www/style.css
+++ b/src/hazelweb/www/style.css
@@ -113,6 +113,27 @@ body {
   justify-content: flex-start;
 }
 
+#card-controls {
+  display: flex;
+  gap: 0.26em;
+  flex-direction: row;
+  align-items: center;
+}
+
+#card-controls select, #card-controls button {
+  background-color: #187346;
+  color: #94deba;
+  border-width: 0;
+  height: 1.3rem;
+  border-radius: 0.3em;
+  box-shadow: 0 3px #000;
+}
+
+#card-controls select:hover, #card-controls button:hover {
+  color: #d7ffec;
+  background-color: #239d60; 
+}
+
 #cardstack-controls {
   margin-top: 10px;
   display: flex;


### PR DESCRIPTION
This does three things, all aimed at decluttering the main panel.

1. Examples are now a cardstack. Performance-oriented examples are now in a separate cardstack.
2. All cardstack controls are moved to the top bar. This includes the cardstack dropdown, a new card selection dropdown (replacing the examples dropdown), and the next/prev card buttons
3. Ctrl-S now serializes the program to the console; the button is gone.

<img width="594" alt="Screen Shot 2021-06-21 at 2 13 28 AM" src="https://user-images.githubusercontent.com/22436459/122715108-6507a980-d236-11eb-954f-cf5ea7b43000.png">

<img width="594" alt="Screen Shot 2021-06-21 at 2 14 08 AM" src="https://user-images.githubusercontent.com/22436459/122715143-70f36b80-d236-11eb-91b3-d97caea7b3c9.png">
