### PR TITLE
Change default buffer back to basic reference

### DIFF
--- a/src/haz3lweb/Init.ml
+++ b/src/haz3lweb/Init.ml
@@ -69,7 +69,7 @@ let startup : PersistentData.t =
           };
         ] );
     documentation =
-      ( 0,
+      ( 2,
         [
           ( "Casting",
             {


### PR DESCRIPTION
https://github.com/hazelgrove/hazel/commit/0e24c16dec762e8aba3e2b748e22833b976677a0 changed the default buffer to the casting documentation buffer. I think this is an accident. This moves it back to the basic reference so new users get this first.

I'm planning on tackling https://github.com/hazelgrove/hazel/issues/1487 but haven't gotten around to it.