### PR TITLE
Fix issues related to OnDelim with Parenthesized and List

### DIFF
--- a/src/hazelcore/CursorPath_Typ.re
+++ b/src/hazelcore/CursorPath_Typ.re
@@ -187,8 +187,8 @@ and holes_zoperand =
   | CursorT(OnDelim(k, _), Parenthesized(body) | List(body)) =>
     let holes = holes(body, [0, ...rev_steps], []);
     switch (k) {
-    | 0 => CursorPath_common.mk_zholes(~holes_before=holes, ())
-    | 1 => CursorPath_common.mk_zholes(~holes_after=holes, ())
+    | 0 => CursorPath_common.mk_zholes(~holes_after=holes, ())
+    | 1 => CursorPath_common.mk_zholes(~holes_before=holes, ())
     | _ => CursorPath_common.no_holes
     };
   | CursorT(OnOp(_) | OnText(_), Parenthesized(_) | List(_)) =>

--- a/src/hazelcore/ZTyp.re
+++ b/src/hazelcore/ZTyp.re
@@ -142,6 +142,7 @@ and move_cursor_left_zoperand =
   | CursorT(OnOp(_) | OnText(_), _) => None
   | CursorT(OnDelim(k, After), ty) =>
     Some(CursorT(OnDelim(k, Before), ty))
+  | CursorT(OnDelim(0, Before), _) => None
   | CursorT(OnDelim(_, Before), Hole | Unit | Int | Float | Bool) => None
   | CursorT(OnDelim(_k, Before), Parenthesized(ty1)) =>
     // _k == 1


### PR DESCRIPTION
Fixed two issues discussed in Jun 16's Office Hour:
1. Fix `OnDelim` for `Parenthesized` and `List` in `holes_zoperand`
2. Fix `OnDelim(0, Before)` in `move_cursor_left_zoperand`