### PR TITLE
Better remolding

### DIFF
--- a/src/core/lang/Form.re
+++ b/src/core/lang/Form.re
@@ -95,6 +95,52 @@ let forms: list((string, t)) = [
       mk_pre(P.let_, Exp, [Pat, Typ, Exp]),
     ),
   ),
+  (
+    "typeann",
+    mk(
+      ss,
+      [":"],
+      {
+        out: Pat,
+        in_: [],
+        nibs: (
+          {shape: Concave(P.ann), sort: Pat},
+          {shape: Concave(P.ann), sort: Typ},
+        ),
+      },
+    ),
+  ),
+  (
+    "case",
+    mk(
+      ds,
+      ["case", "of"],
+      {
+        out: Exp,
+        in_: [Exp],
+        nibs: (
+          {shape: Convex, sort: Exp},
+          {shape: Concave(P.case_), sort: Rul},
+        ),
+      },
+    ),
+  ),
+  (
+    "rule_arr",
+    mk(
+      ss,
+      ["=>"],
+      {
+        out: Rul,
+        in_: [],
+        nibs: (
+          {shape: Concave(P.rule_arr), sort: Pat},
+          {shape: Concave(P.rule_arr), sort: Exp},
+        ),
+      },
+    ),
+  ),
+  ("rule_sep", mk_infix("|", Rul, P.rule_sep)),
   //("times", mk_infix("*", Exp, P.mult)),
   //("divide", mk_infix("/", Exp, P.mult)),
   //("not_equals", mk_infix("!=", Exp, 5)),

--- a/src/core/lang/Form.re
+++ b/src/core/lang/Form.re
@@ -168,7 +168,7 @@ let forms: list((string, t)) = [
   //("rule_rest", mk(ds, ["|", "->"], mk_bin(9, Exp, [Pat]))),
 ];
 
-let get: Token.t => t = name => List.assoc(name, forms);
+let get: String.t => t = name => List.assoc(name, forms);
 
 let delims: list(Token.t) =
   forms

--- a/src/core/lang/Molds.re
+++ b/src/core/lang/Molds.re
@@ -28,6 +28,21 @@ let get = (label: Label.t): list(Mold.t) =>
     [];
   };
 
+// make sure that molds as defined in forms obey remolding optimization assumptions
+let check_labels_have_consistent_right_nibs = {
+  let consistent =
+    Form.forms
+    |> List.map(((_, form: Form.t)) =>
+         get(form.label) |> List.map((m: Mold.t) => snd(m.nibs).shape)
+       )
+    |> List.for_all(shapes => Option.is_some(ListUtil.single_elem(shapes)));
+  if (!consistent) {
+    failwith(
+      "ERROR: not all labels have consistent right nibs (currently assumed for remolding optimization)",
+    );
+  };
+};
+
 let delayed_completes: completions =
   List.filter_map(
     ((_, {expansion, label, _}: Form.t)) =>

--- a/src/core/lang/Precedence.re
+++ b/src/core/lang/Precedence.re
@@ -15,13 +15,17 @@ let mult = 3;
 let plus = 4;
 let concat = 5;
 let eqs = 6;
-let cond = 7;
+let ann = 7;
 let prod = 8;
 let if_ = 9;
 let semi = 10;
 let let_ = 11;
 
-let min = 12;
+let rule_arr = 12;
+let rule_sep = 13;
+let case_ = 14;
+
+let min = 15;
 
 let compare = (p1: t, p2: t): int =>
   (-1) * Int.compare((p1 :> int), (p2 :> int));
@@ -33,9 +37,8 @@ let associativity_map: IntMap.t(Direction.t) =
     (plus, Left),
     (concat, Right),
     (prod, Right),
-    (cond, Left),
+    (ann, Left),
     (eqs, Left),
-    (prod, Right),
   ]
   |> List.to_seq
   |> IntMap.of_seq;

--- a/src/core/lang/Precedence.re
+++ b/src/core/lang/Precedence.re
@@ -39,6 +39,8 @@ let associativity_map: IntMap.t(Direction.t) =
     (prod, Right),
     (ann, Left),
     (eqs, Left),
+    (rule_arr, Right),
+    (rule_sep, Right),
   ]
   |> List.to_seq
   |> IntMap.of_seq;

--- a/src/core/tiles/Mold.re
+++ b/src/core/tiles/Mold.re
@@ -1,8 +1,6 @@
 open Sexplib.Std;
