### PR TITLE
remove context entry gradient

### DIFF
--- a/src/haz3lweb/www/style.css
+++ b/src/haz3lweb/www/style.css
@@ -1418,7 +1418,6 @@ svg.tile-selected {
 
 .context-entry:hover {
   max-width: 400em;
-  -webkit-mask-image: none;
   background-image: linear-gradient(
     0deg,
     rgb(138 99 32),

--- a/src/haz3lweb/www/style.css
+++ b/src/haz3lweb/www/style.css
@@ -1410,7 +1410,6 @@ svg.tile-selected {
   display: flex;
   gap: 0.5em;
   max-width: 17em;
-  -webkit-mask-image: linear-gradient(to right, black 13em, transparent);
   border-top: 0.5px solid #0000;
   border-bottom: 0.5px solid #e2d4a9;
   padding-left: 0.3em;


### PR DESCRIPTION
this was causing issues with the "Correct Implementation" display in Exercises mode and doesn't seem necessary in the context inspector either