### PR TITLE
Fix CI fatal warnings

### DIFF
--- a/dune-workspace
+++ b/dune-workspace
@@ -7,4 +7,9 @@
    (:standard -warn-error +A-26-27-K-58))) ; Disable some unused warnings.
  (release
   (flags
-   (:standard -warn-error +A-58))))
+   (:standard -w
+  @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40
+  -strict-sequence
+  -strict-formats
+  -short-paths
+  -keep-locs -warn-error +A-58))))

--- a/src/haz3lcore/lang/term/Typ.re
+++ b/src/haz3lcore/lang/term/Typ.re
@@ -562,7 +562,7 @@ let rec get_sum_constructors = (ctx: Ctx.t, ty: t): option(sum_map) => {
        the below code will be incorrect! */
     let ty =
       switch (ty |> term_of) {
-      | Rec({term: Var(x), _}, ty_body) =>
+      | Rec({term: Var(x), _}, _ty_body) =>
         switch (Ctx.lookup_alias(ctx, x)) {
         | None => unroll(ty)
         | Some(_) => unroll(ty)


### PR DESCRIPTION
Resolves https://github.com/hazelgrove/hazel/issues/1601

I just inlined all of the warnings we have configured in development (the dune default). By default dune has [minimal warnings](https://github.com/ocaml/dune/blob/897bd784ba2877388001f5e88bd873449d9e83e1/src/dune_rules/ocaml_flags.ml#L50) enabled for release. This should at least make it to where anything failing locally fails on release. It may also be worth it to us to go through and pick an intentional set of warnings/errors that work for us.

P.S. I can also suppress the warning 58 (no cmx file) that happens on every build if we want.