### PR TITLE
add www/* to dune source dependencies

### DIFF
--- a/src/web/dune
+++ b/src/web/dune
@@ -1,5 +1,10 @@
 (include_subdirs unqualified)
 
+(alias
+ (name default)
+ (deps
+  (source_tree www)))
+
 (library
  (name web)
  (modules :standard \ Main)


### PR DESCRIPTION
This PR adds the `www` directory to dune's default source dependency tree. This provides two concrete benefits:

1. Its contents will always be copied into the corresponding `_build` area.
2. `make` will become aware of modifications to html and css files (and whatever else is in there).