### PR TITLE
Fix dynamic pattern matching

### DIFF
--- a/src/haz3lcore/dynamics/transition/Unboxing.re
+++ b/src/haz3lcore/dynamics/transition/Unboxing.re
@@ -242,7 +242,7 @@ let rec unbox: type a. (unbox_request(a), DHExp.t) => unboxed(a) =
     /* Any cast from unknown is indet */
     | (_, Cast(_, {term: Unknown(_), _}, _)) => IndetMatch
 
-    /* Any failed cast is indet */
+    /* Any failed casts cannot be unboxed */
     | (_, FailedCast(_)) => DoesNotMatch
 
     /* Forms that are the wrong type of value - these cases indicate an error

--- a/src/haz3lcore/dynamics/transition/Unboxing.re
+++ b/src/haz3lcore/dynamics/transition/Unboxing.re
@@ -243,7 +243,7 @@ let rec unbox: type a. (unbox_request(a), DHExp.t) => unboxed(a) =
     | (_, Cast(_, {term: Unknown(_), _}, _)) => IndetMatch
 
     /* Any failed cast is indet */
-    | (_, FailedCast(_)) => IndetMatch
+    | (_, FailedCast(_)) => DoesNotMatch
 
     /* Forms that are the wrong type of value - these cases indicate an error
        in elaboration or in the cast calculus. */


### PR DESCRIPTION
Fixes #1640.

There are currently no cases where failed casts should match. 
Can someone confirm that changing this doesn't have unintended behaviour?