### PR TITLE
Go to definition

### DIFF
--- a/src/haz3lcore/statics/Statics.re
+++ b/src/haz3lcore/statics/Statics.re
@@ -1,4 +1,5 @@
 open Sexplib.Std;
+open Util;
 
 /* STATICS
 
@@ -622,3 +623,20 @@ let mk_map =
       map;
     },
   );
+
+let get_binding_site = (id, statics_map) => {
+  open OptUtil.Syntax;
+  let* opt = Id.Map.find_opt(id, statics_map);
+  let* info_exp =
+    switch (opt) {
+    | InfoExp(info_exp) => Some(info_exp)
+    | _ => None
+    };
+
+  let+ entry =
+    switch (info_exp.term.term) {
+    | TermBase.UExp.Var(name) => VarMap.lookup(info_exp.ctx, name)
+    | _ => None
+    };
+  entry.id;
+};

--- a/src/haz3lcore/statics/Statics.re
+++ b/src/haz3lcore/statics/Statics.re
@@ -624,7 +624,7 @@ let mk_map =
     },
   );
 
-let get_binding_site = (id, statics_map) => {
+let get_binding_site = (id: Id.t, statics_map: map): option(Id.t) => {
   open OptUtil.Syntax;
   let* opt = Id.Map.find_opt(id, statics_map);
   let* info_exp =

--- a/src/haz3lcore/zipper/action/Action.re
+++ b/src/haz3lcore/zipper/action/Action.re
@@ -19,7 +19,8 @@ type t =
   | RotateBackpack
   | MoveToBackpackTarget(planar)
   | Pick_up
-  | Put_down;
+  | Put_down
+  | GoToDefinition;
 
 module Failure = {
   [@deriving (show({with_path: false}), sexp, yojson)]
@@ -28,7 +29,8 @@ module Failure = {
     | Cant_insert
     | Cant_destruct
     | Cant_select
-    | Cant_put_down;
+    | Cant_put_down
+    | Cant_go_to_definition;
 };
 
 module Result = {

--- a/src/haz3lcore/zipper/action/Action.re
+++ b/src/haz3lcore/zipper/action/Action.re
@@ -16,7 +16,6 @@ type jump_target =
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t =
   | Move(move)
-  | JumpToId(Id.t)
   | Jump(jump_target)
   | Select(move)
   | Unselect

--- a/src/haz3lcore/zipper/action/Action.re
+++ b/src/haz3lcore/zipper/action/Action.re
@@ -9,9 +9,15 @@ type move =
   | Goal(Measured.Point.t);
 
 [@deriving (show({with_path: false}), sexp, yojson)]
+type jump_target =
+  | TileId(Id.t)
+  | BindingSiteOfIndicatedVar;
+
+[@deriving (show({with_path: false}), sexp, yojson)]
 type t =
   | Move(move)
   | JumpToId(Id.t)
+  | Jump(jump_target)
   | Select(move)
   | Unselect
   | Destruct(Direction.t)
@@ -19,8 +25,7 @@ type t =
   | RotateBackpack
   | MoveToBackpackTarget(planar)
   | Pick_up
-  | Put_down
-  | GoToDefinition;
+  | Put_down;
 
 module Failure = {
   [@deriving (show({with_path: false}), sexp, yojson)]
@@ -29,8 +34,7 @@ module Failure = {
     | Cant_insert
     | Cant_destruct
     | Cant_select
-    | Cant_put_down
-    | Cant_go_to_definition;
+    | Cant_put_down;
 };
 
 module Result = {

--- a/src/haz3lcore/zipper/action/Move.re
+++ b/src/haz3lcore/zipper/action/Move.re
@@ -178,27 +178,6 @@ module Make = (M: Editor.Meta.S) => {
     jump_to_p(z, piece => Piece.id(piece) == id);
   };
 
-  let jump_to_indicated_var = (z: t): option(t) => {
-    open OptUtil.Syntax;
-    let* idx = Indicated.index(z);
-    let (term, _) = MakeTerm.go(Zipper.unselect_and_zip(z));
-    let* statics = Id.Map.find_opt(idx, Statics.mk_map(term));
-
-    let* info_exp =
-      switch (statics) {
-      | Statics.InfoExp(info_exp) => Some(info_exp)
-      | _ => None
-      };
-
-    let* entry =
-      switch (info_exp.term.term) {
-      | TermBase.UExp.Var(name) => VarMap.lookup(info_exp.ctx, name)
-      | _ => None
-      };
-
-    jump_to_id(z, entry.id);
-  };
-
   let vertical = (d: Direction.t, z: t): option(t) =>
     z.selection.content == []
       ? do_vertical(primary(ByChar), d, z)

--- a/src/haz3lcore/zipper/action/Move.re
+++ b/src/haz3lcore/zipper/action/Move.re
@@ -180,14 +180,9 @@ module Make = (M: Editor.Meta.S) => {
 
   let jump_to_indicated_var = (z: t): option(t) => {
     open OptUtil.Syntax;
-    let* (piece, _, _) = Indicated.piece(z);
-    let* statics =
-      switch (piece) {
-      | Base.Tile(tile) =>
-        let (term, _) = MakeTerm.go(Zipper.unselect_and_zip(z));
-        Id.Map.find_opt(tile.id, Statics.mk_map(term));
-      | _ => None
-      };
+    let* idx = Indicated.index(z);
+    let (term, _) = MakeTerm.go(Zipper.unselect_and_zip(z));
+    let* statics = Id.Map.find_opt(idx, Statics.mk_map(term));
 
     let* info_exp =
       switch (statics) {
@@ -200,6 +195,7 @@ module Make = (M: Editor.Meta.S) => {
       | TermBase.UExp.Var(name) => VarMap.lookup(info_exp.ctx, name)
       | _ => None
       };
+
     jump_to_id(z, entry.id);
   };
 

--- a/src/haz3lcore/zipper/action/Move.re
+++ b/src/haz3lcore/zipper/action/Move.re
@@ -200,9 +200,7 @@ module Make = (M: Editor.Meta.S) => {
       | TermBase.UExp.Var(name) => VarMap.lookup(info_exp.ctx, name)
       | _ => None
       };
-
-    let+ move = jump_to_id(z, entry.id);
-    move;
+    jump_to_id(z, entry.id);
   };
 
   let vertical = (d: Direction.t, z: t): option(t) =>

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -24,17 +24,11 @@ let go_z =
       id_gen: IdGen.state,
     )
     : Action.Result.t((Zipper.t, IdGen.state)) => {
-  open OptUtil.Syntax;
-
   let meta =
     switch (meta) {
     | Some(m) => m
     | None => Editor.Meta.init(z)
     };
-  let idx = Indicated.index(z);
-  let (term, _) = MakeTerm.go(Zipper.unselect_and_zip(z));
-  let statics = Statics.mk_map(term);
-
   module M = (val Editor.Meta.module_of_t(meta));
   module Move = Move.Make(M);
   module Select = Select.Make(M);
@@ -44,6 +38,12 @@ let go_z =
     |> Option.map(IdGen.id(id_gen))
     |> Result.of_option(~error=Action.Failure.Cant_move)
   | Jump(jump_target) =>
+    open OptUtil.Syntax;
+
+    let idx = Indicated.index(z);
+    let (term, _) = MakeTerm.go(Zipper.unselect_and_zip(z));
+    let statics = Statics.mk_map(term);
+
     (
       switch (jump_target) {
       | BindingSiteOfIndicatedVar =>
@@ -54,7 +54,7 @@ let go_z =
       }
     )
     |> Option.map(IdGen.id(id_gen))
-    |> Result.of_option(~error=Action.Failure.Cant_move)
+    |> Result.of_option(~error=Action.Failure.Cant_move);
   | Unselect =>
     let z = Zipper.directional_unselect(z.selection.focus, z);
     Ok((z, id_gen));

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -4,7 +4,6 @@ open Zipper;
 let is_write_action = (a: Action.t) => {
   switch (a) {
   | Move(_)
-  | JumpToId(_)
   | Unselect
   | Jump(_)
   | Select(_) => false
@@ -45,10 +44,6 @@ let go_z =
       | TileId(id) => Move.jump_to_id(z, id)
       }
     )
-    |> Option.map(IdGen.id(id_gen))
-    |> Result.of_option(~error=Action.Failure.Cant_move)
-  | JumpToId(id) =>
-    Move.jump_to_id(z, id)
     |> Option.map(IdGen.id(id_gen))
     |> Result.of_option(~error=Action.Failure.Cant_move)
   | Unselect =>

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -6,6 +6,7 @@ let is_write_action = (a: Action.t) => {
   | Move(_)
   | JumpToId(_)
   | Unselect
+  | GoToDefinition => false
   | Select(_) => false
   | Destruct(_)
   | Insert(_)
@@ -77,6 +78,29 @@ let go_z =
     Move.to_backpack_target(d, z)
     |> Option.map(IdGen.id(id_gen))
     |> Result.of_option(~error=Action.Failure.Cant_move)
+  | GoToDefinition =>
+    Indicated.piece(z)
+    |> Option.bind(_, ((piece, _, _)) => {
+         switch (piece) {
+         | Base.Tile(tile) =>
+           let (term, _) = MakeTerm.go(Zipper.unselect_and_zip(z));
+           Id.Map.find_opt(tile.id, Statics.mk_map(term));
+         | _ => None
+         }
+       })
+    |> Option.bind(_, s => {
+         switch (s) {
+         | Statics.InfoExp(info_exp) =>
+           switch (info_exp.term.term) {
+           | TermBase.UExp.Var(name) => VarMap.lookup(info_exp.ctx, name)
+           | _ => None
+           }
+         | _ => None
+         }
+       })
+    |> Option.bind(_, entry => Move.jump_to_id(z, entry.id))
+    |> Option.map(IdGen.id(id_gen))
+    |> Result.of_option(~error=Action.Failure.Cant_go_to_definition)
   };
 };
 

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -89,15 +89,19 @@ let go_z =
           Id.Map.find_opt(tile.id, Statics.mk_map(term));
         | _ => None
         };
-      let* entry =
+
+      let* info_exp =
         switch (statics) {
-        | Statics.InfoExp(info_exp) =>
-          switch (info_exp.term.term) {
-          | TermBase.UExp.Var(name) => VarMap.lookup(info_exp.ctx, name)
-          | _ => None
-          }
+        | Statics.InfoExp(info_exp) => Some(info_exp)
         | _ => None
         };
+
+      let* entry =
+        switch (info_exp.term.term) {
+        | TermBase.UExp.Var(name) => VarMap.lookup(info_exp.ctx, name)
+        | _ => None
+        };
+
       let+ move = Move.jump_to_id(z, entry.id);
       IdGen.id(id_gen, move);
     };

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -6,7 +6,7 @@ let is_write_action = (a: Action.t) => {
   | Move(_)
   | JumpToId(_)
   | Unselect
-  | GoToDefinition => false
+  | GoToDefinition
   | Select(_) => false
   | Destruct(_)
   | Insert(_)

--- a/src/haz3lweb/Keyboard.re
+++ b/src/haz3lweb/Keyboard.re
@@ -43,7 +43,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | "F3" => toggle(Log.debug_update)
     | "F4" => toggle(Log.debug_keystroke)
     | "F5" => toggle(Log.debug_zipper)
-    | "F6" => now(GoToDefinition) // Figure out actual keybinding
+    | "F6" => now(Jump(BindingSiteOfIndicatedVar)) // Figure out actual keybinding
     | "F7" => []
     | "F8" => []
     | "F10" =>

--- a/src/haz3lweb/Keyboard.re
+++ b/src/haz3lweb/Keyboard.re
@@ -43,7 +43,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | "F3" => toggle(Log.debug_update)
     | "F4" => toggle(Log.debug_keystroke)
     | "F5" => toggle(Log.debug_zipper)
-    | "F6" => []
+    | "F6" => now(GoToDefinition) // Figure out actual keybinding
     | "F7" => []
     | "F8" => []
     | "F10" =>

--- a/src/haz3lweb/Keyboard.re
+++ b/src/haz3lweb/Keyboard.re
@@ -43,7 +43,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | "F3" => toggle(Log.debug_update)
     | "F4" => toggle(Log.debug_keystroke)
     | "F5" => toggle(Log.debug_zipper)
-    | "F6" => now(Jump(BindingSiteOfIndicatedVar)) // Figure out actual keybinding
+    | "F6" => []
     | "F7" => []
     | "F8" => []
     | "F10" =>
@@ -63,6 +63,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | (Up, "Delete") => now_save(Destruct(Right))
     | (Up, "Escape") => now(Unselect)
     | (Up, "Tab") => now_save(Put_down) //TODO: if empty, move to next hole
+    | (Up, "F12") => now(Jump(BindingSiteOfIndicatedVar))
     | (Down, "ArrowLeft") => now(Select(Local(Left(ByToken))))
     | (Down, "ArrowRight") => now(Select(Local(Right(ByToken))))
     | (Down, "ArrowUp") => now(Select(Local(Up)))

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -138,7 +138,7 @@ let reevaluate_post_update =
   | PerformAction(
       Move(_) | Select(_) | Unselect | RotateBackpack | MoveToBackpackTarget(_) |
       JumpToId(_) |
-      GoToDefinition,
+      Jump(_),
     )
   | MoveToNextHole(_) //
   | UpdateDoubleTap(_)

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -137,7 +137,8 @@ let reevaluate_post_update =
     }
   | PerformAction(
       Move(_) | Select(_) | Unselect | RotateBackpack | MoveToBackpackTarget(_) |
-      JumpToId(_),
+      JumpToId(_) |
+      GoToDefinition,
     )
   | MoveToNextHole(_) //
   | UpdateDoubleTap(_)

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -137,7 +137,6 @@ let reevaluate_post_update =
     }
   | PerformAction(
       Move(_) | Select(_) | Unselect | RotateBackpack | MoveToBackpackTarget(_) |
-      JumpToId(_) |
       Jump(_),
     )
   | MoveToNextHole(_) //

--- a/src/haz3lweb/view/CtxInspector.re
+++ b/src/haz3lweb/view/CtxInspector.re
@@ -9,7 +9,7 @@ let context_entry_view =
       Attr.many([
         clss(["context-entry"]),
         Attr.on_click(_ =>
-          inject(UpdateAction.PerformAction(JumpToId(id)))
+          inject(UpdateAction.PerformAction(Jump(TileId(id))))
         ),
       ]),
     [text(name), text(":"), Type.view(typ)],

--- a/src/haz3lweb/view/LangDoc.re
+++ b/src/haz3lweb/view/LangDoc.re
@@ -95,7 +95,7 @@ let highlight =
       Attr.many([
         classes,
         Attr.on_click(_ =>
-          inject(UpdateAction.PerformAction(JumpToId(id)))
+          inject(UpdateAction.PerformAction(Jump(TileId(id))))
         ),
       ])
     | None => classes
@@ -149,7 +149,9 @@ let mk_translation =
                       Attr.many([
                         clss(["clickable"]),
                         Attr.on_click(_ =>
-                          inject(UpdateAction.PerformAction(JumpToId(id)))
+                          inject(
+                            UpdateAction.PerformAction(Jump(TileId(id))),
+                          )
                         ),
                       ]),
                     d,


### PR DESCRIPTION
Addresses https://github.com/hazelgrove/hazel/issues/811
---

There's probably a cleaner way to handle the mapping; I wasn't sure if there's a better way to get the statics/term. 

In a separate PR I'd like to add ctrl or alt-click to go to definition.
