### PR TITLE
Text Editor

### DIFF
--- a/src/hazeltext/print.ml
+++ b/src/hazeltext/print.ml
@@ -6,7 +6,7 @@ exception NoLayout
 let string_of_layout (l : 'a Layout.t) : string =
   let rec go (indent : int) (col : int) (l : 'a Layout.t) : string * int =
     match l with
-    | Text s -> (s, col + String.length s)
+    | Text s -> (s, col + Unicode.length s)
     | Cat (l1, l2) ->
         let s1, c1 = go indent col l1 in
         let s2, c2 = go indent c1 l2 in

--- a/src/hazelweb/Hazel.re
+++ b/src/hazelweb/Hazel.re
@@ -141,7 +141,8 @@ let create =
             | None => ()
             };
           };
-          if (Model.is_cell_focused(model)) {
+          if (Model.is_structure_editor_active(model)
+              && Model.is_cell_focused(model)) {
             // if cell is focused in model, make sure
             // cell element is focused in DOM
             switch (Js.Opt.to_option(Dom_html.document##.activeElement)) {

--- a/src/hazelweb/ModelAction.re
+++ b/src/hazelweb/ModelAction.re
@@ -40,6 +40,7 @@ type t =
   | UpdateCursorInspector(CursorInspectorModel.update)
   | SelectHoleInstance(HoleInstance.t)
   | SelectCaseBranch(CursorPath.steps, int)
+  | UpdateTextEditor(TextEditorModel.update)
   | FocusCell
   | BlurCell
   | Redo

--- a/src/hazelweb/Update.re
+++ b/src/hazelweb/Update.re
@@ -54,6 +54,7 @@ let log_action = (action: ModelAction.t, _: State.t): unit => {
   | UpdateCursorInspector(_)
   | SelectHoleInstance(_)
   | SelectCaseBranch(_)
+  | UpdateTextEditor(_)
   | FocusCell
   | BlurCell
   | Undo
@@ -130,6 +131,10 @@ let apply_action =
       | SelectHoleInstance(inst) => model |> Model.select_hole_instance(inst)
       | SelectCaseBranch(path_to_case, branch_index) =>
         Model.select_case_branch(path_to_case, branch_index, model)
+      | UpdateTextEditor(u) => {
+          ...model,
+          text_editor: TextEditorModel.apply_update(u, model.text_editor),
+        }
       | FocusCell => model |> Model.focus_cell
       | BlurCell => model |> Model.blur_cell
       | Undo =>

--- a/src/hazelweb/gui/ActionPanel.re
+++ b/src/hazelweb/gui/ActionPanel.re
@@ -436,13 +436,16 @@ let view = (~inject: ModelAction.t => Event.t, model: Model.t) => {
   let edit_state = Model.get_edit_state(model);
   let cursor_info = Model.get_cursor_info(model);
 
-  let is_action_allowed = (a: Action.t): bool => {
-    switch (Action_Exp.syn_perform(Contexts.initial, a, edit_state)) {
-    | Failed => false
-    | CursorEscaped(_)
-    | Succeeded(_) => true
+  let is_action_allowed = (a: Action.t): bool =>
+    if (Model.is_structure_editor_active(model)) {
+      switch (Action_Exp.syn_perform(Contexts.initial, a, edit_state)) {
+      | Failed => false
+      | CursorEscaped(_)
+      | Succeeded(_) => true
+      };
+    } else {
+      false;
     };
-  };
 
   let body = generate_panel_body(is_action_allowed, cursor_info, inject);
 

--- a/src/hazelweb/gui/Cell.re
+++ b/src/hazelweb/gui/Cell.re
@@ -19,8 +19,6 @@ let view = (~inject, model: Model.t) => {
       Node.div(
         [Attr.id(cell_id)],
         [
-          /* font-specimen used to gather font metrics for caret positioning and other things */
-          Node.div([Attr.id("font-specimen")], [Node.text("X")]),
           Node.div(
             [Attr.id("code-container")],
             [

--- a/src/hazelweb/gui/ContextInspector.re
+++ b/src/hazelweb/gui/ContextInspector.re
@@ -7,6 +7,7 @@ let view =
       ~selected_instance: option(HoleInstance.t),
       ~settings: Settings.Evaluation.t,
       ~font_metrics: FontMetrics.t,
+      ~active: bool,
       program: Program.t,
     )
     : Vdom.Node.t => {
@@ -371,14 +372,23 @@ let view =
       Node.div([], []);
     };
 
+  let inactive_view = {
+    Node.div(
+      [Attr.classes(["inactive-text"])],
+      [Node.text("Context Inspector unavailable")],
+    );
+  };
+
   Node.div(
     [Attr.classes(["panel", "context-inspector-panel"])],
     [
       Panel.view_of_main_title_bar("context"),
-      Node.div(
-        [Attr.classes(["panel-body", "context-inspector-body"])],
-        [context_view, path_viewer],
-      ),
+      active
+        ? Node.div(
+            [Attr.classes(["panel-body", "context-inspector-body"])],
+            [context_view, path_viewer],
+          )
+        : inactive_view,
     ],
   );
 };

--- a/src/hazelweb/gui/ContextInspector.rei
+++ b/src/hazelweb/gui/ContextInspector.rei
@@ -15,6 +15,7 @@ let view:
     ~selected_instance: option(HoleInstance.t),
     ~settings: Settings.Evaluation.t,
     ~font_metrics: FontMetrics.t,
+    ~active: bool,
     Program.t
   ) =>
   Vdom.Node.t;

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -78,7 +78,11 @@ let cell_status_panel = (~settings: Settings.t, ~model: Model.t, ~inject) => {
 let left_sidebar = (~inject: ModelAction.t => Event.t, ~model: Model.t) =>
   Sidebar.left(~inject, ~is_open=model.left_sidebar_open, () =>
     [
-      UndoHistoryPanel.view(~inject, model),
+      UndoHistoryPanel.view(
+        ~inject,
+        ~active=Model.is_structure_editor_active(model),
+        model,
+      ),
       ActionPanel.view(~inject, model),
     ]
   );
@@ -94,6 +98,7 @@ let right_sidebar = (~inject: ModelAction.t => Event.t, ~model: Model.t) => {
         ~selected_instance,
         ~settings=settings.evaluation,
         ~font_metrics=model.font_metrics,
+        ~active=Model.is_structure_editor_active(model),
         program,
       ),
     ]

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -162,6 +162,9 @@ let view = (~inject: ModelAction.t => Event.t, model: Model.t) => {
     div(
       [Attr.id("root")],
       [
+        /* font-specimen used to gather font metrics for caret positioning and other things */
+        /* Ensure any font styling for the editor is applied to this as well */
+        Node.div([Attr.id("font-specimen")], [Node.text("X")]),
         top_bar(~inject, ~model),
         div(
           [Attr.classes(["main-area"])],

--- a/src/hazelweb/gui/Page.re
+++ b/src/hazelweb/gui/Page.re
@@ -154,7 +154,8 @@ let structural_page = (~inject: ModelAction.t => Event.t, ~model: Model.t) => {
 let view = (~inject: ModelAction.t => Event.t, model: Model.t) => {
   let settings = model.settings;
   let current_page =
-    model.text_editor.active ? text_editor_page : structural_page;
+    Model.is_structure_editor_active(model)
+      ? structural_page : text_editor_page;
   TimeUtil.measure_time(
     "Page.view",
     settings.performance.measure && settings.performance.page_view,

--- a/src/hazelweb/gui/TextEditor.re
+++ b/src/hazelweb/gui/TextEditor.re
@@ -1,0 +1,87 @@
+open Incr_dom;
+module Js = Js_of_ocaml.Js;
+module Parsing = Hazeltext.Parsing;
+module Print = Hazeltext.Print;
+
+let ast_from_texteditor_box = (te_model: TextEditorModel.t) => {
+  Parsing.ast_of_string(te_model.current_text);
+};
+
+let switch_button_clickhandler = (inject, te_model: TextEditorModel.t, _) => {
+  Vdom.Event.Many([
+    inject(ModelAction.UpdateTextEditor(TextEditorModel.CloseEditor)),
+    inject(
+      ModelAction.Import(
+        ast_from_texteditor_box(te_model) |> Stdlib.Result.get_ok,
+      ),
+    ),
+  ]);
+};
+
+let textbox_keyhandlers = (inject, model: Model.t) => {
+  Vdom.[
+    Attr.on_input((_, s) =>
+      inject(
+        ModelAction.UpdateTextEditor(TextEditorModel.SetCurrentText(s)),
+      )
+    ),
+    Attr.on_keyup(_ => {
+      let result = ast_from_texteditor_box(model.text_editor);
+      inject(
+        ModelAction.UpdateTextEditor(
+          Stdlib.Result.(
+            is_error(result)
+              ? TextEditorModel.SetErrorText(get_error(result))
+              : TextEditorModel.ClearError
+          ),
+        ),
+      );
+    }),
+  ];
+};
+
+let editor_switch_button = (inject, te_model: TextEditorModel.t) => {
+  Vdom.(
+    Node.span(
+      [Attr.id("button-span")],
+      [
+        Node.button(
+          [
+            Attr.id("editor-switch-button"),
+            Attr.on_click(switch_button_clickhandler(inject, te_model)),
+            ...te_model.valid_text ? [] : [Attr.disabled],
+          ],
+          [Node.text("Switch to Structural Editor")],
+        ),
+      ],
+    )
+  );
+};
+
+let text_editor_body = (inject, model: Model.t) => {
+  Vdom.(
+    Node.div(
+      [Attr.classes(["page"])],
+      [
+        editor_switch_button(inject, model.text_editor),
+        Node.textarea(
+          [
+            Attr.id("text-editor-text-box"),
+            ...textbox_keyhandlers(inject, model),
+          ],
+          [Node.text(model.text_editor.current_text)],
+        ),
+        Node.textarea(
+          [Attr.id("text-editor-errors"), Attr.create("readonly", "")],
+          [Node.text(model.text_editor.error_text)],
+        ),
+      ],
+    )
+  );
+};
+
+let view = (~inject, ~model: Model.t) => {
+  Vdom.(
+    Node.div([Attr.id("page-area")], [text_editor_body(inject, model)])
+  );
+};

--- a/src/hazelweb/gui/TextEditor.re
+++ b/src/hazelweb/gui/TextEditor.re
@@ -11,7 +11,8 @@ let switch_button_clickhandler =
     inject(ModelAction.UpdateTextEditor(TextEditorModel.CloseEditor)),
     inject(
       ModelAction.Import(
-        ast_from_text(te_model.current_text) |> Stdlib.Result.get_ok,
+        ast_from_text(TextEditorModel.get_current_text(te_model))
+        |> Stdlib.Result.get_ok,
       ),
     ),
   ]);
@@ -26,12 +27,13 @@ let textbox_keyhandlers =
       )
     ),
     Attr.on_keyup(_ => {
-      let result = ast_from_text(model.text_editor.current_text);
+      let result =
+        ast_from_text(TextEditorModel.get_current_text(model.text_editor));
       inject(
         ModelAction.UpdateTextEditor(
           Stdlib.Result.(
             is_error(result)
-              ? TextEditorModel.SetErrorText(get_error(result))
+              ? TextEditorModel.SetError(get_error(result))
               : TextEditorModel.ClearError
           ),
         ),
@@ -55,7 +57,7 @@ let editor_switch_button =
                 te_model,
               ),
             ),
-            ...te_model.valid_text ? [] : [Attr.disabled],
+            ...TextEditorModel.is_valid(te_model) ? [] : [Attr.disabled],
           ],
           [Node.text("Switch to Structural Editor")],
         ),
@@ -86,11 +88,11 @@ let text_editor_body = (inject: ModelAction.t => Ui_event.t, model: Model.t) => 
             Attr.style(text_box_height_css(model)),
             ...textbox_keyhandlers(inject, model),
           ],
-          [Node.text(model.text_editor.current_text)],
+          [Node.text(TextEditorModel.get_current_text(model.text_editor))],
         ),
         Node.textarea(
           [Attr.id("text-editor-errors"), Attr.create("readonly", "")],
-          [Node.text(model.text_editor.error_text)],
+          [Node.text(TextEditorModel.get_error_string(model.text_editor))],
         ),
       ],
     )

--- a/src/hazelweb/gui/TextEditor.re
+++ b/src/hazelweb/gui/TextEditor.re
@@ -58,6 +58,18 @@ let editor_switch_button = (inject, te_model: TextEditorModel.t) => {
   );
 };
 
+let text_box_height_css = (model: Model.t) => {
+  let row_height = model.font_metrics.row_height;
+  Css_gen.(
+    height(
+      `Px(
+        (TextEditorModel.line_count(model.text_editor) + 1)
+        * Float.to_int(row_height),
+      ),
+    )
+  );
+};
+
 let text_editor_body = (inject, model: Model.t) => {
   Vdom.(
     Node.div(
@@ -67,6 +79,7 @@ let text_editor_body = (inject, model: Model.t) => {
         Node.textarea(
           [
             Attr.id("text-editor-text-box"),
+            Attr.style(text_box_height_css(model)),
             ...textbox_keyhandlers(inject, model),
           ],
           [Node.text(model.text_editor.current_text)],

--- a/src/hazelweb/gui/TextEditor.re
+++ b/src/hazelweb/gui/TextEditor.re
@@ -1,9 +1,8 @@
 open Incr_dom;
 module Js = Js_of_ocaml.Js;
-module Parsing = Hazeltext.Parsing;
-module Print = Hazeltext.Print;
+module Result = Stdlib.Result;
 
-let ast_from_text = Parsing.ast_of_string;
+let ast_from_text = Hazeltext.Parsing.ast_of_string;
 
 let switch_button_clickhandler =
     (inject: ModelAction.t => Ui_event.t, te_model: TextEditorModel.t, _) => {
@@ -12,7 +11,7 @@ let switch_button_clickhandler =
     inject(
       ModelAction.Import(
         ast_from_text(TextEditorModel.get_current_text(te_model))
-        |> Stdlib.Result.get_ok,
+        |> Result.get_ok,
       ),
     ),
   ]);
@@ -27,13 +26,13 @@ let textbox_keyhandlers =
       )
     ),
     Attr.on_keyup(_ => {
-      let result =
+      let ast =
         ast_from_text(TextEditorModel.get_current_text(model.text_editor));
       inject(
         ModelAction.UpdateTextEditor(
-          Stdlib.Result.(
-            is_error(result)
-              ? TextEditorModel.SetError(get_error(result))
+          Result.(
+            is_error(ast)
+              ? TextEditorModel.SetError(get_error(ast))
               : TextEditorModel.ClearError
           ),
         ),

--- a/src/hazelweb/gui/TextEditor.rei
+++ b/src/hazelweb/gui/TextEditor.rei
@@ -1,0 +1,4 @@
+open Virtual_dom;
+
+let view:
+  (~inject: ModelAction.t => Vdom.Event.t, ~model: Model.t) => Vdom.Node.t;

--- a/src/hazelweb/model/Model.re
+++ b/src/hazelweb/model/Model.re
@@ -9,6 +9,7 @@ type t = {
   mouse_position: ref(MousePosition.t),
   settings: Settings.t,
   cursor_inspector: CursorInspectorModel.t,
+  text_editor: TextEditorModel.t,
 };
 
 let cutoff = (m1, m2) => m1 === m2;
@@ -55,6 +56,7 @@ let init = (): t => {
   };
   let settings = Settings.init;
   let cursor_inspector = CursorInspectorModel.init;
+  let text_editor = TextEditorModel.init;
   let selected_instances = {
     let si = UserSelectedInstances.init;
     switch (
@@ -82,6 +84,7 @@ let init = (): t => {
     mouse_position: ref(MousePosition.{x: 0, y: 0}),
     settings,
     cursor_inspector,
+    text_editor,
   };
 };
 

--- a/src/hazelweb/model/Model.re
+++ b/src/hazelweb/model/Model.re
@@ -146,6 +146,10 @@ let is_cell_focused = model => {
   program.is_focused;
 };
 
+let is_structure_editor_active = (model: t): bool => {
+  !model.text_editor.active;
+};
+
 let get_selected_hole_instance = model =>
   switch (model |> get_program |> Program.cursor_on_exp_hole) {
   | None => None

--- a/src/hazelweb/model/Model.rei
+++ b/src/hazelweb/model/Model.rei
@@ -16,6 +16,7 @@ type t = {
   mouse_position: ref(MousePosition.t),
   settings: Settings.t,
   cursor_inspector: CursorInspectorModel.t,
+  text_editor: TextEditorModel.t,
 };
 
 let cardstack_info: list(CardstackInfo.t);

--- a/src/hazelweb/model/Model.rei
+++ b/src/hazelweb/model/Model.rei
@@ -47,6 +47,11 @@ let focus_cell: t => t;
 let blur_cell: t => t;
 let is_cell_focused: t => bool;
 
+/*
+ * Returns if the main structure editor is active (visible)
+ */
+let is_structure_editor_active: t => bool;
+
 /**
  * Update selected instances when user clicks on a hole
  * instance (in result or context inspector)

--- a/src/hazelweb/model/TextEditorModel.re
+++ b/src/hazelweb/model/TextEditorModel.re
@@ -10,9 +10,9 @@ type t = {
 type update =
   | OpenEditor(Program.t)
   | CloseEditor
-  | ClearError
   | SetCurrentText(string)
-  | SetError(string);
+  | SetError(string)
+  | ClearError;
 
 let init = {active: false, current_text: None, error: None};
 
@@ -38,13 +38,10 @@ let apply_update = (u: update, te_model: t) => {
 let is_valid = (te_model: t) => Option.is_none(te_model.error);
 
 let line_count = (te_model: t) => {
-  {
-    switch (te_model.current_text) {
-    | Some(s) => String.split_on_char('\n', s) |> List.length
-    | None => 0
-    };
-  }
-  |> (x => x + 0);
+  switch (te_model.current_text) {
+  | Some(s) => String.split_on_char('\n', s) |> List.length
+  | None => 0
+  };
 };
 
 let get_error_string = (te_model: t) => {
@@ -52,5 +49,5 @@ let get_error_string = (te_model: t) => {
 };
 
 let get_current_text = (te_model: t) => {
-  Option.get(te_model.current_text);
+  Option.value(te_model.current_text, ~default="");
 };

--- a/src/hazelweb/model/TextEditorModel.re
+++ b/src/hazelweb/model/TextEditorModel.re
@@ -23,29 +23,34 @@ let init = {
   error_text: "",
 };
 
-let toggle_valid = m => {...m, valid_text: !m.valid_text};
+let toggle_valid = (te_model: t) => {
+  ...te_model,
+  valid_text: !te_model.valid_text,
+};
 
-let extract_program_string = prog => {
+let extract_program_string = (prog: Program.t) => {
   let lay = Program.get_layout(~settings=Settings.init, prog);
   Hazeltext.Print.string_of_layout(lay);
 };
 
-let apply_update = (update, t) => {
-  switch (update) {
+let apply_update = (u: update, te_model: t) => {
+  switch (u) {
   | OpenEditor(p) => {
       active: true,
       valid_text: true,
       current_text: extract_program_string(p),
       error_text: "",
     }
-  | CloseEditor => {...t, active: false, valid_text: true}
-  | ToggleValid => toggle_valid(t)
-  | ClearError => {...t, valid_text: true, error_text: ""}
-  | SetCurrentText(s) => {...t, current_text: s}
-  | SetErrorText(s) => {...t, valid_text: false, error_text: s}
+  | CloseEditor => {...te_model, active: false, valid_text: true}
+  | ToggleValid => toggle_valid(te_model)
+  | ClearError => {...te_model, valid_text: true, error_text: ""}
+  | SetCurrentText(s) => {...te_model, current_text: s}
+  | SetErrorText(s) => {...te_model, valid_text: false, error_text: s}
   };
 };
 
-let line_count = t => {
-  String.split_on_char('\n', t.current_text) |> List.length |> (x => x + 0);
+let line_count = (te_model: t) => {
+  String.split_on_char('\n', te_model.current_text)
+  |> List.length
+  |> (x => x + 0);
 };

--- a/src/hazelweb/model/TextEditorModel.re
+++ b/src/hazelweb/model/TextEditorModel.re
@@ -45,3 +45,7 @@ let apply_update = (update, t) => {
   | SetErrorText(s) => {...t, valid_text: false, error_text: s}
   };
 };
+
+let line_count = t => {
+  String.split_on_char('\n', t.current_text) |> List.length |> (x => x + 0);
+};

--- a/src/hazelweb/model/TextEditorModel.re
+++ b/src/hazelweb/model/TextEditorModel.re
@@ -1,0 +1,47 @@
+open Sexplib.Std;
+
+type t = {
+  active: bool,
+  valid_text: bool,
+  current_text: string,
+  error_text: string,
+};
+
+[@deriving sexp]
+type update =
+  | OpenEditor(Program.t)
+  | CloseEditor
+  | ToggleValid
+  | ClearError
+  | SetCurrentText(string)
+  | SetErrorText(string);
+
+let init = {
+  active: false,
+  valid_text: true,
+  current_text: "",
+  error_text: "",
+};
+
+let toggle_valid = m => {...m, valid_text: !m.valid_text};
+
+let extract_program_string = prog => {
+  let lay = Program.get_layout(~settings=Settings.init, prog);
+  Hazeltext.Print.string_of_layout(lay);
+};
+
+let apply_update = (update, t) => {
+  switch (update) {
+  | OpenEditor(p) => {
+      active: true,
+      valid_text: true,
+      current_text: extract_program_string(p),
+      error_text: "",
+    }
+  | CloseEditor => {...t, active: false, valid_text: true}
+  | ToggleValid => toggle_valid(t)
+  | ClearError => {...t, valid_text: true, error_text: ""}
+  | SetCurrentText(s) => {...t, current_text: s}
+  | SetErrorText(s) => {...t, valid_text: false, error_text: s}
+  };
+};

--- a/src/hazelweb/model/TextEditorModel.rei
+++ b/src/hazelweb/model/TextEditorModel.rei
@@ -1,24 +1,34 @@
 type t = {
   active: bool,
-  valid_text: bool,
-  current_text: string,
-  error_text: string,
+  current_text: option(string),
+  error: option(string),
 };
 
 [@deriving sexp]
 type update =
   | OpenEditor(Program.t)
   | CloseEditor
-  | ToggleValid
   | ClearError
   | SetCurrentText(string)
-  | SetErrorText(string);
+  | SetError(string);
 
 let init: t;
 
 let apply_update: (update, t) => t;
 
 /*
+ * Returns if the current text is valid (if there is no error)
+ */
+let is_valid: t => bool;
+
+/*
  * Returns the count of newlines in current_text
  */
 let line_count: t => int;
+
+/*
+ * Returns error as a string, or empty string if no error
+ */
+let get_error_string: t => string;
+
+let get_current_text: t => string;

--- a/src/hazelweb/model/TextEditorModel.rei
+++ b/src/hazelweb/model/TextEditorModel.rei
@@ -8,9 +8,9 @@ type t = {
 type update =
   | OpenEditor(Program.t)
   | CloseEditor
-  | ClearError
   | SetCurrentText(string)
-  | SetError(string);
+  | SetError(string)
+  | ClearError;
 
 let init: t;
 
@@ -22,7 +22,7 @@ let apply_update: (update, t) => t;
 let is_valid: t => bool;
 
 /*
- * Returns the count of newlines in current_text
+ * Returns the count of lines in current_text
  */
 let line_count: t => int;
 
@@ -31,4 +31,7 @@ let line_count: t => int;
  */
 let get_error_string: t => string;
 
+/*
+ * Returns the current text
+ */
 let get_current_text: t => string;

--- a/src/hazelweb/model/TextEditorModel.rei
+++ b/src/hazelweb/model/TextEditorModel.rei
@@ -1,0 +1,19 @@
+type t = {
+  active: bool,
+  valid_text: bool,
+  current_text: string,
+  error_text: string,
+};
+
+[@deriving sexp]
+type update =
+  | OpenEditor(Program.t)
+  | CloseEditor
+  | ToggleValid
+  | ClearError
+  | SetCurrentText(string)
+  | SetErrorText(string);
+
+let init: t;
+
+let apply_update: (update, t) => t;

--- a/src/hazelweb/model/TextEditorModel.rei
+++ b/src/hazelweb/model/TextEditorModel.rei
@@ -17,3 +17,5 @@ type update =
 let init: t;
 
 let apply_update: (update, t) => t;
+
+let line_count: t => int;

--- a/src/hazelweb/model/TextEditorModel.rei
+++ b/src/hazelweb/model/TextEditorModel.rei
@@ -18,4 +18,7 @@ let init: t;
 
 let apply_update: (update, t) => t;
 
+/*
+ * Returns the count of newlines in current_text
+ */
 let line_count: t => int;

--- a/src/hazelweb/www/style.css
+++ b/src/hazelweb/www/style.css
@@ -416,7 +416,8 @@ body {
 
 #text-editor-text-box {
   width: 100%;
-  min-height: 16em;
+  min-height: var(--code-line-height);
+  overflow: hidden;
   box-sizing: border-box;
   resize: none;
   border: 2px solid #CCC;
@@ -426,6 +427,7 @@ body {
   margin-bottom: 0;
   font-family: var(--code-font-family);
   font-size: var(--code-font-size);
+  line-height: var(--code-line-height);
 }
 
 #text-editor-errors {

--- a/src/hazelweb/www/style.css
+++ b/src/hazelweb/www/style.css
@@ -412,6 +412,62 @@ body {
   border-radius:100%;
 }
 
+/* text-editor */
+
+#text-editor-text-box {
+  width: 100%;
+  min-height: 16em;
+  box-sizing: border-box;
+  resize: none;
+  border: 2px solid #CCC;
+  outline: none;
+  padding: 10px;
+  margin-top: 20px;
+  margin-bottom: 0;
+  font-family: var(--code-font-family);
+  font-size: var(--code-font-size);
+}
+
+#text-editor-errors {
+  width: 100%;
+  height: 36px;
+  box-sizing: border-box;
+  resize: none;
+  border: none;
+  outline: none;
+  overflow: hidden;
+  padding: 8px 8px;
+  margin: 0;
+  font-family: var(--code-font-family);
+  background-color: #EEE;
+}
+
+#button-span {
+  display: flex;
+  justify-content: right;
+  margin-top: -0.75rem;
+  margin-bottom: -0.75rem;
+}
+
+#editor-switch-button {
+  text-align: center;
+  color: #3E3E3E;
+  padding: 0.3em 0.8em;
+  background-color: #EBEBEB;
+  border-radius: 0.3em;
+  border: 0px solid dimgray;
+  font-size: 1.0em;
+  transition-duration: 0.3s;
+}
+
+#editor-switch-button:hover {
+  background-color: #DBDBDB;
+}
+
+#editor-switch-button[disabled] {
+  color: #DADADA;
+  background-color: #F7F7F7;
+}
 /* panels */
 
 .panel {

--- a/src/hazelweb/www/style.css
+++ b/src/hazelweb/www/style.css
@@ -412,6 +412,16 @@ body {
   border-radius:100%;
 }
 
+.inactive-text {
+  font-family: var(--code-font-family);
+  font-size: var(--code-font-size);
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+}
+
 /* text-editor */
 
 #text-editor-text-box {


### PR DESCRIPTION
Adds Text Editor to the Hazel page.

When in use, hides the normal editor, as well as hiding/disabling the undo history and context elements.

The toggle editor button will be disabled in Text Editor view when there is a pending error, for which the error is the string editor passed back by Hazeltext parsing.