### PR TITLE
Fix case statements in exptosegment

### DIFF
--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -445,11 +445,12 @@ let rec exp_to_pretty = (~settings: Settings.t, exp: Exp.t): pretty => {
           @ (
             List.map2(
               (id, (p, e)) =>
-                settings.inline
-                  ? []
-                  : [Secondary(Secondary.mk_newline(Id.mk()))]
-                    @ [mk_form("rule", id, [p])]
-                    @ (e |> fold_if(settings.fold_case_clauses)),
+                (
+                  settings.inline
+                    ? [] : [Secondary(Secondary.mk_newline(Id.mk()))]
+                )
+                @ [mk_form("rule", id, [p])]
+                @ (e |> fold_if(settings.fold_case_clauses)),
               ids,
               rs,
             )

--- a/test/Test_ExpToSegment.re
+++ b/test/Test_ExpToSegment.re
@@ -1,0 +1,47 @@
+open Alcotest;
+open Haz3lcore;
+
+let segmentize =
+  ExpToSegment.exp_to_segment(
+    ~settings=ExpToSegment.Settings.of_core(~inline=true, CoreSettings.off),
+    _,
+  );
+
+let tests = (
+  "ExpToSegment",
+  [
+    test_case(
+      "Match statement",
+      `Quick,
+      () => {
+        let segment =
+          segmentize(
+            Match(
+              Var("x") |> Exp.fresh,
+              [
+                (
+                  Constructor("A", Unknown(Internal) |> Typ.fresh)
+                  |> Pat.fresh,
+                  Int(1) |> Exp.fresh,
+                ),
+                (
+                  Constructor("B", Unknown(Internal) |> Typ.fresh)
+                  |> Pat.fresh,
+                  Int(2) |> Exp.fresh,
+                ),
+              ],
+            )
+            |> Exp.fresh,
+          );
+        let serialized = Printer.of_segment(~holes=Some("?"), segment);
+
+        check(
+          string,
+          "Match statement",
+          serialized,
+          "case x | A => 1| B => 2 end",
+        );
+      },
+    ),
+  ],
+);

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -11,6 +11,7 @@ let (suite, _) =
       Test_Evaluator.tests,
       Test_ListUtil.tests,
       Test_MakeTerm.tests,
+      Test_ExpToSegment.tests,
     ],
   );
 Junit.to_file(Junit.make([suite]), "junit_tests.xml");


### PR DESCRIPTION
Fixes the ExpToSegment functionality on match statements when inline is true. Currently this just skips all rules.

Sample output when printed
```
case x | A => 1| B => 2 end
```