### PR TITLE
fix fix-point matching in stepper filter

### DIFF
--- a/src/haz3lcore/dynamics/Stepper.re
+++ b/src/haz3lcore/dynamics/Stepper.re
@@ -247,7 +247,6 @@ let rec evaluate_pending = (~settings, s: t) => {
         }
       )
       |> DHExp.repair_ids;
-    let _ = print_endline(d_loc' |> DHExp.show);
     let d' = EvalCtx.compose(eo.ctx, d_loc');
     let new_step = {
       d,


### PR DESCRIPTION
This PR should solve the issue #1358, by using locally nameless representation of variables to allow two term to be compared modulo alpha-equivlance.

### Implementation

When we compare a function `f` with binders `a1, a2, ...` with another function `g` with binders `b1, b2, ...`, we make each pair of binder share the same uuid, i.e. `a1` and `b1` are mapped to the same uuid `u1`. Then we check the body of `f` and `g` term by term. If the term is a variable and is mapped to a uuid, we check if the two variables have the same uuid; if the term is a variable and is not mapped to a uuid, we lookup the environment and see if their values in environment is the same.

### Discussion

Should `TypFun/TypAp` be transformed into a locally-nameless representation during matching?

### Development

close #1358 