### PR TITLE
Error flag for case expressions' associated DHExp

### DIFF
--- a/src/haz3lcore/dynamics/DH.re
+++ b/src/haz3lcore/dynamics/DH.re
@@ -8,7 +8,7 @@ module rec DHExp: {
     | ExpandingKeyword(MetaVar.t, HoleInstanceId.t, ExpandingKeyword.t)
     | FreeVar(MetaVar.t, HoleInstanceId.t, Var.t)
     | InvalidText(MetaVar.t, HoleInstanceId.t, string)
-    | InconsistentBranches(MetaVar.t, HoleInstanceId.t, case)
+    | InconsistentBranches(MetaVar.t, HoleInstanceId.t, case) // TODO: merge
     | Closure([@opaque] ClosureEnvironment.t, t)
     | BoundVar(Var.t)
     | Sequence(t, t)
@@ -32,13 +32,13 @@ module rec DHExp: {
     | Tuple(list(t))
     | Prj(t, int)
     | Constructor(string)
-    | ConsistentCase(case)
-    | InexhaustiveCase(MetaVar.t, HoleInstanceId.t, case)
+    | ConsistentCase(case) // TODO: merge
+    | InexhaustiveCase(MetaVar.t, HoleInstanceId.t, case) // TODO: merge
     | Cast(t, Typ.t, Typ.t)
     | FailedCast(t, Typ.t, Typ.t)
     | InvalidOperation(t, InvalidOperationError.t)
   and case =
-    | Case(t, list(rule), int)
+    | Case(t, list(rule), int) // TODO: merge
   and rule =
     | Rule(DHPat.t, t);
 
@@ -127,9 +127,9 @@ module rec DHExp: {
     | Tuple(_) => "Tuple"
     | Prj(_) => "Prj"
     | Constructor(_) => "Constructor"
-    | ConsistentCase(_) => "ConsistentCase"
-    | InexhaustiveCase(_, _, _) => "InexhaustiveCase"
-    | InconsistentBranches(_, _, _) => "InconsistentBranches"
+    | ConsistentCase(_) => "ConsistentCase" // TODO: merge
+    | InexhaustiveCase(_, _, _) => "InexhaustiveCase" // TODO: merge
+    | InconsistentBranches(_, _, _) => "InconsistentBranches" // TODO: merge
     | Cast(_, _, _) => "Cast"
     | FailedCast(_, _, _) => "FailedCast"
     | InvalidOperation(_) => "InvalidOperation"

--- a/src/haz3lcore/dynamics/DH.re
+++ b/src/haz3lcore/dynamics/DH.re
@@ -93,7 +93,7 @@ module rec DHExp: {
     | FailedCast(t, Typ.t, Typ.t)
     | InvalidOperation(t, InvalidOperationError.t)
   and case =
-    | Case(t, list(rule), int)
+    | Case(t, list(rule), int) // TODO
   and rule =
     | Rule(DHPat.t, t);
 


### PR DESCRIPTION
This pull request aims to merge the three different case constructs in `DHExp` into one case construct.

The new approach will replace 
`DHExp.ConsistentCase(DHExp.case)`,
`DHExp.InconsistentBranches(MetaVar.t, HoleInstanceId.t, DHExp.case)`,
`DHExp.InexhaustiveCase(MetaVar.t, HoleInstanceId.t, DHExp.case)` (added for #1124),
and `DHExp.case.Case(t, list(rule), int)`

with `DHExp.Case(t, list(rule), int, option((MetaVar.t, HoleInstanceId.t)))`, in which the last parameter indicates whether the corresponding case expression is inconsistent.

Two concerns:
* Do we need to preserve the ability to distinguish consistent/inconsistent case expressions with `DHExp.constructor_string`? If so, the new `Case` construct, as well as the function `DHExp.constructor_string` would be a little bit more complex.
* Do we need to preserve the ability to have different inconsistent case expressions behave (dynamically) differently? If so, `option` might not be enough.