### PR TITLE
Multiple fixes to statics, elaboration, and dynamics with property based tests for each

### DIFF
--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -79,6 +79,7 @@ jobs:
           eval $(opam env)
           make ci
         working-directory: ./source
+        timeout-minutes: 10
       - name: Test Report
         uses: dorny/test-reporter@v1
         with:

--- a/dune-project
+++ b/dune-project
@@ -47,7 +47,7 @@
   ocamlformat
   (junit_alcotest
    (and
-    (>= 2.1.0)
+    (>= 2.2.0)
     :with-test))
   ocaml-lsp-server
   ocaml-index

--- a/hazel.opam
+++ b/hazel.opam
@@ -24,7 +24,7 @@ depends: [
   "uuidm" {= "0.9.8"}
   "unionFind"
   "ocamlformat"
-  "junit_alcotest" {>= "2.1.0" & with-test}
+  "junit_alcotest" {>= "2.2.0" & with-test}
   "ocaml-lsp-server"
   "ocaml-index"
   "qcheck"

--- a/hazel.opam.locked
+++ b/hazel.opam.locked
@@ -102,11 +102,12 @@ depends: [
   "jsonm" {= "1.0.2"}
   "jsonrpc" {= "1.21.0"}
   "jst-config" {= "v0.16.0"}
-  "junit" {= "2.1.0" & with-test}
-  "junit_alcotest" {= "2.1.0" & with-test}
+  "junit" {= "2.2.0" & with-test}
+  "junit_alcotest" {= "2.2.0" & with-test}
   "lambdasoup" {= "1.1.1"}
   "logs" {= "0.7.0"}
   "lsp" {= "1.21.0"}
+  "lwt" {= "5.9.1"}
   "macaddr" {= "5.6.0"}
   "magic-mime" {= "1.3.1"}
   "markup" {= "1.0.3"}
@@ -135,6 +136,7 @@ depends: [
   "ocamlformat-lib" {= "0.27.0"}
   "ocamlformat-rpc-lib" {= "0.27.0"}
   "ocp-indent" {= "1.8.1"}
+  "ocplib-endian" {= "1.2"}
   "octavius" {= "1.2.2"}
   "odoc" {= "2.4.4" & with-doc}
   "odoc-parser" {= "2.4.4" & with-doc}

--- a/src/haz3lcore/dynamics/Evaluator.re
+++ b/src/haz3lcore/dynamics/Evaluator.re
@@ -10,21 +10,56 @@ module Trampoline = {
   type callstack('a, 'b) =
     | Finished: callstack('a, 'a)
     | Continue('a => t('b), callstack('b, 'c)): callstack('a, 'c);
-
-  let rec run: type a b. (t(b), callstack(b, a)) => a =
-    (t: t(b), callstack: callstack(b, a)) => (
-      switch (t) {
-      | Bind(t, f) => (run(t, Continue(f, callstack)): a)
-      | Next(f) => run(f(), callstack)
-      | Done(x) =>
-        switch (callstack) {
-        | Finished => x
-        | Continue(f, callstack) => run(f(x), callstack)
-        }
+  let rec run:
+    type a b.
+      (~step_limit: int=?, ~step_counter: int=?, t(b), callstack(b, a)) => a =
+    (
+      ~step_limit: option(int)=?,
+      ~step_counter=0,
+      t: t(b),
+      callstack: callstack(b, a),
+    ) => (
+      // if (step_counter > 0 && step_counter mod 1000 == 0) {
+      //   print_endline(
+      //     "Step: "
+      //     ++ string_of_int(step_counter)
+      //     ++ ", "
+      //     ++ string_of_int(Option.value(~default=0, step_limit)),
+      //   );
+      // };
+      {
+        switch (step_limit) {
+        | Some(x) when x <= step_counter =>
+          raise(Failure("Step limit reached"))
+        | _ => ()
+        };
+        switch (t) {
+        | Bind(t, f) =>
+          run(
+            ~step_limit?,
+            ~step_counter=step_counter + 1,
+            t,
+            Continue(f, callstack),
+          )
+        | Next(f) =>
+          run(~step_limit?, ~step_counter=step_counter + 1, f(), callstack)
+        | Done(x) =>
+          switch (callstack) {
+          | Finished => x
+          | Continue(f, callstack) =>
+            run(
+              ~step_limit?,
+              ~step_counter=step_counter + 1,
+              f(x),
+              callstack,
+            )
+          }
+        };
       }: a
     );
 
-  let run = run(_, Finished);
+  let run = (~step_limit: option(int)=?, t) =>
+    run(~step_limit?, t, Finished);
 
   let return = x => Done(x);
 
@@ -116,11 +151,11 @@ let rec evaluate = (~in_closure=?, state, env, d) => {
   };
 };
 
-let evaluate = (~env, d: DHExp.t) => {
+let evaluate = (~step_limit: option(int)=?, ~env, d: DHExp.t) => {
   let state = ref(EvaluatorState.init);
   let env = ClosureEnvironment.of_environment(env);
   let result = evaluate(state, env, d);
-  let result = Trampoline.run(result);
+  let result = Trampoline.run(~step_limit?, result);
   let result =
     switch (result) {
     | (Final, x) => x |> Exp.replace_all_ids

--- a/src/haz3lcore/dynamics/Evaluator.re
+++ b/src/haz3lcore/dynamics/Evaluator.re
@@ -1,5 +1,9 @@
 open Transition;
 
+type step_constrained('a) =
+  | StepLimitExceeded
+  | Completed('a);
+
 // This module defines the stack machine for the evaluator.
 module Trampoline = {
   type t('a) =
@@ -12,27 +16,17 @@ module Trampoline = {
     | Continue('a => t('b), callstack('b, 'c)): callstack('a, 'c);
   let rec run:
     type a b.
-      (~step_limit: int=?, ~step_counter: int=?, t(b), callstack(b, a)) => a =
+      (~step_limit: int=?, ~step_counter: int=?, t(b), callstack(b, a)) =>
+      step_constrained(a) =
     (
       ~step_limit: option(int)=?,
       ~step_counter=0,
       t: t(b),
       callstack: callstack(b, a),
-    ) => (
-      // if (step_counter > 0 && step_counter mod 1000 == 0) {
-      //   print_endline(
-      //     "Step: "
-      //     ++ string_of_int(step_counter)
-      //     ++ ", "
-      //     ++ string_of_int(Option.value(~default=0, step_limit)),
-      //   );
-      // };
-      {
-        switch (step_limit) {
-        | Some(x) when x <= step_counter =>
-          raise(Failure("Step limit reached"))
-        | _ => ()
-        };
+    ) => {
+      switch (step_limit) {
+      | Some(x) when x <= step_counter => StepLimitExceeded
+      | _ =>
         switch (t) {
         | Bind(t, f) =>
           run(
@@ -45,7 +39,7 @@ module Trampoline = {
           run(~step_limit?, ~step_counter=step_counter + 1, f(), callstack)
         | Done(x) =>
           switch (callstack) {
-          | Finished => x
+          | Finished => Completed(x)
           | Continue(f, callstack) =>
             run(
               ~step_limit?,
@@ -54,9 +48,9 @@ module Trampoline = {
               callstack,
             )
           }
-        };
-      }: a
-    );
+        }
+      };
+    };
 
   let run = (~step_limit: option(int)=?, t) =>
     run(~step_limit?, t, Finished);
@@ -151,17 +145,29 @@ let rec evaluate = (~in_closure=?, state, env, d) => {
   };
 };
 
-let evaluate = (~step_limit: option(int)=?, ~env, d: DHExp.t) => {
+let evaluate_and_limit =
+    (~step_limit: option(int)=?, ~env, d: DHExp.t)
+    : step_constrained((Exp.t, EvaluatorState.t)) => {
   let state = ref(EvaluatorState.init);
   let env = ClosureEnvironment.of_environment(env);
   let result = evaluate(state, env, d);
   let result = Trampoline.run(~step_limit?, result);
-  let result =
-    switch (result) {
-    | (Final, x) => x |> Exp.replace_all_ids
-    | (Uneval, x) => x |> Exp.replace_all_ids
-    };
-  let result =
-    result |> Exp.substitute_closures(env |> ClosureEnvironment.map_of);
-  (result, state^);
+  switch (result) {
+  | Completed((_, x)) =>
+    Completed((
+      x
+      |> Exp.replace_all_ids
+      |> Exp.substitute_closures(env |> ClosureEnvironment.map_of),
+      state^,
+    ))
+  | StepLimitExceeded => StepLimitExceeded
+  };
+};
+
+let evaluate = (~env, d: DHExp.t): (Exp.t, EvaluatorState.t) => {
+  switch (evaluate_and_limit(~env, d)) {
+  | Completed((x, state)) => (x, state)
+  | StepLimitExceeded =>
+    raise(Failure("Impossible: Step limit exceeded when not set"))
+  };
 };

--- a/src/haz3lcore/dynamics/Evaluator.rei
+++ b/src/haz3lcore/dynamics/Evaluator.rei
@@ -1,5 +1,11 @@
 // INVARIANT: this evaluate function should never return an expression with closures.
 
-let evaluate:
+type step_constrained('a) =
+  | StepLimitExceeded
+  | Completed('a);
+
+let evaluate: (~env: Environment.t, Exp.t) => (Exp.t, EvaluatorState.t);
+
+let evaluate_and_limit:
   (~step_limit: int=?, ~env: Environment.t, Exp.t) =>
-  (Exp.t, EvaluatorState.t);
+  step_constrained((Exp.t, EvaluatorState.t));

--- a/src/haz3lcore/dynamics/Evaluator.rei
+++ b/src/haz3lcore/dynamics/Evaluator.rei
@@ -1,3 +1,5 @@
 // INVARIANT: this evaluate function should never return an expression with closures.
 
-let evaluate: (~env: Environment.t, Exp.t) => (Exp.t, EvaluatorState.t);
+let evaluate:
+  (~step_limit: int=?, ~env: Environment.t, Exp.t) =>
+  (Exp.t, EvaluatorState.t);

--- a/src/haz3lcore/dynamics/transition/Transition.re
+++ b/src/haz3lcore/dynamics/transition/Transition.re
@@ -176,17 +176,17 @@ module Transition = (EV: EV_MODE) => {
             ClosureEnvironment.t,
             DHExp.t
           ) =>
-          'a,
+          EV.result,
         ~mode: [
            | `Substitution
            | `Environment
          ],
-        ~in_closure=?,
-        state,
-        env, // Empty in substitution mode
-        d,
+        ~in_closure: option(unit => unit)=?,
+        state: state,
+        env: TermBase.closure_environment_t, // Empty in substitution mode
+        d: t,
       )
-      : 'a => {
+      : EV.result => {
     // Split DHExp into term and id information
     let (term, rewrap) = DHExp.unwrap(d);
     let wrap_ctx = (term): EvalCtx.t =>

--- a/src/haz3lcore/dynamics/transition/Unboxing.re
+++ b/src/haz3lcore/dynamics/transition/Unboxing.re
@@ -76,6 +76,12 @@ let rec unbox: type a. (unbox_request(a), DHExp.t) => unboxed(a) =
     | (_, Cast(d, x, {term: Parens(y), _})) =>
       unbox(request, Cast(d, x, y) |> DHExp.fresh)
 
+    /* $e and $v could have any type, but are indet */
+
+    | (_, UnOp(Meta(Unquote), _)) => IndetMatch
+    | (_, Constructor(c, _)) when String.starts_with(c, ~prefix="$") =>
+      IndetMatch
+
     /* TupLabels can be anything except for tuplabels with unmatching labels */
     | (TupLabel(tuplabel), TupLabel(_, e)) =>
       if (Option.equal(

--- a/src/haz3lcore/dynamics/transition/Unboxing.re
+++ b/src/haz3lcore/dynamics/transition/Unboxing.re
@@ -256,9 +256,8 @@ let rec unbox: type a. (unbox_request(a), DHExp.t) => unboxed(a) =
         TupLabel(_) |
         Tuple(_) |
         Cast(_) |
-        Ap(_, {term: Constructor(_), _}, _) |
-        TypFun(_) |
-        TypAp(_),
+        TypFun(_, _, _) |
+        Ap(_, {term: Constructor(_), _}, _),
       ) =>
       switch (request) {
       | TupLabel(_) =>
@@ -294,6 +293,7 @@ let rec unbox: type a. (unbox_request(a), DHExp.t) => unboxed(a) =
         Var(_) |
         Let(_) |
         Fun(_, _, _, _) |
+        TypAp(_) |
         FixF(_) |
         TyAlias(_) |
         Use(_) |

--- a/src/haz3lcore/lang/term/Typ.re
+++ b/src/haz3lcore/lang/term/Typ.re
@@ -427,13 +427,7 @@ let rec matched_arrow_strict = (ctx, ty) =>
   | Arrow(ty_in, ty_out) => Some((ty_in, ty_out))
   | Unknown(SynSwitch) =>
     Some((Unknown(SynSwitch) |> temp, Unknown(SynSwitch) |> temp))
-  | _ =>
-    print_endline("matched_arrow_strict: None");
-    print_endline(
-      "term_of(weak_head_normalize(ctx, ty)): "
-      ++ show_term(term_of(weak_head_normalize(ctx, ty))),
-    );
-    None;
+  | _ => None
   };
 
 let matched_arrow = (ctx, ty) =>

--- a/src/haz3lcore/lang/term/Typ.re
+++ b/src/haz3lcore/lang/term/Typ.re
@@ -380,7 +380,6 @@ let is_consistent = (ctx: Ctx.t, ty1: t, ty2: t): bool =>
   join(ctx, ty1, ty2) != None;
 
 let rec weak_head_normalize = (~rec_counter=0, ctx: Ctx.t, ty: t): t => {
-  // TODO Remove
   if (rec_counter > 1000) {
     failwith("weak_head_normalize exceeded 1000 recursive calls");
   };

--- a/src/haz3lcore/lang/term/Typ.re
+++ b/src/haz3lcore/lang/term/Typ.re
@@ -379,16 +379,21 @@ let join_all = (~empty: t, ctx: Ctx.t, ts: list(t)): option(t) =>
 let is_consistent = (ctx: Ctx.t, ty1: t, ty2: t): bool =>
   join(ctx, ty1, ty2) != None;
 
-let rec weak_head_normalize = (ctx: Ctx.t, ty: t): t =>
+let rec weak_head_normalize = (~rec_counter=0, ctx: Ctx.t, ty: t): t => {
+  // TODO Remove
+  if (rec_counter > 1000) {
+    failwith("weak_head_normalize exceeded 1000 recursive calls");
+  };
   switch (term_of(ty)) {
-  | Parens(t) => weak_head_normalize(ctx, t)
+  | Parens(t) => weak_head_normalize(~rec_counter=rec_counter + 1, ctx, t)
   | Var(x) =>
     switch (Ctx.lookup_alias(ctx, x)) {
-    | Some(ty) => weak_head_normalize(ctx, ty)
+    | Some(ty) => weak_head_normalize(~rec_counter=rec_counter + 1, ctx, ty)
     | None => ty
     }
   | _ => ty
   };
+};
 
 let rec normalize = (ctx: Ctx.t, ty: t): t => {
   let (term, rewrap) = unwrap(ty);

--- a/src/haz3lcore/lang/term/Typ.re
+++ b/src/haz3lcore/lang/term/Typ.re
@@ -394,7 +394,11 @@ let rec weak_head_normalize = (~rec_counter=0, ctx: Ctx.t, ty: t): t => {
   };
 };
 
-let rec normalize = (ctx: Ctx.t, ty: t): t => {
+let rec normalize = (~rec_counter=0, ctx: Ctx.t, ty: t): t => {
+  if (rec_counter > 1000) {
+    failwith("normalize exceeded 1000 recursive calls");
+  };
+  let normalize = normalize(~rec_counter=rec_counter + 1);
   let (term, rewrap) = unwrap(ty);
   switch (term) {
   | Var(x) =>

--- a/src/haz3lcore/statics/ConstructorMap.re
+++ b/src/haz3lcore/statics/ConstructorMap.re
@@ -6,7 +6,6 @@ type variant('a) =
   | Variant(Constructor.t, list(Id.t), option('a))
   | BadEntry('a);
 
-// Invariant: Must not have duplicate constructors
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t('a) = list(variant('a));
 
@@ -96,17 +95,21 @@ let is_ground = is_hole =>
 let venn_regions =
     (f: ('a, 'a) => bool, xs: list('a), ys: list('a))
     : (list(('a, 'a)), list('a), list('a)) => {
-  let rec go = (xs, ys, acc, left, right) =>
+  let rec go = (xs, ys, seen_xs, acc, left, right) =>
     switch (xs) {
     | [] => (acc |> List.rev, left |> List.rev, List.rev_append(right, ys))
     | [x, ...xs] =>
       switch (List.partition(f(x, _), ys)) {
-      | ([], _) => go(xs, ys, acc, [x, ...left], right)
-      | ([y], ys') => go(xs, ys', [(x, y), ...acc], left, right)
-      | _ => failwith("Sum type has non-unique constructors")
+      | ([], _) =>
+        switch (List.partition(f(x, _), seen_xs)) {
+        | ([], _) => go(xs, ys, [x, ...seen_xs], acc, [x, ...left], right)
+        | (_, _) => go(xs, ys, seen_xs, acc, left, right)
+        }
+      | ([y, ..._], ys') =>
+        go(xs, ys', [x, ...seen_xs], [(x, y), ...acc], left, right)
       }
     };
-  go(xs, ys, [], [], []);
+  go(xs, ys, [], [], [], []);
 };
 
 let join_entry =

--- a/src/haz3lcore/statics/Coverage.re
+++ b/src/haz3lcore/statics/Coverage.re
@@ -107,6 +107,7 @@ module Ctr = {
            )
         |> Map.of_list,
       )
+    | Rec({term: Var(w), _}, {term: Var(v), _}) when v == w => Unknown
     | Rec(_) => all_ctrs_of_typ(Typ.unroll(ty))
     | Prod(elts) =>
       Finite(Map.singleton(tuple_ctr(List.length(elts)), elts))

--- a/src/haz3lcore/statics/Coverage.re
+++ b/src/haz3lcore/statics/Coverage.re
@@ -92,7 +92,11 @@ module Ctr = {
       }
     };
 
-  let rec all_ctrs_of_typ = (ty: Typ.t): all_ctrs =>
+  let rec all_ctrs_of_typ = (~rec_count=0, ty: Typ.t): all_ctrs => {
+    if (rec_count > 1000) {
+      failwith("Recursion limit exceeded in all_ctrs_of_typ");
+    };
+    let all_ctrs_of_typ = all_ctrs_of_typ(~rec_count=rec_count + 1);
     switch (ty.term) {
     | Sum(map) =>
       Finite(
@@ -136,6 +140,7 @@ module Ctr = {
         "all_ctrs_of_type called with a non-normalized type: " ++ Typ.show(ty),
       )
     };
+  };
 
   let seen_all_ctrs = (seen_ctrs, all_ctrs: all_ctrs) => {
     switch (all_ctrs) {

--- a/src/haz3lcore/statics/Elaborator.re
+++ b/src/haz3lcore/statics/Elaborator.re
@@ -358,7 +358,7 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
               ConstructorMap.BadEntry(Unknown(Internal) |> Typ.temp),
             ])
             |> Typ.temp,
-          t,
+          t |> Option.join,
         );
       Constructor(c, t) |> rewrap |> cast_from(ty);
     | Fun(p, e, _, n) =>

--- a/src/haz3lcore/statics/Elaborator.re
+++ b/src/haz3lcore/statics/Elaborator.re
@@ -236,17 +236,21 @@ let rec elaborate_pattern =
         };
       let t =
         switch (Self.ctr_ana_typ(ctx, ana_ty, c), Ctx.lookup_ctr(ctx, c)) {
-        | (Some(ana_ty), _) => ana_ty
-        | (_, Some({typ: syn_ty, _})) => syn_ty
-        | _ =>
-          Sum([
-            ConstructorMap.Variant(c, [Id.invalid], None),
-            ConstructorMap.BadEntry(Unknown(Internal) |> Typ.temp),
-          ])
-          |> Typ.temp
+        | (Some(ana_ty), _) => Some(Typ.normalize(ctx, ana_ty))
+        | (_, Some({typ: syn_ty, _})) => Some(Typ.normalize(ctx, syn_ty))
+        | _ => None
         };
-      let t = t |> Typ.normalize(ctx);
-      Constructor(c, Some(Some(t))) |> rewrap |> cast_from(t);
+      let ty =
+        OptUtil.get(
+          () =>
+            Sum([
+              ConstructorMap.Variant(c, [Id.invalid], None),
+              ConstructorMap.BadEntry(Unknown(Internal) |> Typ.temp),
+            ])
+            |> Typ.temp,
+          t,
+        );
+      Constructor(c, Some(t)) |> rewrap |> cast_from(ty);
     };
   (dpat, elaborated_type);
 };
@@ -346,6 +350,16 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
         | Common(FreeConstructor(_)) => Some(None)
         | _ => Some(Some(Typ.normalize(ctx, ty)))
         };
+      let ty =
+        OptUtil.get(
+          () =>
+            Sum([
+              ConstructorMap.Variant(c, [Id.invalid], None),
+              ConstructorMap.BadEntry(Unknown(Internal) |> Typ.temp),
+            ])
+            |> Typ.temp,
+          t,
+        );
       Constructor(c, t) |> rewrap |> cast_from(ty);
     | Fun(p, e, _, n) =>
       let (p', typ) = elaborate_pattern(m, p, false);

--- a/src/haz3lcore/statics/Elaborator.re
+++ b/src/haz3lcore/statics/Elaborator.re
@@ -503,9 +503,13 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
       let (args', tys) = List.map(elaborate(m), args) |> ListUtil.unzip;
       let (tyf1, tyf2) = Typ.matched_arrow(ctx, tyf);
       let (args, ty_fargs) =
-        Typ.matched_prod(ctx, args, Exp.match_tup_label, tyf1, (name, b) =>
-          TupLabel(Label(name) |> Exp.fresh, b) |> Exp.fresh
-        );
+        if (List.length(args) > 1) {
+          Typ.matched_prod(ctx, args, Exp.match_tup_label, tyf1, (name, b) =>
+            TupLabel(Label(name) |> Exp.fresh, b) |> Exp.fresh
+          );
+        } else {
+          (args, [tyf1]);
+        };
       let prod_args =
         switch (ty_fargs) {
         | [ty] => ty

--- a/src/haz3lcore/statics/Statics.re
+++ b/src/haz3lcore/statics/Statics.re
@@ -389,6 +389,9 @@ and uexp_to_info_map =
       let ty_out = Unknown(Internal) |> Typ.temp;
       let (e, m) = go(~ana=ty_in, e, m);
       add(~self=Just(ty_out), ~co_ctx=e.co_ctx, m);
+    | UnOp(Meta(Unquote), e) =>
+      let (e, m) = go(~ana=syn, e, m);
+      add(~self=BadOperator("Unquote not in filter"), ~co_ctx=e.co_ctx, m);
     | UnOp(op, e) =>
       let op = Operators.replace_un_op(op, ctx.use_mode); // Replace op if necessary due to `use`
       let op_semantics = Operators.semantics_of_un_op(op);

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -1101,3 +1101,6 @@ and shrink_typ: QCheck.Shrink.t(typ) =
         }
       )
   );
+
+let arb_exp: QCheck.arbitrary(exp) =
+  QCheck.make(~print=show_exp, ~shrink=shrink_exp, gen_exp_sized(50));

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -177,18 +177,23 @@ type exp =
  *
  * ['A'-'Z'] ['a'-'z' 'A'-'Z' '0'-'9' '_']*
  */
-let gen_constructor_ident: QCheck.Gen.t(string) =
-  // TODO handle full constructor ident including nums
-  QCheck.Gen.(
-    let+ leading = char_range('A', 'C');
-    // let+ tail = string_size(~gen=char_range('a', 'c'), int_range(1, 1));
-    let ident = String.make(1, leading);
-    if (List.exists(a => a == ident, Haz3lcore.Form.base_typs)) {
-      "Keyword";
-    } else {
-      ident;
-    }
-  );
+// TODO handle full constructor ident including nums and '
+let gen_constructor_ident: (~minimal_idents: bool) => QCheck.Gen.t(string) =
+  (~minimal_idents) =>
+    QCheck.Gen.(
+      if (minimal_idents) {
+        oneof([pure("A"), pure("B")]);
+      } else {
+        let* leading = char_range('A', 'Z');
+        let+ tail = string_size(~gen=char_range('a', 'z'), int_range(1, 4));
+        let ident = String.make(1, leading) ++ tail;
+        if (List.exists(a => a == ident, Haz3lcore.Form.base_typs)) {
+          "Keyword";
+        } else {
+          ident;
+        };
+      }
+    );
 
 /**
  * Generates a random IDENT string. Used for IDENT in the lexer.
@@ -197,11 +202,18 @@ let gen_constructor_ident: QCheck.Gen.t(string) =
  *
  * ['a'-'z' '_'] ['a'-'z' 'A'-'Z' '0'-'9' '_']*
  */
-let gen_ident: QCheck.Gen.t(string) =
-  // Currently there is an issue if the keyword is a prefix of another word.
-  // `let ? = ina in ?`
-  // Temporarily doing single char identifiers as a fix
-  QCheck.Gen.(string_size(~gen=char_range('a', 'c'), int_range(1, 1)));
+let gen_ident: (~minimal_idents: bool) => QCheck.Gen.t(string) =
+  (~minimal_idents) =>
+    // Currently there is an issue if the keyword is a prefix of another word.
+    // `let ? = ina in ?`
+    // Temporarily doing single char identifiers as a fix
+    QCheck.Gen.(
+      if (minimal_idents) {
+        oneof([pure("x"), pure("y")]);
+      } else {
+        string_size(~gen=char_range('a', 'z'), int_range(1, 1));
+      }
+    );
 
 /**
  * Generates an array of natural numbers of a given size.
@@ -265,13 +277,15 @@ let gen_non_empty_array = (n: int): QCheck.Gen.t(array(int)) =>
  *
  * @return A generator for `tpat` values.
  */
-let gen_tpat: QCheck.Gen.t(tpat) =
-  QCheck.Gen.(
-    let gen_var = map(x => VarTPat(x), gen_ident);
-    let gen_empty = pure(EmptyHoleTPat);
-    // let gen_invalid = map(x => InvalidTPat(x), gen_ident); // Menhir parser doesn't actually support invalid tpat
-    oneof([gen_var, gen_empty])
-  );
+let gen_tpat: (~minimal_idents: bool) => QCheck.Gen.t(tpat) =
+  (~minimal_idents) =>
+    QCheck.Gen.(
+      let gen_ident = gen_ident(~minimal_idents);
+      let gen_var = map(x => VarTPat(x), gen_ident);
+      let gen_empty = pure(EmptyHoleTPat);
+      // let gen_invalid = map(x => InvalidTPat(x), gen_ident); // Menhir parser doesn't actually support invalid tpat
+      oneof([gen_var, gen_empty])
+    );
 
 /**
  * Generates a string literal for use in the program.
@@ -281,7 +295,7 @@ let gen_string_literal: QCheck.Gen.t(string) =
   // TODO This should be anything printable other than `"`
   QCheck.Gen.(string_small_of(char_range('a', 'z')));
 
-let gen_label: QCheck.Gen.t(string) = gen_ident;
+let gen_label: QCheck.Gen.t(string) = gen_ident(~minimal_idents=false);
 
 /**
  * Generates an expression of a given size.
@@ -292,151 +306,154 @@ let gen_label: QCheck.Gen.t(string) = gen_ident;
  * This function is currently used for property tests between MakeTerm and the Menhir parser,
  * so it's not currently set up to generate every possible expression.
  */
-let rec gen_exp_sized = (n: int): QCheck.Gen.t(exp) =>
-  QCheck.Gen.(
-    let leaf =
-      oneof([
-        map(x => Atom(Int(x |> Bigint.of_int)), small_int),
-        map(x => Atom(String(x)), gen_string_literal),
-        map(x => Atom(Float(x)), QCheck.pos_float.gen), // Floats are positive because we use UnOp minus
-        map(x => Var(x), gen_ident),
-        map(x => Atom(Bool(x)), bool),
-        pure(EmptyHole),
-        pure(TupleExp([])),
-        pure(ListExp([])),
-        map(x => Constructor(x, None), gen_constructor_ident),
-      ]);
-    fix(
-      (self: int => t(exp), n) => {
-        switch (n) {
-        | n when n <= 1 => leaf
-        | _ =>
-          oneof([
-            leaf,
-            {
-              let* sizes = gen_sized_array(n);
-              let+ exps = flatten_a(Array.map((n: int) => self(n), sizes));
-              ListExp(Array.to_list(exps));
-            },
-            {
-              let* sizes = gen_non_singleton_array(n);
-              let+ exps =
-                flatten_a(
-                  Array.map(
-                    (n: int) =>
-                      oneof([
-                        {
-                          let* l = gen_label;
-                          let+ e = self(n - 1);
-                          TupLabel(Label(l), e);
-                        },
-                        self(n),
-                      ]),
-                    sizes,
-                  ),
-                );
-              TupleExp(Array.to_list(exps));
-            },
-            {
-              let+ inner = self(n - 1);
-              Test(inner);
-            },
-            {
-              let* op = gen_bin_op;
-              let* e1 = self((n - 1) / 2);
-              let+ e2 = self((n - 1) / 2);
-              BinExp(e1, op, e2);
-            },
-            {
-              let* op = gen_op_un;
-              let+ e = self(n - 1);
-              UnOp(op, e);
-            },
-            {
-              let* e1 = self((n - 1) / 3);
-              let* e2 = self((n - 1) / 3);
-              let+ e3 = self((n - 1) / 3);
-              If(e1, e2, e3);
-            },
-            {
-              let* p = gen_pat_sized((n - 1) / 3);
-              let* e1 = self((n - 1) / 3);
-              let+ e2 = self((n - 1) / 3);
-              Let(p, e1, e2);
-            },
-            {
-              let* p = gen_pat_sized((n - 1) / 2);
-              let+ e = self((n - 1) / 2);
-              Fun(p, e, None);
-            },
-            {
-              let case = n => {
-                let p = gen_pat_sized((n - 1) / 2);
-                let e = self((n - 1) / 2);
-                tup2(p, e);
-              };
-              let* e = self((n - 1) / 2);
-              let* sizes = gen_sized_array((n - 1) / 2);
-              let+ cases = flatten_a(Array.map(case, sizes));
-              CaseExp(e, Array.to_list(cases));
-            },
-            {
-              let* e1 = self((n - 1) / 2);
-              let+ e2 =
-                frequency([
-                  (5, self((n - 1) / 2)),
-                  (1, return(Deferral)),
-                ]);
-              ApExp(e1, e2);
-            },
-            {
-              let* p = gen_pat_sized((n - 1) / 2);
-              let+ e = self((n - 1) / 2);
-              FixF(p, e);
-            },
-            {
-              let* fa = gen_filter_action;
-              let* e1 = self((n - 1) / 2);
-              let+ e2 = self((n - 1) / 2);
-              Filter(fa, e1, e2);
-            },
-            {
-              let* e1 = self((n - 1) / 2);
-              let+ e2 = self((n - 1) / 2);
-              Seq(e1, e2);
-            },
-            {
-              let* e1 = self((n - 1) / 2);
-              let+ e2 = self((n - 1) / 2);
-              Cons(e1, e2);
-            },
-            {
-              let* e1 = self((n - 1) / 2);
-              let+ e2 = self((n - 1) / 2);
-              ListConcat(e1, e2);
-            },
-            {
-              let* tp = gen_tpat;
-              let+ e = self(n - 1);
-              TypFun(tp, e);
-            },
-            {
-              let* t = gen_typ_sized((n - 1) / 2);
-              let+ e = self((n - 1) / 2);
-              TypAp(e, t);
-            },
-            {
-              let* tp = gen_tpat;
-              let* t = gen_typ_sized((n - 1) / 2);
-              let+ e = self((n - 1) / 2);
-              TyAlias(tp, t, e);
-            },
-          ])
-        }
-      },
-      n,
-    )
-  )
+let rec gen_exp_sized = (~minimal_idents: bool, n: int): QCheck.Gen.t(exp) => {
+  open QCheck.Gen;
+  let gen_constructor_ident = gen_constructor_ident(~minimal_idents);
+  let gen_ident = gen_ident(~minimal_idents);
+
+  let gen_pat_sized = n => gen_pat_sized(~minimal_idents, n);
+  let gen_typ_sized = n => gen_typ_sized(~minimal_idents, n);
+  let gen_tpat = gen_tpat(~minimal_idents);
+  let leaf =
+    oneof([
+      map(x => Atom(Int(x |> Bigint.of_int)), small_int),
+      map(x => Atom(String(x)), gen_string_literal),
+      map(x => Atom(Float(x)), QCheck.pos_float.gen), // Floats are positive because we use UnOp minus
+      map(x => Var(x), gen_ident),
+      map(x => Atom(Bool(x)), bool),
+      pure(EmptyHole),
+      pure(TupleExp([])),
+      pure(ListExp([])),
+      map(x => Constructor(x, None), gen_constructor_ident),
+    ]);
+  fix(
+    (self: int => t(exp), n) => {
+      switch (n) {
+      | n when n <= 1 => leaf
+      | _ =>
+        oneof([
+          leaf,
+          {
+            let* sizes = gen_sized_array(n);
+            let+ exps = flatten_a(Array.map((n: int) => self(n), sizes));
+            ListExp(Array.to_list(exps));
+          },
+          {
+            let* sizes = gen_non_singleton_array(n);
+            let+ exps =
+              flatten_a(
+                Array.map(
+                  (n: int) =>
+                    oneof([
+                      {
+                        let* l = gen_label;
+                        let+ e = self(n - 1);
+                        TupLabel(Label(l), e);
+                      },
+                      self(n),
+                    ]),
+                  sizes,
+                ),
+              );
+            TupleExp(Array.to_list(exps));
+          },
+          {
+            let+ inner = self(n - 1);
+            Test(inner);
+          },
+          {
+            let* op = gen_bin_op;
+            let* e1 = self((n - 1) / 2);
+            let+ e2 = self((n - 1) / 2);
+            BinExp(e1, op, e2);
+          },
+          {
+            let* op = gen_op_un;
+            let+ e = self(n - 1);
+            UnOp(op, e);
+          },
+          {
+            let* e1 = self((n - 1) / 3);
+            let* e2 = self((n - 1) / 3);
+            let+ e3 = self((n - 1) / 3);
+            If(e1, e2, e3);
+          },
+          {
+            let* p = gen_pat_sized((n - 1) / 3);
+            let* e1 = self((n - 1) / 3);
+            let+ e2 = self((n - 1) / 3);
+            Let(p, e1, e2);
+          },
+          {
+            let* p = gen_pat_sized((n - 1) / 2);
+            let+ e = self((n - 1) / 2);
+            Fun(p, e, None);
+          },
+          {
+            let case = n => {
+              let p = gen_pat_sized((n - 1) / 2);
+              let e = self((n - 1) / 2);
+              tup2(p, e);
+            };
+            let* e = self((n - 1) / 2);
+            let* sizes = gen_sized_array((n - 1) / 2);
+            let+ cases = flatten_a(Array.map(case, sizes));
+            CaseExp(e, Array.to_list(cases));
+          },
+          {
+            let* e1 = self((n - 1) / 2);
+            let+ e2 =
+              frequency([(5, self((n - 1) / 2)), (1, return(Deferral))]);
+            ApExp(e1, e2);
+          },
+          {
+            let* p = gen_pat_sized((n - 1) / 2);
+            let+ e = self((n - 1) / 2);
+            FixF(p, e);
+          },
+          {
+            let* fa = gen_filter_action;
+            let* e1 = self((n - 1) / 2);
+            let+ e2 = self((n - 1) / 2);
+            Filter(fa, e1, e2);
+          },
+          {
+            let* e1 = self((n - 1) / 2);
+            let+ e2 = self((n - 1) / 2);
+            Seq(e1, e2);
+          },
+          {
+            let* e1 = self((n - 1) / 2);
+            let+ e2 = self((n - 1) / 2);
+            Cons(e1, e2);
+          },
+          {
+            let* e1 = self((n - 1) / 2);
+            let+ e2 = self((n - 1) / 2);
+            ListConcat(e1, e2);
+          },
+          {
+            let* tp = gen_tpat;
+            let+ e = self(n - 1);
+            TypFun(tp, e);
+          },
+          {
+            let* t = gen_typ_sized((n - 1) / 2);
+            let+ e = self((n - 1) / 2);
+            TypAp(e, t);
+          },
+          {
+            let* tp = gen_tpat;
+            let* t = gen_typ_sized((n - 1) / 2);
+            let+ e = self((n - 1) / 2);
+            TyAlias(tp, t, e);
+          },
+        ])
+      }
+    },
+    n,
+  );
+}
 /**
  * Generates a type of a given size.
  *
@@ -446,9 +463,12 @@ let rec gen_exp_sized = (n: int): QCheck.Gen.t(exp) =>
  * This function is currently used for property tests between MakeTerm and the Menhir parser,
  * so it's not currently set up to generate every possible type.
  */
-and gen_typ_sized: int => QCheck.Gen.t(typ) =
-  n =>
+and gen_typ_sized: (~minimal_idents: bool, int) => QCheck.Gen.t(typ) =
+  (~minimal_idents, n) =>
     QCheck.Gen.(
+      let gen_ident = gen_ident(~minimal_idents);
+      let gen_constructor_ident = gen_constructor_ident(~minimal_idents);
+      let gen_tpat = gen_tpat(~minimal_idents);
       let leaf_nodes =
         oneof([
           return(StringType),
@@ -546,9 +566,12 @@ and gen_typ_sized: int => QCheck.Gen.t(typ) =
  * This function is currently used for property tests between MakeTerm and the Menhir parser,
  * so it's not currently set up to generate every possible pattern.
  */
-and gen_pat_sized: int => QCheck.Gen.t(pat) =
-  n =>
+and gen_pat_sized: (~minimal_idents: bool, int) => QCheck.Gen.t(pat) =
+  (~minimal_idents, n) =>
     QCheck.Gen.(
+      let gen_ident = gen_ident(~minimal_idents);
+      let gen_constructor_ident = gen_constructor_ident(~minimal_idents);
+      let gen_typ_sized = n => gen_typ_sized(~minimal_idents, n);
       fix(
         (self, n) => {
           let leaf_nodes =
@@ -642,9 +665,10 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
           | SInt(i) => Shrink.int(i) >|= ((i: int) => Atom(SInt(i)))
           | _ => Iter.empty
           }
-        | Var(x) => Shrink.string(x) >|= ((x: string) => Var(x)) // TODO This isn't great for vars
-        | Constructor(c, _) =>
-          Shrink.string(c) >|= ((c: string) => Constructor(c, None)) // TODO This isn't great for constructors
+        | Var(x) =>
+          Shrink.(filter(x => String.length(x) != 0, string, x))
+          >|= ((x: string) => Var(x)) // TODO This isn't great for vars
+        | Constructor(_, _) => Iter.empty // TODO Constructors. Shrinking needs to preserve constructor ident format
         | ListExp(l) =>
           let* shrunk = Shrink.list(l, ~shrink=shrink_exp);
           switch (shrunk) {
@@ -726,7 +750,9 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
             let* shrunk = Shrink.list(cases, ~shrink=shrink_case);
             return(CaseExp(e, shrunk));
           }
-        | Label(l) => Shrink.string(l) >|= ((l: string) => Label(l))
+        | Label(l) =>
+          Shrink.(filter(l => String.length(l) != 0, string, l))
+          >|= ((l: string) => Label(l))
         | TupLabel(e1, e2) =>
           {
             return(
@@ -954,7 +980,9 @@ and shrink_pat: QCheck.Shrink.t(pat) =
           | SInt(i) => Shrink.int(i) >|= ((i: int) => AtomPat(SInt(i)))
           | _ => Iter.empty
           }
-        | VarPat(x) => Shrink.string(x) >|= ((x: string) => VarPat(x))
+        | VarPat(x) =>
+          Shrink.(filter(x => String.length(x) != 0, string, x))
+          >|= ((x: string) => VarPat(x))
         | ConstructorPat(c, _) =>
           Shrink.string(c) >|= ((c: string) => ConstructorPat(c, None))
         | ListPat(l) =>
@@ -1022,7 +1050,9 @@ and shrink_pat: QCheck.Shrink.t(pat) =
             let* shrunk = shrink_pat(p2);
             return(TupLabelPat(p1, shrunk));
           }
-        | LabelPat(l) => Shrink.string(l) >|= ((l: string) => LabelPat(l))
+        | LabelPat(l) =>
+          Shrink.(filter(l => String.length(l) != 0, string, l))
+          >|= ((l: string) => LabelPat(l))
         | InvalidPat(_)
         | IndicationPat(_)
         | WildPat
@@ -1085,7 +1115,9 @@ and shrink_typ: QCheck.Shrink.t(typ) =
         | RecType(tpat, t) =>
           let* shrunk = shrink_typ(t);
           return(RecType(tpat, shrunk));
-        | LabelType(x) => Shrink.string(x) >|= ((x: string) => LabelType(x))
+        | LabelType(x) =>
+          Shrink.(filter(x => String.length(x) != 0, string, x))
+          >|= ((x: string) => LabelType(x))
         | TupLabelType(t1, t2) =>
           return(t2)
           <+> {
@@ -1109,5 +1141,9 @@ and shrink_typ: QCheck.Shrink.t(typ) =
       )
   );
 
-let arb_exp: QCheck.arbitrary(exp) =
-  QCheck.make(~print=show_exp, ~shrink=shrink_exp, gen_exp_sized(50));
+let arb_exp = (~minimal_idents=false, size) =>
+  QCheck.make(
+    ~print=show_exp,
+    ~shrink=shrink_exp,
+    gen_exp_sized(~minimal_idents, size),
+  );

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -585,7 +585,7 @@ and gen_pat_sized: int => QCheck.Gen.t(pat) =
                           self(n),
                           {
                             let* l = gen_label;
-                            let+ p = self(n - 1);
+                            let+ p = self(size - 1);
                             TupLabelPat(LabelPat(l), p);
                           },
                         ]),

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -585,7 +585,7 @@ and gen_pat_sized: int => QCheck.Gen.t(pat) =
                           self(n),
                           {
                             let* l = gen_label;
-                            let+ p = self(size - 1);
+                            let+ p = self(n - 1);
                             TupLabelPat(LabelPat(l), p);
                           },
                         ]),

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -1048,7 +1048,10 @@ and shrink_typ: QCheck.Shrink.t(typ) =
               )
             );
           let* shrunk = Shrink.list(l, ~shrink=shrink_sumterm);
-          return(SumTyp(shrunk));
+          switch (shrunk) {
+          | [] => Iter.empty
+          | _ => return(SumTyp(shrunk))
+          };
         | TupleType(l) =>
           let* shrunk = Shrink.list(l, ~shrink=shrink_typ);
           switch (shrunk) {

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -646,6 +646,9 @@ and gen_pat_sized: (~minimal_idents: bool, int) => QCheck.Gen.t(pat) =
       )
     );
 
+let shrink_non_empty_string: QCheck.Shrink.t(string) =
+  x => QCheck.Shrink.(filter(x => String.length(x) != 0, string, x));
+
 let rec shrink_exp: QCheck.Shrink.t(exp) =
   QCheck.(
     (exp: exp) =>
@@ -671,9 +674,7 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
           | SInt(i) => Shrink.int(i) >|= ((i: int) => Atom(SInt(i)))
           | _ => Iter.empty
           }
-        | Var(x) =>
-          Shrink.(filter(x => String.length(x) != 0, string, x))
-          >|= ((x: string) => Var(x)) // TODO This isn't great for vars
+        | Var(x) => shrink_non_empty_string(x) >|= ((x: string) => Var(x)) // TODO This isn't great for vars
         | Constructor(_, _) => Iter.empty // TODO Constructors. Shrinking needs to preserve constructor ident format
         | ListExp(l) =>
           let* shrunk = Shrink.list(l, ~shrink=shrink_exp);
@@ -757,8 +758,7 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
             return(CaseExp(e, shrunk));
           }
         | Label(l) =>
-          Shrink.(filter(l => String.length(l) != 0, string, l))
-          >|= ((l: string) => Label(l))
+          shrink_non_empty_string(l) >|= ((l: string) => Label(l))
         | TupLabel(e1, e2) =>
           {
             return(
@@ -987,10 +987,8 @@ and shrink_pat: QCheck.Shrink.t(pat) =
           | _ => Iter.empty
           }
         | VarPat(x) =>
-          Shrink.(filter(x => String.length(x) != 0, string, x))
-          >|= ((x: string) => VarPat(x))
-        | ConstructorPat(c, _) =>
-          Shrink.string(c) >|= ((c: string) => ConstructorPat(c, None))
+          shrink_non_empty_string(x) >|= ((x: string) => VarPat(x))
+        | ConstructorPat(_) => Iter.empty // Needs to preserve constructor ident
         | ListPat(l) =>
           let* shrunk = Shrink.list(l, ~shrink=shrink_pat);
           switch (shrunk) {
@@ -1057,8 +1055,7 @@ and shrink_pat: QCheck.Shrink.t(pat) =
             return(TupLabelPat(p1, shrunk));
           }
         | LabelPat(l) =>
-          Shrink.(filter(l => String.length(l) != 0, string, l))
-          >|= ((l: string) => LabelPat(l))
+          shrink_non_empty_string(l) >|= ((l: string) => LabelPat(l))
         | InvalidPat(_)
         | IndicationPat(_)
         | WildPat
@@ -1121,8 +1118,7 @@ and shrink_typ: QCheck.Shrink.t(typ) =
           let* shrunk = shrink_typ(t);
           return(RecType(tpat, shrunk));
         | LabelType(x) =>
-          Shrink.(filter(x => String.length(x) != 0, string, x))
-          >|= ((x: string) => LabelType(x))
+          shrink_non_empty_string(x) >|= ((x: string) => LabelType(x))
         | TupLabelType(t1, t2) =>
           return(t2)
           <+> {

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -180,9 +180,9 @@ type exp =
 let gen_constructor_ident: QCheck.Gen.t(string) =
   // TODO handle full constructor ident including nums
   QCheck.Gen.(
-    let* leading = char_range('A', 'Z');
-    let+ tail = string_size(~gen=char_range('a', 'z'), int_range(1, 4));
-    let ident = String.make(1, leading) ++ tail;
+    let+ leading = char_range('A', 'C');
+    // let+ tail = string_size(~gen=char_range('a', 'c'), int_range(1, 1));
+    let ident = String.make(1, leading);
     if (List.exists(a => a == ident, Haz3lcore.Form.base_typs)) {
       "Keyword";
     } else {
@@ -201,7 +201,7 @@ let gen_ident: QCheck.Gen.t(string) =
   // Currently there is an issue if the keyword is a prefix of another word.
   // `let ? = ina in ?`
   // Temporarily doing single char identifiers as a fix
-  QCheck.Gen.(string_size(~gen=char_range('a', 'z'), int_range(1, 1)));
+  QCheck.Gen.(string_size(~gen=char_range('a', 'c'), int_range(1, 1)));
 
 /**
  * Generates an array of natural numbers of a given size.

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -101,6 +101,7 @@ type typ =
   | LabelType(string)
   | TupLabelType(typ, typ)
   | IndicationTyp(typ)
+  | ApTyp(typ, typ)
 and sumterm =
   | Variant(string, option(typ))
   | BadEntry(typ)
@@ -526,6 +527,11 @@ and gen_typ_sized: (~minimal_idents: bool, int) => QCheck.Gen.t(typ) =
                 let* gen_tpat = gen_tpat;
                 let+ t = self(n - 1);
                 RecType(gen_tpat, t);
+              },
+              {
+                let* t1 = self((n - 1) / 2);
+                let+ t2 = self((n - 1) / 2);
+                ApTyp(t1, t2);
               },
               {
                 let* sizes = gen_non_empty_array(n - 1);
@@ -1072,8 +1078,7 @@ and shrink_typ: QCheck.Shrink.t(typ) =
                 (sumterm: sumterm) =>
                   Iter.(
                     switch (sumterm) {
-                    | Variant(c, _) =>
-                      Shrink.string(c) >|= ((c: string) => Variant(c, None))
+                    | Variant(_) => Iter.empty
                     | BadEntry(t) =>
                       let* shrunk = shrink_typ(t);
                       return(BadEntry(shrunk));
@@ -1127,6 +1132,16 @@ and shrink_typ: QCheck.Shrink.t(typ) =
           <+> {
             let* shrunk2 = shrink_typ(t2);
             return(TupLabelType(t1, shrunk2));
+          }
+        | ApTyp(t1, t2) =>
+          of_list([t1, t2])
+          <+> {
+            let* shrunk1 = shrink_typ(t1);
+            return(ApTyp(shrunk1, t2));
+          }
+          <+> {
+            let* shrunk2 = shrink_typ(t2);
+            return(ApTyp(t1, shrunk2));
           }
         | IndicationTyp(_)
         | IntType

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -652,12 +652,16 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
           | _ => return(ListExp(shrunk))
           };
         | TupleExp(l) =>
-          let* shrunk = Shrink.list(l, ~shrink=shrink_exp);
-          switch (shrunk) {
-          | [] => Iter.return(TupleExp([]))
-          | [x] => Iter.return(x)
-          | _ => return(TupleExp(shrunk))
-          };
+          if (List.length(l) <= 1) {
+            Iter.empty;
+          } else {
+            let* shrunk = Shrink.list(l, ~shrink=shrink_exp);
+            switch (shrunk) {
+            | [] => Iter.return(TupleExp([]))
+            | [x] => Iter.return(x)
+            | _ => return(TupleExp(shrunk))
+            };
+          }
         | BinExp(e1, op, e2) =>
           {
             of_list([e1, e2]);

--- a/src/haz3lmenhir/AST.re
+++ b/src/haz3lmenhir/AST.re
@@ -738,6 +738,10 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
             return(e);
           }
           <+> {
+            let* shrunk = shrink_exp(e);
+            return(CaseExp(shrunk, cases));
+          }
+          <+> {
             let shrink_case: QCheck.Shrink.t((pat, exp)) =
               QCheck.(
                 (

--- a/src/haz3lmenhir/Conversion.re
+++ b/src/haz3lmenhir/Conversion.re
@@ -445,6 +445,7 @@ and Typ: {
         annotation: true,
         term: of_menhir_ast(t).term,
       }
+    | ApTyp(t1, t2) => ap(of_menhir_ast(t1), of_menhir_ast(t2))
     };
   };
 
@@ -474,7 +475,7 @@ and Typ: {
     | Parens(t) => of_core(t)
     | Label(s) => LabelType(s)
     | TupLabel(t1, t2) => TupLabelType(of_core(t1), of_core(t2))
-    | Ap(_) => raise(Failure("Ap not supported"))
+    | Ap(t1, t2) => ApTyp(of_core(t1), of_core(t2))
     | Sum(constructors) =>
       let sumterms =
         List.map(

--- a/src/haz3lmenhir/Parser.mly
+++ b/src/haz3lmenhir/Parser.mly
@@ -244,6 +244,7 @@ typ:
     | REC; c=tpat; DASH_ARROW; t = typ { RecType(c, t) }
     | OPEN_TRIPLE_CURLY; t = typ; CLOSE_TRIPLE_CURLY { IndicationTyp(t) }
     | OPEN_PAREN; t = typ; CLOSE_PAREN { t }
+    | t1 = typ; OPEN_PAREN; t2 = typ; CLOSE_PAREN { ApTyp(t1, t2) }
 
 tupPatEntry:
     | p = pat {p}

--- a/test/QCheck_Util.re
+++ b/test/QCheck_Util.re
@@ -7,7 +7,7 @@ open Haz3lmenhir;
  * This uses the generator from the Haz3lmenhir AST to produce random instances of `Exp.t`
  * for property-based testing.
  */
-let arb_exp: arbitrary(Exp.t) = {
+let arb_exp = (~minimal_idents: bool, size: int) => {
   let show_core_exp = exp =>
     exp
     |> ExpToSegment.exp_to_segment(
@@ -27,7 +27,7 @@ let arb_exp: arbitrary(Exp.t) = {
       (menhir_exp: AST.exp) =>
         Conversion.Exp.of_menhir_ast(menhir_exp)
         |> Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh()),
-      AST.arb_exp,
+      AST.arb_exp(~minimal_idents, size),
     );
   set_print(show_core_exp, arb_exp);
 };

--- a/test/QCheck_Util.re
+++ b/test/QCheck_Util.re
@@ -1,0 +1,33 @@
+open Haz3lcore;
+open QCheck;
+open Haz3lmenhir;
+
+/**
+ * An arbitrary generator for expressions of type `Exp.t`.
+ * This uses the generator from the Haz3lmenhir AST to produce random instances of `Exp.t`
+ * for property-based testing.
+ */
+let arb_exp: arbitrary(Exp.t) = {
+  let show_core_exp = exp =>
+    exp
+    |> ExpToSegment.exp_to_segment(
+         ~settings=
+           ExpToSegment.Settings.of_core(~inline=true, CoreSettings.off),
+         _,
+       )
+    |> Printer.of_segment(~holes=Some("?"), _);
+  let arb_exp =
+    map(
+      ~rev=
+        (core_exp: Exp.t) => {
+          core_exp
+          |> Grammar.map_exp_annotation(_ => false)
+          |> Conversion.Exp.of_core
+        },
+      (menhir_exp: AST.exp) =>
+        Conversion.Exp.of_menhir_ast(menhir_exp)
+        |> Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh()),
+      AST.arb_exp,
+    );
+  set_print(show_core_exp, arb_exp);
+};

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -970,7 +970,7 @@ in 1|},
       QCheck.Test.make(
         ~name="Elaboration does not crash",
         ~count=1000,
-        QCheck_Util.arb_exp,
+        QCheck_Util.arb_exp(~minimal_idents=true, 50),
         exp => {
           let _ = dhexp_of_uexp(exp);
           true;

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -980,7 +980,6 @@ in 1|},
             switch (msg) {
             | "type application in dynamics" =>
               print_endline("Known failure: " ++ Printexc.to_string(e));
-
               true; // https://github.com/hazelgrove/hazel/issues/1459?issue=hazelgrove%7Chazel%7C1625
             | _ => raise(e)
             }

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -982,7 +982,7 @@ in 1|},
     QCheck_alcotest.to_alcotest(
       QCheck.Test.make(
         ~name="Elaboration does not crash",
-        ~count=1000,
+        ~count=10000,
         QCheck_Util.arb_exp(~minimal_idents=true, 50),
         exp => {
         switch (mk_map(exp)) {

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -966,6 +966,46 @@ in 1|},
         ),
       )
     }),
+    QCheck_alcotest.to_alcotest(
+      Haz3lmenhir.(
+        QCheck.Test.make(
+          ~name="Elaboration does not crash",
+          ~count=1000,
+          QCheck.make(
+            ~print=
+              (exp: Haz3lmenhir.AST.exp) =>
+                Haz3lmenhir.(
+                  Conversion.Exp.of_menhir_ast(exp)
+                  |> Grammar.map_exp_annotation(
+                       _ => IdTagged.IdTag.fresh(),
+                       _,
+                     )
+                  |> ExpToSegment.exp_to_segment(
+                       ~settings=
+                         ExpToSegment.Settings.of_core(
+                           ~inline=true,
+                           CoreSettings.off,
+                         ),
+                       _,
+                     )
+                  |> Printer.of_segment(~holes=Some("?"), _)
+                ),
+            ~shrink=AST.shrink_exp,
+            AST.gen_exp_sized(50),
+          ),
+          exp => {
+            let unit_exp = Conversion.Exp.of_menhir_ast(exp);
+            let core_exp =
+              Grammar.map_exp_annotation(
+                _ => IdTagged.IdTag.fresh(),
+                unit_exp,
+              );
+            let _ = dhexp_of_uexp(core_exp);
+            true;
+          },
+        )
+      ),
+    ),
   ];
 };
 module MenhirElaborationTests = {

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -972,10 +972,24 @@ in 1|},
         ~count=1000,
         QCheck_Util.arb_exp(~minimal_idents=true, 50),
         exp => {
-          let _ = dhexp_of_uexp(exp);
+        switch (mk_map(exp)) {
+        | statics =>
+          switch (Elaborator.elaborate(statics, exp)) {
+          | _ => true
+          | exception (Failure(msg) as e) =>
+            switch (msg) {
+            | "type application in dynamics" =>
+              print_endline("Known failure: " ++ Printexc.to_string(e));
+
+              true; // https://github.com/hazelgrove/hazel/issues/1459?issue=hazelgrove%7Chazel%7C1625
+            | _ => raise(e)
+            }
+          }
+        | exception e =>
+          print_endline("Skipping statics: " ++ Printexc.to_string(e));
           true;
-        },
-      ),
+        }
+      }),
     ),
   ];
 };

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -615,6 +615,17 @@ module PlainTests = {
     );
   };
 
+  let skip_known_bug = (message: string, expression: string) =>
+    test_case("Known Bug: " ++ message, `Quick, () => {
+      [@warning "-21"]
+      {
+        let uexp = parse_exp(expression);
+        let statics = mk_map(uexp);
+        Alcotest.skip();
+        let _ = Elaborator.elaborate(statics, uexp);
+        ();
+      }
+    });
   let tests = [
     test_case("Single integer", `Quick, single_integer),
     test_case("Empty hole", `Quick, empty_hole),
@@ -979,6 +990,14 @@ in 1|},
         ();
       }
     }),
+    skip_known_bug(
+      "Invalid typ ap", // TODO https://github.com/hazelgrove/hazel/issues/1625
+      "let [(A: (Bool(Bool))), (_: (String))] = 0 in ()",
+    ),
+    skip_known_bug(
+      "Type join of ap", // TODO https://github.com/hazelgrove/hazel/issues/1625
+      "type x = + B((forall x -> ?)(?)) in case a | B => 0| B => 0 end",
+    ),
     QCheck_alcotest.to_alcotest(
       QCheck.Test.make(
         ~name="Elaboration does not crash",

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -977,19 +977,10 @@ in 1|},
         ),
       )
     }),
-    test_case("Nontermination in typ normalization", `Quick, () => {
-      [@warning "-21"]
-      {
-        Alcotest.skip(); // https://github.com/hazelgrove/hazel/issues/1627
-        let _ =
-          dhexp_of_uexp(
-            parse_exp(
-              {|type x = x in (([] @ false) @ [] @< Float >) @< x([(())]) > @ case test 0.000006 end:: "f":: ? | B => (())| x => (())| (()) => ?| [] => ?| ? => 12 end|},
-            ),
-          );
-        ();
-      }
-    }),
+    skip_known_bug(
+      "Nontermination in typ normalization",
+      {|type x = x in (([] @ false) @ [] @< Float >) @< x([(())]) > @ case test 0.000006 end:: "f":: ? | B => (())| x => (())| (()) => ?| [] => ?| ? => 12 end|},
+    ),
     skip_known_bug(
       "Invalid typ ap", // TODO https://github.com/hazelgrove/hazel/issues/1625
       "let [(A: (Bool(Bool))), (_: (String))] = 0 in ()",

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -966,6 +966,19 @@ in 1|},
         ),
       )
     }),
+    test_case("Nontermination in typ normalization", `Quick, () => {
+      [@warning "-21"]
+      {
+        Alcotest.skip(); // https://github.com/hazelgrove/hazel/issues/1627
+        let _ =
+          dhexp_of_uexp(
+            parse_exp(
+              {|type x = x in (([] @ false) @ [] @< Float >) @< x([(())]) > @ case test 0.000006 end:: "f":: ? | B => (())| x => (())| (()) => ?| [] => ?| ? => 12 end|},
+            ),
+          );
+        ();
+      }
+    }),
     QCheck_alcotest.to_alcotest(
       QCheck.Test.make(
         ~name="Elaboration does not crash",
@@ -978,9 +991,18 @@ in 1|},
           | _ => true
           | exception (Failure(msg) as e) =>
             switch (msg) {
-            | "type application in dynamics" =>
+            | _
+                when
+                  List.exists(
+                    (==)(msg),
+                    [
+                      "type application in dynamics", // https://github.com/hazelgrove/hazel/issues/1459?issue=hazelgrove%7Chazel%7C1625
+                      "normalize exceeded 1000 recursive calls", // https://github.com/hazelgrove/hazel/issues/1627
+                      "Type join of ap" // https://github.com/hazelgrove/hazel/issues/1459?issue=hazelgrove%7Chazel%7C1625
+                    ],
+                  ) =>
               print_endline("Known failure: " ++ Printexc.to_string(e));
-              true; // https://github.com/hazelgrove/hazel/issues/1459?issue=hazelgrove%7Chazel%7C1625
+              true;
             | _ => raise(e)
             }
           }

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -967,43 +967,14 @@ in 1|},
       )
     }),
     QCheck_alcotest.to_alcotest(
-      Haz3lmenhir.(
-        QCheck.Test.make(
-          ~name="Elaboration does not crash",
-          ~count=1000,
-          QCheck.make(
-            ~print=
-              (exp: Haz3lmenhir.AST.exp) =>
-                Haz3lmenhir.(
-                  Conversion.Exp.of_menhir_ast(exp)
-                  |> Grammar.map_exp_annotation(
-                       _ => IdTagged.IdTag.fresh(),
-                       _,
-                     )
-                  |> ExpToSegment.exp_to_segment(
-                       ~settings=
-                         ExpToSegment.Settings.of_core(
-                           ~inline=true,
-                           CoreSettings.off,
-                         ),
-                       _,
-                     )
-                  |> Printer.of_segment(~holes=Some("?"), _)
-                ),
-            ~shrink=AST.shrink_exp,
-            AST.gen_exp_sized(50),
-          ),
-          exp => {
-            let unit_exp = Conversion.Exp.of_menhir_ast(exp);
-            let core_exp =
-              Grammar.map_exp_annotation(
-                _ => IdTagged.IdTag.fresh(),
-                unit_exp,
-              );
-            let _ = dhexp_of_uexp(core_exp);
-            true;
-          },
-        )
+      QCheck.Test.make(
+        ~name="Elaboration does not crash",
+        ~count=1000,
+        QCheck_Util.arb_exp,
+        exp => {
+          let _ = dhexp_of_uexp(exp);
+          true;
+        },
       ),
     ),
   ];

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -428,16 +428,21 @@ let qcheck_evaluator_does_not_crash_test =
     ) {
     | exp =>
       switch (
-        Evaluator.evaluate(~env=Builtins.env_init, ~step_limit=10000, exp)
+        Evaluator.evaluate_and_limit(
+          ~env=Builtins.env_init,
+          ~step_limit=10000,
+          exp,
+        )
       ) {
-      | (_, _) => true
+      | Completed((_, _))
+      | StepLimitExceeded => true
       | exception e =>
         switch (e) {
         | Failure(msg)
             when
               List.exists(
                 (==)(msg),
-                ["Step limit reached", "type application in dynamics"] // "type application in dynamics" https://github.com/hazelgrove/hazel/issues/1625
+                ["type application in dynamics"] // "type application in dynamics" https://github.com/hazelgrove/hazel/issues/1625
               ) =>
           print_endline("Skipping failure: " ++ msg);
           true;

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -412,67 +412,52 @@ let test_typfun_application = () =>
     )
     |> Exp.fresh,
   );
-let count = ref(0);
-let qcheck_evaluator_does_not_crash_test =
-  Haz3lmenhir.(
-    QCheck.Test.make(
-      ~name="Evaluator does not crash",
-      ~count=100000,
-      QCheck.make(~print=AST.show_exp, AST.gen_exp_sized(20)),
-      exp => {
-        let unit_exp = Conversion.Exp.of_menhir_ast(exp);
-        let core_exp =
-          Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh(), unit_exp);
-        // if (count^ mod 10 == 0) {
-        //   print_endline("Evaluating: " ++ string_of_int(count^));
-        // };
-        // count := count^ + 1;
-        switch (
-          Evaluator.evaluate(
-            ~env=Builtins.env_init,
-            ~step_limit=10000,
-            elaborate(core_exp),
-          )
-        ) {
-        | (_, _) => true
-        | exception e =>
-          print_endline(
-            "ExpToSegment: "
-            ++ Printer.of_segment(
-                 ~holes=Some("?"),
-                 ExpToSegment.exp_to_segment(
-                   ~settings={
-                     inline: true,
-                     fold_case_clauses: false,
-                     fold_fn_bodies: false,
-                     hide_fixpoints: false,
-                     fold_cast_types: false,
-                     show_filters: true,
-                     show_unknown_as_hole: true,
-                   },
-                   core_exp,
-                 ),
-               ),
-          );
 
-          switch (e) {
-          | Failure(msg)
-              when
-                List.exists(
-                  (==)(msg),
-                  [
-                    "Sum type has non-unique constructors",
-                    "Step limit reached",
-                  ],
-                ) =>
-            print_endline("Skipping failure: " ++ msg);
-            true;
-          | _ => raise(e)
-          };
-        };
-      },
-    )
-  );
+let qcheck_evaluator_does_not_crash_test =
+  QCheck.Test.make(
+    ~name="Evaluator does not crash", ~count=100000, QCheck_Util.arb_exp, exp => {
+    switch (
+      Evaluator.evaluate(
+        ~env=Builtins.env_init,
+        ~step_limit=10000,
+        elaborate(exp),
+      )
+    ) {
+    | (_, _) => true
+    | exception e =>
+      print_endline(
+        "ExpToSegment: "
+        ++ Printer.of_segment(
+             ~holes=Some("?"),
+             ExpToSegment.exp_to_segment(
+               ~settings={
+                 inline: true,
+                 fold_case_clauses: false,
+                 fold_fn_bodies: false,
+                 hide_fixpoints: false,
+                 fold_cast_types: false,
+                 show_filters: true,
+                 show_unknown_as_hole: true,
+               },
+               exp,
+             ),
+           ),
+      );
+
+      switch (e) {
+      | Failure(msg)
+          when
+            List.exists(
+              (==)(msg),
+              ["Sum type has non-unique constructors", "Step limit reached"],
+            ) =>
+        print_endline("Skipping failure: " ++ msg);
+        true;
+      | _ => raise(e)
+      };
+    }
+  });
+
 let tests = (
   "Evaluator",
   [

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -413,6 +413,45 @@ let test_typfun_application = () =>
     |> Exp.fresh,
   );
 
+let qcheck_evaluator_does_not_crash_test =
+  Haz3lmenhir.(
+    QCheck.Test.make(
+      ~name="Evaluator does not crash",
+      ~count=10000,
+      QCheck.make(~print=AST.show_exp, AST.gen_exp_sized(7)),
+      exp => {
+        let unit_exp = Conversion.Exp.of_menhir_ast(exp);
+        let core_exp =
+          Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh(), unit_exp);
+
+        switch (
+          Evaluator.evaluate(~env=Builtins.env_init, elaborate(core_exp))
+        ) {
+        | (_, _) => true
+        | exception e =>
+          print_endline(
+            "ExpToSegment: "
+            ++ Printer.of_segment(
+                 ~holes=Some("?"),
+                 ExpToSegment.exp_to_segment(
+                   ~settings={
+                     inline: true,
+                     fold_case_clauses: false,
+                     fold_fn_bodies: false,
+                     hide_fixpoints: false,
+                     fold_cast_types: false,
+                     show_filters: true,
+                     show_unknown_as_hole: true,
+                   },
+                   core_exp,
+                 ),
+               ),
+          );
+          raise(e);
+        };
+      },
+    )
+  );
 let tests = (
   "Evaluator",
   [
@@ -781,5 +820,6 @@ in fn("hello")|},
         probe_test({|let PROBE(x) : (a=String) = "a" in x|}, uexp);
       },
     ),
+    QCheck_alcotest.to_alcotest(qcheck_evaluator_does_not_crash_test),
   ],
 );

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -445,12 +445,7 @@ let qcheck_evaluator_does_not_crash_test =
       );
 
       switch (e) {
-      | Failure(msg)
-          when
-            List.exists(
-              (==)(msg),
-              ["Sum type has non-unique constructors", "Step limit reached"],
-            ) =>
+      | Failure(msg) when List.exists((==)(msg), ["Step limit reached"]) =>
         print_endline("Skipping failure: " ++ msg);
         true;
       | _ => raise(e)

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -413,6 +413,17 @@ let test_typfun_application = () =>
     |> Exp.fresh,
   );
 
+let skip_current_unboxing_error = (err: string, expression: string) =>
+  test_case(err ++ " (Unboxing Error)", `Quick, () => {
+    [@warning "-21"]
+    {
+      // Currently fails https://github.com/hazelgrove/hazel/issues/1588
+      Alcotest.skip();
+      let exp = parse_and_evaluate(expression);
+      check(pass, err, exp, exp);
+    }
+  });
+
 let qcheck_evaluator_does_not_crash_test =
   QCheck.Test.make(
     ~name="Evaluator does not crash",
@@ -835,6 +846,39 @@ in fn("hello")|},
         probe_test({|let PROBE(x) : (a=String) = "a" in x|}, uexp);
       },
     ),
+    skip_current_unboxing_error(
+      "InvalidBoxSumConstructor",
+      "let B : (+B( )) = ? in ?",
+    ),
+    skip_current_unboxing_error(
+      "InvalidBoxedListLit",
+      "type g = + On in let [] = On in",
+    ),
+    skip_current_unboxing_error(
+      "InvalidBoxedListCons",
+      "let (_:: []) = type y = + B in B in ?",
+    ),
+    skip_current_unboxing_error(
+      "InvalidBoxedBoolLit",
+      "type y = + B(Float) in if B then false else A",
+    ),
+    skip_current_unboxing_error(
+      "InvalidBoxedTuple",
+      "let () = type x = + A in A in ?",
+    ),
+    skip_current_unboxing_error(
+      "InvalidBoxedTypfun",
+      "type y = + B in case true  | a => B end @<?> ",
+    ),
+    skip_current_unboxing_error(
+      "InvalidBoxedSumConstructor",
+      "type x = + A(Float) in let A = a in 0",
+    ),
+    skip_current_unboxing_error(
+      "InvalidBoxedStringLit",
+      {|type y = + A in ""++A|},
+    ),
+    skip_current_unboxing_error("InvalidBoxedIntLit", "type y = + A in -A"),
     QCheck_alcotest.to_alcotest(qcheck_evaluator_does_not_crash_test),
   ],
 );

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -412,20 +412,27 @@ let test_typfun_application = () =>
     )
     |> Exp.fresh,
   );
