### PR TITLE
Fix multiplication/division precedence

### DIFF
--- a/src/haz3lcore/lang/Precedence.re
+++ b/src/haz3lcore/lang/Precedence.re
@@ -6,38 +6,101 @@ open Util;
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t = int;
 
+[@deriving show({with_path: false})]
+type precedence_element =
+  | Unquote
+  | Ap
+  | Neg
+  | Power
+  | Mult
+  | Not
+  | Plus
+  | Cons
+  | Concat
+  | Eqs
+  | And
+  | Or
+  | Ann
+  | If
+  | Fun
+  | Semi
+  | Let
+  | Filter
+  | RuleArr
+  | RulePre
+  | RuleSep
+  | Case
+  | Comma
+  | TypePlus
+  | TypeArrow
+  | TypeProd;
+
+let ordering: list(list(precedence_element)) = [
+  [Unquote],
+  [Ap],
+  [Neg],
+  [TypePlus],
+  [TypeArrow],
+  [Power],
+  [Mult, Not],
+  [Plus],
+  [Cons],
+  [Concat],
+  [Eqs],
+  [And],
+  [Or],
+  [Ann],
+  [If],
+  [Fun],
+  [Comma, TypeProd],
+  [Semi],
+  [Let],
+  [Filter],
+  [RuleArr],
+  [RulePre],
+  [RuleSep],
+  [Case],
+];
+
+let ordering_indexed: list((precedence_element, int)) =
+  ordering
+  |> List.mapi((i, l) => l |> List.map(e => (e, i + 1)))
+  |> List.concat;
+
+let assoc_ordering_index: precedence_element => int =
+  e => List.assoc(e, ordering_indexed);
+
 let max: t = 0;
+let unquote = assoc_ordering_index(Unquote);
+let ap = assoc_ordering_index(Ap);
+let neg = assoc_ordering_index(Neg);
+let power = assoc_ordering_index(Power);
+let mult = assoc_ordering_index(Mult);
+let not_ = assoc_ordering_index(Not);
+let plus = assoc_ordering_index(Plus);
+let cons = assoc_ordering_index(Cons);
+let concat = assoc_ordering_index(Concat);
+let eqs = assoc_ordering_index(Eqs);
+let and_ = assoc_ordering_index(And);
+let or_ = assoc_ordering_index(Or);
+let ann = assoc_ordering_index(Ann);
+let if_ = assoc_ordering_index(If);
+let fun_ = assoc_ordering_index(Fun);
+let semi = assoc_ordering_index(Semi);
+let let_ = assoc_ordering_index(Let);
+let filter = assoc_ordering_index(Filter);
+let rule_arr = assoc_ordering_index(RuleArr);
+let rule_pre = assoc_ordering_index(RulePre);
+let rule_sep = assoc_ordering_index(RuleSep);
+let case_ = assoc_ordering_index(Case);
 
-let unquote = 1;
-let ap = 2;
-let neg = 3;
-let power = 4;
-let mult = 5;
-let not_ = 5;
-let plus = 6;
-let cons = 7;
-let concat = 8;
-let eqs = 9;
-let and_ = 10;
-let or_ = 11;
-let ann = 12;
-let if_ = 13;
-let fun_ = 14;
-let semi = 16;
-let let_ = 17;
-let filter = 18;
-let rule_arr = 19;
-let rule_pre = 20;
-let rule_sep = 21;
-let case_ = 22;
+let comma = assoc_ordering_index(Comma);
 
-let comma = 15;
+let type_plus = assoc_ordering_index(TypePlus);
+let type_arrow = assoc_ordering_index(TypeArrow);
+let type_prod = assoc_ordering_index(TypeProd);
 
-let type_plus = 4;
-let type_arrow = 5;
-let type_prod = comma;
-
-let min = 26;
+let min: t = List.length(ordering) + 1;
 
 let compare = (p1: t, p2: t): int =>
   (-1) * Int.compare((p1 :> int), (p2 :> int));


### PR DESCRIPTION
I added a new encoding so we don't have to manually track precedence numbers. I didn't realize precedence was being stored on the tiles in the persisted programs. I'm not sure how we want to handle rolling this out with that or if we want to go back to the older number encoding so we can babysit them more. 

I'm also open to other ideas on how to avoid breaking it for everyone.

Before
![Screenshot from 2024-12-02 16-47-25](https://github.com/user-attachments/assets/8fa0e818-3a9a-4fcb-a36c-1a26882d8a57)
After
![Screenshot from 2024-12-02 16-47-31](https://github.com/user-attachments/assets/e14f1836-bf19-4353-bece-ff4480732813)
