### PR TITLE
Fix incr_dom build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,36 @@ For a smoother dev experience, use `make watch` to automatically watch
 for file changes. This will require installing `fswatch` (see INSTALL.md).
 You can also run `make watch-release` to continuously build the release
 build (takes longer per build).
-   
+
+#### Clean Build
+
+To obtain an clean build, you may need to:
+
+- Clone the repository (if you have not), and
+  enter the project root of your cloned Hazel project.
+
+  ```sh
+  git clone git@github.com:hazelgrove/hazel.git
+  cd hazel
+  ```
+
+- Setup a local OCaml environment specific to the project, and compile.
+  If you have setup a local OCaml environment (there is a directory
+  called `_opam`), you may want to first remove it.
+
+  ```sh
+  # opam switch remove ./
+  opam switch create ./ 4.14.0
+  eval $(opam env)
+  make deps
+  make
+  ```
+
+This sets up a standalone OCaml environment in the cloned project,
+independent of the one you sent in your home directory. This allow you to
+alternate dependencies, or test dependencies changes, without affect
+existing OCaml projects.
+
 ### Debugging
 
 #### Printing

--- a/opam.export
+++ b/opam.export
@@ -169,3 +169,9 @@ installed: [
   "xdg.3.3.1"
   "yojson.1.7.0"
 ]
+pinned: [
+  "async_js.v0.15.1"
+  "incr_dom.v0.15.1"
+  "sexplib.v0.15.1"
+  "virtual_dom.v0.15.1"
+]

