### PR TITLE
(possibly bad) fix of image livelit impossible syn crash

### DIFF
--- a/src/hazelcore/Statics_Exp.re
+++ b/src/hazelcore/Statics_Exp.re
@@ -2205,13 +2205,11 @@ module rec M: Statics_Exp_Sig.S = {
         syn_fix_holes_operand(ctx, u_gen, ~renumber_empty_holes, e);
       let is_insufficient_params =
         switch (UHExp.get_err_status_operand(e)) {
-        | InHole(TypeInconsistent(Some(InsufficientParams)), _) => true
+        | InHole(TypeInconsistent(Some(InsufficientParams)), _)
         | _ => false
         };
-      if (is_insufficient_params) {
+      if (is_insufficient_params || HTyp.consistent(ty, ty')) {
         (e, u_gen);
-      } else if (HTyp.consistent(ty, ty')) {
-        (UHExp.set_err_status_operand(NotInHole, e), u_gen);
       } else {
         let (u, u_gen) = MetaVarGen.next_hole(u_gen);
         (

--- a/src/hazelcore/Statics_Exp.re
+++ b/src/hazelcore/Statics_Exp.re
@@ -2205,8 +2205,8 @@ module rec M: Statics_Exp_Sig.S = {
         syn_fix_holes_operand(ctx, u_gen, ~renumber_empty_holes, e);
       let is_insufficient_params =
         switch (UHExp.get_err_status_operand(e)) {
-        | InHole(TypeInconsistent(Some(InsufficientParams)), _) => false
-        | _ => true
+        | InHole(TypeInconsistent(Some(InsufficientParams)), _) => true
+        | _ => false
         };
       if (is_insufficient_params) {
         (e, u_gen);

--- a/src/hazelcore/Statics_Exp.re
+++ b/src/hazelcore/Statics_Exp.re
@@ -1862,7 +1862,6 @@ module rec M: Statics_Exp_Sig.S = {
           }
         };
       };
-
     (
       UHExp.ApLivelit(llu, err_status, name, lln, model, splice_info),
       typ,
@@ -2204,7 +2203,14 @@ module rec M: Statics_Exp_Sig.S = {
     | FreeLivelit(_) =>
       let (e, ty', u_gen) =
         syn_fix_holes_operand(ctx, u_gen, ~renumber_empty_holes, e);
-      if (HTyp.consistent(ty, ty')) {
+      let is_insufficient_params =
+        switch (UHExp.get_err_status_operand(e)) {
+        | InHole(TypeInconsistent(Some(InsufficientParams)), _) => false
+        | _ => true
+        };
+      if (is_insufficient_params) {
+        (e, u_gen);
+      } else if (HTyp.consistent(ty, ty')) {
         (UHExp.set_err_status_operand(NotInHole, e), u_gen);
       } else {
         let (u, u_gen) = MetaVarGen.next_hole(u_gen);


### PR DESCRIPTION
This fixes the crash but I'm not sure the fix is well-considered. The issue is that the livelit is loosing it's InsufficientParams label in the below logic. But I'm not clear on why these checks are happening in the first place, instead of just calling ana_fix_holes_operand and being done with it