### PR TITLE
Restore basic err hole decorations

### DIFF
--- a/src/core/tiles/Piece.re
+++ b/src/core/tiles/Piece.re
@@ -35,6 +35,7 @@ let nib_sorts =
   );
 
 let sorted_children = get(_ => [], _ => [], Tile.sorted_children);
+let children = p => sorted_children(p) |> List.split |> snd;
 
 // let is_balanced =
 //   fun

--- a/src/web/util/SvgUtil.re
+++ b/src/web/util/SvgUtil.re
@@ -68,14 +68,14 @@ module Path = {
 
   let reverse = List.rev_map(scale_cmd(~scale_x=-1., ~scale_y=-1.));
 
-  let transpose_cmd = (v: Vector.t) =>
+  let translate_cmd = (v: Vector.t) =>
     fun
     | (Z | M_(_) | L_(_) | H_(_) | V_(_) | A_(_)) as cmd => cmd
     | M({x, y}) => M({x: x +. v.dx, y: y +. v.dy})
     | L({x, y}) => L({x: x +. v.dx, y: y +. v.dy})
     | H({x}) => H({x: x +. v.dx})
     | V({y}) => V({y: y +. v.dy});
-  let transpose = v => List.map(transpose_cmd(v));
+  let translate = v => List.map(translate_cmd(v));
 
   let string_of_flag =
     fun

--- a/src/web/view/Deco.re
+++ b/src/web/view/Deco.re
@@ -251,7 +251,7 @@ module Deco =
   };
 
   let err_holes = (z: Zipper.t) => {
-    let seg = Zipper.zip(z);
+    let seg = Zipper.unselect_and_zip(z);
     let ranges = TermRanges.mk(seg);
     let measured = Measured.of_segment(seg);
     let (_, _, info_map) = Statics.mk_map(MakeTerm.go(seg));

--- a/src/web/view/Deco.re
+++ b/src/web/view/Deco.re
@@ -237,6 +237,8 @@ module Deco =
       ? targets(backpack, seg) : [];
   };
 
+  // recurses through skel structure to enable experimentation
+  // with hiding nested err holes
   let err_holes = (z: Zipper.t) => {
     let seg = Zipper.unselect_and_zip(z);
     let ranges = TermRanges.mk(seg);

--- a/src/web/view/Deco.re
+++ b/src/web/view/Deco.re
@@ -313,12 +313,12 @@ module Deco =
            |> TupleUtil.map2(List.concat);
          (
            l,
-           SvgUtil.Path.[m(~x=l.col, ~y=l.row), ...l_edge]
-           @ r_edge
+           SvgUtil.Path.[m(~x=l.col, ~y=l.row), ...r_edge]
+           @ l_edge
            @ [SvgUtil.Path.Z]
            |> SvgUtil.Path.translate({
                 dx: Float.of_int(- l.col),
-                dy: Float.of_int(- l.row + 1),
+                dy: Float.of_int(- l.row),
               }),
          );
        })

--- a/src/web/view/Deco.re
+++ b/src/web/view/Deco.re
@@ -318,7 +318,7 @@ module Deco =
            @ [SvgUtil.Path.Z]
            |> SvgUtil.Path.translate({
                 dx: Float.of_int(- l.col),
-                dy: Float.of_int(- l.row),
+                dy: Float.of_int(- l.row + 1),
               }),
          );
        })
@@ -339,5 +339,6 @@ module Deco =
       selected_pieces(zipper),
       backback(zipper),
       targets'(zipper.backpack, sel_seg),
+      err_holes(zipper),
     ]);
 };

