### PR TITLE
Cursor inspector now uses typ equality as opposed to full structural equality

### DIFF
--- a/src/haz3lcore/lang/term/TPat.re
+++ b/src/haz3lcore/lang/term/TPat.re
@@ -29,3 +29,5 @@ let show_cls: cls => string =
   | MultiHole => "Broken type alias"
   | EmptyHole => "Empty type alias hole"
   | Var => "Type alias";
+
+let temp: term => t = term => {term, ids: [Id.invalid], copied: false};

--- a/src/haz3lcore/lang/term/Typ.re
+++ b/src/haz3lcore/lang/term/Typ.re
@@ -282,7 +282,7 @@ let rec join = (~resolve=false, ctx: Ctx.t, ty1: t, ty2: t): option(t) => {
       | None => ty1
       };
     let+ ty_body = join(~resolve, ctx, ty1', ty2);
-    Forall(x1, ty_body) |> temp;
+    Forall(x2, ty_body) |> temp;
   /* Note for above: there is no danger of free variable capture as
      subst itself performs capture avoiding substitution. However this
      may generate internal type variable names that in corner cases can

--- a/src/haz3lcore/lang/term/Typ.re
+++ b/src/haz3lcore/lang/term/Typ.re
@@ -275,12 +275,12 @@ let rec join = (~resolve=false, ctx: Ctx.t, ty1: t, ty2: t): option(t) => {
     Rec(tp1, ty_body) |> temp;
   | (Rec(_), _) => None
   | (Forall(x1, ty1), Forall(x2, ty2)) =>
-    let ctx = Ctx.extend_dummy_tvar(ctx, x1);
     let ty1' =
       switch (TPat.tyvar_of_utpat(x2)) {
       | Some(x2) => subst(Var(x2) |> temp, x1, ty1)
       | None => ty1
       };
+    let ctx = Ctx.extend_dummy_tvar(ctx, x2);
     let+ ty_body = join(~resolve, ctx, ty1', ty2);
     Forall(x2, ty_body) |> temp;
   /* Note for above: there is no danger of free variable capture as

--- a/src/haz3lcore/statics/TermBase.re
+++ b/src/haz3lcore/statics/TermBase.re
@@ -621,7 +621,7 @@ and Typ: {
 
   let subst: (t, TPat.t, t) => t;
 
-  let fast_equal: (t, t) => bool;
+  let fast_equal: (~alpha_equivalence: bool=?, t, t) => bool;
 } = {
   [@deriving (show({with_path: false}), sexp, yojson)]
   type term = typ_term;
@@ -723,22 +723,33 @@ and Typ: {
   /* Type Equality: This coincides with alpha equivalence for normalized types.
      Other types may be equivalent but this will not detect so if they are not normalized. */
 
-  let rec eq_internal = (n: int, t1: t, t2: t) => {
+  let rec eq_internal = (~alpha_equivalence: bool, n: int, t1: t, t2: t) => {
     switch (IdTagged.term_of(t1), IdTagged.term_of(t2)) {
-    | (Parens(t1), _) => eq_internal(n, t1, t2)
-    | (_, Parens(t2)) => eq_internal(n, t1, t2)
+    | (Parens(t1), _) => eq_internal(~alpha_equivalence, n, t1, t2)
+    | (_, Parens(t2)) => eq_internal(~alpha_equivalence, n, t1, t2)
     | (TupLabel(label1, t1'), TupLabel(label2, t2')) =>
-      eq_internal(n, label1, label2) && eq_internal(n, t1', t2')
+      eq_internal(~alpha_equivalence, n, label1, label2)
+      && eq_internal(~alpha_equivalence, n, t1', t2')
     | (TupLabel(_), _) => false
     | (Rec(x1, t1), Rec(x2, t2))
     | (Forall(x1, t1), Forall(x2, t2)) =>
-      let alpha_subst =
-        subst({
-          term: Var("=" ++ string_of_int(n)),
-          copied: false,
-          ids: [Id.invalid],
-        });
-      eq_internal(n + 1, alpha_subst(x1, t1), alpha_subst(x2, t2));
+      if (alpha_equivalence) {
+        let alpha_subst =
+          subst({
+            term: Var("=" ++ string_of_int(n)),
+            copied: false,
+            ids: [Id.invalid],
+          });
+        eq_internal(
+          ~alpha_equivalence,
+          n + 1,
+          alpha_subst(x1, t1),
+          alpha_subst(x2, t2),
+        );
+      } else {
+        TPat.fast_equal(x1, x2)
+        && eq_internal(~alpha_equivalence, n + 1, t1, t2);
+      }
     | (Rec(_), _) => false
     | (Forall(_), _) => false
     | (Int, Int) => true
@@ -753,27 +764,31 @@ and Typ: {
       LabeledTuple.match_labels(name1, name2)
     | (Label(_), _) => false
     | (Ap(t1, t2), Ap(t1', t2')) =>
-      eq_internal(n, t1, t1') && eq_internal(n, t2, t2')
+      eq_internal(~alpha_equivalence, n, t1, t1')
+      && eq_internal(~alpha_equivalence, n, t2, t2')
     | (Ap(_), _) => false
     | (Unknown(_), Unknown(_)) => true
     | (Unknown(_), _) => false
     | (Arrow(t1, t2), Arrow(t1', t2')) =>
-      eq_internal(n, t1, t1') && eq_internal(n, t2, t2')
+      eq_internal(~alpha_equivalence, n, t1, t1')
+      && eq_internal(~alpha_equivalence, n, t2, t2')
     | (Arrow(_), _) => false
-    | (Prod(tys1), Prod(tys2)) => List.equal(eq_internal(n), tys1, tys2)
+    | (Prod(tys1), Prod(tys2)) =>
+      List.equal(eq_internal(~alpha_equivalence, n), tys1, tys2)
     | (Prod(_), _) => false
-    | (List(t1), List(t2)) => eq_internal(n, t1, t2)
+    | (List(t1), List(t2)) => eq_internal(~alpha_equivalence, n, t1, t2)
     | (List(_), _) => false
     | (Sum(sm1), Sum(sm2)) =>
       /* Does not normalize the types. */
-      ConstructorMap.equal(eq_internal(n), sm1, sm2)
+      ConstructorMap.equal(eq_internal(~alpha_equivalence, n), sm1, sm2)
     | (Sum(_), _) => false
     | (Var(n1), Var(n2)) => n1 == n2
     | (Var(_), _) => false
     };
   };
 
-  let fast_equal = eq_internal(0);
+  let fast_equal = (~alpha_equivalence=true, t1, t2) =>
+    eq_internal(~alpha_equivalence, 0, t1, t2);
 }
 and TPat: {
   [@deriving (show({with_path: false}), sexp, yojson)]

--- a/src/haz3lweb/app/inspector/CursorInspector.re
+++ b/src/haz3lweb/app/inspector/CursorInspector.re
@@ -273,7 +273,8 @@ let common_ok_view =
         text(":"),
         view_type(ana),
       ]
-    | (_, Ana(Consistent({ana, syn, _}))) when ana == syn =>
+    | (_, Ana(Consistent({ana, syn, _})))
+        when Typ.fast_equal(~alpha_equivalence=false, ana, syn) =>
       switch (syn.term) {
       | Label(l) => [code(l), text(" is a valid label")]
       | _ =>

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -31,8 +31,8 @@ let eq_info_error_exp = (a: Info.error_exp, b: Info.error_exp) => {
 let testable_info_error_exp =
   testable(Fmt.using(Info.show_error_exp, Fmt.string), eq_info_error_exp);
 
-let status_exp: testable(Info.status_exp) =
-  testable(Fmt.using(Info.show_status_exp, Fmt.string), (==));
+let testable_error: testable(Info.error) =
+  testable(Fmt.using(Info.show_error, Fmt.string), (==));
 module FreshId = {
   let arrow = (a, b) => Arrow(a, b) |> Typ.fresh;
   let unknown = a => Unknown(a) |> Typ.fresh;
@@ -75,20 +75,11 @@ let inconsistent_typecheck = (name, exp) => {
     `Quick,
     () => {
       let s = statics(exp);
-      let errors: list(Info.status_exp) =
-        List.map(
-          (id: Id.t) => {
-            let info = Id.Map.find(id, s);
-            switch (info) {
-            | InfoExp(ie) => ie.status
-            | _ => fail("Expected InfoExp")
-            };
-          },
-          Statics.Map.error_ids(s),
-        );
+
+      let errors = List.map(snd, Statics.collect_errors(s));
 
       Alcotest.check(
-        neg(list(status_exp)),
+        neg(list(testable_error)),
         "Missing Static Errors",
         [],
         errors,
@@ -102,18 +93,8 @@ let fully_consistent_typecheck = (name, serialized, expected, exp) => {
     `Quick,
     () => {
       let s = statics(exp);
-      let errors =
-        List.map(
-          (id: Id.t) => {
-            let info = Id.Map.find(id, s);
-            switch (info) {
-            | InfoExp(ie) => ie.status
-            | _ => fail("Expected InfoExp")
-            };
-          },
-          Statics.Map.error_ids(s),
-        );
-      Alcotest.check(list(status_exp), "Static Errors", [], errors);
+      let errors = List.map(snd, Statics.collect_errors(s));
+      Alcotest.check(list(testable_error), "Static Errors", [], errors);
       alco_check(serialized, expected, type_of(exp));
     },
   );
@@ -1115,6 +1096,22 @@ let tests = (
           Statics.get_error_at(s, IdTagged.rep_id(tuple)),
         );
       },
+    ),
+    fully_consistent_typecheck(
+      "Forall alpha equivalent in cast",
+      {|let x : forall a -> a = in (x : forall b -> b)|},
+      Some(
+        Forall(Var("b") |> TPat.fresh, Var("b") |> Typ.fresh) |> Typ.fresh,
+      ),
+      parse_exp({|let x : forall a -> a = in (x : forall b -> b)|}),
+    ),
+    fully_consistent_typecheck(
+      "Forall alpha equivalent in let",
+      {|let x : forall a -> a = in let y : forall b -> b = x in 1|},
+      Some(int),
+      parse_exp(
+        {|let x : forall a -> a = in let y : forall b -> b = x in 1|},
+      ),
     ),
   ],
 );

--- a/test/Test_Typ.re
+++ b/test/Test_Typ.re
@@ -1,0 +1,48 @@
+open Alcotest;
+open Haz3lcore;
+
+let tests = (
+  "Typ",
+  [
+    test_case(
+      "Typ join on polymorphic types",
+      `Quick,
+      () => {
+        let t =
+          Typ.join(
+            [],
+            Forall(Var("a") |> TPat.temp, Var("a") |> Typ.temp) |> Typ.temp,
+            Forall(Var("b") |> TPat.temp, Var("b") |> Typ.temp) |> Typ.temp,
+          );
+        check(
+          option(testable(Fmt.using(Typ.show, Fmt.string), Typ.fast_equal)),
+          "Forall alpha equivalent",
+          Some(
+            Forall(Var("a") |> TPat.temp, Var("a") |> Typ.temp) |> Typ.temp,
+          ),
+          t,
+        );
+      },
+    ),
+    test_case(
+      "Capture avoiding substitution",
+      `Quick,
+      () => {
+        let t =
+          Typ.join(
+            [],
+            Forall(Var("a") |> TPat.temp, Var("a") |> Typ.temp) |> Typ.temp,
+            Forall(Var("b") |> TPat.temp, Var("b") |> Typ.temp) |> Typ.temp,
+          );
+        check(
+          option(testable(Fmt.using(Typ.show, Fmt.string), Typ.fast_equal)),
+          "Forall alpha equivalent",
+          Some(
+            Forall(Var("a") |> TPat.temp, Var("a") |> Typ.temp) |> Typ.temp,
+          ),
+          t,
+        );
+      },
+    ),
+  ],
+);

--- a/test/Test_Typ.re
+++ b/test/Test_Typ.re
@@ -25,22 +25,28 @@ let tests = (
       },
     ),
     test_case(
-      "Capture avoiding substitution",
+      "Equality alpha equivalent",
       `Quick,
       () => {
-        let t =
-          Typ.join(
-            [],
+        check(
+          bool,
+          "Forall alpha equivalent",
+          true,
+          Typ.fast_equal(
+            ~alpha_equivalence=true,
             Forall(Var("a") |> TPat.temp, Var("a") |> Typ.temp) |> Typ.temp,
             Forall(Var("b") |> TPat.temp, Var("b") |> Typ.temp) |> Typ.temp,
-          );
-        check(
-          option(testable(Fmt.using(Typ.show, Fmt.string), Typ.fast_equal)),
-          "Forall alpha equivalent",
-          Some(
-            Forall(Var("a") |> TPat.temp, Var("a") |> Typ.temp) |> Typ.temp,
           ),
-          t,
+        );
+        check(
+          bool,
+          "Forall non alpha equivalent",
+          false,
+          Typ.fast_equal(
+            ~alpha_equivalence=false,
+            Forall(Var("a") |> TPat.temp, Var("a") |> Typ.temp) |> Typ.temp,
+            Forall(Var("b") |> TPat.temp, Var("b") |> Typ.temp) |> Typ.temp,
+          ),
         );
       },
     ),

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -10,6 +10,7 @@ let (suite, _) =
       Test_MakeTerm.tests,
       Test_Menhir.tests,
       Test_StringUtil.tests,
+      Test_Typ.tests,
       Test_Statics.tests,
       Test_Evaluator.tests,
       Test_ListUtil.tests,


### PR DESCRIPTION
Old version
![Screenshot from 2024-11-18 14-22-40](https://github.com/user-attachments/assets/ddf4a8f6-d39c-4c7e-af3a-46b951ffb958)
New version
![Screenshot from 2024-11-18 14-23-22](https://github.com/user-attachments/assets/d87cfb01-1dd9-4ed5-adea-b0eb1e4981a5)