### PR TITLE
Type aliases (merge into ADTs)

### DIFF
--- a/src/haz3lcore/statics/Ctx.re
+++ b/src/haz3lcore/statics/Ctx.re
@@ -1,18 +1,9 @@
-open Sexplib.Std;
 open Util.OptUtil.Syntax;
+include TypBase.Ctx;
 
-[@deriving (show({with_path: false}), sexp, yojson)]
-type entry =
-  | VarEntry({
-      name: Token.t,
-      id: Id.t,
-      typ: Typ.t,
-    })
-  | TVarEntry({
-      name: Token.t,
-      id: Id.t,
-      kind: Kind.t,
-    });
+let empty: t = VarMap.empty;
+
+let extend = (entry: entry, ctx: t): t => [entry, ...ctx];
 
 let get_id = (entry: entry) =>
   switch (entry) {
@@ -20,37 +11,10 @@ let get_id = (entry: entry) =>
   | TVarEntry({id, _}) => id
   };
 
-[@deriving (show({with_path: false}), sexp, yojson)]
-type t = list(entry);
-
-[@deriving (show({with_path: false}), sexp, yojson)]
-type co_item = {
-  id: Id.t,
-  mode: Typ.mode,
-};
-
-[@deriving (show({with_path: false}), sexp, yojson)]
-type co_entry = list(co_item);
-
-[@deriving (show({with_path: false}), sexp, yojson)]
-type co = VarMap.t_(co_entry);
-
-let empty: t = VarMap.empty;
-
-let extend = (entry: entry, ctx: t): t => [entry, ...ctx];
-
 let lookup_var = (ctx: t, t: Token.t) =>
   List.find_map(
     fun
     | VarEntry({name, typ, _}) when name == t => Some(typ)
-    | _ => None,
-    ctx,
-  );
-
-let lookup_tvar = (ctx: t, t: Token.t) =>
-  List.find_map(
-    fun
-    | TVarEntry({name, kind, _}) when name == t => Some(kind)
     | _ => None,
     ctx,
   );

--- a/src/haz3lcore/statics/Kind.re
+++ b/src/haz3lcore/statics/Kind.re
@@ -1,3 +1,1 @@
-[@deriving (show({with_path: false}), sexp, yojson)]
-type t =
-  | Singleton(Typ.t);
+include TypBase.Kind;

--- a/src/haz3lcore/statics/Statics.re
+++ b/src/haz3lcore/statics/Statics.re
@@ -505,7 +505,7 @@ and uexp_to_info_map =
       );
     let (ty_body, free, m_body) =
       uexp_to_info_map(~ctx=ctx_def_and_body, ~mode, body);
-    // let ty_body = Typ.subst(ty, name, ty_body);
+    let ty_body = Typ.subst(ty, name, ty_body);
     let (_ty_def, m_typ) = utyp_to_info_map(~ctx=ctx_def_and_body, utyp);
     add(~self=Just(ty_body), ~free, union_m([m_typat, m_body, m_typ]));
   | TyAlias(typat, _, e) =>

--- a/src/haz3lcore/statics/Statics.re
+++ b/src/haz3lcore/statics/Statics.re
@@ -499,7 +499,7 @@ and uexp_to_info_map =
         TVarEntry({
           name,
           id: Term.UTPat.rep_id(typat),
-          kind: Singleton(ty),
+          kind: Singleton(Term.utyp_to_ty(utyp)),
         }),
         ctx,
       );

--- a/src/haz3lcore/statics/Statics.re
+++ b/src/haz3lcore/statics/Statics.re
@@ -505,6 +505,7 @@ and uexp_to_info_map =
       );
     let (ty_body, free, m_body) =
       uexp_to_info_map(~ctx=ctx_def_and_body, ~mode, body);
+    let ty_body = Typ.subst(Term.utyp_to_ty(utyp), name, ty_body);
     let (_ty_def, m_typ) = utyp_to_info_map(~ctx=ctx_def_and_body, utyp);
     add(~self=Just(ty_body), ~free, union_m([m_typat, m_body, m_typ]));
   | TyAlias(typat, _, e) =>

--- a/src/haz3lcore/statics/Statics.re
+++ b/src/haz3lcore/statics/Statics.re
@@ -499,13 +499,13 @@ and uexp_to_info_map =
         TVarEntry({
           name,
           id: Term.UTPat.rep_id(typat),
-          kind: Singleton(Term.utyp_to_ty(utyp)),
+          kind: Singleton(ty),
         }),
         ctx,
       );
     let (ty_body, free, m_body) =
       uexp_to_info_map(~ctx=ctx_def_and_body, ~mode, body);
