### PR TITLE
Add test-quick target for faster test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ test:
 	dune build @ocaml-index @src/fmt @test/fmt --auto-promote src test --profile dev
 	node $(TEST_DIR)/haz3ltest.bc.js
 
+test-quick:
+	dune build @ocaml-index @src/fmt @test/fmt --auto-promote src test --profile dev
+	node $(TEST_DIR)/haz3ltest.bc.js -q
+
 watch-test:
 	dune build @ocaml-index @fmt @runtest @default --profile dev --auto-promote --watch
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ You can run all of the unit tests located in `test` by running `make test`.
 
 Unit tests are written using the [Alcotest framework](https://github.com/mirage/alcotest).
 
+See more documentation in the [test README](test/README.md)
+
 #### Coverage
 Code coverage is provided by [bisect_ppx](https://github.com/aantron/bisect_ppx). To collect coverage statistics from tests run `make coverage`. After coverage statistics are generated, running `make generate-coverage-html` will generate a local webpage at `_coverage/index.html` that can be viewed to see line coverage per module.
 

--- a/run_tests
+++ b/run_tests
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Builds the JS file and runs it with node, forwarding any arguments.
+# All paths are resolved relative to this script's location.
+
+set -e
+
+# Resolve the directory this script lives in
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Path to the JS target relative to the script
+JS_TARGET="$SCRIPT_DIR/_build/default/test/haz3ltest.bc.js"
+
+# Run Dune in the script's directory
+(cd "$SCRIPT_DIR" && dune build test)
+
+# Execute the compiled JavaScript with node
+node "$JS_TARGET" "$@"

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,85 @@
+# Hazel Test Suite
+
+This directory contains the test suite for the Hazel project.
+
+## Overview
+
+- **Test Framework:** [Alcotest](https://github.com/mirage/alcotest)
+- **Execution:** Tests can be run via `make` commands or directly with Node.js.
+
+## How to Run Tests
+
+### 1. Using Make
+
+- **Run all tests (including slow and property-based):**
+    ```sh
+    make test
+    ```
+
+- **Run only quick tests (skip slow/property-based):**
+    ```sh
+    make test-quick
+    ```
+
+### 2. Using Node.js Directly
+
+- **Run the test suite:**
+    ```sh
+    node _build/default/test/haz3ltest.bc.js
+    ```
+
+- **Filter tests by group or number:**
+    - Run all tests in the "Statics" group with quick output:
+        ```sh
+        node _build/default/test/haz3ltest.bc.js test 'Statics.*' -q
+        ```
+    - Run only test 19 from the "Evaluator" group:
+        ```sh
+        node _build/default/test/haz3ltest.bc.js test 'Evaluator' 19
+        ```
+
+## Additional Information
+
+- You can pass CLI arguments to filter and control test execution.
+- For more CLI options, refer to the [Alcotest documentation](https://github.com/mirage/alcotest).
+
+## Test File Structure
+
+- All test files are located in this directory and its `statics/` subdirectory.
+- Each file tests a specific module or feature (e.g., `Test_Evaluator.re` for the evaluator).
+- Property-based tests use [QCheck](https://github.com/c-cube/qcheck) and are included when running the full test suite.
+
+## Adding New Tests
+
+- To add a new test, create a new file named `Test_<Feature>.re` or add to an existing file.
+- Use the [Alcotest](https://github.com/mirage/alcotest) API for defining test cases.
+- Utility functions for property-based testing are in `QCheck_Util.re`.
+
+## Troubleshooting
+
+- If you encounter build errors, ensure all dependencies are installed:
+    ```sh
+    make deps
+    ```
+- For issues with Node.js execution, check your Node.js version (>=14 recommended).
+
+## Code Coverage
+
+- **Run tests with coverage instrumentation:**
+    ```sh
+    make coverage
+    ```
+  This will run the test suite and collect coverage data.
+
+- **Generate an HTML coverage report:**
+    ```sh
+    make generate-coverage-html
+    ```
+  This will produce an HTML file with a coverage overview, which you can open in your browser to inspect which parts of the codebase are covered by tests.
+
+## Continuous Integration
+
+- Tests are automatically run on each pull request via GitHub Actions.
+- CI status can be viewed on the repository main page.
+- The test suite uses [junit_alcotest](https://github.com/Khady/ocaml-junit) to generate a `junit.xml` report, which is picked up by CI for test result reporting.
+- Coverage information is uploaded to [Codecov](https://about.codecov.io/) to provide coverage metrics on pull requests.

--- a/test/README.md
+++ b/test/README.md
@@ -5,13 +5,30 @@ This directory contains the test suite for the Hazel project.
 ## Overview
 
 - **Test Framework:** [Alcotest](https://github.com/mirage/alcotest)
-- **Execution:** Tests can be run via `make` commands or directly with Node.js.
+- **Execution:** Tests are run via the `run_tests` script or `make` commands.
 
 ## How to Run Tests
 
-### 1. Using Make
+### 1. Using the run_tests Script
 
 - **Run all tests (including slow and property-based):**
+    ```sh
+    ./run_tests
+    ```
+
+- **Filter tests by group or number:**
+    - Run all tests in the "Statics" group with quick output:
+        ```sh
+        ./run_tests test 'Statics.*' -q
+        ```
+    - Run only test 19 from the "Evaluator" group:
+        ```sh
+        ./run_tests test 'Evaluator' 19
+        ```
+
+### 2. Using Make
+
+- **Run all tests:**
     ```sh
     make test
     ```
@@ -21,26 +38,10 @@ This directory contains the test suite for the Hazel project.
     make test-quick
     ```
 
-### 2. Using Node.js Directly
-
-- **Run the test suite:**
-    ```sh
-    node _build/default/test/haz3ltest.bc.js
-    ```
-
-- **Filter tests by group or number:**
-    - Run all tests in the "Statics" group with quick output:
-        ```sh
-        node _build/default/test/haz3ltest.bc.js test 'Statics.*' -q
-        ```
-    - Run only test 19 from the "Evaluator" group:
-        ```sh
-        node _build/default/test/haz3ltest.bc.js test 'Evaluator' 19
-        ```
-
 ## Additional Information
 
-- You can pass CLI arguments to filter and control test execution.
+- `./run_tests` is a shell script that first builds the tests using `dune` (the OCaml build system), then runs them using `node`.
+- You can pass CLI arguments to `./run_tests` to filter and control test execution.
 - For more CLI options, refer to the [Alcotest documentation](https://github.com/mirage/alcotest).
 
 ## Test File Structure

--- a/test/README.md
+++ b/test/README.md
@@ -17,7 +17,7 @@ This directory contains the test suite for the Hazel project.
     ```
 
 - **Filter tests by group or number:**
-    - Run all tests in the "Statics" group with quick output:
+    - Run all tests in the "Statics" group with quick output (excluding slow/property-based):
         ```sh
         ./run_tests test 'Statics.*' -q
         ```

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -3,6 +3,7 @@ open Junit_alcotest;
 let (suite, _) =
   run_and_report(
     ~and_exit=false,
+    ~argv=Sys.argv,
     "HazelTests",
     [
       Test_Grammar.tests,


### PR DESCRIPTION
- Also allow for custom args to be passed to alcotest using a `run_tests` script
- Adds Make target for test-quick to only run quick tests
- Adds a readme to the tests directory describing our test suite

For example you can run all quick statics tests by running 
```sh
./run_tests test -q
```

or just Evaluator test 19
```sh
./run_tests test 'Evaluator' 19
```