### PR TITLE
fix: add prebundle.js to deps

### DIFF
--- a/src/haz3lweb/www/dune
+++ b/src/haz3lweb/www/dune
@@ -6,6 +6,7 @@
 
 (rule
  (targets bundled.js)
+ (deps prebundle.js)
  (action
   (run
    %{project_root}/node_modules/esbuild/bin/esbuild


### PR DESCRIPTION
This PR adds prebundle.js to dune so that it will copy the file to the `_build` directory when building the target if the sandboxing is enabled.