### PR TITLE
Simpler selection decoration

### DIFF
--- a/src/haz3lcore/Measured.re
+++ b/src/haz3lcore/Measured.re
@@ -70,7 +70,9 @@ module Rows = {
 };
 
 module Shards = {
+  [@deriving (show({with_path: false}), sexp, yojson)]
   type shard = (int, measurement);
+  [@deriving (show({with_path: false}), sexp, yojson)]
   type t = list(shard);
 
   // elements of returned list are nonempty

--- a/src/haz3lcore/tiles/Piece.re
+++ b/src/haz3lcore/tiles/Piece.re
@@ -137,3 +137,11 @@ let get_outside_sorts = (~default_sort=Sort.Any, p: t): list(Sort.t) =>
     | (Concave(_), Concave(_)) => [sort_l, sort_r]
     };
   };
+
+let mold_of = (~shape=Nib.Shape.Convex, p: t) =>
+  // TODO(d) fix sorts
+  switch (p) {
+  | Tile(t) => t.mold
+  | Grout(g) => Mold.of_grout(g, Any)
+  | Secondary(_) => Mold.of_secondary({sort: Any, shape})
+  };

--- a/src/haz3lcore/tiles/Tile.re
+++ b/src/haz3lcore/tiles/Tile.re
@@ -29,6 +29,7 @@ let nibs = (t: t) => {
   let (_, r) = Mold.nibs(~index=r_shard(t), t.mold);
   (l, r);
 };
+
 let shapes = (t: t) => {
   let (l, r) = nibs(t);
   (l.shape, r.shape);

--- a/src/haz3lweb/view/dec/PieceDec.re
+++ b/src/haz3lweb/view/dec/PieceDec.re
@@ -4,22 +4,6 @@ open Virtual_dom.Vdom;
 open Node;
 open SvgUtil;
 
-module Profile = {
-  type shard = (Id.t, int);
-  type tiles = list((Id.t, Mold.t, Measured.Shards.t));
-
-  type style =
-    | Root(Measured.Point.t, Measured.Point.t)
-    | Selected(shard, shard)
-    | SelectedBuffer(shard, shard);
-
-  type t = {
-    style,
-    caret: shard,
-    tiles,
-  };
-};
-
 let run: Nib.Shape.t => float =
   fun
   | Convex => +. DecUtil.short_tip_width
@@ -54,29 +38,31 @@ let simple_shard_path = ((l, r): Nibs.shapes, length: int): list(Path.cmd) =>
     ],
   );
 
-let chunky_shard_path =
+let simple_shard =
     (
-      {origin, last}: Measured.measurement,
-      (l, r): Nibs.shapes,
-      indent_col: int,
-      max_col: int,
+      ~font_metrics,
+      ~shapes,
+      ~measurement: Measured.measurement,
+      ~path_cls,
+      ~base_cls,
     )
