### PR TITLE
Fix for cannot backspace over space

### DIFF
--- a/src/hazelcore/Action_Exp.re
+++ b/src/hazelcore/Action_Exp.re
@@ -1154,7 +1154,8 @@ and syn_perform_opseq =
       ),
     )
       when ZExp.is_before_zoperand(zhole) =>
-    let new_zseq = ZSeq.ZOperand(ZExp.place_before_operand(operand), (E, suffix));
+    let new_zseq =
+      ZSeq.ZOperand(ZExp.place_before_operand(operand), (E, suffix));
     Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
 
   /* ... + [k-1]  <|_ + [k+1] + ...  ==>   ... + [k-1]| + [k+1] + ... */

--- a/src/hazelcore/ZExp.re
+++ b/src/hazelcore/ZExp.re
@@ -961,3 +961,19 @@ and cursor_on_EmptyHole_zrule =
   | CursorR(_)
   | RuleZP(_) => None
   | RuleZE(_, ze) => cursor_on_EmptyHole(ze);
+
+let starts_with_hole_and_space = zline =>
+  /* True if zline begins with an empty hole followed by a space operator */
+  switch (zline) {
+  | ExpLineZ(
+      ZOpSeq(
+        _,
+        ZOperand(
+          CursorE(OnDelim(_, Before), EmptyHole(_)),
+          (E, A(Space, _)),
+        ),
+      ),
+    ) =>
+    true
+  | _ => false
+  };


### PR DESCRIPTION
This (partially) addressed #280. This is a bit of a hack; I feel there may be no great way to address this in the current implementation.

The issue is the line-handling code in the block-level perform functions captures Deletes/Backspaces actions made at the end/beginning of the line. This seems reasonable to me; the issue feels more like it arises due to the fact that we are relying on deleting holes from the 'wrong side'; i.e., the way hole removal with backspace works right now, the cursor has to be on the left of the hole. This feels off to me?

Nonetheless, this PR fixes the issue I think while maintaining previous hole removal behavior. I only made the fix for the backspace expr(syn+ana) cases. The delete case and pattern cases would be analogous but I want someone else to test this.

I'm putting up another PR which takes the other tack: changing the way hole deletion works. This is more aggressive change., though I think it feels better for the most part.
