### PR TITLE
Fix linebreak in comments bug

### DIFF
--- a/src/haz3lcore/tiles/Secondary.re
+++ b/src/haz3lcore/tiles/Secondary.re
@@ -8,11 +8,7 @@ and secondary_content =
   | Whitespace(string)
   | Comment(string);
 
-let space = " ";
-let linebreak = "⏎"; //alternative: "¶"
-let comment = Re.Str.regexp("^#[^#]*#$");
-
-let mk_space = id => {content: Whitespace(space), id};
+let mk_space = id => {content: Whitespace(Form.space), id};
 
 let construct_comment = content =>
   if (String.equal(content, "#")) {
@@ -24,14 +20,14 @@ let construct_comment = content =>
 let is_space: t => bool =
   w =>
     switch (w.content) {
-    | Whitespace(s) => s == space
+    | Whitespace(s) => s == Form.space
     | _ => false
     };
 
 let is_linebreak: t => bool =
   w =>
     switch (w.content) {
-    | Whitespace(s) => s == linebreak
+    | Whitespace(s) => s == Form.linebreak
     | _ => false
     };
 

--- a/src/haz3lcore/zipper/Printer.re
+++ b/src/haz3lcore/zipper/Printer.re
@@ -116,7 +116,7 @@ let zipper_of_string =
     ((Zipper.t, IdGen.state), string) => (Zipper.t, IdGen.state) =
     ((z, id_gen), c) => {
       switch (
-        Perform.go_z(Insert(c == "\n" ? Secondary.linebreak : c), z, id_gen)
+        Perform.go_z(Insert(c == "\n" ? Form.linebreak : c), z, id_gen)
       ) {
       | Error(err) =>
         print_endline(

--- a/src/haz3lweb/Keyboard.re
+++ b/src/haz3lweb/Keyboard.re
@@ -61,9 +61,7 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | (Down, "ArrowUp") => now(Select(Resize(Local(Up))))
     | (Down, "ArrowDown") => now(Select(Resize(Local(Down))))
     | (_, "Shift") => update_double_tap(model)
-    | (_, "Enter") =>
-      //TODO(andrew): using funky char to avoid weird regexp issues with using \n
-      now_save(Insert(Secondary.linebreak))
+    | (_, "Enter") => now_save(Insert(Form.linebreak))
     | _ when Form.is_valid_char(key) && String.length(key) == 1 =>
       /* TODO(andrew): length==1 is hack to prevent things
          like F5 which are now valid tokens and also weird

--- a/src/haz3lweb/LangDocMessages.re
+++ b/src/haz3lweb/LangDocMessages.re
@@ -94,8 +94,8 @@ let mk_if = Example.mk_tile(Form.get("if_"));
 let mk_test = Example.mk_tile(Form.get("test"));
 let mk_case = Example.mk_tile(Form.get("case"));
 let mk_rule = Example.mk_tile(Form.get("rule"));
-let linebreak = () => Example.mk_secondary(Secondary.linebreak);
-let space = () => Example.mk_secondary(Secondary.space);
+let linebreak = () => Example.mk_secondary(Form.linebreak);
+let space = () => Example.mk_secondary(Form.space);
 
 let mk_example = str => {
   switch (Printer.zipper_of_string(0, str)) {

--- a/src/haz3lweb/view/Code.re
+++ b/src/haz3lweb/view/Code.re
@@ -35,14 +35,14 @@ let of_grout = [Node.text(Unicode.nbsp)];
 let of_secondary =
   Core.Memo.general(
     ~cache_size_bound=1000000, ((secondary_icons, indent, content)) =>
-    if (String.equal(Secondary.get_string(content), Secondary.linebreak)) {
-      let str = secondary_icons ? Secondary.linebreak : "";
+    if (String.equal(Secondary.get_string(content), Form.linebreak)) {
+      let str = secondary_icons ? Form.linebreak : "";
       [
         span_c("linebreak", [text(str)]),
         Node.br(),
         Node.text(StringUtil.repeat(indent, Unicode.nbsp)),
       ];
-    } else if (String.equal(Secondary.get_string(content), Secondary.space)) {
+    } else if (String.equal(Secondary.get_string(content), Form.space)) {
       let str = secondary_icons ? "·" : Unicode.nbsp;
       [span_c("secondary", [text(str)])];
     } else if (Secondary.content_is_comment(content)) {


### PR DESCRIPTION
Currently having linebreaks in comments is not supported for multiple reasons; needs special support in metrics and elsewhere. However it is not explicitly disallowed, resulting in broken behavior. This specifically disallows linebreak insertion in comments until linebreak support is implemented more generally.

Incidentally, this also makes the structural change of inverting the dependency between Secondary and Form. Secondary should be considered a semantic module, not syntactic. As far as possible, all lexer/token concerns should be handled in Form to facilitate future abstraction of the syntax model.