### PR TITLE
Undarken holes

### DIFF
--- a/src/haz3lcore/lang/Form.re
+++ b/src/haz3lcore/lang/Form.re
@@ -69,7 +69,7 @@ let mk_nul_infix = (t: Token.t, prec) =>
 /* Token Recognition Predicates */
 let is_arbitary_int = regexp("^-?\\d+[0-9_]*$");
 let is_arbitary_float = x =>
-  x != "." && regexp("^-?[0-9]*\\.?[0-9]*((e|E)-?[0-9]*)?$", x);
+  x != "." && x != "-" && regexp("^-?[0-9]*\\.?[0-9]*((e|E)-?[0-9]*)?$", x);
 let is_int = str => is_arbitary_int(str) && int_of_string_opt(str) != None;
 /* NOTE: The is_arbitary_int check is necessary to prevent
    minuses from being parsed as part of the int token. */

--- a/src/haz3lcore/lang/Form.re
+++ b/src/haz3lcore/lang/Form.re
@@ -94,14 +94,12 @@ let is_ctr = is_capitalized_name;
 let base_typs = ["String", "Int", "Float", "Bool"];
 let is_base_typ = regexp("^(" ++ String.concat("|", base_typs) ++ ")$");
 let is_typ_var = is_capitalized_name;
-let is_partial_base_typ = x => !is_base_typ(x) && is_capitalized_name(x);
 let wild = "_";
 let is_wild = regexp("^" ++ wild ++ "$");
 
 /* The below case represents tokens which we want the user to be able to
    type in, but which have no reasonable semantic interpretation */
-let is_bad_lit = str =>
-  is_bad_int(str) || is_bad_float(str) || is_partial_base_typ(str);
+let is_bad_lit = str => is_bad_int(str) || is_bad_float(str);
 
 /* is_string: last clause is a somewhat hacky way of making sure
    there are at most two quotes, in order to prevent merges */

--- a/src/haz3lcore/statics/MakeTerm.re
+++ b/src/haz3lcore/statics/MakeTerm.re
@@ -34,45 +34,6 @@ type unsorted =
   | Post(t, tiles)
   | Bin(t, tiles, t);
 
-type dark_id = int;
-let dark_gen = ref(-1);
-let dark_id = () => {
-  let id = dark_gen^;
-  dark_gen := id - 1;
-  id;
-};
-let dark_hole = (~ids=[], s: Sort.t): t => {
-  let id = dark_id();
-  switch (s) {
-  // put dark id last to avoid messing with rep id
-  | Exp => Exp({ids: ids @ [id], term: EmptyHole})
-  | _ => failwith("dark_hole todo")
-  };
-};
-
-// TODO flesh out incomplete cases
-// TODO review dark hole
-let _complete_root =
-  fun
-  | Op(_) as root => root
-  | Pre(tiles, r) as root =>
-    switch (tiles) {
-    | ([(id, tile)], []) =>
-      switch (tile) {
-      | (["("], []) => Op(single(id, (["(", ")"], [r])))
-      | (["let"], []) =>
-        Pre(
-          single(id, (Labels.let_, [r, dark_hole(Exp)])),
-          dark_hole(Exp),
-        )
-      | (["let", "="], [pat]) =>
-        Pre(single(id, (Labels.let_, [pat, r])), dark_hole(Exp))
-      | _ => root
-      }
-    | _ => root
-    }
-  | root => root;
-
 let is_nary =
     (is_sort: any => option('sort), delim: Token.t, (delims, kids): tiles)
     : option(list('sort)) =>
@@ -140,11 +101,6 @@ let return = (wrap, ids, tm) => {
   map := TermMap.add_all(ids, wrap(tm), map^);
   tm;
 };
-let return_dark_hole = (~ids=[], s) => {
-  let hole = dark_hole(~ids, s);
-  map := TermMap.add_all(Term.ids(hole), hole, map^);
-  hole;
-};
 
 let parse_sum_term: UTyp.t => UTyp.variant =
   fun
@@ -165,13 +121,13 @@ let rec go_s = (s: Sort.t, skel: Skel.t, seg: Segment.t): any =>
     let tm = unsorted(skel, seg);
     let ids = ids(tm);
     switch (ListUtil.hd_opt(ids)) {
-    | None => return_dark_hole(Exp)
+    | None => Exp(exp(unsorted(skel, seg)))
     | Some(id) =>
       switch (TileMap.find_opt(id, TileMap.mk(seg))) {
-      | None => return_dark_hole(~ids, Exp)
+      | None => Exp(exp(unsorted(skel, seg)))
       | Some(t) =>
         if (t.mold.out == Any) {
-          return_dark_hole(~ids, Exp);
+          Exp(exp(unsorted(skel, seg)));
         } else {
           go_s(t.mold.out, skel, seg);
         }

--- a/src/haz3lweb/view/Deco.re
+++ b/src/haz3lweb/view/Deco.re
@@ -62,8 +62,6 @@ module Deco =
       // TermIds.find(Piece.id(p), M.terms)
       Id.Map.find(Piece.id(p), M.terms)
       |> Term.ids
-      // filter out dark ids (see MakeTerm)
-      |> List.filter(id => id >= 0)
       |> List.map(id => {
            let t = tile(id);
            (id, t.mold, Measured.find_shards(t, M.map));


### PR DESCRIPTION
@dm0n3y could you take a look at this? It's an attempt to remove dark holes while retaining the behavior as I understand it (which is not very well). Basically in the case where I can't figure out a reasonable sort I just go with Exp instead of the dark hole thing; not sure if this might cause problems I'm not anticipating.

The reason I'm trying to make this change is that in my UUID branch I'm getting Not_found exceptions due to the fact I had to remove dark hole filtering. I seem to be getting these in a pretty specific case: Exactly when you have an Any-sorted operand inside a multihole. These are pretty liminal cases; the representative examples are:

- `11111111111><1` (first operand is too big to be an integer; is classified by bad_lit mold and gets assigned Any sort)
- `.><1` (we need to allow a dot on its own to be able to enter floats; is classified by bad_float mold with Any sort)
