### PR TITLE
bring back function ap in stepper

### DIFF
--- a/src/haz3lcore/dynamics/Evaluator.re
+++ b/src/haz3lcore/dynamics/Evaluator.re
@@ -101,7 +101,15 @@ module Eval = Transition(EvaluatorEVMode);
 
 let rec evaluate = (~in_closure=?, state, env, d) => {
   open Trampoline.Syntax;
-  let.trampoline u = Eval.transition(evaluate, ~in_closure?, state, env, d);
+  let.trampoline u =
+    Eval.transition(
+      evaluate,
+      ~mode=`Environment,
+      ~in_closure?,
+      state,
+      env,
+      d,
+    );
   switch (u) {
   | (Final, x) => (EvaluatorEVMode.Final, x) |> Trampoline.return
   | (Uneval, x) => Trampoline.Next(() => evaluate(state, env, x))

--- a/src/haz3lcore/dynamics/Substitution.re
+++ b/src/haz3lcore/dynamics/Substitution.re
@@ -1,34 +1,30 @@
 /**
  * Whether dp contains the variable x outside of a hole.
  */
-let rec binds_var = (m: Statics.Map.t, x: Var.t, dp: DHPat.t): bool =>
-  switch (Statics.get_pat_error_at(m, Pat.rep_id(dp))) {
-  | Some(_) => false
-  | None =>
-    switch (dp |> Pat.term_of) {
-    | EmptyHole
-    | MultiHole(_)
-    | Wild
-    | Invalid(_)
-    | Atom(_)
-    | Label(_)
-    | Constructor(_) => false
-    | Cast(y, _, _)
-    | Parens(y)
-    | Probe(y, _) => binds_var(m, x, y)
-    | Var(y) => Var.equal(x, y)
-    | TupLabel(_, dp) => binds_var(m, x, dp)
-    | Tuple(dps) => dps |> List.exists(binds_var(m, x))
-    | Cons(dp1, dp2) => binds_var(m, x, dp1) || binds_var(m, x, dp2)
-    | ListLit(d_list) =>
-      let new_list = List.map(binds_var(m, x), d_list);
-      List.fold_left((||), false, new_list);
-    | Ap(_, _) => false
-    }
+let rec binds_var = (x: Var.t, dp: DHPat.t): bool =>
+  switch (dp |> Pat.term_of) {
+  | EmptyHole
+  | MultiHole(_)
+  | Wild
+  | Invalid(_)
+  | Atom(_)
+  | Label(_)
+  | Constructor(_) => false
+  | Cast(y, _, _)
+  | Parens(y)
+  | Probe(y, _) => binds_var(x, y)
+  | Var(y) => Var.equal(x, y)
+  | TupLabel(_, dp) => binds_var(x, dp)
+  | Tuple(dps) => dps |> List.exists(binds_var(x))
+  | Cons(dp1, dp2) => binds_var(x, dp1) || binds_var(x, dp2)
+  | ListLit(d_list) =>
+    let new_list = List.map(binds_var(x), d_list);
+    List.fold_left((||), false, new_list);
+  | Ap(_, _) => false
   };
 
 /* closed substitution [d1/x]d2 */
-let rec subst_var = (m, d1: DHExp.t, x: Var.t, d2: DHExp.t): DHExp.t => {
+let rec subst_var = (d1: DHExp.t, x: Var.t, d2: DHExp.t): DHExp.t => {
   let (term, rewrap) = DHExp.unwrap(d2);
   switch (term) {
   | Var(y) =>
@@ -40,86 +36,85 @@ let rec subst_var = (m, d1: DHExp.t, x: Var.t, d2: DHExp.t): DHExp.t => {
   | Invalid(_) => d2
   | Undefined => d2
   | Seq(d3, d4) =>
-    let d3 = subst_var(m, d1, x, d3);
-    let d4 = subst_var(m, d1, x, d4);
+    let d3 = subst_var(d1, x, d3);
+    let d4 = subst_var(d1, x, d4);
     Seq(d3, d4) |> rewrap;
   | Filter(filter, dbody) =>
-    let dbody = subst_var(m, d1, x, dbody);
-    let filter = subst_var_filter(m, d1, x, filter);
+    let dbody = subst_var(d1, x, dbody);
+    let filter = subst_var_filter(d1, x, filter);
     Filter(filter, dbody) |> rewrap;
   | Let(dp, d3, d4) =>
-    let d3 = subst_var(m, d1, x, d3);
+    let d3 = subst_var(d1, x, d3);
     let d4 =
-      if (binds_var(m, x, dp)) {
+      if (binds_var(x, dp)) {
         d4;
       } else {
-        subst_var(m, d1, x, d4);
+        subst_var(d1, x, d4);
       };
     Let(dp, d3, d4) |> rewrap;
   | FixF(y, d3, env) =>
-    let env' = Option.map(subst_var_env(m, d1, x), env);
+    let env' = Option.map(subst_var_env(d1, x), env);
     let d3 =
-      if (binds_var(m, x, y)) {
+      if (binds_var(x, y)) {
         d3;
       } else {
-        subst_var(m, d1, x, d3);
+        subst_var(d1, x, d3);
       };
     FixF(y, d3, env') |> rewrap;
   | Fun(dp, d3, ty, s) =>
-    if (binds_var(m, x, dp)) {
+    if (binds_var(x, dp)) {
       Fun(dp, d3, ty, s) |> rewrap;
     } else {
-      let d3 = subst_var(m, d1, x, d3);
+      let d3 = subst_var(d1, x, d3);
       Fun(dp, d3, ty, s) |> rewrap;
     }
-  | TypFun(tpat, d3, s) =>
-    TypFun(tpat, subst_var(m, d1, x, d3), s) |> rewrap
+  | TypFun(tpat, d3, s) => TypFun(tpat, subst_var(d1, x, d3), s) |> rewrap
   | Closure(env, d3) =>
     /* Closure shouldn't appear during substitution (which
        only is called from elaboration currently) */
-    let env' = subst_var_env(m, d1, x, env);
-    let d3' = subst_var(m, d1, x, d3);
+    let env' = subst_var_env(d1, x, env);
+    let d3' = subst_var(d1, x, d3);
     Closure(env', d3') |> rewrap;
   | Ap(dir, d3, d4) =>
-    let d3 = subst_var(m, d1, x, d3);
-    let d4 = subst_var(m, d1, x, d4);
+    let d3 = subst_var(d1, x, d3);
+    let d4 = subst_var(d1, x, d4);
     Ap(dir, d3, d4) |> rewrap;
   | BuiltinFun(_) => d2
-  | Test(d3) => Test(subst_var(m, d1, x, d3)) |> rewrap
+  | Test(d3) => Test(subst_var(d1, x, d3)) |> rewrap
   | Atom(_)
   | Label(_)
   | Constructor(_) => d2
-  | ListLit(ds) => ListLit(List.map(subst_var(m, d1, x), ds)) |> rewrap
+  | ListLit(ds) => ListLit(List.map(subst_var(d1, x), ds)) |> rewrap
   | Cons(d3, d4) =>
-    let d3 = subst_var(m, d1, x, d3);
-    let d4 = subst_var(m, d1, x, d4);
+    let d3 = subst_var(d1, x, d3);
+    let d4 = subst_var(d1, x, d4);
     Cons(d3, d4) |> rewrap;
   | ListConcat(d3, d4) =>
-    let d3 = subst_var(m, d1, x, d3);
-    let d4 = subst_var(m, d1, x, d4);
+    let d3 = subst_var(d1, x, d3);
+    let d4 = subst_var(d1, x, d4);
     ListConcat(d3, d4) |> rewrap;
-  | TupLabel(label, d) => TupLabel(label, subst_var(m, d1, x, d)) |> rewrap
+  | TupLabel(label, d) => TupLabel(label, subst_var(d1, x, d)) |> rewrap
   | Dot(d3, d4) =>
-    let d3 = subst_var(m, d1, x, d3);
-    let d4 = subst_var(m, d1, x, d4);
+    let d3 = subst_var(d1, x, d3);
+    let d4 = subst_var(d1, x, d4);
     Dot(d3, d4) |> rewrap;
-  | Tuple(ds) => Tuple(List.map(subst_var(m, d1, x), ds)) |> rewrap
+  | Tuple(ds) => Tuple(List.map(subst_var(d1, x), ds)) |> rewrap
   | UnOp(op, d3) =>
-    let d3 = subst_var(m, d1, x, d3);
+    let d3 = subst_var(d1, x, d3);
     UnOp(op, d3) |> rewrap;
   | BinOp(op, d3, d4) =>
-    let d3 = subst_var(m, d1, x, d3);
-    let d4 = subst_var(m, d1, x, d4);
+    let d3 = subst_var(d1, x, d3);
+    let d4 = subst_var(d1, x, d4);
     BinOp(op, d3, d4) |> rewrap;
   | Match(ds, rules) =>
-    let ds = subst_var(m, d1, x, ds);
+    let ds = subst_var(d1, x, ds);
     let rules =
       List.map(
         ((p, v)) =>
-          if (binds_var(m, x, p)) {
+          if (binds_var(x, p)) {
             (p, v);
           } else {
-            (p, subst_var(m, d1, x, v));
+            (p, subst_var(d1, x, v));
           },
         rules,
       );
@@ -128,45 +123,44 @@ let rec subst_var = (m, d1: DHExp.t, x: Var.t, d2: DHExp.t): DHExp.t => {
   // TODO: handle multihole
   | MultiHole(_d2) => d2 //MultiHole(List.map(subst_var(m, d1, x), ds)) |> rewrap
   | Cast(d, ty1, ty2) =>
-    let d' = subst_var(m, d1, x, d);
+    let d' = subst_var(d1, x, d);
     Cast(d', ty1, ty2) |> rewrap;
   | FailedCast(d, ty1, ty2) =>
-    let d' = subst_var(m, d1, x, d);
+    let d' = subst_var(d1, x, d);
     FailedCast(d', ty1, ty2) |> rewrap;
   | DynamicErrorHole(d, err) =>
-    let d' = subst_var(m, d1, x, d);
+    let d' = subst_var(d1, x, d);
     DynamicErrorHole(d', err) |> rewrap;
   | If(d4, d5, d6) =>
-    let d4' = subst_var(m, d1, x, d4);
-    let d5' = subst_var(m, d1, x, d5);
-    let d6' = subst_var(m, d1, x, d6);
+    let d4' = subst_var(d1, x, d4);
+    let d5' = subst_var(d1, x, d5);
+    let d6' = subst_var(d1, x, d6);
     If(d4', d5', d6') |> rewrap;
   | TyAlias(tp, ut, d4) =>
-    let d4' = subst_var(m, d1, x, d4);
+    let d4' = subst_var(d1, x, d4);
     TyAlias(tp, ut, d4') |> rewrap;
   | Use(t, d) =>
-    let d' = subst_var(m, d1, x, d);
+    let d' = subst_var(d1, x, d);
     Use(t, d') |> rewrap;
   | Parens(d4) =>
-    let d4' = subst_var(m, d1, x, d4);
+    let d4' = subst_var(d1, x, d4);
     Parens(d4') |> rewrap;
   | Probe(d4, pr) =>
-    let d4' = subst_var(m, d1, x, d4);
+    let d4' = subst_var(d1, x, d4);
     Probe(d4', pr) |> rewrap;
   | Deferral(_) => d2
   | DeferredAp(d3, d4s) =>
-    let d3 = subst_var(m, d1, x, d3);
-    let d4s = List.map(subst_var(m, d1, x), d4s);
+    let d3 = subst_var(d1, x, d3);
+    let d4s = List.map(subst_var(d1, x), d4s);
     DeferredAp(d3, d4s) |> rewrap;
   | TypAp(d3, ut) =>
-    let d3 = subst_var(m, d1, x, d3);
+    let d3 = subst_var(d1, x, d3);
     TypAp(d3, ut) |> rewrap;
   };
 }
 
 and subst_var_env =
-    (m, d1: DHExp.t, x: Var.t, env: ClosureEnvironment.t)
-    : ClosureEnvironment.t => {
+    (d1: DHExp.t, x: Var.t, env: ClosureEnvironment.t): ClosureEnvironment.t => {
   Environment.foldo(
     ((x', d': DHExp.t), map) => {
       let d' =
@@ -176,14 +170,14 @@ and subst_var_env =
         | FixF(_) =>
           map
           |> Environment.foldo(
-               ((x'', d''), d) => subst_var(m, d'', x'', d),
+               ((x'', d''), d) => subst_var(d'', x'', d),
                d',
              )
         | _ => d'
         };
 
       /* Substitute. */
-      let d' = subst_var(m, d1, x, d');
+      let d' = subst_var(d1, x, d');
       Environment.extend(map, (x', d'));
     },
     Environment.empty,
@@ -192,17 +186,17 @@ and subst_var_env =
 }
 
 and subst_var_filter =
-    (m, d1: DHExp.t, x: Var.t, flt: TermBase.StepperFilterKind.t)
+    (d1: DHExp.t, x: Var.t, flt: TermBase.StepperFilterKind.t)
     : TermBase.StepperFilterKind.t => {
-  flt |> TermBase.StepperFilterKind.map(subst_var(m, d1, x));
+  flt |> TermBase.StepperFilterKind.map(subst_var(d1, x));
 };
 
-let subst = (m, env: Environment.t, d: DHExp.t): DHExp.t =>
+let subst = (env: Environment.t, d: DHExp.t): DHExp.t =>
   env
   |> Environment.foldo(
        (xd: (Var.t, DHExp.t), d2) => {
          let (x, d1) = xd;
-         subst_var(m, d1, x, d2);
+         subst_var(d1, x, d2);
        },
        d,
      );

--- a/src/haz3lcore/dynamics/ValueChecker.re
+++ b/src/haz3lcore/dynamics/ValueChecker.re
@@ -53,14 +53,30 @@ module ValueCheckerEVMode: {
 module CV = Transition(ValueCheckerEVMode);
 
 let rec check_value = (~in_closure=?, state, env, d) =>
-  CV.transition(check_value, ~in_closure?, state, env, d);
+  CV.transition(check_value, ~mode=`Environment, ~in_closure?, state, env, d);
 
 let rec check_value_mod_ctx = (~in_closure=?, (), env, d) =>
   switch (DHExp.term_of(d)) {
   | Var(x) =>
     switch (ClosureEnvironment.lookup(env, x)) {
     | Some(v) => check_value_mod_ctx(~in_closure?, (), env, v)
-    | None => CV.transition(check_value_mod_ctx, ~in_closure?, (), env, d)
+    | None =>
+      CV.transition(
+        check_value_mod_ctx,
+        ~mode=`Environment,
+        ~in_closure?,
+        (),
+        env,
+        d,
+      )
     }
-  | _ => CV.transition(check_value_mod_ctx, ~in_closure?, (), env, d)
+  | _ =>
+    CV.transition(
+      check_value_mod_ctx,
+      ~mode=`Environment,
+      ~in_closure?,
+      (),
+      env,
+      d,
+    )
   };

--- a/src/haz3lcore/dynamics/stepper/EvaluatorStep.re
+++ b/src/haz3lcore/dynamics/stepper/EvaluatorStep.re
@@ -322,6 +322,7 @@ module Decompose = {
       Decomp.transition(
         decompose,
         ~in_closure=Option.value(~default=() => (), in_closure),
+        ~mode=`Substitution,
         state,
         env,
         exp,
@@ -372,6 +373,7 @@ module TakeStep = {
     TakeStepEV.transition(
       (~in_closure as _=?, _, _, _) => None,
       ~in_closure=Option.value(~default=() => (), in_closure),
+      ~mode=`Substitution,
       state,
       env,
       d,

--- a/src/haz3lcore/dynamics/transition/Transition.re
+++ b/src/haz3lcore/dynamics/transition/Transition.re
@@ -177,9 +177,13 @@ module Transition = (EV: EV_MODE) => {
             DHExp.t
           ) =>
           'a,
+        ~mode: [
+           | `Substitution
+           | `Environment
+         ],
         ~in_closure=?,
         state,
-        env,
+        env, // Empty in substitution mode
         d,
       )
       : 'a => {
@@ -191,32 +195,46 @@ module Transition = (EV: EV_MODE) => {
         ids: [rep_id(d)],
       });
 
-    let (let.wrap_closure) = (env, f: unit => rule) => {
-      wrap_closure_when_done(~in_closure, d, env, f());
-    };
+    let (let.wrap_closure) = (env, f: unit => rule) =>
+      switch (mode) {
+      | `Environment => wrap_closure_when_done(~in_closure, d, env, f())
+      | `Substitution => f()
+      };
+
+    let subst_env = (env, d) =>
+      switch (mode) {
+      | `Environment => Closure(env, d) |> fresh
+      | `Substitution => d |> Substitution.subst(env.env)
+      };
 
     // Transition rules
     switch (term) {
     | Var(x) =>
-      let. _ = otherwise(env, Var(x) |> rewrap);
-      switch (ClosureEnvironment.lookup(env, x)) {
-      | Some(d) =>
-        let is_value =
-          switch (d |> Exp.term_of) {
-          | FixF(_, _, _) => false // fixpoints aren't final
-          | Let(_, _, _) => false // could be mutually-recursive fixpoint
-          | _ => true // all other closure entries should be final
-          };
-        Step({
-          expr: d |> fast_copy(Id.mk()),
-          state_update,
-          kind: VarLookup,
-          is_value,
-        });
-      | None =>
-        let.wrap_closure _ = env;
+      switch (mode) {
+      | `Environment =>
+        let. _ = otherwise(env, Var(x) |> rewrap);
+        switch (ClosureEnvironment.lookup(env, x)) {
+        | Some(d) =>
+          let is_value =
+            switch (d |> Exp.term_of) {
+            | FixF(_, _, _) => false // fixpoints aren't final
+            | Let(_, _, _) => false // could be mutually-recursive fixpoint
+            | _ => true // all other closure entries should be final
+            };
+          Step({
+            expr: d |> fast_copy(Id.mk()),
+            state_update,
+            kind: VarLookup,
+            is_value,
+          });
+        | None =>
+          let.wrap_closure _ = env;
+          Indet;
+        };
+      | `Substitution =>
+        let. _ = otherwise(env, d);
         Indet;
-      };
+      }
     | Seq(d1, d2) =>
       let. _ = otherwise(env, d1 => Seq(d1, d2) |> rewrap)
       and. _ =
@@ -235,7 +253,7 @@ module Transition = (EV: EV_MODE) => {
       let {matches, closures} = matches(dp, d1');
       let.match env' = (env, matches, env.call_stack);
       Step({
-        expr: closure(env', d2),
+        expr: subst_env(env', d2),
         state_update: capture_closures(env, state, closures),
         kind: LetBind,
         is_value: false,
@@ -265,7 +283,7 @@ module Transition = (EV: EV_MODE) => {
             env,
           );
         Step({
-          expr: closure(env'', d1),
+          expr: subst_env(env'', d1),
           state_update,
           kind: FixUnwrap,
           is_value: false,
@@ -290,7 +308,7 @@ module Transition = (EV: EV_MODE) => {
             env,
           );
         Step({
-          expr: closure(env'', d1),
+          expr: subst_env(env'', d1),
           state_update,
           kind: FixUnwrap,
           is_value: false,
@@ -386,12 +404,35 @@ module Transition = (EV: EV_MODE) => {
               function_lexical_env,
             );
           Step({
-            expr: closure(env'', d3),
+            expr: subst_env(env'', d3),
             state_update: capture_closures(env'', state, matches.closures),
             kind: FunAp,
             is_value: false,
           });
         };
+      | FunNoEnv(dp, d3) when mode == `Substitution =>
+        let matches = matches(dp, d2');
+        switch (matches.matches) {
+        | IndetMatch
+        | DoesNotMatch => Indet
+        | Matches(function_arg_env) =>
+          Step({
+            expr:
+              subst_env(
+                function_arg_env |> ClosureEnvironment.of_environment,
+                d3,
+              ),
+            state_update:
+              capture_closures(
+                function_arg_env |> ClosureEnvironment.of_environment,
+                state,
+                matches.closures,
+              ),
+            kind: FunAp,
+            is_value: false,
+          })
+        };
+      | FunNoEnv(_) => Indet
       | FunCast(d3', ty1, ty2, ty1', ty2') =>
         Step({
           expr: cast(ap(dir, d3', cast(d2', ty1', ty1)), ty2, ty2'),

--- a/src/haz3lcore/dynamics/transition/Unboxing.re
+++ b/src/haz3lcore/dynamics/transition/Unboxing.re
@@ -30,6 +30,7 @@ type unboxed_tfun =
 type unboxed_fun =
   | Constructor(string)
   | FunEnv(Pat.t, Exp.t, ClosureEnvironment.t)
+  | FunNoEnv(Pat.t, Exp.t)
   | FunCast(DHExp.t, Typ.t, Typ.t, Typ.t, Typ.t)
   | BuiltinFun(string)
   | DeferredAp(DHExp.t, list(DHExp.t));
@@ -203,6 +204,7 @@ let rec unbox: type a. (unbox_request(a), DHExp.t) => unboxed(a) =
     | (Fun, Constructor(name, _)) => Matches(Constructor(name)) // Perhaps we should check if the constructor actually is a function?
     | (Fun, Closure(env', {term: Fun(dp, d3, _, _), _})) =>
       Matches(FunEnv(dp, d3, env'))
+    | (Fun, Fun(dp, d3, _, _)) => Matches(FunNoEnv(dp, d3))
     | (
         Fun,
         Cast(


### PR DESCRIPTION
I removed closures from the stepper because doing proofs when there's closures around is almost impossible but I forgot that our function semantics require closures to run. 🤦  I cherry-picked some stuff from the proofs branch and now this pr now lets us step functions again.