### PR TITLE
Better output for unit test results in Github actions

### DIFF
--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           name: Test Report
           path: junit_tests*.xml
-          reporter: jest-junit
+          reporter: java-junit
           working-directory: ./source
       - name: Checkout the website build artifacts repo
         uses: actions/checkout@v2

--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -56,6 +56,7 @@ jobs:
           name: Test Report
           path: junit_tests*.xml
           reporter: jest-junit
+          working-directory: ./source
       - name: Checkout the website build artifacts repo
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -56,6 +56,7 @@ jobs:
           name: Test Report
           path: junit_tests*.xml
           reporter: java-junit
+          fail-on-error: false
           working-directory: ./source
       - name: Checkout the website build artifacts repo
         uses: actions/checkout@v2

--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -50,15 +50,12 @@ jobs:
             echo "::set-output name=tests_passed::false"
           fi
         working-directory: ./source
-      - uses: LouisBrunner/checks-action@v2.0.0
-        if: always()
+      - name: Test Report
+        uses: dorny/test-reporter@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Test Results
-          conclusion: ${{ steps.test.outputs.tests_passed == 'true' && 'success' || 'failure' }}
-          output_text_description_file: ./source/test_output
-          output: |
-            {"summary":"${{ steps.test.outputs.tests_passed == 'true' && 'Tests Passed' || 'Tests Failed' }}"}
+          name: Test Report
+          path: junit_tests*.xml
+          reporter: jest-junit
       - name: Checkout the website build artifacts repo
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -52,11 +52,12 @@ jobs:
         working-directory: ./source
       - name: Test Report
         uses: dorny/test-reporter@v1
+        continue-on-error: true
         with:
           name: Test Report
           path: junit_tests*.xml
           reporter: java-junit
-          fail-on-error: false
+          fail-on-error: true
           working-directory: ./source
       - name: Checkout the website build artifacts repo
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ setup.log
 .vscode
 .history
 .code-workspace
+
+# unit tests
+*.xml

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ repl:
 
 test:
 	dune build @src/fmt --auto-promote src --profile dev
-	node $(TEST_DIR)/haz3ltest.bc.js test
+	node $(TEST_DIR)/haz3ltest.bc.js
 
 clean:
 	dune clean

--- a/opam.export
+++ b/opam.export
@@ -78,6 +78,8 @@ installed: [
   "js_of_ocaml-ppx.5.6.0"
   "jsonm.1.0.2"
   "jst-config.v0.15.1"
+  "junit.2.0.2"
+  "junit_alcotest.2.0.1"
   "lambda-term.3.3.2"
   "lambdasoup.1.0.0"
   "logs.0.7.0"

--- a/src/test/dune
+++ b/src/test/dune
@@ -2,7 +2,7 @@
 
 (test
  (name haz3ltest)
- (libraries haz3lcore alcotest)
+ (libraries haz3lcore alcotest junit junit_alcotest)
  (modes js)
  (preprocess
   (pps js_of_ocaml-ppx)))

--- a/src/test/haz3ltest.re
+++ b/src/test/haz3ltest.re
@@ -1,3 +1,9 @@
-open Alcotest;
+open Junit_alcotest;
 
-run("Dynamics", [("Elaboration", Test_Elaboration.elaboration_tests)]);
+let (suite, _) =
+  run_and_report(
+    ~and_exit=false,
+    "Dynamics",
+    [("Elaboration", Test_Elaboration.elaboration_tests)],
+  );
+Junit.to_file(Junit.make([suite]), "junit_tests.xml");


### PR DESCRIPTION
This PR converts the alcotest unit test results to a junit xml file to allow for a better interface for the test results in the github actions.

The libraries junit and junit_alcotest were used (https://github.com/Khady/ocaml-junit)

@7h3kk1d is planning to use (https://github.com/marketplace/actions/test-reporter)