### PR TITLE
Bigger integers

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -52,7 +52,8 @@
   ocaml-lsp-server
   qcheck
   qcheck-alcotest
-  ppx_deriving_qcheck))
+  ppx_deriving_qcheck
+  bignum))
 
 ; After upgrading to opam 2.2 use with-dev https://opam.ocaml.org/blog/opam-2-2-0/
 

--- a/src/haz3lcore/dynamics/Builtins.re
+++ b/src/haz3lcore/dynamics/Builtins.re
@@ -53,8 +53,6 @@ module Pervasives = {
     let nan = Float(Float.nan) |> fresh;
     let epsilon_float = Float(epsilon_float) |> fresh;
     let pi = Float(Float.pi) |> fresh;
-    let max_int = Int(Int.max_int) |> fresh;
-    let min_int = Int(Int.min_int) |> fresh;
 
     [@warning "-8"]
     // let-unbox guarantees that the tuple will have length 2
@@ -88,7 +86,7 @@ module Pervasives = {
 
     let string_of_int = d => {
       let-unbox n = (Int, d);
-      Some(fresh(String(string_of_int(n))));
+      Some(fresh(String(Bigint.to_string(n))));
     };
 
     let string_of_float = d => {
@@ -103,17 +101,17 @@ module Pervasives = {
 
     let int_of_float = d => {
       let-unbox f = (Float, d);
-      Some(fresh(Int(int_of_float(f))));
+      Some(fresh(Int(Bigint.of_float(f))));
     };
 
     let float_of_int = d => {
       let-unbox n = (Int, d);
-      Some(fresh(Float(float_of_int(n))));
+      Some(fresh(Float(Bigint.to_float(n))));
     };
 
     let abs = d => {
       let-unbox n = (Int, d);
-      Some(fresh(Int(abs(n))));
+      Some(fresh(Int(Bigint.abs(n))));
     };
 
     let float_op = (fn, d) => {
@@ -154,7 +152,7 @@ module Pervasives = {
     };
 
     let int_of_string =
-      of_string(int_of_string_opt, n => Int(n) |> DHExp.fresh);
+      of_string(Bigint.of_string_opt, n => Int(n) |> DHExp.fresh);
     let float_of_string =
       of_string(float_of_string_opt, f => Float(f) |> DHExp.fresh);
     let bool_of_string =
@@ -164,7 +162,7 @@ module Pervasives = {
       binary((d1, d2) => {
         let-unbox m = (Int, d1);
         let-unbox n = (Int, d2);
-        if (n == 0) {
+        if (n == Bigint.zero) {
           Some(
             fresh(
               DynamicErrorHole(
@@ -174,20 +172,20 @@ module Pervasives = {
             ),
           );
         } else {
-          Some(fresh(Int(m mod n)));
+          Some(fresh(Int(Bigint.rem(m, n))));
         };
       });
 
     let string_length = d => {
       let-unbox s = (String, d);
-      Some(fresh(Int(String.length(s))));
+      Some(fresh(Int(String.length(s) |> Bigint.of_int)));
     };
 
     let string_compare =
       binary((d1, d2) => {
         let-unbox s1 = (String, d1);
         let-unbox s2 = (String, d2);
-        Some(fresh(Int(String.compare(s1, s2))));
+        Some(fresh(Int(String.compare(s1, s2) |> Bigint.of_int)));
       });
 
     let string_trim = d => {
@@ -212,8 +210,8 @@ module Pervasives = {
     let string_sub = name =>
       ternary((d1, d2, d3) => {
         let-unbox s = (String, d1);
-        let-unbox idx = (Int, d2);
-        let-unbox len = (Int, d3);
+        let-unbox idx = (OCamlInt, d2);
+        let-unbox len = (OCamlInt, d3);
         try(Some(fresh(String(String.sub(s, idx, len))))) {
         | _ =>
           let d' = BuiltinFun(name) |> DHExp.fresh;
@@ -243,8 +241,6 @@ module Pervasives = {
     |> const("nan", Float, nan)
     |> const("epsilon_float", Float, epsilon_float)
     |> const("pi", Float, pi)
-    |> const("max_int", Int, max_int)
-    |> const("min_int", Int, min_int)
     |> fn("is_finite", Float, Bool, is_finite)
     |> fn("is_infinite", Float, Bool, is_infinite)
     |> fn("is_nan", Float, Bool, is_nan)

--- a/src/haz3lcore/dynamics/EvaluatorError.re
+++ b/src/haz3lcore/dynamics/EvaluatorError.re
@@ -19,6 +19,7 @@ type t =
   | InvalidBoxedTuple(DHExp.t)
   | InvalidBuiltin(string)
   | BadBuiltinAp(string, list(DHExp.t))
-  | InvalidProjection(int);
+  | InvalidProjection(int)
+  | IntegerTooBig(Bigint.t);
 
 exception Exception(t);

--- a/src/haz3lcore/dynamics/Transition.re
+++ b/src/haz3lcore/dynamics/Transition.re
@@ -477,7 +477,7 @@ module Transition = (EV: EV_MODE) => {
         );
       let-unbox n = (Int, d1');
       Step({
-        expr: Int(- n) |> fresh,
+        expr: Int(Bigint.neg(n)) |> fresh,
         state_update,
         kind: UnOp(Int(Minus)),
         is_value: true,
@@ -545,39 +545,41 @@ module Transition = (EV: EV_MODE) => {
         );
       let-unbox n1 = (Int, d1');
       let-unbox n2 = (Int, d2');
-      Step({
-        expr:
-          (
-            switch (op) {
-            | Plus => Int(n1 + n2)
-            | Minus => Int(n1 - n2)
-            | Power when n2 < 0 =>
-              DynamicErrorHole(
-                BinOp(Int(op), d1', d2') |> rewrap,
-                NegativeExponent,
-              )
-            | Power => Int(IntUtil.ipow(n1, n2))
-            | Times => Int(n1 * n2)
-            | Divide when n2 == 0 =>
-              DynamicErrorHole(
-                BinOp(Int(op), d1', d2') |> rewrap,
-                DivideByZero,
-              )
-            | Divide => Int(n1 / n2)
-            | LessThan => Bool(n1 < n2)
-            | LessThanOrEqual => Bool(n1 <= n2)
-            | GreaterThan => Bool(n1 > n2)
-            | GreaterThanOrEqual => Bool(n1 >= n2)
-            | Equals => Bool(n1 == n2)
-            | NotEquals => Bool(n1 != n2)
-            }
-          )
-          |> fresh,
-        state_update,
-        kind: BinIntOp(op),
-        // False so that InvalidOperations are caught and made indet by the next step
-        is_value: false,
-      });
+      Bigint.(
+        Step({
+          expr:
+            (
+              switch (op) {
+              | Plus => Int(n1 + n2)
+              | Minus => Int(n1 - n2)
+              | Power when n2 < zero =>
+                DynamicErrorHole(
+                  BinOp(Int(op), d1', d2') |> rewrap,
+                  NegativeExponent,
+                )
+              | Power => Int(Bigint.pow(n1, n2))
+              | Times => Int(n1 * n2)
+              | Divide when n2 == zero =>
+                DynamicErrorHole(
+                  BinOp(Int(op), d1', d2') |> rewrap,
+                  DivideByZero,
+                )
+              | Divide => Int(n1 / n2)
+              | LessThan => Bool(n1 < n2)
+              | LessThanOrEqual => Bool(n1 <= n2)
+              | GreaterThan => Bool(n1 > n2)
+              | GreaterThanOrEqual => Bool(n1 >= n2)
+              | Equals => Bool(n1 == n2)
+              | NotEquals => Bool(n1 != n2)
+              }
+            )
+            |> fresh,
+          state_update,
+          kind: BinIntOp(op),
+          // False so that InvalidOperations are caught and made indet by the next step
+          is_value: false,
+        })
+      );
     | BinOp(Float(op), d1, d2) =>
       let. _ =
         otherwise(env, (d1, d2) => BinOp(Float(op), d1, d2) |> rewrap)

--- a/src/haz3lcore/dynamics/Unboxing.re
+++ b/src/haz3lcore/dynamics/Unboxing.re
@@ -27,7 +27,8 @@ type unboxed_fun =
   | DeferredAp(DHExp.t, list(DHExp.t));
 
 type unbox_request('a) =
-  | Int: unbox_request(int)
+  | Int: unbox_request(Bigint.t)
+  | OCamlInt: unbox_request(int) // For builtins that require OCaml ints
   | Float: unbox_request(float)
   | Bool: unbox_request(bool)
   | String: unbox_request(string)
@@ -102,6 +103,13 @@ let rec unbox: type a. (unbox_request(a), DHExp.t) => unboxed(a) =
     | (Float, Float(f)) => Matches(f)
     | (String, String(s)) => Matches(s)
     | (Label, Label(s)) => Matches(s)
+
+    /* Can only unbox an OCaml int if it's small enough */
+    | (OCamlInt, Int(i)) =>
+      switch (Bigint.to_int(i)) {
+      | Some(i) => Matches(i)
+      | None => raise(EvaluatorError.Exception(IntegerTooBig(i)))
+      }
 
     /* Lists can be either lists or list casts */
     | (List, ListLit(l)) => Matches(l)
@@ -246,6 +254,7 @@ let rec unbox: type a. (unbox_request(a), DHExp.t) => unboxed(a) =
       | TupLabel(_) =>
         raise(EvaluatorError.Exception(InvalidBoxedTupLabel(expr)))
       | Bool => raise(EvaluatorError.Exception(InvalidBoxedBoolLit(expr)))
+      | OCamlInt
       | Int => raise(EvaluatorError.Exception(InvalidBoxedIntLit(expr)))
       | Float => raise(EvaluatorError.Exception(InvalidBoxedFloatLit(expr)))
       | String =>

--- a/src/haz3lcore/lang/term/Grammar.re
+++ b/src/haz3lcore/lang/term/Grammar.re
@@ -35,7 +35,7 @@ and exp_term('a) =
   | Deferral(deferral_position_t)
   | Undefined
   | Bool(bool)
-  | Int(int)
+  | Int(Bigint.t)
   | Float(float)
   | String(string)
   | ListLit(list(exp_t('a)))
@@ -75,7 +75,7 @@ and pat_term('a) =
   | EmptyHole
   | MultiHole(list(any_t('a)))
   | Wild
-  | Int(int)
+  | Int(Bigint.t)
   | Float(float)
   | Bool(bool)
   | String(string)

--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -724,7 +724,8 @@ let rec exp_to_pretty = (~settings: Settings.t, exp: Exp.t): pretty => {
     p_just([Grout({id, shape: Convex})]);
   | Undefined => text_to_pretty(exp |> Exp.rep_id, Sort.Exp, "undefined")
   | Bool(b) => text_to_pretty(exp |> Exp.rep_id, Sort.Exp, Bool.to_string(b))
-  | Int(n) => text_to_pretty(exp |> Exp.rep_id, Sort.Exp, Int.to_string(n))
+  | Int(n) =>
+    text_to_pretty(exp |> Exp.rep_id, Sort.Exp, Bigint.to_string(n))
   // TODO: do floats print right?
   | Float(f) =>
     text_to_pretty(exp |> Exp.rep_id, Sort.Exp, Printf.sprintf("%f", f))
@@ -1069,7 +1070,8 @@ and pat_to_pretty = (~settings: Settings.t, pat: Pat.t): pretty => {
     p_just([Grout({id, shape: Convex})]);
   | Wild => text_to_pretty(pat |> Pat.rep_id, Sort.Pat, "_")
   | Var(v) => text_to_pretty(pat |> Pat.rep_id, Sort.Pat, v)
-  | Int(n) => text_to_pretty(pat |> Pat.rep_id, Sort.Pat, Int.to_string(n))
+  | Int(n) =>
+    text_to_pretty(pat |> Pat.rep_id, Sort.Pat, Bigint.to_string(n))
   | Float(f) =>
     text_to_pretty(pat |> Pat.rep_id, Sort.Pat, Printf.sprintf("%f", f))
   | Bool(b) => text_to_pretty(pat |> Pat.rep_id, Sort.Pat, Bool.to_string(b))

--- a/src/haz3lcore/statics/Coverage.re
+++ b/src/haz3lcore/statics/Coverage.re
@@ -13,7 +13,7 @@ module Constraint = {
   type t =
     | Truth
     | Hole
-    | Int(int)
+    | Int(Bigint.t)
     | Float(float)
     | String(string)
     | Ap(Constructor.t, option(t))
@@ -54,7 +54,7 @@ module Ctr = {
 
   // Ctrs for primitive types
   // Names here should not be anotherwise valid sum type constructor names.
-  let of_int = n => mk(string_of_int(n), 0);
+  let of_int = n => mk(Bigint.to_string(n), 0);
   let of_float = x => mk(string_of_float(x), 0);
   let of_string = s => mk("\"" ++ s, 0); // don't need closing quote, just need to distinguish from others
   let tuple_ctr: int => t = n => mk("tuple", n);
@@ -114,8 +114,8 @@ module Ctr = {
       )
     | Bool => Finite(Map.of_list([(true_ctr, []), (false_ctr, [])]))
     | Unknown(_) => Unknown
-    | Int // technically int and float are finite, but ya know
-    | Float
+    | Int
+    | Float // technically float is finite, but ya know
     | String
     | Arrow(_)
     | Forall(_)
@@ -188,7 +188,7 @@ module Submatrices = {
   };
 
   type seen = {
-    seen_ints: IntSet.t,
+    seen_ints: BigintSet.t,
     seen_floats: FloatSet.t,
     seen_strings: StringSet.t,
     seen_ctrs: Ctr.Set.t,
@@ -199,7 +199,7 @@ module Submatrices = {
   };
 
   let init_seen = {
-    seen_ints: IntSet.empty,
+    seen_ints: BigintSet.empty,
     seen_floats: FloatSet.empty,
     seen_strings: StringSet.empty,
     seen_ctrs: Ctr.Set.empty,
@@ -224,10 +224,10 @@ module Submatrices = {
         | [] => seen
         | [Int(n), ..._] => {
             ...seen,
-            seen_ints: IntSet.add(n, seen.seen_ints),
+            seen_ints: BigintSet.add(n, seen.seen_ints),
             first_col_redundant_rows:
               add_redundant_row_if(
-                IntSet.mem(n, seen.seen_ints) || seen.seen_truth,
+                BigintSet.mem(n, seen.seen_ints) || seen.seen_truth,
                 row.idx,
                 seen.first_col_redundant_rows,
               ),

--- a/src/haz3lcore/statics/MakeTerm.re
+++ b/src/haz3lcore/statics/MakeTerm.re
@@ -206,7 +206,7 @@ and exp_term: unsorted => (Exp.term, list(Id.t)) = {
       | ([t], []) when Form.is_empty_list(t) => ret(ListLit([]))
       | ([t], []) when Form.is_bool(t) => ret(Bool(bool_of_string(t)))
       | ([t], []) when Form.is_undefined(t) => ret(Undefined)
-      | ([t], []) when Form.is_int(t) => ret(Int(int_of_string(t)))
+      | ([t], []) when Form.is_int(t) => ret(Int(Bigint.of_string(t)))
       | ([t], []) when Form.is_string(t) =>
         ret(String(Form.strip_quotes(t)))
       | ([t], []) when Form.is_float(t) => ret(Float(float_of_string(t)))
@@ -432,7 +432,7 @@ and pat_term: unsorted => (Pat.term, list(Id.t)) = {
         | ([t], []) when Form.is_empty_list(t) => ListLit([])
         | ([t], []) when Form.is_bool(t) => Bool(bool_of_string(t))
         | ([t], []) when Form.is_float(t) => Float(float_of_string(t))
-        | ([t], []) when Form.is_int(t) => Int(int_of_string(t))
+        | ([t], []) when Form.is_int(t) => Int(Bigint.of_string(t))
         | ([t], []) when Form.is_string(t) => String(Form.strip_quotes(t))
         | ([t], []) when Form.is_var(t) => Var(t)
         | ([t], []) when Form.is_wild(t) => Wild

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -109,7 +109,7 @@ type pat =
   | CastPat(pat, typ, typ)
   | EmptyHolePat
   | WildPat
-  | IntPat(int)
+  | IntPat(Bigint.t)
   | FloatPat(
       [@equal (a, b) => Printf.(sprintf("%f", a) == sprintf("%f", b))] float,
     )
@@ -138,7 +138,7 @@ type deferral_pos =
 
 [@deriving (show({with_path: false}), sexp, eq)]
 type exp =
-  | Int(int)
+  | Int(Bigint.t)
   | Float
       // This equality condition is used to say that two floats are equal if they are equal in the ExpToSegment serialization
       (
@@ -305,7 +305,7 @@ let rec gen_exp_sized = (n: int): QCheck.Gen.t(exp) =>
   QCheck.Gen.(
     let leaf =
       oneof([
-        map(x => Int(x), small_int),
+        map(x => Int(x |> Bigint.of_int), small_int),
         map(x => String(x), gen_string_literal),
         map(x => Float(x), QCheck.pos_float.gen), // Floats are positive because we use UnOp minus
         map(x => Var(x), gen_ident),
@@ -568,7 +568,7 @@ and gen_pat_sized: int => QCheck.Gen.t(pat) =
             oneof([
               return(WildPat),
               return(EmptyHolePat),
-              map(x => IntPat(x), small_int),
+              map(x => IntPat(Bigint.of_int(x)), small_int),
               map(x => FloatPat(x), QCheck.pos_float.gen),
               map(x => VarPat(x), gen_ident),
               map(x => StringPat(x), gen_string_literal),

--- a/src/haz3lmenhir/Parser.mly
+++ b/src/haz3lmenhir/Parser.mly
@@ -260,7 +260,7 @@ nonAscriptingPat:
     | c = CONSTRUCTOR_IDENT { ConstructorPat(c, None)}
     | c = CONSTRUCTOR_IDENT; TILDE; t = typ;  { CastPat(ConstructorPat(c, None), UnknownType(Internal), t) }
     | p = IDENT { VarPat(p) }
-    | i = INT { IntPat i }
+    | i = INT { IntPat (Bigint.of_int i) } // todo(matt): support bigints in menhir
     | f = FLOAT { FloatPat f }
     | s = STRING { StringPat s}
     | TRUE { BoolPat true}
@@ -316,7 +316,7 @@ tupExpEntry:
 
 exp:
     | b = binExp { b }
-    | i = INT { Int i }
+    | i = INT { Int (Bigint.of_int(i)) } // todo(matt): support bigints in menhir
     | f = FLOAT { Float f }
     | v = IDENT { Var v }
     | c = CONSTRUCTOR_IDENT { Constructor(c, None)}

--- a/src/haz3lweb/app/explainthis/ExplainThis.re
+++ b/src/haz3lweb/app/explainthis/ExplainThis.re
@@ -712,7 +712,7 @@ let get_doc =
                     Printf.sprintf(
                       Scanf.format_from_string(msg, "%s%s%s%s"),
                       Id.to_string(pat_id),
-                      string_of_int(i),
+                      Bigint.to_string(i),
                       Id.to_string(pat_id),
                       Id.to_string(body_id),
                     ),
@@ -1306,7 +1306,7 @@ let get_doc =
                       Scanf.format_from_string(msg, "%s%s%s%s%s"),
                       Id.to_string(def_id),
                       Id.to_string(pat_id),
-                      string_of_int(i),
+                      Bigint.to_string(i),
                       Id.to_string(def_id),
                       Id.to_string(body_id),
                     ),
@@ -2006,7 +2006,11 @@ let get_doc =
         ~format=
           Some(
             msg =>
-              Printf.sprintf(Scanf.format_from_string(msg, "%i%i"), i, i),
+              Printf.sprintf(
+                Scanf.format_from_string(msg, "%s%s"),
+                i |> Bigint.to_string,
+                i |> Bigint.to_string,
+              ),
           ),
         TerminalPat.intlit(i),
       )

--- a/src/haz3lweb/app/explainthis/data/TerminalExp.re
+++ b/src/haz3lweb/app/explainthis/data/TerminalExp.re
@@ -36,14 +36,14 @@ let bool_exp = (b: bool): form => {
 };
 let bool_exps = (b: bool): group => {id: BoolExp, forms: [bool_exp(b)]};
 
-let int_exp = (n: int): form => {
+let int_exp = (n: Bigint.t): form => {
   id: IntExp,
-  syntactic_form: [n |> string_of_int |> exp],
+  syntactic_form: [n |> Bigint.to_string |> exp],
   expandable_id: None,
   explanation: "A signed integer literal.",
   examples: [],
 };
-let int_exps = (i: int): group => {id: IntExp, forms: [int_exp(i)]};
+let int_exps = (i: Bigint.t): group => {id: IntExp, forms: [int_exp(i)]};
 
 let float_exp = (f: float): form => {
   id: FloatExp,

--- a/src/haz3lweb/app/explainthis/data/TerminalPat.re
+++ b/src/haz3lweb/app/explainthis/data/TerminalPat.re
@@ -11,11 +11,11 @@ let wild_pat: form = {
   };
 };
 
-let intlit_pat = (i: int): form => {
+let intlit_pat = (i: Bigint.t): form => {
   let explanation = "Only expressions with value `%i` match the *`%i` pattern*.";
   {
     id: IntPat,
-    syntactic_form: [i |> string_of_int |> abbreviate |> pat],
+    syntactic_form: [i |> Bigint.to_string |> abbreviate |> pat],
     expandable_id: None,
     explanation,
     examples: [],
@@ -90,7 +90,7 @@ let ctr_pat = (name: string): form => {
 
 let wild: group = {id: WildPat, forms: [wild_pat]};
 
-let intlit = (i: int): group => {id: IntPat, forms: [intlit_pat(i)]};
+let intlit = (i: Bigint.t): group => {id: IntPat, forms: [intlit_pat(i)]};
 
 let floatlit = (f: float): group => {
   id: FloatPat,

--- a/src/util/BigInt.re
+++ b/src/util/BigInt.re
@@ -1,0 +1,14 @@
+include Bigint;
+include Ppx_yojson_conv_lib.Yojson_conv.Primitives;
+
+let t_of_yojson = (json): t => {
+  let str = string_of_yojson(json);
+  switch (of_string_opt(str)) {
+  | Some(int) => int
+  | None => raise(Failure("Invalid JSON for BigInt"))
+  };
+};
+
+let yojson_of_t = (int): Yojson.Safe.t => {
+  yojson_of_string(to_string(int));
+};

--- a/src/util/IntUtil.re
+++ b/src/util/IntUtil.re
@@ -4,15 +4,3 @@ let modulo = (x, y) => {
   let result = x mod y;
   result >= 0 ? result : result + y;
 };
-
-let ipow = (base: int, exponent: int): int => {
-  let rec ipow_iter = (b: int, e: int, r: int): int =>
-    if (e === 0) {
-      r;
-    } else if (e land 1 !== 0) {
-      ipow_iter(b * b, e lsr 1, r * b);
-    } else {
-      ipow_iter(b * b, e lsr 1, r);
-    };
-  ipow_iter(base, exponent, 1);
-};

--- a/src/util/Sets.re
+++ b/src/util/Sets.re
@@ -4,6 +4,12 @@ module IntSet =
     let compare = compare;
   });
 
+module BigintSet =
+  Set.Make({
+    type t = Bigint.t;
+    let compare = Bigint.compare;
+  });
+
 module BoolSet =
   Set.Make({
     type t = bool;

--- a/src/util/Util.re
+++ b/src/util/Util.re
@@ -23,6 +23,7 @@ module Point = Point;
 module Calc = Calc;
 module Sets = Sets;
 module Maps = Maps;
+module Bigint = BigInt;
 
 // Used by [@deriving sexp, yojson)]
 include Sexplib.Std;

--- a/src/util/dune
+++ b/src/util/dune
@@ -1,6 +1,6 @@
 (library
  (name util)
- (libraries re base ptmap bonsai bonsai.web virtual_dom yojson)
+ (libraries re base ptmap bonsai bonsai.web virtual_dom yojson bignum)
  (js_of_ocaml)
  (instrumentation
   (backend bisect_ppx))

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -20,7 +20,7 @@ let parse_exp = (s: string) => {
 
 module PlainTests = {
   let u1: Exp.t = {
-    term: Int(8),
+    term: Int(8 |> Bigint.of_int),
     annotation: {
       ids: [id_at(0)],
       copied: false,
@@ -58,7 +58,11 @@ module PlainTests = {
   let u4: Exp.t =
     Let(
       Tuple([Var("a") |> Pat.fresh, Var("b") |> Pat.fresh]) |> Pat.fresh,
-      Tuple([Int(4) |> Exp.fresh, Int(6) |> Exp.fresh]) |> Exp.fresh,
+      Tuple([
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
+        Int(6 |> Bigint.of_int) |> Exp.fresh,
+      ])
+      |> Exp.fresh,
       BinOp(Int(Minus), Var("a") |> Exp.fresh, Var("b") |> Exp.fresh)
       |> Exp.fresh,
     )
@@ -97,7 +101,11 @@ module PlainTests = {
     );
 
   let u6: Exp.t =
-    If(Bool(false) |> Exp.fresh, Int(8) |> Exp.fresh, Int(6) |> Exp.fresh)
+    If(
+      Bool(false) |> Exp.fresh,
+      Int(8 |> Bigint.of_int) |> Exp.fresh,
+      Int(6 |> Bigint.of_int) |> Exp.fresh,
+    )
     |> Exp.fresh;
 
   let consistent_if = () =>
@@ -111,7 +119,11 @@ module PlainTests = {
   let f =
     Fun(
       Var("x") |> Pat.fresh,
-      BinOp(Int(Plus), Int(4) |> Exp.fresh, Int(5) |> Exp.fresh)
+      BinOp(
+        Int(Plus),
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
+        Int(5 |> Bigint.of_int) |> Exp.fresh,
+      )
       |> Exp.fresh,
       None,
       None,
@@ -121,7 +133,11 @@ module PlainTests = {
   let f' =
     Fun(
       Var("x") |> Pat.fresh,
-      BinOp(Int(Plus), Int(4) |> Exp.fresh, Int(5) |> Exp.fresh)
+      BinOp(
+        Int(Plus),
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
+        Int(5 |> Bigint.of_int) |> Exp.fresh,
+      )
       |> Exp.fresh,
       Some(Unknown(Hole(EmptyHole)) |> Typ.fresh),
       None,
@@ -139,10 +155,14 @@ module PlainTests = {
 
   let u8: Exp.t =
     Match(
-      BinOp(Int(Equals), Int(4) |> Exp.fresh, Int(3) |> Exp.fresh)
+      BinOp(
+        Int(Equals),
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
+        Int(3 |> Bigint.of_int) |> Exp.fresh,
+      )
       |> Exp.fresh,
       [
-        (Bool(true) |> Pat.fresh, Int(24) |> Exp.fresh),
+        (Bool(true) |> Pat.fresh, Int(24 |> Bigint.of_int) |> Exp.fresh),
         (Bool(false) |> Pat.fresh, Bool(false) |> Exp.fresh),
       ],
     )
@@ -150,13 +170,17 @@ module PlainTests = {
 
   let d8: Exp.t =
     Match(
-      BinOp(Int(Equals), Int(4) |> Exp.fresh, Int(3) |> Exp.fresh)
+      BinOp(
+        Int(Equals),
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
+        Int(3 |> Bigint.of_int) |> Exp.fresh,
+      )
       |> Exp.fresh,
       [
         (
           Bool(true) |> Pat.fresh,
           Cast(
-            Int(24) |> Exp.fresh,
+            Int(24 |> Bigint.of_int) |> Exp.fresh,
             Int |> Typ.fresh,
             Unknown(Internal) |> Typ.fresh,
           )
@@ -192,13 +216,17 @@ module PlainTests = {
       |> Pat.fresh,
       Fun(
         Var("x") |> Pat.fresh,
-        BinOp(Int(Plus), Int(1) |> Exp.fresh, Var("x") |> Exp.fresh)
+        BinOp(
+          Int(Plus),
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
+          Var("x") |> Exp.fresh,
+        )
         |> Exp.fresh,
         None,
         None,
       )
       |> Exp.fresh,
-      Int(55) |> Exp.fresh,
+      Int(55 |> Bigint.of_int) |> Exp.fresh,
     )
     |> Exp.fresh;
 
@@ -207,13 +235,17 @@ module PlainTests = {
       Var("f") |> Pat.fresh,
       Fun(
         Var("x") |> Pat.fresh,
-        BinOp(Int(Plus), Int(1) |> Exp.fresh, Var("x") |> Exp.fresh)
+        BinOp(
+          Int(Plus),
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
+          Var("x") |> Exp.fresh,
+        )
         |> Exp.fresh,
         Some(Int |> Typ.fresh),
         Some("f"),
       )
       |> Exp.fresh,
-      Int(55) |> Exp.fresh,
+      Int(55 |> Bigint.of_int) |> Exp.fresh,
     )
     |> Exp.fresh;
 
@@ -231,7 +263,7 @@ module PlainTests = {
         Var("string_sub") |> Exp.fresh,
         [
           String("hello") |> Exp.fresh,
-          Int(1) |> Exp.fresh,
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
           Deferral(InAp) |> Exp.fresh,
         ],
       )
@@ -241,7 +273,7 @@ module PlainTests = {
           Var("string_sub") |> Exp.fresh,
           [
             String("hello") |> Exp.fresh,
-            Int(1) |> Exp.fresh,
+            Int(1 |> Bigint.of_int) |> Exp.fresh,
             Deferral(InAp) |> Exp.fresh,
           ],
         )
@@ -258,12 +290,12 @@ module PlainTests = {
           Var("string_sub") |> Exp.fresh,
           [
             String("hello") |> Exp.fresh,
-            Int(1) |> Exp.fresh,
+            Int(1 |> Bigint.of_int) |> Exp.fresh,
             Deferral(InAp) |> Exp.fresh,
           ],
         )
         |> Exp.fresh,
-        Int(2) |> Exp.fresh,
+        Int(2 |> Bigint.of_int) |> Exp.fresh,
       )
       |> Exp.fresh,
       dhexp_of_uexp(
@@ -273,12 +305,12 @@ module PlainTests = {
             Var("string_sub") |> Exp.fresh,
             [
               String("hello") |> Exp.fresh,
-              Int(1) |> Exp.fresh,
+              Int(1 |> Bigint.of_int) |> Exp.fresh,
               Deferral(InAp) |> Exp.fresh,
             ],
           )
           |> Exp.fresh,
-          Int(2) |> Exp.fresh,
+          Int(2 |> Bigint.of_int) |> Exp.fresh,
         )
         |> Exp.fresh,
       ),
@@ -322,7 +354,7 @@ module PlainTests = {
             Deferral(InAp) |> Exp.fresh,
             Deferral(InAp) |> Exp.fresh,
             Cast(
-              Int(3) |> Exp.fresh,
+              Int(3 |> Bigint.of_int) |> Exp.fresh,
               Int |> Typ.fresh,
               Unknown(Internal) |> Typ.fresh,
             )
@@ -355,7 +387,7 @@ module PlainTests = {
             [
               Deferral(InAp) |> Exp.fresh,
               Deferral(InAp) |> Exp.fresh,
-              Int(3) |> Exp.fresh,
+              Int(3 |> Bigint.of_int) |> Exp.fresh,
             ],
           )
           |> Exp.fresh,
@@ -409,7 +441,7 @@ module PlainTests = {
             String("123 Maple St") |> Exp.fresh,
             String("Ann Arbor") |> Exp.fresh,
             String("MI") |> Exp.fresh,
-            Int(48103) |> Exp.fresh,
+            Int(48103 |> Bigint.of_int) |> Exp.fresh,
           ])
           |> Exp.fresh,
         )
@@ -434,7 +466,10 @@ module PlainTests = {
           |> Exp.fresh,
           TupLabel(Label("state") |> Exp.fresh, String("MI") |> Exp.fresh)
           |> Exp.fresh,
-          TupLabel(Label("zipcode") |> Exp.fresh, Int(48103) |> Exp.fresh)
+          TupLabel(
+            Label("zipcode") |> Exp.fresh,
+            Int(48103 |> Bigint.of_int) |> Exp.fresh,
+          )
           |> Exp.fresh,
         ])
         |> Exp.fresh,
@@ -516,7 +551,7 @@ module PlainTests = {
         |> Pat.fresh,
         Parens(
           Tuple([
-            Int(1) |> Exp.fresh,
+            Int(1 |> Bigint.of_int) |> Exp.fresh,
             Float(1.0) |> Exp.fresh,
             TupLabel(Label("c") |> Exp.fresh, Bool(true) |> Exp.fresh)
             |> Exp.fresh,
@@ -534,7 +569,10 @@ module PlainTests = {
       Let(
         Var("val") |> Pat.fresh,
         Tuple([
-          TupLabel(Label("a") |> Exp.fresh, Int(1) |> Exp.fresh)
+          TupLabel(
+            Label("a") |> Exp.fresh,
+            Int(1 |> Bigint.of_int) |> Exp.fresh,
+          )
           |> Exp.fresh,
           TupLabel(Label("b") |> Exp.fresh, String("a") |> Exp.fresh)
           |> Exp.fresh,
@@ -646,7 +684,10 @@ module PlainTests = {
         Let(
           Var("zip_only") |> Pat.fresh,
           Tuple([
-            TupLabel(Label("zip") |> Exp.fresh, Int(12345) |> Exp.fresh)
+            TupLabel(
+              Label("zip") |> Exp.fresh,
+              Int(12345 |> Bigint.of_int) |> Exp.fresh,
+            )
             |> Exp.fresh,
           ])
           |> Exp.fresh,
@@ -684,7 +725,10 @@ module PlainTests = {
           )
           |> Exp.fresh,
           Tuple([
-            TupLabel(Label("a") |> Exp.fresh, Int(1) |> Exp.fresh)
+            TupLabel(
+              Label("a") |> Exp.fresh,
+              Int(1 |> Bigint.of_int) |> Exp.fresh,
+            )
             |> Exp.fresh,
           ])
           |> Exp.fresh,
@@ -719,7 +763,10 @@ module PlainTests = {
           )
           |> Exp.fresh,
           Tuple([
-            TupLabel(Label("a") |> Exp.fresh, Int(1) |> Exp.fresh)
+            TupLabel(
+              Label("a") |> Exp.fresh,
+              Int(1 |> Bigint.of_int) |> Exp.fresh,
+            )
             |> Exp.fresh,
           ])
           |> Exp.fresh,
@@ -737,7 +784,7 @@ module PlainTests = {
             TupLabel(
               Label("c") |> Exp.fresh,
               FailedCast(
-                Int(1) |> Exp.fresh,
+                Int(1 |> Bigint.of_int) |> Exp.fresh,
                 Int |> Typ.fresh,
                 String |> Typ.fresh,
               )
@@ -804,7 +851,10 @@ module PlainTests = {
           )
           |> Exp.fresh,
           Tuple([
-            TupLabel(Label("a") |> Exp.fresh, Int(1) |> Exp.fresh)
+            TupLabel(
+              Label("a") |> Exp.fresh,
+              Int(1 |> Bigint.of_int) |> Exp.fresh,
+            )
             |> Exp.fresh,
           ])
           |> Exp.fresh,
@@ -819,7 +869,10 @@ module PlainTests = {
         Let(
           Var("x") |> Pat.fresh,
           Tuple([
-            TupLabel(Label("a") |> Exp.fresh, Int(1) |> Exp.fresh)
+            TupLabel(
+              Label("a") |> Exp.fresh,
+              Int(1 |> Bigint.of_int) |> Exp.fresh,
+            )
             |> Exp.fresh,
           ])
           |> Exp.fresh,
@@ -944,10 +997,14 @@ module MenhirElaborationTests = {
 ";
   let inconsistent_case_uexp: Exp.t =
     Match(
-      BinOp(Int(Equals), Int(4) |> Exp.fresh, Int(3) |> Exp.fresh)
+      BinOp(
+        Int(Equals),
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
+        Int(3 |> Bigint.of_int) |> Exp.fresh,
+      )
       |> Exp.fresh,
       [
-        (Bool(true) |> Pat.fresh, Int(24) |> Exp.fresh),
+        (Bool(true) |> Pat.fresh, Int(24 |> Bigint.of_int) |> Exp.fresh),
         (Bool(false) |> Pat.fresh, Bool(false) |> Exp.fresh),
       ],
     )
@@ -961,7 +1018,11 @@ module MenhirElaborationTests = {
 
   //Consistent if statement menhir test
   let consistent_if_uexp: Exp.t =
-    If(Bool(false) |> Exp.fresh, Int(8) |> Exp.fresh, Int(6) |> Exp.fresh)
+    If(
+      Bool(false) |> Exp.fresh,
+      Int(8 |> Bigint.of_int) |> Exp.fresh,
+      Int(6 |> Bigint.of_int) |> Exp.fresh,
+    )
     |> Exp.fresh;
 
   let consistent_if_str = "
@@ -977,7 +1038,7 @@ module MenhirElaborationTests = {
   //Single integer menhir test
   let single_int_str = "8";
   let single_int_uexp: Exp.t = {
-    term: Int(8),
+    term: Int(8 |> Bigint.of_int),
     annotation: {
       ids: [id_at(0)],
       copied: false,
@@ -995,7 +1056,11 @@ module MenhirElaborationTests = {
   let let_exp_uexp: Exp.t =
     Let(
       Tuple([Var("a") |> Pat.fresh, Var("b") |> Pat.fresh]) |> Pat.fresh,
-      Tuple([Int(4) |> Exp.fresh, Int(6) |> Exp.fresh]) |> Exp.fresh,
+      Tuple([
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
+        Int(6 |> Bigint.of_int) |> Exp.fresh,
+      ])
+      |> Exp.fresh,
       BinOp(Int(Minus), Var("a") |> Exp.fresh, Var("b") |> Exp.fresh)
       |> Exp.fresh,
     )
@@ -1010,7 +1075,12 @@ module MenhirElaborationTests = {
   let typ_ap_str = "(typfun x -> 4)@<Int>";
   let typ_ap_uexp: Exp.t =
     TypAp(
-      TypFun(Var("x") |> TPat.fresh, Int(4) |> Exp.fresh, None) |> Exp.fresh,
+      TypFun(
+        Var("x") |> TPat.fresh,
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
+        None,
+      )
+      |> Exp.fresh,
       Int |> Typ.fresh,
     )
     |> Exp.fresh;
@@ -1019,7 +1089,11 @@ module MenhirElaborationTests = {
 
   let failed_cast_str = "1 ?{Int => String}";
   let failed_cast_uexp: Exp.t =
-    FailedCast(Int(1) |> Exp.fresh, Int |> Typ.fresh, String |> Typ.fresh)
+    FailedCast(
+      Int(1 |> Bigint.of_int) |> Exp.fresh,
+      Int |> Typ.fresh,
+      String |> Typ.fresh,
+    )
     |> Exp.fresh;
   let failed_cast_menhir = () =>
     alco_check_menhir(
@@ -1044,7 +1118,11 @@ module MenhirElaborationTests = {
   let dynamic_error_hole_uexp: Exp.t = {
     term:
       DynamicErrorHole(
-        BinOp(Int(Divide), Int(1) |> Exp.fresh, Int(0) |> Exp.fresh)
+        BinOp(
+          Int(Divide),
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
+          Int(0 |> Bigint.of_int) |> Exp.fresh,
+        )
         |> Exp.fresh,
         InvalidOperationError.DivideByZero,
       ),
@@ -1088,7 +1166,7 @@ module MenhirElaborationTests = {
 
   let test_str = "test 1 ?{Int => Bool} end";
   let test_uexp: Exp.t = {
-    term: Test(Int(1) |> Exp.fresh),
+    term: Test(Int(1 |> Bigint.of_int) |> Exp.fresh),
     annotation: {
       ids: [id_at(0)],
       copied: false,
@@ -1100,11 +1178,11 @@ module MenhirElaborationTests = {
   let filter_str = "eval 1 in 0";
   let stepper_filter_kind: TermBase.stepper_filter_kind_t =
     Filter({
-      pat: Int(1) |> Exp.fresh,
+      pat: Int(1 |> Bigint.of_int) |> Exp.fresh,
       act: (FilterAction.Eval, FilterAction.All),
     });
   let filter_uexp: Exp.t = {
-    term: Filter(stepper_filter_kind, Int(0) |> Exp.fresh),
+    term: Filter(stepper_filter_kind, Int(0 |> Bigint.of_int) |> Exp.fresh),
     annotation: {
       ids: [id_at(0)],
       copied: false,
@@ -1128,9 +1206,9 @@ undef
   let list_exp_uexp: Exp.t = {
     term:
       ListLit([
-        Int(1) |> Exp.fresh,
-        Int(2) |> Exp.fresh,
-        Int(3) |> Exp.fresh,
+        Int(1 |> Bigint.of_int) |> Exp.fresh,
+        Int(2 |> Bigint.of_int) |> Exp.fresh,
+        Int(3 |> Bigint.of_int) |> Exp.fresh,
       ]),
     annotation: {
       ids: [id_at(0)],
@@ -1173,8 +1251,16 @@ x
   let list_concat_uexp: Exp.t = {
     term:
       ListConcat(
-        ListLit([Int(1) |> Exp.fresh, Int(2) |> Exp.fresh]) |> Exp.fresh,
-        ListLit([Int(3) |> Exp.fresh, Int(4) |> Exp.fresh]) |> Exp.fresh,
+        ListLit([
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
+          Int(2 |> Bigint.of_int) |> Exp.fresh,
+        ])
+        |> Exp.fresh,
+        ListLit([
+          Int(3 |> Bigint.of_int) |> Exp.fresh,
+          Int(4 |> Bigint.of_int) |> Exp.fresh,
+        ])
+        |> Exp.fresh,
       ),
     annotation: {
       ids: [id_at(0)],
@@ -1190,7 +1276,7 @@ x
 
   let unop_str = "-1";
   let unop_uexp: Exp.t = {
-    term: UnOp(Int(Minus), Int(1) |> Exp.fresh),
+    term: UnOp(Int(Minus), Int(1 |> Bigint.of_int) |> Exp.fresh),
     annotation: {
       ids: [id_at(0)],
       copied: false,
@@ -1201,7 +1287,11 @@ x
 
   let seq_str = "1; 2";
   let seq_uexp: Exp.t = {
-    term: Seq(Int(1) |> Exp.fresh, Int(2) |> Exp.fresh),
+    term:
+      Seq(
+        Int(1 |> Bigint.of_int) |> Exp.fresh,
+        Int(2 |> Bigint.of_int) |> Exp.fresh,
+      ),
     annotation: {
       ids: [id_at(0)],
       copied: false,
@@ -1212,7 +1302,12 @@ x
 
   let fixf_str = "fix x -> 1{Int => Unknown Internal}";
   let fixf_uexp: Exp.t = {
-    term: FixF(Var("x") |> Pat.fresh, Int(1) |> Exp.fresh, None),
+    term:
+      FixF(
+        Var("x") |> Pat.fresh,
+        Int(1 |> Bigint.of_int) |> Exp.fresh,
+        None,
+      ),
     annotation: {
       ids: [id_at(0)],
       copied: false,

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -36,23 +36,40 @@ let parse_and_evaluate_test =
   );
 
 let test_int = () =>
-  evaluation_test("8", Int(8) |> Exp.fresh, Int(8) |> Exp.fresh);
+  evaluation_test(
+    "8",
+    Int(8 |> Bigint.of_int) |> Exp.fresh,
+    Int(8 |> Bigint.of_int) |> Exp.fresh,
+  );
 
 let test_sum = () =>
   evaluation_test(
     "4 + 5",
-    Int(9) |> Exp.fresh,
-    BinOp(Int(Plus), Int(4) |> Exp.fresh, Int(5) |> Exp.fresh) |> Exp.fresh,
+    Int(9 |> Bigint.of_int) |> Exp.fresh,
+    BinOp(
+      Int(Plus),
+      Int(4 |> Bigint.of_int) |> Exp.fresh,
+      Int(5 |> Bigint.of_int) |> Exp.fresh,
+    )
+    |> Exp.fresh,
   );
 
 let test_labeled_tuple_projection = () =>
   evaluation_test(
     "(a=1, b=2, c=?).a",
-    Int(1) |> Exp.fresh,
+    Int(1 |> Bigint.of_int) |> Exp.fresh,
     Dot(
       Tuple([
-        TupLabel(Label("a") |> Exp.fresh, Int(1) |> Exp.fresh) |> Exp.fresh,
-        TupLabel(Label("b") |> Exp.fresh, Int(2) |> Exp.fresh) |> Exp.fresh,
+        TupLabel(
+          Label("a") |> Exp.fresh,
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
+        )
+        |> Exp.fresh,
+        TupLabel(
+          Label("b") |> Exp.fresh,
+          Int(2 |> Bigint.of_int) |> Exp.fresh,
+        )
+        |> Exp.fresh,
         TupLabel(Label("c") |> Exp.fresh, EmptyHole |> Exp.fresh)
         |> Exp.fresh,
       ])
@@ -66,7 +83,11 @@ let test_function_application = () =>
   evaluation_test(
     "float_of_int(1)",
     Float(1.0) |> Exp.fresh,
-    Ap(Forward, Var("float_of_int") |> Exp.fresh, Int(1) |> Exp.fresh)
+    Ap(
+      Forward,
+      Var("float_of_int") |> Exp.fresh,
+      Int(1 |> Bigint.of_int) |> Exp.fresh,
+    )
     |> Exp.fresh,
   );
 
@@ -80,12 +101,12 @@ let test_function_deferral = () =>
         Var("string_sub") |> Exp.fresh,
         [
           String("hello") |> Exp.fresh,
-          Int(1) |> Exp.fresh,
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
           Deferral(InAp) |> Exp.fresh,
         ],
       )
       |> Exp.fresh,
-      Int(2) |> Exp.fresh,
+      Int(2 |> Bigint.of_int) |> Exp.fresh,
     )
     |> Exp.fresh,
   );
@@ -120,7 +141,7 @@ let test_ap_of_hole_deferral = () =>
           )
           |> Exp.fresh,
           Cast(
-            Int(3) |> Exp.fresh,
+            Int(3 |> Bigint.of_int) |> Exp.fresh,
             Int |> Typ.fresh,
             Unknown(Internal) |> Typ.fresh,
           )
@@ -173,7 +194,7 @@ let test_ap_of_hole_deferral = () =>
           Deferral(InAp) |> Exp.fresh,
           Deferral(InAp) |> Exp.fresh,
           Cast(
-            Int(3) |> Exp.fresh,
+            Int(3 |> Bigint.of_int) |> Exp.fresh,
             Int |> Typ.fresh,
             Unknown(Internal) |> Typ.fresh,
           )
@@ -203,7 +224,7 @@ let test_ap_of_hole_deferral = () =>
 let test_multi_arg_builtin_cast = () =>
   evaluation_test(
     "string_compare((\"Hello\", \"World\"):(?, ?))",
-    Int(-1) |> Exp.fresh,
+    Int((-1) |> Bigint.of_int) |> Exp.fresh,
     Ap(
       Forward,
       BuiltinFun("string_compare") |> Exp.fresh,
@@ -238,17 +259,17 @@ let test_multi_arg_builtin_cast = () =>
 let test_variable_capture = () =>
   evaluation_test(
     {|let u = 5 in let f = fun () -> u in let u = 3 in f()|},
-    Int(5) |> Exp.fresh,
+    Int(5 |> Bigint.of_int) |> Exp.fresh,
     Let(
       Var("u") |> Pat.fresh,
-      Int(5) |> Exp.fresh,
+      Int(5 |> Bigint.of_int) |> Exp.fresh,
       Let(
         Var("f") |> Pat.fresh,
         Fun(Tuple([]) |> Pat.fresh, Var("u") |> Exp.fresh, None, None)
         |> Exp.fresh,
         Let(
           Var("u") |> Pat.fresh,
-          Int(3) |> Exp.fresh,
+          Int(3 |> Bigint.of_int) |> Exp.fresh,
           Ap(Forward, Var("f") |> Exp.fresh, Tuple([]) |> Exp.fresh)
           |> Exp.fresh,
         )
@@ -275,11 +296,15 @@ let test_unbound_lookup = () =>
 let test_unevaluated_if = () =>
   evaluation_test(
     "let x = 5 in if ? then x else x",
-    If(EmptyHole |> Exp.fresh, Int(5) |> Exp.fresh, Int(5) |> Exp.fresh)
+    If(
+      EmptyHole |> Exp.fresh,
+      Int(5 |> Bigint.of_int) |> Exp.fresh,
+      Int(5 |> Bigint.of_int) |> Exp.fresh,
+    )
     |> Exp.fresh,
     Let(
       Var("x") |> Pat.fresh,
-      Int(5) |> Exp.fresh,
+      Int(5 |> Bigint.of_int) |> Exp.fresh,
       If(
         EmptyHole |> Exp.fresh,
         Var("x") |> Exp.fresh,
@@ -294,7 +319,7 @@ let test_invalid_constructor_match = () => {
   let invalid_constructor_match =
     Let(
       Constructor("T", Some(Unknown(Internal) |> Typ.fresh)) |> Pat.fresh,
-      Int(1) |> Exp.fresh,
+      Int(1 |> Bigint.of_int) |> Exp.fresh,
       EmptyHole |> Exp.fresh,
     )
     |> Exp.fresh
@@ -309,13 +334,18 @@ let test_invalid_constructor_match = () => {
 let test_typfun_application = () =>
   evaluation_test(
     "(typfun T -> fun x -> 1)@<Int>(2)",
-    Int(1) |> Exp.fresh,
+    Int(1 |> Bigint.of_int) |> Exp.fresh,
     Ap(
       Forward,
       TypAp(
         TypFun(
           Var("T") |> TPat.fresh,
-          Fun(Var("x") |> Pat.fresh, Int(1) |> Exp.fresh, None, None)
+          Fun(
+            Var("x") |> Pat.fresh,
+            Int(1 |> Bigint.of_int) |> Exp.fresh,
+            None,
+            None,
+          )
           |> Exp.fresh,
           None,
         )
@@ -323,7 +353,7 @@ let test_typfun_application = () =>
         Int |> Typ.fresh,
       )
       |> Exp.fresh,
-      Int(2) |> Exp.fresh,
+      Int(2 |> Bigint.of_int) |> Exp.fresh,
     )
     |> Exp.fresh,
   );
@@ -387,8 +417,8 @@ in fn("hello")|},
     test_case("Negative integer literal", `Quick, () =>
       evaluation_test(
         "-8",
-        Int(-8) |> Exp.fresh,
-        UnOp(Int(Minus), Int(8) |> Exp.fresh) |> Exp.fresh,
+        Int((-8) |> Bigint.of_int) |> Exp.fresh,
+        UnOp(Int(Minus), Int(8 |> Bigint.of_int) |> Exp.fresh) |> Exp.fresh,
       )
     ),
   ],

--- a/test/Test_ExpToSegment.re
+++ b/test/Test_ExpToSegment.re
@@ -84,7 +84,7 @@ let tests = (
               children: [],
             }),
           ],
-          exp_to_segment(Exp.temp(Int(1))),
+          exp_to_segment(Exp.temp(Int(1 |> Bigint.of_int))),
         );
         check(
           segment,
@@ -162,7 +162,12 @@ let tests = (
           zipper_parse("(1, 2)"),
           Some(
             exp_to_segment(
-              Exp.temp(Tuple([Exp.temp(Int(1)), Exp.temp(Int(2))])),
+              Exp.temp(
+                Tuple([
+                  Exp.temp(Int(1 |> Bigint.of_int)),
+                  Exp.temp(Int(2 |> Bigint.of_int)),
+                ]),
+              ),
             ),
           ),
         );
@@ -181,7 +186,10 @@ let tests = (
               Exp.temp(
                 Tuple([
                   Exp.temp(
-                    TupLabel(Exp.temp(Label("x")), Exp.temp(Int(1))),
+                    TupLabel(
+                      Exp.temp(Label("x")),
+                      Exp.temp(Int(1 |> Bigint.of_int)),
+                    ),
                   ),
                 ]),
               ),
@@ -205,8 +213,14 @@ let tests = (
             Match(
               Var("x") |> Exp.fresh,
               [
-                (Constructor("A", None) |> Pat.fresh, Int(1) |> Exp.fresh),
-                (Constructor("B", None) |> Pat.fresh, Int(2) |> Exp.fresh),
+                (
+                  Constructor("A", None) |> Pat.fresh,
+                  Int(1 |> Bigint.of_int) |> Exp.fresh,
+                ),
+                (
+                  Constructor("B", None) |> Pat.fresh,
+                  Int(2 |> Bigint.of_int) |> Exp.fresh,
+                ),
               ],
             )
             |> Exp.fresh,
@@ -231,7 +245,7 @@ let tests = (
               Var("string_sub") |> Exp.fresh,
               [
                 String("hello") |> Exp.fresh,
-                Int(1) |> Exp.fresh,
+                Int(1 |> Bigint.of_int) |> Exp.fresh,
                 Deferral(InAp) |> Exp.fresh,
               ],
             )
@@ -265,8 +279,11 @@ let tests = (
         let segment =
           segmentize(
             Filter(
-              Filter({pat: Int(1) |> Exp.fresh, act: (Step, One)}),
-              Int(2) |> Exp.fresh,
+              Filter({
+                pat: Int(1 |> Bigint.of_int) |> Exp.fresh,
+                act: (Step, One),
+              }),
+              Int(2 |> Bigint.of_int) |> Exp.fresh,
             )
             |> Exp.fresh,
           );
@@ -287,8 +304,12 @@ let tests = (
             segmentize(
               BinOp(
                 Int(Power),
-                Int(2) |> Exp.fresh,
-                BinOp(Int(Power), Int(3) |> Exp.fresh, Int(4) |> Exp.fresh)
+                Int(2 |> Bigint.of_int) |> Exp.fresh,
+                BinOp(
+                  Int(Power),
+                  Int(3 |> Bigint.of_int) |> Exp.fresh,
+                  Int(4 |> Bigint.of_int) |> Exp.fresh,
+                )
                 |> Exp.fresh,
               )
               |> Exp.fresh,
@@ -304,9 +325,13 @@ let tests = (
             segmentize(
               BinOp(
                 Int(Power),
-                BinOp(Int(Power), Int(2) |> Exp.fresh, Int(3) |> Exp.fresh)
+                BinOp(
+                  Int(Power),
+                  Int(2 |> Bigint.of_int) |> Exp.fresh,
+                  Int(3 |> Bigint.of_int) |> Exp.fresh,
+                )
                 |> Exp.fresh,
-                Int(4) |> Exp.fresh,
+                Int(4 |> Bigint.of_int) |> Exp.fresh,
               )
               |> Exp.fresh,
             ),
@@ -326,7 +351,7 @@ let tests = (
                   Var("x") |> Typ.fresh,
                 )
                 |> Typ.fresh,
-                Int(1) |> Exp.fresh,
+                Int(1 |> Bigint.of_int) |> Exp.fresh,
               )
               |> Exp.fresh,
             ),

--- a/test/Test_MakeTerm.re
+++ b/test/Test_MakeTerm.re
@@ -20,7 +20,7 @@ let tests = (
   "MakeTerm",
   [
     test_case("Integer Literal", `Quick, () => {
-      exp_check(Int(0) |> Exp.fresh, "0")
+      exp_check(Int(0 |> Bigint.of_int) |> Exp.fresh, "0")
     }),
     test_case("Float literal", `Quick, () => {
       exp_check(Float(2.000000) |> Exp.fresh, "2.000000")
@@ -32,7 +32,10 @@ let tests = (
       exp_check(Var("x") |> Exp.fresh, "x")
     }),
     test_case("Parenthesized Expression", `Quick, () => {
-      exp_check(Parens(Int(0) |> Exp.fresh) |> Exp.fresh, "(0)")
+      exp_check(
+        Parens(Int(0 |> Bigint.of_int) |> Exp.fresh) |> Exp.fresh,
+        "(0)",
+      )
     }),
     test_case("Floating operation", `Quick, () => {
       exp_check(
@@ -49,7 +52,7 @@ let tests = (
       exp_check(
         Let(
           Var("x") |> Pat.fresh,
-          Int(1) |> Exp.fresh,
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
           Var("x") |> Exp.fresh,
         )
         |> Exp.fresh,
@@ -69,7 +72,7 @@ let tests = (
           Var("f") |> Pat.fresh,
           Fun(Var("x") |> Pat.fresh, Var("x") |> Exp.fresh, None, None)  // It seems as though the function naming happens during elaboration and not during parsing
           |> Exp.fresh,
-          Int(1) |> Exp.fresh,
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
         )
         |> Exp.fresh,
         "let f = fun x -> x in 1",
@@ -95,7 +98,7 @@ let tests = (
         TyAlias(
           Var("x") |> TPat.fresh,
           Int |> Typ.fresh,
-          Int(1) |> Exp.fresh,
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
         )
         |> Exp.fresh,
         "type x = Int in 1",
@@ -130,7 +133,10 @@ let tests = (
           Var("x") |> Pat.fresh,
           Parens(
             Tuple([
-              TupLabel(Label("l") |> Exp.fresh, Int(32) |> Exp.fresh)
+              TupLabel(
+                Label("l") |> Exp.fresh,
+                Int(32 |> Bigint.of_int) |> Exp.fresh,
+              )
               |> Exp.fresh,
             ])
             |> Exp.fresh,
@@ -164,7 +170,10 @@ let tests = (
       exp_check(
         Parens(
           Tuple([
-            TupLabel(Label("l") |> Exp.fresh, Int(32) |> Exp.fresh)
+            TupLabel(
+              Label("l") |> Exp.fresh,
+              Int(32 |> Bigint.of_int) |> Exp.fresh,
+            )
             |> Exp.fresh,
             TupLabel(Label("l2") |> Exp.fresh, String("") |> Exp.fresh)
             |> Exp.fresh,
@@ -195,7 +204,10 @@ let tests = (
           |> Pat.fresh,
           Parens(
             Tuple([
-              TupLabel(Label("l") |> Exp.fresh, Int(32) |> Exp.fresh)
+              TupLabel(
+                Label("l") |> Exp.fresh,
+                Int(32 |> Bigint.of_int) |> Exp.fresh,
+              )
               |> Exp.fresh,
               TupLabel(Label("l2") |> Exp.fresh, String("") |> Exp.fresh)
               |> Exp.fresh,
@@ -214,8 +226,9 @@ let tests = (
         Parens(
           Tuple([
             TupLabel(
-              MultiHole([Exp(Int(1) |> Exp.fresh)]) |> Exp.fresh,
-              Int(3) |> Exp.fresh,
+              MultiHole([Exp(Int(1 |> Bigint.of_int) |> Exp.fresh)])
+              |> Exp.fresh,
+              Int(3 |> Bigint.of_int) |> Exp.fresh,
             )
             |> Exp.fresh,
           ])

--- a/test/Test_Menhir.re
+++ b/test/Test_Menhir.re
@@ -179,7 +179,11 @@ let qcheck_menhir_serialized_equivalent_test =
 let tests = (
   "MenhirParser",
   [
-    full_parser_test("Integer Literal", Int(8) |> Exp.fresh, "8"),
+    full_parser_test(
+      "Integer Literal",
+      Int(8 |> Bigint.of_int) |> Exp.fresh,
+      "8",
+    ),
     full_parser_test(
       "Fun",
       Fun(Var("x") |> Pat.fresh, Var("x") |> Exp.fresh, None, None)
@@ -201,7 +205,11 @@ let tests = (
     ),
     full_parser_test(
       "BinOp",
-      BinOp(Int(Plus), Int(4) |> Exp.fresh, Int(5) |> Exp.fresh)
+      BinOp(
+        Int(Plus),
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
+        Int(5 |> Bigint.of_int) |> Exp.fresh,
+      )
       |> Exp.fresh,
       "4 + 5",
     ),
@@ -209,7 +217,7 @@ let tests = (
       "Let",
       Let(
         Var("x") |> Pat.fresh,
-        Int(5) |> Exp.fresh,
+        Int(5 |> Bigint.of_int) |> Exp.fresh,
         Var("x") |> Exp.fresh,
       )
       |> Exp.fresh,
@@ -217,15 +225,22 @@ let tests = (
     ),
     full_parser_test(
       "Tuple",
-      Tuple([Int(4) |> Exp.fresh, Int(5) |> Exp.fresh]) |> Exp.fresh,
+      Tuple([
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
+        Int(5 |> Bigint.of_int) |> Exp.fresh,
+      ])
+      |> Exp.fresh,
       "(4, 5)",
     ),
     full_parser_test(
       "Match",
       Match(
-        Int(4) |> Exp.fresh,
+        Int(4 |> Bigint.of_int) |> Exp.fresh,
         [
-          (Int(1) |> Pat.fresh, String("hello") |> Exp.fresh),
+          (
+            Int(1 |> Bigint.of_int) |> Pat.fresh,
+            String("hello") |> Exp.fresh,
+          ),
           (Wild |> Pat.fresh, String("world") |> Exp.fresh),
         ],
       )
@@ -237,7 +252,11 @@ let tests = (
     ),
     full_parser_test(
       "If",
-      If(Bool(true) |> Exp.fresh, Int(8) |> Exp.fresh, Int(6) |> Exp.fresh)
+      If(
+        Bool(true) |> Exp.fresh,
+        Int(8 |> Bigint.of_int) |> Exp.fresh,
+        Int(6 |> Bigint.of_int) |> Exp.fresh,
+      )
       |> Exp.fresh,
       "if true then 8 else 6",
     ),
@@ -249,15 +268,16 @@ let tests = (
     ),
     full_parser_test(
       "Cons",
-      Cons(Int(1) |> Exp.fresh, ListLit([]) |> Exp.fresh) |> Exp.fresh,
+      Cons(Int(1 |> Bigint.of_int) |> Exp.fresh, ListLit([]) |> Exp.fresh)
+      |> Exp.fresh,
       "1 :: []",
     ),
     full_parser_test(
       "ListLit",
       ListLit([
-        Int(1) |> Exp.fresh,
-        Int(2) |> Exp.fresh,
-        Int(3) |> Exp.fresh,
+        Int(1 |> Bigint.of_int) |> Exp.fresh,
+        Int(2 |> Bigint.of_int) |> Exp.fresh,
+        Int(3 |> Bigint.of_int) |> Exp.fresh,
       ])
       |> Exp.fresh,
       "[1, 2, 3]",
@@ -306,14 +326,22 @@ let tests = (
     ),
     full_parser_test(
       "Type Alias",
-      TyAlias(Var("x") |> TPat.fresh, Int |> Typ.fresh, Int(1) |> Exp.fresh)
+      TyAlias(
+        Var("x") |> TPat.fresh,
+        Int |> Typ.fresh,
+        Int(1 |> Bigint.of_int) |> Exp.fresh,
+      )
       |> Exp.fresh,
       "type x = Int in 1",
     ),
     full_parser_test(
       "Test",
       Test(
-        BinOp(Int(Equals), Int(3) |> Exp.fresh, Int(3) |> Exp.fresh)
+        BinOp(
+          Int(Equals),
+          Int(3 |> Bigint.of_int) |> Exp.fresh,
+          Int(3 |> Bigint.of_int) |> Exp.fresh,
+        )
         |> Exp.fresh,
       )
       |> Exp.fresh,
@@ -322,8 +350,11 @@ let tests = (
     full_parser_test(
       "Filter",
       Filter(
-        Filter({act: (Eval, All), pat: Int(3) |> Exp.fresh}),
-        Int(3) |> Exp.fresh,
+        Filter({
+          act: (Eval, All),
+          pat: Int(3 |> Bigint.of_int) |> Exp.fresh,
+        }),
+        Int(3 |> Bigint.of_int) |> Exp.fresh,
       )
       |> Exp.fresh,
       "eval 3 in 3" // TODO Use other filter commands
@@ -331,8 +362,16 @@ let tests = (
     full_parser_test(
       "List Concat",
       ListConcat(
-        ListLit([Int(1) |> Exp.fresh, Int(2) |> Exp.fresh]) |> Exp.fresh,
-        ListLit([Int(3) |> Exp.fresh, Int(4) |> Exp.fresh]) |> Exp.fresh,
+        ListLit([
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
+          Int(2 |> Bigint.of_int) |> Exp.fresh,
+        ])
+        |> Exp.fresh,
+        ListLit([
+          Int(3 |> Bigint.of_int) |> Exp.fresh,
+          Int(4 |> Bigint.of_int) |> Exp.fresh,
+        ])
+        |> Exp.fresh,
       )
       |> Exp.fresh,
       "[1, 2] @ [3, 4]",
@@ -341,9 +380,13 @@ let tests = (
       "times and divide precendence",
       BinOp(
         Int(Divide),
-        BinOp(Int(Times), Int(1) |> Exp.fresh, Int(2) |> Exp.fresh)
+        BinOp(
+          Int(Times),
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
+          Int(2 |> Bigint.of_int) |> Exp.fresh,
+        )
         |> Exp.fresh,
-        Int(3) |> Exp.fresh,
+        Int(3 |> Bigint.of_int) |> Exp.fresh,
       )
       |> Exp.fresh,
       "1 * 2 / 3",
@@ -352,9 +395,13 @@ let tests = (
       "plus and minus precendence",
       BinOp(
         Int(Plus),
-        BinOp(Int(Minus), Int(1) |> Exp.fresh, Int(2) |> Exp.fresh)
+        BinOp(
+          Int(Minus),
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
+          Int(2 |> Bigint.of_int) |> Exp.fresh,
+        )
         |> Exp.fresh,
-        Int(3) |> Exp.fresh,
+        Int(3 |> Bigint.of_int) |> Exp.fresh,
       )
       |> Exp.fresh,
       "1 - 2 + 3",
@@ -367,21 +414,30 @@ let tests = (
           Int(Minus),
           BinOp(
             Int(Plus),
-            UnOp(Int(Minus), Int(1) |> Exp.fresh) |> Exp.fresh,
-            Int(2) |> Exp.fresh,
+            UnOp(Int(Minus), Int(1 |> Bigint.of_int) |> Exp.fresh)
+            |> Exp.fresh,
+            Int(2 |> Bigint.of_int) |> Exp.fresh,
           )
           |> Exp.fresh,
           BinOp(
             Int(Times),
-            BinOp(Int(Divide), Int(3) |> Exp.fresh, Int(4) |> Exp.fresh)
+            BinOp(
+              Int(Divide),
+              Int(3 |> Bigint.of_int) |> Exp.fresh,
+              Int(4 |> Bigint.of_int) |> Exp.fresh,
+            )
             |> Exp.fresh,
-            BinOp(Int(Power), Int(5) |> Exp.fresh, Int(6) |> Exp.fresh)
+            BinOp(
+              Int(Power),
+              Int(5 |> Bigint.of_int) |> Exp.fresh,
+              Int(6 |> Bigint.of_int) |> Exp.fresh,
+            )
             |> Exp.fresh,
           )
           |> Exp.fresh,
         )
         |> Exp.fresh,
-        Int(8) |> Exp.fresh,
+        Int(8 |> Bigint.of_int) |> Exp.fresh,
       )
       |> Exp.fresh,
       "-1 + 2 - 3 / 4 * 5 ** 6 >= 8",
@@ -426,7 +482,7 @@ let tests = (
           Unknown(Internal) |> Typ.fresh,
         )
         |> Pat.fresh,
-        Int(5) |> Exp.fresh,
+        Int(5 |> Bigint.of_int) |> Exp.fresh,
         Var("x") |> Exp.fresh,
       )
       |> Exp.fresh,
@@ -436,7 +492,11 @@ let tests = (
       "named_function",
       Fun(
         (Var("x"): Pat.term) |> Pat.fresh,
-        BinOp(Int(Plus), Var("x") |> Exp.fresh, Int(5) |> Exp.fresh)
+        BinOp(
+          Int(Plus),
+          Var("x") |> Exp.fresh,
+          Int(5 |> Bigint.of_int) |> Exp.fresh,
+        )
         |> Exp.fresh,
         None,
         Some("f"),
@@ -461,7 +521,7 @@ let tests = (
         Ap(
           Forward,
           Constructor("C", None) |> Exp.fresh,
-          Int(7) |> Exp.fresh,
+          Int(7 |> Bigint.of_int) |> Exp.fresh,
         )
         |> Exp.fresh,
         Var("x") |> Exp.fresh,
@@ -502,7 +562,11 @@ let tests = (
       Ap(
         Forward,
         Var("f") |> Exp.fresh,
-        Tuple([Int(1) |> Exp.fresh, Int(2) |> Exp.fresh]) |> Exp.fresh,
+        Tuple([
+          Int(1 |> Bigint.of_int) |> Exp.fresh,
+          Int(2 |> Bigint.of_int) |> Exp.fresh,
+        ])
+        |> Exp.fresh,
       )
       |> Exp.fresh,
       "f(1, 2)",

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -221,7 +221,10 @@ let tests = (
             no_error_pat(Var("x")),
             no_error_exp(
               Parens(
-                Tuple([Int(1) |> no_error_exp, Int(2) |> no_error_exp])
+                Tuple([
+                  Int(1 |> Bigint.of_int) |> no_error_exp,
+                  Int(2 |> Bigint.of_int) |> no_error_exp,
+                ])
                 |> no_error_exp,
               ),
             ),
@@ -372,7 +375,7 @@ let tests = (
                 ),
               ),
             ),
-            Int(1),
+            Int(1 |> Bigint.of_int),
           ),
           Var("x") |> no_error_exp,
         )
@@ -578,7 +581,7 @@ let tests = (
                     ),
                   ),
                   Tuple([
-                    no_error_exp(Int(1)),
+                    no_error_exp(Int(1 |> Bigint.of_int)),
                     no_error_exp(Float(1.2)),
                     error_exp(
                       Exp(
@@ -697,7 +700,7 @@ let tests = (
                       ),
                       Label("a"),
                     ),
-                    no_error_exp(Int(3)),
+                    no_error_exp(Int(3 |> Bigint.of_int)),
                   ),
                 ),
               ]),
@@ -714,15 +717,23 @@ let tests = (
             Common(
               NoType(
                 BadLabel(
-                  Exp(MultiHole([Exp(Int(1) |> Exp.fresh)]) |> Exp.fresh),
+                  Exp(
+                    MultiHole([Exp(Int(1 |> Bigint.of_int) |> Exp.fresh)])
+                    |> Exp.fresh,
+                  ),
                 ),
               ),
             ),
           ),
           Dot(
-            Tuple([no_error_exp(Int(1)), no_error_exp(Int(2))])
+            Tuple([
+              no_error_exp(Int(1 |> Bigint.of_int)),
+              no_error_exp(Int(2 |> Bigint.of_int)),
+            ])
             |> no_error_exp,
-            no_error_exp(MultiHole([Exp(no_error_exp(Int(1)))])),
+            no_error_exp(
+              MultiHole([Exp(no_error_exp(Int(1 |> Bigint.of_int)))]),
+            ),
           ),
         ),
       )
@@ -814,7 +825,10 @@ let tests = (
                   TupleLabelError({
                     malformed_labels: [
                       Exp(
-                        MultiHole([Exp(Int(1) |> Exp.fresh)]) |> Exp.fresh,
+                        MultiHole([
+                          Exp(Int(1 |> Bigint.of_int) |> Exp.fresh),
+                        ])
+                        |> Exp.fresh,
                       ),
                     ],
                     duplicate_labels: [],
@@ -840,7 +854,9 @@ let tests = (
                       TupleLabelError({
                         malformed_labels: [
                           Exp(
-                            MultiHole([Exp(Int(1) |> Exp.fresh)])
+                            MultiHole([
+                              Exp(Int(1 |> Bigint.of_int) |> Exp.fresh),
+                            ])
                             |> Exp.fresh,
                           ),
                         ],
@@ -862,14 +878,18 @@ let tests = (
                           NoType(
                             BadLabel(
                               Exp(
-                                MultiHole([Exp(Int(1) |> Exp.fresh)])
+                                MultiHole([
+                                  Exp(Int(1 |> Bigint.of_int) |> Exp.fresh),
+                                ])
                                 |> Exp.fresh,
                               ),
                             ),
                           ),
                         ),
                       ),
-                      MultiHole([Exp(no_error_exp(Int(1)))]),
+                      MultiHole([
+                        Exp(no_error_exp(Int(1 |> Bigint.of_int))),
+                      ]),
                     ),
                     no_error_exp(String("hello")),
                   ),
@@ -877,7 +897,7 @@ let tests = (
                 no_error_exp(
                   TupLabel(
                     no_error_exp(Label("a")),
-                    no_error_exp(Int(3)),
+                    no_error_exp(Int(3 |> Bigint.of_int)),
                   ),
                 ),
               ]),
@@ -992,7 +1012,7 @@ let tests = (
                           Exp(Common(NoType(InvalidLabel("c")))),
                           Label("c"),
                         ),
-                        no_error_exp(Int(1)),
+                        no_error_exp(Int(1 |> Bigint.of_int)),
                       ),
                     ),
                     no_error_exp(
@@ -1044,12 +1064,12 @@ let tests = (
                   Tuple([
                     TupLabel(
                       no_error_exp(Label("a")),
-                      no_error_exp(Int(1)),
+                      no_error_exp(Int(1 |> Bigint.of_int)),
                     )
                     |> no_error_exp,
                     TupLabel(
                       no_error_exp(Label("b")),
-                      no_error_exp(Int(2)),
+                      no_error_exp(Int(2 |> Bigint.of_int)),
                     )
                     |> no_error_exp,
                   ]),
@@ -1068,7 +1088,7 @@ let tests = (
         no_error_exp(
           BinOp(
             Int(Plus),
-            no_error_exp(Int(1)),
+            no_error_exp(Int(1 |> Bigint.of_int)),
             error_exp(
               Exp(
                 Common(


### PR DESCRIPTION
Found some more integers at the end of the number line, thought we might want them in Hazel.

![image](https://github.com/user-attachments/assets/fdd67a1c-1fb5-4db1-a3ce-4af71e66896e)

This pr replaces the integers in Hazel with big integers, similar to python 3.0's approach to integers. Means we can't get integer overflows, and importantly for my work means integers are a little more mathematically well-behaved.

I tried running my AoC code on this branch and it didn't cause any slowdown.