-    let ty_body = Typ.subst(Term.utyp_to_ty(utyp), name, ty_body);
+    // let ty_body = Typ.subst(ty, name, ty_body);
     let (_ty_def, m_typ) = utyp_to_info_map(~ctx=ctx_def_and_body, utyp);
     add(~self=Just(ty_body), ~free, union_m([m_typat, m_body, m_typ]));
   | TyAlias(typat, _, e) =>

--- a/src/haz3lcore/statics/Statics.re
+++ b/src/haz3lcore/statics/Statics.re
@@ -492,7 +492,7 @@ and uexp_to_info_map =
     );
   | TyAlias({term: Var(name), _} as typat, utyp, body) =>
     let m_typat = utpat_to_info_map(~ctx, typat);
-    let ty = Term.utyp_to_ty(utyp);
+    let ty = Term.UTyp.to_typ(ctx, utyp);
     let ty = List.mem(name, Typ.free_vars(ty)) ? Typ.Rec(name, ty) : ty;
     let ctx_def_and_body =
       Ctx.extend(
@@ -648,7 +648,7 @@ and upat_to_info_map =
 and utyp_to_info_map =
     (~ctx, {ids, term} as utyp: Term.UTyp.t): (Typ.t, map) => {
   let cls = Term.UTyp.cls_of_term(term);
-  let ty = Term.utyp_to_ty(utyp);
+  let ty = Term.UTyp.to_typ(ctx, utyp);
   let add = self => add_info(ids, InfoTyp({cls, self, term: utyp}));
   let just = m => (ty, add(Just(ty), m));
   //TODO(andrew): make this return free, replacing Typ.free_vars

--- a/src/haz3lcore/statics/Typ.re
+++ b/src/haz3lcore/statics/Typ.re
@@ -239,8 +239,10 @@ let rec subst = (s: t, x: Token.t, ty: t) => {
   | Prod(tys) => Prod(List.map(ty => subst(s, x, ty), tys))
   | LabelSum(tys) =>
     LabelSum(List.map(ty => {tag: ty.tag, typ: subst(s, x, ty.typ)}, tys))
+  | Rec(y, ty) when Token.compare(x, y) == 0 => Rec(y, ty)
+  | Rec(y, ty) => Rec(y, subst(s, x, ty))
   | Sum(ty1, ty2) => Sum(subst(s, x, ty1), subst(s, x, ty2))
   | List(ty) => List(subst(s, x, ty))
-  | Var(y) => x == y ? s : Var(y)
+  | Var(y) => Token.compare(x, y) == 0 ? s : Var(y)
   };
 };

--- a/src/haz3lcore/statics/Typ.re
+++ b/src/haz3lcore/statics/Typ.re
@@ -227,3 +227,20 @@ let rec free_vars = (~bound=[], ty: t): list(Token.t) =>
   | Prod(tys) => List.concat(List.map(free_vars(~bound), tys))
   | Rec(x, ty) => free_vars(~bound=[x] @ bound, ty)
   };
+
+let rec subst = (s: t, x: Token.t, ty: t) => {
+  switch (ty) {
+  | Int => Int
+  | Float => Float
+  | Bool => Bool
+  | String => String
+  | Unknown(prov) => Unknown(prov)
+  | Arrow(ty1, ty2) => Arrow(subst(s, x, ty1), subst(s, x, ty2))
+  | Prod(tys) => Prod(List.map(ty => subst(s, x, ty), tys))
+  | LabelSum(tys) =>
+    LabelSum(List.map(ty => {tag: ty.tag, typ: subst(s, x, ty.typ)}, tys))
+  | Sum(ty1, ty2) => Sum(subst(s, x, ty1), subst(s, x, ty2))
+  | List(ty) => List(subst(s, x, ty))
+  | Var(y) => x == y ? s : Var(y)
+  };
+};