-
+let count = ref(0);
 let qcheck_evaluator_does_not_crash_test =
   Haz3lmenhir.(
     QCheck.Test.make(
       ~name="Evaluator does not crash",
-      ~count=10000,
-      QCheck.make(~print=AST.show_exp, AST.gen_exp_sized(7)),
+      ~count=100000,
+      QCheck.make(~print=AST.show_exp, AST.gen_exp_sized(20)),
       exp => {
         let unit_exp = Conversion.Exp.of_menhir_ast(exp);
         let core_exp =
           Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh(), unit_exp);
-
+        // if (count^ mod 10 == 0) {
+        //   print_endline("Evaluating: " ++ string_of_int(count^));
+        // };
+        // count := count^ + 1;
         switch (
-          Evaluator.evaluate(~env=Builtins.env_init, elaborate(core_exp))
+          Evaluator.evaluate(
+            ~env=Builtins.env_init,
+            ~step_limit=10000,
+            elaborate(core_exp),
+          )
         ) {
         | (_, _) => true
         | exception e =>
@@ -447,7 +454,21 @@ let qcheck_evaluator_does_not_crash_test =
                  ),
                ),
           );
-          raise(e);
+
+          switch (e) {
+          | Failure(msg)
+              when
+                List.exists(
+                  (==)(msg),
+                  [
+                    "Sum type has non-unique constructors",
+                    "Step limit reached",
+                  ],
+                ) =>
+            print_endline("Skipping failure: " ++ msg);
+            true;
+          | _ => raise(e)
+          };
         };
       },
     )

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -429,8 +429,8 @@ let qcheck_evaluator_does_not_crash_test =
     | exp =>
       switch (
         Evaluator.evaluate(~env=Builtins.env_init, ~step_limit=10000, exp)
-    ) {
-    | (_, _) => true
+      ) {
+      | (_, _) => true
       | exception e =>
         switch (e) {
         | Failure(msg) when List.exists((==)(msg), ["Step limit reached"]) =>
@@ -453,7 +453,7 @@ let qcheck_evaluator_does_not_crash_test =
       print_endline(
         "Skipping statics/elaborate failure: " ++ Printexc.to_string(e),
       );
-        true;
+      true;
     }
   });
 

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -415,7 +415,10 @@ let test_typfun_application = () =>
 
 let qcheck_evaluator_does_not_crash_test =
   QCheck.Test.make(
-    ~name="Evaluator does not crash", ~count=100000, QCheck_Util.arb_exp, exp => {
+    ~name="Evaluator does not crash",
+    ~count=10000,
+    QCheck_Util.arb_exp(~minimal_idents=true, 50),
+    exp => {
     switch (
       Evaluator.evaluate(
         ~env=Builtins.env_init,

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -433,7 +433,12 @@ let qcheck_evaluator_does_not_crash_test =
       | (_, _) => true
       | exception e =>
         switch (e) {
-        | Failure(msg) when List.exists((==)(msg), ["Step limit reached"]) =>
+        | Failure(msg)
+            when
+              List.exists(
+                (==)(msg),
+                ["Step limit reached", "type application in dynamics"] // "type application in dynamics" https://github.com/hazelgrove/hazel/issues/1625
+              ) =>
           print_endline("Skipping failure: " ++ msg);
           true;
         // https://github.com/hazelgrove/hazel/issues/1588 unboxing errors

--- a/test/Test_Evaluator.re
+++ b/test/Test_Evaluator.re
@@ -420,39 +420,40 @@ let qcheck_evaluator_does_not_crash_test =
     QCheck_Util.arb_exp(~minimal_idents=true, 50),
     exp => {
     switch (
-      Evaluator.evaluate(
-        ~env=Builtins.env_init,
-        ~step_limit=10000,
-        elaborate(exp),
+      Elaborator.elaborate(
+        Statics.mk(CoreSettings.on, Builtins.ctx_init(Some(Int)), exp),
+        exp,
       )
+      |> fst
+    ) {
+    | exp =>
+      switch (
+        Evaluator.evaluate(~env=Builtins.env_init, ~step_limit=10000, exp)
     ) {
     | (_, _) => true
+      | exception e =>
+        switch (e) {
+        | Failure(msg) when List.exists((==)(msg), ["Step limit reached"]) =>
+          print_endline("Skipping failure: " ++ msg);
+          true;
+        // https://github.com/hazelgrove/hazel/issues/1588 unboxing errors
+        | EvaluatorError.Exception(InvalidBoxedListLit(_))
+        | EvaluatorError.Exception(InvalidBoxedBoolLit(_))
+        | EvaluatorError.Exception(InvalidBoxedListCons(_))
+        | EvaluatorError.Exception(InvalidBoxedTuple(_))
+        | EvaluatorError.Exception(InvalidBoxedSumConstructor(_))
+        | EvaluatorError.Exception(InvalidBoxedFloatLit(_))
+        | EvaluatorError.Exception(InvalidBoxedIntLit(_))
+        | EvaluatorError.Exception(InvalidBoxedStringLit(_))
+        | EvaluatorError.Exception(InvalidBoxedTypFun(_)) => true
+        | _ => raise(e)
+        }
+      }
     | exception e =>
       print_endline(
-        "ExpToSegment: "
-        ++ Printer.of_segment(
-             ~holes=Some("?"),
-             ExpToSegment.exp_to_segment(
-               ~settings={
-                 inline: true,
-                 fold_case_clauses: false,
-                 fold_fn_bodies: false,
-                 hide_fixpoints: false,
-                 fold_cast_types: false,
-                 show_filters: true,
-                 show_unknown_as_hole: true,
-               },
-               exp,
-             ),
-           ),
+        "Skipping statics/elaborate failure: " ++ Printexc.to_string(e),
       );
-
-      switch (e) {
-      | Failure(msg) when List.exists((==)(msg), ["Step limit reached"]) =>
-        print_endline("Skipping failure: " ++ msg);
         true;
-      | _ => raise(e)
-      };
     }
   });
 

--- a/test/Test_Grammar.re
+++ b/test/Test_Grammar.re
@@ -4,11 +4,7 @@ let qcheck_map_annotation_test =
   QCheck.Test.make(
     ~name="Map annotation to something and back",
     ~count=100,
-    QCheck.make(
-      ~print=Haz3lmenhir.AST.show_exp,
-      ~shrink=Haz3lmenhir.AST.shrink_exp,
-      Haz3lmenhir.AST.gen_exp_sized(7),
-    ),
+    Haz3lmenhir.AST.arb_exp(7),
     exp => {
       let indicated_exp = Haz3lmenhir.Conversion.Exp.of_menhir_ast(exp);
       let core_exp =

--- a/test/Test_Menhir.re
+++ b/test/Test_Menhir.re
@@ -107,12 +107,8 @@ let qcheck_menhir_maketerm_equivalent_test =
   QCheck.Test.make(
     ~name="Menhir and maketerm are equivalent",
     ~count=100,
-    AST.arb_exp(7),
-    exp => {
-      let unit_exp = Conversion.Exp.of_menhir_ast(exp);
-      let core_exp =
-        Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh(), unit_exp);
-
+    QCheck_Util.arb_exp(~minimal_idents=false, 7),
+    core_exp => {
       let segment =
         ExpToSegment.exp_to_segment(
           ~settings=

--- a/test/Test_Menhir.re
+++ b/test/Test_Menhir.re
@@ -107,11 +107,7 @@ let qcheck_menhir_maketerm_equivalent_test =
   QCheck.Test.make(
     ~name="Menhir and maketerm are equivalent",
     ~count=100,
-    QCheck.make(
-      ~print=AST.show_exp,
-      ~shrink=AST.shrink_exp,
-      AST.gen_exp_sized(7),
-    ),
+    AST.arb_exp(7),
     exp => {
       let unit_exp = Conversion.Exp.of_menhir_ast(exp);
       let core_exp =
@@ -165,11 +161,7 @@ let qcheck_menhir_serialized_equivalent_test =
   QCheck.Test.make(
     ~name="Menhir through ExpToSegment and back",
     ~count=1000,
-    QCheck.make(
-      ~print=AST.show_exp,
-      ~shrink=AST.shrink_exp,
-      AST.gen_exp_sized(7),
-    ),
+    AST.arb_exp(7),
     exp => {
       let unit_exp = Conversion.Exp.of_menhir_ast(exp);
       let core_exp =

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -154,29 +154,27 @@ module FTemp =
     let default_value = (): IdTagged.IdTag.t => {ids: [Id.invalid]};
   });
 
-let show_ast_exp: Haz3lmenhir.AST.exp => string =
-  (exp: Haz3lmenhir.AST.exp) => {
-    open Haz3lmenhir;
-    let core_exp = Conversion.Exp.of_menhir_ast(exp);
-    let core_exp =
-      Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh(), core_exp);
-    Printer.of_segment(
-      ~holes=Some("?"),
-      ExpToSegment.exp_to_segment(
-        ~settings=
-          ExpToSegment.Settings.of_core(~inline=true, CoreSettings.off),
-        core_exp,
-      ),
-    );
-  };
-
 let qcheck_statics_does_not_crash =
   Haz3lmenhir.(
     QCheck.Test.make(
       ~name="Statics does not crash",
       ~count=1000,
       QCheck.make(
-        ~print=show_ast_exp,
+        ~print=
+          (exp: Haz3lmenhir.AST.exp) =>
+            Haz3lmenhir.(
+              Conversion.Exp.of_menhir_ast(exp)
+              |> Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh(), _)
+              |> ExpToSegment.exp_to_segment(
+                   ~settings=
+                     ExpToSegment.Settings.of_core(
+                       ~inline=true,
+                       CoreSettings.off,
+                     ),
+                   _,
+                 )
+              |> Printer.of_segment(~holes=Some("?"), _)
+            ),
         ~shrink=AST.shrink_exp,
         AST.gen_exp_sized(50),
       ),

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -155,37 +155,14 @@ module FTemp =
   });
 
 let qcheck_statics_does_not_crash =
-  Haz3lmenhir.(
-    QCheck.Test.make(
-      ~name="Statics does not crash",
-      ~count=1000,
-      QCheck.make(
-        ~print=
-          (exp: Haz3lmenhir.AST.exp) =>
-            Haz3lmenhir.(
-              Conversion.Exp.of_menhir_ast(exp)
-              |> Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh(), _)
-              |> ExpToSegment.exp_to_segment(
-                   ~settings=
-                     ExpToSegment.Settings.of_core(
-                       ~inline=true,
-                       CoreSettings.off,
-                     ),
-                   _,
-                 )
-              |> Printer.of_segment(~holes=Some("?"), _)
-            ),
-        ~shrink=AST.shrink_exp,
-        AST.gen_exp_sized(50),
-      ),
-      exp => {
-        let unit_exp = Conversion.Exp.of_menhir_ast(exp);
-        let core_exp =
-          Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh(), unit_exp);
-        let _ = statics(core_exp);
-        true;
-      },
-    )
+  QCheck.Test.make(
+    ~name="Statics does not crash",
+    ~count=1000,
+    QCheck_Util.arb_exp,
+    exp => {
+      let _ = statics(exp);
+      true;
+    },
   );
 
 let tests = (

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -166,6 +166,7 @@ let qcheck_statics_does_not_crash =
     | exception (Failure(f) as e) =>
       switch (f) {
       | "Type join of ap" => true // TODO https://github.com/hazelgrove/hazel/issues/1459
+      | "normalize exceeded 1000 recursive calls" => true // TODO https://github.com/hazelgrove/hazel/issues/1622?issue=hazelgrove%7Chazel%7C1623
       | "weak_head_normalize exceeded 1000 recursive calls" => true // TODO https://github.com/hazelgrove/hazel/issues/1621
       | "Recursion limit exceeded in all_ctrs_of_typ" => true // TODO https://github.com/hazelgrove/hazel/issues/1624
       | _

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -160,10 +160,25 @@ let qcheck_statics_does_not_crash =
     ~count=10000,
     QCheck_Util.arb_exp(~minimal_idents=true, 50),
     exp => {
-      let _ = statics(exp);
-      true;
-    },
-  );
+    switch (statics(exp)) {
+    | _m => true
+    | exception Stack_overflow => true // TODO https://github.com/hazelgrove/hazel/issues/1622
+    | exception (Failure(f) as e) =>
+      switch (f) {
+      | "Type join of ap" => true // TODO https://github.com/hazelgrove/hazel/issues/1459
+      | "weak_head_normalize exceeded 1000 recursive calls" => true // TODO https://github.com/hazelgrove/hazel/issues/1621
+      | "Recursion limit exceeded in all_ctrs_of_typ" => true // TODO https://github.com/hazelgrove/hazel/issues/1624
+      | _
+          when
+            String.starts_with(
+              ~prefix="all_ctrs_of_type called with a non-normalized type:",
+              f,
+            ) =>
+        true
+      | _ => raise(e)
+      }
+    }
+  });
 
 let tests = (
   "Statics",

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -157,7 +157,7 @@ module FTemp =
 let qcheck_statics_does_not_crash =
   QCheck.Test.make(
     ~name="Statics does not crash",
-    ~count=1000,
+    ~count=10000,
     QCheck_Util.arb_exp,
     exp => {
       let _ = statics(exp);

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -181,6 +181,17 @@ let qcheck_statics_does_not_crash =
     }
   });
 
+let skip_known_bug = (message: string, expression: string) =>
+  test_case("Known Bug: " ++ message, `Quick, () => {
+    [@warning "-21"]
+    {
+      let uexp = parse_exp(expression);
+      Alcotest.skip();
+      let _ = statics(uexp);
+      ();
+    }
+  });
+
 let tests = (
   "Statics",
   FTemp.(
@@ -1042,6 +1053,22 @@ case (? : (rec t -> +Z+S(t)))
 end
         |},
         Some(int()),
+      ),
+      skip_known_bug(
+        "Typ.weak_head_normalize infinite recursion", // https://github.com/hazelgrove/hazel/issues/1621
+        "type y = y in type ? = y in ?",
+      ),
+      skip_known_bug(
+        "Coverage.all_ctrs_of_typ infinite recursion", // https://github.com/hazelgrove/hazel/issues/1624
+        "fun ((()): ((rec x -> (rec y -> x)))) -> []",
+      ),
+      skip_known_bug(
+        "all_ctrs_of_type called with a non-normalized type", // https://github.com/hazelgrove/hazel/issues/1626
+        {|fun (?: (Float((+ A(Bool))))) -> ""|},
+      ),
+      skip_known_bug(
+        "Type join of ap", // https://github.com/hazelgrove/hazel/issues/1459
+        "type x = Int(Float) in let y : x =  1",
       ),
       QCheck_alcotest.to_alcotest(qcheck_statics_does_not_crash),
     ]

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -174,7 +174,7 @@ let qcheck_statics_does_not_crash =
               ~prefix="all_ctrs_of_type called with a non-normalized type:",
               f,
             ) =>
-        true
+        true // https://github.com/hazelgrove/hazel/issues/1626
       | _ => raise(e)
       }
     }

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -153,6 +153,43 @@ module FTemp =
     type t = IdTagged.IdTag.t;
     let default_value = (): IdTagged.IdTag.t => {ids: [Id.invalid]};
   });
+
+let show_ast_exp: Haz3lmenhir.AST.exp => string =
+  (exp: Haz3lmenhir.AST.exp) => {
+    open Haz3lmenhir;
+    let core_exp = Conversion.Exp.of_menhir_ast(exp);
+    let core_exp =
+      Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh(), core_exp);
+    Printer.of_segment(
+      ~holes=Some("?"),
+      ExpToSegment.exp_to_segment(
+        ~settings=
+          ExpToSegment.Settings.of_core(~inline=true, CoreSettings.off),
+        core_exp,
+      ),
+    );
+  };
+
+let qcheck_statics_does_not_crash =
+  Haz3lmenhir.(
+    QCheck.Test.make(
+      ~name="Statics does not crash",
+      ~count=1000,
+      QCheck.make(
+        ~print=show_ast_exp,
+        ~shrink=AST.shrink_exp,
+        AST.gen_exp_sized(50),
+      ),
+      exp => {
+        let unit_exp = Conversion.Exp.of_menhir_ast(exp);
+        let core_exp =
+          Grammar.map_exp_annotation(_ => IdTagged.IdTag.fresh(), unit_exp);
+        let _ = statics(core_exp);
+        true;
+      },
+    )
+  );
+
 let tests = (
   "Statics",
   FTemp.(
@@ -1015,6 +1052,7 @@ end
         |},
         Some(int()),
       ),
+      QCheck_alcotest.to_alcotest(qcheck_statics_does_not_crash),
     ]
   ),
 );

--- a/test/Test_Statics.re
+++ b/test/Test_Statics.re
@@ -158,7 +158,7 @@ let qcheck_statics_does_not_crash =
   QCheck.Test.make(
     ~name="Statics does not crash",
     ~count=10000,
-    QCheck_Util.arb_exp,
+    QCheck_Util.arb_exp(~minimal_idents=true, 50),
     exp => {
       let _ = statics(exp);
       true;


### PR DESCRIPTION
* @Negabinary added fixes for meta unquote and some constructor unboxing issues
* Adds qcheck tests for Statics, Elaboration, and Evaluation assuring that they don't throw exceptions
  * Known exceptions are caught and logged
* Adds type-level type application to menhir paser and qcheck generators.
* Adds a generator based on the menhir one that makes hazel core expressions and prints them nicely
  * Adds a generator flag to limit the number of identifiers to make variable/constructor matches more common
* Adds limits to existing functions that were not terminating
* Adds a step limit to the evaluator 
  * I'm interested in adding the step counter limit to the evaluator. My machine gets about 40,500,000 steps in 30 seconds
* Adds a timeout to the github action for running tests
* Bump junit_alcotest to 2.2.0 to get proper test outputs for skipped tests


# Remaining Failures
- https://github.com/hazelgrove/hazel/issues/1588
  - `let (B: ((+ B(Float)))) = ? in`
  - `type g = + On in let [] = On in`
  -  [(let (_:: []) = type y = + B in B in ?)]
  - `[(type y = + B(Float) in if B then false else A)] `
  - `let (()) = type x = + A in A in (())`
  -  `type y = + B in case true  | a => B end @< > `
  -  `type x = + A(Float) in let A = a in 0`
  -  `type y = + A in -A`
  -  `type y = + A in ""++A`
-  https://github.com/hazelgrove/hazel/issues/1459?issue=hazelgrove%7Chazel%7C1625
- https://github.com/hazelgrove/hazel/issues/1622
- https://github.com/hazelgrove/hazel/issues/1459
- https://github.com/hazelgrove/hazel/issues/1621
- https://github.com/hazelgrove/hazel/issues/1624
- https://github.com/hazelgrove/hazel/issues/1626
