### PR TITLE
Readd warnings failing build in dev but exclude some unused warnings

### DIFF
--- a/dune-workspace
+++ b/dune-workspace
@@ -1,9 +1,10 @@
 (lang dune 3.16)
 
+; List of warning codes found at https://ocaml.org/manual/5.2/comp.html#s:comp-options
 (env
  (dev
   (flags
-   (:standard -warn-error -A)))
+   (:standard -warn-error +A-26-27-32-33-34-35-38-39-58))) ; Disable some unused warnings.
  (release
   (flags
    (:standard -warn-error +A-58))))

--- a/dune-workspace
+++ b/dune-workspace
@@ -4,7 +4,7 @@
 (env
  (dev
   (flags
-   (:standard -warn-error +A-26-27-32-33-34-35-38-39-58))) ; Disable some unused warnings.
+   (:standard -warn-error +A-26-27-K-58))) ; Disable some unused warnings.
  (release
   (flags
    (:standard -warn-error +A-58))))


### PR DESCRIPTION
Disabled Warnings:
    26: Unused variable
    27: Unused Variable Strict
    32: Unused value declaration
    33: Unused open statement
    34: Unused type declaration
    35: Unused for-loop index
    38: Unused extension
    39: Unused rec flag
    58: Missing cmx file This was already in use

Rationale:
I had previously disabled warnings in dev in https://github.com/hazelgrove/hazel/pull/1378. The idea being that you shouldn't restrict the ability to build given warnings, just the ability to deploy. Unfortunately dune only announces warnings the first time a module is built so you could have long lived local issues for serious warnings, i.e. missing cases in pattern-matching.
 
Unused warnings are allowed because they show up regularly as part of writing code and are easy to fix after a build failure in CI by just removing the unused code.