### PR TITLE
Fix Switch Scratchpads/Exercisemodes

### DIFF
--- a/src/haz3lweb/app/editors/mode/ExercisesMode.re
+++ b/src/haz3lweb/app/editors/mode/ExercisesMode.re
@@ -474,13 +474,14 @@ module View = {
           | Previous =>
             inject(
               Update.SwitchExercise(
-                model.current - 1 mod List.length(model.exercises),
+                (model.current + List.length(model.exercises) - 1)
+                mod List.length(model.exercises),
               ),
             )
           | Next =>
             inject(
               Update.SwitchExercise(
-                model.current + 1 mod List.length(model.exercises),
+                (model.current + 1) mod List.length(model.exercises),
               ),
             ),
         ~indicator=

--- a/src/haz3lweb/view/ScratchMode.re
+++ b/src/haz3lweb/view/ScratchMode.re
@@ -347,7 +347,8 @@ module View = {
         | Previous =>
           inject(
             SwitchSlide(
-              (model.current - 1) mod List.length(model.scratchpads),
+              (model.current + List.length(model.scratchpads) - 1)
+              mod List.length(model.scratchpads),
             ),
           )
         | Next =>


### PR DESCRIPTION
Neither of the following in [6df1774](https://github.com/hazelgrove/hazel/commit/6df1774d64832ebaf8397fed1527b0b48431707c) is a correct cyclic page switching. Fix here.

https://github.com/hazelgrove/hazel/blob/6df1774d64832ebaf8397fed1527b0b48431707c/src/haz3lweb/view/ScratchMode.re#L346-L358

https://github.com/hazelgrove/hazel/blob/6df1774d64832ebaf8397fed1527b0b48431707c/src/haz3lweb/app/editors/mode/ExercisesMode.re#L473-L485