### PR TITLE
Run dune fmt before dev/ test without failure and add make watch-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ setup-instructor:
 setup-student: 
 	cp src/haz3lweb/ExerciseSettings_student.re src/haz3lweb/ExerciseSettings.re
 
-dev-helper: 
+dev-helper:
+	dune fmt --auto-promote || true
 	dune build @src/fmt --auto-promote src --profile dev
 
 dev: setup-instructor dev-helper
@@ -58,6 +59,7 @@ repl:
 	dune utop src/haz3lcore
 
 test:
+	dune fmt --auto-promote || true
 	dune build @src/fmt @test/fmt --auto-promote src test --profile dev
 	node $(TEST_DIR)/haz3ltest.bc.js
 

--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,8 @@ test:
 	dune build @src/fmt @test/fmt --auto-promote src test --profile dev
 	node $(TEST_DIR)/haz3ltest.bc.js
 
+watch-test:
+	dune build @fmt @runtest --auto-promote --watch
+
 clean:
 	dune clean


### PR DESCRIPTION
- dune fmt returns a non-zero exit code if autoformatting promotion happens
- So this will run the dune fmt auto-promote and ignore the exit code then run the standard build in dev so you don't have to run make twice
- Release is left unchanged since we want the build to fail on invalid formatting
- `make watch` already seems to work
- Added `make watch-test`

### TLDR
Running `make`/`make test` will reformat then continue on with build/test