### PR TITLE
modified keyboard file to add shift+home/end equivalent to cmd+shift+left/right

### DIFF
--- a/src/haz3lweb/Keyboard.re
+++ b/src/haz3lweb/Keyboard.re
@@ -60,6 +60,8 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | (Down, "ArrowRight") => now(Select(Resize(Local(Right(ByToken)))))
     | (Down, "ArrowUp") => now(Select(Resize(Local(Up))))
     | (Down, "ArrowDown") => now(Select(Resize(Local(Down))))
+    | (Down, "Home") => now(Select(Resize(Extreme(Left(ByToken)))))
+    | (Down, "End") => now(Select(Resize(Extreme(Right(ByToken)))))
     | (_, "Shift") => update_double_tap(model)
     | (_, "Enter") =>
       //TODO(andrew): using funky char to avoid weird regexp issues with using \n


### PR DESCRIPTION
I believe this closes #800 . Assuming the task was to implement shift+home and shift+end (all OS) equivalent to cmd+shift+left/right arrows (Mac). 