-    : list(Path.cmd) =>
-  List.flatten(
-    Path.[
-      [
-        m(~x=0, ~y=0),
-        h(~x=max_col - origin.col + 1),
-        v(~y=last.row - origin.row),
-        h(~x=last.col - origin.col),
-      ],
-      r_hook(r),
-      [h(~x=indent_col - origin.col), v(~y=1), h(~x=0)],
-      l_hook(l),
-    ],
+    : t =>
+  DecUtil.code_svg_sized(
+    ~font_metrics,
+    ~measurement,
+    ~base_cls,
+    ~path_cls,
+    simple_shard_path(shapes, measurement.last.col - measurement.origin.col),
   );
 
-let simple_shard =
+let simple_shard_selected =
+    (~font_metrics, ~shapes, ~measurement: Measured.measurement, ~buffer): t => {
+  let path_cls = ["tile-path", buffer ? "selected-buffer" : "selected"];
+  let base_cls = ["tile-selected"];
+  simple_shard(~font_metrics, ~measurement, ~shapes, ~path_cls, ~base_cls);
+};
+
+let simple_shard_indicated =
     (
       ~font_metrics,
       ~has_caret,
@@ -85,27 +71,19 @@ let simple_shard =
       ~measurement: Measured.measurement,
     )
     : t => {
-  let path =
-    simple_shard_path(shapes, measurement.last.col - measurement.origin.col);
   let path_cls =
     ["tile-path", "raised", Sort.to_string(sort)]
     @ (has_caret ? ["indicated-caret"] : ["indicated"]);
   let base_cls = ["tile-indicated"];
-  DecUtil.code_svg_sized(
-    ~font_metrics,
-    ~measurement,
-    ~base_cls,
-    ~path_cls,
-    path,
-  );
+  simple_shard(~font_metrics, ~measurement, ~shapes, ~path_cls, ~base_cls);
 };
 
-let simple_shards =
+let simple_shards_indicated =
     (~font_metrics: FontMetrics.t, ~caret: (Id.t, int), (id, mold, shards))
     : list(t) =>
   List.map(
     ((index, measurement)) =>
-      simple_shard(
+      simple_shard_indicated(
         ~font_metrics,
         ~has_caret=caret == (id, index),
         ~shapes=Mold.nib_shapes(~index, mold),
@@ -114,73 +92,6 @@ let simple_shards =
       ),
     shards,
   );
-
-let simple_shard_child =
-    (
-      ~font_metrics: FontMetrics.t,
-      (mold: Mold.t, {origin, last}: Measured.measurement),
-    )
-    : t => {
-  let nib_shapes = Mold.nib_shapes(mold);
-  let path = simple_shard_path(nib_shapes, last.col - origin.col);
-  let clss = ["indicated-child", Sort.to_string(mold.out)];
-  DecUtil.code_svg_sized(
-    ~font_metrics,
-    ~measurement={origin, last},
-    ~path_cls=clss,
-    ~base_cls=["child-backing"],
-    path,
-  );
-};
-
-let chunky_shard =
-    (
-      ~font_metrics: FontMetrics.t,
-      ~style_cls: string,
-      ~rows: Measured.Rows.t,
-      (i, j): (Profile.shard, Profile.shard),
-      tiles: Profile.tiles,
-    ) => {
-  let (nib_l, origin) = {
-    let (id, index) = i;
-    let (_, mold, shards) =
-      switch (List.find_opt(((id', _, _)) => id' == id, tiles)) {
-      | Some(x) => x
-      | None => failwith("chunky_shard 1")
-      };
-    (
-      fst(Mold.nib_shapes(~index, mold)),
-      ListUtil.assoc_err(index, shards, "chunky_shard").origin,
-    );
-  };
-  let (nib_r, last) = {
-    let (id, index) = j;
-    let (_, mold, shards) =
-      switch (List.find_opt(((id', _, _)) => id' == id, tiles)) {
-      | Some(x) => x
-      | None => failwith("chunky_shard 2")
-      };
-    (
-      snd(Mold.nib_shapes(~index, mold)),
-      ListUtil.assoc_err(index, shards, "chunky_shard").last,
-    );
-  };
-  let indent_col = Measured.Rows.find(origin.row, rows).indent;
-  let max_col =
-    ListUtil.range(~lo=origin.row, last.row + 1)
-    |> List.map(r => Measured.Rows.find(r, rows).max_col)
-    |> List.fold_left(max, 0);
-  let path =
-    chunky_shard_path({origin, last}, (nib_l, nib_r), indent_col, max_col);
-  let clss = ["tile-path", style_cls, "raised"];
-  DecUtil.code_svg_sized(
-    ~font_metrics,
-    ~measurement={origin, last},
-    ~base_cls=["tile-selected"],
-    ~path_cls=clss,
-    path,
-  );
-};
 
 let shadowfudge = Path.cmdfudge(~y=DecUtil.shadow_adj);
 
@@ -196,7 +107,7 @@ let bi_lines =
     (
       ~font_metrics: FontMetrics.t,
       ~rows: Measured.Rows.t,
-      tiles: Profile.tiles,
+      tiles: list((Id.t, Mold.t, Measured.Shards.t)),
     )
     : list(t) => {
   let shards = shards_of_tiles(tiles);
@@ -398,36 +309,16 @@ let uni_lines =
      );
 };
 
-let view =
+let indicated =
     (
       ~font_metrics: FontMetrics.t,
       ~rows: Measured.Rows.t,
-      ~segs: list((Mold.t, Measured.measurement))=[],
-      {style, caret, tiles}: Profile.t,
+      ~caret,
+      ~tiles,
+      range,
     )
-    : list(Node.t) =>
-  switch (style) {
-  | Selected(i, j) => [
-      chunky_shard(
-        ~style_cls="selected",
-        ~font_metrics,
-        ~rows,
-        (i, j),
-        tiles,
-      ),
-    ]
-  | SelectedBuffer(i, j) => [
-      chunky_shard(
-        ~style_cls="selected-buffer",
-        ~font_metrics,
-        ~rows,
-        (i, j),
-        tiles,
-      ),
-    ]
-  | Root(l, r) =>
-    List.concat_map(simple_shards(~font_metrics, ~caret), tiles)
-    @ List.map(simple_shard_child(~font_metrics), segs)
-    @ uni_lines(~font_metrics, ~rows, (l, r), tiles)
-    @ bi_lines(~font_metrics, ~rows, tiles)
-  };
+    : list(Node.t) => {
+  List.concat_map(simple_shards_indicated(~font_metrics, ~caret), tiles)
+  @ uni_lines(~font_metrics, ~rows, range, tiles)
+  @ bi_lines(~font_metrics, ~rows, tiles);
+};

--- a/src/haz3lweb/view/dec/PieceDec.re
+++ b/src/haz3lweb/view/dec/PieceDec.re
@@ -42,9 +42,10 @@ let simple_shard =
     (
       ~font_metrics,
       ~shapes,
-      ~measurement: Measured.measurement,
       ~path_cls,
       ~base_cls,
+      ~fudge=DecUtil.fzero,
+      measurement: Measured.measurement,
     )
     : t =>
   DecUtil.code_svg_sized(
@@ -52,14 +53,27 @@ let simple_shard =
     ~measurement,
     ~base_cls,
     ~path_cls,
+    ~fudge,
     simple_shard_path(shapes, measurement.last.col - measurement.origin.col),
   );
 
 let simple_shard_selected =
     (~font_metrics, ~shapes, ~measurement: Measured.measurement, ~buffer): t => {
-  let path_cls = ["tile-path", buffer ? "selected-buffer" : "selected"];
+  let path_cls = [
+    "tile-path",
+    "raised",
+    buffer ? "selected-buffer" : "selected",
+  ];
   let base_cls = ["tile-selected"];
-  simple_shard(~font_metrics, ~measurement, ~shapes, ~path_cls, ~base_cls);
+  simple_shard(
+    /* Increase height slightly to avoid leaving spaces between selected lines */
+    ~fudge={height: 0.3, top: 0., width: 0., left: 0.},
+    ~font_metrics,
+    ~shapes,
+    ~path_cls,
+    ~base_cls,
+    measurement,
+  );
 };
 
 let simple_shard_indicated =
@@ -75,7 +89,7 @@ let simple_shard_indicated =
     ["tile-path", "raised", Sort.to_string(sort)]
     @ (has_caret ? ["indicated-caret"] : ["indicated"]);
   let base_cls = ["tile-indicated"];
-  simple_shard(~font_metrics, ~measurement, ~shapes, ~path_cls, ~base_cls);
+  simple_shard(~font_metrics, ~shapes, ~path_cls, ~base_cls, measurement);
 };
 
 let simple_shards_indicated =

--- a/src/haz3lweb/www/style.css
+++ b/src/haz3lweb/www/style.css
@@ -74,7 +74,7 @@
   --nul-text-color: red;
   --nul-off-color: var(--nul-text-color);
   --nul-token-color: var(--nul-text-color);
-  --nul-shadow-color: var(--nul-text-color);
+  --nul-shadow-color: #ffa000;;
   --nul-bg-color: #ffacac;
   --nul-bg-off-color: var(--nul-bg-color);
 

--- a/src/util/ListUtil.re
+++ b/src/util/ListUtil.re
@@ -453,3 +453,30 @@ let assoc_err = (x, xs, err: string) =>
 
 let update_assoc = ((k, v)) =>
   List.map(((k', v')) => k == k' ? (k, v) : (k', v'));
+
+/* Give a list of optional 'a, split the
+ * list up using the Nones as dividers */
+let split_at_nones = (xs: list(option('a))): list(list('a)) => {
+  let rec go = (xs, acc) =>
+    switch (xs) {
+    | [] => acc
+    | [None, ...xs] => go(xs, [[], ...acc])
+    | [Some(x), ...xs] =>
+      switch (acc) {
+      | [acc, ...accs] => go(xs, [[x, ...acc], ...accs])
+      | [] => go(xs, [[x]])
+      }
+    };
+  go(xs, []) |> List.map(List.rev) |> List.rev;
+};
+
+/* Give a list of lists, return a list of pairs of
+ * the first and last element of each list. */
+let first_and_last = (xss: list(list('a))): list(('a, 'a)) =>
+  xss
+  |> List.filter_map(
+       fun
+       | [] => None
+       | [x] => Some((x, x))
+       | [x, ...xs] => Some((x, last(xs))),
+     );


### PR DESCRIPTION
Now:
<img width="701" alt="Screenshot 2024-01-26 at 2 29 50 AM" src="https://github.com/hazelgrove/hazel/assets/22436459/5a475b18-02d0-432c-8b95-3ca7574c1df7">
Before:
<img width="701" alt="Screenshot 2024-01-26 at 2 30 30 AM" src="https://github.com/hazelgrove/hazel/assets/22436459/fe280346-bfb6-4eff-a7c1-70b73da55c60">

As well as making selections less boxy, this also eliminates the thin line sometimes left between selection rows.
