### PR TITLE
Add Coq export functionality for arithmetic stepper expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HTML_DIR=$(shell pwd)/_build/default/src/haz3lweb/www
+HTML_DIR="$(shell pwd)/_build/default/src/haz3lweb/www"
 SERVER="http://0.0.0.0:8000/"
 
 all: dev
@@ -38,7 +38,7 @@ release-student: setup-student
 	dune build @src/fmt --auto-promote src --profile dev
 
 echo-html-dir:
-	@echo "$(HTML_DIR)"
+	@echo $(HTML_DIR)
 
 serve:
 	cd $(HTML_DIR); python3 -m http.server 8000

--- a/src/haz3lcore/dynamics/CoqExport.re
+++ b/src/haz3lcore/dynamics/CoqExport.re
@@ -1,0 +1,91 @@
+/*
+ Coq export for Hazel arithmetic expressions
+ */
+
+open EvaluatorStep;
+
+let rec string_of_d = (d: DHExp.t) => {
+  switch (d) {
+  | BinIntOp(op, arg1, arg2) =>
+    string_of_d(arg1)
+    ++ ""
+    ++ TermBase.UExp.int_op_to_string(op)
+    ++ ""
+    ++ string_of_d(arg2)
+  | IntLit(n) => string_of_int(n)
+  | _ => "ERROR"
+  };
+};
+// Takes a single step
+let single_step_export = (ind, step) => {
+  let {d_loc, d_loc', ctx, _} = step;
+  let oldFragmentString =
+    switch (d_loc) {
+    | BinIntOp(op, IntLit(arg1), IntLit(arg2)) =>
+      let oldExprOperString = TermBase.UExp.int_op_to_string(op);
+      String.concat(
+        "",
+        [string_of_int(arg1), oldExprOperString, string_of_int(arg2)],
+      );
+    | _ => "ERROR"
+    };
+  let newFragmentString =
+    switch (d_loc') {
+    | IntLit(arg) => string_of_int(arg)
+    | _ => "ERROR"
+    };
+
+  //Printf.printf("Step: %s -> %s\n", oldFragmentString, newFragmentString);
+  let oldExprString = string_of_d(compose(ctx, d_loc));
+  let newExpr = compose(ctx, d_loc');
+  let newExprString = string_of_d(newExpr);
+  //Printf.printf("old: %s\n", oldExprString);
+  //Printf.printf("new: %s\n", newExprString);
+  let extraTactic =
+    switch (d_loc) {
+    | BinIntOp(Plus, _, _) => "repeat rewrite Nat.add_assoc. "
+    | _ => ""
+    };
+  let coqLemmaString =
+    Printf.sprintf(
+      "Lemma equiv_exp%d:%s = %s.\nProof.\nintros.\ncut (%s=%s).\n- intros. rewrite <- H at 1. %s reflexivity.\n- intros. cbv. reflexivity.\nQed.",
+      ind,
+      newExprString,
+      oldExprString,
+      oldFragmentString,
+      newFragmentString,
+      extraTactic,
+    );
+  //Printf.printf("Coq proof:\n%s\n", coqLemmaString);
+  coqLemmaString;
+};
+
+// Takes a list of steps and generates the Coq proof of equivalence between the first and last steps
+let exportCoq = steps =>
+  if (List.length(steps) == 0) {
+    print_endline("Not exporting proof with no steps");
+  } else {
+    let lemmasAndInvocations =
+      List.mapi(
+        (ind, step) =>
+          (
+            single_step_export(List.length(steps) - ind, step),
+            Printf.sprintf(
+              "rewrite -> equiv_exp%d.",
+              List.length(steps) - ind,
+            ),
+          ),
+        steps,
+      );
+    let (lemmas, invocations) = List.split(lemmasAndInvocations);
+    let finalExpr = string_of_d(List.hd(steps).d_loc');
+    let firstExpr = string_of_d(List.nth(steps, List.length(steps) - 1).d);
+    Printf.printf(
+      "Require Import Nat.\nRequire Export Plus.\nRequire Export Mult.\n%s\nTheorem equiv_exp:%s=%s.\nProof.\nintros.\n%s\nreflexivity. Qed.",
+      String.concat("\n", lemmas),
+      finalExpr,
+      firstExpr,
+      String.concat("\n", invocations),
+    );
+    ();
+  };

--- a/src/haz3lcore/dynamics/CoqExport.re
+++ b/src/haz3lcore/dynamics/CoqExport.re
@@ -31,7 +31,7 @@ let rec index_of_like_terms_helper_ctx = (d: EvalCtx.t, v: int) => {
   };
 };
 
-// For some integer literal t and context AST d, find out how many occurrences of t do not occur to the right of the Mark in D.
+// For some integer literal t and context AST d, find out how many occurrences of t do not occur to the right of the Mark in d.
 
 let index_of_like_terms = (d: EvalCtx.t, v: DHExp.t) => {
   switch (v) {

--- a/src/haz3lcore/dynamics/CoqExport.re
+++ b/src/haz3lcore/dynamics/CoqExport.re
@@ -101,7 +101,7 @@ let single_step_export = (ind, step) => {
 // Takes a list of steps and generates the Coq proof of equivalence between the first and last steps
 let exportCoq = steps =>
   if (List.length(steps) == 0) {
-    print_endline("Not exporting proof with no steps");
+    "Not exporting proof with no steps";
   } else {
     let lemmasAndInvocations =
       List.mapi(
@@ -118,12 +118,12 @@ let exportCoq = steps =>
     let (lemmas, invocations) = List.split(lemmasAndInvocations);
     let finalExpr = string_of_d(List.hd(steps).d_loc');
     let firstExpr = string_of_d(List.nth(steps, List.length(steps) - 1).d);
-    Printf.printf(
+    // Return a string that is the Coq proof but don't print to console
+    Printf.sprintf(
       "Require Import Nat.\nRequire Export Plus.\nRequire Export Mult.\n%s\nTheorem equiv_exp:%s=%s.\nProof.\nintros.\n%s\nreflexivity. Qed.",
       String.concat("\n", lemmas),
       finalExpr,
       firstExpr,
       String.concat("\n", invocations),
     );
-    ();
   };

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -528,7 +528,9 @@ let rec apply =
       switch (result) {
       | NoElab
       | Evaluation(_) => ()
-      | Stepper(stepper) => CoqExport.exportCoq(stepper.previous)
+      // TODO(jiawei): make this unit type or decide to keep print_endline
+      | Stepper(stepper) =>
+        CoqExport.exportCoq(stepper.previous) |> print_endline
       };
       Ok(model);
     | ToggleStepper(key) =>

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -528,7 +528,7 @@ let rec apply =
       switch (result) {
       | NoElab
       | Evaluation(_) => ()
-      | Stepper(_stepper) => print_endline("Hello world!")
+      | Stepper(_stepper) => CoqExport.exportCoq(_stepper.previous)
       };
       Ok(model);
     | ToggleStepper(key) =>

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -528,7 +528,7 @@ let rec apply =
       switch (result) {
       | NoElab
       | Evaluation(_) => ()
-      | Stepper(_stepper) => CoqExport.exportCoq(_stepper.previous)
+      | Stepper(stepper) => CoqExport.exportCoq(stepper.previous)
       };
       Ok(model);
     | ToggleStepper(key) =>

--- a/src/haz3lweb/view/StepperView.re
+++ b/src/haz3lweb/view/StepperView.re
@@ -63,8 +63,19 @@ let stepper_view =
       ],
     );
   let coq_button =
-    Widgets.button(Icons.star, _ =>
-      inject(StepperAction(result_key, CoqExport))
+    Widgets.button(
+      Icons.star,
+      _ => {
+        // Call the stepper export method
+        let coq_data = CoqExport.exportCoq(stepper.previous);
+        // Output to a file
+        JsUtil.download_string_file(
+          ~filename="stepper-coq-export.v",
+          ~content_type="text/plain",
+          ~contents=coq_data,
+        );
+        Virtual_dom.Vdom.Effect.Ignore;
+      },
     );
   let hide_stepper =
     Widgets.toggle(~tooltip="Show Stepper", "s", true, _ =>


### PR DESCRIPTION
This PR will add Coq export functionality similar to the Interactive Evaluator to Hazel, for simple arithmetic expressions (without variables)