### PR TITLE
Select term

### DIFF
--- a/src/haz3lcore/Measured.re
+++ b/src/haz3lcore/Measured.re
@@ -177,10 +177,11 @@ let find_shards' = (id: Id.t, map) =>
   | Some(ss) => ss
   };
 
-let find_w = (w: Whitespace.t, map) => Id.Map.find(w.id, map.whitespace);
-let find_g = (g: Grout.t, map) => Id.Map.find(g.id, map.grout);
+let find_w = (w: Whitespace.t, map): measurement =>
+  Id.Map.find(w.id, map.whitespace);
+let find_g = (g: Grout.t, map): measurement => Id.Map.find(g.id, map.grout);
 // returns the measurement spanning the whole tile
-let find_t = (t: Tile.t, map) => {
+let find_t = (t: Tile.t, map): measurement => {
   let shards = Id.Map.find(t.id, map.tiles);
   let first = List.assoc(Tile.l_shard(t), shards);
   let last = List.assoc(Tile.r_shard(t), shards);
@@ -188,13 +189,31 @@ let find_t = (t: Tile.t, map) => {
 };
 // let find_a = ({shards: (l, r), _} as a: Ancestor.t, map) =>
 //   List.assoc(l @ r, Id.Map.find(a.id, map.tiles));
-let find_p = (p: Piece.t, map) =>
+let find_p = (p: Piece.t, map): measurement =>
   p
   |> Piece.get(
        w => find_w(w, map),
        g => find_g(g, map),
        t => find_t(t, map),
      );
+
+let find_by_id = (id: Id.t, map: t): measurement => {
+  switch (Id.Map.find_opt(id, map.whitespace)) {
+  | Some(m) => m
+  | None =>
+    switch (Id.Map.find_opt(id, map.grout)) {
+    | Some(m) => m
+    | None =>
+      switch (Id.Map.find_opt(id, map.tiles)) {
+      | Some(shards) =>
+        let first = List.assoc(List.hd(shards) |> fst, shards);
+        let last = List.assoc(ListUtil.last(shards) |> fst, shards);
+        {origin: first.origin, last: last.last};
+      | None => failwith("Measured.find_by_id: not found")
+      }
+    }
+  };
+};
 
 let union2 = (map: t, map': t) => {
   tiles:

--- a/src/haz3lcore/Measured.re
+++ b/src/haz3lcore/Measured.re
@@ -197,19 +197,21 @@ let find_p = (p: Piece.t, map): measurement =>
        t => find_t(t, map),
      );
 
-let find_by_id = (id: Id.t, map: t): measurement => {
+let find_by_id = (id: Id.t, map: t): option(measurement) => {
   switch (Id.Map.find_opt(id, map.whitespace)) {
-  | Some(m) => m
+  | Some(m) => Some(m)
   | None =>
     switch (Id.Map.find_opt(id, map.grout)) {
-    | Some(m) => m
+    | Some(m) => Some(m)
     | None =>
       switch (Id.Map.find_opt(id, map.tiles)) {
       | Some(shards) =>
         let first = List.assoc(List.hd(shards) |> fst, shards);
         let last = List.assoc(ListUtil.last(shards) |> fst, shards);
-        {origin: first.origin, last: last.last};
-      | None => failwith("Measured.find_by_id: not found")
+        Some({origin: first.origin, last: last.last});
+      | None =>
+        Printf.printf("Measured.WARNING: id %d not found", id);
+        None;
       }
     }
   };

--- a/src/haz3lcore/zipper/action/Action.re
+++ b/src/haz3lcore/zipper/action/Action.re
@@ -9,10 +9,20 @@ type move =
   | Goal(Measured.Point.t);
 
 [@deriving (show({with_path: false}), sexp, yojson)]
+type term =
+  | Current
+  | Id(Id.t);
+
+[@deriving (show({with_path: false}), sexp, yojson)]
+type select =
+  | Resize(move)
+  | Term(term);
+
+[@deriving (show({with_path: false}), sexp, yojson)]
 type t =
   | Move(move)
   | JumpToId(Id.t)
-  | Select(move)
+  | Select(select)
   | Unselect
   | Destruct(Direction.t)
   | Insert(string)

--- a/src/haz3lcore/zipper/action/Move.re
+++ b/src/haz3lcore/zipper/action/Move.re
@@ -162,12 +162,12 @@ module Make = (M: Editor.Meta.S) => {
   let to_start = do_extreme(primary(ByToken), Up);
 
   let jump_to_id = (z: t, id: Id.t): option(t) => {
+    let* {origin, _} = Measured.find_by_id(id, M.measured);
     let z =
       switch (to_start(z)) {
       | None => z
       | Some(z) => z
       };
-    let* {origin, _} = Measured.find_by_id(id, M.measured);
     switch (do_towards(primary(ByChar), origin, z)) {
     | None => Some(z)
     | Some(z) => Some(z)

--- a/src/haz3lcore/zipper/action/Move.re
+++ b/src/haz3lcore/zipper/action/Move.re
@@ -159,23 +159,12 @@ module Make = (M: Editor.Meta.S) => {
     do_towards(f, goal, z);
   };
 
-  let rec move_left_until_p = (z: t, p: Piece.t => bool): option(t) => {
-    let* (piece, _, _) = Indicated.piece'(~no_ws=true, ~ign=_ => false, z);
-    if (p(piece)) {
-      Some(z);
-    } else {
-      let* z = Zipper.move(Right, z);
-      move_left_until_p(z, p);
-    };
-  };
-
-  let jump_to_p = (z: t, p: Piece.t => bool): option(t) => {
-    let* z = do_extreme(primary(ByToken), Up, z);
-    move_left_until_p(z, p);
-  };
+  let to_start = do_extreme(primary(ByToken), Up);
 
   let jump_to_id = (z: t, id: Id.t): option(t) => {
-    jump_to_p(z, piece => Piece.id(piece) == id);
+    let* z = to_start(z);
+    let Measured.{origin, _} = Measured.find_by_id(id, M.measured);
+    do_towards(primary(ByChar), origin, z);
   };
 
   let vertical = (d: Direction.t, z: t): option(t) =>
@@ -253,8 +242,6 @@ module Make = (M: Editor.Meta.S) => {
       };
     };
   };
-
-  let to_start = do_extreme(primary(ByToken), Up);
 
   let go = (d: Action.move, z: Zipper.t): option(Zipper.t) =>
     switch (d) {

--- a/src/haz3lcore/zipper/action/Move.re
+++ b/src/haz3lcore/zipper/action/Move.re
@@ -162,9 +162,16 @@ module Make = (M: Editor.Meta.S) => {
   let to_start = do_extreme(primary(ByToken), Up);
 
   let jump_to_id = (z: t, id: Id.t): option(t) => {
-    let* z = to_start(z);
-    let Measured.{origin, _} = Measured.find_by_id(id, M.measured);
-    do_towards(primary(ByChar), origin, z);
+    let z =
+      switch (to_start(z)) {
+      | None => z
+      | Some(z) => z
+      };
+    let* {origin, _} = Measured.find_by_id(id, M.measured);
+    switch (do_towards(primary(ByChar), origin, z)) {
+    | None => Some(z)
+    | Some(z) => Some(z)
+    };
   };
 
   let vertical = (d: Direction.t, z: t): option(t) =>

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -44,7 +44,21 @@ let go_z =
   | Unselect =>
     let z = Zipper.directional_unselect(z.selection.focus, z);
     Ok((z, id_gen));
-  | Select(d) =>
+  | Select(Term(Current)) =>
+    switch (Indicated.index(z)) {
+    | None => Error(Action.Failure.Cant_select)
+    | Some(id) =>
+      switch (Select.term(id, z)) {
+      | Some(z) => Ok((z, id_gen))
+      | None => Error(Action.Failure.Cant_select)
+      }
+    }
+  | Select(Term(Id(id))) =>
+    switch (Select.term(id, z)) {
+    | Some(z) => Ok((z, id_gen))
+    | None => Error(Action.Failure.Cant_select)
+    }
+  | Select(Resize(d)) =>
     Select.go(d, z)
     |> Option.map(IdGen.id(id_gen))
     |> Result.of_option(~error=Action.Failure.Cant_select)

--- a/src/haz3lcore/zipper/action/Select.re
+++ b/src/haz3lcore/zipper/action/Select.re
@@ -21,11 +21,12 @@ module Make = (M: Editor.Meta.S) => {
 
   let range = (l: Id.t, r: Id.t, z: Zipper.t): option(Zipper.t) => {
     let* z = Move.jump_to_id(z, l);
-    let Measured.{last, _} = Measured.find_by_id(r, M.measured);
+    let* Measured.{last, _} = Measured.find_by_id(r, M.measured);
     Move.do_towards(primary, last, z);
   };
 
   let term = (id: Id.t, z: Zipper.t): option(Zipper.t) => {
+    //TODO: check if selection is already a term: no-op in this case
     let* (l, r) = TermRanges.find_opt(id, M.term_ranges);
     range(Piece.id(l), Piece.id(r), z);
   };

--- a/src/haz3lcore/zipper/action/Select.re
+++ b/src/haz3lcore/zipper/action/Select.re
@@ -1,4 +1,5 @@
 open Util;
+open OptUtil.Syntax;
 
 module Make = (M: Editor.Meta.S) => {
   module Move = Move.Make(M);
@@ -17,6 +18,17 @@ module Make = (M: Editor.Meta.S) => {
 
   let vertical = (d: Direction.t, ed: Zipper.t): option(Zipper.t) =>
     Move.do_vertical(primary, d, ed);
+
+  let range = (l: Id.t, r: Id.t, z: Zipper.t): option(Zipper.t) => {
+    let* z = Move.jump_to_id(z, l);
+    let Measured.{last, _} = Measured.find_by_id(r, M.measured);
+    Move.do_towards(primary, last, z);
+  };
+
+  let term = (id: Id.t, z: Zipper.t): option(Zipper.t) => {
+    let* (l, r) = TermRanges.find_opt(id, M.term_ranges);
+    range(Piece.id(l), Piece.id(r), z);
+  };
 
   let go = (d: Action.move, z: Zipper.t) =>
     switch (d) {

--- a/src/haz3lweb/Keyboard.re
+++ b/src/haz3lweb/Keyboard.re
@@ -43,7 +43,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | "F3" => toggle(Log.debug_update)
     | "F4" => toggle(Log.debug_keystroke)
     | "F5" => toggle(Log.debug_zipper)
-    | "F6" => []
+    | "F6" => now(Select(Term(Current)))
     | "F7" => []
     | "F8" => []
     | "F10" =>
@@ -63,10 +63,10 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | (Up, "Delete") => now_save(Destruct(Right))
     | (Up, "Escape") => now(Unselect)
     | (Up, "Tab") => now_save(Put_down) //TODO: if empty, move to next hole
-    | (Down, "ArrowLeft") => now(Select(Local(Left(ByToken))))
-    | (Down, "ArrowRight") => now(Select(Local(Right(ByToken))))
-    | (Down, "ArrowUp") => now(Select(Local(Up)))
-    | (Down, "ArrowDown") => now(Select(Local(Down)))
+    | (Down, "ArrowLeft") => now(Select(Resize(Local(Left(ByToken)))))
+    | (Down, "ArrowRight") => now(Select(Resize(Local(Right(ByToken)))))
+    | (Down, "ArrowUp") => now(Select(Resize(Local(Up))))
+    | (Down, "ArrowDown") => now(Select(Resize(Local(Down))))
     | (_, "Shift") => update_double_tap(model)
     | (_, "Enter") =>
       //TODO(andrew): using funky char to avoid weird regexp issues with using \n
@@ -82,29 +82,29 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     switch (key) {
     | "Z"
     | "z" => now_save_u(Redo)
-    | "ArrowLeft" => now(Select(Extreme(Left(ByToken))))
-    | "ArrowRight" => now(Select(Extreme(Right(ByToken))))
-    | "ArrowUp" => now(Select(Extreme(Up)))
-    | "ArrowDown" => now(Select(Extreme(Down)))
+    | "ArrowLeft" => now(Select(Resize(Extreme(Left(ByToken)))))
+    | "ArrowRight" => now(Select(Resize(Extreme(Right(ByToken)))))
+    | "ArrowUp" => now(Select(Resize(Extreme(Up))))
+    | "ArrowDown" => now(Select(Resize(Extreme(Down))))
     | _ => []
     }
   | {key: D(key), sys: PC, shift: Down, meta: Up, ctrl: Down, alt: Up} =>
     switch (key) {
     | "Z"
     | "z" => now_save_u(Redo)
-    | "ArrowLeft" => now(Select(Local(Left(ByToken))))
-    | "ArrowRight" => now(Select(Local(Right(ByToken))))
-    | "ArrowUp" => now(Select(Local(Up)))
-    | "ArrowDown" => now(Select(Local(Down)))
-    | "Home" => now(Select(Extreme(Up)))
-    | "End" => now(Select(Extreme(Down)))
+    | "ArrowLeft" => now(Select(Resize(Local(Left(ByToken)))))
+    | "ArrowRight" => now(Select(Resize(Local(Right(ByToken)))))
+    | "ArrowUp" => now(Select(Resize(Local(Up))))
+    | "ArrowDown" => now(Select(Resize(Local(Down))))
+    | "Home" => now(Select(Resize(Extreme(Up))))
+    | "End" => now(Select(Resize(Extreme(Down))))
     | _ => []
     }
   | {key: D(key), sys: Mac, shift: Up, meta: Down, ctrl: Up, alt: Up} =>
     switch (key) {
     | "z" => now_save_u(Undo)
     | "p" => now(Pick_up)
-    | "a" => now(Move(Extreme(Up))) @ now(Select(Extreme(Down)))
+    | "a" => now(Move(Extreme(Up))) @ now(Select(Resize(Extreme(Down))))
     | "k" => [ResetCurrentEditor]
     | _ when is_digit(key) => [SwitchSlide(int_of_string(key))]
     | "ArrowLeft" => now(Move(Extreme(Left(ByToken))))
@@ -117,7 +117,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     switch (key) {
     | "z" => now_save_u(Undo)
     | "p" => now(Pick_up)
-    | "a" => now(Move(Extreme(Up))) @ now(Select(Extreme(Down)))
+    | "a" => now(Move(Extreme(Up))) @ now(Select(Resize(Extreme(Down))))
     | "k" => [ResetCurrentEditor]
     | _ when is_digit(key) => [SwitchSlide(int_of_string(key))]
     | "ArrowLeft" => now(Move(Local(Left(ByToken))))

--- a/src/haz3lweb/Keyboard.re
+++ b/src/haz3lweb/Keyboard.re
@@ -43,7 +43,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | "F3" => toggle(Log.debug_update)
     | "F4" => toggle(Log.debug_keystroke)
     | "F5" => toggle(Log.debug_zipper)
-    | "F6" => now(Select(Term(Current)))
+    | "F6" => []
     | "F7" => []
     | "F8" => []
     | "F10" =>
@@ -103,6 +103,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
   | {key: D(key), sys: Mac, shift: Up, meta: Down, ctrl: Up, alt: Up} =>
     switch (key) {
     | "z" => now_save_u(Undo)
+    | "d" => now(Select(Term(Current)))
     | "p" => now(Pick_up)
     | "a" => now(Move(Extreme(Up))) @ now(Select(Resize(Extreme(Down))))
     | "k" => [ResetCurrentEditor]
@@ -116,6 +117,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
   | {key: D(key), sys: PC, shift: Up, meta: Up, ctrl: Down, alt: Up} =>
     switch (key) {
     | "z" => now_save_u(Undo)
+    | "d" => now(Select(Term(Current)))
     | "p" => now(Pick_up)
     | "a" => now(Move(Extreme(Up))) @ now(Select(Resize(Extreme(Down))))
     | "k" => [ResetCurrentEditor]

--- a/src/haz3lweb/util/JsUtil.re
+++ b/src/haz3lweb/util/JsUtil.re
@@ -25,16 +25,11 @@ let shift_held = evt => Js.to_bool(evt##.shiftKey);
 let alt_held = evt => Js.to_bool(evt##.altKey);
 let meta_held = evt => Js.to_bool(evt##.metaKey);
 
-// let to_sys_clipboard = (string: string): unit =>
-//   Js.Unsafe.coerce(Dom_html.window##.navigator)##.clipboard##writeText(
-//     Js.string(string),
-//   );
+let num_clicks = (evt: Js.t(Js_of_ocaml.Dom_html.mouseEvent)): int =>
+  Js.Unsafe.coerce(evt)##.detail;
 
-// let from_sys_clipboard = (callback: string => unit): Promise.t(unit) =>
-//   Js.Unsafe.coerce(Dom_html.window##.navigator)##.clipboard##readText()
-//   |> Promise.then_(~fulfilled=s =>
-//        s |> Js.to_string |> callback |> Promise.resolve
-//      );
+let is_double_click = (evt: Js.t(Js_of_ocaml.Dom_html.mouseEvent)): bool =>
+  num_clicks(evt) == 2;
 
 let download_string_file =
     (~filename: string, ~content_type: string, ~contents: string) => {

--- a/src/haz3lweb/view/Cell.re
+++ b/src/haz3lweb/view/Cell.re
@@ -103,9 +103,10 @@ let code_cell_view =
               ["cell-item", "cell", ...clss]
               @ (selected ? ["selected"] : ["deselected"]),
             ),
-            Attr.on_double_click(_ =>
-              inject(Update.PerformAction(Select(Term(Current))))
-            ),
+            Attr.on_double_click(_ => {
+              print_endline("double click detected");
+              inject(Update.PerformAction(Select(Term(Current))));
+            }),
             Attr.on_mousedown(
               mousedown_handler(
                 ~inject,

--- a/src/haz3lweb/view/Cell.re
+++ b/src/haz3lweb/view/Cell.re
@@ -103,17 +103,16 @@ let code_cell_view =
               ["cell-item", "cell", ...clss]
               @ (selected ? ["selected"] : ["deselected"]),
             ),
-            Attr.on_double_click(_ => {
-              print_endline("double click detected");
-              inject(Update.PerformAction(Select(Term(Current))));
-            }),
-            Attr.on_mousedown(
-              mousedown_handler(
-                ~inject,
-                ~font_metrics,
-                ~target_id=code_id,
-                ~additional_updates=mousedown_updates,
-              ),
+            Attr.on_mousedown(evt =>
+              JsUtil.is_double_click(evt)
+                ? inject(Update.PerformAction(Select(Term(Current))))
+                : mousedown_handler(
+                    ~inject,
+                    ~font_metrics,
+                    ~target_id=code_id,
+                    ~additional_updates=mousedown_updates,
+                    evt,
+                  )
             ),
           ]),
         Option.to_list(caption) @ code,

--- a/src/haz3lweb/view/Cell.re
+++ b/src/haz3lweb/view/Cell.re
@@ -103,6 +103,9 @@ let code_cell_view =
               ["cell-item", "cell", ...clss]
               @ (selected ? ["selected"] : ["deselected"]),
             ),
+            Attr.on_double_click(_ =>
+              inject(Update.PerformAction(Select(Term(Current))))
+            ),
             Attr.on_mousedown(
               mousedown_handler(
                 ~inject,

--- a/src/haz3lweb/view/Cell.re
+++ b/src/haz3lweb/view/Cell.re
@@ -23,7 +23,7 @@ let mousedown_overlay = (~inject, ~font_metrics, ~target_id) =>
           on_mouseup(_ => inject(Update.Mouseup)),
           on_mousemove(e => {
             let goal = get_goal(~font_metrics, ~target_id, e);
-            inject(Update.PerformAction(Select(Goal(goal))));
+            inject(Update.PerformAction(Select(Resize(Goal(goal)))));
           }),
         ],
       ),


### PR DESCRIPTION
There's more that could be done here so I'm trying to set scope. Right now you can either double-click or use Ctrl-D to select the term currently indicated by the caret.

1. There is one limitation in that the current TermRanges implementation considers the square brackets of list literals and the case end delimiters of cases to be distinct terms from their contents. I don't fully understand the implications of updating TermRanges so this should probably be a separate ticket.

2. I've done some thinking about cycling behaviours / different click arities to change between different kinds of selections, but haven't reached any firm conclusions. My biggest question is around semantic versus syntactic selection options. like in vscode double click selects token, then another single click selects line. i could see us doing something similar, but if we try to incorporate both syntactic and semantic options there's too many to cycle through: token, tile, term, line, and it's not obvious to me what should give. maybe line is no longer necessary given that tile will often do the same (or better). in any case, more design decisions to be made there so should be a separate ticket imo

