### PR TITLE
Closure saving

### DIFF
--- a/src/haz3lcore/StructureShareSexp.re
+++ b/src/haz3lcore/StructureShareSexp.re
@@ -1,0 +1,76 @@
+/*
+     This module adds helpers for creating s-expressions that use some structural sharing
+     (https://www.ocamlwiki.com/wiki/Structural_sharing) instead of copying all instances
+     of the same record.
+ */
+
+let structure_share_map: ref(option(Id.Map.t(Sexplib.Sexp.t))) = ref(None);
+
+[@deriving sexp]
+type structure_shared = (Sexplib.Sexp.t, Id.Map.t(Sexplib.Sexp.t));
+
+// To be used on the data structure where the structure sharing takes place
+let structure_share_here =
+    (
+      key_f: 'a => Id.t,
+      sexp_of_t: 'a => Sexplib.Sexp.t,
+      t_of_sexp: Sexplib.Sexp.t => 'a,
+    )
+    : ('a => Sexplib.Sexp.t, Sexplib.Sexp.t => 'a) => {
+  let sexp_of_t' = (thing: 'a): Sexplib.Sexp.t => {
+    switch (structure_share_map^) {
+    | Some(m) =>
+      let sexp = sexp_of_t(thing);
+      let key = key_f(thing);
+      structure_share_map := Some(Id.Map.update(key, _ => Some(sexp), m));
+      Id.sexp_of_t(key);
+    | None => sexp_of_t(thing)
+    };
+  };
+  let t_of_sexp' = sexp => {
+    switch (structure_share_map^) {
+    | Some(m) =>
+      let id = Id.t_of_sexp(sexp);
+      let thing_s =
+        switch (Id.Map.find_opt(id, m)) {
+        | Some(t) => t
+        | None => failwith("structure-sharing deserialization failed")
+        };
+      t_of_sexp(thing_s);
+    | None => t_of_sexp(sexp)
+    };
+  };
+  (sexp_of_t', t_of_sexp');
+};
+
+// To be used on the root of the data structure currently being serialized
+let structure_share_in = (sexp_of_t, t_of_sexp) => {
+  let sexp_of_t' = (thing: 'a): Sexplib.Sexp.t => {
+    switch (structure_share_map^) {
+    | None =>
+      structure_share_map := Some(Id.Map.empty);
+      let sexp = sexp_of_t(thing);
+      let result: structure_shared = (
+        sexp,
+        structure_share_map^ |> Option.get,
+      );
+      structure_share_map := None;
+      sexp_of_structure_shared(result);
+    | Some(_) => sexp_of_t(thing)
+    };
+  };
+
+  // To be used only on the root of the data structure currently being serialized
+  let t_of_sexp' = (sexp: Sexplib.Sexp.t): 'a => {
+    switch (structure_share_map^) {
+    | None =>
+      let (sexp, map) = structure_shared_of_sexp(sexp);
+      structure_share_map := Some(map);
+      let thing = t_of_sexp(sexp);
+      structure_share_map := None;
+      thing;
+    | Some(_) => t_of_sexp(sexp)
+    };
+  };
+  (sexp_of_t', t_of_sexp');
+};

--- a/src/haz3lcore/StructureShareSexp.rei
+++ b/src/haz3lcore/StructureShareSexp.rei
@@ -1,0 +1,9 @@
+// To be used on the data structure where the structure sharing takes place
+let structure_share_here:
+  ('a => Id.t, 'a => Sexplib.Sexp.t, Sexplib.Sexp.t => 'a) =>
+  ('a => Sexplib.Sexp.t, Sexplib.Sexp.t => 'a);
+
+// To be used only on the root of the data structure currently being serialized
+let structure_share_in:
+  ('a => Sexplib.Sexp.t, Sexplib.Sexp.t => 'a) =>
+  ('a => Sexplib.Sexp.t, Sexplib.Sexp.t => 'a);

--- a/src/haz3lcore/dynamics/DH.re
+++ b/src/haz3lcore/dynamics/DH.re
@@ -410,6 +410,8 @@ and ClosureEnvironment: {
 
     let id_of = ((ei, _)) => ei;
     let map_of = ((_, map)) => map;
+    let (sexp_of_t, t_of_sexp) =
+      StructureShareSexp.structure_share_here(id_of, sexp_of_t, t_of_sexp);
   };
   include Inner;
 

--- a/src/haz3lcore/dynamics/Stepper.re
+++ b/src/haz3lcore/dynamics/Stepper.re
@@ -223,7 +223,9 @@ let current_expr = (s: t) =>
   | (StepperError(_) | StepTimeout, []) => s.elab
   };
 
