### PR TITLE
Parentheses reverse deletion fix

### DIFF
--- a/src/hazelcore/Action_Exp.re
+++ b/src/hazelcore/Action_Exp.re
@@ -1095,23 +1095,25 @@ and syn_perform_opseq =
       ZOperand(
         ParenthesizedZ((
           [],
-          ExpLineZ(ZOpSeq(_, ZOperand(zop, (prefix, suffix)))),
+          ExpLineZ(
+            ZOpSeq(_, ZOperand(zop, (inner_prefix, inner_suffix))) as inner_zopseq,
+          ),
           [],
         )),
-        (upper_prefix, upper_suffix),
+        (prefix, suffix),
       ),
     )
       when
-        ZExp.is_before_zoperand(zop)
+        ZExp.is_before_zopseq(inner_zopseq)
         && a == Backspace
-        || ZExp.is_after_zoperand(zop)
+        || ZExp.is_after_zopseq(inner_zopseq)
         && a == Delete =>
     let new_zseq =
       ZSeq.ZOperand(
         zop,
         (
-          Seq.affix_affix(upper_prefix, prefix),
-          Seq.affix_affix(suffix, upper_suffix),
+          Seq.affix_affix(inner_prefix, prefix),
+          Seq.affix_affix(inner_suffix, suffix),
         ),
       );
     Succeeded(SynDone(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq)));
@@ -2452,23 +2454,25 @@ and ana_perform_opseq =
       ZOperand(
         ParenthesizedZ((
           [],
-          ExpLineZ(ZOpSeq(_, ZOperand(zop, (prefix, suffix)))),
+          ExpLineZ(
+            ZOpSeq(_, ZOperand(zop, (inner_prefix, inner_suffix))) as inner_zopseq,
+          ),
           [],
         )),
-        (upper_prefix, upper_suffix),
+        (prefix, suffix),
       ),
     )
       when
-        ZExp.is_before_zoperand(zop)
+        ZExp.is_before_zopseq(inner_zopseq)
         && a == Backspace
-        || ZExp.is_after_zoperand(zop)
+        || ZExp.is_after_zopseq(inner_zopseq)
         && a == Delete =>
     let new_zseq =
       ZSeq.ZOperand(
         zop,
         (
-          Seq.affix_affix(upper_prefix, prefix),
-          Seq.affix_affix(suffix, upper_suffix),
+          Seq.affix_affix(inner_prefix, prefix),
+          Seq.affix_affix(inner_suffix, suffix),
         ),
       );
     Succeeded(AnaDone(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty)));

--- a/src/hazelcore/Action_Pat.re
+++ b/src/hazelcore/Action_Pat.re
@@ -437,21 +437,23 @@ and syn_perform_opseq =
   | (
       a,
       ZOperand(
-        ParenthesizedZ(ZOpSeq(_, ZOperand(zop, (prefix, suffix)))),
-        (upper_prefix, upper_suffix),
+        ParenthesizedZ(
+          ZOpSeq(_, ZOperand(zop, (inner_prefix, inner_suffix))) as inner_zopseq,
+        ),
+        (prefix, suffix),
       ),
     )
       when
-        ZPat.is_before_zoperand(zop)
+        ZPat.is_before_zopseq(inner_zopseq)
         && a == Backspace
-        || ZPat.is_after_zoperand(zop)
+        || ZPat.is_after_zopseq(inner_zopseq)
         && a == Delete =>
     let new_zseq =
       ZSeq.ZOperand(
         zop,
         (
-          Seq.affix_affix(upper_prefix, prefix),
-          Seq.affix_affix(suffix, upper_suffix),
+          Seq.affix_affix(inner_prefix, prefix),
+          Seq.affix_affix(inner_suffix, suffix),
         ),
       );
     Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq));
@@ -943,21 +945,23 @@ and ana_perform_opseq =
   | (
       a,
       ZOperand(
-        ParenthesizedZ(ZOpSeq(_, ZOperand(zop, (prefix, suffix)))),
-        (upper_prefix, upper_suffix),
+        ParenthesizedZ(
+          ZOpSeq(_, ZOperand(zop, (inner_prefix, inner_suffix))) as inner_zopseq,
+        ),
+        (prefix, suffix),
       ),
     )
       when
