### PR TITLE
move undo history panel to left sidebar

### DIFF
--- a/src/hazelweb/gui/ActionPanel.re
+++ b/src/hazelweb/gui/ActionPanel.re
@@ -4,7 +4,7 @@ let action_panel = (children: list(Node.t)): Node.t => {
   let panel_title =
     Node.div(
       [Attr.classes(["panel-title-bar", "title-bar"])],
-      [Node.text("Edit Actions")],
+      [Node.text("Available Edit Actions")],
     );
 
   let panel_body =

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -24,7 +24,7 @@ let branch_panel =
 let history_panel = (~inject): Node.t => {
   button(
     [
-      Attr.id("cardstack-next-button"),
+      Attr.classes(["button"]),
       Attr.on_click(_ => inject(ModelAction.ToggleLeftSidebar)),
     ],
     [text("history")],

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -21,15 +21,16 @@ let branch_panel =
     ],
   );
 
-let history_panel = (~inject): Node.t => {
-  button(
-    [
-      Attr.classes(["button"]),
-      Attr.on_click(_ => inject(ModelAction.ToggleLeftSidebar)),
-    ],
-    [text("history")],
-  );
-};
+// // button to toggle history panel
+// let history_panel = (~inject): Node.t => {
+//   button(
+//     [
+//       Attr.classes(["button"]),
+//       Attr.on_click(_ => inject(ModelAction.ToggleLeftSidebar)),
+//     ],
+//     [text("history")],
+//   );
+// };
 
 let top_bar = (~inject: ModelAction.t => Ui_event.t, ~model: Model.t) => {
   div(
@@ -37,7 +38,7 @@ let top_bar = (~inject: ModelAction.t => Ui_event.t, ~model: Model.t) => {
     [
       logo_panel,
       CardsPanel.view(~inject, ~model),
-      history_panel(~inject),
+      // history_panel(~inject),
       ActionMenu.view(~inject),
     ],
   );

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -1,5 +1,6 @@
 open Virtual_dom.Vdom;
 open Node;
+
 let logo_panel =
   a(
     [Attr.classes(["logo-text"]), Attr.href("https://hazel.org")],
@@ -20,12 +21,23 @@ let branch_panel =
     ],
   );
 
+let history_panel = (~inject): Node.t => {
+  button(
+    [
+      Attr.id("cardstack-next-button"),
+      Attr.on_click(_ => inject(ModelAction.ToggleLeftSidebar)),
+    ],
+    [text("history")],
+  );
+};
+
 let top_bar = (~inject: ModelAction.t => Ui_event.t, ~model: Model.t) => {
   div(
     [Attr.classes(["top-bar"])],
     [
       logo_panel,
       CardsPanel.view(~inject, ~model),
+      history_panel(~inject),
       ActionMenu.view(~inject),
     ],
   );
@@ -76,7 +88,10 @@ let cell_status_panel = (~settings: Settings.t, ~model: Model.t, ~inject) => {
 
 let left_sidebar = (~inject: ModelAction.t => Event.t, ~model: Model.t) =>
   Sidebar.left(~inject, ~is_open=model.left_sidebar_open, () =>
-    [ActionPanel.view(~inject, model)]
+    [
+      UndoHistoryPanel.view(~inject, model),
+      ActionPanel.view(~inject, model),
+    ]
   );
 
 let right_sidebar = (~inject: ModelAction.t => Event.t, ~model: Model.t) => {
@@ -92,7 +107,6 @@ let right_sidebar = (~inject: ModelAction.t => Event.t, ~model: Model.t) => {
         ~font_metrics=model.font_metrics,
         program,
       ),
-      UndoHistoryPanel.view(~inject, model),
       SettingsPanel.view(~inject, settings),
     ]
   );

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -21,24 +21,12 @@ let branch_panel =
     ],
   );
 
-// // button to toggle history panel
-// let history_panel = (~inject): Node.t => {
-//   button(
-//     [
-//       Attr.classes(["button"]),
-//       Attr.on_click(_ => inject(ModelAction.ToggleLeftSidebar)),
-//     ],
-//     [text("history")],
-//   );
-// };
-
 let top_bar = (~inject: ModelAction.t => Ui_event.t, ~model: Model.t) => {
   div(
     [Attr.classes(["top-bar"])],
     [
       logo_panel,
       CardsPanel.view(~inject, ~model),
-      // history_panel(~inject),
       ActionMenu.view(~inject),
     ],
   );

--- a/src/hazelweb/gui/UndoHistoryPanel.re
+++ b/src/hazelweb/gui/UndoHistoryPanel.re
@@ -1088,7 +1088,7 @@ let view = (~inject: ModelAction.t => Vdom.Event.t, model: Model.t) => {
         Attr.classes(["panel", "context-inspector-panel"]),
       ],
       [
-        Panel.view_of_main_title_bar("history"),
+        Panel.view_of_main_title_bar("Edit Action History"),
         button_bar_view(model.undo_history),
         Node.div(
           if (model.undo_history.preview_on_hover) {


### PR DESCRIPTION
This PR adds a "history" button on top_bar to view/hide history panel.