### PR TITLE
Hide stepper filters & bring back function names

### DIFF
--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -18,7 +18,7 @@ module Settings = {
     fold_fn_bodies: !settings.evaluation.show_fn_bodies,
     hide_fixpoints: !settings.evaluation.show_fixpoints,
     fold_cast_types: !settings.evaluation.show_casts,
-    show_filters: false,
+    show_filters: settings.evaluation.show_stepper_filters,
   };
 };
 
@@ -308,12 +308,6 @@ let rec parenthesize =
     )
     |> rewrap
   | Test(e) => Test(parenthesize(e) |> paren_at(Precedence.min)) |> rewrap
-  // | Filter(f, e) =>
-  //   Filter(
-  //     f, // TODO: Filters
-  //     parenthesize(e) |> paren_at(Precedence.min),
-  //   )
-  //   |> rewrap
   | Parens(e) =>
     Parens(parenthesize(~already_paren=true, e) |> paren_at(Precedence.min))
     |> rewrap
@@ -707,14 +701,18 @@ let rec exp_to_pretty = (~settings: Settings.t, exp: Exp.t): pretty => {
     let id = exp |> Exp.rep_id;
     let* p = go(pat);
     let+ e = go(e);
-    let form =
-      switch (act) {
-      | (Step, One) => Form.FilterPause
-      | (Step, All) => Form.FilterDebug
-      | (Eval, One) => Form.FilterHide
-      | (Eval, All) => Form.FilterEval
-      };
-    [mk_form(form, id, [p])] @ e;
+    settings.show_filters
+      ? {
+        let form =
+          switch (act) {
+          | (Step, One) => Form.FilterPause
+          | (Step, All) => Form.FilterDebug
+          | (Eval, One) => Form.FilterHide
+          | (Eval, All) => Form.FilterEval
+          };
+        [mk_form(form, id, [p])] @ e;
+      }
+      : e;
   // Forms which should be removed by substitute_closures
   | Closure(_) => failwith("closure not removed before printing")
   // Other cases

--- a/src/haz3lcore/statics/Elaborator.re
+++ b/src/haz3lcore/statics/Elaborator.re
@@ -454,14 +454,14 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
         |> Option.get
         |> List.exists(f => VarMap.lookup(co_ctx, f) != None);
       if (!is_recursive) {
-        let def = add_name(Pat.get_var(p), def);
         let (def, ty2) = elaborate(m, def);
+        let def = add_name(Pat.get_var(p), def);
         let (body, ty) = elaborate(m, body);
         Let(p, fresh_cast(def, ty2, ty1), body) |> rewrap |> cast_from(ty);
       } else {
         // TODO: Add names to mutually recursive functions
-        let def = add_name(Option.map(s => s ++ "+", Pat.get_var(p)), def);
         let (def, ty2) = elaborate(m, def);
+        let def = add_name(Option.map(s => s ++ "+", Pat.get_var(p)), def);
         let (body, ty) = elaborate(m, body);
         let fixf =
           (FixF(p, fresh_cast(def, ty2, ty1), None): Exp.term)

--- a/src/haz3lweb/view/NutMenu.re
+++ b/src/haz3lweb/view/NutMenu.re
@@ -89,7 +89,12 @@ let stepper_group = (~globals: Globals.t) => {
         s.show_hidden_steps,
         Evaluation(ShowHiddenSteps),
       ),
-      ("⏯️", "Filters", s.show_stepper_filters, Evaluation(ShowFilters)),
+      (
+        "⏯️",
+        "Show filters",
+        s.show_stepper_filters,
+        Evaluation(ShowFilters),
+      ),
     ],
   );
 };


### PR DESCRIPTION
Fixes #1488 and fixes #1529 

![image](https://github.com/user-attachments/assets/d3e1efaa-6872-40f0-9c71-a8cc27171f80)
