### PR TITLE
Fix EANEHole rule

### DIFF
--- a/src/hazelcore/dynamics/Elaborator_Exp.re
+++ b/src/hazelcore/dynamics/Elaborator_Exp.re
@@ -652,7 +652,7 @@ and ana_elab_operand =
       let sigma = Environment.id_env(gamma);
       let delta =
         MetaVarMap.add(u, (Delta.ExpressionHole, ty, gamma), delta);
-      Elaborates(NonEmptyHole(reason, u, 0, sigma, d), Hole, delta);
+      Elaborates(NonEmptyHole(reason, u, 0, sigma, d), ty, delta);
     };
   | Case(InconsistentBranches(_, u), _, _) =>
     switch (syn_elab_operand(ctx, delta, operand)) {


### PR DESCRIPTION
Fix type assignment for type-inconsistent non-empty holes in `ana_elab_operand` in order to match rule EANEHole. Holes in analytic position should be assigned the analyzed type, not type `Hole`.

This caused unnecessary casts to be inserted but otherwise seems to not cause differences in elaboration/evaluation.