### PR TITLE
IndexedDB Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ independent of the one you sent in your home directory. This allow you to
 alternate dependencies, or test dependencies changes, without affect
 existing OCaml projects.
 
+NOTE: You may see the following warning when building:
+
+```
+Warning 58 [no-cmx-file]: no cmx file was found in path for module Ezjs_idb, and its interface was not compiled with -opaque
+```
+
+This is due to an upstream library issue and does not cause problems with Hazel: 
+
+  https://github.com/OCamlPro/ezjs_idb/issues/1
+
 ### Debugging
 
 #### Printing

--- a/opam.export
+++ b/opam.export
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 compiler: ["ocaml-base-compiler.5.0.0"]
 roots: [
+  "ezjs_idb.0.1.1"
   "incr_dom.v0.15.1"
   "lwt.5.6.1"
   "lwt-dllist.1.0.1"
@@ -39,6 +40,8 @@ installed: [
   "camlp-streams.5.0.1"
   "chrome-trace.3.7.0"
   "cmdliner.1.1.1"
+  "conf-autoconf.0.1"
+  "conf-which.1"
   "core.v0.15.1"
   "core_kernel.v0.15.0"
   "cppo.1.6.9"
@@ -51,6 +54,8 @@ installed: [
   "dune-rpc.3.6.2"
   "dyn.3.6.2"
   "either.1.0.0"
+  "ezjs_idb.0.1.1"
+  "ezjs_min.0.3.0"
   "ezjsonm.1.3.0"
   "fiber.3.6.2"
   "fieldslib.v0.15.0"

--- a/src/haz3lweb/Export.re
+++ b/src/haz3lweb/Export.re
@@ -20,21 +20,15 @@ type all_f22 = {
 };
 
 let mk_all = (~instructor_mode, ~log) => {
-  print_endline("Mk all");
   let settings = Store.Settings.export();
-  print_endline("Settings OK");
   let langDocMessages = Store.LangDocMessages.export();
-  print_endline("LangDocMessages OK");
   let scratch = Store.Scratch.export();
-  print_endline("Scratch OK");
   let examples = Store.Examples.export();
-  print_endline("Examples OK");
   let exercise =
     Store.Exercise.export(
       ~specs=ExerciseSettings.exercises,
       ~instructor_mode,
     );
-  print_endline("Exercise OK");
   {settings, langDocMessages, scratch, examples, exercise, log};
 };
 

--- a/src/haz3lweb/Export.re
+++ b/src/haz3lweb/Export.re
@@ -19,7 +19,7 @@ type all_f22 = {
   log: string,
 };
 
-let mk_all = (~instructor_mode) => {
+let mk_all = (~instructor_mode, ~log) => {
   print_endline("Mk all");
   let settings = Store.Settings.export();
   print_endline("Settings OK");
@@ -35,12 +35,11 @@ let mk_all = (~instructor_mode) => {
       ~instructor_mode,
     );
   print_endline("Exercise OK");
-  let log = Log.export();
   {settings, langDocMessages, scratch, examples, exercise, log};
 };
 
-let export_all = (~instructor_mode) => {
-  mk_all(~instructor_mode) |> yojson_of_all;
+let export_all = (~instructor_mode, ~log) => {
+  mk_all(~instructor_mode, ~log) |> yojson_of_all;
 };
 
 let import_all = (data, ~specs) => {

--- a/src/haz3lweb/Log.re
+++ b/src/haz3lweb/Log.re
@@ -1,61 +1,6 @@
-/*
-   Logging system for actions. Persists log in local storage.
-
-   Careful: local storage has a maximum size of around 5MB in most browsers. Once
-   this limit is exceeded, remaining entries are printed to console rather than
-   persisted.
- */
+/* Logging system for actions. Persists log via IndexedDB */
 
 open Sexplib.Std;
-open Ezjs_min;
-open Ezjs_idb;
-open Types;
-
-module Store = Store(StringTr, StringTr);
-
-let test_db = "test_db";
-let test_table = "test_table";
-
-let upgrade = (db: t(iDBDatabase), e) =>
-  if (e.new_version >= 1 && e.old_version == 0) {
-    ignore @@ Store.create(db, test_table);
-  };
-
-let error = _e => print_endline("error: ");
-
-let add = db => {
-  let st = Store.store(~mode=READWRITE, db, test_table);
-  let key = "test-key";
-  let value = "test-value";
-  Store.add(
-    ~key,
-    ~callback=key => print_endline("added key:" ++ key),
-    st,
-    value,
-  );
-};
-
-let get = db => {
-  let st = Store.store(~mode=READWRITE, db, test_table);
-  let key = "test-key";
-  Store.get_key(
-    ~error,
-    st,
-    v =>
-      switch (v) {
-      | None => print_endline("key not found")
-      | Some(v) => print_endline("value:" ++ v)
-      },
-    K(key),
-  );
-};
-
-let doo = {
-  print_endline("adding to db");
-  openDB(~upgrade, ~error, ~version=1, test_db, db => add(db));
-  print_endline("getting from db");
-  openDB(~upgrade, ~error, ~version=1, test_db, db => get(db));
-};
 
 let is_action_logged: UpdateAction.t => bool =
   fun
@@ -70,108 +15,102 @@ let is_action_logged: UpdateAction.t => bool =
   | UpdateResult(_)
   | DebugAction(_)
   | ExportPersistentData
-  | Benchmark(_) => false
-  | ReparseCurrentEditor
-  | Set(_)
   | FinishImportAll(_)
   | FinishImportScratchpad(_)
-  | ResetCurrentEditor
+  | Benchmark(_) => false
+  | Set(_)
   | SetMode(_)
+  | UpdateLangDocMessages(_)
   | SwitchScratchSlide(_)
   | SwitchExampleSlide(_)
   | SwitchEditor(_)
+  | ResetCurrentEditor
+  | ReparseCurrentEditor
   | PerformAction(_)
   | Cut
   | Copy
   | Paste(_)
   | Undo
   | Redo
-  | MoveToNextHole(_)
-  | UpdateLangDocMessages(_) => true;
+  | MoveToNextHole(_) => true;
 
-let storage_key = "LOG_" ++ ExerciseSettings.log_key;
-let max_log_string_length = 4_750_000; // based on 5MB limit on localstore in browser
+module DB = {
+  open Ezjs_idb;
+
+  module Store = Ezjs_idb.Store(StringTr, StringTr);
+
+  type db = Ezjs_min.t(Types.iDBDatabase);
+
+  let db_name = "hazel_db";
+  let table_name = "log";
+
+  let kv_store = (db: db): Store.store =>
+    Store.store(~mode=READWRITE, db, table_name);
+
+  let with_db = (f): unit => {
+    let error = _: unit => print_endline("ERROR: Log.IDBKV.open");
+    let upgrade = (db: db, e: db_upgrade): unit =>
+      e.new_version >= 1 && e.old_version == 0
+        ? ignore(Store.create(db, table_name)) : ();
+    openDB(~upgrade, ~error, ~version=1, db_name, db => f(db));
+  };
+
+  let add = (key: string, value: string): unit =>
+    with_db(db =>
+      Store.add(~key, ~callback=_key => (), kv_store(db), value)
+    );
+
+  let get = (key: string, f: option(string) => unit): unit => {
+    let error = _ => Printf.printf("ERROR: Log.IDBKV.get");
+    with_db(db => Store.get(~error, kv_store(db), f, K(key)));
+  };
+
+  let get_all = (f: list(string) => unit): unit => {
+    let error = _ => Printf.printf("ERROR: Log.IDBKV.get_all");
+    with_db(db => Store.get_all(~error, kv_store(db), f));
+  };
+
+  let clear_and = (callback): unit => {
+    let error = _ => Printf.printf("ERROR: Log.IDBKV.clear");
+    with_db(db => Store.clear(~error, ~callback, kv_store(db)));
+  };
+};
 
 module Entry = {
   [@deriving (show({with_path: false}), yojson, sexp)]
   type t = (Model.timestamp, UpdateAction.t);
 
+  [@deriving (show({with_path: false}), yojson, sexp)]
+  type s = list(t);
+
   let mk = (update): t => {
     (JsUtil.timestamp(), update);
   };
 
-  let to_string = ((timestamp, update): t) => {
-    /*let status =
-      switch (entry.error) {
-      | None => "SUCCESS"
-      | Some(failure) => "FAILURE(" ++ UpdateAction.Failure.show(failure) ++ ")"
-      };*/
-    Printf.sprintf(
-      "%.0f: %s",
-      timestamp,
-      UpdateAction.show(update),
-      //status,
+  let save = ((ts, action): t) =>
+    DB.add(
+      Printf.sprintf("%.0f", ts),
+      (ts, action) |> sexp_of_t |> Sexplib.Sexp.to_string,
     );
-  };
-
-  let serialize = (entry: t): string => {
-    entry |> sexp_of_t |> Sexplib.Sexp.to_string;
-  };
-
-  let deserialize = (s: string): t => {
-    s |> Sexplib.Sexp.of_string |> t_of_sexp;
-  };
 };
 
-let init_log = () => {
-  JsUtil.set_localstore(storage_key, "");
-};
+let import = (data: string): unit =>
+  /* Should be fine to fire saves concurrently? */
+  DB.clear_and(() =>
+    try(
+      data
+      |> Sexplib.Sexp.of_string
+      |> Entry.s_of_sexp
+      |> List.iter(Entry.save)
+    ) {
+    | _ => Printf.printf("Log.Entry.import: Deserialization error")
+    }
+  );
 
-let rec get_log_string = () => {
-  switch (JsUtil.get_localstore(storage_key)) {
-  | Some(log) => log
-  | None =>
-    init_log();
-    get_log_string();
-  };
-};
-
-let append_entry = (entry: Entry.t) => {
-  let log_string = get_log_string();
-  let entry_string = Entry.serialize(entry);
-  let new_log_string = log_string ++ entry_string;
-  if (String.length(new_log_string) >= max_log_string_length) {
-    print_endline("Log limit exceeded. Printing new entries to console.");
-    print_endline("Log entry: " ++ entry_string);
-  } else {
-    JsUtil.set_localstore(storage_key, new_log_string);
-  };
-};
-
-[@deriving sexp]
-type entries = list(Entry.t);
-
-let logstring_to_entries = (s: string) => {
-  // make the adjacent entries into a single list and deserialize as an sexp
-  "(" ++ s ++ ")" |> Sexplib.Sexp.of_string |> entries_of_sexp;
-};
-
-let entries_to_logstring = (entries: entries): string => {
-  let s = entries |> sexp_of_entries |> Sexplib.Sexp.to_string;
-  // chop off leading and trailing parens
-  String.sub(s, 1, String.length(s) - 2);
-};
-
-let export = () => {
-  get_log_string();
-};
-
-let import = data => {
-  JsUtil.set_localstore(storage_key, data);
-};
-
-let update = (action: UpdateAction.t) =>
+let update = (action: UpdateAction.t): unit =>
   if (is_action_logged(action)) {
-    let new_entry = Entry.mk(action);
-    append_entry(new_entry);
+    Entry.save(Entry.mk(action));
   };
+
+let get_and = (f: string => unit): unit =>
+  DB.get_all(entries => f("(" ++ String.concat(" ", entries) ++ ")"));

--- a/src/haz3lweb/ProgramEvaluator.re
+++ b/src/haz3lweb/ProgramEvaluator.re
@@ -114,7 +114,12 @@ module WorkerPool: M with type response = (key, option(eval_result)) = {
 
   type t = Pool.t;
 
-  let max = 10;
+  /* NOTE(andrew): I set this from 10 to 0 since these guys
+   * aren't doing anything atm. Plus the indexedDB library
+   * shits up the console trying to access window on threads
+   * which don't have one. */
+  let max = 0;
+
   let timeout = 2000; /* ms */
 
   let init = () => {

--- a/src/haz3lweb/dune
+++ b/src/haz3lweb/dune
@@ -12,6 +12,8 @@
   \
   Worker)
  (libraries
+  ezjs_min
+  ezjs_idb
   str
   incr_dom
   virtual_dom.input_widgets

--- a/src/haz3lweb/view/Page.re
+++ b/src/haz3lweb/view/Page.re
@@ -5,10 +5,12 @@ open Util.Web;
 open Haz3lcore;
 open Widgets;
 
-let download_editor_state = (~instructor_mode) => {
-  let data = Export.export_all(~instructor_mode);
-  JsUtil.download_json(ExerciseSettings.filename, data);
-};
+let download_editor_state = (~instructor_mode) =>
+  Log.get_and(log => {
+    let data = Export.export_all(~instructor_mode, ~log);
+    JsUtil.download_json(ExerciseSettings.filename, data);
+  });
+
 let menu_icon = {
   let attr =
     Attr.many(


### PR DESCRIPTION
Closes #988.

This replaces localstorage logging with an IndexedDB table. PKs are (string) timestamps, entries are the existing Log.Entry data structure, serialized to strings via sexps.

This passes my basic functionality and perf tests. I haven't tried to test it at scale (1000s of actions). I'm not worried about updating, that should be far more efficient now, but exporting and importing might be interesting. Importing in particular fires as many queries as there are log entries in the imported file.

I disabled the webworkers (since they're not doing anything), as otherwise the IndexedDB library fills the console with (non-fatal) errors about trying to access window (IndexedDB is accessed via window.indexedDB). This is thrown from a callback, not sure how to fix this without forking the library.

One outstanding issue: On compilation I get the message:
`Warning 58 [no-cmx-file]: no cmx file was found in path for module Ezjs_idb, and its interface was not compiled with -opaque`
Not sure how to suppress this.

