### PR TITLE
Global undo

### DIFF
--- a/src/haz3lcore/zipper/Editor.re
+++ b/src/haz3lcore/zipper/Editor.re
@@ -78,26 +78,11 @@ module State = {
   };
 };
 
-module History = {
-  [@deriving (show({with_path: false}), sexp, yojson)]
-  type affix = list((Action.t, State.t));
-  [@deriving (show({with_path: false}), sexp, yojson)]
-  type t = (affix, affix);
-
-  let empty = ([], []);
-
-  let add = (a: Action.t, state: State.t, (pre, _): t): t => (
-    [(a, state), ...pre],
-    [],
-  );
-};
-
 module Model = {
   [@deriving (show({with_path: false}), sexp, yojson)]
   type t = {
     // Updated
     state: State.t,
-    history: History.t,
     // Calculated
     [@opaque]
     syntax: CachedSyntax.t,
@@ -108,7 +93,6 @@ module Model = {
       zipper,
       col_target: None,
     },
-    history: History.empty,
     syntax:
       CachedSyntax.init(
         zipper,
@@ -156,7 +140,7 @@ module Update = {
         ~settings: CoreSettings.t,
         a: Action.t,
         old_statics,
-        {state, history, syntax}: Model.t,
+        {state, syntax}: Model.t,
       )
       : Action.Result.t(Model.t) => {
     open Result.Syntax;
@@ -172,7 +156,7 @@ module Update = {
               Buffer(Clear),
               Model.to_move_s({
                 state,
-                history,
+
                 syntax,
               }),
               state.zipper,
@@ -187,10 +171,6 @@ module Update = {
       } else {
         syntax;
       };
-
-    // 2. Add to undo history
-    let history =
-      Action.is_historic(a) ? History.add(a, state, history) : history;
 
     // 3. Record target column if moving up/down
     let col_target =
@@ -216,7 +196,7 @@ module Update = {
         a,
         Model.to_move_s({
           state,
-          history,
+
           syntax,
         }),
         state.zipper,
@@ -231,38 +211,9 @@ module Update = {
         zipper,
         col_target,
       },
-      history,
       syntax,
     };
   };
-
-  let undo = (ed: Model.t) =>
-    switch (ed.history) {
-    | ([], _) => None
-    | ([(a, prev), ...before], after) =>
-      Some(
-        Model.{
-          state: prev,
-          history: (before, [(a, ed.state), ...after]),
-          syntax: ed.syntax // Will be recalculated in calculate
-        },
-      )
-    };
-  let redo = (ed: Model.t) =>
-    switch (ed.history) {
-    | (_, []) => None
-    | (before, [(a, next), ...after]) =>
-      Some(
-        Model.{
-          state: next,
-          history: ([(a, ed.state), ...before], after),
-          syntax: ed.syntax // Will be recalculated in calculate
-        },
-      )
-    };
-
-  let can_undo = ed => Option.is_some(undo(ed));
-  let can_redo = ed => Option.is_some(redo(ed));
 
   let calculate =
       (
@@ -270,7 +221,7 @@ module Update = {
         ~is_edited,
         new_statics,
         dyn_map,
-        {syntax, state, history}: Model.t,
+        {syntax, state}: Model.t,
       ) => {
     // 1. Recalculate the autocomplete buffer if necessary
     let zipper =
@@ -283,7 +234,6 @@ module Update = {
             Model.to_move_s({
               syntax,
               state,
-              history,
             }),
             state.zipper,
           )
@@ -302,7 +252,6 @@ module Update = {
 
     // Recombine
     Model.{
-      history,
       state: {
         ...state,
         zipper,

--- a/src/haz3lweb/Main.re
+++ b/src/haz3lweb/Main.re
@@ -21,6 +21,7 @@ let apply =
     (
       model: Page.Model.t,
       action: Page.Update.t,
+      ~schedule_effect,
       ~schedule_action,
       ~schedule_autosave,
     )
@@ -36,6 +37,7 @@ let apply =
       Page.Update.update(
         ~import_log=Log.import,
         ~get_log_and=Log.get_and,
+        ~schedule_effect,
         ~schedule_action,
         action,
         model,
@@ -95,7 +97,11 @@ let start = {
               schedule_event(alarm_inject(action))
             | Inactive => ()
             };
-          apply(~schedule_action, ~schedule_autosave);
+          apply(
+            ~schedule_action,
+            ~schedule_effect=schedule_event,
+            ~schedule_autosave,
+          );
         },
       ~default_model=Page.Store.load(),
       ~can_undo=Page.Update.can_undo,

--- a/src/haz3lweb/Main.re
+++ b/src/haz3lweb/Main.re
@@ -83,7 +83,7 @@ let apply =
 let start = {
   let%sub save_scheduler = BonsaiUtil.Alarm.alarm;
   let%sub (app_model, app_inject) =
-    Bonsai.state_machine1(
+    BonsaiUndo.state_machine_with_undo(
       (module Page.Model),
       (module Page.Update),
       ~apply_action=
@@ -98,6 +98,7 @@ let start = {
           apply(~schedule_action, ~schedule_autosave);
         },
       ~default_model=Page.Store.load(),
+      ~can_undo=Page.Update.can_undo,
       save_scheduler,
     );
 

--- a/src/haz3lweb/Settings.re
+++ b/src/haz3lweb/Settings.re
@@ -98,6 +98,13 @@ module Update = {
     | ExplainThis(ExplainThisModel.Settings.action)
     | FlipAnimations;
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | Evaluation(ShowSettings) => false
+    | _ => true
+    };
+  };
+
   let update = (action, settings: Model.t): Updated.t(Model.t) => {
     (
       switch (action) {

--- a/src/haz3lweb/app/editors/Editors.re
+++ b/src/haz3lweb/app/editors/Editors.re
@@ -77,6 +77,14 @@ module Update = {
     // Exercises
     | Exercises(ExercisesMode.Update.t);
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | SwitchMode(_) => true
+    | Scratch(action) => ScratchMode.Update.can_undo(action)
+    | Exercises(action) => ExercisesMode.Update.can_undo(action)
+    };
+  };
+
   let update = (~globals: Globals.t, ~schedule_action, action, model: Model.t) => {
     switch (action, model) {
     | (Scratch(action), Scratch(m)) =>

--- a/src/haz3lweb/app/editors/cell/CellEditor.re
+++ b/src/haz3lweb/app/editors/cell/CellEditor.re
@@ -37,6 +37,13 @@ module Update = {
     | MainEditor(CodeEditable.Update.t)
     | ResultAction(EvalResult.Update.t);
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | MainEditor(action) => CodeEditable.Update.can_undo(action)
+    | ResultAction(action) => EvalResult.Update.can_undo(action)
+    };
+  };
+
   let update = (~settings, action, model: Model.t) => {
     switch (action) {
     | MainEditor(action) =>

--- a/src/haz3lweb/app/editors/code/CodeEditable.re
+++ b/src/haz3lweb/app/editors/code/CodeEditable.re
@@ -20,6 +20,16 @@ module Update = {
 
   exception CantReset;
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | Perform(action) => Action.is_historic(action)
+    | Undo => false
+    | Redo => false
+    | TAB => true
+    | DebugConsole(_) => false
+    };
+  };
+
   let update =
       (~settings: Settings.t, action: t, model: Model.t): Updated.t(Model.t) => {
     let perform = (action, model: Model.t) =>

--- a/src/haz3lweb/app/editors/code/CodeEditable.re
+++ b/src/haz3lweb/app/editors/code/CodeEditable.re
@@ -13,8 +13,6 @@ module Update = {
   [@deriving (show({with_path: false}), sexp, yojson)]
   type t =
     | Perform(Action.t)
-    | Undo
-    | Redo
     | TAB
     | DebugConsole(string);
 
@@ -23,8 +21,6 @@ module Update = {
   let can_undo = (action: t) => {
     switch (action) {
     | Perform(action) => Action.is_historic(action)
-    | Undo => false
-    | Redo => false
     | TAB => true
     | DebugConsole(_) => false
     };
@@ -77,26 +73,6 @@ module Update = {
          );
     switch (action) {
     | Perform(action) => perform(action, model)
-    | Undo =>
-      switch (Editor.Update.undo(model.editor)) {
-      | Some(editor) =>
-        Model.{
-          ...model,
-          editor,
-        }
-        |> Updated.return
-      | None => model |> Updated.return_quiet
-      }
-    | Redo =>
-      switch (Editor.Update.redo(model.editor)) {
-      | Some(editor) =>
-        Model.{
-          ...model,
-          editor,
-        }
-        |> Updated.return
-      | None => model |> Updated.return_quiet
-      }
     | DebugConsole(key) =>
       DebugConsole.print(~settings, model, key);
       model |> Updated.return_quiet;
@@ -133,36 +109,14 @@ module Selection = {
         CodeWithStatics.Model.get_cursor_info(model)
         |> map(x => Update.Perform(x)),
       editor_read_only: false,
-      undo_action: Some(Update.Undo),
-      redo_action: Some(Update.Redo),
     };
   };
 
   let handle_key_event =
       (~selection as (), _: Model.t): (Key.t => option(Update.t)) =>
     fun
-    | {
-        key: D("Z" | "z"),
-        sys: Mac,
-        shift: Down,
-        meta: Down,
-        ctrl: Up,
-        alt: Up,
-      }
-    | {
-        key: D("Z" | "z"),
-        sys: PC,
-        shift: Down,
-        meta: Up,
-        ctrl: Down,
-        alt: Up,
-      } =>
-      Some(Update.Redo)
     | {key: D("Tab"), sys: _, shift: Up, meta: Up, ctrl: Up, alt: Up} =>
       Some(Update.TAB)
-    | {key: D("Z" | "z"), sys: Mac, shift: Up, meta: Down, ctrl: Up, alt: Up}
-    | {key: D("Z" | "z"), sys: PC, shift: Up, meta: Up, ctrl: Down, alt: Up} =>
-      Some(Update.Undo)
     | {key: D(key), sys: Mac | PC, shift: Down, meta: Up, ctrl: Up, alt: Up}
         when Keyboard.is_f_key(key) =>
       Some(Update.DebugConsole(key))

--- a/src/haz3lweb/app/editors/code/CodeSelectable.re
+++ b/src/haz3lweb/app/editors/code/CodeSelectable.re
@@ -16,6 +16,16 @@ module Update = {
     | Unselect(option(Util.Direction.t))
     | Copy;
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | Move(move) => Action.is_historic(Move(move))
+    | Jump(target) => Action.is_historic(Jump(target))
+    | Select(select) => Action.is_historic(Select(select))
+    | Unselect(dir) => Action.is_historic(Unselect(dir))
+    | Copy => false
+    };
+  };
+
   let update = (~settings, action: t, model: Model.t): Updated.t(Model.t) => {
     let action': CodeEditable.Update.t =
       switch (action) {

--- a/src/haz3lweb/app/editors/code/CodeSelectable.re
+++ b/src/haz3lweb/app/editors/code/CodeSelectable.re
@@ -59,8 +59,6 @@ module Update = {
         Project(_) |
         Introduce,
       )
-    | Undo
-    | Redo
     | DebugConsole(_)
     | TAB => None;
 

--- a/src/haz3lweb/app/editors/mode/ExercisesMode.re
+++ b/src/haz3lweb/app/editors/mode/ExercisesMode.re
@@ -188,6 +188,16 @@ module Update = {
     | ExportTransitionary
     | ExportGrading;
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | SwitchExercise(_) => true
+    | Exercise(action) => ExerciseMode.Update.can_undo(action)
+    | ExportModule => false
+    | ExportSubmission => false
+    | ExportTransitionary => false
+    | ExportGrading => false
+    };
+  };
   let export_exercise_module = (exercises: Model.t): unit => {
     let exercise = Model.get_current(exercises);
     let module_name = exercise.editors.module_name;

--- a/src/haz3lweb/app/editors/result/EvalResult.re
+++ b/src/haz3lweb/app/editors/result/EvalResult.re
@@ -104,6 +104,15 @@ module Update = {
     | EvalEditorAction(CodeSelectable.Update.t)
     | UpdateResult(Haz3lcore.ProgramResult.t(Haz3lcore.ProgramResult.inner));
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | ToggleStepper => true
+    | StepperAction(action) => StepperView.Update.can_undo(action)
+    | EvalEditorAction(action) => CodeSelectable.Update.can_undo(action)
+    | UpdateResult(_) => false
+    };
+  };
+
   // Update is meant to make minimal changes to the model, and calculate will do the rest.
   let update = (~settings, action, model: Model.t): Updated.t(Model.t) =>
     switch (action, model) {

--- a/src/haz3lweb/app/editors/result/StepperEditor.re
+++ b/src/haz3lweb/app/editors/result/StepperEditor.re
@@ -30,6 +30,8 @@ module Update = {
     };
   };
 
+  let can_undo = CodeSelectable.Update.can_undo;
+
   let calculate =
       (
         ~settings,

--- a/src/haz3lweb/app/globals/Globals.re
+++ b/src/haz3lweb/app/globals/Globals.re
@@ -88,6 +88,22 @@ module Update = {
     ...model,
     color_highlights,
   };
+
+  let can_undo = (action: t) => {
+    switch (action) {
+    | SetMousedown(_) => false
+    | SetShowBackpackTargets(_) => false
+    | SetFontMetrics(_) => false
+    | Set(action) => Settings.Update.can_undo(action)
+    | JumpToTile(_) => false
+    | InitImportAll(_) => true
+    | FinishImportAll(_) => true
+    | ExportPersistentData => false
+    | ActiveEditor(_) => false
+    | Undo => false
+    | Redo => false
+    };
+  };
 };
 
 type t = Model.t;

--- a/src/haz3lweb/explainthis/ExplainThisUpdate.re
+++ b/src/haz3lweb/explainthis/ExplainThisUpdate.re
@@ -9,6 +9,15 @@ type update =
   | ToggleExampleFeedback(group_id, form_id, example_id, feedback_option)
   | UpdateGroupSelection(group_id, form_id);
 
+let can_undo = (action: update) => {
+  switch (action) {
+  | SpecificityOpen(_) => false
+  | ToggleExplanationFeedback(_) => false
+  | ToggleExampleFeedback(_) => false
+  | UpdateGroupSelection(_) => false
+  };
+};
+
 let set_update =
     (explainThisModel: ExplainThisModel.t, u: update)
     : Updated.t(ExplainThisModel.t) => {

--- a/src/haz3lweb/view/ExerciseMode.re
+++ b/src/haz3lweb/view/ExerciseMode.re
@@ -60,6 +60,14 @@ module Update = {
     | ResetEditor(Exercise.pos)
     | ResetExercise;
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | Editor(_, action) => CellEditor.Update.can_undo(action)
+    | ResetEditor(_) => true
+    | ResetExercise => true
+    };
+  };
+
   let update =
       (~settings: Settings.t, ~schedule_action as _, action, model: Model.t)
       : Updated.t(Model.t) => {

--- a/src/haz3lweb/view/Page.re
+++ b/src/haz3lweb/view/Page.re
@@ -73,6 +73,7 @@ module Update = {
       (
         ~import_log,
         ~schedule_action,
+        ~schedule_effect,
         ~globals: Globals.Model.t,
         action: Globals.Update.t,
         model: Model.t,
@@ -173,46 +174,24 @@ module Update = {
         };
       };
     | Undo =>
-      let cursor_info =
-        Editors.Selection.get_cursor_info(
-          ~selection=model.selection,
-          model.editors,
-        );
-      switch (cursor_info.undo_action) {
-      | None => model |> return_quiet
-      | Some(action) =>
-        let* editors =
-          Editors.Update.update(
-            ~globals=model.globals,
-            ~schedule_action=a => schedule_action(Editors(a)),
-            action,
-            model.editors,
-          );
-        {
-          ...model,
-          editors,
-        };
+      let undo = BonsaiUndo.UndoController.get_undo();
+      switch (undo) {
+      | None =>
+        print_endline("Cannot undo");
+        model |> return_quiet;
+      | Some(effect) =>
+        schedule_effect(effect);
+        model |> return_quiet;
       };
     | Redo =>
-      let cursor_info =
-        Editors.Selection.get_cursor_info(
-          ~selection=model.selection,
-          model.editors,
-        );
-      switch (cursor_info.redo_action) {
-      | None => model |> return_quiet
-      | Some(action) =>
-        let* editors =
-          Editors.Update.update(
-            ~globals=model.globals,
-            ~schedule_action=a => schedule_action(Editors(a)),
-            action,
-            model.editors,
-          );
-        {
-          ...model,
-          editors,
-        };
+      let redo = BonsaiUndo.UndoController.get_redo();
+      switch (redo) {
+      | None =>
+        print_endline("Cannot redo");
+        model |> return_quiet;
+      | Some(effect) =>
+        schedule_effect(effect);
+        model |> return_quiet;
       };
     };
   };
@@ -221,6 +200,7 @@ module Update = {
       (
         ~import_log,
         ~get_log_and,
+        ~schedule_effect,
         ~schedule_action: t => unit,
         action: t,
         model: Model.t,
@@ -232,7 +212,14 @@ module Update = {
     };
     switch (action) {
     | Globals(action) =>
-      update_global(~globals, ~import_log, ~schedule_action, action, model)
+      update_global(
+        ~globals,
+        ~import_log,
+        ~schedule_effect,
+        ~schedule_action,
+        action,
+        model,
+      )
     | Editors(action) =>
       let* editors =
         Editors.Update.update(
@@ -328,6 +315,26 @@ module Selection = {
       Some(Update.Globals(SetShowBackpackTargets(false)))
     | {key: D("F7"), sys: Mac | PC, shift: Down, meta: Up, ctrl: Up, alt: Up} =>
       Some(Update.Benchmark(Start))
+    | {
+        key: D("Z" | "z"),
+        sys: Mac,
+        shift: Down,
+        meta: Down,
+        ctrl: Up,
+        alt: Up,
+      }
+    | {
+        key: D("Z" | "z"),
+        sys: PC,
+        shift: Down,
+        meta: Up,
+        ctrl: Down,
+        alt: Up,
+      } =>
+      Some(Update.Globals(Redo))
+    | {key: D("Z" | "z"), sys: Mac, shift: Up, meta: Down, ctrl: Up, alt: Up}
+    | {key: D("Z" | "z"), sys: PC, shift: Up, meta: Up, ctrl: Down, alt: Up} =>
+      Some(Update.Globals(Undo))
     | _ =>
       Editors.Selection.handle_key_event(~selection, ~event, model.editors)
       |> Option.map(x => Update.Editors(x))
@@ -454,15 +461,6 @@ module View = {
                 ++ Keyboard.meta(Os.is_mac^ ? Mac : PC)
                 ++ " + k)",
             ),
-            {
-              let undo = BonsaiUndo.UndoController.get_undo();
-              button_d(
-                Icons.undo,
-                ~disabled=undo == None,
-                undo |> Option.value(~default=Effect.Ignore),
-                ~tooltip="Undo (Test)",
-              );
-            },
             link(
               Icons.github,
               "https://github.com/hazelgrove/hazel",

--- a/src/haz3lweb/view/Page.re
+++ b/src/haz3lweb/view/Page.re
@@ -67,6 +67,8 @@ module Update = {
     | Start
     | Save;
 
+  let equal = (===);
+
   let update_global =
       (
         ~import_log,
@@ -272,6 +274,18 @@ module Update = {
     };
   };
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | Globals(action) => Globals.Update.can_undo(action)
+    | Editors(action) => Editors.Update.can_undo(action)
+    | ExplainThis(action) => ExplainThisUpdate.can_undo(action)
+    | MakeActive(_) => false
+    | Benchmark(_) => false
+    | Start => false
+    | Save => false
+    };
+  };
+
   let calculate = (~schedule_action, ~is_edited, model: Model.t) => {
     let editors =
       Editors.Update.calculate(
@@ -440,6 +454,15 @@ module View = {
                 ++ Keyboard.meta(Os.is_mac^ ? Mac : PC)
                 ++ " + k)",
             ),
+            {
+              let undo = BonsaiUndo.UndoController.get_undo();
+              button_d(
+                Icons.undo,
+                ~disabled=undo == None,
+                undo |> Option.value(~default=Effect.Ignore),
+                ~tooltip="Undo (Test)",
+              );
+            },
             link(
               Icons.github,
               "https://github.com/hazelgrove/hazel",

--- a/src/haz3lweb/view/ScratchMode.re
+++ b/src/haz3lweb/view/ScratchMode.re
@@ -89,6 +89,17 @@ module Update = {
     | Export
     | Encode;
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | CellAction(action) => CellEditor.Update.can_undo(action)
+    | SwitchSlide(_) => true
+    | ResetCurrent => true
+    | InitImportScratchpad(_) => true
+    | FinishImportScratchpad(_) => false
+    | Export => false
+    };
+  };
+
   let export_scratch_slide = (model: Model.t): unit => {
     Store.save(model |> Model.persist);
     let data = Store.export();

--- a/src/haz3lweb/view/ScratchMode.re
+++ b/src/haz3lweb/view/ScratchMode.re
@@ -97,6 +97,7 @@ module Update = {
     | InitImportScratchpad(_) => true
     | FinishImportScratchpad(_) => false
     | Export => false
+    | Encode => false
     };
   };
 

--- a/src/haz3lweb/view/StepperView.re
+++ b/src/haz3lweb/view/StepperView.re
@@ -86,6 +86,14 @@ module Update = {
     | StepForward(int)
     | StepBackward;
 
+  let can_undo = (action: t) => {
+    switch (action) {
+    | StepperEditor(_, action) => StepperEditor.Update.can_undo(action)
+    | StepForward(_) => true
+    | StepBackward => true
+    };
+  };
+
   let update = (~settings, action: t, model: Model.t): Updated.t(Model.t) => {
     switch (action) {
     | StepForward(idx) =>

--- a/src/util/Aba.re
+++ b/src/util/Aba.re
@@ -1,7 +1,7 @@
 open Sexplib.Std;
 open Ppx_yojson_conv_lib.Yojson_conv;
 // invariant: List.length(as) == List.length(bs) + 1
-[@deriving (show({with_path: false}), sexp, yojson)]
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
 type t('a, 'b) = (list('a), list('b));
 
 let mk = (as_: list('a), bs: list('b)): t('a, 'b) => {
@@ -78,6 +78,14 @@ let map_hd = (f_a: 'a => 'a, (as_, bs): t('a, 'b)): t('a, 'b) => (
   [as_ |> List.hd |> f_a, ...as_ |> List.tl],
   bs,
 );
+
+let pop = ((as_, bs): t('a, 'b)): option(('a, 'b, t('a, 'b))) =>
+  switch (bs) {
+  | [] => None
+  | [b, ...bs] =>
+    let (a, as_) = ListUtil.split_first(as_);
+    Some((a, b, mk(as_, bs)));
+  };
 
 let trim = ((as_, bs): t('a, 'b)): option(('a, t('b, 'a), 'a)) =>
   switch (bs) {

--- a/src/util/BonsaiUndo.re
+++ b/src/util/BonsaiUndo.re
@@ -1,0 +1,204 @@
+open Bonsai;
+open Sexplib;
+open Sexplib.Std;
+open Bonsai.Let_syntax;
+
+module UndoController = {
+  type register_entry = {
+    undo: Effect.t(unit),
+    redo: Effect.t(unit),
+  };
+
+  let register: Hashtbl.t(string, register_entry) = Hashtbl.create(100);
+
+  type history_entry =
+    | Action({
+        component: string,
+        action: Sexp.t,
+      })
+    | Undo({component: string})
+    | Redo({component: string});
+
+  let history: ref(list(history_entry)) = ref([]);
+
+  let get_undo = () => {
+    let rec go = (n: int, acc: list(history_entry)) => {
+      switch (acc) {
+      | [] => None
+      | [Action({component, _}), ..._] when n == 0 =>
+        Some(Hashtbl.find(register, component).undo)
+      | [Action(_), ...xs] => go(n - 1, xs)
+      | [Undo(_), ...xs] => go(n + 1, xs)
+      | [Redo(_), ...xs] => go(n - 1, xs)
+      };
+    };
+    go(0, history^);
+  };
+
+  let get_redo = () => {
+    let rec go = (n: int, acc: list(history_entry)) => {
+      switch (acc) {
+      | [] => None
+      | [Undo({component, _}), ..._] when n == 0 =>
+        Some(Hashtbl.find(register, component).undo)
+      | [Undo(_), ...xs] => go(n - 1, xs)
+      | [Redo(_), ...xs] => go(n + 1, xs)
+      | [Action(_), ..._] => None
+      };
+    };
+    go(0, history^);
+  };
+
+  let register_component =
+      (component: string, undo: Effect.t(unit), redo: Effect.t(unit)) => {
+    Hashtbl.add(register, component, {undo, redo});
+  };
+
+  let unregister_component = (component: string) => {
+    Hashtbl.remove(register, component);
+  };
+
+  let add_action = (component: string, action: Sexp.t) => {
+    history := [Action({component, action}), ...history^];
+  };
+
+  let add_undo = (component: string) => {
+    history := [Undo({component: component}), ...history^];
+  };
+
+  let add_redo = (component: string) => {
+    history := [Redo({component: component}), ...history^];
+  };
+};
+
+[@deriving (sexp, eq)]
+type historic_action('a) =
+  | Action('a)
+  | Undo
+  | Redo;
+
+module HistoricModel = (Model: Bonsai.Model, Action: Bonsai.Model) => {
+  [@deriving (sexp, eq)]
+  type t = {
+    current: Model.t,
+    past: list(Model.t),
+    future: list(Model.t),
+  };
+};
+
+module HistoricAction = (Action: Bonsai.Model) => {
+  [@deriving (sexp, eq)]
+  type t = historic_action(Action.t);
+};
+
+module UndoRedo = {
+  type t = {
+    undo: Effect.t(unit),
+    redo: Effect.t(unit),
+  };
+
+  let sexp_of_t = (_: t) => Sexp.Atom("UndoRedo");
+  let t_of_sexp = (_: Sexp.t) => {undo: Effect.Ignore, redo: Effect.Ignore};
+  let equal = (x, y) => x.undo == y.undo && x.redo == y.redo;
+};
+
+let state_machine_with_undo =
+    (
+      type model,
+      type action,
+      type input,
+      module Model: Bonsai.Model with type t = model,
+      module Action: Bonsai.Model with type t = action,
+      ~default_model: model,
+      ~apply_action:
+         (
+           ~inject: action => Effect.t(unit),
+           ~schedule_event: Effect.t(unit) => unit,
+           Computation_status.t(input),
+           model,
+           action
+         ) =>
+         model,
+      ~can_undo: action => bool=_ => true,
+      input: Value.t(input),
+    )
+    : Computation.t((model, action => Effect.t(unit))) => {
+  module Model' = HistoricModel(Model, Action);
+  module Action' = HistoricAction(Action);
+  let%sub path = path_id;
+  let input' = {
+    let%map path = path
+    and input = input;
+    (input, path);
+  };
+  let%sub sm =
+    state_machine1(
+      (module Model'),
+      (module Action'),
+      ~default_model={current: default_model, past: [], future: []},
+      ~apply_action=
+        (~inject, ~schedule_event, input, {current, past, future}, action) => {
+          let (input, path) =
+            switch (input) {
+            | Computation_status.Active((input, path)) => (
+                Computation_status.Active(input),
+                path,
+              )
+            | Computation_status.Inactive => (
+                Computation_status.Inactive,
+                "INVALID_COMPONENT",
+              )
+            };
+          switch (action) {
+          | Action(action) =>
+            let current' =
+              apply_action(
+                ~inject=x => inject(Action(x)),
+                ~schedule_event,
+                input,
+                current,
+                action,
+              );
+            if (can_undo(action)) {
+              UndoController.add_action(path, action |> Action.sexp_of_t);
+              {current: current', past: [current, ...past], future: []};
+            } else {
+              {current: current', past, future};
+            };
+          | Undo when !List.is_empty(past) =>
+            UndoController.add_undo(path);
+            {
+              current: past |> List.hd,
+              past: past |> List.tl,
+              future: [current, ...future],
+            };
+          | Undo => {current, past, future}
+          | Redo when !List.is_empty(future) =>
+            UndoController.add_redo(path);
+            {
+              current: future |> List.hd,
+              past: [current, ...past],
+              future: future |> List.tl,
+            };
+          | Redo => {current, past, future}
+          };
+        },
+      input',
+    );
+  let undo_redo = {
+    let%map (_, inject) = sm;
+    UndoRedo.{undo: inject(Undo), redo: inject(Redo)};
+  };
+  let callback = {
+    let%map path = path;
+    (UndoRedo.{undo, redo}) => {
+      Effect.of_sync_fun(
+        () => UndoController.register_component(path, undo, redo),
+        (),
+      );
+    };
+  };
+  let%sub () = Edge.on_change((module UndoRedo), undo_redo, ~callback);
+  let%arr (model, inject) = sm;
+  (model.current, x => inject(Action(x)));
+};

--- a/src/util/BonsaiUndo.re
+++ b/src/util/BonsaiUndo.re
@@ -51,7 +51,14 @@ module UndoController = {
 
   let register_component =
       (component: string, undo: Effect.t(unit), redo: Effect.t(unit)) => {
-    Hashtbl.add(register, component, {undo, redo});
+    Hashtbl.add(
+      register,
+      component,
+      {
+        undo,
+        redo,
+      },
+    );
   };
 
   let unregister_component = (component: string) => {
@@ -59,7 +66,14 @@ module UndoController = {
   };
 
   let add_action = (component: string, action: Sexp.t) => {
-    history := [Action({component, action}), ...history^];
+    history :=
+      [
+        Action({
+          component,
+          action,
+        }),
+        ...history^,
+      ];
   };
 
   let add_undo = (component: string) => {
@@ -98,7 +112,10 @@ module UndoRedo = {
   };
 
   let sexp_of_t = (_: t) => Sexp.Atom("UndoRedo");
-  let t_of_sexp = (_: Sexp.t) => {undo: Effect.Ignore, redo: Effect.Ignore};
+  let t_of_sexp = (_: Sexp.t) => {
+    undo: Effect.Ignore,
+    redo: Effect.Ignore,
+  };
   let equal = (x, y) => x.undo == y.undo && x.redo == y.redo;
 };
 
@@ -135,7 +152,11 @@ let state_machine_with_undo =
     state_machine1(
       (module Model'),
       (module Action'),
-      ~default_model={current: default_model, past: [], future: []},
+      ~default_model={
+        current: default_model,
+        past: [],
+        future: [],
+      },
       ~apply_action=
         (~inject, ~schedule_event, input, {current, past, future}, action) => {
           let (input, path) =
@@ -161,9 +182,17 @@ let state_machine_with_undo =
               );
             if (can_undo(action)) {
               UndoController.add_action(path, action |> Action.sexp_of_t);
-              {current: current', past: [current, ...past], future: []};
+              {
+                current: current',
+                past: [current, ...past],
+                future: [],
+              };
             } else {
-              {current: current', past, future};
+              {
+                current: current',
+                past,
+                future,
+              };
             };
           | Undo when !List.is_empty(past) =>
             UndoController.add_undo(path);
@@ -172,7 +201,11 @@ let state_machine_with_undo =
               past: past |> List.tl,
               future: [current, ...future],
             };
-          | Undo => {current, past, future}
+          | Undo => {
+              current,
+              past,
+              future,
+            }
           | Redo when !List.is_empty(future) =>
             UndoController.add_redo(path);
             {
@@ -180,14 +213,21 @@ let state_machine_with_undo =
               past: [current, ...past],
               future: future |> List.tl,
             };
-          | Redo => {current, past, future}
+          | Redo => {
+              current,
+              past,
+              future,
+            }
           };
         },
       input',
     );
   let undo_redo = {
     let%map (_, inject) = sm;
-    UndoRedo.{undo: inject(Undo), redo: inject(Redo)};
+    UndoRedo.{
+      undo: inject(Undo),
+      redo: inject(Redo),
+    };
   };
   let callback = {
     let%map path = path;

--- a/src/util/Util.re
+++ b/src/util/Util.re
@@ -1,5 +1,6 @@
 module Aba = Aba;
 module BonsaiUtil = BonsaiUtil;
+module BonsaiUndo = BonsaiUndo;
 module Bigint = BigInt;
 module Direction = Direction;
 module Either = Either;

--- a/src/util/dune
+++ b/src/util/dune
@@ -11,6 +11,7 @@
    ppx_let
    ppx_sexp_conv
    ppx_deriving.show
+   ppx_deriving.eq
    bonsai.ppx_bonsai)))
 
 (env


### PR DESCRIPTION
This pr shows a design for a global log / undo / redo that will work even when we split up our model into multiple incrementally calculated Bonsai models.

The basic architecture is that each component keeps track of its own undo history, and then a global "undo controller" keeps track of a list of which order components need to undo in.

