### PR TITLE
Fix bug where `make` commands would fail if the path contained spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HTML_DIR=$(shell pwd)/_build/default/src/haz3lweb/www
+HTML_DIR="$(shell pwd)/_build/default/src/haz3lweb/www"
 SERVER="http://0.0.0.0:8000/"
 
 all: dev
@@ -38,7 +38,7 @@ release-student: setup-student
 	dune build @src/fmt --auto-promote src --profile dev
 
 echo-html-dir:
-	@echo "$(HTML_DIR)"
+	@echo $(HTML_DIR)
 
 serve:
 	cd $(HTML_DIR); python3 -m http.server 8000


### PR DESCRIPTION
We noticed that `make serve` and other commands using `$HTML_DIR` would fail if the path/working directory contained spaces. For instance, `/home/user/Dropbox (University of Michigan)/hazel...`. The fix is to quote the directory so it isn't parsed as two different arguments separated by a space. 

Thanks Nishant and Matt for discovering the bug and reviewing the fix.