### PR TITLE
added simple #debug mode for instances where loading is hanging

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,14 @@ build (takes longer per build).
    
 ### Debugging
 
+#### Printing
 You can print to the browser console using the standard `print_endline` function. This is probably the easiest method right now.
 
+#### Source Maps
 `js_of_ocaml` does support source maps and has some other flags that might be useful. If you experiment with those and get them to work, please update this README with some notes.
+
+#### Debug Mode
+If Hazel is hanging on load or when you perform certain actions, you can load into Debug Mode by appending `#debug` to the URL and reloading. From there, you have some buttons that will change settings or reset local storage. Refresh without the `#debug` flag and hopefully you can resolve the situation from there.
 
 ### Testing
 

--- a/src/haz3lweb/DebugAction.re
+++ b/src/haz3lweb/DebugAction.re
@@ -1,0 +1,13 @@
+[@deriving (show({with_path: false}), sexp, yojson)]
+type t =
+  | TurnOffDynamics
+  | ClearLocalStorage;
+
+let perform = action => {
+  switch (action) {
+  | TurnOffDynamics =>
+    let settings = LocalStorage.Settings.load();
+    LocalStorage.Settings.save({...settings, dynamics: false});
+  | ClearLocalStorage => JsUtil.clear_localstore()
+  };
+};

--- a/src/haz3lweb/Editors.re
+++ b/src/haz3lweb/Editors.re
@@ -3,6 +3,7 @@ open Haz3lcore;
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t =
+  | DebugLoad
   | Scratch(int, list(ScratchSlide.state))
   | School(int, list(SchoolExercise.spec), SchoolExercise.state);
 