-// supports tiles that take different-sorted unichildren
-// but for now the codebase assumes that tiles only take
-// same-sorted unichildren
-// TODO refactor nibs
+open Util;
+
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t = {
   out: Sort.t,
@@ -94,3 +92,14 @@ let of_whitespace = (l: Nib.t) => {
   out: l.sort,
   in_: [],
 };
+
+let fits_shape = (d: Direction.t, s: Nib.Shape.t, m: t): bool => {
+  let s' = Direction.choose(d, nib_shapes(m));
+  Nib.Shape.fits(s, s');
+};
+
+let consistent_shapes = (ms: list(t)) =>
+  ms
+  |> List.map(nib_shapes)
+  |> List.split
+  |> TupleUtil.map2(ListUtil.single_elem);

--- a/src/core/tiles/Nibs.re
+++ b/src/core/tiles/Nibs.re
@@ -1,6 +1,7 @@
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t = (Nib.t, Nib.t);
 
+[@deriving show]
 type shapes = (Nib.Shape.t, Nib.Shape.t);
 
 let flip = ((l, r): t) => (r, l);

--- a/src/core/tiles/Piece.re
+++ b/src/core/tiles/Piece.re
@@ -80,10 +80,10 @@ let is_whitespace: t => bool =
   | Whitespace(_) => true
   | _ => false;
 
-let is_tile: t => bool =
+let is_tile: t => option(Tile.t) =
   fun
-  | Whitespace(_) => true
-  | _ => false;
+  | Tile(t) => Some(t)
+  | _ => None;
 
 let monotile: t => option(Token.t) =
   fun

--- a/src/core/zipper/Relatives.re
+++ b/src/core/zipper/Relatives.re
@@ -57,11 +57,9 @@ let parent =
 let disassemble = ({siblings, ancestors}: t): Siblings.t =>
   Siblings.concat([siblings, Ancestors.disassemble(ancestors)]);
 
-let remold = ({siblings, ancestors}: t): list(t) => {
-  open ListUtil.Syntax;
-  // let+ ancestors = Ancestors.remold(ancestors)
+let remold = ({siblings, ancestors}: t): t => {
   let s = Ancestors.sort(ancestors);
-  let+ siblings = Siblings.remold(siblings, s);
+  let siblings = Siblings.remold(siblings, s);
   {ancestors, siblings};
 };
 

--- a/src/core/zipper/Siblings.re
+++ b/src/core/zipper/Siblings.re
@@ -8,6 +8,7 @@ type t = (Segment.t, Segment.t);
 
 let empty = Segment.(empty, empty);
 
+let unzip: (int, Segment.t) => t = ListUtil.split_n;
 let zip = (~sel=Segment.empty, (pre, suf): t) =>
   Segment.concat([pre, sel, suf]);
 
@@ -31,12 +32,8 @@ let concat = (sibss: list(t)): t =>
 //   |> List.for_all(((_, shards)) => Shard.consistent_molds(shards) != []);
 // };
 
-let remold = ((pre, suf): t, s): list(t) => {
-  open ListUtil.Syntax;
-  let+ pre = Segment.remold(pre, s)
-  and+ suf = Segment.remold(suf, s);
-  (pre, suf);
-};
+let remold = ((pre, _) as sibs: t, s: Sort.t): t =>
+  Segment.remold(zip(sibs), s) |> unzip(List.length(pre));
 
 let shapes = ((pre, suf): t) => {
   let s = Nib.Shape.concave();

--- a/src/core/zipper/Zipper.re
+++ b/src/core/zipper/Zipper.re
@@ -83,18 +83,7 @@ let neighbor_monotiles: Siblings.t => (option(Token.t), option(Token.t)) =
 let remold_regrout = (d: Direction.t, z: t): IdGen.t(t) => {
   assert(Selection.is_empty(z.selection));
   open IdGen.Syntax;
-  let* state = IdGen.get;
-  let ls_relatives =
-    Relatives.remold(z.relatives)
-    |> List.map(rs => Relatives.regrout(d, rs, state))
-    |> List.sort(((rel, _), (rel', _)) => {
-         open Relatives;
-         let c = Int.compare(sort_rank(rel), sort_rank(rel'));
-         c != 0 ? c : Int.compare(shape_rank(rel), shape_rank(rel'));
-       });
-  assert(ls_relatives != []);
-  let (relatives, state) = List.hd(ls_relatives);
-  let+ () = IdGen.put(state);
+  let+ relatives = Relatives.regrout(d, Relatives.remold(z.relatives));
   {...z, relatives};
 };
 

--- a/src/util/IntMap.re
+++ b/src/util/IntMap.re
@@ -1,3 +1,15 @@
 include Ptmap;
 
 let singleton = (k, v) => Ptmap.add(k, v, Ptmap.empty);
+
+let disj_union = (m: t('a), m': t('a)): t('a) =>
+  union(
+    (_, _, _) =>
+      raise(
+        Invalid_argument(
+          "IntMap.disj_union expects input maps to have disjoint key sets",
+        ),
+      ),
+    m,
+    m',
+  );

--- a/src/util/ListUtil.re
+++ b/src/util/ListUtil.re
@@ -305,3 +305,9 @@ let rotate = (xs: list('x)): list('x) =>
   | [] => []
   | [hd, ...tl] => tl @ [hd]
   };
+
+let single_elem = (xs: list('x)): option('x) =>
+  switch (xs) {
+  | [] => None
+  | [hd, ...tl] => List.for_all((==)(hd), tl) ? Some(hd) : None
+  };

--- a/src/web/LocalStorage.re
+++ b/src/web/LocalStorage.re
@@ -85,8 +85,11 @@ let parse_to_zid = (id_gen: IdGen.state, str: string): option(Zipper.state) =>
     |> List.fold_left(insert_to_zid, (Model.empty_zipper, id_gen))
     |> Option.some
   ) {
-  | _ =>
-    print_endline("WARNING: parse_to_zid: exception during parse");
+  | e =>
+    print_endline(
+      "WARNING: parse_to_zid: exception during parse: "
+      ++ Printexc.to_string(e),
+    );
     None;
   };
 


### PR DESCRIPTION
Relaxes assumption made for remolding optimization in https://github.com/hazelgrove/tylr/pull/9 that tiles should have same nib sorts as output sort, in exchange for other assumptions that match our grammars so far:
- right nib shapes are never ambiguous for a given label
- filtering molds by shape before sort does not create unnecessary sort inconsistencies (imprecise but enough for handling unary/binary minus and paren/ap)

This change may also have uncovered a bug where remolding should in general take place beyond the focal segment, eg any segment directly contained by or directly containing put down shards, but this was an existing bug introduced by https://github.com/hazelgrove/tylr/pull/9 so not fixing here. Concretely this is observed when picking up an `=` in a let and putting back down with caret ending up in the let definition, which leaves the pattern sort-inconsistent. I think previous optimization happened to get away with this because it happened to preserve the original pattern mold, but the proper fix is to reassign molds beyond focal segment.