### PR TITLE
Cleanup KeyComboAction.get_model_action_from_kc

### DIFF
--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -7,11 +7,11 @@ let get_model_action_from_kc =
   let construct = (shape: Action.shape): option(ModelAction.t) =>
     Some(EditAction(Construct(shape)));
 
-  let (cursor_on_type, cursor_on_comment) =
+  let cursor_on_type =
     switch (cursor_info) {
-    | {typed: OnType, _} => (true, false)
-    | {cursor_term: Line(_, CommentLine(_)), _} => (false, true)
-    | _ => (false, false)
+    | {typed: OnType, _} => true
+    | {cursor_term: Line(_, CommentLine(_)), _} => false
+    | _ => false
     };
 
   /* When adding or updating key combo actions, make sure to appropriately update
@@ -41,7 +41,6 @@ let get_model_action_from_kc =
   | Asterisk => construct(SOp(STimes))
   | Slash => construct(SOp(SDivide))
   | LT => construct(SOp(SLessThan))
-  | Space when cursor_on_comment => construct(SChar(" "))
   | Space => construct(SOp(SSpace))
   | Comma => construct(SOp(SComma))
   | LeftBracket when cursor_on_type => construct(SList)

--- a/src/hazelweb/gui/KeyComboAction.re
+++ b/src/hazelweb/gui/KeyComboAction.re
@@ -10,7 +10,6 @@ let get_model_action_from_kc =
   let cursor_on_type =
     switch (cursor_info) {
     | {typed: OnType, _} => true
-    | {cursor_term: Line(_, CommentLine(_)), _} => false
     | _ => false
     };
 
@@ -74,11 +73,10 @@ let get_model_action =
   let construct = (shape: Action.shape): option(ModelAction.t) =>
     Some(EditAction(Construct(shape)));
 
-  let (_cursor_on_type, cursor_on_comment) =
+  let cursor_on_comment =
     switch (cursor_info) {
-    | {typed: OnType, _} => (true, false)
-    | {cursor_term: Line(_, CommentLine(_)), _} => (false, true)
-    | _ => (false, false)
+    | {cursor_term: Line(_, CommentLine(_)), _} => true
+    | _ => false
     };
 
   let key_combo = HazelKeyCombos.of_evt(evt);


### PR DESCRIPTION
Noticed this when working on string literal character insertions. I could be wrong about this...

Cleans up `KeyComboAction.get_model_action_from_kc` a little bit by removing the unnecessary `cursor_on_comment`. The `single_key_in_comment` already intercepts character insertions (including space) into comment lines.