### PR TITLE
fix ana_perform behavior for type inconsistencies to not call syn_perform

### DIFF
--- a/src/hazelcore/UHExp.re
+++ b/src/hazelcore/UHExp.re
@@ -210,12 +210,6 @@ and set_err_status_operand = (err, operand) =>
   | Parenthesized(body) => Parenthesized(body |> set_err_status(err))
   };
 
-let is_inconsistent = operand =>
-  switch (operand |> get_err_status_operand) {
-  | InHole(TypeInconsistent, _) => true
-  | _ => false
-  };
-
 /* put e in a new hole, if it is not already in a hole */
 let rec mk_inconsistent = (u_gen: MetaVarGen.t, e: t): (t, MetaVarGen.t) =>
   mk_inconsistent_block(u_gen, e)

--- a/src/hazelcore/UHExp.rei
+++ b/src/hazelcore/UHExp.rei
@@ -95,8 +95,6 @@ let set_err_status_opseq: (ErrStatus.t, opseq) => opseq;
 
 let set_err_status_operand: (ErrStatus.t, operand) => operand;
 
-let is_inconsistent: operand => bool;
-
 let mk_inconsistent_opseq: (MetaVarGen.t, opseq) => (opseq, MetaVarGen.t);
 
 let mk_inconsistent_operand:

--- a/src/hazelcore/UHPat.re
+++ b/src/hazelcore/UHPat.re
@@ -111,12 +111,6 @@ and set_err_status_operand = (err, operand) =>
   | TypeAnn(_, op, ann) => TypeAnn(err, op, ann)
   };
 
-let is_inconsistent = (p: t): bool =>
-  switch (get_err_status(p)) {
-  | InHole(TypeInconsistent, _) => true
-  | _ => false
-  };
-
 /* put p in a new hole, if it is not already in a hole */
 let rec mk_inconsistent = (u_gen: MetaVarGen.t, p: t): (t, MetaVarGen.t) =>
   mk_inconsistent_opseq(u_gen, p)

--- a/src/hazelcore/UHPat.rei
+++ b/src/hazelcore/UHPat.rei
@@ -60,8 +60,6 @@ let set_err_status_opseq: (ErrStatus.t, t) => t;
 
 let set_err_status_operand: (ErrStatus.t, operand) => operand;
 
-let is_inconsistent: t => bool;
-
 /* put p in a new hole, if it is not already in a hole */
 let mk_inconsistent: (MetaVarGen.t, t) => (t, MetaVarGen.t);
 

--- a/src/hazelcore/ZExp.re
+++ b/src/hazelcore/ZExp.re
@@ -551,9 +551,6 @@ let empty_zrule = (u_gen: MetaVarGen.t): (zrule, MetaVarGen.t) => {
   (zrule, u_gen);
 };
 
-let is_inconsistent = zoperand =>
-  zoperand |> erase_zoperand |> UHExp.is_inconsistent;
-
 let rec move_cursor_left = (ze: t): option(t) =>
   ze |> move_cursor_left_zblock
 and move_cursor_left_zblock =

--- a/src/hazelcore/ZPat.re
+++ b/src/hazelcore/ZPat.re
@@ -232,8 +232,6 @@ let new_EmptyHole = (u_gen: MetaVarGen.t): (zoperand, MetaVarGen.t) => {
   (place_before_operand(hole), u_gen);
 };
 
-let is_inconsistent = (zp: t): bool => UHPat.is_inconsistent(erase(zp));
-
 let move_cursor_left_zoperator: zoperator => option(zoperator) =
   fun
   | (OnText(_) | OnDelim(_, _), _) => None


### PR DESCRIPTION
ana_perform should proceed normally even if there is currently a type inconsistency -- it was written in a way that would make sense for explicit non-empty holes a la Hazelnut but Hazel does hole fixing so not necessary here