### PR TITLE
Remove unnecessary print statement

### DIFF
--- a/src/haz3lweb/Editors.re
+++ b/src/haz3lweb/Editors.re
@@ -56,7 +56,6 @@ let perform_action =
       CoreSettings.on
     | _ => settings
     };
-  print_endline("action: " ++ Action.show(a));
   switch (Perform.go(~settings, a, get_editor(editors))) {
   | Error(err) => Error(FailedToPerform(err))
   | Ok(ed) => Ok(put_editor(ed, editors))


### PR DESCRIPTION
closes #1403 

We can make a separate PR for https://github.com/hazelgrove/hazel/issues/1403#issuecomment-2389408249. I'm guessing we can just have github comment on every print statement in a diff?