### PR TITLE
Address '>' Parsing

### DIFF
--- a/src/haz3lcore/lang/Form.re
+++ b/src/haz3lcore/lang/Form.re
@@ -302,7 +302,10 @@ let forms: list((string, t)) = [
   ("ap_exp", mk(ii, ["(", ")"], mk_post(P.ap, Exp, [Exp]))),
   ("ap_pat", mk(ii, ["(", ")"], mk_post(P.ap, Pat, [Pat]))),
   ("ap_typ", mk(ii, ["(", ")"], mk_post(P.ap, Typ, [Typ]))),
-  ("ap_exp_typ", mk(ii, ["@<", ">"], mk_post(P.ap, Exp, [Typ]))),
+  (
+    "ap_exp_typ",
+    mk((Instant, Static), ["@<", ">"], mk_post(P.ap, Exp, [Typ])),
+  ),
   ("at_sign", mk_nul_infix("@", P.eqs)), // HACK: SUBSTRING REQ
   ("case", mk(ds, ["case", "end"], mk_op(Exp, [Rul]))),
   ("test", mk(ds, ["test", "end"], mk_op(Exp, [Exp]))),


### PR DESCRIPTION
Addresses #1275 .

Due to the way forms are stored, some weird behavior can happen if a `@<` is added immediately prior to a numerical `>`.
E.g. `id>5` --> `id@<>5` causes the whole `@<>` construct to be registered as an invalid binary operator.
I'm not that that this is an easy fix.

However, this does work for:
 - Typing just plain numerical `>`
 - Adding type applications
 - Adding type applications to the left of a > when there is whitespace (e.g. `id > 5` -> `id@<?> > 5` works fine)