--- a/opam.export
+++ b/opam.export
@@ -3,7 +3,7 @@ compiler: ["ocaml-base-compiler.4.14.0"]
 roots: [
   "async_js.v0.15.1"
   "camomile.1.0.2"
-  "incr_dom.v0.15.0"
+  "incr_dom.v0.15.1"
   "lwt.5.6.1"
   "lwt-dllist.1.0.1"
   "merlin.4.5-414"
@@ -16,7 +16,7 @@ roots: [
   "sexplib.v0.15.1"
   "tezt.2.0.0"
   "unionFind.20220122"
-  "virtual_dom.v0.15.0"
+  "virtual_dom.v0.15.1"
 ]
 installed: [
   "abstract_algebra.v0.15.0"
@@ -61,7 +61,7 @@ installed: [
   "fmt.0.9.0"
   "gen_js_api.1.1.1"
   "hex.1.5.0"
-  "incr_dom.v0.15.0"
+  "incr_dom.v0.15.1"
   "incr_map.v0.15.0"
   "incr_select.v0.15.0"
   "incremental.v0.15.0"
@@ -165,128 +165,7 @@ installed: [
   "uri-sexp.4.2.0"
   "uutf.1.0.3"
   "variantslib.v0.15.0"
-  "virtual_dom.v0.15.0"
+  "virtual_dom.v0.15.1"
   "xdg.3.3.1"
   "yojson.1.7.0"
 ]
-pinned: [
-  "async_js.v0.15.1"
-  "incr_dom.v0.15.0"
-  "sexplib.v0.15.1"
-  "virtual_dom.v0.15.0"
-]
-package "incr_dom" {
-  opam-version: "2.0"
-  version: "v0.15.0"
-  synopsis: "A library for building dynamic webapps, using Js_of_ocaml"
-  description: """\
-The library is designed roughly on a model/view/controller model.
-Your application is built out of:
-
-- A functional model type that tracks the state of your application.
-
-- An incremental /view/ function for computing an HTML-like
-  representation of how your application should render on the browser.
-  The is based on the [[https://github.com/Matt-Esch/virtual-dom][virtual-dom]] javascript library.
-
-- An action type that is used to schedule events that update the
-  model.
-
-Combined with the ability to use Async, and in particular to send out
-network requests using websockets, this should allow the easy
-construction of rich web applications in a fairly comprehensible
-style.
-
-If you want a more concrete sense of how this works, look in the
-examples directory."""
-  maintainer: "Jane Street developers"
-  authors: "Jane Street Group, LLC"
-  license: "MIT"
-  homepage: "https://github.com/janestreet/incr_dom"
-  doc:
-    "https://ocaml.janestreet.com/ocaml-core/latest/doc/incr_dom/index.html"
-  bug-reports: "https://github.com/janestreet/incr_dom/issues"
-  depends: [
-    "ocaml" {>= "4.08.0"}
-    "async_js"
-    "async_kernel"
-    "core"
-    "incr_map"
-    "incr_select"
-    "incremental"
-    "ppx_jane"
-    "virtual_dom"
-    "dune" {>= "2.0.0"}
-    "js_of_ocaml" {>= "4.0"}
-    "js_of_ocaml-ppx" {>= "4.0"}
-  ]
-  build: ["dune" "build" "-p" name "-j" jobs]
-  dev-repo: "git+https://github.com/janestreet/incr_dom.git"
-  url {
-    src: "git+https://github.com/janestreet/incr_dom.git"
-  }
-}
-package "sexplib" {
-  opam-version: "2.0"
-  version: "v0.15.1"
-  synopsis: "Library for serializing OCaml values to and from S-expressions"
-  description: """\
-Part of Jane Street's Core library
-The Core suite of libraries is an industrial strength alternative to
-OCaml's standard library that was developed by Jane Street, the
-largest industrial user of OCaml."""
-  maintainer: "Jane Street developers"
-  authors: "Jane Street Group, LLC"
-  license: "MIT"
-  homepage: "https://github.com/janestreet/sexplib"
-  doc:
-    "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib/index.html"
-  bug-reports: "https://github.com/janestreet/sexplib/issues"
-  depends: [
-    "ocaml" {>= "4.08.0"}
-    "parsexp"
-    "sexplib0"
-    "dune" {>= "2.0.0"}
-    "num"
-  ]
-  build: ["dune" "build" "-p" name "-j" jobs]
-  dev-repo: "git+https://github.com/janestreet/sexplib.git"
-  url {
-    src: "git+https://github.com/janestreet/sexplib.git"
-  }
-}
-package "virtual_dom" {
-  opam-version: "2.0"
-  version: "v0.15.0"
-  synopsis: "OCaml bindings for the virtual-dom library"
-  description: """\
-The library itself may be found at
-https://github.com/Matt-Esch/virtual-dom."""
-  maintainer: "Jane Street developers"
-  authors: "Jane Street Group, LLC"
-  license: "MIT"
-  homepage: "https://github.com/janestreet/virtual_dom"
-  doc:
-    "https://ocaml.janestreet.com/ocaml-core/latest/doc/virtual_dom/index.html"
-  bug-reports: "https://github.com/janestreet/virtual_dom/issues"
-  depends: [
-    "ocaml" {>= "4.08.0"}
-    "base"
-    "core"
-    "core_kernel"
-    "ppx_jane"
-    "base64" {>= "3.4.0"}
-    "dune" {>= "2.0.0"}
-    "gen_js_api" {>= "1.0.8"}
-    "js_of_ocaml" {>= "4.0"}
-    "js_of_ocaml-ppx" {>= "4.0"}
-    "lambdasoup" {>= "0.6.3"}
-    "tyxml" {>= "4.3.0"}
-    "uri" {>= "3.0.0"}
-  ]
-  build: ["dune" "build" "-p" name "-j" jobs]
-  dev-repo: "git+https://github.com/janestreet/virtual_dom.git"
-  url {
-    src: "git+https://github.com/dedbox/virtual_dom.git"
-  }
-}


### PR DESCRIPTION
As reported by Adam Chen (I'm unable to find their github username, sorry), a fresh build yields the error message when building [incr_dom](https://github.com/janestreet/incr_dom):
```
[ERROR] The compilation of incr_dom.v0.15.0 failed at "dune build -p incr_dom -j 3".

#=== ERROR while compiling incr_dom.v0.15.0 ===================================#
# context     2.1.4 | linux/x86_64 | ocaml-system.4.14.0 | pinned(git+https://github.com/janestreet/incr_dom.git#7a89c037)
# path        ~/workspace/hazel/_opam/.opam-switch/build/incr_dom.v0.15.0
# command     ~/.local/share/opam/opam-init/hooks/sandbox.sh build dune build -p incr_dom -j 3
# exit-code   1
# env-file    ~/.local/share/opam/log/incr_dom-149222-7af57e.env
# output-file ~/.local/share/opam/log/incr_dom-149222-7af57e.out
### output ###
# (cd _build/default[...]
# File "vdom_file_download/vdom_file_download.ml", line 16, characters 5-35:
# 16 |   if Ppx_inline_test_lib.am_running
#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Ppx_inline_test_lib.am_running
# (cd _build/default[...]
# File "vdom_file_download/vdom_file_download.ml", line 16, characters 5-35:
# 16 |   if Ppx_inline_test_lib.am_running
#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Ppx_inline_test_lib.am_running
```
The cause is a change introduced by incr_dom commit [7a89c03](https://github.com/janestreet/incr_dom/commit/7a89c037f638059e2f7229cab073e8066075baf2).

Alternative approaches to solve the problem:
1. Pin incr_dom to eariler commit [d5d2da7](https://github.com/janestreet/incr_dom/commit/d5d2da716b35d566ac48b7140ea7e683525e8de8)
2. Only unpin and upgrade incr_dom to 0.15.1
3. Do a dependency audit and bumps versions. I think we can unpin all pinned packages, and upgrade some janestreet ocaml packages to 0.15.1. Not sure how it will turn out.