### PR TITLE
Module alias

### DIFF
--- a/src/haz3lcore/dynamics/Elaborator.re
+++ b/src/haz3lcore/dynamics/Elaborator.re
@@ -251,13 +251,31 @@ let rec dhexp_of_uexp =
         let* ddef = dhexp_of_uexp(m, def);
         let* dbody = dhexp_of_uexp(m, body);
         let+ ty_body = fixed_exp_typ(m, body);
+        /* if get module type, apply alias(Let).*/
+        let is_alias =
+          switch (Id.Map.find_opt(Term.UExp.rep_id(def), m)) {
+          | Some(InfoExp({ty, _})) =>
+            switch (ty) {
+            | Module(_) => true
+            | _ => false
+            }
+          | _ => false
+          };
         switch (Term.UPat.get_recursive_bindings(p)) {
         | None =>
           /* not recursive */
-          DHExp.Module(dp, ddef, dbody)
+          if (is_alias) {
+            DHExp.Let(dp, ddef, dbody);
+          } else {
+            DHExp.Module(dp, ddef, dbody);
+          }
         | Some([f]) =>
           /* simple recursion */
-          Module(dp, FixF(f, ty_body, add_name(Some(f), ddef)), dbody)
+          if (is_alias) {
+            Let(dp, FixF(f, ty_body, add_name(Some(f), ddef)), dbody);
+          } else {
+            Module(dp, FixF(f, ty_body, add_name(Some(f), ddef)), dbody);
+          }
         | Some(fs) =>
           /* mutual recursion */
           let ddef =
@@ -279,7 +297,11 @@ let rec dhexp_of_uexp =
                  },
                  (0, ddef),
                );
-          Module(dp, FixF(self_id, ty_body, substituted_def), dbody);
+          if (is_alias) {
+            Let(dp, FixF(self_id, ty_body, substituted_def), dbody);
+          } else {
+            Module(dp, FixF(self_id, ty_body, substituted_def), dbody);
+          };
         };
       | Dot(e_mod, e_mem) =>
         let* e_mod = dhexp_of_uexp(m, e_mod);

--- a/src/haz3lcore/statics/Statics.re
+++ b/src/haz3lcore/statics/Statics.re
@@ -318,8 +318,14 @@ and uexp_to_info_map =
     let (p_syn, _) =
       go_pat(~is_synswitch=true, ~co_ctx=CoCtx.empty, ~mode=Syn, p, m);
     let def_ctx = extend_let_def_ctx(ctx, p, p_syn.ctx, def);
+
+    let (def1, m1) = go(~mode=Syn, def, m);
     let (inner_ctx, def, m) =
-      go_module(~ctx=def_ctx, ~mode=Mode.Ana(p_syn.ty), def, m, []);
+      switch (def1.ty) {
+      /* if get module type, apply alias.*/
+      | Module(module_ctx) => (module_ctx, def1, m1)
+      | _ => go_module(~ctx=def_ctx, ~mode=Mode.Ana(p_syn.ty), def, m, [])
+      };
     /* Analyze pattern to incorporate def type into ctx */
     let (p_ana, m) =
       go_pat(
@@ -890,8 +896,13 @@ and uexp_to_module =
       | SynFun => p_syn.ty
       };
     let def_ctx = extend_let_def_ctx(ctx, p, p_syn.ctx, def);
+    let (def1, m1) = go(~mode=Syn, def, m);
     let (inner_ctx, def, m) =
-      go_module(~ctx=def_ctx, ~mode=Mode.Ana(ty_pat), def, m, []);
+      switch (def1.ty) {
+      /* if get module type, apply alias.*/
+      | Module(module_ctx) => (module_ctx, def1, m1)
+      | _ => go_module(~ctx=def_ctx, ~mode=Mode.Ana(ty_pat), def, m, [])
+      };
     let typ_def: Typ.t = Module(inner_ctx);
     let ty_def =
       switch (mode_pat) {


### PR DESCRIPTION
Add module alias to work with functions.
`Module` keyword now automatically applies alias if the definition exp has module type (instead of generate from context).
<img width="243" alt="{D9CF2EFF-848F-44a2-A4EF-ED822AFEB3E7}" src="https://github.com/hazelgrove/hazel/assets/71319371/34605d80-7644-4016-bc90-d8de24445979">