-let step_pending = (eo: EvalObj.t, {elab, previous, current, next}: t) =>
+let step_pending = (idx: int, {elab, previous, current, next}: t) => {
+  // TODO[Matt]: change to nth_opt after refactor
+  let eo = List.nth(next, idx);
   switch (current) {
   | StepperOK(d, s) => {
       elab,
@@ -250,6 +252,7 @@ let step_pending = (eo: EvalObj.t, {elab, previous, current, next}: t) =>
       next,
     }
   };
+};
 
 let init = (elab: DHExp.t) => {
   {
@@ -325,8 +328,7 @@ let rec evaluate_full = (~settings, s: t) => {
   | StepperError(_)
   | StepTimeout => s
   | StepperOK(_) when s.next == [] => s
-  | StepperOK(_) =>
-    s |> step_pending(List.hd(s.next)) |> evaluate_full(~settings)
+  | StepperOK(_) => s |> step_pending(0) |> evaluate_full(~settings)
   | StepPending(_) =>
     evaluate_pending(~settings, s) |> evaluate_full(~settings)
   };

--- a/src/haz3lcore/dynamics/Stepper.re
+++ b/src/haz3lcore/dynamics/Stepper.re
@@ -462,6 +462,12 @@ type persistent = {
   current,
 };
 
+let (sexp_of_persistent, persistent_of_sexp) =
+  StructureShareSexp.structure_share_in(
+    sexp_of_persistent,
+    persistent_of_sexp,
+  );
+
 // Remove EvalObj.t objects from stepper to prevent problems when loading
 let to_persistent: t => persistent =
   fun

--- a/src/haz3lcore/prog/ModelResult.re
+++ b/src/haz3lcore/prog/ModelResult.re
@@ -1,5 +1,3 @@
-open EvaluatorStep;
-
 [@deriving (show({with_path: false}), sexp, yojson)]
 type evaluation =
   | ResultOk(ProgramResult.t)
@@ -30,8 +28,8 @@ let update_stepper = f =>
   | Evaluation(_) as e => e
   | Stepper(s) => Stepper(f(s));
 
-let step_forward = (x: EvalObj.t, mr: t) =>
-  mr |> update_stepper(Stepper.step_pending(x));
+let step_forward = (idx: int, mr: t) =>
+  mr |> update_stepper(Stepper.step_pending(idx));
 
 let step_backward = (~settings, mr: t) =>
   mr |> update_stepper(Stepper.step_backward(~settings));

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -511,11 +511,11 @@ let rec apply =
     | Benchmark(Finish) =>
       Benchmark.finish();
       Ok(model);
-    | StepperAction(key, StepForward(obj)) =>
+    | StepperAction(key, StepForward(idx)) =>
       let r =
         model.results
         |> ModelResults.find(key)
-        |> ModelResult.step_forward(obj);
+        |> ModelResult.step_forward(idx);
       Ok({...model, results: model.results |> ModelResults.add(key, r)});
     | StepperAction(key, StepBackward) =>
       let r =

--- a/src/haz3lweb/UpdateAction.re
+++ b/src/haz3lweb/UpdateAction.re
@@ -29,7 +29,7 @@ type settings_action =
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type stepper_action =
-  | StepForward(EvaluatorStep.EvalObj.t)
+  | StepForward(int)
   | StepBackward;
 
 [@deriving (show({with_path: false}), sexp, yojson)]

--- a/src/haz3lweb/view/dhcode/layout/DHAnnot.re
+++ b/src/haz3lweb/view/dhcode/layout/DHAnnot.re
@@ -17,6 +17,6 @@ type t =
   | FailedCastDecoration
   | CastDecoration
   | OperationError(InvalidOperationError.t)
-  | Steppable(EvaluatorStep.EvalObj.t)
+  | Steppable(int)
   | Stepped
   | Substituted;

--- a/src/haz3lweb/view/dhcode/layout/DHDoc_Exp.re
+++ b/src/haz3lweb/view/dhcode/layout/DHDoc_Exp.re
@@ -122,7 +122,7 @@ let mk =
             previous_step: option(step),
             hidden_steps: list(step),
             chosen_step: option(step),
-            next_steps: list((EvalCtx.t, EvalObj.t)),
+            next_steps: list((EvalCtx.t, int)),
             recent_subst: list(Var.t),
             recursive_calls: list(Var.t),
           )
@@ -671,7 +671,7 @@ let mk =
     previous_step,
     hidden_steps,
     chosen_step,
-    List.map((x: EvalObj.t) => (x.ctx, x), next_steps),
+    List.mapi((idx, x: EvalObj.t) => (x.ctx, idx), next_steps),
     [],
     [],
   );


### PR DESCRIPTION
This PR changes the way closures are saved in s-expressions to reduce file sizes.

#1195 pointed out that recursive calls can make save files blow up quite quickly. Analysing these files shows that much of the file is just closures, and some of these closures are saved 100s of time.

It turns out that removing duplicate closures was able to shrink the file in #1195 to roughly a quarter of the original size. This is less of a reduction than we were expecting. Interestingly, also, once the reduction has taken place, the closures take up a very small portion of the file, so we cannot make further progress by just changing closures alone.