--- a/src/haz3lcore/statics/TypBase.re
+++ b/src/haz3lcore/statics/TypBase.re
@@ -1,0 +1,104 @@
+open Sexplib.Std;
+
+module rec Ctx: {
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type entry =
+    | VarEntry({
+        name: Token.t,
+        id: Id.t,
+        typ: Typ.t,
+      })
+    | TVarEntry({
+        name: Token.t,
+        id: Id.t,
+        kind: Kind.t,
+      });
+
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type t = list(entry);
+
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type co_item = {
+    id: Id.t,
+    mode: Typ.mode,
+  };
+
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type co_entry = list(co_item);
+
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type co = VarMap.t_(co_entry);
+
+  let lookup_tvar: (t, Token.t) => option(Kind.t);
+} = {
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type entry =
+    | VarEntry({
+        name: Token.t,
+        id: Id.t,
+        typ: Typ.t,
+      })
+    | TVarEntry({
+        name: Token.t,
+        id: Id.t,
+        kind: Kind.t,
+      });
+
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type t = list(entry);
+
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type co_item = {
+    id: Id.t,
+    mode: Typ.mode,
+  };
+
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type co_entry = list(co_item);
+
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type co = VarMap.t_(co_entry);
+
+  let lookup_tvar = (ctx: t, t: Token.t) =>
+    List.find_map(
+      fun
+      | TVarEntry({name, kind, _}) when name == t => Some(kind)
+      | _ => None,
+      ctx,
+    );
+}
+and Kind: {
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type t =
+    | Singleton(Typ.t);
+  let normalize: (Ctx.t, Typ.t) => Typ.t;
+} = {
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type t =
+    | Singleton(Typ.t);
+  let rec normalize = (ctx, typ) => {
+    switch (typ) {
+    | Typ.Var(x) =>
+      switch (Ctx.lookup_tvar(ctx, x)) {
+      | Some(Singleton(typ)) => normalize(ctx, typ)
+      | None => typ
+      }
+    | Typ.Unknown(_)
+    | Int
+    | Float
+    | Bool
+    | String => typ
+    | List(t) => List(normalize(ctx, t))
+    | Arrow(t1, t2) => Arrow(normalize(ctx, t1), normalize(ctx, t2))
+    | LabelSum(ts) =>
+      LabelSum(
+        List.map(
+          (Typ.{typ, tag}) => Typ.{typ: normalize(ctx, typ), tag},
+          ts,
+        ),
+      )
+    | Sum(t1, t2) => Sum(normalize(ctx, t1), normalize(ctx, t2))
+    | Prod(ts) => Prod(List.map(t => normalize(ctx, t), ts))
+    };
+  };
+};

--- a/src/haz3lcore/statics/TypBase.re
+++ b/src/haz3lcore/statics/TypBase.re
@@ -97,6 +97,7 @@ and Kind: {
           ts,
         ),
       )
+    | Rec(x, ty) => Rec(x, normalize(ctx, ty))
     | Sum(t1, t2) => Sum(normalize(ctx, t1), normalize(ctx, t2))
     | Prod(ts) => Prod(List.map(t => normalize(ctx, t), ts))
     };

--- a/src/haz3lweb/view/CtxInspector.re
+++ b/src/haz3lweb/view/CtxInspector.re
@@ -16,13 +16,8 @@ let context_entry_view = (~inject, entry: Haz3lcore.Ctx.entry): Node.t =>
         ),
       ]),
     switch (entry) {
-    | VarEntry({name, typ, _}) => [text(name), text(":"), Type.view(typ)]
-    | TVarEntry({name, kind, _}) => [
-        text("type "),
-        text(name),
-        text("::"),
-        Kind.view(kind),
-      ]
+    | VarEntry({name, typ, _}) => Type.view_entry(name, typ)
+    | TVarEntry({name, kind, _}) => Kind.view_entry(name, kind)
     },
   );
 

--- a/src/haz3lweb/view/Kind.re
+++ b/src/haz3lweb/view/Kind.re
@@ -3,12 +3,22 @@ open Node;
 open Util.Web;
 
 // TODO: (poly) Finish the skeleton
-let kind_view = (cls: string, s: string): Node.t =>
-  div(~attr=clss(["kind-view", cls]), [text(s)]);
 
 // TODO: (poly) Finish the skeleton
-let view = (ty: Haz3lcore.Kind.t): Node.t =>
+let view = (ty: Haz3lcore.Kind.t): list(Node.t) =>
   switch (ty) {
-  | Singleton(_ty) =>
-    div(~attr=clss(["kind-view"]), [kind_view("Singleton", "Singleton")])
+  | Singleton(ty) => [
+      text("::"),
+      div(
+        ~attr=clss(["kind-view"]),
+        [div(~attr=clss(["kind-view", "Singleton"]), [Type.view(ty)])],
+      ),
+    ]
   };
+
+let view_entry = (name, kind) => [
+  text("type "),
+  text(name),
+  text(" "),
+  ...view(kind),
+];

--- a/src/haz3lweb/view/Type.re
+++ b/src/haz3lweb/view/Type.re
@@ -80,3 +80,10 @@ let rec view = (ty: Haz3lcore.Typ.t): Node.t =>
 and tagged_view = (t: Haz3lcore.Typ.tagged) =>
   t.typ == Prod([])
     ? [text(t.tag)] : [text(t.tag ++ "("), view(t.typ), text(")")];
+
+let view_entry = (name, typ) => [
+  text(name),
+  text(" "),
+  text(":"),
+  view(typ),
+];


### PR DESCRIPTION
- Implemented capture-avoid substitution
- Refactored `UTyp.to_typ` for polymorphism use
- Drafted `normalize` for polymorphism use
- Changed the view of `CtxInspector`