--- a/src/web/view/Deco.re
+++ b/src/web/view/Deco.re
@@ -282,30 +282,25 @@ module Deco =
          });
     err_ranges
     |> List.map(((l: Measured.point, r: Measured.point)) => {
-         let (l_edge, r_edge) =
+         open SvgUtil.Path;
+         let r_edge =
            ListUtil.range(~lo=l.row, r.row + 1)
-           |> List.map(i => {
+           |> List.concat_map(i => {
                 let row = Measured.Rows.find(i, measured.rows);
-                let l_edge =
-                  SvgUtil.Path.[
-                    h(~x=i == l.row ? l.col : row.indent),
-                    v_(~dy=-1),
-                  ];
-                let r_edge =
-                  SvgUtil.Path.[
-                    h(~x=i == r.row ? r.col : row.max_col),
-                    v_(~dy=1),
-                  ];
-                (l_edge, r_edge);
+                [h(~x=i == r.row ? r.col : row.max_col), v_(~dy=1)];
+              });
+         let l_edge =
+           ListUtil.range(~lo=l.row, r.row + 1)
+           |> List.rev_map(i => {
+                let row = Measured.Rows.find(i, measured.rows);
+                [h(~x=i == l.row ? l.col : row.indent), v_(~dy=-1)];
               })
-           |> List.split
-           |> TupleUtil.map2(List.concat);
+           |> List.concat;
+         let path = [m(~x=l.col, ~y=l.row), ...r_edge] @ l_edge @ [Z];
          (
            l,
-           SvgUtil.Path.[m(~x=l.col, ~y=l.row), ...r_edge]
-           @ l_edge
-           @ [SvgUtil.Path.Z]
-           |> SvgUtil.Path.translate({
+           path
+           |> translate({
                 dx: Float.of_int(- l.col),
                 dy: Float.of_int(- l.row),
               }),

--- a/src/web/view/Deco.re
+++ b/src/web/view/Deco.re
@@ -237,19 +237,6 @@ module Deco =
       ? targets(backpack, seg) : [];
   };
 
-  let error_holes = zipper => {
-    //TODO
-    let _ci =
-      switch (zipper |> Indicated.index) {
-      | Some(index) =>
-        let (_, _, info_map) =
-          zipper |> Zipper.zip |> MakeTerm.go |> Statics.mk_map;
-        Id.Map.find_opt(index, info_map);
-      | None => None
-      };
-    ();
-  };
-
   let err_holes = (z: Zipper.t) => {
     let seg = Zipper.unselect_and_zip(z);
     let ranges = TermRanges.mk(seg);

--- a/src/web/view/dec/PieceDec.re
+++ b/src/web/view/dec/PieceDec.re
@@ -128,7 +128,13 @@ let chunky_shard =
   let path =
     chunky_shard_path({origin, last}, (nib_l, nib_r), indent_col, max_col);
   let clss = ["tile-path", "selected", "raised", Sort.to_string(mold.out)];
-  DecUtil.code_svg(~font_metrics, ~origin, ~path_cls=clss, path);
+  DecUtil.code_svg(
+    ~font_metrics,
+    ~origin,
+    ~base_cls=["tile-selected"],
+    ~path_cls=clss,
+    path,
+  );
 };
 
 let shadowfudge = Path.cmdfudge(~y=DecUtil.shadow_adj);

--- a/src/web/www/style.css
+++ b/src/web/www/style.css
@@ -120,6 +120,7 @@
   --genie-z: 1;
   --empty-hole-z: 5;
   --tile-z: 4;
+  --err-hole-z: 5;
   --code-text-z: 6;
   --code-text-shards-z: 7;
   --bar-z: 0;
@@ -650,6 +651,10 @@ svg {
   z-index: -1;
 }
 
+svg.tile-selected {
+  z-index: var(--tile-z);
+}
+
 .tile-path.selected {
   fill: var(--selection-color);
 }
@@ -922,6 +927,7 @@ svg {
   stroke: var(--err-color);
   stroke-width: 1.2px;
   /* mix-blend-mode: color; */
+  z-index: var(--err-hole-z);
 }
 .code-container svg.err-hole path {
   vector-effect: non-scaling-stroke;

--- a/src/web/www/style.css
+++ b/src/web/www/style.css
@@ -84,7 +84,7 @@
   --pat-shadow-color: var(--pat-off-color);
   --pat-bg-color: #b2e8ff;
   --pat-bg-off-color: #d7f3ff;
-  
+
   --typ-text-color: #772cff;/*#24ae62;*/
   --typ-off-color: #975dff; /*#7fc97f;*/
   --typ-delim-color: #cfb5ff; /*#aee5c6;*/
@@ -916,6 +916,17 @@ svg {
 
 /* STATICS */
 
+.code-container svg.err-hole {
+  fill: #d001;
+  stroke-dasharray: 1,1;
+  stroke: var(--err-color);
+  stroke-width: 1.2px;
+  /* mix-blend-mode: color; */
+}
+.code-container svg.err-hole path {
+  vector-effect: non-scaling-stroke;
+}
+
 .typ-view {
   color: var(--typ-text-color);
   display: flex;
@@ -1220,7 +1231,7 @@ svg {
   bottom: 0.15em;
   margin-left: 0.17em;
   font-size: 64%;
-  vertical-align: super;  
+  vertical-align: super;
 }
 .test-inspector .test-instance:before {
   position: relative;


### PR DESCRIPTION
Restores err hole decorations. Basic rectangular contour following the shape of the error term's textual content. Needs some polish to integrate with existing tile decorations, both indicated and selected -- coming soon. Merging this for now so that others can work with visual semantic feedback.

<img width="204" alt="image" src="https://user-images.githubusercontent.com/8718124/186489265-5a699330-aca9-43a6-b86b-a39902539583.png">
