### PR TITLE
Encapsulate click-and-drag logic into Cell component

### DIFF
--- a/src/web/view/Cell.re
+++ b/src/web/view/Cell.re
@@ -1,0 +1,76 @@
+open Virtual_dom.Vdom;
+open Core;
+
+let get_goal = (~font_metrics: FontMetrics.t, ~target_id, e) => {
+  let rect = JSUtil.force_get_elem_by_id(target_id)##getBoundingClientRect;
+  let goal_x = float_of_int(e##.clientX);
+  let goal_y = float_of_int(e##.clientY);
+  Measured.Point.{
+    row: Float.to_int((goal_y -. rect##.top) /. font_metrics.row_height),
+    col:
+      Float.(
+        to_int(round((goal_x -. rect##.left) /. font_metrics.col_width))
+      ),
+  };
+};
+
+let mousedown_overlay = (~inject, ~font_metrics, ~target_id) =>
+  Node.div(
+    Attr.[
+      id("mousedown-overlay"),
+      on_mouseup(_ => inject(Update.Mouseup)),
+      on_mousemove(e => {
+        let goal = get_goal(~font_metrics, ~target_id, e);
+        inject(Update.PerformAction(Select(Goal(goal))));
+      }),
+    ],
+    [],
+  );
+
+let mousedown_handler =
+    (~inject, ~font_metrics, ~target_id, ~additional_updates=[], e) => {
+  let goal = get_goal(~font_metrics, ~target_id, e);
+  Event.Many(
+    List.map(
+      inject,
+      Update.[
+        Mousedown,
+        PerformAction(Move(Goal(goal))),
+        ...additional_updates,
+      ],
+    ),
+  );
+};
+
+let view =
+    (
+      ~inject,
+      ~font_metrics,
+      ~clss=[],
+      ~selected: bool,
+      ~mousedown: bool,
+      ~mousedown_updates: list(Update.t)=[],
+      ~show_code: bool,
+      ~code_id: string,
+      ~caption: option(Node.t)=?,
+      code: Node.t,
+    )
+    : Node.t => {
+  let mousedown_overlay =
+    mousedown
+      ? [mousedown_overlay(~inject, ~font_metrics, ~target_id=code_id)] : [];
+  Node.div(
+    [
+      Attr.classes(["cell", ...clss] @ (selected ? ["selected"] : [])),
+      Attr.on_mousedown(
+        mousedown_handler(
+          ~inject,
+          ~font_metrics,
+          ~target_id=code_id,
+          ~additional_updates=mousedown_updates,
+        ),
+      ),
+    ],
+    Option.to_list(caption) @ (show_code ? mousedown_overlay @ [code] : []),
+  );
+};

--- a/src/web/view/Cell.re
+++ b/src/web/view/Cell.re
@@ -57,7 +57,7 @@ let view =
     )
     : Node.t => {
   let mousedown_overlay =
-    mousedown
+    selected && mousedown
       ? [mousedown_overlay(~inject, ~font_metrics, ~target_id=code_id)] : [];
   Node.div(
     [

--- a/src/web/view/SchoolMode.re
+++ b/src/web/view/SchoolMode.re
@@ -231,34 +231,21 @@ let cell_view =
       ~measured=editor.state.meta.measured,
       zipper,
     );
-  let mousedown_overlay =
-    selected == idx && mousedown
-      ? [
-        SimpleMode.mousedown_overlay(
-          ~inject,
-          ~font_metrics,
-          ~target_id=code_container_id,
-        ),
-      ]
-      : [];
   div(
     [clss(["cell-container"])],
     [cell_chapter_view]
     @ [
-      div(
-        [
-          Attr.classes(["cell"] @ (selected == idx ? ["selected"] : [])),
-          Attr.on_mousedown(
-            SimpleMode.mousedown_handler(
-              ~inject,
-              ~font_metrics,
-              ~target_id=code_container_id,
-              ~additional_updates=[Update.SwitchEditor(idx)],
-            ),
-          ),
-        ],
-        [cell_caption_view]
-        @ (show_code ? mousedown_overlay @ [code_view] : []),
+      Cell.view(
+        ~inject,
+        ~font_metrics,
+        ~clss=["school"],
+        ~selected=selected == idx,
+        ~mousedown,
+        ~mousedown_updates=[Update.SwitchEditor(idx)],
+        ~show_code,
+        ~code_id=code_container_id,
+        ~caption=cell_caption_view,
+        code_view,
       ),
     ]
     @ result_bar,

--- a/src/web/www/style.css
+++ b/src/web/www/style.css
@@ -267,12 +267,6 @@ svg {
   font-family: 'Helvetica Neue';
 }
 
-@media screen and (min-height: 800px) {
-  .code-container {
-    top: max(min(30%, 100vh - 350px), 64px);
-  }
-}
-
 /* TOP BAR */
 
 #top-bar {
@@ -477,19 +471,22 @@ svg {
   padding-left: 0px;
 }
 
-.cell{
+.cell {
   display: flex;
+  flex-direction: column;
+  user-select: none;
+}
+
+.cell.school {
   gap: 1em;
   /* border-radius: 0.4em; */
   padding-left: 1em;
   padding: 1em;
   padding-left: 1.2em;
   border-left: 1px solid var(--top_bar_icon_fill);
-  user-select: none;
-  flex-direction: column;
 }
 
-.cell.selected{
+.cell.school.selected{
   border-left: 1px solid var(--cell-selected-accent);
   background-color: #fffcf3;
 }


### PR DESCRIPTION
Encapsulates the click-and-drag logic (implemented via a mousedown whole-page overlay) into a reusable component called `Cell`. May want to rename this in the future if we have other intentions with the cell terminology. Fixes https://github.com/hazelgrove/hazel/issues/730 where mouse actions in cursor inspector would trigger the mousedown overlay and cause the cursor to move.

cc @cyrus- since you've been touching school cell stuff