### PR TITLE
Stop parenthesizing non-nullary constructors in ExpToSegment

### DIFF
--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -44,7 +44,8 @@ let rec external_precedence = (exp: Exp.t): Precedence.t => {
   | BuiltinFun(_)
   | Undefined
   | Label(_)
-  | TupLabel(_) => Precedence.max
+  | TupLabel(_)
+  | Constructor(_) => Precedence.max
 
   // Same goes for forms which are already surrounded
   | Parens(_)
@@ -54,7 +55,6 @@ let rec external_precedence = (exp: Exp.t): Precedence.t => {
 
   // Other forms
   | UnOp(Meta(Unquote), _) => Precedence.unquote
-  | Constructor(_) // Constructor is here because we currently always add a type annotation to constructors
   | Cast(_)
   | FailedCast(_) => Precedence.cast
   | Ap(Forward, _, _)

--- a/test/Test_ExpToSegment.re
+++ b/test/Test_ExpToSegment.re
@@ -352,5 +352,13 @@ let tests = (
     test_case("Function call", `Quick, () => {
       equivalent_to_make_term("a(1, 2)")
     }),
+    test_case(
+      "Singleton constructor",
+      `Quick,
+      () => {
+        equivalent_to_make_term("A");
+        equivalent_to_make_term("B(1)");
+      },
+    ),
   ],
 );


### PR DESCRIPTION
Stops adding parentheses around variant constructors when they're being applied to arguments in exptosegment.

Before
![Screenshot From 2025-03-16 06-35-11](https://github.com/user-attachments/assets/d868c72c-38fe-4201-8389-efa019c7c347)
After
![Screenshot From 2025-03-16 06-34-45](https://github.com/user-attachments/assets/447392ae-a5cf-44c6-a9d8-1f6b83dcbc82)