@@ -14,17 +15,20 @@ type school = (int, list(SchoolExercise.spec), SchoolExercise.state);
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type mode =
+  | DebugLoad
   | Scratch
   | School;
 
 let rotate_mode = (editors: t) =>
   switch (editors) {
+  | DebugLoad => DebugLoad
   | Scratch(_) => School
   | School(_) => Scratch
   };
 
 let get_editor_and_id = (editors: t): (Id.t, Editor.t) =>
   switch (editors) {
+  | DebugLoad => failwith("no editors in debug load mode")
   | Scratch(n, slides) =>
     assert(n < List.length(slides));
     let slide = List.nth(slides, n);
@@ -41,6 +45,7 @@ let get_editor = (editors: t): Editor.t => snd(get_editor_and_id(editors));
 
 let put_editor_and_id = (id: Id.t, ed: Editor.t, eds: t): t =>
   switch (eds) {
+  | DebugLoad => failwith("no editors in debug load mode")
   | Scratch(n, slides) =>
     assert(n < List.length(slides));
     let slide = List.nth(slides, n);
@@ -60,6 +65,7 @@ let get_zipper = (editors: t): Zipper.t => get_editor(editors).state.zipper;
 
 let get_spliced_elabs = (editors: t): list((ModelResults.key, DHExp.t)) => {
   switch (editors) {
+  | DebugLoad => []
   | Scratch(n, slides) =>
     let slide = List.nth(slides, n);
     ScratchSlide.spliced_elabs(slide);
@@ -69,6 +75,7 @@ let get_spliced_elabs = (editors: t): list((ModelResults.key, DHExp.t)) => {
 
 let set_instructor_mode = (editors: t, instructor_mode: bool): t =>
   switch (editors) {
+  | DebugLoad => failwith("no editors in debug load mode")
   | Scratch(_) => editors
   | School(n, specs, exercise) =>
     School(
@@ -80,12 +87,14 @@ let set_instructor_mode = (editors: t, instructor_mode: bool): t =>
 
 let num_slides = (editors: t): int =>
   switch (editors) {
+  | DebugLoad => 0
   | Scratch(_, slides) => List.length(slides)
   | School(_, specs, _) => List.length(specs)
   };
 
 let cur_slide = (editors: t): int =>
   switch (editors) {
+  | DebugLoad => 0
   | Scratch(n, _)
   | School(n, _, _) => n
   };

--- a/src/haz3lweb/Log.re
+++ b/src/haz3lweb/Log.re
@@ -28,7 +28,8 @@ let is_action_logged: Update.t => bool =
   | SetShowBackpackTargets(_)
   | InitImportAll(_)
   | InitImportScratchpad(_)
-  | UpdateResult(_) => false
+  | UpdateResult(_)
+  | DebugAction(_) => false
   | ResetCurrentEditor
   | Set(_)
   | FinishImportAll(_)

--- a/src/haz3lweb/Main.re
+++ b/src/haz3lweb/Main.re
@@ -142,15 +142,11 @@ let fragment =
 
 let initial_model = {
   // NOTE: load settings first to get last editor mode
-  let model = Update.load_model(Model.blank);
   switch (fragment) {
-  | "dynamics-off" =>
-    print_endline("Turning off dynamics...");
-    let settings = {...model.settings, dynamics: false};
-    LocalStorage.Settings.save(settings);
-    let model = {...model, settings};
+  | "debug" => Model.debug
+  | _ =>
+    let model = Update.load_model(Model.blank);
     model;
-  | _ => model
   };
 };
 

--- a/src/haz3lweb/Main.re
+++ b/src/haz3lweb/Main.re
@@ -141,7 +141,6 @@ let fragment =
   };
 
 let initial_model = {
-  // NOTE: load settings first to get last editor mode
   switch (fragment) {
   | "debug" => Model.debug
   | _ =>

--- a/src/haz3lweb/Model.re
+++ b/src/haz3lweb/Model.re
@@ -28,6 +28,8 @@ let settings_init = {
   mode: Editors.Scratch,
 };
 
+let settings_debug = {...settings_init, mode: Editors.DebugLoad};
+
 let fix_instructor_mode = settings =>
   if (settings.instructor_mode && !SchoolSettings.show_instructor) {
     {...settings, instructor_mode: false};
@@ -63,3 +65,4 @@ let mk = editors => {
 };
 
 let blank = mk(Editors.Scratch(0, []));
+let debug = mk(Editors.DebugLoad);

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -4,6 +4,7 @@ include UpdateAction; // to prevent circularity
 
 let save_editors = (model: Model.t): unit =>
   switch (model.editors) {
+  | DebugLoad => failwith("no editors in debug load mode")
   | Scratch(n, slides) => LocalStorage.Scratch.save((n, slides))
   | School(n, specs, exercise) =>
     LocalStorage.School.save(
@@ -91,6 +92,7 @@ let load_model = (model: Model.t): Model.t => {
   let model = {...model, settings, langDocMessages};
   let model =
     switch (model.settings.mode) {
+    | DebugLoad => model
     | Scratch =>
       let (idx, slides) = LocalStorage.Scratch.load();
       {...model, editors: Scratch(idx, slides)};
@@ -113,6 +115,7 @@ let load_model = (model: Model.t): Model.t => {
 
 let load_default_editor = (model: Model.t): Model.t =>
   switch (model.editors) {
+  | DebugLoad => model
   | Scratch(_) =>
     let (idx, editors) = LocalStorage.Scratch.init();
     {...model, editors: Scratch(idx, editors)};
@@ -152,7 +155,8 @@ let reevaluate_post_update =
   | InitImportAll(_)
   | InitImportScratchpad(_)
   | FailedInput(_)
-  | UpdateLangDocMessages(_) => false
+  | UpdateLangDocMessages(_)
+  | DebugAction(_) => false
   // may not be necessary on all of these
   // TODO review and prune
   | ResetCurrentEditor
@@ -241,7 +245,8 @@ let apply =
       Ok(model);
     | FinishImportScratchpad(data) =>
       switch (model.editors) {
-      | School(_) => assert(false)
+      | DebugLoad => failwith("impossible")
+      | School(_) => failwith("impossible")
       | Scratch(idx, slides) =>
         switch (data) {
         | None => Ok(model)
@@ -256,6 +261,7 @@ let apply =
     | ResetSlide =>
       let model =
         switch (model.editors) {
+        | DebugLoad => failwith("impossible")
         | Scratch(n, slides) =>
           let slides =
             Util.ListUtil.put_nth(n, ScratchSlidesInit.init_nth(n), slides);
@@ -277,6 +283,7 @@ let apply =
       Ok(model);
     | SwitchSlide(n) =>
       switch (model.editors) {
+      | DebugLoad => failwith("impossible")
       | Scratch(m, _) when m == n => Error(FailedToSwitch)
       | Scratch(_, slides) =>
         switch (n < List.length(slides)) {
@@ -299,6 +306,7 @@ let apply =
       }
     | SwitchEditor(n) =>
       switch (model.editors) {
+      | DebugLoad => failwith("impossible")
       | Scratch(_) => Error(FailedToSwitch) // one editor per scratch
       | School(m, specs, exercise) =>
         let exercise = SchoolExercise.switch_editor(n, exercise);
@@ -401,6 +409,9 @@ let apply =
         |> ModelResult.update_current(res);
       let results = model.results |> ModelResults.add(key, r);
       Ok({...model, results});
+    | DebugAction(a) =>
+      DebugAction.perform(a);
+      Ok(model);
     };
   reevaluate_post_update(update)
     ? m |> Result.map(~f=evaluate_and_schedule(state, ~schedule_action)) : m;

--- a/src/haz3lweb/UpdateAction.re
+++ b/src/haz3lweb/UpdateAction.re
@@ -41,7 +41,8 @@ type t =
   | SetShowBackpackTargets(bool)
   | MoveToNextHole(Direction.t)
   | UpdateResult(ModelResults.Key.t, ModelResult.current)
-  | UpdateLangDocMessages(LangDocMessages.update);
+  | UpdateLangDocMessages(LangDocMessages.update)
+  | DebugAction(DebugAction.t);
 
 module Failure = {
   [@deriving (show({with_path: false}), sexp, yojson)]

--- a/src/haz3lweb/util/JsUtil.re
+++ b/src/haz3lweb/util/JsUtil.re
@@ -81,6 +81,12 @@ let get_localstore = (k: string): option(string) =>
   | _ => None
   };
 
+let clear_localstore = () => {
+  let local_store =
+    Js.Optdef.get(Dom_html.window##.localStorage, () => assert(false));
+  local_store##clear;
+};
+
 let confirm = message => {
   Js.to_bool(Dom_html.window##confirm(Js.string(message)));
 };

--- a/src/haz3lweb/view/DebugMode.re
+++ b/src/haz3lweb/view/DebugMode.re
@@ -1,0 +1,27 @@
+open Virtual_dom.Vdom;
+
+let btn = (~inject, caption, action) => {
+  Node.(
+    button(
+      ~attr=Attr.many([Attr.on_click(_ => inject(action))]),
+      [text(caption)],
+    )
+  );
+};
+
+let view = (~inject) => {
+  Node.(
+    div([
+      btn(
+        ~inject,
+        "turn off dynamics",
+        UpdateAction.DebugAction(TurnOffDynamics),
+      ),
+      btn(
+        ~inject,
+        "clear local storage (LOSE ALL DATA!)",
+        UpdateAction.DebugAction(ClearLocalStorage),
+      ),
+    ])
+  );
+};

--- a/src/haz3lweb/view/Page.re
+++ b/src/haz3lweb/view/Page.re
@@ -43,6 +43,7 @@ let slide_toggle_view = (~inject, ~model: Model.t, ~caption, ~control) => {
 
 let editor_mode_toggle_view = (~inject: Update.t => 'a, ~model: Model.t) => {
   switch (model.editors) {
+  | DebugLoad => failwith("impossible")
   | Scratch(_) =>
     slide_toggle_view(~inject, ~model, ~caption="Scratch", ~control=None)
   | School(_) =>
@@ -191,6 +192,7 @@ let main_ui_view =
       } as model: Model.t,
     ) => {
   switch (editors) {
+  | DebugLoad => [DebugMode.view(~inject)]
   | Scratch(idx, slides) =>
     let toolbar_buttons =
       ScratchMode.toolbar_buttons(~inject, List.nth(slides, idx));


### PR DESCRIPTION
Append `#debug` to URL and refresh and you'll load into a simple GUI with currently two buttons:

1. turn off dynamics (which can help if you experience an infinite loop) -- replaces previous `#dynamics-off` #900 
2. clear local storage entirely (which can help if local storage contains something that isn't being loaded in current version of Hazel -- we try to avoid this situation -- or loading is taking a long time and you don't care to save previous state)