-        ZPat.is_before_zoperand(zop)
+        ZPat.is_before_zopseq(inner_zopseq)
         && a == Backspace
-        || ZPat.is_after_zoperand(zop)
+        || ZPat.is_after_zopseq(inner_zopseq)
         && a == Delete =>
     let new_zseq =
       ZSeq.ZOperand(
         zop,
         (
-          Seq.affix_affix(upper_prefix, prefix),
-          Seq.affix_affix(suffix, upper_suffix),
+          Seq.affix_affix(inner_prefix, prefix),
+          Seq.affix_affix(inner_suffix, suffix),
         ),
       );
     Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));

--- a/src/hazelcore/Action_Pat.re
+++ b/src/hazelcore/Action_Pat.re
@@ -431,6 +431,31 @@ and syn_perform_opseq =
 
   /* Deletion */
 
+  /* This case prevents deletion of parentheses from the front with backspace
+     or from the rear with delete from taking two keypresses, the first of
+     which does not result in caret movement. */
+  | (
+      a,
+      ZOperand(
+        ParenthesizedZ(ZOpSeq(_, ZOperand(zop, (prefix, suffix)))),
+        (upper_prefix, upper_suffix),
+      ),
+    )
+      when
+        ZPat.is_before_zoperand(zop)
+        && a == Backspace
+        || ZPat.is_after_zoperand(zop)
+        && a == Delete =>
+    let new_zseq =
+      ZSeq.ZOperand(
+        zop,
+        (
+          Seq.affix_affix(upper_prefix, prefix),
+          Seq.affix_affix(suffix, upper_suffix),
+        ),
+      );
+    Succeeded(mk_and_syn_fix_ZOpSeq(ctx, u_gen, new_zseq));
+
   | (Delete, ZOperator((OnOp(After as side), _), _))
   | (Backspace, ZOperator((OnOp(Before as side), _), _)) =>
     syn_perform_opseq(ctx, u_gen, Action_common.escape(side), zopseq)
@@ -911,6 +936,31 @@ and ana_perform_opseq =
     ana_move(ctx, u_gen, a, zopseq, ty)
 
   /* Deletion */
+
+  /* This case prevents deletion of parentheses from the front with backspace
+     or from the rear with delete from taking two keypresses, the first of
+     which does not result in caret movement. */
+  | (
+      a,
+      ZOperand(
+        ParenthesizedZ(ZOpSeq(_, ZOperand(zop, (prefix, suffix)))),
+        (upper_prefix, upper_suffix),
+      ),
+    )
+      when
+        ZPat.is_before_zoperand(zop)
+        && a == Backspace
+        || ZPat.is_after_zoperand(zop)
+        && a == Delete =>
+    let new_zseq =
+      ZSeq.ZOperand(
+        zop,
+        (
+          Seq.affix_affix(upper_prefix, prefix),
+          Seq.affix_affix(suffix, upper_suffix),
+        ),
+      );
+    Succeeded(mk_and_ana_fix_ZOpSeq(ctx, u_gen, new_zseq, ty));
 
   | (Delete, ZOperator((OnOp(After as side), _), _))
   | (Backspace, ZOperator((OnOp(Before as side), _), _)) =>

--- a/src/hazelcore/Action_Typ.re
+++ b/src/hazelcore/Action_Typ.re
@@ -130,21 +130,23 @@ and perform_opseq =
   | (
       a,
       ZOperand(
-        ParenthesizedZ(ZOpSeq(_, ZOperand(zop, (prefix, suffix)))),
-        (upper_prefix, upper_suffix),
+        ParenthesizedZ(
+          ZOpSeq(_, ZOperand(zop, (inner_prefix, inner_suffix))) as inner_zopseq,
+        ),
+        (prefix, suffix),
       ),
     )
       when
-        ZTyp.is_before_zoperand(zop)
+        ZTyp.is_before_zopseq(inner_zopseq)
         && a == Backspace
-        || ZTyp.is_after_zoperand(zop)
+        || ZTyp.is_after_zopseq(inner_zopseq)
         && a == Delete =>
     let new_zseq =
       ZSeq.ZOperand(
         zop,
         (
-          Seq.affix_affix(upper_prefix, prefix),
-          Seq.affix_affix(suffix, upper_suffix),
+          Seq.affix_affix(inner_prefix, prefix),
+          Seq.affix_affix(inner_suffix, suffix),
         ),
       );
     Succeeded(ZTyp.mk_ZOpSeq(new_zseq));

