### PR TITLE
Codecov support

### DIFF
--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           eval $(opam env)
           make test
+          make coverage
         working-directory: ./source
       - name: Test Report
         uses: dorny/test-reporter@v1
@@ -81,3 +82,9 @@ jobs:
           fail-on-error: true
           fail-on-empty: true # Use an empty test report to detect when something failed with the test runner
           working-directory: ./source
+      - name: Send coverage report to Codecov
+        run: opam exec -- bisect-ppx-report send-to Codecov --verbose
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          PULL_REQUEST_NUMBER: ${{ github.event.number }}
+        working-directory: ./source

--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -70,14 +70,13 @@ jobs:
         id: test
         run: |
           eval $(opam env)
-          make test
-          make coverage
+          make ci
         working-directory: ./source
       - name: Test Report
         uses: dorny/test-reporter@v1
         with:
           name: Test Report
-          path: junit_tests*.xml
+          path: ./_build/default/test/junit_tests*.xml
           reporter: java-junit
           fail-on-error: true
           fail-on-empty: true # Use an empty test report to detect when something failed with the test runner

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ coverage:
 	dune runtest --instrument-with bisect_ppx --force
 	bisect-ppx-report summary
 
+ci:
+	dune build --profile dev
+	dune runtest --instrument-with bisect_ppx --force
+	
 generate-coverage-html:
 	bisect-ppx-report html
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hazel ![Build Status](https://github.com/hazelgrove/hazel/actions/workflows/deploy_branches.yml/badge.svg)
+# Hazel ![Build Status](https://github.com/hazelgrove/hazel/actions/workflows/deploy_branches.yml/badge.svg) [![codecov](https://codecov.io/gh/hazelgrove/hazel/graph/badge.svg?token=lOGAH9Shqe)](https://codecov.io/gh/hazelgrove/hazel)
 
 Hazel is a live functional-programming environment rooted in the principles of
 type theory. You can find the relevant papers and more motivation at [the Hazel

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  branch: dev
+
 coverage:
   status:
     project: # more options at https://docs.codecov.com/docs/commit-status

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project: # more options at https://docs.codecov.com/docs/commit-status
+      default:
+        target: auto # Monotonically increasing coverage
+        threshold: 0% # Allows coverage to drop by 0%

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,11 @@ coverage:
       default:
         target: auto # Monotonically increasing coverage
         threshold: 0% # Allows coverage to drop by 0%
+
+comment:
+  layout: " diff, files"
+  behavior: default # update comment, if exists. Otherwise post new
+  require_changes: true
+  require_base: false
+  require_head: true
+  hide_project_coverage: false

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -340,5 +340,12 @@ in fn("hello")|},
     test_case("Variable capture", `Quick, test_variable_capture),
     test_case("Unbound lookup", `Quick, test_unbound_lookup),
     test_case("Unevaluated if closure", `Quick, test_unevaluated_if),
+    test_case("Negative integer literal", `Quick, () =>
+      evaluation_test(
+        "-8",
+        Int(-8) |> Exp.fresh,
+        UnOp(Int(Minus), Int(8) |> Exp.fresh) |> Exp.fresh,
+      )
+    ),
   ],
 );


### PR DESCRIPTION
### Support for codecov.io
This should give us CI checks for coverage as well as PR comments.

### Note
Due to https://github.com/aantron/bisect_ppx/issues/391 our coverage metrics are based on all of the linked files in the test suite. If a file is untested and not linked in from another tested file it won't show up in coverage. I'm planning on trying to address this in a future PR.