### PR TITLE
fix mysterious code deleletion bug #1449

### DIFF
--- a/src/haz3lcore/assistant/TyDi.re
+++ b/src/haz3lcore/assistant/TyDi.re
@@ -77,6 +77,14 @@ let get_buffer = (z: Zipper.t): option(Token.t) =>
 
 /* Populates the suggestion buffer with a type-directed suggestion */
 let set_buffer = (~info_map: Statics.Map.t, z: Zipper.t): option(Zipper.t) => {
+  let* _ =
+    switch (z.selection.mode) {
+    /* Make sure not to populate the completion buffer if there is a non-empty
+     * selection, otherwise it will get clobbered by the buffer */
+    | Buffer(Unparsed) => Some()
+    | Normal when Selection.is_empty(z.selection) => Some()
+    | Normal => None
+    };
   let* tok_to_left = token_to_left(z);
   let* index = Indicated.index(z);
   let* ci = Id.Map.find_opt(index, info_map);


### PR DESCRIPTION
Closes #1449. See @7h3kk1d's repro.

Not totally sure when this got introduced. I don't think it was a thing months ago, but I can't immediately figure out how this case was prevented before. My current theory is that the order of operations here wrt movement/selection was different pre editor-componentization so this never had the chance to occur, but I haven't done a bisect to confirm this yet.