### PR TITLE
ci secondary fixes

### DIFF
--- a/src/haz3lcore/zipper/action/Indicated.re
+++ b/src/haz3lcore/zipper/action/Indicated.re
@@ -106,9 +106,15 @@ let ci_of = (z: Zipper.t, info_map: Statics.Map.t): option(Statics.Info.t) =>
   | Some((p, _, _)) => Id.Map.find_opt(Piece.id(p), info_map)
   | None =>
     let sibs = sibs_with_sel(z);
-    /* Favoring left over right here is nicer for comments */
     let* cls =
       switch (Siblings.neighbors(sibs)) {
+      /* If on side of comment, say we're on comment */
+      | (Some(Secondary(sl)), Some(Secondary(_)))
+          when Secondary.is_comment(sl) =>
+        Some(Secondary.cls_of(sl))
+      | (Some(Secondary(_)), Some(Secondary(sr)))
+          when Secondary.is_comment(sr) =>
+        Some(Secondary.cls_of(sr))
       | (_, Some(Secondary(s)))
       | (Some(Secondary(s)), _) => Some(Secondary.cls_of(s))
       | _ => None

--- a/src/haz3lweb/view/ExplainThis.re
+++ b/src/haz3lweb/view/ExplainThis.re
@@ -601,7 +601,7 @@ let get_doc =
       mode: message_mode,
     )
     : (list(Node.t), (list(Node.t), ColorSteps.t), list(Node.t)) => {
-  let simple = msg => ([text(msg)], ([], (Id.Map.empty, 0)), []);
+  let simple = msg => ([], ([text(msg)], (Id.Map.empty, 0)), []);
   let default = simple("No docs available");
   let get_specificity_level = group_id =>
     fst(ExplainThisModel.get_form_and_options(group_id, docs)).id;
@@ -2356,7 +2356,7 @@ let get_doc =
     switch (s.cls) {
     | Secondary(Whitespace) => simple("A semantic void, pervading but inert")
     | Secondary(Comment) =>
-      simple("Comments are ignored by compilers but treasured by readers")
+      simple("Comments are ignored by systems but treasured by readers")
     | _ => failwith("ExplainThis: Secondary Impossible")
     }
   | None => default
@@ -2434,27 +2434,27 @@ let view =
             ],
           ),
         ]
-        @ (
-          syn_form == []
-            ? []
-            : [
-              section(
-                ~section_clss="syntactic-form",
-                ~title=
-                  switch (info) {
-                  | None => "Whitespace or Comment"
-                  | Some(info) => Info.cls_of(info) |> Term.Cls.show
-                  },
-                [
+        @ [
+          section(
+            ~section_clss="syntactic-form",
+            ~title=
+              switch (info) {
+              | None => "Whitespace or Comment"
+              | Some(info) => Info.cls_of(info) |> Term.Cls.show
+              },
+            (
+              syn_form == []
+                ? []
+                : [
                   div(
                     ~attr=clss(["cell-container"]),
                     [div(~attr=clss(["cell-item"]), syn_form)],
                   ),
                 ]
-                @ explanation,
-              ),
-            ]
-        )
+            )
+            @ explanation,
+          ),
+        ]
         @ (
           example == []
             ? []

--- a/src/haz3lweb/www/style.css
+++ b/src/haz3lweb/www/style.css
@@ -329,6 +329,10 @@ body {
   justify-content: space-between;
   gap: 1.2em;
 }
+#main.Scratch .cell-container,
+#main.Documentation .cell-container {
+  min-width: 30em;
+}
 #main.Exercises .cell-container {
   width: auto;
 }
@@ -675,7 +679,6 @@ select {
 }
 
 .cell-container {
-  min-width: 30em;
   width: fit-content;
   border-radius: 0.4em;
   border-left: 2px solid var(--top_bar_icon_fill);


### PR DESCRIPTION
1. compilers => systems in comments msg
2. show description of secondary in explanation field; now wraps correctly
3. if secondary on both sides, one of which is a comment, favor saying we're on a comment