### PR TITLE
Add button to reconstruct state from a session export via log replay

### DIFF
--- a/src/haz3lweb/Log.re
+++ b/src/haz3lweb/Log.re
@@ -26,7 +26,8 @@ let is_action_logged: UpdateAction.t => bool =
   | Set(_)
   | FinishImportAll(_)
   | FinishImportScratchpad(_)
-  | FinishReplay(_)
+  | StartReplay(_)
+  | StepReplay(_)
   | ResetSlide
   | ToggleMode
   | SwitchSlide(_)

--- a/src/haz3lweb/Log.re
+++ b/src/haz3lweb/Log.re
@@ -19,12 +19,14 @@ let is_action_logged: UpdateAction.t => bool =
   | SetShowBackpackTargets(_)
   | InitImportAll(_)
   | InitImportScratchpad(_)
+  | InitReplay(_)
   | UpdateResult(_)
   | DebugAction(_) => false
   | ResetCurrentEditor
   | Set(_)
   | FinishImportAll(_)
   | FinishImportScratchpad(_)
+  | FinishReplay(_)
   | ResetSlide
   | ToggleMode
   | SwitchSlide(_)

--- a/src/haz3lweb/UpdateAction.re
+++ b/src/haz3lweb/UpdateAction.re
@@ -23,6 +23,8 @@ type t =
   | FinishImportAll(option(string))
   | InitImportScratchpad([@opaque] Js_of_ocaml.Js.t(Js_of_ocaml.File.file))
   | FinishImportScratchpad(option(string))
+  | InitReplay([@opaque] Js_of_ocaml.Js.t(Js_of_ocaml.File.file))
+  | FinishReplay(option(string))
   | ResetSlide
   | Save
   | ToggleMode

--- a/src/haz3lweb/UpdateAction.re
+++ b/src/haz3lweb/UpdateAction.re
@@ -24,7 +24,8 @@ type t =
   | InitImportScratchpad([@opaque] Js_of_ocaml.Js.t(Js_of_ocaml.File.file))
   | FinishImportScratchpad(option(string))
   | InitReplay([@opaque] Js_of_ocaml.Js.t(Js_of_ocaml.File.file))
-  | FinishReplay(option(string))
+  | StartReplay(option(string))
+  | StepReplay(list((int, t)))
   | ResetSlide
   | Save
   | ToggleMode

--- a/src/haz3lweb/view/Page.re
+++ b/src/haz3lweb/view/Page.re
@@ -139,6 +139,17 @@ let top_bar_view =
               },
               ~tooltip="Import Submission",
             ),
+            file_select_button(
+              "replay-submission",
+              Icons.import,
+              file => {
+                switch (file) {
+                | None => Virtual_dom.Vdom.Effect.Ignore
+                | Some(file) => inject(InitReplay(file))
+                }
+              },
+              ~tooltip="Replay Submission",
+            ),
             button(
               Icons.eye,
               _ => inject(Set(SecondaryIcons)),


### PR DESCRIPTION
**Summary**

Meta issue: https://github.com/hazelgrove/hazel/issues/969

It's currently possible to save a snapshot export of a user session as a file, then import it later. However, this import functionality simply loads the exact snapshot rather than building the state procedurally using the action log. For data analysis purposes, it would be nice to be able to build the state incrementally, which this PR introduces.

**Implementation**

First, load the export file. Next, parse the log and turn the list of timestamps into a list of time diffs. Then, kick off the first action in the log. Each action is responsible for executing, delaying, then kicking off the subsequent action.

**Caveats**

- Button has same icon as import button.
- Since the log does not include information about whether the original action succeeded, on replay, we don't know if the action failed because of a state mismatch or because the original action failed.
- `Update.apply` is now recursive.
- `Update.t` and `Log.t` are vaguely mutually recursive now, since logs contain actions, but certain actions (like `StartReplay`) reference logs. I get around this in a slightly hacky way, but I don't think it's a big deal.

**Testing**

Manually tested with some replays I generated. 

Eventually, we might want to set up an automated check to see if the log-replay state matches the imported final state at some point, but unless there's an easily accessible "session state ~matches" function that already exists, I'm not sure it's worth it right now.

**Example**

Other than triggering the replay, I do not take any action (eg: typing or clicking) during this clip.

https://user-images.githubusercontent.com/87710069/215351495-8944491e-0436-4488-b37d-6ab33831c80c.mov


