### PR TITLE
fix exercise export

### DIFF
--- a/src/haz3lschool/Exercise.re
+++ b/src/haz3lschool/Exercise.re
@@ -24,13 +24,10 @@ module F = (ExerciseEnv: ExerciseEnv) => {
   };
 
   [@deriving (show({with_path: false}), sexp, yojson)]
-  type predicate = Term.UExp.t => bool;
-
-  [@deriving (show({with_path: false}), sexp, yojson)]
   type hint = string;
 
   [@deriving (show({with_path: false}), sexp, yojson)]
-  type syntax_test = (hint, predicate);
+  type syntax_test = (hint, SyntaxTest.predicate);
 
   [@deriving (show({with_path: false}), sexp, yojson)]
   type syntax_tests = list(syntax_test);

--- a/src/haz3lschool/Grading.re
+++ b/src/haz3lschool/Grading.re
@@ -173,7 +173,8 @@ module F = (ExerciseEnv: Exercise.ExerciseEnv) => {
     let mk = (~your_impl: Editor.t, ~tests: syntax_tests): t => {
       let user_impl_term = EditorUtil.stitch([your_impl]);
 
-      let predicates = List.map(((_, p)) => p, tests);
+      let predicates =
+        List.map(((_, p)) => SyntaxTest.predicate_fn(p), tests);
       let hints = List.map(((h, _)) => h, tests);
       let syntax_results = SyntaxTest.check(user_impl_term, predicates);
 

--- a/src/haz3lschool/SyntaxTest.re
+++ b/src/haz3lschool/SyntaxTest.re
@@ -238,3 +238,15 @@ let check =
       length == 0 ? 1. : float_of_int(passing) /. float_of_int(length),
   };
 };
+
+[@deriving (show({with_path: false}), sexp, yojson)]
+type predicate =
+  | VarApplied(string)
+  | IsRecursive(string);
+
+let predicate_fn = predicate => {
+  switch (predicate) {
+  | VarApplied(name) => var_applied(name)
+  | IsRecursive(name) => is_recursive(name)
+  };
+};

--- a/src/haz3lweb/exercises/Ex_OddlyRecursive.ml
+++ b/src/haz3lweb/exercises/Ex_OddlyRecursive.ml
@@ -3156,8 +3156,5 @@ let exercise : Exercise.spec =
         hints = [ "zero" ];
       };
     syntax_tests =
-      [
-        ("not is applied", Haz3lschool.SyntaxTest.var_applied "not");
-        ("odd is recursive", Haz3lschool.SyntaxTest.is_recursive "odd");
-      ];
+      [ ("odd is recursive", Haz3lschool.SyntaxTest.IsRecursive "odd") ];
   }

--- a/src/haz3lweb/exercises/Ex_RecursiveFibonacci.ml
+++ b/src/haz3lweb/exercises/Ex_RecursiveFibonacci.ml
@@ -3161,5 +3161,5 @@ let exercise : Exercise.spec =
         hints = [];
       };
     syntax_tests =
-      [ ("fib is recursive", Haz3lschool.SyntaxTest.is_recursive "fib") ];
+      [ ("fib is recursive", Haz3lschool.SyntaxTest.IsRecursive "fib") ];
   }


### PR DESCRIPTION
Removes the higher order functions in exercises so they can be exported without errors.