### PR TITLE
Fix wrong decomposition of constructor application

### DIFF
--- a/src/haz3lweb/LangDocMessages.re
+++ b/src/haz3lweb/LangDocMessages.re
@@ -3452,8 +3452,6 @@ let find = (p: 'a => bool, xs: list('a), err: string): 'a =>
   };
 
 let get_group = (group_id, doc: t) => {
-  print_endline("get group: " ++ group_id);
-  List.iter(((id, _)) => print_endline("has group: " ++ id), doc.groups);
   let (_, form_group) =
     find(
       ((id, _)) => id == group_id,


### PR DESCRIPTION
Buggy case:
```
type IntList =
  + Cons(Int,IntList)
  + Empty
in
let length : IntList -> Int =
  fun x -> case x
    | Cons(y,ys) => length(ys) + 1
    | Empty => 0
  end
in
length(Cons(2,Cons(1,Empty)))
```

Old implementation will stuck stepping the application of constructor onto a literal. Now can proceed.