### PR TITLE
Improvements to stepper rewrite checker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "hazel",
-      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@esbuild-plugins/node-resolve": "^0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
   "packages": {
     "": {
       "name": "hazel",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@esbuild-plugins/node-resolve": "^0.2.2",

--- a/src/haz3lweb/app/editors/stepper/RewriteChecker.re
+++ b/src/haz3lweb/app/editors/stepper/RewriteChecker.re
@@ -4,9 +4,9 @@ open Js_of_ocaml;
 let rec print_exp_for_algebrite = (exp: Exp.t): string =>
   switch (exp.term) {
   | Int(value) => string_of_int(value)
+  // TODO Nats?
   | Float(value) => string_of_float(value)
   | Bool(value) => string_of_bool(value)
-  | String(value) => value
   | BinOp(op, exp_left, exp_right) =>
     "("
     ++ print_exp_for_algebrite(exp_left)
@@ -15,14 +15,23 @@ let rec print_exp_for_algebrite = (exp: Exp.t): string =>
     ++ " "
     ++ print_exp_for_algebrite(exp_right)
     ++ ")"
+  | UnOp(Int(Minus), exp) =>
+    "(" ++ "-" ++ print_exp_for_algebrite(exp) ++ ")"
   | Parens(exp) => "(" ++ print_exp_for_algebrite(exp) ++ ")"
   | Var(value) => value
-  | _ => "Unknown"
+  // TODO: think harder about weird corner cases where we'd want to ensure the types in Cast are valid
+  | Cast(exp, _, _) => print_exp_for_algebrite(exp)
+  // If we don't know how to print the expression, we can use a hash to create a unique string
+  // Modulo keeps it short
+  | _ => "unknown_" ++ string_of_int(Hashtbl.hash(exp) mod 100000)
   };
 
 let checkEquality = (expr1, expr2): bool => {
   let algebrite = Js.Unsafe.global##.Algebrite;
+  print_endline(expr1);
+  print_endline(expr2);
   let diffExpr = Printf.sprintf("simplify((%s)-(%s))", expr1, expr2);
+  print_endline(diffExpr);
   let algebrite_result = algebrite##run(Js.string(diffExpr));
   switch (Js.to_string(algebrite_result)) {
   | "0" => true
@@ -32,6 +41,14 @@ let checkEquality = (expr1, expr2): bool => {
 
 // underscores indicate unused arguments
 let check_rewrite = (_from: Exp.t, _to: Exp.t): bool => {
+  // TODO maybe type-check a bit here so that we don't have to handle
+  // differing types on the Algebrite side
+  // Or maybe Matt will guarantee _from and _to always have the same type
+  // perhaps some Cast
+
+  // TODO return Some(bool) instead of bool in case we encounter a case we can't handle?
+  print_endline(Exp.show(_from));
+  print_endline(Exp.show(_to));
   let left_str = print_exp_for_algebrite(_from);
   let right_str = print_exp_for_algebrite(_to);
   if (left_str == "Unknown" || right_str == "Unknown") {

--- a/src/haz3lweb/app/editors/stepper/RewriteChecker.re
+++ b/src/haz3lweb/app/editors/stepper/RewriteChecker.re
@@ -36,10 +36,7 @@ let rec print_exp_for_algebrite = (exp: Exp.t): string =>
 
 let checkEquality = (expr1, expr2): bool => {
   let algebrite = Js.Unsafe.global##.Algebrite;
-  print_endline(expr1);
-  print_endline(expr2);
   let diffExpr = Printf.sprintf("simplify((%s)-(%s))", expr1, expr2);
-  print_endline(diffExpr);
   let algebrite_result = algebrite##run(Js.string(diffExpr));
   switch (Js.to_string(algebrite_result)) {
   | "0" => true
@@ -55,8 +52,6 @@ let check_rewrite = (_from: Exp.t, _to: Exp.t): bool => {
   // perhaps some Cast
 
   // TODO return Some(bool) instead of bool in case we encounter a case we can't handle?
-  print_endline(Exp.show(_from));
-  print_endline(Exp.show(_to));
   let left_str = print_exp_for_algebrite(_from);
   let right_str = print_exp_for_algebrite(_to);
   if (left_str == "Unknown" || right_str == "Unknown") {

--- a/src/haz3lweb/app/editors/stepper/RewriteChecker.re
+++ b/src/haz3lweb/app/editors/stepper/RewriteChecker.re
@@ -7,6 +7,14 @@ let rec print_exp_for_algebrite = (exp: Exp.t): string =>
   // TODO Nats?
   | Float(value) => string_of_float(value)
   | Bool(value) => string_of_bool(value)
+  // We have to manually map ** (power) to ^ in Algebrite.
+  | BinOp(Int(Power), exp_left, exp_right) =>
+    "("
+    ++ print_exp_for_algebrite(exp_left)
+    ++ " ^ "
+    ++ print_exp_for_algebrite(exp_right)
+    ++ ")"
+  // The other operators should work fine as-is.
   | BinOp(op, exp_left, exp_right) =>
     "("
     ++ print_exp_for_algebrite(exp_left)

--- a/src/haz3lweb/app/editors/stepper/RewriteChecker.re
+++ b/src/haz3lweb/app/editors/stepper/RewriteChecker.re
@@ -51,7 +51,7 @@ let checkEquality = (expr1, expr2): bool => {
 let check_rewrite = (_from: Exp.t, _to: Exp.t): bool => {
   // TODO maybe type-check a bit here so that we don't have to handle
   // differing types on the Algebrite side
-  // Or maybe Matt will guarantee _from and _to always have the same type
+  // Or maybe the stepper itself will guarantee _from and _to always have the same type
   // perhaps some Cast
 
   // TODO return Some(bool) instead of bool in case we encounter a case we can't handle?


### PR DESCRIPTION
improvements to rewrite checker:

- [x] Don't handle strings
- [x] Unique identifiers for unknown terms
- [x] Handle `Casts` naively
- [ ] Think more about bugs arising from blindly printing the `exp` of a `Cast`
- [ ] Handle `Nat`s, once added
- [x] `UnOp` handling
- [x] Rewrite `**` to `^` for `Power` in Algebrite
- [ ] Type-check incoming `Exp`s a little bit when the rewrite checker is invoked
- [ ] Pass around `Some(Bool)` in case we ever can't handle some sort of expression