### PR TITLE
Unprojection method (Non-compiling draft)

### DIFF
--- a/src/haz3lcore/interface/ProjectorInterface.re
+++ b/src/haz3lcore/interface/ProjectorInterface.re
@@ -106,6 +106,8 @@ module type PROJECTOR = {
       model'
     ) =>
     View.t;
+
+  let unproject: model' => editor_model;
 };
 
 module Defaults = {

--- a/src/haz3lcore/projectors/Projector.re
+++ b/src/haz3lcore/projectors/Projector.re
@@ -316,6 +316,41 @@ let init =
   };
 };
 
+let unproject =
+    (
+      type ed,
+      type ed_a,
+      type ed_f,
+      ~editor_module,
+      model: model(ed, ed_a, ed_f),
+    )
+    : ed => {
+  let.gadt W(kind_gadt) = kind;
+  let methods = to_module(editor_module, gadt1);
+  let unproject =
+    methods
+    |> (
+      (
+        type p_m,
+        type p_a,
+        type p_f,
+        module Methods:
+          ProjectorInterface.PROJECTOR with
+            type model' = p_m and
+            type action' = p_a and
+            type focus' = p_f and
+            type editor_model = ed_m,
+        model,
+        focus,
+      ) => (
+        {
+          Methods.unproject(model);
+        }: ed
+      )
+    );
+  unproject(model);
+};
+
 let update =
     (
       type ed_m,

--- a/src/haz3lcore/projectors/implementations/CardProj.re
+++ b/src/haz3lcore/projectors/implementations/CardProj.re
@@ -713,4 +713,7 @@ module M =
       enter_right: None,
     };
   };
+
+  let unproject = (model: model(_)) =>
+    Editor.Model.mk(Model.to_term(model));
 };

--- a/src/haz3lcore/projectors/implementations/CheckboxProj.re
+++ b/src/haz3lcore/projectors/implementations/CheckboxProj.re
@@ -46,9 +46,12 @@ module M =
 
   let update = (~common as _, ~sort as _, ~id as _, b, Toggle) => !b;
 
+  let term_of = (model: model(_)): Term.Any.t =>
+    Exp(Atom(Bool(model)) |> Exp.fresh);
+
   let mk_term = (~sort as _, ~prev as _, m): (model('a), Calc.t(Any.t)) => (
     m,
-    NewValue(Exp(Atom(Bool(m)) |> Exp.fresh)),
+    NewValue(term_of(m)),
   );
 
   let calculate = (~common as _, model) => model;
@@ -77,4 +80,6 @@ module M =
         (),
       ),
     );
+
+  let unproject = (model: model(_)) => Editor.Model.mk(term_of(model));
 };

--- a/src/haz3lcore/projectors/implementations/FoldProj.re
+++ b/src/haz3lcore/projectors/implementations/FoldProj.re
@@ -96,4 +96,6 @@ module M =
         [text(m.text), hover_view(~common, info.sort, m.ed)],
       ),
     );
+
+  let unproject = (model: model(_)) => model.ed;
 };

--- a/src/haz3lcore/projectors/implementations/PairProj.re
+++ b/src/haz3lcore/projectors/implementations/PairProj.re
@@ -265,4 +265,7 @@ module M =
           ),
         ),
     };
+
+  let unproject = (model: model(_)) =>
+    Editor.Model.mk(mk_term(model, ~sort=Exp, ~prev=Pending));
 };

--- a/src/haz3lcore/projectors/implementations/ProbeProj.re
+++ b/src/haz3lcore/projectors/implementations/ProbeProj.re
@@ -960,4 +960,6 @@ module M =
       enter_right: None,
     };
   };
+
+  let unproject = (model: model(_)) => model.ed;
 };

--- a/src/haz3lcore/projectors/implementations/SliderFProj.re
+++ b/src/haz3lcore/projectors/implementations/SliderFProj.re
@@ -82,9 +82,12 @@ module M =
 
   let update = (~common as _, ~sort as _, ~id as _, _, Set(f)) => f;
 
+  let term_of = (model: model(_)): Term.Any.t =>
+    Exp(Atom(Float(model)) |> Exp.fresh);
+
   let mk_term = (~sort as _, ~prev as _, m): (model', Calc.t(Any.t)) => (
     m,
-    NewValue(Exp(Atom(Float(m)) |> Exp.fresh)),
+    NewValue(term_of(m)),
   );
 
   let calculate = (~common as _, model) => model;
@@ -115,4 +118,6 @@ module M =
       enter_left: None,
       enter_right: None,
     };
+
+  let unproject = (model: model(_)) => Editor.Model.mk(term_of(model));
 };

