### PR TITLE
removed wildcards from syntax tests and added filter support

### DIFF
--- a/src/haz3lschool/SyntaxTest.re
+++ b/src/haz3lschool/SyntaxTest.re
@@ -10,6 +10,16 @@ type syntax_result = {
 let rec find_var_upat = (name: string, upat: Term.UPat.t): bool => {
   switch (upat.term) {
   | Var(x) => x == name
+  | EmptyHole
+  | Wild
+  | Triv
+  | Invalid(_)
+  | MultiHole(_)
+  | Int(_)
+  | Float(_)
+  | Bool(_)
+  | String(_)
+  | Constructor(_) => false
   | Cons(up1, up2) => find_var_upat(name, up1) || find_var_upat(name, up2)
   | ListLit(l)
   | Tuple(l) =>
@@ -17,13 +27,21 @@ let rec find_var_upat = (name: string, upat: Term.UPat.t): bool => {
   | Parens(up) => find_var_upat(name, up)
   | Ap(up1, up2) => find_var_upat(name, up1) || find_var_upat(name, up2)
   | TypeAnn(up, _) => find_var_upat(name, up)
-  | _ => false
   };
 };
 
 let rec var_mention = (name: string, uexp: Term.UExp.t): bool => {
   switch (uexp.term) {
   | Var(x) => x == name
+  | EmptyHole
+  | Triv
+  | Invalid(_)
+  | MultiHole(_)
+  | Bool(_)
+  | Int(_)
+  | Float(_)
+  | String(_)
+  | Constructor(_) => false
   | Fun(args, body) =>
     find_var_upat(name, args) ? false : var_mention(name, body)
   | ListLit(l)
@@ -35,8 +53,10 @@ let rec var_mention = (name: string, uexp: Term.UExp.t): bool => {
   | Test(u)
   | Parens(u)
   | UnOp(_, u)
-  | TyAlias(_, _, u) => var_mention(name, u)
+  | TyAlias(_, _, u)
+  | Filter(_, _, u) => var_mention(name, u)
   | Ap(u1, u2)
+  | Pipeline(u1, u2)
   | Seq(u1, u2)
   | Cons(u1, u2)
   | ListConcat(u1, u2)
@@ -53,12 +73,21 @@ let rec var_mention = (name: string, uexp: Term.UExp.t): bool => {
          false,
          l,
        )
-  | _ => false
   };
 };
 
 let rec var_applied = (name: string, uexp: Term.UExp.t): bool => {
   switch (uexp.term) {
+  | Var(_)
+  | EmptyHole
+  | Triv
+  | Invalid(_)
+  | MultiHole(_)
+  | Bool(_)
+  | Int(_)
+  | Float(_)
+  | String(_)
+  | Constructor(_) => false
   | Fun(args, body) =>
     find_var_upat(name, args) ? false : var_applied(name, body)
   | ListLit(l)
@@ -70,10 +99,16 @@ let rec var_applied = (name: string, uexp: Term.UExp.t): bool => {
   | Test(u)
   | Parens(u)
   | UnOp(_, u)
-  | TyAlias(_, _, u) => var_applied(name, u)
+  | TyAlias(_, _, u)
+  | Filter(_, _, u) => var_applied(name, u)
   | Ap(u1, u2) =>
     switch (u1.term) {
     | Var(x) => x == name ? true : var_applied(name, u2)
+    | _ => var_applied(name, u1) || var_applied(name, u2)
+    }
+  | Pipeline(u1, u2) =>
+    switch (u2.term) {
+    | Var(x) => x == name ? true : var_applied(name, u1)
     | _ => var_applied(name, u1) || var_applied(name, u2)
     }
   | Cons(u1, u2)
@@ -92,8 +127,6 @@ let rec var_applied = (name: string, uexp: Term.UExp.t): bool => {
          false,
          l,
        )
-
-  | _ => false
   };
 };
 
@@ -127,7 +160,18 @@ let rec find_in_let =
         ul,
       );
     }
-  | _ => l
+  | (Var(_), _)
+  | (Tuple(_), _)
+  | (
+      EmptyHole | Wild | Triv | Invalid(_) | MultiHole(_) | Int(_) | Float(_) |
+      Bool(_) |
+      String(_) |
+      ListLit(_) |
+      Constructor(_) |
+      Cons(_, _) |
+      Ap(_, _),
+      _,
+    ) => l
   };
 };
 
@@ -143,8 +187,11 @@ let rec find_fn =
   | Fun(_, body) => l |> find_fn(name, body)
   | Parens(u1)
   | UnOp(_, u1)
-  | TyAlias(_, _, u1) => l |> find_fn(name, u1)
+  | TyAlias(_, _, u1)
+  | Test(u1)
+  | Filter(_, _, u1) => l |> find_fn(name, u1)
   | Ap(u1, u2)
+  | Pipeline(u1, u2)
   | Seq(u1, u2)
   | Cons(u1, u2)
   | ListConcat(u1, u2)
@@ -157,7 +204,16 @@ let rec find_fn =
       l |> find_fn(name, u1),
       ul,
     )
-  | _ => l
+  | EmptyHole
+  | Triv
+  | Invalid(_)
+  | MultiHole(_)
+  | Bool(_)
+  | Int(_)
+  | Float(_)
+  | String(_)
+  | Constructor(_)
+  | Var(_) => l
   };
 };
 
@@ -176,6 +232,17 @@ let is_recursive = (name: string, uexp: Term.UExp.t): bool => {
 
 let rec tail_check = (name: string, uexp: Term.UExp.t): bool => {
   switch (uexp.term) {
+  | EmptyHole
+  | Triv
+  | Invalid(_)
+  | MultiHole(_)
+  | Bool(_)
+  | Int(_)
+  | Float(_)
+  | String(_)
+  | Constructor(_)
+  | Var(_)
+  | Pipeline(_, _) => true
   | Fun(args, body) =>
     find_var_upat(name, args) ? false : tail_check(name, body)
   | Let(p, def, body) =>
@@ -187,6 +254,7 @@ let rec tail_check = (name: string, uexp: Term.UExp.t): bool => {
     !List.fold_left((acc, ue) => {acc || var_mention(name, ue)}, false, l)
   | Test(_) => false
   | TyAlias(_, _, u)
+  | Filter(_, _, u)
   | Parens(u) => tail_check(name, u)
   | UnOp(_, u) => !var_mention(name, u)
   | Ap(u1, u2) => var_mention(name, u2) ? false : tail_check(name, u1)
@@ -207,8 +275,6 @@ let rec tail_check = (name: string, uexp: Term.UExp.t): bool => {
           true,
           l,
         )
-
-  | _ => true
   };
 };
 


### PR DESCRIPTION
@ruiz-m I should have picked this up in code review, but the wildcards in the syntax tests definition means they weren't coming to the attention of folks adding new language features -- see diff. in the future make sure we avoid using wildcards for datatypes that may evolve.