### PR TITLE
reset current editor

### DIFF
--- a/src/haz3lweb/Keyboard.re
+++ b/src/haz3lweb/Keyboard.re
@@ -105,6 +105,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | "z" => now_save_u(Undo)
     | "p" => now(Pick_up)
     | "a" => now(Move(Extreme(Up))) @ now(Select(Extreme(Down)))
+    | "k" => [ResetCurrentEditor]
     | _ when is_digit(key) => [SwitchSlide(int_of_string(key))]
     | "ArrowLeft" => now(Move(Extreme(Left(ByToken))))
     | "ArrowRight" => now(Move(Extreme(Right(ByToken))))
@@ -117,6 +118,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | "z" => now_save_u(Undo)
     | "p" => now(Pick_up)
     | "a" => now(Move(Extreme(Up))) @ now(Select(Extreme(Down)))
+    | "k" => [ResetCurrentEditor]
     | _ when is_digit(key) => [SwitchSlide(int_of_string(key))]
     | "ArrowLeft" => now(Move(Local(Left(ByToken))))
     | "ArrowRight" => now(Move(Local(Right(ByToken))))

--- a/src/haz3lweb/Log.re
+++ b/src/haz3lweb/Log.re
@@ -29,6 +29,7 @@ let is_action_logged: Update.t => bool =
   | InitImportAll(_)
   | InitImportScratchpad(_)
   | UpdateResult(_) => false
+  | ResetCurrentEditor
   | Set(_)
   | FinishImportAll(_)
   | FinishImportScratchpad(_)

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -153,6 +153,7 @@ let reevaluate_post_update =
   | FailedInput(_) => false
   // may not be necessary on all of these
   // TODO review and prune
+  | ResetCurrentEditor
   | PerformAction(Destruct(_) | Insert(_) | Pick_up | Put_down)
   | FinishImportAll(_)
   | FinishImportScratchpad(_)
@@ -335,6 +336,21 @@ let apply =
           ...model,
           editors: Editors.put_editor_and_id(id, ed, model.editors),
         });
+      };
+    | ResetCurrentEditor =>
+      /* This serializes the current editor to text, resets the current
+         editor, and then deserializes. It is intended as a (tactical)
+         nuclear option for weird backpack states */
+      let (id, ed) = Editors.get_editor_and_id(model.editors);
+      let zipper_init = Zipper.init(id);
+      let ed_str = Printer.to_string_editor(ed);
+      switch (Printer.zipper_of_string(~zipper_init, id + 1, ed_str)) {
+      | None => Error(CantReset)
+      | Some((z, id)) =>
+        //TODO: add correct action to history (Pick_up is wrong)
+        let editor = Haz3lcore.Editor.new_state(Pick_up, z, ed);
+        let editors = Editors.put_editor_and_id(id, editor, model.editors);
+        Ok({...model, editors});
       };
     | Undo =>
       let (id, ed) = Editors.get_editor_and_id(model.editors);

--- a/src/haz3lweb/UpdateAction.re
+++ b/src/haz3lweb/UpdateAction.re
@@ -32,6 +32,7 @@ type t =
   | SetLogoFontMetrics(FontMetrics.t)
   | PerformAction(Action.t)
   | FailedInput(FailedInput.reason) //TODO(andrew): refactor as failure?
+  | ResetCurrentEditor
   | Cut
   | Copy
   | Paste(string)
@@ -47,6 +48,7 @@ module Failure = {
     | CantUndo
     | CantRedo
     | CantPaste
+    | CantReset
     | FailedToLoad
     | FailedToSwitch
     | UnrecognizedInput(FailedInput.reason)

--- a/src/haz3lweb/view/Printer.re
+++ b/src/haz3lweb/view/Printer.re
@@ -61,6 +61,15 @@ let pretty_print = (~measured: Measured.t, z: Zipper.t): string =>
   )
   |> String.concat("\n");
 
+let to_string_editor = (editor: Editor.t): string =>
+  to_rows(
+    ~measured=editor.state.meta.measured,
+    ~caret=None,
+    ~indent=" ",
+    ~segment=Zipper.unselect_and_zip(editor.state.zipper),
+  )
+  |> String.concat("\n");
+
 let to_string_selection = (editor: Editor.t): string =>
   to_rows(
     ~measured=editor.state.meta.measured,


### PR DESCRIPTION
Press Ctrl/Cmd-K to reset the backpack and reparse the current editor state as a string. Shouldn't be necessary when there aren't any more bugs, one day.