### PR TITLE
Fix underscore

### DIFF
--- a/src/hazelcore/Action_Exp.re
+++ b/src/hazelcore/Action_Exp.re
@@ -313,13 +313,11 @@ let mk_syn_text =
       );
     let ze = ZExp.ZBlock.wrap(CursorE(text_cursor, var));
     Succeeded(SynDone((ze, HTyp.Hole, u_gen)));
-  | Underscore as shape
-  | Var(_) as shape =>
-    let x =
-      switch (shape) {
-      | Var(x) => x
-      | _ => "_"
-      };
+  | Underscore =>
+    let (it, u_gen) = UHExp.new_InvalidText(u_gen, "_");
+    let ze = ZExp.ZBlock.wrap(CursorE(text_cursor, it));
+    Succeeded(SynDone((ze, HTyp.Hole, u_gen)));
+  | Var(x) =>
     switch (VarMap.lookup(ctx |> Contexts.gamma, x)) {
     | Some(ty) =>
       let ze = ZExp.ZBlock.wrap(CursorE(text_cursor, UHExp.var(x)));

--- a/src/hazelcore/Var.re
+++ b/src/hazelcore/Var.re
@@ -7,7 +7,8 @@ let eq = String.equal;
 
 let length = String.length;
 
-let valid_regex = Re.Str.regexp("^[_a-zA-Z][_a-zA-Z0-9']*$");
+let valid_regex =
+  Re.Str.regexp("^\\([a-zA-Z]\\|_[_a-zA-Z0-9]\\)[_a-zA-Z0-9']*$");
 let is_valid = s => Re.Str.string_match(valid_regex, s, 0);
 
 /* helper function for guarding options with is_valid */


### PR DESCRIPTION
Fix a single underscore in expression position to be invalid text, instead of a free variable.
Additionally, updates Var.valid_regexp to not allow a single underscore to be considered a variable.

Closes #571 