### PR TITLE
Better expansion/barfing (expansion bug fix)

### DIFF
--- a/src/haz3lcore/lang/Form.re
+++ b/src/haz3lcore/lang/Form.re
@@ -179,7 +179,7 @@ let forms: list((string, t)) = [
   ("parens_pat", mk(ii, ["(", ")"], mk_op(Pat, [Pat]))),
   ("parens_typ", mk(ii, ["(", ")"], mk_op(Typ, [Typ]))),
   ("fun_", mk(ds, ["fun", "->"], mk_pre(P.fun_, Exp, [Pat]))),
-  ("if_", mk(di, ["if", "then", "else"], mk_pre(P.if_, Exp, [Exp, Exp]))),
+  ("if_", mk(ds, ["if", "then", "else"], mk_pre(P.if_, Exp, [Exp, Exp]))),
   ("ap_exp", mk(ii, ["(", ")"], mk_post(P.ap, Exp, [Exp]))),
   ("ap_pat", mk(ii, ["(", ")"], mk_post(P.ap, Pat, [Pat]))),
   ("let_", mk(ds, ["let", "=", "in"], mk_pre(P.let_, Exp, [Pat, Exp]))),

--- a/src/haz3lcore/lang/Molds.re
+++ b/src/haz3lcore/lang/Molds.re
@@ -2,7 +2,7 @@ open Sexplib.Std;
 open Util;
 
 [@deriving (show({with_path: false}), sexp, yojson)]
-type completions = list((Token.t, (list(Token.t), Direction.t)));
+type expansions = list((Token.t, (list(Token.t), Direction.t)));
 
 let forms_assoc: list((Label.t, list(Mold.t))) =
   List.fold_left(
@@ -30,7 +30,7 @@ let get = (label: Label.t): list(Mold.t) =>
     [];
   };
 
-let delayed_completes: completions =
+let delayed_expansions: expansions =
   List.filter_map(
     ((_, {expansion, label, _}: Form.t)) =>
       switch (expansion, label) {
@@ -49,7 +49,7 @@ let delayed_completes: completions =
   |> List.flatten
   |> List.sort_uniq(compare);
 
-let instant_completes: completions =
+let instant_expansions: expansions =
   List.filter_map(
     ((_, {expansion, label, _}: Form.t)) =>
       switch (expansion, label) {
@@ -68,20 +68,20 @@ let instant_completes: completions =
   |> List.flatten
   |> List.sort_uniq(compare);
 
-let delayed_completion:
-  (Token.t, Direction.t) => (list(Token.t), Direction.t) =
+let delayed_expansion: (Token.t, Direction.t) => (list(Token.t), Direction.t) =
   (s, direction_preference) =>
     /* Completions which must be defered as they are ambiguous prefixes */
-    switch (List.assoc_opt(s, delayed_completes)) {
-    | Some(completion) => completion
+    switch (List.assoc_opt(s, delayed_expansions)) {
+    | Some(expansion) => expansion
     | None => ([s], direction_preference)
     };
 
-let instant_completion:
-  (Token.t, Direction.t) => (list(Token.t), Direction.t) =
+let will_expand = kw => List.length(delayed_expansion(kw, Left) |> fst) > 1;
+
+let instant_expansion: (Token.t, Direction.t) => (list(Token.t), Direction.t) =
   (s, direction_preference) =>
     /* Completions which can or must be executed immediately */
-    switch (List.assoc_opt(s, instant_completes)) {
-    | Some(completion) => completion
+    switch (List.assoc_opt(s, instant_expansions)) {
+    | Some(expansion) => expansion
     | None => ([s], direction_preference)
     };

--- a/src/haz3lcore/lang/Molds.re
+++ b/src/haz3lcore/lang/Molds.re
@@ -68,20 +68,22 @@ let instant_expansions: expansions =
   |> List.flatten
   |> List.sort_uniq(compare);
 
-let delayed_expansion: (Token.t, Direction.t) => (list(Token.t), Direction.t) =
-  (s, direction_preference) =>
+let delayed_expansion: Token.t => (list(Token.t), Direction.t) =
+  s =>
     /* Completions which must be defered as they are ambiguous prefixes */
     switch (List.assoc_opt(s, delayed_expansions)) {
     | Some(expansion) => expansion
-    | None => ([s], direction_preference)
+    | None => ([s], Right)
     };
 
-let will_expand = kw => List.length(delayed_expansion(kw, Left) |> fst) > 1;
-
-let instant_expansion: (Token.t, Direction.t) => (list(Token.t), Direction.t) =
-  (s, direction_preference) =>
+let instant_expansion: Token.t => (list(Token.t), Direction.t) =
+  s =>
     /* Completions which can or must be executed immediately */
     switch (List.assoc_opt(s, instant_expansions)) {
     | Some(expansion) => expansion
-    | None => ([s], direction_preference)
+    | None => ([s], Right)
     };
+
+let is_delayed = kw => List.length(delayed_expansion(kw) |> fst) > 1;
+
+let is_instant = kw => List.length(instant_expansion(kw) |> fst) > 1;

--- a/src/haz3lcore/zipper/Backpack.re
+++ b/src/haz3lcore/zipper/Backpack.re
@@ -268,7 +268,7 @@ let remove_matching = (ts: list(Tile.t), bp: t) =>
     ts,
   );
 
-let is_first_matching = (t: Token.t, bp: t): bool =>
+let will_barf = (t: Token.t, bp: t): bool =>
   /* Does the first selection in the backpack consist
      of a single token which matches the one provided? */
   switch (bp) {

--- a/src/haz3lcore/zipper/Selection.re
+++ b/src/haz3lcore/zipper/Selection.re
@@ -2,13 +2,13 @@ open Util;
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t = {
-  focus: Direction.t,
+  focus: Direction.t, //TODO: deprecate
   content: Segment.t,
 };
 
-let mk = (focus, content) => {focus, content};
+let mk = content => {focus: Left, content};
 
-let empty = mk(Left, Segment.empty);
+let empty = mk(Segment.empty);
 
 let map = (f, sel) => {...sel, content: f(sel.content)};
 

--- a/src/haz3lcore/zipper/Selection.re
+++ b/src/haz3lcore/zipper/Selection.re
@@ -2,10 +2,11 @@ open Util;
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t = {
-  focus: Direction.t, //TODO: deprecate
+  focus: Direction.t,
   content: Segment.t,
 };
 
+/* NOTE: backpack no longer uses selection focus */
 let mk = content => {focus: Left, content};
 
 let empty = mk(Segment.empty);

--- a/src/haz3lcore/zipper/Siblings.re
+++ b/src/haz3lcore/zipper/Siblings.re
@@ -90,11 +90,12 @@ let regrout = ((pre, suf): t) => {
   ((pre, s_l, trim_l), suf);
 };
 
+let left_neighbor: t => option(Piece.t) = ((l, _)) => ListUtil.last_opt(l);
+
+let right_neighbor: t => option(Piece.t) = ((_, r)) => ListUtil.hd_opt(r);
+
 let neighbors: t => (option(Piece.t), option(Piece.t)) =
-  ((l, r)) => (
-    l == [] ? None : Some(ListUtil.last(l)),
-    r == [] ? None : Some(List.hd(r)),
-  );
+  n => (left_neighbor(n), right_neighbor(n));
 
 let trim_whitespace = ((l_sibs, r_sibs): t) => (
   Segment.trim_whitespace(Right, l_sibs),

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -109,14 +109,14 @@ let sibs_with_sel =
 let pop_backpack = (z: t) =>
   Backpack.pop(Relatives.local_incomplete_tiles(z.relatives), z.backpack);
 
+let left_neighbor_monotile: Siblings.t => option(Token.t) =
+  s => s |> Siblings.left_neighbor |> OptUtil.and_then(Piece.monotile);
+
+let right_neighbor_monotile: Siblings.t => option(Token.t) =
+  s => s |> Siblings.right_neighbor |> OptUtil.and_then(Piece.monotile);
+
 let neighbor_monotiles: Siblings.t => (option(Token.t), option(Token.t)) =
-  siblings =>
-    switch (Siblings.neighbors(siblings)) {
-    | (Some(l), Some(r)) => (Piece.monotile(l), Piece.monotile(r))
-    | (Some(l), None) => (Piece.monotile(l), None)
-    | (None, Some(r)) => (None, Piece.monotile(r))
-    | (None, None) => (None, None)
-    };
+  s => (left_neighbor_monotile(s), right_neighbor_monotile(s));
 
 let remold_regrout = (d: Direction.t, z: t): IdGen.t(t) => {
   assert(Selection.is_empty(z.selection));

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -118,12 +118,20 @@ let right_neighbor_monotile: Siblings.t => option(Token.t) =
 let neighbor_monotiles: Siblings.t => (option(Token.t), option(Token.t)) =
   s => (left_neighbor_monotile(s), right_neighbor_monotile(s));
 
-let remold_regrout = (d: Direction.t, z: t): IdGen.t(t) => {
+let regrout = (d: Direction.t, z: t): IdGen.t(t) => {
   assert(Selection.is_empty(z.selection));
   open IdGen.Syntax;
-  let+ relatives = Relatives.regrout(d, Relatives.remold(z.relatives));
+  let+ relatives = Relatives.regrout(d, z.relatives);
   {...z, relatives};
 };
+
+let remold = (z: t): t => {
+  assert(Selection.is_empty(z.selection));
+  {...z, relatives: Relatives.remold(z.relatives)};
+};
+
+let remold_regrout = (d: Direction.t, z: t): IdGen.t(t) =>
+  z |> remold |> regrout(d);
 
 let unselect = (z: t): t => {
   let relatives =

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -225,7 +225,7 @@ let destruct = (~destroy_kids=true, z: t): t => {
   {...z, backpack};
 };
 
-let directional_destruct = (d: Direction.t, z: t): option(t) =>
+let delete = (d: Direction.t, z: t): option(t) =>
   z |> select(d) |> Option.map(destruct);
 
 let put_down = (d: Direction.t, z: t): option(t) => {
@@ -292,7 +292,7 @@ let replace =
     : option(state) =>
   /* i.e. select and construct, overwriting the selection */
   z
-  |> select(caret)
+  |> delete(caret)
   |> Option.map(z => construct(~caret, ~backpack, l, z, id_gen));
 
 let replace_mono = (d: Direction.t, t: Token.t, state: state): option(state) =>

--- a/src/haz3lcore/zipper/action/Destruct.re
+++ b/src/haz3lcore/zipper/action/Destruct.re
@@ -13,10 +13,10 @@ let destruct =
   let delete_right = z =>
     z
     |> Zipper.set_caret(Outer)
-    |> Zipper.directional_destruct(Right)
+    |> Zipper.delete(Right)
     |> Option.map(IdGen.id(id_gen));
   let delete_left = z =>
-    z |> Zipper.directional_destruct(Left) |> Option.map(IdGen.id(id_gen));
+    z |> Zipper.delete(Left) |> Option.map(IdGen.id(id_gen));
   switch (d, caret, neighbor_monotiles((l_sibs, r_sibs))) {
   /* When there's a selection, defer to Outer */
   | _ when z.selection.content != [] =>
@@ -51,7 +51,7 @@ let destruct =
     /* Note: Counterintuitve, but yes, these cases are identically handled */
     z
     |> Zipper.set_caret(Outer)
-    |> Zipper.directional_destruct(Right)
+    |> Zipper.delete(Right)
     |> Option.map(IdGen.id(id_gen))
   //| (_, Inner(_), (_, None)) => None
   | (Left, Outer, (Some(t), _)) when Token.length(t) > 1 =>
@@ -61,7 +61,7 @@ let destruct =
     Zipper.replace_mono(Right, Token.rm_first(t), (z, id_gen))
   | (_, Outer, (Some(_), _)) /* t.length == 1 */
   | (_, Outer, (None, _)) =>
-    z |> Zipper.directional_destruct(d) |> Option.map(IdGen.id(id_gen))
+    z |> Zipper.delete(d) |> Option.map(IdGen.id(id_gen))
   };
 };
 
@@ -69,8 +69,8 @@ let merge =
     ((l, r): (Token.t, Token.t), (z, id_gen): state): option(state) =>
   z
   |> Zipper.set_caret(Inner(0, Token.length(l) - 1))  // note monotile assumption
-  |> Zipper.directional_destruct(Left)
-  |> OptUtil.and_then(Zipper.directional_destruct(Right))
+  |> Zipper.delete(Left)
+  |> OptUtil.and_then(Zipper.delete(Right))
   |> Option.map(z => Zipper.construct_mono(Right, l ++ r, z, id_gen));
 
 let go = (d: Direction.t, (z, id_gen): state): option(state) => {

--- a/src/haz3lcore/zipper/action/Destruct.re
+++ b/src/haz3lcore/zipper/action/Destruct.re
@@ -33,9 +33,9 @@ let destruct =
   /* Remove inner character */
   | (Left, Inner(_, c_idx), (_, Some(t))) =>
     let z = Zipper.update_caret(Zipper.Caret.decrement, z);
-    Zipper.replace(Right, [Token.rm_nth(c_idx, t)], (z, id_gen));
+    Zipper.replace_mono(Right, Token.rm_nth(c_idx, t), (z, id_gen));
   | (Right, Inner(_, c_idx), (_, Some(t))) when c_idx == last_inner_pos(t) =>
-    Zipper.replace(Right, [Token.rm_nth(c_idx + 1, t)], (z, id_gen))
+    Zipper.replace_mono(Right, Token.rm_nth(c_idx + 1, t), (z, id_gen))
     |> OptUtil.and_then(((z, id_gen)) =>
          z
          |> Zipper.set_caret(Outer)
@@ -44,7 +44,7 @@ let destruct =
        )
   /* If not on last inner position */
   | (Right, Inner(_, c_idx), (_, Some(t))) =>
-    Zipper.replace(Right, [Token.rm_nth(c_idx + 1, t)], (z, id_gen))
+    Zipper.replace_mono(Right, Token.rm_nth(c_idx + 1, t), (z, id_gen))
   /* Can't subdestruct in delimiter, so just destruct on whole delimiter */
   | (Left, Inner(_), (_, None))
   | (Right, Inner(_), (_, None)) =>
@@ -56,9 +56,9 @@ let destruct =
   //| (_, Inner(_), (_, None)) => None
   | (Left, Outer, (Some(t), _)) when Token.length(t) > 1 =>
     //Option.map(IdGen.id(id_gen)
-    Zipper.replace(Left, [Token.rm_last(t)], (z, id_gen))
+    Zipper.replace_mono(Left, Token.rm_last(t), (z, id_gen))
   | (Right, Outer, (_, Some(t))) when Token.length(t) > 1 =>
-    Zipper.replace(Right, [Token.rm_first(t)], (z, id_gen))
+    Zipper.replace_mono(Right, Token.rm_first(t), (z, id_gen))
   | (_, Outer, (Some(_), _)) /* t.length == 1 */
   | (_, Outer, (None, _)) =>
     z |> Zipper.directional_destruct(d) |> Option.map(IdGen.id(id_gen))
@@ -71,7 +71,7 @@ let merge =
   |> Zipper.set_caret(Inner(0, Token.length(l) - 1))  // note monotile assumption
   |> Zipper.directional_destruct(Left)
   |> OptUtil.and_then(Zipper.directional_destruct(Right))
-  |> Option.map(z => Zipper.construct(Right, [l ++ r], z, id_gen));
+  |> Option.map(z => Zipper.construct_mono(Right, l ++ r, z, id_gen));
 
 let go = (d: Direction.t, (z, id_gen): state): option(state) => {
   let* (z, id_gen) = destruct(d, (z, id_gen));

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -6,8 +6,8 @@ let barf = (d: Direction.t, (z, id_gen): state): option(state) => {
   /* Removes the d-neighboring tile and drops from backpack;
      precondition: the d-neighbor should be a monotile
      string-matching the dropping shard */
-  let* z = select(d, z);
-  let+ z = z |> Zipper.destruct |> Zipper.put_down(d);
+  let* z = delete(d, z);
+  let+ z = Zipper.put_down(d, z);
   (z, id_gen);
 };
 
@@ -67,7 +67,7 @@ let expand_neighbors_and_make_new_tile =
 
 let replace_tile =
     (t: Token.t, d: Direction.t, (z, id_gen): state): option(state) => {
-  let+ z = Zipper.directional_destruct(d, z);
+  let+ z = Zipper.delete(d, z);
   make_new_tile(t, d, z, id_gen);
 };
 

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -65,8 +65,12 @@ let expand_neighbors_and_make_new_tile =
      barf the "then", before it is buried by the ")" added to the BP.
      The order here could be revisited if barfing was more sophisticated.
      */
-  let* state = expand_or_barf_left_neighbor(state);
-  let+ (z, id_gen) = expand_or_barf_right_neighbor(state);
+  let* (z, id_gen) = expand_or_barf_left_neighbor(state);
+  let (z, id_gen) = remold_regrout(Left, z, id_gen);
+  /* Note to david: I'm not sure why the above regrout is necessary.
+     Without it, there is a Nonconvex segment error thrown in exactly
+     one case, the double barf case: insert space on "if then|else" */
+  let+ (z, id_gen) = expand_or_barf_right_neighbor((z, id_gen));
   make_new_tile(char, Left, z, id_gen);
 };
 

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -54,15 +54,20 @@ let make_new_tile = (t: Token.t, caret: Direction.t, z: t): IdGen.t(t) =>
 let expand_neighbors_and_make_new_tile =
     (char: Token.t, state: state): option(state) => {
   /* Trigger a token boundary event and create a new tile.
-     This process proceeds left-to-right, potentially involving both
-     neighboring tiles, and potentially triggering up to 3 expansion
-     or backpack barf events. In particular, both left and right
-     neighboring monotiles may undergo delayed (aka keyword) expansion,
-     and the newly-created single-character token may undergo instant
-     expansion.*/
-  let* (z, id_gen) = expand_or_barf_left_neighbor(state);
-  let state = make_new_tile(char, Left, z, id_gen);
-  expand_or_barf_right_neighbor(state);
+     This process potentially involves both neighboring tiles,
+     potentially triggering up to 3 expansions or backpack barfs.
+     In particular, both left and right neighboring monotiles may
+     undergo delayed (aka keyword) expansion, and the newly-created
+     single-character token may undergo instant expansion. Currently
+     made the decision to expand or barf the neighbors before making
+     the new tile because barfing is limited to the top of the backpack,
+     and I wanted things like "if|then", when you enter a "(", to
+     barf the "then", before it is buried by the ")" added to the BP.
+     The order here could be revisited if barfing was more sophisticated.
+     */
+  let* state = expand_or_barf_left_neighbor(state);
+  let+ (z, id_gen) = expand_or_barf_right_neighbor(state);
+  make_new_tile(char, Left, z, id_gen);
 };
 
 let replace_tile =

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -66,7 +66,7 @@ let expand_neighbors_and_make_new_tile =
      The order here could be revisited if barfing was more sophisticated.
      */
   let* (z, id_gen) = expand_or_barf_left_neighbor(state);
-  let (z, id_gen) = remold_regrout(Left, z, id_gen);
+  let (z, id_gen) = regrout(Left, z, id_gen);
   /* Note to david: I'm not sure why the above regrout is necessary.
      Without it, there is a Nonconvex segment error thrown in exactly
      one case, the double barf case: insert space on "if then|else" */

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -93,7 +93,7 @@ let go_z =
       /* Alternatively, putting down inside token could eiter merge-in or split */
       switch (z.caret) {
       | Inner(_) => None
-      | Outer => Zipper.put_down(z)
+      | Outer => Zipper.put_down(Left, z)
       };
     z
     |> Option.map(z => remold_regrout(Left, z, id_gen))


### PR DESCRIPTION
This overhauls the entire expansion and backpack barfing system, fixing the expansion bug and attempting to make both the behavior and implementation clearer and more consistent.

As a reminder the expansion bug (as i've been calling it, but barfing bug is more accurate) affects situations like this:
"let a = b|in", where pressing space fails to drop "in" from the backpack.

First, recall some vocabulary:

- expansion: the process of a monotile expanding into a multitile. a given form can be configured to expand from either its first delimiter, its second delimiter, or both. furthermore, the expansion for each of those delmiters can be configured to be either instant or delayed 
- instant expansion: when expansion occurs immediately after a delimiter is created, e.g. for "(" or ")"
- delayed expansion: when expansion occurs only after a token boundary event, e.g. when " " (or "," or whatever) is pressed on "let|"
- barfing: when the token adjacent to the caret matches the token at the top of the backpack and is replaced by the dropped backpack token
- insertion: the action of inserting a new character. this can result in either a modification insertion, where an existing token is modified (either at the ends or internally) or a creation insertion, aka a token boundary event. modification insertions can result in instant expansions, but only token boundary events result in delayed expansions.
- token boundary event: when insertion would not result in a valid token, so a new token must be created. this occurs in two different cases: (a) the caret is at an outer position and the new character cannot be appended to either neighbour, or (b) the caret is at an inner position, resulting in the token being split.

Previously, token boundary events only triggered delayed expansion on the token to the left. Now, they can trigger up to three expansions/barfings: one for the left neighbor of the caret, one for the newly inserted thing, and one for the right neighbor. for example, pressing "(" on "if|if" will trigger three expansions. It's debatable whether the expansion of the last "if" is desired behavior, but I think there's a consistency case to be made, since we definitely do want to trigger a barf if we press " " on let a = b|in", and I feel the behavior is easier to predict if expansion and barfing happen in exactly the same circumstances I think... please debate if you disagree.

Another similar (but technically independent) consistency change  is that now barfings use the same delayed/instant behavior as expansions. Since parentheses are still instant, typing ")" on "(|" results in an instant drop. however, on "if 1 the", typing "n" no longer results in a drop; you need to press the space first. I think that this feels better... the instant drop feels to me a little jarring. It also seems to be necessary to permit entry of variables which have a keyword as a prefix.

One current sub-optimal but farily niche behavior: consider "(if|if" with ")" in the backpack. if ")" is pressed, i would guess that the first "if" would be expanded, and then the ")" would be barfed, and then the second "if" would be expanded. however, because the expansion of the first if, the ")" is no longer top of the backpack, so the ")" is treated as fresh and a "(" is added to the backpack. This is addressable in principle but I'm not sure whether it's worth it at this point.

Implementation note, mostly for @dmoon1221: backpack selection foci direction is no longer used at all, I felt they were complicating things. construct now takes two directional parameters, one reflecting the direction you want to insert it wrt to the caret, and the other reflecting what order you want to add shard to the backpack in. This means that after you insert a fresh ")" you end up on the 'wrong' side, but i think this is probably principle-of-least-surprisey.