### PR TITLE
add opam repository archive to CI Build

### DIFF
--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           path: "_opam"
           key: ${{ runner.os }}-modules-${{ hashFiles('./source/hazel.opam.locked') }}
+      - name: Add opam repository archive
+        run: |
+          eval $(opam env)
+          export OPAMYES=1
+          opam repo add archive git+https://github.com/ocaml/opam-repository-archive
       - name: Install dependencies
         run: |
           eval $(opam env)


### PR DESCRIPTION
Builds are broken as of https://github.com/ocaml/opam-repository/pull/27977. Not sure if there's a better long term fix.