--- a/src/haz3lcore/projectors/implementations/SliderProj.re
+++ b/src/haz3lcore/projectors/implementations/SliderProj.re
@@ -82,9 +82,12 @@ module M =
 
   let update = (~common as _, ~sort as _, ~id as _, _, Set(n)) => n;
 
+  let term_of = (model: model(_)): Term.Any.t =>
+    Exp(Atom(Int(model)) |> Exp.fresh);
+
   let mk_term = (~sort as _, ~prev as _, m): (model', Calc.t(Any.t)) => (
     m,
-    NewValue(Exp(Atom(Int(m)) |> Exp.fresh)),
+    NewValue(term_of(m)),
   );
 
   let calculate = (~common as _, model) => model;
@@ -115,4 +118,6 @@ module M =
       enter_left: None,
       enter_right: None,
     };
+
+  let unproject = (model: model(_)) => Editor.Model.mk(term_of(model));
 };

--- a/src/haz3lcore/projectors/implementations/TextAreaProj.re
+++ b/src/haz3lcore/projectors/implementations/TextAreaProj.re
@@ -90,19 +90,11 @@ module M =
 
   let update = (~common as _, ~sort as _, ~id as _, _model, SetString(s)) => s;
 
-  let mk_term = (~sort, ~prev, m: model'): (model', Calc.t(Any.t)) => {
-    (
-      m,
-      Calc.set(
-        ~eq=Language.Any.fast_equal,
-        switch (sort) {
-        | Sort.Exp => Exp(Atom(String(m)) |> Language.Exp.fresh)
-        | Sort.Pat => Pat(Atom(String(m)) |> Language.Pat.fresh)
-        | _ => Any()
-        },
-        prev,
-      ),
-    );
+  let term_of = (model: model(_)): Term.Any.t =>
+    Exp(Atom(String(model)) |> Exp.fresh);
+
+  let mk_term = (~sort as _, ~prev, m: model'): (model', Calc.t(Any.t)) => {
+    (m, Calc.set(~eq=Language.Any.fast_equal, term_of(m), prev));
   };
 
   let calculate = (~common as _, model) => model;
@@ -157,4 +149,6 @@ module M =
         ]),
     );
   };
+
+  let unproject = (model: model(_)) => Editor.Model.mk(term_of(model));
 };

--- a/src/haz3lcore/projectors/implementations/TypeProj.re
+++ b/src/haz3lcore/projectors/implementations/TypeProj.re
@@ -211,4 +211,6 @@ module M =
       enter_right: None,
     };
   };
+
+  let unproject = (model: model(_)) => model.ed;
 };

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -223,7 +223,8 @@ let rec go =
       let name = Form.parse_livelit(t);
       switch (Language.Ctx.lookup_livelit(ctx, name)) {
       // if we find a matching livelit, insert it, projected
-      | Some(ll) =>
+      | Some(_ll) =>
+        //TODO(andrew): or matt.
         // let exp_to_segment =
         //   ExpToSegment.(
         //     exp_to_segment(

--- a/src/web/Haz3lcore.re
+++ b/src/web/Haz3lcore.re
@@ -94,6 +94,9 @@ module rec Projector: {
 
     let get_cached_term = (Haz3lcorep.Projector.V(_, _, exp_cache)) =>
       Calc.get_saved_exc(exp_cache);
+
+    let unproject: t => Editor.Model.t =
+      Haz3lcorep.Projector.unproject(~editor_module=(module Editor));
   };
 
   module Update = {


### PR DESCRIPTION
Some questions are coming up here.

The exact signature of this method is unclear to me. I think we basically need to return an editor, even though what we really want out is a segment. Not sure what it needs as input, besides the model. From working through the projectors, it seems like it needs sort as well, for at least the pair projector, unless we pass the sort through the pair projector model.

For the pair projector, it's not totally clear how to abstract the parts of unproject which are common with maketerm. It's not obvious to me how to just use maketerm in the unproject implementation, given the Calc abstraction? but presumably that's possible?

But if we wanted to do a real implementation in this case, I think we maybe need another Editor method, the opposite of Editor.split which I implemented to extract sub-editors. But the API in the other direction is slightly unclear. Morally we want to do something like: take a term-with-holes-with-ids, and a map of ids to editors, and make an editor by basically doing an ExpToSegment on the holey term, except when we hit subterms with the given ids, we substitute those with the corresponding things in the map of editors/segments. I guess we could just adapt ExpToSegment to support this functionality, but it all feels a bit loose to me. Like we can use our EmptyHoles for the 'holes' in the term-with-holes, but that feels slightly arbitrary.