### PR TITLE
Perfmageddon

### DIFF
--- a/src/haz3lcore/Measured.re
+++ b/src/haz3lcore/Measured.re
@@ -223,27 +223,6 @@ let find_by_id = (id: Id.t, map: t): option(measurement) => {
   };
 };
 
-let union2 = (map: t, map': t) => {
-  tiles:
-    Id.Map.union((_, ms, ms') => Some(ms @ ms'), map.tiles, map'.tiles),
-  grout: Id.Map.union((_, m, _) => Some(m), map.grout, map'.grout),
-  secondary:
-    Id.Map.union((_, m, _) => Some(m), map.secondary, map'.secondary),
-  rows:
-    Rows.union(
-      (_, s: Rows.shape, s': Rows.shape) =>
-        Some({
-          indent: min(s.indent, s'.indent),
-          max_col: max(s.max_col, s'.max_col),
-        }),
-      map.rows,
-      map'.rows,
-    ),
-  linebreaks:
-    Id.Map.union((_, i, _) => Some(i), map.linebreaks, map'.linebreaks),
-};
-let union = List.fold_left(union2, empty);
-
 let post_tile_indent = (t: Tile.t) => {
   // hack for indent following fun/if tiles.
   // proper fix involves updating mold datatype

--- a/src/haz3lcore/TermRanges.re
+++ b/src/haz3lcore/TermRanges.re
@@ -54,3 +54,5 @@ let rec mk = (~map=empty, seg: Segment.t) => {
        union(map, snd(go(Segment.skel(seg)))),
      );
 };
+
+let mk = Core.Memo.general(~cache_size_bound=1000, mk);

--- a/src/haz3lcore/TermRanges.re
+++ b/src/haz3lcore/TermRanges.re
@@ -6,6 +6,14 @@ type nonrec t = t(range);
 
 let union = union((_, range, _) => Some(range));
 
+/* PERF: Up to 50% reduction in some cases by memoizing
+ * this function. Might be better though to just do an
+ * unmemoized traversal building a hashtbl avoiding unioning.
+
+   TODO(andrew): Consider setting a limit for the hashtbl size */
+let range_hash: Hashtbl.t(Tile.segment, Id.Map.t(range)) =
+  Hashtbl.create(1000);
+
 // NOTE: this calculation is out of sync with
 // MakeTerm, which matches things like list brackets
 // and case...end to separators inside eg list commas
@@ -15,7 +23,7 @@ let union = union((_, range, _) => Some(range));
 // TODO(d) fix or derive from other info
 //
 // tail-recursive in outer recursion
-let rec mk = (~map=empty, seg: Segment.t) => {
+let rec mk' = (seg: Segment.t) => {
   let rec go = (skel: Skel.t): (range, t) => {
     let root = Skel.root(skel) |> Aba.map_a(List.nth(seg));
     let root_l = Aba.first_a(root);
@@ -50,9 +58,14 @@ let rec mk = (~map=empty, seg: Segment.t) => {
   };
   Segment.children(seg)
   |> List.fold_left(
-       (map, kid) => mk(~map, kid),
-       union(map, snd(go(Segment.skel(seg)))),
+       (map, kid) => union(map, mk(kid)),
+       union(empty, snd(go(Segment.skel(seg)))),
      );
-};
-
-let mk = Core.Memo.general(~cache_size_bound=1000, mk);
+}
+and mk = seg =>
+  try(Hashtbl.find(range_hash, seg)) {
+  | _ =>
+    let res = mk'(seg);
+    Hashtbl.add(range_hash, seg, res);
+    res;
+  };

--- a/src/haz3lcore/lang/Form.re
+++ b/src/haz3lcore/lang/Form.re
@@ -69,7 +69,7 @@ let mk_nul_infix = (t: Token.t, prec) =>
 /* Token Recognition Predicates */
 let is_arbitary_int = regexp("^-?\\d+[0-9_]*$");
 let is_arbitary_float = x =>
-  x != "." && regexp("^-?[0-9]*\\.?[0-9]*((e|E)-?[0-9]*)?$", x);
+  x != "." && x != "-" && regexp("^-?[0-9]*\\.?[0-9]*((e|E)-?[0-9]*)?$", x);
 let is_int = str => is_arbitary_int(str) && int_of_string_opt(str) != None;
 /* NOTE: The is_arbitary_int check is necessary to prevent
    minuses from being parsed as part of the int token. */
@@ -100,8 +100,7 @@ let is_wild = regexp("^" ++ wild ++ "$");
 
 /* The below case represents tokens which we want the user to be able to
    type in, but which have no reasonable semantic interpretation */
-let is_bad_lit = str =>
-  is_bad_int(str) || is_bad_float(str) || is_partial_base_typ(str);
+let is_bad_lit = str => is_bad_int(str) || is_bad_float(str);
 
 /* is_string: last clause is a somewhat hacky way of making sure
    there are at most two quotes, in order to prevent merges */

--- a/src/haz3lcore/tiles/Segment.re
+++ b/src/haz3lcore/tiles/Segment.re
@@ -398,11 +398,13 @@ and remold_exp = (shape, seg: t): t =>
     }
   };
 
-let skel = seg =>
-  seg
-  |> List.mapi((i, p) => (i, p))
-  |> List.filter(((_, p)) => !Piece.is_secondary(p))
-  |> Skel.mk;
+let skel =
+  Core.Memo.general(~cache_size_bound=1000, seg =>
+    seg
+    |> List.mapi((i, p) => (i, p))
+    |> List.filter(((_, p)) => !Piece.is_secondary(p))
+    |> Skel.mk
+  );
 
 let sorted_children = List.concat_map(Piece.sorted_children);
 let children = seg => List.map(snd, sorted_children(seg));

--- a/src/haz3lcore/tiles/Segment.re
+++ b/src/haz3lcore/tiles/Segment.re
@@ -399,7 +399,7 @@ and remold_exp = (shape, seg: t): t =>
   };
 
 let skel =
-  Core.Memo.general(~cache_size_bound=1000, seg =>
+  Core.Memo.general(~cache_size_bound=10000, seg =>
     seg
     |> List.mapi((i, p) => (i, p))
     |> List.filter(((_, p)) => !Piece.is_secondary(p))

--- a/src/haz3lcore/zipper/Backpack.re
+++ b/src/haz3lcore/zipper/Backpack.re
@@ -217,6 +217,11 @@ let shard_info = (bp: t) => {
   info;
 };
 
+/* PERF: This becomes very costly when there are a lot of things
+   in the backpack; e.g. if you open 23 parens, it's almost 100%
+   of the keystoke cost, for a 55x total slowdown  */
+let shard_info = Core.Memo.general(~cache_size_bound=1000, shard_info);
+
 let push = sel => Selection.is_empty(sel) ? Fun.id : List.cons(sel);
 
 let push_s: (list(Selection.t), t) => t = List.fold_right(push);

--- a/src/haz3lcore/zipper/Printer.re
+++ b/src/haz3lcore/zipper/Printer.re
@@ -114,7 +114,7 @@ let zipper_of_string =
     (~zipper_init=Zipper.init(), str: string): option(Zipper.t) => {
   let insert = (z: option(Zipper.t), c: string): option(Zipper.t) => {
     let* z = z;
-    try(Insert.go(c == "\n" ? Form.linebreak : c, z)) {
+    try(Insert.go(c == "\n" || c == "\r" ? Form.linebreak : c, z)) {
     | exn =>
       print_endline("WARN: zipper_of_string: " ++ Printexc.to_string(exn));
       None;

--- a/src/haz3lcore/zipper/Printer.re
+++ b/src/haz3lcore/zipper/Printer.re
@@ -114,7 +114,7 @@ let zipper_of_string =
     (~zipper_init=Zipper.init(), str: string): option(Zipper.t) => {
   let insert = (z: option(Zipper.t), c: string): option(Zipper.t) => {
     let* z = z;
-    try(Insert.go(c == "\n" || c == "\r" ? Form.linebreak : c, z)) {
+    try(Insert.go(c == "\n" || c == "\r\n" ? Form.linebreak : c, z)) {
     | exn =>
       print_endline("WARN: zipper_of_string: " ++ Printexc.to_string(exn));
       None;

--- a/src/haz3lcore/zipper/Printer.re
+++ b/src/haz3lcore/zipper/Printer.re
@@ -113,11 +113,9 @@ let zipper_of_string =
     (~zipper_init=Zipper.init(), str: string): option(Zipper.t) => {
   let insert_to_zid: (Zipper.t, string) => Zipper.t =
     (z, c) => {
-      switch (Perform.go_z(Insert(c == "\n" ? Form.linebreak : c), z)) {
-      | Error(err) =>
-        print_endline(
-          "WARNING: zipper_of_string: insert: " ++ Action.Failure.show(err),
-        );
+      switch (Insert.go(c == "\n" ? Form.linebreak : c, z)) {
+      | None =>
+        print_endline("WARNING: zipper_of_string: insert returned none ");
         z;
       | exception exn =>
         print_endline(
@@ -125,7 +123,7 @@ let zipper_of_string =
           ++ Printexc.to_string(exn),
         );
         z;
-      | Ok(r) => r
+      | Some(r) => r
       };
     };
   str

--- a/src/haz3lcore/zipper/Printer.re
+++ b/src/haz3lcore/zipper/Printer.re
@@ -114,7 +114,7 @@ let zipper_of_string =
     (~zipper_init=Zipper.init(), str: string): option(Zipper.t) => {
   let insert = (z: option(Zipper.t), c: string): option(Zipper.t) => {
     let* z = z;
-    try(Insert.go(c == "\n" || c == "\r\n" ? Form.linebreak : c, z)) {
+    try(c == "\r" ? Some(z) : Insert.go(c == "\n" ? Form.linebreak : c, z)) {
     | exn =>
       print_endline("WARN: zipper_of_string: " ++ Printexc.to_string(exn));
       None;

--- a/src/haz3lcore/zipper/action/Action.re
+++ b/src/haz3lcore/zipper/action/Action.re
@@ -25,6 +25,7 @@ type term =
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type select =
+  | All
   | Resize(move)
   | Term(term);
 

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -72,6 +72,15 @@ let go_z =
       | None => Error(Action.Failure.Cant_select)
       }
     }
+  | Select(All) =>
+    switch (Move.do_extreme(Move.primary(ByToken), Up, z)) {
+    | Some(z) =>
+      switch (Select.go(Extreme(Down), z)) {
+      | Some(z) => Ok(z)
+      | None => Error(Action.Failure.Cant_select)
+      }
+    | None => Error(Action.Failure.Cant_select)
+    }
   | Select(Term(Id(id))) =>
     switch (Select.term(id, z)) {
     | Some(z) => Ok(z)

--- a/src/haz3lweb/Keyboard.re
+++ b/src/haz3lweb/Keyboard.re
@@ -4,35 +4,20 @@ let is_printable = s => Re.Str.(string_match(regexp("^[ -~]$"), s, 0));
 let is_digit = s => Re.Str.(string_match(regexp("^[0-9]$"), s, 0));
 let is_f_key = s => Re.Str.(string_match(regexp("^F[0-9][0-9]*$"), s, 0));
 
-let update_double_tap = (model: Model.t): list(Update.t) => {
-  let cur_time = JsUtil.timestamp();
-  switch (model.double_tap) {
-  | None => [UpdateDoubleTap(Some(cur_time))]
-  | Some(prev_time) =>
-    if (cur_time -. prev_time < 400.) {
-      [
-        UpdateDoubleTap(None),
-        // PerformAction(RotateBackpack) // TODO(cyrus) disabling double tab here, but would be good to give it a different hotkey
-      ];
-    } else {
-      [UpdateDoubleTap(Some(cur_time))];
-    }
-  };
-};
-
-let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
+let handle_key_event = (k: Key.t, ~model: Model.t): option(Update.t) => {
   let zipper = Editors.get_zipper(model.editors);
   let restricted = Backpack.restricted(zipper.backpack);
-  let now = a => [Update.PerformAction(a) /*Update.UpdateDoubleTap(None)*/];
-  let now_save_u = u => Update.[u, Save] /*UpdateDoubleTap(None)*/;
-  let now_save = a => now_save_u(PerformAction(a)); // TODO move saving logic out of keyboard handling code to avoid bugs if we start using other input modalities
-  let print = str => str |> print_endline |> (_ => []);
+  let now = (a: Action.t): option(UpdateAction.t) =>
+    Some(PerformAction(a));
+  let print = str => str |> print_endline |> (_ => None);
   switch (k) {
   | {key: U(key), _} =>
+    /* NOTE: Remember that since there is a keyup for every
+       keydown, making an update here may trigger an entire
+       redraw, contingent on model.cutoff */
     switch (key) {
-    | "Shift" => [] // NOTE: don't update double_tap here
-    | "Alt" => [SetShowBackpackTargets(false)]
-    | _ => [UpdateDoubleTap(None)]
+    | "Alt" => Some(SetShowBackpackTargets(false))
+    | _ => None
     }
   | {key: D(key), sys: _, shift: Down, meta: Up, ctrl: Up, alt: Up}
       when is_f_key(key) =>
@@ -57,8 +42,8 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
         }
       | _ => print("DEBUG: No indicated index")
       };
-    | "F7" => [Benchmark(Start)]
-    | _ => []
+    | "F7" => Some(Benchmark(Start))
+    | _ => None
     };
   | {key: D(key), sys: _, shift, meta: Up, ctrl: Up, alt: Up} =>
     switch (shift, key) {
@@ -68,84 +53,83 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
     | (Up, "ArrowDown") => now(Move(Local(Down)))
     | (Up, "Home") => now(Move(Extreme(Left(ByToken))))
     | (Up, "End") => now(Move(Extreme(Right(ByToken))))
-    | (Up, "Backspace") => now_save(Destruct(Left))
-    | (Up, "Delete") => now_save(Destruct(Right))
+    | (Up, "Backspace") => now(Destruct(Left))
+    | (Up, "Delete") => now(Destruct(Right))
     | (Up, "Escape") => now(Unselect)
     | (Up, "Tab") =>
       Zipper.can_put_down(zipper)
-        ? [PerformAction(Put_down), Save] : [MoveToNextHole(Right)]
+        ? Some(PerformAction(Put_down)) : Some(MoveToNextHole(Right))
     | (Up, "F12") => now(Jump(BindingSiteOfIndicatedVar))
-    | (Down, "Tab") => [MoveToNextHole(Left)]
+    | (Down, "Tab") => Some(MoveToNextHole(Left))
     | (Down, "ArrowLeft") => now(Select(Resize(Local(Left(ByToken)))))
     | (Down, "ArrowRight") => now(Select(Resize(Local(Right(ByToken)))))
     | (Down, "ArrowUp") => now(Select(Resize(Local(Up))))
     | (Down, "ArrowDown") => now(Select(Resize(Local(Down))))
     | (Down, "Home") => now(Select(Resize(Extreme(Left(ByToken)))))
     | (Down, "End") => now(Select(Resize(Extreme(Right(ByToken)))))
-    | (_, "Shift") => update_double_tap(model)
-    | (_, "Enter") => now_save(Insert(Form.linebreak))
+    | (_, "Enter") => now(Insert(Form.linebreak))
     | _ when Form.is_valid_char(key) && String.length(key) == 1 =>
       /* TODO(andrew): length==1 is hack to prevent things
          like F5 which are now valid tokens and also weird
          unicode shit which is multichar i guess */
-      now_save(Insert(key))
-    | _ => []
+      now(Insert(key))
+    | _ => None
     }
   | {key: D(key), sys: Mac, shift: Down, meta: Down, ctrl: Up, alt: Up} =>
     switch (key) {
     | "Z"
-    | "z" => now_save_u(Redo)
+    | "z" => Some(Redo)
     | "ArrowLeft" => now(Select(Resize(Extreme(Left(ByToken)))))
     | "ArrowRight" => now(Select(Resize(Extreme(Right(ByToken)))))
     | "ArrowUp" => now(Select(Resize(Extreme(Up))))
     | "ArrowDown" => now(Select(Resize(Extreme(Down))))
-    | _ => []
+    | _ => None
     }
   | {key: D(key), sys: PC, shift: Down, meta: Up, ctrl: Down, alt: Up} =>
     switch (key) {
     | "Z"
-    | "z" => now_save_u(Redo)
+    | "z" => Some(Redo)
     | "ArrowLeft" => now(Select(Resize(Local(Left(ByToken)))))
     | "ArrowRight" => now(Select(Resize(Local(Right(ByToken)))))
     | "ArrowUp" => now(Select(Resize(Local(Up))))
     | "ArrowDown" => now(Select(Resize(Local(Down))))
     | "Home" => now(Select(Resize(Extreme(Up))))
     | "End" => now(Select(Resize(Extreme(Down))))
-    | _ => []
+    | _ => None
     }
   | {key: D(key), sys: Mac, shift: Up, meta: Down, ctrl: Up, alt: Up} =>
     switch (key) {
-    | "z" => now_save_u(Undo)
+    | "z" => Some(Undo)
     | "d" => now(Select(Term(Current)))
-    | "p" => now(Pick_up)
-    | "a" => now(Move(Extreme(Up))) @ now(Select(Resize(Extreme(Down))))
-    | "k" => [ReparseCurrentEditor]
-    | _ when is_digit(key) => [SwitchScratchSlide(int_of_string(key))]
+    | "p" => Some(PerformAction(Pick_up))
+    | "a" => now(Select(All))
+    | "k" => Some(ReparseCurrentEditor)
+    | _ when is_digit(key) => Some(SwitchScratchSlide(int_of_string(key)))
     | "ArrowLeft" => now(Move(Extreme(Left(ByToken))))
     | "ArrowRight" => now(Move(Extreme(Right(ByToken))))
     | "ArrowUp" => now(Move(Extreme(Up)))
     | "ArrowDown" => now(Move(Extreme(Down)))
-    | _ => []
+    | _ => None
     }
   | {key: D(key), sys: PC, shift: Up, meta: Up, ctrl: Down, alt: Up} =>
     switch (key) {
-    | "z" => now_save_u(Undo)
+    | "z" => Some(Undo)
     | "d" => now(Select(Term(Current)))
-    | "p" => now(Pick_up)
-    | "a" => now(Move(Extreme(Up))) @ now(Select(Resize(Extreme(Down))))
-    | "k" => [ReparseCurrentEditor]
-    | _ when is_digit(key) => [SwitchScratchSlide(int_of_string(key))]
+    | "p" => Some(PerformAction(Pick_up))
+    | "a" => now(Select(All))
+    | "k" => Some(ReparseCurrentEditor)
+    | _ when is_digit(key) => Some(SwitchScratchSlide(int_of_string(key)))
     | "ArrowLeft" => now(Move(Local(Left(ByToken))))
     | "ArrowRight" => now(Move(Local(Right(ByToken))))
     | "Home" => now(Move(Extreme(Up)))
     | "End" => now(Move(Extreme(Down)))
-    | _ => []
+    | _ => None
     }
   | {key: D(key), sys: Mac, shift: Up, meta: Up, ctrl: Down, alt: Up} =>
     switch (key) {
     | "a" => now(Move(Extreme(Left(ByToken))))
     | "e" => now(Move(Extreme(Right(ByToken))))
-    | _ => []
+    | _ => None
     }
   | {key: D(key), sys, shift: Up, meta: Up, ctrl: Up, alt: Down} =>
     switch (sys, key) {
@@ -155,11 +139,11 @@ let handle_key_event = (k: Key.t, ~model: Model.t): list(Update.t) => {
       now(MoveToBackpackTarget(Right(ByToken)))
     | (Mac, "ArrowLeft") => now(Move(Local(Left(ByToken))))
     | (Mac, "ArrowRight") => now(Move(Local(Right(ByToken))))
-    | (_, "Alt") => [SetShowBackpackTargets(true), UpdateDoubleTap(None)]
+    | (_, "Alt") => Some(SetShowBackpackTargets(true))
     | (_, "ArrowUp") => now(MoveToBackpackTarget(Up))
     | (_, "ArrowDown") => now(MoveToBackpackTarget(Down))
-    | _ => []
+    | _ => None
     }
-  | _ => []
+  | _ => None
   };
 };

--- a/src/haz3lweb/Log.re
+++ b/src/haz3lweb/Log.re
@@ -10,7 +10,6 @@ open Sexplib.Std;
 
 let is_action_logged: UpdateAction.t => bool =
   fun
-  | UpdateDoubleTap(_)
   | Mousedown
   | Mouseup
   | Save

--- a/src/haz3lweb/Main.re
+++ b/src/haz3lweb/Main.re
@@ -146,9 +146,9 @@ module App = {
       ~on_display=(_, ~schedule_action) => {
         if (edit_action_applied^
             && JsUtil.timestamp()
-            -. last_edit_action^ > 2000.0) {
+            -. last_edit_action^ > 1000.0) {
           /* If an edit action has been applied, but no other edit action
-             has been applied for 2 seconds, save the model. */
+             has been applied for 1 second, save the model. */
           edit_action_applied := false;
           print_endline("Saving...");
           schedule_action(Update.Save);

--- a/src/haz3lweb/Model.re
+++ b/src/haz3lweb/Model.re
@@ -11,7 +11,6 @@ type t = {
   font_metrics: FontMetrics.t,
   logo_font_metrics: FontMetrics.t,
   show_backpack_targets: bool,
-  double_tap: option(timestamp),
   mousedown: bool,
   langDocMessages: LangDocMessages.t,
 };
@@ -26,7 +25,6 @@ let mk = editors => {
   font_metrics: FontMetrics.init,
   logo_font_metrics: FontMetrics.init,
   show_backpack_targets: false,
-  double_tap: None,
   mousedown: false,
   langDocMessages: LangDocMessages.init,
 };

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -160,7 +160,7 @@ let perform_action = (model: Model.t, a: Action.t): Result.t(Model.t) =>
   | Ok(ed) =>
     let model = {...model, editors: Editors.put_editor(ed, model.editors)};
     /* Note: Not saving here as saving is costly to do each keystroke,
-       we wait until 2 seconds after the last edit action (see Main.re) */
+       we wait a second after the last edit action (see Main.re) */
     Ok(model);
   };
 

--- a/src/haz3lweb/UpdateAction.re
+++ b/src/haz3lweb/UpdateAction.re
@@ -21,7 +21,6 @@ type benchmark_action =
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t =
   | Set(settings_action)
-  | UpdateDoubleTap(option(float))
   | Mousedown
   | Mouseup
   | InitImportAll([@opaque] Js_of_ocaml.Js.t(Js_of_ocaml.File.file))

--- a/src/haz3lweb/UpdateAction.re
+++ b/src/haz3lweb/UpdateAction.re
@@ -67,3 +67,11 @@ module Result = {
   include Result;
   type t('success) = Result.t('success, Failure.t);
 };
+
+let is_edit: t => bool =
+  fun
+  | Cut
+  | Undo
+  | Redo
+  | PerformAction(Insert(_) | Destruct(_) | Pick_up | Put_down) => true
+  | _ => false;

--- a/src/haz3lweb/view/BackpackView.re
+++ b/src/haz3lweb/view/BackpackView.re
@@ -32,7 +32,7 @@ let backpack_sel_view =
         ),
       ]),
     // zwsp necessary for containing box to stretch to contain trailing newline
-    Text.of_segment(Any, content) @ [text(Unicode.zwsp)],
+    Text.of_segment(true, Any, content) @ [text(Unicode.zwsp)],
   );
 };
 

--- a/src/haz3lweb/view/BackpackView.re
+++ b/src/haz3lweb/view/BackpackView.re
@@ -32,8 +32,7 @@ let backpack_sel_view =
         ),
       ]),
     // zwsp necessary for containing box to stretch to contain trailing newline
-    Text.of_segment(~sort=Any, ~no_sorts=true, content)
-    @ [text(Unicode.zwsp)],
+    Text.of_segment(Any, content) @ [text(Unicode.zwsp)],
   );
 };
 

--- a/src/haz3lweb/view/Cell.re
+++ b/src/haz3lweb/view/Cell.re
@@ -174,6 +174,8 @@ let deco =
     (
       ~zipper,
       ~measured,
+      ~term_ranges,
+      ~unselected,
       ~segment,
       ~font_metrics,
       ~show_backpack_targets,
@@ -182,7 +184,6 @@ let deco =
       ~test_results: option(Interface.test_results),
       ~color_highlighting: option(ColorSteps.colorMap),
     ) => {
-  let unselected = Zipper.unselect_and_zip(zipper);
   module Deco =
     Deco.Deco({
       let font_metrics = font_metrics;
@@ -190,7 +191,7 @@ let deco =
       let show_backpack_targets = show_backpack_targets;
       let (_term, terms) = MakeTerm.go(unselected);
       let info_map = info_map;
-      let term_ranges = TermRanges.mk(unselected);
+      let term_ranges = term_ranges;
       let tiles = TileMap.mk(unselected);
     });
   let decos = selected ? Deco.all(zipper, segment) : Deco.err_holes(zipper);
@@ -269,6 +270,7 @@ let editor_view =
   //~eval_result: option(option(DHExp.t))
 
   let zipper = editor.state.zipper;
+  let term_ranges = editor.state.meta.term_ranges;
   let segment = Zipper.zip(zipper);
   let unselected = Zipper.unselect_and_zip(zipper);
   let measured = editor.state.meta.measured;
@@ -284,7 +286,9 @@ let editor_view =
   let deco_view =
     deco(
       ~zipper,
+      ~unselected,
       ~measured,
+      ~term_ranges,
       ~segment,
       ~font_metrics,
       ~show_backpack_targets,

--- a/src/haz3lweb/view/Code.re
+++ b/src/haz3lweb/view/Code.re
@@ -55,8 +55,9 @@ let of_secondary =
    the memoization in place for delims and secondary above as it still
    seems like a marginal positive (5-10% difference).
 
-   TODO(andrew): Consider setting a limit for the hashtbl size? */
-let piece_hash = Hashtbl.create(10000);
+   TODO(andrew): Consider setting a limit for the hashtbl size */
+let piece_hash: Hashtbl.t((Sort.t, Piece.t), list(t)) =
+  Hashtbl.create(10000);
 
 module Text = (M: {
                  let map: Measured.t;

--- a/src/haz3lweb/view/Deco.re
+++ b/src/haz3lweb/view/Deco.re
@@ -258,7 +258,7 @@ module Deco =
 
   // recurses through skel structure to enable experimentation
   // with hiding nested err holes
-  let err_holes = (z: Zipper.t) => {
+  let _err_holes = (z: Zipper.t) => {
     let seg = Zipper.unselect_and_zip(z);
     let is_err = (id: Id.t) =>
       switch (Id.Map.find_opt(id, M.info_map)) {
@@ -296,6 +296,17 @@ module Deco =
       go_skel(Segment.skel(seg)) @ bi_ids;
     };
     go_seg(seg) |> List.map(term_highlight(~clss=["err-hole"]));
+  };
+
+  // faster infomap traversal
+  let err_holes = (_z: Zipper.t) => {
+    Id.Map.fold(
+      (id, info, acc) =>
+        Info.is_error(info)
+          ? [term_highlight(~clss=["err-hole"], id), ...acc] : acc,
+      M.info_map,
+      [],
+    );
   };
 
   let all = (zipper, sel_seg) =>

--- a/src/haz3lweb/view/Deco.re
+++ b/src/haz3lweb/view/Deco.re
@@ -302,8 +302,19 @@ module Deco =
   let err_holes = (_z: Zipper.t) => {
     Id.Map.fold(
       (id, info, acc) =>
-        Info.is_error(info)
-          ? [term_highlight(~clss=["err-hole"], id), ...acc] : acc,
+        /* Because of artefacts in Maketerm ID handling,
+         * there are be situations where ids appear in the
+         * info_map which do not occur in term_ranges. These
+         * ids should be purely duplicative, so skipping them
+         * when iterating over the info_map should have no
+         * effect, beyond supressing the resulting Not_found exs */
+        switch (Id.Map.find_opt(id, M.term_ranges)) {
+        | Some(_) when Info.is_error(info) => [
+            term_highlight(~clss=["err-hole"], id),
+            ...acc,
+          ]
+        | _ => acc
+        },
       M.info_map,
       [],
     );


### PR DESCRIPTION
Currently offers an up to an order-of-magnitude speedup on best-case edit action keystrokes

The biggest gains are due to eliminating extraneous Incr_dom cycles happening on ~ every keystroke:

- Due to the legacy doubletap detection, every KeyUp event was triggering a new cycle. Removing this gives a ~50%+ overall speedup
- Saving was happening every keystroke, in fact sometimes twice (on keyup as well). This was a double-whammy, as saving on edit actions was being done in Keyboard by scheduling an additional event. The ability of the key handlers to return a list of updates, each of which triggers a full incr_dom cycle, is a moral hazard and has been removed; each key event now returns an option(Action) instead. Saving also no longer happens after every edit action; rather it happens 1 second after the last edit action happened. Together this is a ~200-400% overall speedup.
- There was a check in the on_display hook which scrolled the caret into view which was gated on detecting a change in the model. This is expensive, not because of the model comparison, but simply because the old_model is in the Incr monad, and mapping into Incr triggers a cycle. Removing this check gives a ~50% speedup.

Other gains:

- 5x speedup to Paste by bypassing Editor Meta recalculation
- Huge speedup in very imbalanced states by memoizing Backpack.shard_info
- 10x speedup in Holes Deco by just scanning info_map instead of recursing
- 2x speedup for Termranges.mk; was called twice with no memoization. I now passing it through directly as it's clean to do so, but I also memoized it defensively
- 60% speedup for Code.view by recursively memoizing Text.of_tile
- 30% speedup for MakeTerm by memoizing Skel.mk

Remaining possible speedups:

- Logging: Gets slow with lots of entries. With localstore you can't just append, you need to set. Could switch to a system for which each entry gets its own a KV pair of something.
- Saving Editors to LocalStorage: I caused a bit of a regression when I moved to serializing the entire Editors. Probably not a priority with the new save delay system, but could use some TLC eventually.
- Backpack: If we are still experiencing too much slowdown in unbalanced states, shard_info could be greatly speeded up if we were to eliminate unrestricted pick-up functionality (i.e. the ability to have backpack selections containing multiple shards)
- Maketerm: The recursion structure in Maketerm makes recursive memoization difficult. We want to memoize something that's likely to have physical equality i.e. substructures which are likely literally preserved over edits, like segments or tiles. But the core Maketerm functions (go_s, unsorted) take both a segment and a skel as arguments; since the skel is derived, we're never going to have physical equality for substructures if the superstructure changes. I'm wondering if it's possible to internalize skel generation to these functions; instead of sending in a skel, send in a subsegment
- PtMaps/Maps/Hashtbls: Replace remaining ptmap use with plain maps and/or replace maps use with hashtbls everywhere. I'm unsure as to the overall impact but it could be significant; probably worth doing more bottom-up profiling. As a stopgap we're still unioning in some places which could be turned into traversals (e.g. TermRanges)
- Elaboration Views: Right now turning off dynamics can slow things down as it takes time to render large elaborations. This is partially addressed in `llmass` as it makes it possible to actually turn of statics, resulting in no elaboration being generated. There should probably be a separate toggle for elaboration though.
- Zipper pass fusion: In general we could probably consider some more structured architecture for passes over the zipper. Currently we have MakeTerm, Measured, TermRanges, and Code.view which all do zipper passes. Two or more of these could potentially be fused into a single 'SyntaxInfo' pass. SyntaxInfo could potentially collect some information which is either being reproduced ad-hoc in many places (expected sort) or currently lives in static info (term, cls, list of ancestor ids)