### PR TITLE
UndoHistory: Switch previous_action from Action.t to ModelAction.t

### DIFF
--- a/src/hazelweb/model/Model.re
+++ b/src/hazelweb/model/Model.re
@@ -34,7 +34,7 @@ let init = (): t => {
       cardstacks_after_action: cardstacks,
       cardstacks_after_move: cardstacks,
       cursor_term_info,
-      previous_action: Init,
+      previous_action: EditAction(Init),
       action_group: Init,
       timestamp,
     };
@@ -163,7 +163,7 @@ let select_hole_instance = ((u, i): HoleInstance.t, model: t): t =>
   |> map_selected_instances(UserSelectedInstances.add(u, i))
   |> focus_cell;
 
-let update_program = (a: Action.t, new_program, model) => {
+let update_program = (a: ModelAction.t, new_program, model) => {
   let old_program = model |> get_program;
   let update_selected_instances = si => {
     let si =
@@ -226,7 +226,8 @@ let perform_edit_action = (a: Action.t, model: t): t => {
     () => {
       let new_program =
         model |> get_program |> Program.perform_edit_action(a);
-      model |> update_program(a, new_program);
+      let ma = ModelAction.EditAction(a);
+      model |> update_program(ma, new_program);
     },
   );
 };
@@ -236,7 +237,8 @@ let move_via_key = (move_key, model) => {
     model
     |> get_program
     |> Program.move_via_key(~settings=model.settings, move_key);
-  model |> update_program(action, new_program);
+  let model_action = ModelAction.EditAction(action);
+  model |> update_program(model_action, new_program);
 };
 
 let move_via_click = (row_col, model) => {
@@ -244,7 +246,8 @@ let move_via_click = (row_col, model) => {
     model
     |> get_program
     |> Program.move_via_click(~settings=model.settings, row_col);
-  model |> update_program(action, new_program);
+  let model_action = ModelAction.EditAction(action);
+  model |> update_program(model_action, new_program);
 };
 
 let select_case_branch =
@@ -252,9 +255,10 @@ let select_case_branch =
   let program = model |> get_program;
   let action = Program.move_to_case_branch(path_to_case, branch_index);
   let new_program = Program.perform_edit_action(action, program);
+  let model_action = ModelAction.EditAction(action);
   model
   |> put_program(new_program)
-  |> update_program(action, new_program)
+  |> update_program(model_action, new_program)
   |> focus_cell;
 };
 

--- a/src/hazelweb/model/UndoHistory.re
+++ b/src/hazelweb/model/UndoHistory.re
@@ -8,7 +8,7 @@ type undo_history_entry = {
      if there is a movement action, update it. */
   cardstacks_after_move: ZCardstacks.t,
   cursor_term_info: UndoHistoryCore.cursor_term_info,
-  previous_action: Action.t,
+  previous_action: ModelAction.t,
   action_group: UndoHistoryCore.action_group,
   timestamp: UndoHistoryCore.timestamp,
 };
@@ -461,217 +461,225 @@ let get_new_action_group =
       ~prev_group: undo_history_group,
       ~new_cardstacks_before: ZCardstacks.t,
       ~new_cursor_term_info: UndoHistoryCore.cursor_term_info,
-      ~action: Action.t,
+      ~action: ModelAction.t,
     )
     : option(UndoHistoryCore.action_group) =>
   switch (action) {
-  | Delete =>
-    delete(~prev_group, ~new_cardstacks_before, ~new_cursor_term_info)
-  | Backspace =>
-    backspace(~prev_group, ~new_cardstacks_before, ~new_cursor_term_info)
-  | Construct(shape) =>
-    switch (shape) {
-    | SLine =>
-      switch (
-        CursorInfo_Exp.get_outer_zrules(new_cursor_term_info.zexp_before)
-      ) {
-      | None => Some(ConstructEdit(shape))
-      | Some(zrules_before) =>
+  | EditAction(action) =>
+    switch (action) {
+    | Delete =>
+      delete(~prev_group, ~new_cardstacks_before, ~new_cursor_term_info)
+    | Backspace =>
+      backspace(~prev_group, ~new_cardstacks_before, ~new_cursor_term_info)
+    | Construct(shape) =>
+      switch (shape) {
+      | SLine =>
         switch (
-          CursorInfo_Exp.get_outer_zrules(new_cursor_term_info.zexp_after)
+          CursorInfo_Exp.get_outer_zrules(new_cursor_term_info.zexp_before)
         ) {
         | None => Some(ConstructEdit(shape))
-        | Some(zrules_after) =>
-          if (ZList.length(zrules_before) < ZList.length(zrules_after)) {
-            Some(CaseRule);
-          } else {
-            Some(ConstructEdit(shape));
+        | Some(zrules_before) =>
+          switch (
+            CursorInfo_Exp.get_outer_zrules(new_cursor_term_info.zexp_after)
+          ) {
+          | None => Some(ConstructEdit(shape))
+          | Some(zrules_after) =>
+            if (ZList.length(zrules_before) < ZList.length(zrules_after)) {
+              Some(CaseRule);
+            } else {
+              Some(ConstructEdit(shape));
+            }
           }
         }
-      }
-    | SCommentLine
-    | SParenthesized
-    /***
-     * SCloseParens, SCloseBraces and SCloseSquareBrackets are edit actions
-     * (with no structural change) which result in movement of the cursor,
-     * therefore undoing them should be supported
-     */
-    | SCloseParens
-    | SCloseBraces
-    | SCloseSquareBracket
-    | SList
-    | SAnn
-    | SLam
-    | SListNil
-    | SInj(_)
-    | SLet
-    | SCase => Some(ConstructEdit(shape))
-    | SChar(_) =>
-      if (group_entry(
-            ~prev_group,
-            ~new_cardstacks_before,
-            ~new_action_group=
-              VarGroup(
-                Edit({
-                  start_from: new_cursor_term_info.cursor_term_before,
-                  end_with: new_cursor_term_info.cursor_term_after,
-                }),
-              ),
-          )) {
-        switch (get_initial_entry_in_group(prev_group)) {
-        | None =>
-          Some(VarGroup(Insert(new_cursor_term_info.cursor_term_after)))
-        | Some(initial_entry) =>
-          if (UndoHistoryCore.is_var_insert(initial_entry.action_group)) {
-            Some(VarGroup(Insert(new_cursor_term_info.cursor_term_after)));
-          } else {
-            Some(
-              VarGroup(
-                Edit({
-                  start_from:
-                    initial_entry.cursor_term_info.cursor_term_before,
-                  end_with: new_cursor_term_info.cursor_term_after,
-                }),
-              ),
-            );
-          }
-        };
-      } else if (CursorInfo_common.is_empty_hole(
-                   new_cursor_term_info.cursor_term_before,
-                 )
-                 || CursorInfo_common.is_empty_line(
-                      new_cursor_term_info.cursor_term_before,
-                    )
-                 || !
-                      CursorInfo_common.cursor_term_is_editable(
+      | SCommentLine
+      | SParenthesized
+      /***
+       * SCloseParens, SCloseBraces and SCloseSquareBrackets are edit actions
+       * (with no structural change) which result in movement of the cursor,
+       * therefore undoing them should be supported
+       */
+      | SCloseParens
+      | SCloseBraces
+      | SCloseSquareBracket
+      | SList
+      | SAnn
+      | SLam
+      | SListNil
+      | SInj(_)
+      | SLet
+      | SCase => Some(ConstructEdit(shape))
+      | SChar(_) =>
+        if (group_entry(
+              ~prev_group,
+              ~new_cardstacks_before,
+              ~new_action_group=
+                VarGroup(
+                  Edit({
+                    start_from: new_cursor_term_info.cursor_term_before,
+                    end_with: new_cursor_term_info.cursor_term_after,
+                  }),
+                ),
+            )) {
+          switch (get_initial_entry_in_group(prev_group)) {
+          | None =>
+            Some(VarGroup(Insert(new_cursor_term_info.cursor_term_after)))
+          | Some(initial_entry) =>
+            if (UndoHistoryCore.is_var_insert(initial_entry.action_group)) {
+              Some(
+                VarGroup(Insert(new_cursor_term_info.cursor_term_after)),
+              );
+            } else {
+              Some(
+                VarGroup(
+                  Edit({
+                    start_from:
+                      initial_entry.cursor_term_info.cursor_term_before,
+                    end_with: new_cursor_term_info.cursor_term_after,
+                  }),
+                ),
+              );
+            }
+          };
+        } else if (CursorInfo_common.is_empty_hole(
+                     new_cursor_term_info.cursor_term_before,
+                   )
+                   || CursorInfo_common.is_empty_line(
                         new_cursor_term_info.cursor_term_before,
-                        // <<<<<<< HEAD
-                        //                       )) {
-                        //         Some(VarGroup(Insert(new_cursor_term_info.cursor_term_after)));
-                        //       } else {
-                        //         Some(
-                        //           VarGroup(
-                        //             Edit({
-                        //               start_from: new_cursor_term_info.cursor_term_before,
-                        //               end_with: new_cursor_term_info.cursor_term_after,
-                        //             }),
-                        //           ),
-                        //         );
-                        //       }
-                        // =======
                       )
-                 || !
-                      CursorInfo_common.cursor_term_is_editable(
-                        new_cursor_term_info.cursor_term_before,
-                      )) {
-        Some(VarGroup(Insert(new_cursor_term_info.cursor_term_after)));
-      } else {
-        Some(
-          VarGroup(
-            Edit({
-              start_from: new_cursor_term_info.cursor_term_before,
-              end_with: new_cursor_term_info.cursor_term_after,
-            }),
-          ),
-        );
-      }
+                   || !
+                        CursorInfo_common.cursor_term_is_editable(
+                          new_cursor_term_info.cursor_term_before,
+                          // <<<<<<< HEAD
+                          //                       )) {
+                          //         Some(VarGroup(Insert(new_cursor_term_info.cursor_term_after)));
+                          //       } else {
+                          //         Some(
+                          //           VarGroup(
+                          //             Edit({
+                          //               start_from: new_cursor_term_info.cursor_term_before,
+                          //               end_with: new_cursor_term_info.cursor_term_after,
+                          //             }),
+                          //           ),
+                          //         );
+                          //       }
+                          // =======
+                        )
+                   || !
+                        CursorInfo_common.cursor_term_is_editable(
+                          new_cursor_term_info.cursor_term_before,
+                        )) {
+          Some(VarGroup(Insert(new_cursor_term_info.cursor_term_after)));
+        } else {
+          Some(
+            VarGroup(
+              Edit({
+                start_from: new_cursor_term_info.cursor_term_before,
+                end_with: new_cursor_term_info.cursor_term_after,
+              }),
+            ),
+          );
+        }
 
-    | SOp(op) =>
-      switch (op) {
-      | SMinus
-      | SPlus
-      | STimes
-      | SDivide
-      | SLessThan
-      | SGreaterThan
-      | SEquals
-      | SComma
-      | SArrow
-      | SVBar
-      | SCons
-      | SAnd
-      | SOr => Some(ConstructEdit(shape))
-      | SSpace =>
-        switch (new_cursor_term_info.cursor_term_before) {
-        | ExpOperand(pos, uexp_operand) =>
-          switch (uexp_operand) {
-          | Var(_, InVarHole(Keyword(k), _), _) =>
-            switch (k) {
-            | Let =>
-              switch (
-                UndoHistoryCore.get_cursor_pos(
-                  new_cursor_term_info.cursor_term_before,
-                )
-              ) {
-              | OnText(pos) =>
-                if (pos == 3) {
-                  /* the caret is at the end of "let" */
-                  Some(
-                    ConstructEdit(SLet),
-                  );
+      | SOp(op) =>
+        switch (op) {
+        | SMinus
+        | SPlus
+        | STimes
+        | SDivide
+        | SLessThan
+        | SGreaterThan
+        | SEquals
+        | SComma
+        | SArrow
+        | SVBar
+        | SCons
+        | SAnd
+        | SOr => Some(ConstructEdit(shape))
+        | SSpace =>
+          switch (new_cursor_term_info.cursor_term_before) {
+          | ExpOperand(pos, uexp_operand) =>
+            switch (uexp_operand) {
+            | Var(_, InVarHole(Keyword(k), _), _) =>
+              switch (k) {
+              | Let =>
+                switch (
+                  UndoHistoryCore.get_cursor_pos(
+                    new_cursor_term_info.cursor_term_before,
+                  )
+                ) {
+                | OnText(pos) =>
+                  if (pos == 3) {
+                    /* the caret is at the end of "let" */
+                    Some(
+                      ConstructEdit(SLet),
+                    );
+                  } else {
+                    Some(ConstructEdit(SOp(SSpace)));
+                  }
+                | OnDelim(_, _)
+                | OnOp(_) => Some(ConstructEdit(SOp(SSpace)))
+                }
+
+              | Case =>
+                switch (
+                  UndoHistoryCore.get_cursor_pos(
+                    new_cursor_term_info.cursor_term_before,
+                  )
+                ) {
+                | OnText(pos) =>
+                  if (pos == 4) {
+                    /* the caret is at the end of "case" */
+                    Some(
+                      ConstructEdit(SCase),
+                    );
+                  } else {
+                    Some(ConstructEdit(SOp(SSpace)));
+                  }
+                | OnDelim(_, _)
+                | OnOp(_) => Some(ConstructEdit(SOp(SSpace)))
+                }
+              }
+            | Var(_, _, var) =>
+              switch (pos) {
+              | OnText(index) =>
+                let (left_var, _) = Var.split(index, var);
+                if (Var.is_let(left_var)) {
+                  Some(ConstructEdit(SLet));
+                } else if (Var.is_case(left_var)) {
+                  Some(ConstructEdit(SCase));
                 } else {
                   Some(ConstructEdit(SOp(SSpace)));
-                }
+                };
               | OnDelim(_, _)
               | OnOp(_) => Some(ConstructEdit(SOp(SSpace)))
               }
 
-            | Case =>
-              switch (
-                UndoHistoryCore.get_cursor_pos(
-                  new_cursor_term_info.cursor_term_before,
-                )
-              ) {
-              | OnText(pos) =>
-                if (pos == 4) {
-                  /* the caret is at the end of "case" */
-                  Some(
-                    ConstructEdit(SCase),
-                  );
-                } else {
-                  Some(ConstructEdit(SOp(SSpace)));
-                }
-              | OnDelim(_, _)
-              | OnOp(_) => Some(ConstructEdit(SOp(SSpace)))
-              }
+            | ApPalette(_, _, _, _) =>
+              failwith("ApPalette is not implemented")
+            | _ => Some(ConstructEdit(SOp(SSpace)))
             }
-          | Var(_, _, var) =>
-            switch (pos) {
-            | OnText(index) =>
-              let (left_var, _) = Var.split(index, var);
-              if (Var.is_let(left_var)) {
-                Some(ConstructEdit(SLet));
-              } else if (Var.is_case(left_var)) {
-                Some(ConstructEdit(SCase));
-              } else {
-                Some(ConstructEdit(SOp(SSpace)));
-              };
-            | OnDelim(_, _)
-            | OnOp(_) => Some(ConstructEdit(SOp(SSpace)))
-            }
-
-          | ApPalette(_, _, _, _) => failwith("ApPalette is not implemented")
           | _ => Some(ConstructEdit(SOp(SSpace)))
           }
-        | _ => Some(ConstructEdit(SOp(SSpace)))
         }
-      }
 
-    | SApPalette(_) => failwith("ApPalette is not implemented")
+      | SApPalette(_) => failwith("ApPalette is not implemented")
+      }
+    | SwapUp => Some(SwapEdit(Up))
+    | SwapDown => Some(SwapEdit(Down))
+    | SwapLeft => Some(SwapEdit(Left))
+    | SwapRight => Some(SwapEdit(Right))
+    | MoveTo(_)
+    | MoveLeft
+    | MoveRight
+    | MoveToNextHole
+    | MoveToPrevHole
+    | Init => None
+    | UpdateApPalette(_) =>
+      failwith("ApPalette is not implemented in undo_history")
     }
-  | SwapUp => Some(SwapEdit(Up))
-  | SwapDown => Some(SwapEdit(Down))
-  | SwapLeft => Some(SwapEdit(Left))
-  | SwapRight => Some(SwapEdit(Right))
-  | MoveTo(_)
-  | MoveLeft
-  | MoveRight
-  | MoveToNextHole
-  | MoveToPrevHole
-  | Init => None
-  | UpdateApPalette(_) =>
-    failwith("ApPalette is not implemented in undo_history")
+  | _ => None
   };
+
 let get_cursor_term_info =
     (
       ~new_cardstacks_after: ZCardstacks.t,
@@ -706,7 +714,7 @@ let push_edit_state =
       undo_history: t,
       new_cardstacks_before: ZCardstacks.t,
       new_cardstacks_after: ZCardstacks.t,
-      action: Action.t,
+      action: ModelAction.t,
     )
     : t => {
   let prev_group = ZList.prj_z(undo_history.groups);

--- a/src/hazelweb/model/UndoHistory.rei
+++ b/src/hazelweb/model/UndoHistory.rei
@@ -6,7 +6,7 @@ type undo_history_entry = {
      if there is a movement action, update it. */
   cardstacks_after_move: ZCardstacks.t,
   cursor_term_info: UndoHistoryCore.cursor_term_info,
-  previous_action: Action.t,
+  previous_action: ModelAction.t,
   action_group: UndoHistoryCore.action_group,
   timestamp: UndoHistoryCore.timestamp,
 };
@@ -68,7 +68,7 @@ let shift_history: (int, int, bool, t) => t;
  * entry for performing action `a` starting with cardstacks `before`
  * and resulting in cardstacks `after`.
  */
-let push_edit_state: (t, ZCardstacks.t, ZCardstacks.t, Action.t) => t;
+let push_edit_state: (t, ZCardstacks.t, ZCardstacks.t, ModelAction.t) => t;
 
 /**
  * Returns the `UndoHistoryCore.cursor_term_info` associated with


### PR DESCRIPTION
Have UndoHistory track ModelActions instead of Actions for the previous_action.
This will be needed to have an Import entry in the Undo History.