--- a/src/hazelcore/UndoHistoryCore.re
+++ b/src/hazelcore/UndoHistoryCore.re
@@ -10,6 +10,9 @@ type delete_group =
   | Term(cursor_term, start_from_insertion)
   /* cursor_term is insufficient for space, empty line and type annotation deletion,
      so we add the following three constructors */
+  | ParenthesesFromTheInside
+  /* Special case action for deleting parentheses in a single keystrokes when
+     the cursor is on a contained operand bordering the parentheses */
   | Space
   | EmptyLine
   | TypeAnn;
@@ -98,6 +101,7 @@ let group_action_group =
   | (VarGroup(_), DeleteEdit(delete_group)) =>
     switch (delete_group) {
     | Term(_, _) => true
+    | ParenthesesFromTheInside
     | Space
     | EmptyLine
     | TypeAnn => false

--- a/src/hazelcore/UndoHistoryCore.rei
+++ b/src/hazelcore/UndoHistoryCore.rei
@@ -8,6 +8,9 @@ type delete_group =
   | Term(cursor_term, start_from_insertion)
   /* cursor_term is insufficient for space, empty line and type annotation deletion,
      so we add the following three constructors */
+  | ParenthesesFromTheInside
+  /* Special case action for deleting parentheses in a single keystrokes when
+     the cursor is on a contained operand bordering the parentheses */
   | Space
   | EmptyLine
   | TypeAnn;

--- a/src/hazelweb/gui/UndoHistoryPanel.re
+++ b/src/hazelweb/gui/UndoHistoryPanel.re
@@ -332,6 +332,8 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
     switch (undo_history_entry.action_group) {
     | DeleteEdit(edit_detail) =>
       switch (edit_detail) {
+      | ParenthesesFromTheInside =>
+        indicate_words_view("delete parentheses from inside")
       | Term(cursor_term, start_from_insertion) =>
         let indicate_words =
           if (start_from_insertion) {"insert and delete "} else {"delete "};
@@ -443,7 +445,8 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
       switch (edit_detail) {
       | Term(cursor_term, _) => Some(get_cursor_term_tag_typ(cursor_term))
       | Space
-      | EmptyLine =>
+      | EmptyLine
+      | ParenthesesFromTheInside =>
         Some(
           get_cursor_term_tag_typ(
             undo_history_entry.cursor_term_info.cursor_term_before,

--- a/src/hazelweb/model/UndoHistory.re
+++ b/src/hazelweb/model/UndoHistory.re
@@ -332,6 +332,42 @@ let is_parentheses_delete_action = (a: Action.t, zexp: ZExp.t): bool => {
         || ZExp.is_after_zopseq(inner_zopseq)
         && a == Delete =>
     true
+  | (_, LetLineZP(pat, _), _)
+  | (
+      _,
+      ExpLineZ(
+        ZOpSeq(_, ZOperand(CaseZR(_, _, (_, RuleZP(pat, _), _)), _)),
+      ),
+      _,
+    )
+  | (_, ExpLineZ(ZOpSeq(_, ZOperand(LamZP(_, pat, _), _))), _) =>
+    switch (pat) {
+    | ZOpSeq(_, ZOperand(ParenthesizedZ(inner_zopseq), _))
+        when
+          ZPat.is_before_zopseq(inner_zopseq)
+          && a == Backspace
+          || ZPat.is_after_zopseq(inner_zopseq)
+          && a == Delete =>
+      true
+    | ZOpSeq(
+        _,
+        ZOperand(
+          TypeAnnZA(
+            _,
+            _,
+            ZOpSeq(_, ZOperand(ParenthesizedZ(inner_zopseq), _)),
+          ),
+          _,
+        ),
+      )
+        when
+          ZTyp.is_before_zopseq(inner_zopseq)
+          && a == Backspace
+          || ZTyp.is_after_zopseq(inner_zopseq)
+          && a == Delete =>
+      true
+    | _ => false
+    }
   | _ => false
   };
 };


### PR DESCRIPTION
Backspacing an opening parens or deleting closing parens no longer requires two keystrokes.

Not sure if there is a more principled approach here