### PR TITLE
Codecov setting changes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
     project: # more options at https://docs.codecov.com/docs/commit-status
       default:
         target: auto # Monotonically increasing coverage
-        threshold: 0% # Allows coverage to drop by 0%
+        threshold: 2% # Allows coverage to drop by 2%
 
 comment:
   layout: " diff, files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,10 @@ coverage:
       default:
         target: auto # Monotonically increasing coverage
         threshold: 2% # Allows coverage to drop by 2%
+        informational: true
+    patch:
+      default:
+        informational: true
 
 comment:
   layout: " diff, files"


### PR DESCRIPTION
### Codecov changes

- Makes status checks informational: This means they don't mark the build as failed
- Allows leniency for project coverage since qcheck tests cause some variance