### PR TITLE
Add Coq file export to stepper button instead of console logging

### DIFF
--- a/src/haz3lcore/dynamics/CoqExport.re
+++ b/src/haz3lcore/dynamics/CoqExport.re
@@ -101,7 +101,7 @@ let single_step_export = (ind, step) => {
 // Takes a list of steps and generates the Coq proof of equivalence between the first and last steps
 let exportCoq = steps =>
   if (List.length(steps) == 0) {
-    print_endline("Not exporting proof with no steps");
+    "Not exporting proof with no steps";
   } else {
     let lemmasAndInvocations =
       List.mapi(
@@ -118,12 +118,12 @@ let exportCoq = steps =>
     let (lemmas, invocations) = List.split(lemmasAndInvocations);
     let finalExpr = string_of_d(List.hd(steps).d_loc');
     let firstExpr = string_of_d(List.nth(steps, List.length(steps) - 1).d);
-    Printf.printf(
+    // Return a string that is the Coq proof but don't print to console
+    Printf.sprintf(
       "Require Import Nat.\nRequire Export Plus.\nRequire Export Mult.\n%s\nTheorem equiv_exp:%s=%s.\nProof.\nintros.\n%s\nreflexivity. Qed.",
       String.concat("\n", lemmas),
       finalExpr,
       firstExpr,
       String.concat("\n", invocations),
     );
-    ();
   };

--- a/src/haz3lweb/Update.re
+++ b/src/haz3lweb/Update.re
@@ -528,7 +528,9 @@ let rec apply =
       switch (result) {
       | NoElab
       | Evaluation(_) => ()
-      | Stepper(stepper) => CoqExport.exportCoq(stepper.previous)
+      // TODO(jiawei): make this unit type or decide to keep print_endline
+      | Stepper(stepper) =>
+        CoqExport.exportCoq(stepper.previous) |> print_endline
       };
       Ok(model);
     | ToggleStepper(key) =>

--- a/src/haz3lweb/view/StepperView.re
+++ b/src/haz3lweb/view/StepperView.re
@@ -63,8 +63,19 @@ let stepper_view =
       ],
     );
   let coq_button =
-    Widgets.button(Icons.star, _ =>
-      inject(StepperAction(result_key, CoqExport))
+    Widgets.button(
+      Icons.star,
+      _ => {
+        // Call the stepper export method
+        let coq_data = CoqExport.exportCoq(stepper.previous);
+        // Output to a file
+        JsUtil.download_string_file(
+          ~filename="stepper-coq-export.v",
+          ~content_type="text/plain",
+          ~contents=coq_data,
+        );
+        Virtual_dom.Vdom.Effect.Ignore;
+      },
     );
   let hide_stepper =
     Widgets.toggle(~tooltip="Show Stepper", "s", true, _ =>


### PR DESCRIPTION
add .v file export to StepperView, CoqExport, and Update.

- `CoqExport.re`: Changes return type of `CoqExport.exportCoq` to `string` from `unit`
- `StepperView.re`: Writes file `stepper-coq-export.v` using `JsUtil.download_string_file`
- `Update.re`: Pipes stepper output to `print_endline` (this can be removed later and is marked with a TODO)
