### PR TITLE
Fix case checker on recursive types

### DIFF
--- a/src/haz3lcore/dynamics/Constraint.re
+++ b/src/haz3lcore/dynamics/Constraint.re
@@ -130,6 +130,7 @@ let of_ap = (ctx, mode, ctr: option(Constructor.t), arg: t, syn_ty): t =>
     switch (ty) {
     | Some(ty) =>
       switch (Typ.weak_head_normalize(ctx, ty)) {
+      | Rec(_, Sum(map))
       | Sum(map) =>
         let num_variants = ConstructorMap.cardinal(map);
         switch (ConstructorMap.nth(map, name)) {


### PR DESCRIPTION
Fixed by adding a specific case analysis for recursive sum types.
Before:
![image](https://github.com/hazelgrove/hazel/assets/108375845/e5a03549-6ab1-47ea-974e-fe4f6b7152fd)

After:
![image](https://github.com/hazelgrove/hazel/assets/108375845/70893fc6-5e0f-4797-a207-9cd73555cf69)

Not sure why we are able to get away with this case analysis before though. It seems this bug was introduced after #1217 or #1274 was merged.