### PR TITLE
Add floating point less-than operator

### DIFF
--- a/src/core/dynamics/elaborator.re
+++ b/src/core/dynamics/elaborator.re
@@ -31,7 +31,8 @@ let int_op_of: Term.UExp.exp_op_int => DHExp.BinIntOp.t =
 
 let float_op_of: Term.UExp.exp_op_float => DHExp.BinFloatOp.t =
   fun
-  | Plus => FPlus;
+  | Plus => FPlus
+  | Lt => FLessThan;
 
 let bool_op_of: Term.UExp.exp_op_bool => DHExp.BinBoolOp.t =
   fun

--- a/src/core/lang/Form.re
+++ b/src/core/lang/Form.re
@@ -69,6 +69,7 @@ let forms: list((string, t)) = [
   ("fplus", mk_infix("+.", Exp, P.plus)),
   ("equals", mk_infix("=", Exp, P.eqs)),
   ("lt", mk_infix("<", Exp, P.eqs)),
+  ("flt", mk_infix("<.", Exp, P.eqs)),
   ("bitwise_and", mk_infix("&", Exp, 5)), // substring req
   ("logical_and", mk_infix("&&", Exp, 5)),
   ("type-arrow", mk_infix("->", Typ, 6)), // bad sorts

--- a/src/core/statics/Statics.re
+++ b/src/core/statics/Statics.re
@@ -134,6 +134,8 @@ let rec uexp_to_info_map =
   | OpInt(Lt, e1, e2) => binop(e1, e2, Ana(Int), Ana(Int), Just(Bool))
   | OpFloat(Plus, e1, e2) =>
     binop(e1, e2, Ana(Float), Ana(Float), Just(Float))
+  | OpFloat(Lt, e1, e2) =>
+    binop(e1, e2, Ana(Float), Ana(Float), Just(Bool))
   | OpBool(And, e1, e2) => binop(e1, e2, Ana(Bool), Ana(Bool), Just(Bool))
   | Pair(e1, e2) =>
     let (mode_l, mode_r) = Typ.matched_prod_mode(mode);

--- a/src/core/statics/Term.re
+++ b/src/core/statics/Term.re
@@ -108,7 +108,8 @@ module UExp = {
 
   [@deriving (show({with_path: false}), sexp, yojson)]
   type exp_op_float =
-    | Plus;
+    | Plus
+    | Lt;
 
   [@deriving (show({with_path: false}), sexp, yojson)]
   type exp_op_bool =
@@ -196,6 +197,7 @@ module UExp = {
     | OpInt(Plus) => "Integer Addition"
     | OpInt(Lt) => "Integer Less-Than"
     | OpFloat(Plus) => "Float Addition"
+    | OpFloat(Lt) => "Float Less-Than"
     | OpBool(And) => "Boolean Conjunction";
 };
 
@@ -263,6 +265,7 @@ and of_piece = (p: Piece.t, children_h: list(UExp.t)): UExp.t => {
       | (["+"], [l, r], []) => OpInt(Plus, l, r)
       | (["+."], [l, r], []) => OpFloat(Plus, l, r)
       | (["<"], [l, r], []) => OpInt(Lt, l, r)
+      | (["<."], [l, r], []) => OpFloat(Lt, l, r)
       | (["&&"], [l, r], []) => OpBool(And, l, r)
       | (["fun", "->"], [body], [pat]) => Fun(upat_of_seg(pat), body)
       | (["funann", ":", "->"], [body], [pat, typ]) =>


### PR DESCRIPTION
This PR adds a less-than operator `<.` for floating point numbers.