### PR TITLE
Switch from unpkg to esm as a temporary cdn fix for ninjakeys

### DIFF
--- a/src/haz3lweb/www/index.html
+++ b/src/haz3lweb/www/index.html
@@ -15,14 +15,7 @@
       rel="stylesheet"
     />
 
-    <!-- The current version of lit-html is broken so this overwrites it for the ninja-keys import. -->
-    <script type="importmap">
-      {
-          "imports": {
-              "https://unpkg.com/lit-html@latest/directives/ref.js?module": "https://unpkg.com/lit-html@2.2.6/directives/ref.js?module"
-          }
-      }
-  </script>
+
   <script type="module" src="ninja_module.js"></script>
 
   </head>

--- a/src/haz3lweb/www/ninja_module.js
+++ b/src/haz3lweb/www/ninja_module.js
@@ -1,5 +1,5 @@
-import {NinjaKeys} from 'https://unpkg.com/ninja-keys?module';
-import hotkeys from "https://unpkg.com/hotkeys-js@3.8.7?module"
+import {NinjaKeys} from 'https://esm.sh/ninja-keys';
+import hotkeys from "https://esm.sh/hotkeys-js@3.8.7"
 
 
 // This is the default behavior for the hotkeys module but I'm overriding it for the clipboard-shim


### PR DESCRIPTION
Doing this as a hotfix since all of our hotkeys and command palette are broken due to unpkg issues.

I'm looking at https://github.com/hazelgrove/hazel/issues/1557 as the real solution.