### PR TITLE
add associativity axioms

### DIFF
--- a/src/haz3lcore/proof/Axioms.re
+++ b/src/haz3lcore/proof/Axioms.re
@@ -55,4 +55,129 @@ let v: ProofCtx.t =
          None,
        )
        |> Exp.fresh,
+     )
+  |> ProofCtx.add_entry(
+       "Assoc(+)",
+       Fun(
+         Var("x") |> Pat.fresh,
+         Fun(
+           Var("y") |> Pat.fresh,
+           Fun(
+             Var("z") |> Pat.fresh,
+             BinOp(
+               Int(Equals),
+               BinOp(
+                 Int(Plus),
+                 Var("x") |> Exp.fresh,
+                 BinOp(
+                   Int(Plus),
+                   Var("y") |> Exp.fresh,
+                   Var("z") |> Exp.fresh,
+                 )
+                 |> Exp.fresh,
+               )
+               |> Exp.fresh,
+               BinOp(
+                 Int(Plus),
+                 BinOp(
+                   Int(Plus),
+                   Var("x") |> Exp.fresh,
+                   Var("y") |> Exp.fresh,
+                 )
+                 |> Exp.fresh,
+                 Var("z") |> Exp.fresh,
+               )
+               |> Exp.fresh,
+             )
+             |> Exp.fresh,
+             Some(Int |> Typ.fresh),
+             None,
+           )
+           |> Exp.fresh,
+           Some(Int |> Typ.fresh),
+           None,
+         )
+         |> Exp.fresh,
+         Some(Int |> Typ.fresh),
+         None,
+       )
+       |> Exp.fresh,
+     )
+  |> ProofCtx.add_entry(
+       "Comm(*)",
+       Fun(
+         Var("x") |> Pat.fresh,
+         Fun(
+           Var("y") |> Pat.fresh,
+           BinOp(
+             Int(Equals),
+             BinOp(
+               Int(Times),
+               Var("x") |> Exp.fresh,
+               Var("y") |> Exp.fresh,
+             )
+             |> Exp.fresh,
+             BinOp(
+               Int(Times),
+               Var("y") |> Exp.fresh,
+               Var("x") |> Exp.fresh,
+             )
+             |> Exp.fresh,
+           )
+           |> Exp.fresh,
+           Some(Int |> Typ.fresh),
+           None,
+         )
+         |> Exp.fresh,
+         Some(Int |> Typ.fresh),
+         None,
+       )
+       |> Exp.fresh,
+     )
+  |> ProofCtx.add_entry(
+       "Assoc(*)",
+       Fun(
+         Var("x") |> Pat.fresh,
+         Fun(
+           Var("y") |> Pat.fresh,
+           Fun(
+             Var("z") |> Pat.fresh,
+             BinOp(
+               Int(Equals),
+               BinOp(
+                 Int(Times),
+                 Var("x") |> Exp.fresh,
+                 BinOp(
+                   Int(Times),
+                   Var("y") |> Exp.fresh,
+                   Var("z") |> Exp.fresh,
+                 )
+                 |> Exp.fresh,
+               )
+               |> Exp.fresh,
+               BinOp(
+                 Int(Times),
+                 BinOp(
+                   Int(Times),
+                   Var("x") |> Exp.fresh,
+                   Var("y") |> Exp.fresh,
+                 )
+                 |> Exp.fresh,
+                 Var("z") |> Exp.fresh,
+               )
+               |> Exp.fresh,
+             )
+             |> Exp.fresh,
+             Some(Int |> Typ.fresh),
+             None,
+           )
+           |> Exp.fresh,
+           Some(Int |> Typ.fresh),
+           None,
+         )
+         |> Exp.fresh,
+         Some(Int |> Typ.fresh),
+         None,
+       )
+       |> Exp.fresh,
      );


### PR DESCRIPTION
Add new Axioms to allow associativity for (Integer) addition and multiplication, as well as commutativity for multiplication. 
![Screenshot 2025-03-13 at 11 53 05 AM](https://github.com/user-attachments/assets/0b9cd602-e2c1-4f2f-8581-ed46e990d786)
![Screenshot 2025-03-13 at 11 53 14 AM](https://github.com/user-attachments/assets/79f6a37c-6ff9-45df-9828-742a1cb1eb77)
![Screenshot 2025-03-13 at 11 53 19 AM](https://github.com/user-attachments/assets/78a99b6c-54f0-4bb0-a4d8-2d041cefc4b0)
![Screenshot 2025-03-13 at 11 53 35 AM](https://github.com/user-attachments/assets/6af675aa-a9a7-4828-aba0-537ef4564d13)
![Screenshot 2025-03-13 at 11 53 48 AM](https://github.com/user-attachments/assets/055acee9-5d18-4156-a6d2-ebd867d08d1f)
![Screenshot 2025-03-13 at 11 54 00 AM](https://github.com/user-attachments/assets/656daab4-a699-40c9-b9a6-72d95c4ff8d1)
