### PR TITLE
Fix missing (and extra) steppable

### DIFF
--- a/src/haz3lcore/dynamics/EvalCtx.re
+++ b/src/haz3lcore/dynamics/EvalCtx.re
@@ -245,10 +245,7 @@ let rec unwrap = (ctx: t, sel: cls): option(t) => {
   | (tag, Closure(_, c)) => unwrap(c, tag)
   | (Cast, _) => Some(ctx)
   | (tag, Cast(c, _, _)) => unwrap(c, tag)
-  | (tag, Mark) =>
-    print_endline("==== unwrap(_, Mark) ====");
-    print_endline("tag = " ++ show_cls(tag));
-    print_endline("---- unwrap(_, Mark) ----");
+  | (_, Mark) =>
     None;
   | (_, _) =>
     // print_endline(

--- a/src/haz3lcore/dynamics/EvalCtx.re
+++ b/src/haz3lcore/dynamics/EvalCtx.re
@@ -162,7 +162,6 @@ let rec unwrap = (ctx: t, sel: cls): option(t) => {
       ++ Sexplib.Sexp.to_string_hum(sexp_of_t(ctx)),
     );
     raise(EvaluatorError.Exception(StepDoesNotMatch));
-  | (_, Mark) => None
   | (BoundVar, c)
   | (NonEmptyHole, NonEmptyHole(_, _, _, c))
   | (Closure, Closure(_, c))
@@ -239,12 +238,18 @@ let rec unwrap = (ctx: t, sel: cls): option(t) => {
   | (Sequence2, Sequence1(_))
   | (ListConcat1, ListConcat2(_))
   | (ListConcat2, ListConcat1(_)) => None
-  | (Closure, _) => Some(ctx)
-  | (tag, Closure(_, c)) => unwrap(c, tag)
+  | (FilterPattern, _) => None
   | (Filter, _) => Some(ctx)
   | (tag, Filter(_, c)) => unwrap(c, tag)
+  | (Closure, _) => Some(ctx)
+  | (tag, Closure(_, c)) => unwrap(c, tag)
   | (Cast, _) => Some(ctx)
   | (tag, Cast(c, _, _)) => unwrap(c, tag)
+  | (tag, Mark) =>
+    print_endline("==== unwrap(_, Mark) ====");
+    print_endline("tag = " ++ show_cls(tag));
+    print_endline("---- unwrap(_, Mark) ----");
+    None;
   | (_, _) =>
     // print_endline(
     //   Sexplib.Sexp.to_string_hum(sexp_of_cls(tag))

--- a/src/haz3lcore/dynamics/EvalCtx.re
+++ b/src/haz3lcore/dynamics/EvalCtx.re
@@ -245,8 +245,7 @@ let rec unwrap = (ctx: t, sel: cls): option(t) => {
   | (tag, Closure(_, c)) => unwrap(c, tag)
   | (Cast, _) => Some(ctx)
   | (tag, Cast(c, _, _)) => unwrap(c, tag)
-  | (_, Mark) =>
-    None;
+  | (_, Mark) => None
   | (_, _) =>
     // print_endline(
     //   Sexplib.Sexp.to_string_hum(sexp_of_cls(tag))

--- a/src/haz3lweb/view/dhcode/layout/DHDoc_Exp.re
+++ b/src/haz3lweb/view/dhcode/layout/DHDoc_Exp.re
@@ -436,13 +436,6 @@ let mk =
           fail();
         } else {
           let bindings = DHPat.bound_vars(dp);
-          print_endline("===");
-          print_endline(ClosureEnvironment.show(env));
-          print_endline(
-            ClosureEnvironment.show(
-              ClosureEnvironment.without_keys(bindings, env),
-            ),
-          );
           let def_doc = go_formattable(ddef, Let1);
           vseps([
             hcats([
@@ -520,7 +513,6 @@ let mk =
           DHDoc_common.Delim.mk(")"),
         ]);
       | Fun(dp, ty, Closure(env', d), s) =>
-        print_endline(DHExp.show(d));
         if (settings.show_fn_bodies) {
           let bindings = DHPat.bound_vars(dp);
           let body_doc =
@@ -568,7 +560,7 @@ let mk =
           | None => annot(DHAnnot.Collapsed, text("<anon fn>"))
           | Some(name) => annot(DHAnnot.Collapsed, text("<" ++ name ++ ">"))
           };
-        };
+        }
       | Fun(dp, ty, dbody, s) =>
         if (settings.show_fn_bodies) {
           let bindings = DHPat.bound_vars(dp);


### PR DESCRIPTION
This PR fix missing and extra (overlapped) area in stepper filter.

**Solution**: always returns `None` when unwrapping on `FilterPattern`, and delay the match of `Mark` until every `Filter` and `Closure` are unwrapped.

![Screenshot from 2024-01-25 22-11-43](https://github.com/hazelgrove/hazel/assets/29998228/75e37f22-156d-49fc-9a88-5366ff2de34b)
