### PR TITLE
Fix caret animation bug

### DIFF
--- a/src/hazelweb/Hazel.re
+++ b/src/hazelweb/Hazel.re
@@ -52,13 +52,17 @@ let on_startup = (~schedule_action, _) => {
   Async_kernel.Deferred.return(State.State);
 };
 
-let restart_cursor_animation = caret_elem => {
-  caret_elem##.classList##remove(Js.string("blink"));
-  // necessary to trigger reflow
-  // <https://css-tricks.com/restart-css-animation/>
-  let _ = caret_elem##getBoundingClientRect;
-  caret_elem##.classList##add(Js.string("blink"));
-};
+let restart_cursor_animation = () =>
+  try({
+    let caret_elem = JSUtil.force_get_elem_by_id("caret");
+    caret_elem##.classList##remove(Js.string("blink"));
+    // necessary to trigger reflow
+    // <https://css-tricks.com/restart-css-animation/>
+    let _ = caret_elem##getBoundingClientRect;
+    caret_elem##.classList##add(Js.string("blink"));
+  }) {
+  | _ => ()
+  };
 
 let scroll_cursor_into_view_if_needed = caret_elem => {
   let page_rect =
@@ -99,7 +103,11 @@ let create =
   TimeUtil.measure_time(
     "Hazel.create", performance.measure && performance.hazel_create, () =>
     Component.create(
-      ~apply_action=Update.apply_action(model),
+      ~apply_action=
+        (action, state) => {
+          restart_cursor_animation();
+          Update.apply_action(model, action, state);
+        },
       // for things that require actual DOM manipulation post-render
       ~on_display=
         (_, ~schedule_action as _) => {
@@ -117,7 +125,6 @@ let create =
             | _ => UHCode.focus()
             };
             let caret_elem = JSUtil.force_get_elem_by_id("caret");
-            restart_cursor_animation(caret_elem);
             scroll_cursor_into_view_if_needed(caret_elem);
           };
         },


### PR DESCRIPTION
closes #427. This restores caret animation, addressing the issue which causes choppy behavior on cursor movement by restarting the animation on-action versus on on-display. 

(As a reminder, the issue with making such calls on_display is that as of the last time we updated incr_dom, on_display is called every ~20ms regardless of whether or not the state is dirty, causing the animation to continuously restart and hence appear static)