### PR TITLE
haz3l-evaluation-gas

### DIFF
--- a/src/haz3lcore/dune
+++ b/src/haz3lcore/dune
@@ -2,7 +2,7 @@
 
 (library
  (name haz3lcore)
- (libraries util re sexplib unionFind)
+ (libraries util re sexplib unionFind lwt)
  (js_of_ocaml
   (flags
    (:include js-of-ocaml-flags-%{profile})))

--- a/src/haz3lcore/dynamics/Evaluator.re
+++ b/src/haz3lcore/dynamics/Evaluator.re
@@ -491,6 +491,7 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
     | _ when depth_out =>
       print_endline("OutOfFuel");
       // raise(EvaluatorError.Exception(OutOfFuel));
+      let* () = reset_step;
       Indet(InvalidOperation(Triv, OutOfFuel)) |> return;
 
     | BoundVar(x) =>

--- a/src/haz3lcore/dynamics/Evaluator.re
+++ b/src/haz3lcore/dynamics/Evaluator.re
@@ -482,13 +482,13 @@ let eval_bin_float_op =
 let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
   (env, d) => {
     /* Increment number of evaluation steps (calls to `evaluate`). */
-    let* () = take_step;
-    let* s = get;
-    let (_, scr) = time_out(s);
+    // let* () = take_step;
+    let* state = get;
+    let (_, depth_out) = time_out(state);
     // let (state, steps) = state |> time_out;
 
     switch (d) {
-    | _ when scr =>
+    | _ when depth_out =>
       print_endline("OutOfFuel");
       raise(EvaluatorError.Exception(OutOfFuel));
 
@@ -534,6 +534,7 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
       };
 
     | FixF(f, _, d') =>
+      let* () = take_step;
       let* env' = evaluate_extend_env(Environment.singleton((f, d)), env);
       evaluate(env', d');
 

--- a/src/haz3lcore/dynamics/Evaluator.re
+++ b/src/haz3lcore/dynamics/Evaluator.re
@@ -482,7 +482,7 @@ let eval_bin_float_op =
 let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
   (env, d) => {
     /* Increment number of evaluation steps (calls to `evaluate`). */
-    // let* () = take_step;
+    let* () = take_step;
     let* state = get;
     let (_, depth_out) = time_out(state);
     // let (state, steps) = state |> time_out;
@@ -490,7 +490,8 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
     switch (d) {
     | _ when depth_out =>
       print_endline("OutOfFuel");
-      raise(EvaluatorError.Exception(OutOfFuel));
+      // raise(EvaluatorError.Exception(OutOfFuel));
+      Indet(InvalidOperation(Triv, OutOfFuel)) |> return;
 
     | BoundVar(x) =>
       let d =
@@ -534,7 +535,7 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
       };
 
     | FixF(f, _, d') =>
-      let* () = take_step;
+      // let* () = take_step;
       let* env' = evaluate_extend_env(Environment.singleton((f, d)), env);
       evaluate(env', d');
 

--- a/src/haz3lcore/dynamics/Evaluator.re
+++ b/src/haz3lcore/dynamics/Evaluator.re
@@ -479,15 +479,19 @@ let eval_bin_float_op =
   };
 };
 
-let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
-  (env, d) => {
+let rec evaluate:
+  (ClosureEnvironment.t, DHExp.t, EvaluatorState.t) => m(EvaluatorResult.t) =
+  (env, d, state) => {
     /* Increment number of evaluation steps (calls to `evaluate`). */
     let* () = take_step;
+    let state = EvaluatorState.take_step(state);
+    let (state, steps) = state |> time_out;
 
     switch (d) {
-    // | _ when time_out =>
-    //   print_endline("OutOfFuel");
-    //   raise(EvaluatorError.Exception(OutOfFuel));
+    | _ when steps =>
+      print_endline("OutOfFuel");
+      raise(EvaluatorError.Exception(OutOfFuel));
+
     | BoundVar(x) =>
       let d =
         x
@@ -498,12 +502,12 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
            });
       /* We need to call [evaluate] on [d] again since [env] does not store
        * final expressions. */
-      evaluate(env, d);
+      evaluate(env, d, state);
 
     | Sequence(d1, d2) =>
-      let* r1 = evaluate(env, d1);
+      let* r1 = evaluate(env, d1, state);
       switch (r1) {
-      | BoxedValue(_d1) => evaluate(env, d2)
+      | BoxedValue(_d1) => evaluate(env, d2, state)
       /* FIXME THIS IS A HACK FOR 490; for now, just return evaluated d2 even
        * if evaluated d1 is indet. */
       | Indet(_d1) =>
@@ -512,11 +516,11 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
         /* | BoxedValue(d2) */
         /* | Indet(d2) => Indet(Sequence(d1, d2)) |> return */
         /* }; */
-        evaluate(env, d2)
+        evaluate(env, d2, state)
       };
 
     | Let(dp, d1, d2) =>
-      let* r1 = evaluate(env, d1);
+      let* r1 = evaluate(env, d1, state);
       switch (r1) {
       | BoxedValue(d1)
       | Indet(d1) =>
@@ -525,23 +529,23 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
         | DoesNotMatch => Indet(Closure(env, Let(dp, d1, d2))) |> return
         | Matches(env') =>
           let* env = evaluate_extend_env(env', env);
-          evaluate(env, d2);
+          evaluate(env, d2, state);
         }
       };
 
     | FixF(f, _, d') =>
       let* env' = evaluate_extend_env(Environment.singleton((f, d)), env);
-      evaluate(env', d');
+      evaluate(env', d', state);
 
     | Fun(_) => BoxedValue(Closure(env, d)) |> return
 
     | Ap(d1, d2) =>
-      let* r1 = evaluate(env, d1);
+      let* r1 = evaluate(env, d1, state);
       switch (r1) {
-      | BoxedValue(TestLit(id)) => evaluate_test(env, id, d2)
+      | BoxedValue(TestLit(id)) => evaluate_test(env, id, d2, state)
 
       | BoxedValue(Closure(closure_env, Fun(dp, _, d3)) as d1) =>
-        let* r2 = evaluate(env, d2);
+        let* r2 = evaluate(env, d2, state);
         switch (r2) {
         | BoxedValue(d2)
         | Indet(d2) =>
@@ -552,23 +556,27 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
             // evaluate a closure: extend the closure environment with the
             // new bindings introduced by the function application.
             let* env = evaluate_extend_env(env', closure_env);
-            evaluate(env, d3);
+            evaluate(env, d3, state);
           }
         };
       | BoxedValue(Cast(d1', Arrow(ty1, ty2), Arrow(ty1', ty2')))
       | Indet(Cast(d1', Arrow(ty1, ty2), Arrow(ty1', ty2'))) =>
-        let* r2 = evaluate(env, d2);
+        let* r2 = evaluate(env, d2, state);
         switch (r2) {
         | BoxedValue(d2')
         | Indet(d2') =>
           /* ap cast rule */
-          evaluate(env, Cast(Ap(d1', Cast(d2', ty1', ty1)), ty2, ty2'))
+          evaluate(
+            env,
+            Cast(Ap(d1', Cast(d2', ty1', ty1)), ty2, ty2'),
+            state,
+          )
         };
       | BoxedValue(d1') =>
         print_endline("InvalidBoxedFun");
         raise(EvaluatorError.Exception(InvalidBoxedFun(d1')));
       | Indet(d1') =>
-        let* r2 = evaluate(env, d2);
+        let* r2 = evaluate(env, d2, state);
         switch (r2) {
         | BoxedValue(d2')
         | Indet(d2') => Indet(Ap(d1', d2')) |> return
@@ -584,13 +592,13 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
     | Triv => BoxedValue(d) |> return
 
     | BinBoolOp(op, d1, d2) =>
-      let* r1 = evaluate(env, d1);
+      let* r1 = evaluate(env, d1, state);
       switch (r1) {
       | BoxedValue(BoolLit(b1) as d1') =>
         switch (eval_bin_bool_op_short_circuit(op, b1)) {
         | Some(b3) => BoxedValue(b3) |> return
         | None =>
-          let* r2 = evaluate(env, d2);
+          let* r2 = evaluate(env, d2, state);
           switch (r2) {
           | BoxedValue(BoolLit(b2)) =>
             BoxedValue(eval_bin_bool_op(op, b1, b2)) |> return
@@ -604,7 +612,7 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
         print_endline("InvalidBoxedBoolLit");
         raise(EvaluatorError.Exception(InvalidBoxedBoolLit(d1')));
       | Indet(d1') =>
-        let* r2 = evaluate(env, d2);
+        let* r2 = evaluate(env, d2, state);
         switch (r2) {
         | BoxedValue(d2')
         | Indet(d2') => Indet(BinBoolOp(op, d1', d2')) |> return
@@ -612,10 +620,10 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
       };
 
     | BinIntOp(op, d1, d2) =>
-      let* r1 = evaluate(env, d1);
+      let* r1 = evaluate(env, d1, state);
       switch (r1) {
       | BoxedValue(IntLit(n1) as d1') =>
-        let* r2 = evaluate(env, d2);
+        let* r2 = evaluate(env, d2, state);
         switch (r2) {
         | BoxedValue(IntLit(n2)) =>
           switch (op, n1, n2) {
@@ -638,7 +646,7 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
         print_endline("InvalidBoxedIntLit");
         raise(EvaluatorError.Exception(InvalidBoxedIntLit(d1')));
       | Indet(d1') =>
-        let* r2 = evaluate(env, d2);
+        let* r2 = evaluate(env, d2, state);
         switch (r2) {
         | BoxedValue(d2')
         | Indet(d2') => Indet(BinIntOp(op, d1', d2')) |> return
@@ -646,10 +654,10 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
       };
 
     | BinFloatOp(op, d1, d2) =>
-      let* r1 = evaluate(env, d1);
+      let* r1 = evaluate(env, d1, state);
       switch (r1) {
       | BoxedValue(FloatLit(f1) as d1') =>
-        let* r2 = evaluate(env, d2);
+        let* r2 = evaluate(env, d2, state);
         switch (r2) {
         | BoxedValue(FloatLit(f2)) =>
           BoxedValue(eval_bin_float_op(op, f1, f2)) |> return
@@ -662,7 +670,7 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
         print_endline("InvalidBoxedFloatLit");
         raise(EvaluatorError.Exception(InvalidBoxedFloatLit(d1')));
       | Indet(d1') =>
-        let* r2 = evaluate(env, d2);
+        let* r2 = evaluate(env, d2, state);
         switch (r2) {
         | BoxedValue(d2')
         | Indet(d2') => Indet(BinFloatOp(op, d1', d2')) |> return
@@ -670,15 +678,15 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
       };
 
     | Inj(ty, side, d1) =>
-      let* r1 = evaluate(env, d1);
+      let* r1 = evaluate(env, d1, state);
       switch (r1) {
       | BoxedValue(d1') => BoxedValue(Inj(ty, side, d1')) |> return
       | Indet(d1') => Indet(Inj(ty, side, d1')) |> return
       };
 
     | Pair(d1, d2) =>
-      let* d1' = evaluate(env, d1);
-      let* d2' = evaluate(env, d2);
+      let* d1' = evaluate(env, d1, state);
+      let* d2' = evaluate(env, d2, state);
       switch (d1', d2') {
       | (Indet(d1), Indet(d2))
       | (Indet(d1), BoxedValue(d2))
@@ -688,8 +696,8 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
       };
 
     | Cons(d1, d2) =>
-      let* d1 = evaluate(env, d1);
-      let* d2 = evaluate(env, d2);
+      let* d1 = evaluate(env, d1, state);
+      let* d2 = evaluate(env, d2, state);
       switch (d1, d2) {
       | (Indet(d1), Indet(d2))
       | (Indet(d1), BoxedValue(d2))
@@ -718,7 +726,7 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
         List.fold_right(
           (ele, ele_list) => {
             let* ele_list = ele_list;
-            let+ ele' = evaluate(env, ele);
+            let+ ele' = evaluate(env, ele, state);
             switch (ele') {
             | BoxedValue(ele') => [ele'] @ ele_list
             | _ => [ele, ...ele_list]
@@ -730,7 +738,7 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
       BoxedValue(ListLit(x1, x2, x3, ty, evaluated_lst));
 
     | ConsistentCase(Case(d1, rules, n)) =>
-      evaluate_case(env, None, d1, rules, n)
+      evaluate_case(env, None, d1, rules, n, state)
 
     /* Generalized closures evaluate to themselves. Only
        lambda closures are BoxedValues; other closures are all Indet. */
@@ -742,12 +750,12 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
 
     /* Hole expressions */
     | InconsistentBranches(u, i, Case(d1, rules, n)) =>
-      evaluate_case(env, Some((u, i)), d1, rules, n)
+      evaluate_case(env, Some((u, i)), d1, rules, n, state)
 
     | EmptyHole(u, i) => Indet(Closure(env, EmptyHole(u, i))) |> return
 
     | NonEmptyHole(reason, u, i, d1) =>
-      let* r1 = evaluate(env, d1);
+      let* r1 = evaluate(env, d1, state);
       switch (r1) {
       | BoxedValue(d1')
       | Indet(d1') =>
@@ -764,7 +772,7 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
 
     /* Cast calculus */
     | Cast(d1, ty, ty') =>
-      let* r1 = evaluate(env, d1);
+      let* r1 = evaluate(env, d1, state);
       switch (r1) {
       | BoxedValue(d1') as result =>
         switch (ground_cases_of(ty), ground_cases_of(ty')) {
@@ -792,11 +800,11 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
           /* ITExpand rule */
           let d' =
             DHExp.Cast(Cast(d1', ty, ty'_grounded), ty'_grounded, ty');
-          evaluate(env, d');
+          evaluate(env, d', state);
         | (NotGroundOrHole(ty_grounded), Hole) =>
           /* ITGround rule */
           let d' = DHExp.Cast(Cast(d1', ty, ty_grounded), ty_grounded, ty');
-          evaluate(env, d');
+          evaluate(env, d', state);
         | (Ground, NotGroundOrHole(_))
         | (NotGroundOrHole(_), Ground) =>
           /* can't do anything when casting between diseq, non-hole types */
@@ -832,11 +840,11 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
           /* ITExpand rule */
           let d' =
             DHExp.Cast(Cast(d1', ty, ty'_grounded), ty'_grounded, ty');
-          evaluate(env, d');
+          evaluate(env, d', state);
         | (NotGroundOrHole(ty_grounded), Hole) =>
           /* ITGround rule */
           let d' = DHExp.Cast(Cast(d1', ty, ty_grounded), ty_grounded, ty');
-          evaluate(env, d');
+          evaluate(env, d', state);
         | (Ground, NotGroundOrHole(_))
         | (NotGroundOrHole(_), Ground) =>
           /* can't do anything when casting between diseq, non-hole types */
@@ -852,7 +860,7 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
       };
 
     | FailedCast(d1, ty, ty') =>
-      let* r1 = evaluate(env, d1);
+      let* r1 = evaluate(env, d1, state);
       switch (r1) {
       | BoxedValue(d1')
       | Indet(d1') => Indet(FailedCast(d1', ty, ty')) |> return
@@ -873,9 +881,10 @@ and evaluate_case =
       scrut: DHExp.t,
       rules: list(DHExp.rule),
       current_rule_index: int,
+      state: EvaluatorState.t,
     )
     : m(EvaluatorResult.t) => {
-  let* rscrut = evaluate(env, scrut);
+  let* rscrut = evaluate(env, scrut, state);
   switch (rscrut) {
   | BoxedValue(scrut)
   | Indet(scrut) =>
@@ -905,7 +914,7 @@ and evaluate_case =
       | Matches(env') =>
         // extend environment with new bindings introduced
         let* env = evaluate_extend_env(env', env);
-        evaluate(env, d);
+        evaluate(env, d, state);
       // by the rule and evaluate the expression.
       | DoesNotMatch =>
         evaluate_case(
@@ -914,6 +923,7 @@ and evaluate_case =
           scrut,
           rules,
           current_rule_index + 1,
+          state,
         )
       }
     }
@@ -936,10 +946,13 @@ and evaluate_extend_env =
   [ident] with [args].
  */
 and evaluate_ap_builtin =
-    (env: ClosureEnvironment.t, ident: string, args: list(DHExp.t))
+    (_: ClosureEnvironment.t, ident: string, _: list(DHExp.t))
     : m(EvaluatorResult.t) => {
   switch (Builtins.lookup_form(ident)) {
-  | Some((eval, _)) => eval(env, args, evaluate)
+  // | Some((eval, _)) => eval(env, args, evaluate, state)
+  | Some((_, _)) =>
+    print_endline("InvalidBuiltin");
+    raise(EvaluatorError.Exception(InvalidBuiltin(ident)));
   | None =>
     print_endline("InvalidBuiltin");
     raise(EvaluatorError.Exception(InvalidBuiltin(ident)));
@@ -947,38 +960,43 @@ and evaluate_ap_builtin =
 }
 
 and evaluate_test =
-    (env: ClosureEnvironment.t, n: KeywordID.t, arg: DHExp.t)
+    (
+      env: ClosureEnvironment.t,
+      n: KeywordID.t,
+      arg: DHExp.t,
+      state: EvaluatorState.t,
+    )
     : m(EvaluatorResult.t) => {
   let* (arg_show, arg_result) =
     switch (DHExp.strip_casts(arg)) {
     | BinBoolOp(op, arg_d1, arg_d2) =>
       let mk_op = (arg_d1, arg_d2) => DHExp.BinBoolOp(op, arg_d1, arg_d2);
-      evaluate_test_eq(env, mk_op, arg_d1, arg_d2);
+      evaluate_test_eq(env, mk_op, arg_d1, arg_d2, state);
     | BinIntOp(op, arg_d1, arg_d2) =>
       let mk_op = (arg_d1, arg_d2) => DHExp.BinIntOp(op, arg_d1, arg_d2);
-      evaluate_test_eq(env, mk_op, arg_d1, arg_d2);
+      evaluate_test_eq(env, mk_op, arg_d1, arg_d2, state);
     | BinFloatOp(op, arg_d1, arg_d2) =>
       let mk_op = (arg_d1, arg_d2) => DHExp.BinFloatOp(op, arg_d1, arg_d2);
-      evaluate_test_eq(env, mk_op, arg_d1, arg_d2);
+      evaluate_test_eq(env, mk_op, arg_d1, arg_d2, state);
 
     | Ap(Ap(arg_d1, arg_d2), arg_d3) =>
-      let* arg_d1 = evaluate(env, arg_d1);
-      let* arg_d2 = evaluate(env, arg_d2);
-      let* arg_d3 = evaluate(env, arg_d3);
+      let* arg_d1 = evaluate(env, arg_d1, state);
+      let* arg_d2 = evaluate(env, arg_d2, state);
+      let* arg_d3 = evaluate(env, arg_d3, state);
       let arg_show =
         DHExp.Ap(
           Ap(EvaluatorResult.unbox(arg_d1), EvaluatorResult.unbox(arg_d2)),
           EvaluatorResult.unbox(arg_d3),
         );
-      let* arg_result = evaluate(env, arg_show);
+      let* arg_result = evaluate(env, arg_show, state);
       (arg_show, arg_result) |> return;
 
     | Ap(arg_d1, arg_d2) =>
       let mk = (arg_d1, arg_d2) => DHExp.Ap(arg_d1, arg_d2);
-      evaluate_test_eq(env, mk, arg_d1, arg_d2);
+      evaluate_test_eq(env, mk, arg_d1, arg_d2, state);
 
     | _ =>
-      let* arg = evaluate(env, arg);
+      let* arg = evaluate(env, arg, state);
       (EvaluatorResult.unbox(arg), arg) |> return;
     };
 
@@ -1005,14 +1023,15 @@ and evaluate_test_eq =
       mk_arg_op: (DHExp.t, DHExp.t) => DHExp.t,
       arg_d1: DHExp.t,
       arg_d2: DHExp.t,
+      state: EvaluatorState.t,
     )
     : m((DHExp.t, EvaluatorResult.t)) => {
-  let* arg_d1 = evaluate(env, arg_d1);
-  let* arg_d2 = evaluate(env, arg_d2);
+  let* arg_d1 = evaluate(env, arg_d1, state);
+  let* arg_d2 = evaluate(env, arg_d2, state);
 
   let arg_show =
     mk_arg_op(EvaluatorResult.unbox(arg_d1), EvaluatorResult.unbox(arg_d2));
-  let* arg_result = evaluate(env, arg_show);
+  let* arg_result = evaluate(env, arg_show, state);
 
   (arg_show, arg_result) |> return;
 };
@@ -1021,5 +1040,5 @@ let evaluate = (env, d) => {
   let es = EvaluatorState.init;
   let (env, es) =
     es |> EvaluatorState.with_eig(ClosureEnvironment.of_environment(env));
-  evaluate(env, d, es);
+  evaluate(env, d, es, es);
 };

--- a/src/haz3lcore/dynamics/Evaluator.re
+++ b/src/haz3lcore/dynamics/Evaluator.re
@@ -940,13 +940,11 @@ and evaluate_extend_env =
   [ident] with [args].
  */
 and evaluate_ap_builtin =
-    (_: ClosureEnvironment.t, ident: string, _: list(DHExp.t))
+    (env: ClosureEnvironment.t, ident: string, args: list(DHExp.t))
     : m(EvaluatorResult.t) => {
   switch (Builtins.lookup_form(ident)) {
   // | Some((eval, _)) => eval(env, args, evaluate, state)
-  | Some((_, _)) =>
-    print_endline("InvalidBuiltin");
-    raise(EvaluatorError.Exception(InvalidBuiltin(ident)));
+  | Some((eval, _)) => eval(env, args, evaluate)
   | None =>
     print_endline("InvalidBuiltin");
     raise(EvaluatorError.Exception(InvalidBuiltin(ident)));

--- a/src/haz3lcore/dynamics/Evaluator.re
+++ b/src/haz3lcore/dynamics/Evaluator.re
@@ -1,3 +1,4 @@
+// open Lwt.Syntax;
 open Util;
 open EvaluatorMonad;
 open EvaluatorMonad.Syntax;
@@ -484,6 +485,9 @@ let rec evaluate: (ClosureEnvironment.t, DHExp.t) => m(EvaluatorResult.t) =
     let* () = take_step;
 
     switch (d) {
+    // | _ when time_out =>
+    //   print_endline("OutOfFuel");
+    //   raise(EvaluatorError.Exception(OutOfFuel));
     | BoundVar(x) =>
       let d =
         x

--- a/src/haz3lcore/dynamics/EvaluatorMonad.re
+++ b/src/haz3lcore/dynamics/EvaluatorMonad.re
@@ -7,6 +7,8 @@ let put_eig = eig => modify(EvaluatorState.put_eig(eig));
 let with_eig = f => modify'(EvaluatorState.with_eig(f));
 
 let take_step = get >>= (state => put(EvaluatorState.take_step(state)));
+
+let reset_step = get >>= (state => put(EvaluatorState.reset_step(state)));
 let get_step = get >>| EvaluatorState.get_step;
 let time_out = get >>| EvaluatorState.time_out;
 

--- a/src/haz3lcore/dynamics/EvaluatorMonad.re
+++ b/src/haz3lcore/dynamics/EvaluatorMonad.re
@@ -7,6 +7,8 @@ let put_eig = eig => modify(EvaluatorState.put_eig(eig));
 let with_eig = f => modify'(EvaluatorState.with_eig(f));
 
 let take_step = get >>= (state => put(EvaluatorState.take_step(state)));
+let get_step = get >>| EvaluatorState.get_step;
+let time_out = get >>| EvaluatorState.time_out;
 
 let add_test = (id, report) =>
   get >>= (state => put(EvaluatorState.add_test(state, id, report)));

--- a/src/haz3lcore/dynamics/EvaluatorMonad.rei
+++ b/src/haz3lcore/dynamics/EvaluatorMonad.rei
@@ -23,6 +23,7 @@ let with_eig: (EnvironmentIdGen.t => ('a, EnvironmentIdGen.t)) => t('a);
   See {!val:EvaluatorState.take_step}
  */
 let take_step: t(unit);
+let reset_step: t(unit);
 let get_step: t(int);
 
 let time_out: t(bool);

--- a/src/haz3lcore/dynamics/EvaluatorMonad.rei
+++ b/src/haz3lcore/dynamics/EvaluatorMonad.rei
@@ -23,5 +23,8 @@ let with_eig: (EnvironmentIdGen.t => ('a, EnvironmentIdGen.t)) => t('a);
   See {!val:EvaluatorState.take_step}
  */
 let take_step: t(unit);
+let get_step: t(int);
+
+let time_out: t(bool);
 
 let add_test: (KeywordID.t, TestMap.instance_report) => t(unit);

--- a/src/haz3lcore/dynamics/EvaluatorState.re
+++ b/src/haz3lcore/dynamics/EvaluatorState.re
@@ -25,7 +25,7 @@ let take_step = ({stats, _} as es) => {
 
 let get_step = ({stats, _}) => stats |> EvaluatorStats.get_step;
 
-let time_out = ({stats, _}) => stats |> EvaluatorStats.get_step > 100;
+let time_out = ({stats, _}) => stats |> EvaluatorStats.get_step > 64;
 
 let add_test = ({tests, _} as es, id, report) => {
   let tests = tests |> TestMap.extend((id, report));

--- a/src/haz3lcore/dynamics/EvaluatorState.re
+++ b/src/haz3lcore/dynamics/EvaluatorState.re
@@ -23,6 +23,11 @@ let take_step = ({stats, _} as es) => {
   stats: stats |> EvaluatorStats.take_step,
 };
 
+let reset_step = ({stats, _} as es) => {
+  ...es,
+  stats: stats |> EvaluatorStats.reset_step,
+};
+
 let get_step = ({stats, _}) => stats |> EvaluatorStats.get_step;
 
 let time_out = ({stats, _}) => stats |> EvaluatorStats.get_step > 64;

--- a/src/haz3lcore/dynamics/EvaluatorState.re
+++ b/src/haz3lcore/dynamics/EvaluatorState.re
@@ -25,6 +25,8 @@ let take_step = ({stats, _} as es) => {
 
 let get_step = ({stats, _}) => stats |> EvaluatorStats.get_step;
 
+let time_out = ({stats, _}) => stats |> EvaluatorStats.get_step > 100;
+
 let add_test = ({tests, _} as es, id, report) => {
   let tests = tests |> TestMap.extend((id, report));
   {...es, tests};

--- a/src/haz3lcore/dynamics/EvaluatorState.rei
+++ b/src/haz3lcore/dynamics/EvaluatorState.rei
@@ -42,6 +42,8 @@ let take_step: t => t;
  */
 let get_step: t => int;
 
+let time_out: t => bool;
+
 let add_test: (t, KeywordID.t, TestMap.instance_report) => t;
 
 let get_tests: t => TestMap.t;

--- a/src/haz3lcore/dynamics/EvaluatorState.rei
+++ b/src/haz3lcore/dynamics/EvaluatorState.rei
@@ -37,6 +37,8 @@ let with_eig: (EnvironmentIdGen.t => ('a, EnvironmentIdGen.t), t) => ('a, t);
  */
 let take_step: t => t;
 
+let reset_step: t => t;
+
 /**
   [get_step es] is the number of steps taken.
  */

--- a/src/haz3lcore/dynamics/EvaluatorStats.re
+++ b/src/haz3lcore/dynamics/EvaluatorStats.re
@@ -7,3 +7,5 @@ let initial: t = {step: 0};
 
 let take_step = ({step}) => {step: step + 1};
 let get_step = ({step}) => step;
+
+let time_out = ({step}) => step > 100;

--- a/src/haz3lcore/dynamics/EvaluatorStats.re
+++ b/src/haz3lcore/dynamics/EvaluatorStats.re
@@ -6,6 +6,7 @@ type t = {step: int};
 let initial: t = {step: 0};
 
 let take_step = ({step}) => {step: step + 1};
+let reset_step = ({step}) => {step: step * 0};
 let get_step = ({step}) => step;
 
 let time_out = ({step}) => step > 100;

--- a/src/haz3lcore/dynamics/InvalidOperationError.re
+++ b/src/haz3lcore/dynamics/InvalidOperationError.re
@@ -6,5 +6,5 @@ type t =
 let err_msg = (err: t): string =>
   switch (err) {
   | DivideByZero => "Error: Divide by Zero"
-  | OutOfFuel => "Error: Out of Fuel"
+  | OutOfFuel => "Error: Recursion Limit Exceeded"
   };

--- a/src/haz3lweb/view/dhcode/DHCode.re
+++ b/src/haz3lweb/view/dhcode/DHCode.re
@@ -61,7 +61,7 @@ let view_of_layout =
                )
              | OperationError(OutOfFuel) => (
                  //TODO: custom class
-                 [with_cls("DivideByZero", txt)],
+                 [with_cls("OutOfFuel", txt)],
                  ds,
                )
              | VarHole(_) => ([with_cls("InVarHole", txt)], ds)
@@ -186,7 +186,7 @@ let view_of_layout_tylr =
                )
              | OperationError(OutOfFuel) => (
                  //TODO: custom class
-                 [with_cls("DivideByZero", txt)],
+                 [with_cls("OutOfFuel", txt)],
                  ds,
                )
              | VarHole(_) => ([with_cls("InVarHole", txt)], ds)

--- a/src/haz3lweb/www/index.html
+++ b/src/haz3lweb/www/index.html
@@ -19,6 +19,8 @@
           <img width="200px" height="200px" src="img/hazelnut.svg" style="position:fixed; transform: scale(0.25); filter: invert()"/>
         </div>
         <p style="font-size:4em; color: black;">loading</p>
+        <p>if the program is taking too long to load, please click the button below</p>
+        <button id = "reload" type="button" onclick="localStorage.clear(); location.reload(), document.getElementById('reload').innerHTML='loading';">clear and reload</button>
       </div>
     </div>
   </body>


### PR DESCRIPTION
This PR adds gas to the evaluator to show time-out error caused by bottomless recursion.

- The quick fix was added to help testing the timeout bug, it could be safely removed after the problem resolved.