### PR TITLE
Fix CI status check if tests don't compile

### DIFF
--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -33,32 +33,11 @@ jobs:
           export OPAMYES=1
           make deps 
         working-directory: ./source
-      - name: Build Hazel
+      - name: Build Release
         run: |
           eval $(opam env)
           make release
         working-directory: ./source
-      - name: Run Tests
-        id: test
-        continue-on-error: true
-        run: |
-          eval $(opam env)
-          make test > test_output
-          if [ $? -eq 0 ]; then
-            echo "::set-output name=tests_passed::true"
-          else
-            echo "::set-output name=tests_passed::false"
-          fi
-        working-directory: ./source
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        continue-on-error: true
-        with:
-          name: Test Report
-          path: junit_tests*.xml
-          reporter: java-junit
-          fail-on-error: true
-          working-directory: ./source
       - name: Checkout the website build artifacts repo
         uses: actions/checkout@v2
         with:
@@ -79,3 +58,18 @@ jobs:
           git status
           git diff-index --quiet HEAD || (git commit -m "github-deploy-action-${BRANCH_NAME}"; git push)
         working-directory: ./server
+      - name: Run Tests
+        id: test
+        run: |
+          eval $(opam env)
+          make test
+        working-directory: ./source
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        with:
+          name: Test Report
+          path: junit_tests*.xml
+          reporter: java-junit
+          fail-on-error: true
+          fail-on-empty: true # Use an empty test report to detect when something failed with the test runner
+          working-directory: ./source

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -247,12 +247,12 @@ let u9: Term.UExp.t = {
                 BinOp(
                   Int(Plus),
                   {ids: [id_at(9)], term: Int(1)},
-                  {ids: [id_at(10)], term: Var("x")},
+                  {ids: [id_at(10)], term: Var("u")},
                 ),
             },
           ),
       },
-      {ids: [id_at(11)], term: Int()},
+      {ids: [id_at(11)], term: Int(55)},
     ),
 };
 let d9: DHExp.t =

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -247,7 +247,7 @@ let u9: Term.UExp.t = {
                 BinOp(
                   Int(Plus),
                   {ids: [id_at(9)], term: Int(1)},
-                  {ids: [id_at(10)], term: Var("u")},
+                  {ids: [id_at(10)], term: Var("x")},
                 ),
             },
           ),

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -252,7 +252,7 @@ let u9: Term.UExp.t = {
             },
           ),
       },
-      {ids: [id_at(11)], term: Int(55)},
+      {ids: [id_at(11)], term: Int()},
     ),
 };
 let d9: DHExp.t =


### PR DESCRIPTION
There was an issue: if tests failed to compile, we didn't publish a status check for tests. This changes it to where if there's no test report it fails the build. This does block the deployment but I don't see a way to have the empty test report mark a failed status check but continue on the action without writing something custom. For now, I think it's fine for people to comment out the non-compiling tests.