### PR TITLE
Fix performance issue of mk_comma_seq in DHDoc_common

### DIFF
--- a/src/haz3lweb/view/dhcode/layout/DHDoc_common.re
+++ b/src/haz3lweb/view/dhcode/layout/DHDoc_common.re
@@ -120,25 +120,20 @@ let mk_TagLit = Doc.text;
 
 let mk_Cons = (hd, tl) => Doc.(hcats([hd, text("::"), tl]));
 
-let rec mk_comma_seq = (ld, rd, l, ol) =>
-  switch (l) {
-  | [] =>
-    if (l == ol) {
-      Doc.(hcats([text(ld), text(rd)]));
-    } else {
-      Doc.(hcats([text(rd)]));
-    }
-  | [hd, ...tl] =>
-    if (l == ol) {
-      Doc.(hcats([text(ld), hd, mk_comma_seq(ld, rd, tl, ol)]));
-    } else {
-      Doc.(hcats([text(", "), hd, mk_comma_seq(ld, rd, tl, ol)]));
-    }
+let mk_comma_seq = (ld, rd, l) => {
+  let rec mk_comma_seq_inner = l => {
+    switch (l) {
+    | [] => []
+    | [hd] => [hd]
+    | [hd, ...tl] => Doc.([hd, text(", ")] @ mk_comma_seq_inner(tl))
+    };
   };
+  Doc.(hcats([text(ld)] @ mk_comma_seq_inner(l) @ [text(rd)]));
+};
 
-let mk_ListLit = l => mk_comma_seq("[", "]", l, l);
+let mk_ListLit = l => mk_comma_seq("[", "]", l);
 
-let mk_Tuple = elts => mk_comma_seq("", "", elts, elts);
+let mk_Tuple = elts => mk_comma_seq("", "", elts);
 
 let mk_Ap = (doc1, doc2) =>
   Doc.(hcats([doc1, text("("), doc2, text(")")]));


### PR DESCRIPTION
The original implementation compare the two list every recursion to tell if this is the last element in the last when rendering, which can take a bit longer if the list is long. This PR modify the implementation so it only use linear time.