### PR TITLE
Syntax fixes

### DIFF
--- a/src/haz3lcore/TyDi/TyDi.re
+++ b/src/haz3lcore/TyDi/TyDi.re
@@ -35,9 +35,9 @@ let suggest = (ci: Info.t, z: Zipper.t): list(t) => {
   | InfoTyp({cls: Typ(TupLabel), _}) => [] // TODO: Autocomplete for labels
   | _ =>
     suggest_backpack(z)
+    @ TyDiForms.suggest_leading(ci)
     @ (
       TyDiForms.suggest_operand(ci)
-      @ TyDiForms.suggest_leading(ci)
       @ TyDiCtx.suggest_variable(ci)
       @ TyDiCtx.suggest_lookahead_variable(ci)
       |> List.sort(TyDiSuggestion.compare)

--- a/src/haz3lcore/TyDi/TyDiCtx.re
+++ b/src/haz3lcore/TyDi/TyDiCtx.re
@@ -38,6 +38,19 @@ let bound_variables = (ty_expect: Typ.t, ctx: Ctx.t): list(TyDiSuggestion.t) =>
     ctx.entries,
   );
 
+let bound_livelits = (ty_expect: Typ.t, ctx: Ctx.t): list(TyDiSuggestion.t) =>
+  List.filter_map(
+    fun
+    | Ctx.LivelitEntry({expansion_t, name, _})
+        when Typ.is_consistent(ctx, ty_expect, expansion_t) =>
+      Some({
+        content: "^" ++ name,
+        strategy: Exp(Common(FromCtx(expansion_t))),
+      })
+    | _ => None,
+    ctx.entries,
+  );
+
 let bound_constructors =
     (wrap: strategy_common => strategy, ty: Typ.t, ctx: Ctx.t)
     : list(TyDiSuggestion.t) =>
@@ -109,6 +122,7 @@ let suggest_variable = (ci: Info.t): list(TyDiSuggestion.t) => {
   switch (ci) {
   | InfoExp({ana, _}) =>
     bound_variables(ana, ctx)
+    @ bound_livelits(ana, ctx)
     @ bound_aps(ana, ctx)
     @ bound_constructors(x => Exp(Common(x)), ana, ctx)
     @ bound_constructor_aps(x => Exp(Common(x)), ana, ctx)
@@ -169,6 +183,8 @@ let suggest_lookahead_variable = (ci: Info.t): list(TyDiSuggestion.t) => {
     | Atom(Bool) =>
       /* TODO: Find a UI to make these less confusing */
       exp_refs(Atom(Int) |> Typ.fresh)
+      @ exp_refs(Atom(SInt) |> Typ.fresh)
+      @ exp_refs(Atom(Nat) |> Typ.fresh)
       @ exp_refs(Atom(Float) |> Typ.fresh)
       @ exp_refs(Atom(String) |> Typ.fresh)
       @ exp_aps(Atom(Int) |> Typ.fresh)

--- a/src/haz3lcore/TyDi/TyDiForms.re
+++ b/src/haz3lcore/TyDi/TyDiForms.re
@@ -1,5 +1,3 @@
-open Util;
-open OptUtil.Syntax;
 open Language;
 
 /* This module generates TyDi suggestions which depend
@@ -23,17 +21,14 @@ module Typ = {
     ("_", unk),
   ];
 
+  /* Only need to add forms here if they have a non-trivial type */
   let of_leading_delim: list((Token.t, Typ.t)) = [
-    ("case" ++ leading_expander, unk),
     ("fun" ++ leading_expander, Arrow(unk, unk) |> Typ.fresh),
     (
       "typfun" ++ leading_expander,
       Forall(Var("") |> TPat.fresh, unk) |> Typ.fresh,
     ),
-    ("if" ++ leading_expander, unk),
-    ("let" ++ leading_expander, unk),
     ("test" ++ leading_expander, Prod([]) |> Typ.fresh),
-    ("type" ++ leading_expander, unk),
   ];
 
   let of_infix_delim: list((Token.t, Typ.term)) = [
@@ -87,11 +82,13 @@ module Typ = {
       )
       : list((Token.t, Typ.t)) =>
     List.filter_map(
-      delim => {
-        let* self_ty = List.assoc_opt(delim, self_tys);
-        Typ.is_consistent(ctx, expected_ty, self_ty)
-          ? Some((delim, self_ty)) : None;
-      },
+      delim =>
+        switch (List.assoc_opt(delim, self_tys)) {
+        | None => Some((delim, unk))
+        | Some(self_ty) when Typ.is_consistent(ctx, expected_ty, self_ty) =>
+          Some((delim, self_ty))
+        | Some(_) => None
+        },
       delims,
     );
 };

--- a/src/haz3lcore/TyDi/TyDiForms.re
+++ b/src/haz3lcore/TyDi/TyDiForms.re
@@ -44,7 +44,7 @@ module Typ = {
     (";", Unknown(Internal)),
     ("&&", Atom(Bool)),
     ("\\/", Atom(Bool)),
-    ("||", Atom(Bool)),
+    //("||", Atom(Bool)),
     ("$==", Atom(Bool)),
     ("==.", Atom(Bool)),
     ("==", Atom(Bool)),

--- a/src/haz3lcore/TyDi/TyDiForms.re
+++ b/src/haz3lcore/TyDi/TyDiForms.re
@@ -68,7 +68,7 @@ module Typ = {
     ("-.", Atom(Float)),
     ("*.", Atom(Float)),
     ("/.", Atom(Float)),
-    ("**.", Atom(Float)),
+    //("**.", Atom(Float)), /* annoying as *. is more common */
     ("++", Atom(String)),
   ];
 

--- a/src/haz3lcore/lang/Form.re
+++ b/src/haz3lcore/lang/Form.re
@@ -123,7 +123,7 @@ let is_potential_operand =
  *  delimiters, string delimiters, or the instant expanding paired
  *  delimiters: ()[]| */
 let potential_operator_regexp =
-  regexp("^[^a-zA-Z0-9_'?\"#\n\\s\\[\\]\\(\\)]+$"); /* Multiline operators not supported */
+  regexp("^[^a-zA-Z0-9_'?\\^\"#\n\\s\\[\\]\\(\\)]+$"); /* Multiline operators not supported */
 let is_potential_operator = match(potential_operator_regexp);
 let begins_with_potential_operator =
   match(regexp("^[^a-zA-Z0-9_'?\"#\n\\s\\[\\]\\(\\)]+"));

--- a/src/haz3lcore/lang/MakeTerm.re
+++ b/src/haz3lcore/lang/MakeTerm.re
@@ -243,13 +243,13 @@ and exp_term: unsorted => (Exp.term, list(Id.t)) = {
         | term => ret(ListLit([term]))
         }
       | (["test", "end"], [Exp(test)]) => ret(Test(test))
-      | (
-          ["case", "end"],
-          [Rul({term: Rules(scrut, rules), annotation: {ids, _}})],
-        ) => (
-          Match(scrut, rules),
-          ids,
-        )
+      | (["case", "end"], [Rul({term, annotation: {ids, _}})]) =>
+        switch (term) {
+        | Rules(scrut, rules) => (Match(scrut, rules), ids)
+        // If the rule parser is correct, below should be impossible
+        | MultiHole(anys) => (MultiHole(anys), ids)
+        | Invalid(string) => (Invalid(string), ids)
+        }
       | ([t], []) when t != " " && !Form.is_explicit_hole(t) =>
         ret(Invalid(t))
       | _ => ret(hole(tm))
@@ -729,45 +729,30 @@ and tpat_term: unsorted => TPat.term = {
   | tm => ret(hole(tm));
 }
 
-// and rul = unsorted => {
-//   let term = rul_term(unsorted);
-//   let ids = ids(unsorted);
-//   return(r => Rul(r), ids, {ids, term});
-// }
 and rul = (unsorted): Rul.t => {
-  let hole: Rul.term = Hole(kids_of_unsorted(unsorted));
-  switch (exp(unsorted)) {
+  let e = exp(unsorted);
+  let mk_rules = (scrut: Exp.t, rules, ids): Rul.t => {
+    term: Rules(scrut, rules),
+    annotation: {
+      ids: ids,
+    },
+  };
+  switch (e) {
   | {term: MultiHole(_), _} =>
     switch (unsorted) {
     | Bin(Exp(scrut), tiles, Exp(last_clause)) =>
       switch (is_rules(tiles)) {
-      | Some((ps, leading_clauses)) => {
-          annotation: {
-            ids: ids(unsorted),
-          },
-          term:
-            Rules(scrut, List.combine(ps, leading_clauses @ [last_clause])),
-        }
-      | None => {
-          term: hole,
-          annotation: {
-            ids: ids(unsorted),
-          },
-        }
+      | Some((ps, leading_clauses)) =>
+        mk_rules(
+          scrut,
+          List.combine(ps, leading_clauses @ [last_clause]),
+          ids(unsorted),
+        )
+      | None => mk_rules(e, [], [])
       }
-    | _ => {
-        term: hole,
-        annotation: {
-          ids: ids(unsorted),
-        },
-      }
+    | _ => mk_rules(e, [], [])
     }
-  | e => {
-      term: Rules(e, []),
-      annotation: {
-        ids: [],
-      },
-    }
+  | _ => mk_rules(e, [], [])
   };
 }
 

--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -568,8 +568,8 @@ and parenthesize_rul = (~show_filters: bool, rul: Rul.t): Rul.t => {
       ),
     )
     |> rewrap
-  | Hole(xs) =>
-    Hole(List.map(parenthesize_any(~show_filters), xs)) |> rewrap
+  | MultiHole(xs) =>
+    MultiHole(List.map(parenthesize_any(~show_filters), xs)) |> rewrap
   };
 }
 

--- a/src/haz3lcore/projectors/ProjectorPerform.re
+++ b/src/haz3lcore/projectors/ProjectorPerform.re
@@ -172,6 +172,10 @@ let go =
       };
       Ok(z);
     }
-  | Escape(id, d) => Ok(jump_to_side_of_id(d, z, id))
+  | Escape(id, d) =>
+    switch (jump_to_side_of_id(d, z, id)) {
+    | Some(z) => Ok(z)
+    | None => Error(Cant_project)
+    }
   };
 };

--- a/src/haz3lcore/projectors/implementations/LivelitProj.re
+++ b/src/haz3lcore/projectors/implementations/LivelitProj.re
@@ -18,9 +18,7 @@ module M: Projector = {
         }),
       ) =>
       Some((llname, model))
-    | _ =>
-      print_endline("Warning - LivelitProj.get: Not an InfoExp term");
-      None;
+    | _ => None
     };
 
   let init = (any: Language.Term.Any.t) =>

--- a/src/haz3lcore/tiles/Base.re
+++ b/src/haz3lcore/tiles/Base.re
@@ -29,3 +29,36 @@ let mk_secondary = (id, content) => [
     content,
   }),
 ];
+
+/* If the piece is parentheses, return the child. Otherwise,
+ * return a singleton segment consisting of the piece */
+let unparenthesize = (piece: piece): segment =>
+  switch (piece) {
+  | Tile({
+      label: ["(", ")"],
+      mold: {nibs: ({shape: Convex, _}, {shape: Convex, _}), _},
+      children: [seg],
+      _,
+    }) => seg
+  | _ => [piece]
+  };
+
+let rec segment_to_string =
+        (~holes=" ", ~concave_holes=" ", seg: segment): string =>
+  seg
+  |> List.map(piece_to_string(~holes, ~concave_holes))
+  |> String.concat("")
+and piece_to_string =
+    (~holes: string, ~concave_holes: string, p: piece): string =>
+  switch (p) {
+  | Tile(t) => tile_to_string(~holes, ~concave_holes, t)
+  | Grout({shape: Concave, _}) => concave_holes
+  | Grout({shape: Convex, _}) => holes
+  | Secondary(w) => Secondary.get_string(w.content)
+  | Projector(p) =>
+    segment_to_string(~holes, ~concave_holes, unparenthesize(p.syntax))
+  }
+and tile_to_string = (~holes: string, ~concave_holes: string, t: tile): string =>
+  Aba.mk(t.shards, t.children)
+  |> Aba.join(List.nth(t.label), segment_to_string(~holes, ~concave_holes))
+  |> String.concat("");

--- a/src/haz3lcore/tiles/Mold.re
+++ b/src/haz3lcore/tiles/Mold.re
@@ -126,31 +126,28 @@ let mk_bin' = (p, out, sort_l, in_, sort_r) => {
   };
 };
 
-let nibs = (~index=?, mold: t): Nibs.t =>
-  switch (index) {
-  | None => mold.nibs
-  | Some(i) =>
-    let (l, r) = mold.nibs;
-    let in_ = mold.in_;
-    let l =
-      i == 0
-        ? l
-        : Nib.{
-            shape: Shape.concave(),
-            sort: List.nth(in_, i - 1),
-          };
-    let r =
-      i == List.length(in_)
-        ? r
-        : Nib.{
-            shape: Shape.concave(),
-            sort: List.nth(in_, i),
-          };
-    (l, r);
-  };
+let nibs = (~index, mold: t): Nibs.t => {
+  let (l, r) = mold.nibs;
+  let in_ = mold.in_;
+  let l =
+    index == 0
+      ? l
+      : Nib.{
+          shape: Shape.concave(),
+          sort: List.nth(in_, index - 1),
+        };
+  let r =
+    index == List.length(in_)
+      ? r
+      : Nib.{
+          shape: Shape.concave(),
+          sort: List.nth(in_, index),
+        };
+  (l, r);
+};
 
-let nib_shapes = (~index=?, mold: t): Nibs.shapes => {
-  let (nib_l, nib_r) = nibs(~index?, mold);
+let nib_shapes = (~index, mold: t): Nibs.shapes => {
+  let (nib_l, nib_r) = nibs(~index, mold);
   (nib_l.shape, nib_r.shape);
 };
 

--- a/src/haz3lcore/tiles/Mold.re
+++ b/src/haz3lcore/tiles/Mold.re
@@ -187,6 +187,12 @@ let is_infix_op = (mold: t): bool =>
   | _ => false
   };
 
+let is_prefix_op = (mold: t): bool =>
+  switch (mold.nibs, mold.in_) {
+  | (({shape: Convex, _}, {shape: Concave(_), _}), []) => true
+  | _ => false
+  };
+
 let chevron = (sort: Sort.t, p: Precedence.t, d: Util.Direction.t): t =>
   switch (d) {
   | Right => mk_post(p, sort, [])

--- a/src/haz3lcore/tiles/Piece.re
+++ b/src/haz3lcore/tiles/Piece.re
@@ -224,16 +224,3 @@ let is_term = (p: t) =>
   | Secondary(_) => false // debatable
   | _ => false
   };
-
-/* If the piece is parentheses, return the child. Otherwise,
- * return a singleton segment consisting of the piece */
-let unparenthesize = (piece: t): list(t) =>
-  switch (piece) {
-  | Tile({
-      label: ["(", ")"],
-      mold: {nibs: ({shape: Convex, _}, {shape: Convex, _}), _},
-      children: [seg],
-      _,
-    }) => seg
-  | _ => [piece]
-  };

--- a/src/haz3lcore/tiles/Segment.re
+++ b/src/haz3lcore/tiles/Segment.re
@@ -426,13 +426,13 @@ and remold_exp = (shape, seg: t): t =>
     }
   };
 
-let skel =
-  Core.Memo.general(~cache_size_bound=10000, seg =>
-    seg
-    |> List.mapi((i, p) => (i, p))
-    |> List.filter(((_, p)) => !Piece.is_secondary(p))
-    |> Skel.mk
-  );
+let skel = seg => {
+  print_endline("seg before skel: " ++ show(seg));
+  seg
+  |> List.mapi((i, p) => (i, p))
+  |> List.filter(((_, p)) => !Piece.is_secondary(p))
+  |> Skel.mk;
+};
 
 let sorted_children = List.concat_map(Piece.sorted_children);
 let children = seg => List.map(snd, sorted_children(seg));
@@ -850,20 +850,4 @@ module IDs = {
   };
 };
 
-let rec to_string = (~holes, seg: t): string =>
-  seg |> List.map(str_from_piece(~holes)) |> String.concat("")
-and str_from_piece = (~holes, p: Piece.t): string =>
-  switch (p) {
-  | Tile(t) => str_from_tile(~holes, t)
-  | Grout({shape: Concave, _}) => " "
-  | Grout({shape: Convex, _}) when holes != None => Option.get(holes)
-  | Grout({shape: Convex, _}) => " "
-  | Secondary(w) =>
-    Secondary.is_linebreak(w) ? "\n" : Secondary.get_string(w.content)
-  | Projector(p) => to_string(~holes, Piece.unparenthesize(p.syntax))
-  }
-and str_from_tile = (~holes, t: Tile.t): string =>
-  Aba.mk(t.shards, t.children)
-  |> Aba.join(str_from_delim(t), to_string(~holes))
-  |> String.concat("")
-and str_from_delim = (t: Piece.tile, i: int): string => List.nth(t.label, i);
+let to_string = Base.segment_to_string;

--- a/src/haz3lcore/tiles/Segment.re
+++ b/src/haz3lcore/tiles/Segment.re
@@ -426,12 +426,13 @@ and remold_exp = (shape, seg: t): t =>
     }
   };
 
-let skel = seg => {
-  seg
-  |> List.mapi((i, p) => (i, p))
-  |> List.filter(((_, p)) => !Piece.is_secondary(p))
-  |> Skel.mk;
-};
+let skel =
+  Core.Memo.general(~cache_size_bound=10000, seg =>
+    seg
+    |> List.mapi((i, p) => (i, p))
+    |> List.filter(((_, p)) => !Piece.is_secondary(p))
+    |> Skel.mk
+  );
 
 let sorted_children = List.concat_map(Piece.sorted_children);
 let children = seg => List.map(snd, sorted_children(seg));

--- a/src/haz3lcore/tiles/Segment.re
+++ b/src/haz3lcore/tiles/Segment.re
@@ -428,12 +428,12 @@ and remold_exp = (shape, seg: t): t =>
   };
 
 let skel =
-  Core.Memo.general(~cache_size_bound=10000, seg =>
+  Core.Memo.general(~cache_size_bound=10000, seg => {
     seg
     |> List.mapi((i, p) => (i, p))
     |> List.filter(((_, p)) => !Piece.is_secondary(p))
     |> Skel.mk
-  );
+  });
 
 let sorted_children = List.concat_map(Piece.sorted_children);
 let children = seg => List.map(snd, sorted_children(seg));

--- a/src/haz3lcore/tiles/Segment.re
+++ b/src/haz3lcore/tiles/Segment.re
@@ -58,19 +58,20 @@ let shape_affix =
     | [] => (empty_wgw, r, [])
     | [p, ...tl] =>
       let (wgw, s, tl) = go(tl, r);
+      let shape =
+        switch (Piece.shapes(p)) {
+        | Some(shapes) =>
+          shapes |> (d == Left ? TupleUtil.swap : Fun.id) |> fst
+        | None => s
+        };
       switch (p) {
       | Secondary(w) =>
         let (wss, gs) = wgw;
         let (ws, wss) = ListUtil.split_first(wss);
-        (([[w, ...ws], ...wss], gs), s, tl);
-      | Grout(g) => (Aba.cons([], g, wgw), s, tl)
-      | Projector(p) =>
-        let (l, _) =
-          ProjectorCore.shapes(p) |> (d == Left ? TupleUtil.swap : Fun.id);
-        (empty_wgw, l, tl);
-      | Tile(t) =>
-        let (l, _) = Tile.shapes(t) |> (d == Left ? TupleUtil.swap : Fun.id);
-        (empty_wgw, l, tl);
+        (([[w, ...ws], ...wss], gs), shape, tl);
+      | Grout(g) => (Aba.cons([], g, wgw), shape, tl)
+      | Projector(_) => (empty_wgw, shape, tl)
+      | Tile(_) => (empty_wgw, shape, tl)
       };
     };
   go((d == Left ? List.rev : Fun.id)(affix), r);

--- a/src/haz3lcore/tiles/Segment.re
+++ b/src/haz3lcore/tiles/Segment.re
@@ -427,7 +427,6 @@ and remold_exp = (shape, seg: t): t =>
   };
 
 let skel = seg => {
-  print_endline("seg before skel: " ++ show(seg));
   seg
   |> List.mapi((i, p) => (i, p))
   |> List.filter(((_, p)) => !Piece.is_secondary(p))

--- a/src/haz3lcore/tiles/Skel.re
+++ b/src/haz3lcore/tiles/Skel.re
@@ -48,14 +48,17 @@ let rel = (p1: Piece.t, p2: Piece.t): option(rel) =>
     let lbl2 = (==)(t2.label);
     //TODO: unhardcode
     let comma = [","];
-    let case = ["case"];
+    let case = ["case", "end"];
     let rule = ["|", "=>"];
     let plus = ["+"];
     let eq =
       [
         lbl1(case) && lbl2(rule),
         lbl1(rule) && lbl2(rule),
-        lbl1(comma) && lbl2(comma) && t1.mold == t2.mold,
+        lbl1(comma)
+        && lbl2(comma)
+        && Mold.is_infix_op(t1.mold)
+        && Mold.is_infix_op(t2.mold),
         lbl1(plus)
         && lbl2(plus)
         && Mold.is_infix_op(t1.mold)

--- a/src/haz3lcore/tiles/Skel.re
+++ b/src/haz3lcore/tiles/Skel.re
@@ -50,12 +50,16 @@ let rel = (p1: Piece.t, p2: Piece.t): option(rel) =>
     let comma = [","];
     let case = ["case"];
     let rule = ["|", "=>"];
+    let plus = ["+"];
     let eq =
       [
         lbl1(case) && lbl2(rule),
         lbl1(rule) && lbl2(rule),
         lbl1(comma) && lbl2(comma) && t1.mold == t2.mold,
-        lbl1(["+"]) && lbl2(["+"]) && t1.mold == t2.mold,
+        lbl1(plus)
+        && lbl2(plus)
+        && Mold.is_infix_op(t1.mold)
+        && Mold.is_infix_op(t2.mold),
       ]
       |> List.fold_left((||), false);
     if (eq) {
@@ -142,9 +146,7 @@ module Stacks = {
       let is = List.map(fst, chain);
       let split_kids = n =>
         try(ListUtil.split_n(n, stacks.output) |> PairUtil.map_fst(List.rev)) {
-        | _ =>
-          //prerr_endline(show(stacks));
-          failwith("Skel.push_output: split_kids: index out of bounds")
+        | _ => failwith("Skel.push_output: split_kids: index out of bounds")
         };
       let output =
         switch (l, r) {

--- a/src/haz3lcore/tiles/Tile.re
+++ b/src/haz3lcore/tiles/Tile.re
@@ -17,6 +17,12 @@ let l_shard = t =>
 let r_shard = t =>
   OptUtil.get_or_raise(Empty_tile, ListUtil.last_opt(t.shards));
 
+let shard_on_side = (d: Direction.t, t: t) =>
+  switch (d) {
+  | Left => l_shard(t)
+  | Right => r_shard(t)
+  };
+
 let has_end = (d: Direction.t, t) =>
   switch (d) {
   | Left => l_shard(t) == 0

--- a/src/haz3lcore/tiles/Token.re
+++ b/src/haz3lcore/tiles/Token.re
@@ -8,7 +8,7 @@ module Index = {
   type t = int;
 };
 
-let length = String.length;
+let length = Unicode.length;
 let compare = String.compare;
 let rm_nth = Util.StringUtil.remove_nth;
 let rm_last = Util.StringUtil.remove_last;

--- a/src/haz3lcore/zipper/Ancestors.re
+++ b/src/haz3lcore/zipper/Ancestors.re
@@ -27,7 +27,7 @@ let regrout = (ancs: t) =>
     ((a, sibs): generation, regrouted) => {
       let regrouted = regrouted;
       let ((pre, l, trim_l), (trim_r, r, suf)) = Siblings.regrout(sibs);
-      let (l', r') = TupleUtil.map2(Nib.shape, Mold.nibs(a.mold));
+      let (l', r') = TupleUtil.map2(Nib.shape, Ancestor.nibs(a));
       let trim_l = Segment.Trim.regrout(Left, (l, l'), trim_l);
       let trim_r = Segment.Trim.regrout(Right, (r', r), trim_r);
       let pre = pre @ Segment.Trim.to_seg(trim_l);

--- a/src/haz3lcore/zipper/Backpack.re
+++ b/src/haz3lcore/zipper/Backpack.re
@@ -275,21 +275,6 @@ let remove_matching = (ts: list(Tile.t), bp: t) =>
     ts,
   );
 
-let will_barf = (t: Token.t, bp: t): bool =>
-  /* Does the first selection in the backpack consist
-     of a single token which matches the one provided? */
-  switch (bp) {
-  | [] => false
-  | [{content: [p], _}, ..._] =>
-    switch (p) {
-    | Tile({shards: [i], label, _}) =>
-      assert(i < List.length(label));
-      List.nth(label, i) == t;
-    | _ => false
-    }
-  | _ => false
-  };
-
 let remove_uni_tiles_with_deep_matches = (bp: t, sel: Selection.t): t => {
   /* This is a hack to prevent incomplete tiles inside selection tiles
    * from being orphaned on deletion, e.g. if you delete segment "([)"

--- a/src/haz3lcore/zipper/Printer.re
+++ b/src/haz3lcore/zipper/Printer.re
@@ -1,35 +1,14 @@
 open Util;
 
-let remove_all_projectors: Segment.t => Segment.t =
-  ZipperBase.MapPiece.of_segment(
-    fun
-    | Projector(pr) => Piece.unparenthesize(pr.syntax)
-    | x => [x],
-  );
+let remove_projector: Piece.t => Segment.t =
+  fun
+  | Projector(pr) => Piece.unparenthesize(pr.syntax)
+  | x => [x];
 
 let measured_no_projectors = (segment: Segment.t) =>
   segment
-  |> remove_all_projectors
+  |> ZipperBase.MapPiece.of_segment(remove_projector)
   |> Measured.of_segment(_, ProjectorCore.Shape.Map.empty);
-
-/* This is a low-level function; use below entry point */
-let rec of_segment = (~holes, ~concave_holes, seg: Segment.t): string =>
-  seg |> List.map(of_piece(~holes, ~concave_holes)) |> String.concat("")
-and of_piece = (~holes, ~concave_holes, p: Piece.t): string =>
-  switch (p) {
-  | Tile(t) => of_tile(~holes, ~concave_holes, t)
-  | Grout({shape: Concave, _}) => concave_holes
-  | Grout({shape: Convex, _}) => holes
-  | Secondary(w) =>
-    Secondary.is_linebreak(w) ? "\n" : Secondary.get_string(w.content)
-  | Projector(p) =>
-    of_segment(~holes, ~concave_holes, Piece.unparenthesize(p.syntax))
-  }
-and of_tile = (~holes, ~concave_holes, t: Tile.t): string =>
-  Aba.mk(t.shards, t.children)
-  |> Aba.join(of_delim(t), of_segment(~holes, ~concave_holes))
-  |> String.concat("")
-and of_delim = (t: Piece.tile, i: int): string => List.nth(t.label, i);
 
 let add_caret =
     (caret: option((string, Point.t)), rows: list(string)): list(string) =>
@@ -44,9 +23,12 @@ let add_caret =
   | None => rows
   };
 
-let mk_indent = (segment, measured, indent: string, rows: list(string)) =>
+let add_indent = (measured: Measured.t, indent: string, i: int, r: string) =>
+  StringUtil.repeat(Measured.Rows.find(i, measured.rows).indent, indent) ++ r;
+
+let add_indents = (segment, measured, indent: string, rows: list(string)) =>
   if (indent == "") {
-    /* If no indentation is needed, we don't need to bother calculating measures */
+    /* If no indentation is needed, we don't need to bother calculating measured */
     rows;
   } else {
     let measured =
@@ -54,15 +36,7 @@ let mk_indent = (segment, measured, indent: string, rows: list(string)) =>
       | Some(m) => m
       | None => measured_no_projectors(segment)
       };
-    List.mapi(
-      (i, r) =>
-        StringUtil.repeat(
-          Measured.Rows.find(i, measured.rows).indent,
-          indent,
-        )
-        ++ r,
-      rows,
-    );
+    List.mapi(add_indent(measured, indent), rows);
   };
 
 /* Use this to pretty-print segments. Note that printing holes with
@@ -79,9 +53,9 @@ let of_segment =
     )
     : string =>
   segment
-  |> of_segment(~holes, ~concave_holes)
+  |> Segment.to_string(~holes, ~concave_holes)
   |> String.split_on_char('\n')
-  |> mk_indent(segment, measured, indent)
+  |> add_indents(segment, measured, indent)
   |> add_caret(caret)
   |> String.concat("\n");
 
@@ -93,11 +67,6 @@ let of_zipper =
    * we must recalculate the measured after removing projectors */
   let measured = measured_no_projectors(segment);
   let caret =
-    switch (caret) {
-    | None => None
-    | Some(char) =>
-      let caret_pos = Zipper.caret_point(measured, z);
-      Some((char, caret_pos));
-    };
+    Option.map(char => (char, Zipper.caret_point(measured, z)), caret);
   of_segment(~holes?, ~concave_holes?, ~indent?, ~caret, ~measured, segment);
 };

--- a/src/haz3lcore/zipper/Relatives.re
+++ b/src/haz3lcore/zipper/Relatives.re
@@ -102,6 +102,7 @@ let regrout = (d: Direction.t, {siblings, ancestors}: t): t => {
   let siblings = {
     let ((pre, s_l, trim_l), (trim_r, s_r, suf)) =
       Siblings.regrout(siblings);
+
     let (trim_l, trim_r) = {
       open Segment.Trim;
       let ((_, gs_l), (_, gs_r)) = (trim_l, trim_r);

--- a/src/haz3lcore/zipper/Relatives.re
+++ b/src/haz3lcore/zipper/Relatives.re
@@ -102,7 +102,6 @@ let regrout = (d: Direction.t, {siblings, ancestors}: t): t => {
   let siblings = {
     let ((pre, s_l, trim_l), (trim_r, s_r, suf)) =
       Siblings.regrout(siblings);
-
     let (trim_l, trim_r) = {
       open Segment.Trim;
       let ((_, gs_l), (_, gs_r)) = (trim_l, trim_r);

--- a/src/haz3lcore/zipper/Siblings.re
+++ b/src/haz3lcore/zipper/Siblings.re
@@ -76,6 +76,12 @@ let left_neighbor: t => option(Piece.t) = ((l, _)) => ListUtil.last_opt(l);
 
 let right_neighbor: t => option(Piece.t) = ((_, r)) => ListUtil.hd_opt(r);
 
+let neighbor = (d: Direction.t, (l, r): t): option(Piece.t) =>
+  switch (d) {
+  | Left => left_neighbor((l, r))
+  | Right => right_neighbor((l, r))
+  };
+
 let neighbors: t => (option(Piece.t), option(Piece.t)) =
   n => (left_neighbor(n), right_neighbor(n));
 

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -69,6 +69,18 @@ let unzip = (seg: Segment.t): t => {
 let pop_backpack = (z: t) =>
   Backpack.pop(Relatives.local_incomplete_tiles(z.relatives), z.backpack);
 
+let will_barf = (t: Token.t, z: t): bool =>
+  switch (pop_backpack(z)) {
+  | Some((_, {content: [p], _}, _)) =>
+    switch (p) {
+    | Tile({shards: [i], label, _}) =>
+      assert(i < List.length(label));
+      List.nth(label, i) == t;
+    | _ => false
+    }
+  | _ => false
+  };
+
 let left_neighbor_monotile: Siblings.t => option(Token.t) =
   s => s |> Siblings.left_neighbor |> OptUtil.and_then(Piece.monotile);
 

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -282,7 +282,7 @@ let remold_regrout_prev = (z: t): t =>
   switch (move(Left, z)) {
   | None => z
   | Some(z_left) =>
-    let z_left = z_left |> regrout(Right);
+    let z_left = z_left |> remold |> regrout(Right);
     switch (move(Right, z_left)) {
     | None => failwith("Zipper.put_down: move fail")
     | Some(z_right) => z_right

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -26,7 +26,6 @@ let next_blank = _ => Id.mk();
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
 type chunkiness =
   | ByChar
-  | MonoByChar
   | ByToken;
 
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
@@ -195,6 +194,9 @@ let directional_unselect = (d: Direction.t, z: t): t => {
     selection,
   });
 };
+
+let unselect = (z: t): t =>
+  z.selection.content == [] ? z : directional_unselect(z.selection.focus, z);
 
 let move = (d: Direction.t, z: t): option(t) =>
   if (Selection.is_empty(z.selection)) {
@@ -563,7 +565,9 @@ let try_to_dump_backpack = (zipper: t) => {
 
 let smart_seg = (~dump_backpack: bool, ~erase_buffer: bool, z: t) => {
   let z = erase_buffer ? clear_unparsed_buffer(z) : z;
+  // print_endline("z before: " ++ Siblings.show(z.relatives.siblings));
   let z = dump_backpack ? try_to_dump_backpack(z) : z;
+  // print_endline("z after: " ++ Siblings.show(z.relatives.siblings));
   unselect_and_zip(~erase_buffer, z);
 };
 

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -81,11 +81,10 @@ let neighbor_monotiles: Siblings.t => (option(Token.t), option(Token.t)) =
 let regrout = (d: Direction.t, z: t): t => {
   assert(Selection.is_empty(z.selection));
   let relatives = Relatives.regrout(d, z.relatives);
-  let z = {
+  {
     ...z,
     relatives,
   };
-  z;
 };
 
 let remold = (z: t): t => {
@@ -566,9 +565,7 @@ let try_to_dump_backpack = (zipper: t) => {
 
 let smart_seg = (~dump_backpack: bool, ~erase_buffer: bool, z: t) => {
   let z = erase_buffer ? clear_unparsed_buffer(z) : z;
-  // print_endline("z before: " ++ Siblings.show(z.relatives.siblings));
   let z = dump_backpack ? try_to_dump_backpack(z) : z;
-  // print_endline("z after: " ++ Siblings.show(z.relatives.siblings));
   unselect_and_zip(~erase_buffer, z);
 };
 

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -81,10 +81,11 @@ let neighbor_monotiles: Siblings.t => (option(Token.t), option(Token.t)) =
 let regrout = (d: Direction.t, z: t): t => {
   assert(Selection.is_empty(z.selection));
   let relatives = Relatives.regrout(d, z.relatives);
-  {
+  let z = {
     ...z,
     relatives,
   };
+  z;
 };
 
 let remold = (z: t): t => {
@@ -282,7 +283,7 @@ let remold_regrout_prev = (z: t): t =>
   switch (move(Left, z)) {
   | None => z
   | Some(z_left) =>
-    let z_left = z_left |> regrout(Right) |> remold;
+    let z_left = z_left |> regrout(Right);
     switch (move(Right, z_left)) {
     | None => failwith("Zipper.put_down: move fail")
     | Some(z_right) => z_right

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -581,7 +581,4 @@ let smart_seg = (~dump_backpack: bool, ~erase_buffer: bool, z: t) => {
   unselect_and_zip(~erase_buffer, z);
 };
 
-let seg_for_view = smart_seg(~erase_buffer=false, ~dump_backpack=false);
-let seg_for_sem = smart_seg(~erase_buffer=true, ~dump_backpack=true);
-
 let seg_without_buffer = smart_seg(~erase_buffer=true, ~dump_backpack=false);

--- a/src/haz3lcore/zipper/ZipperBase.re
+++ b/src/haz3lcore/zipper/ZipperBase.re
@@ -175,11 +175,3 @@ module MapPiece = {
   let fast_local = (f: Piece.t => Piece.t, id: Id.t, z: t): t =>
     fast_local_seg(p => [f(p)], id, z);
 };
-
-let remove_all_projectors = (z: t): t =>
-  MapPiece.go(
-    fun
-    | Projector(pr) => Piece.unparenthesize(pr.syntax)
-    | x => [x],
-    z,
-  );

--- a/src/haz3lcore/zipper/action/Destruct.re
+++ b/src/haz3lcore/zipper/action/Destruct.re
@@ -75,12 +75,24 @@ let destruct =
   };
 };
 
-let merge = ((l, r): (Token.t, Token.t), z: t): option(t) =>
+let merge = ((l, r): (Token.t, Token.t), z: t): option(t) => {
+  let z = Zipper.set_caret(Inner(0, Token.length(l) - 1), z); /* Note monotile assumption */
+  let* z = Zipper.delete(Left, z);
+  let* z = Zipper.delete(Right, z);
+  let z = Zipper.construct_mono(Right, l ++ r, z);
+  /* Regrouting direction needed to merge prefixs into infix eg ! */
+  let z = remold_regrout(Right, z);
+  Some(z);
+};
+
+let parent_merge = (lbl: Label.t, z: t): t => {
   z
-  |> Zipper.set_caret(Inner(0, Token.length(l) - 1))  // note monotile assumption
-  |> Zipper.delete(Left)
-  |> OptUtil.and_then(Zipper.delete(Right))
-  |> Option.map(Zipper.construct_mono(Right, l ++ r));
+  |> Zipper.delete_parent
+  |> Zipper.set_caret(Inner(0, 0))  /* Note 2-token assumption */
+  |> Zipper.construct(~caret=Right, ~backpack=Left, lbl)
+  /* Below regrouting important for parens/ap positioning */
+  |> remold_regrout(Right);
+};
 
 /* Check if containing duo form has a mono equivalent e.g. list literals */
 let parent_duomerges = (z: Zipper.t) => {
@@ -101,15 +113,9 @@ let go = (d: Direction.t, z: t): option(t) => {
     /* Note: we must do the no_siblings check, it does not suffice
        to check no monotile neighbors as there could be other neighbors
        for example edge case: "((|))" */
-    z
-    |> Zipper.delete_parent
-    |> Zipper.set_caret(Inner(0, 0))
-    |> Zipper.construct(~caret=Right, ~backpack=Left, lbl)
-    /* Below regrouting important for parens/ap positioning */
-    |> Zipper.regrout(Right)
-    |> Option.some
+    z |> parent_merge(lbl) |> Option.some
   | (_, Outer, (Some(l), Some(r))) when Molds.allow_merge(l, r) =>
-    merge((l, r), z)
-  | _ => Some(z)
+    z |> merge((l, r))
+  | _ => Some(z) |> Option.map(remold_regrout(d))
   };
 };

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -266,7 +266,7 @@ let rec go =
 
         let model_zipper =
           model_segment
-          |> Segment.to_string(~holes=None)
+          |> Segment.to_string
           |> StringUtil.to_list
           |> List.fold_left(insert, Some(z));
 

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -216,11 +216,11 @@ let split = (z: t, char: string, idx: int, t: Token.t): option(t) => {
       | Some(z) => z
       };
     } else {
-      z
-      |> remold_regrout_prev
-      |> make_new_tile(char, Left)
-      |> remold_regrout(Right)
-      |> move_into_if_stringlit_or_comment(char);
+      let z = remold(z);
+      let z = z |> remold_regrout_prev |> make_new_tile(char, Left);
+      let z = z |> remold_regrout(Right);
+      let z = z |> move_into_if_stringlit_or_comment(char);
+      z;
     };
   };
 };

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -95,7 +95,9 @@ let expand_neighbors_and_make_new_tile = (char: Token.t, state: t): option(t) =>
   let* z = expand_or_barf_left_neighbor(state);
   let+ z = expand_or_barf_right_neighbor(z);
   let z = remold_regrout_prev(z);
-  make_new_tile(char, Left, z);
+  let z = make_new_tile(char, Left, z);
+  let z = remold_regrout_prev(z);
+  z;
 };
 
 let replace_tile = (t: Token.t, d: Direction.t, z: t): option(t) => {

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -156,6 +156,19 @@ let should_supress_space = (z: t): bool => {
   };
 };
 
+let move_into_if_stringlit_or_comment = (char, z) =>
+  /* This is special-case logic for advancing the caret to position between the quotes
+     in newly-created stringlits. The main stringlit special-case is in Zipper.constuct
+     and ideally this logic would be located there as well, but both regrouting and
+     subsequent caret position logic at this function's callsites dicate that this
+     be done after. Not too happy about this tbh. */
+  Form.is_string_delim(char) || Form.is_comment_delim(char)
+    ? switch (move(Left, z)) {
+      | None => z
+      | Some(z) => z |> set_caret(Inner(0, 0))
+      }
+    : z;
+
 let split = (z: t, char: string, idx: int, t: Token.t): option(t) => {
   /* Current this necessarily creates three tokens; two from splitting
    * the existing one, and a new one. The two splitting tokens may become
@@ -171,8 +184,11 @@ let split = (z: t, char: string, idx: int, t: Token.t): option(t) => {
     let+ z = insert_duo([l, r], z);
     /* If we're inserting a space, don't bother to insert it;
      * we'll get a convex grout anyway from regrouting */
+
     (Form.space != char ? make_new_tile(char, Left, z) : z)
-    |> remold_regrout(Right);
+    |> remold_regrout(Right)
+    |> move_into_if_stringlit_or_comment(char);
+
   | None =>
     /* If contemplating changing regrouting behavior here, try these
      * two cases: pressing (A) space and (B) open parens on:
@@ -200,25 +216,11 @@ let split = (z: t, char: string, idx: int, t: Token.t): option(t) => {
       z
       |> remold_regrout_prev
       |> make_new_tile(char, Left)
-      |> remold_regrout(Right);
+      |> remold_regrout(Right)
+      |> move_into_if_stringlit_or_comment(char);
     };
   };
 };
-
-let opt_regrold = d => Option.map(remold_regrout(d));
-
-let move_into_if_stringlit_or_comment = (char, z) =>
-  /* This is special-case logic for advancing the caret to position between the quotes
-     in newly-created stringlits. The main stringlit special-case is in Zipper.constuct
-     and ideally this logic would be located there as well, but both regrouting and
-     subsequent caret position logic at this function's callsites dicate that this
-     be done after. Not too happy about this tbh. */
-  Form.is_string_delim(char) || Form.is_comment_delim(char)
-    ? switch (move(Left, z)) {
-      | None => z
-      | Some(z) => z |> set_caret(Inner(0, 0))
-      }
-    : z;
 
 let closing_stringlit_or_comment = (char, t) =>
   Form.is_string(t)
@@ -317,7 +319,7 @@ let rec go =
       ? z
         |> Zipper.set_caret(Inner(d_idx, idx))
         |> Zipper.replace_mono(Right, new_t)
-        |> opt_regrold(Left)
+        |> Option.map(remold_regrout(Left))
       : split(z, char, idx, t);
   /* Can't insert inside delimiter */
   | (Inner(_, _), (_, None)) => None
@@ -334,12 +336,12 @@ let rec go =
     z
     |> insert_outer(char)
     |> Option.map(Zipper.set_caret(caret))
-    |> opt_regrold(Left)
+    |> Option.map(remold_regrout(Left))
     |> Option.map(move_into_if_stringlit_or_comment(char));
   | (Outer, (_, None)) =>
     z
     |> insert_outer(char)
-    |> opt_regrold(Left)
+    |> Option.map(remold_regrout(Left))
     |> Option.map(move_into_if_stringlit_or_comment(char))
   };
 };

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -24,7 +24,7 @@ let expand_or_barf_left_neighbor = (z as s: t): option(t) =>
   /* If left neighbor is a monotile (a) string-matching the shard at the
      top of the backpack, barf it, or (b) an expansing keyword, expand it. */
   switch (left_neighbor_monotile(z.relatives.siblings)) {
-  | Some(t) when Backpack.will_barf(t, z.backpack) => barf(Left, s)
+  | Some(t) when Zipper.will_barf(t, z) => barf(Left, s)
   | Some(t) when Molds.is_delayed(t) => delayed_expand(t, Left, s)
   | _ => Some(s)
   };
@@ -33,7 +33,7 @@ let expand_or_barf_right_neighbor = (z as s: t): option(t) =>
   /* If right neighbor is a monotile (a) string-matching the shard at the
      top of the backpack, barf it, or (b) an expansing keyword, expand it. */
   switch (right_neighbor_monotile(z.relatives.siblings)) {
-  | Some(t) when Backpack.will_barf(t, z.backpack) => barf(Right, s)
+  | Some(t) when Zipper.will_barf(t, z) => barf(Right, s)
   | Some(t) when Molds.is_delayed(t) => delayed_expand(t, Right, s)
   | _ => Some(s)
   };
@@ -67,11 +67,14 @@ let make_new_tile = (t: Token.t, caret: Direction.t, z: t): t =>
   /* Adds a new tile at the caret. If the new token matches the top
      of the backpack, the backpack shard is dropped. Otherwise, we
      construct a new tile, which may immediately expand. */
-  Backpack.will_barf(t, z.backpack)
+  Zipper.will_barf(t, z)
     ? switch (neighbor_can_duomerge(t, z.relatives.siblings)) {
       | Some((lbl, d)) =>
-        Zipper.replace(~caret=d, ~backpack=d, lbl, z) |> Option.get
-      | None => put_down(caret, z) |> Option.get
+        let z = Zipper.replace(~caret=d, ~backpack=d, lbl, z) |> Option.get;
+        z;
+      | None =>
+        let z = put_down(caret, z) |> Option.get;
+        z;
       }
     : {
       let (lbl, backpack) = Molds.instant_expansion(t);

--- a/src/haz3lcore/zipper/action/Move.re
+++ b/src/haz3lcore/zipper/action/Move.re
@@ -94,7 +94,6 @@ module type S = {
 module Make = (M: S) => {
   let caret_point = Zipper.caret_point(M.measured);
   let primary = primary;
-
   let is_at_side_of_row = (d: Direction.t, z: Zipper.t) => {
     let Point.{row, col} = caret_point(z);
     switch (Zipper.move(d, z)) {

--- a/src/haz3lcore/zipper/action/Move.re
+++ b/src/haz3lcore/zipper/action/Move.re
@@ -262,33 +262,29 @@ module Make = (M: S) => {
     | Some(z) => Some(z)
     };
 
-  /* Jump to id moves the caret to the leftmost edge of
+  /* This moves the caret to the directionmost edge of
    * the piece with the target id. Note that this may not
    * mean that the piece at that id will be considered
-   * indicate from the point of view of the code decorations
-   * and cursor info display, since for example in the
-   * expression with (caret "|") "true && !|flag", the
-   * caret is at the leftmost edge of flag, but the not
-   * operator ("!") is indicated */
-  let jump_to_id = (z: t, id: Id.t): option(t) => {
-    let* {origin, _} = Measured.find_by_id(id, M.measured);
-    let z =
-      switch (to_start(z)) {
-      | None => z
-      | Some(z) => z
+   * indicated from the point of view of the code deco
+   * and cursor info display. This is true even when the
+   * direction is set to the Left, though in relatively
+   * few cases including for example `true && !|flag`,
+   * where the caret (|) is at the leftmost edge of
+   * `flag`, but the not operator ("!") is indicated */
+  let jump_to_side_of_id = (d: Direction.t, z, id): option(t) => {
+    let jump_to_left_of_id = (z: t, id: Id.t): option(t) => {
+      let* {origin, _} = Measured.find_by_id(id, M.measured);
+      let z =
+        switch (to_start(z)) {
+        | None => z
+        | Some(z) => z
+        };
+      switch (do_towards(primary(ByChar), origin, z)) {
+      | None => Some(z)
+      | Some(z) => Some(z)
       };
-    switch (do_towards(primary(ByChar), origin, z)) {
-    | None => Some(z)
-    | Some(z) => Some(z)
     };
-  };
-
-  let jump_to_side_of_id = (d: Direction.t, z, id) => {
-    let z =
-      switch (jump_to_id(z, id)) {
-      | Some(z) => z /* Move to left of id */
-      | None => z
-      };
+    let+ z = jump_to_left_of_id(z, id);
     switch (d) {
     | Left => z
     | Right =>
@@ -299,10 +295,10 @@ module Make = (M: S) => {
     };
   };
 
-  /* Same as jump to id, but if the end position doesn't
-   * indicate the target id, move one token to the right.
-   * This is an approximate solution (that I believe works
-   * for all current cases) */
+  /* Moves to the left side of the token with the given id,
+   * then checks if it's indicated. If not, move one token
+   * to the right. I believe but have not proved this
+   * always results in the token being indicated  */
   let jump_to_id_indicated = (z: t, id: Id.t): option(t) => {
     let* {origin, _} = Measured.find_by_id(id, M.measured);
     let z =

--- a/src/haz3lcore/zipper/action/Move.re
+++ b/src/haz3lcore/zipper/action/Move.re
@@ -2,89 +2,86 @@ open Zipper;
 open Util;
 open OptUtil.Syntax;
 
-[@deriving (show({with_path: false}), sexp, yojson)]
-type movability =
-  | CanEnter(int, int)
-  | CanPass
-  | CantEven;
+/* A label and an index into that label, representing a delimiter */
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type indexed = option((int, Label.t));
 
-let movability = (chunkiness: chunkiness, label, delim_idx): movability => {
-  assert(delim_idx < List.length(label));
-  switch (chunkiness, label, delim_idx) {
-  | (ByChar, _, _)
-  | (MonoByChar, [_], 0) =>
-    let char_max = Token.length(List.nth(label, delim_idx)) - 2;
-    char_max < 0 ? CanPass : CanEnter(delim_idx, char_max);
-  | (ByToken, _, _)
-  | (MonoByChar, _, _) => CanPass
+/* The index of a delimiter and its maximum internal caret position */
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type token_info = option((int, int));
+
+let piece_neighbor = (d: Direction.t, p: Piece.t): indexed =>
+  switch (p) {
+  | Tile(t) => Some((Tile.shard_on_side(Direction.toggle(d), t), t.label))
+  | Secondary(w) => Some((0, [Secondary.get_string(w.content)]))
+  | Grout(_) => None
+  | Projector(_) => None
+  };
+
+let ancestor_neighbor = (d: Direction.t, ancestors: Ancestors.t): indexed => {
+  let+ {shards: (l, r), label, _} = Ancestors.parent(ancestors);
+  switch (d) {
+  | Left => (ListUtil.last(l), label)
+  | Right => (List.hd(r), label)
   };
 };
 
-let neighbor_movability =
-    (chunkiness: chunkiness, {relatives: {siblings, ancestors}, _}: t)
-    : (movability, movability) => {
-  let movability = movability(chunkiness);
-  let (supernhbr_l, supernhbr_r) =
-    switch (ancestors) {
-    | [] => (CantEven, CantEven)
-    | [({children: (l_kids, _), label, _}, _), ..._] => (
-        movability(label, List.length(l_kids)),
-        movability(label, List.length(l_kids) + 1),
-      )
-    };
-  let (l_nhbr, r_nhbr) = Siblings.neighbors(siblings);
-  let l =
-    switch (l_nhbr) {
-    | Some(Tile({label, _})) => movability(label, List.length(label) - 1)
-    | Some(Secondary(w)) when Secondary.is_comment(w) =>
-      // Comments are always length >= 2
-      let content_string = Secondary.get_string(w.content);
-      CanEnter(
-        Unicode.length(content_string) - 1,
-        Unicode.length(content_string) - 2,
-      );
-    | Some(Secondary(_) | Grout(_) | Projector(_)) => CanPass
-    | None => supernhbr_l
-    };
-  let r =
-    switch (r_nhbr) {
-    | Some(Tile({label, _})) => movability(label, 0)
-    | Some(Secondary(w)) when Secondary.is_comment(w) =>
-      // Comments are always length >= 2
-      let content_string = Secondary.get_string(w.content);
-      CanEnter(0, Unicode.length(content_string) - 2);
-    | Some(Secondary(_) | Grout(_) | Projector(_)) => CanPass
-    | None => supernhbr_r
-    };
-  (l, r);
+let indexes = ((delim_idx: int, label: Label.t)): token_info => {
+  assert(delim_idx < List.length(label));
+  let char_max = Token.length(List.nth(label, delim_idx)) - 2;
+  char_max < 0 ? None : Some((delim_idx, char_max));
 };
 
-let pop_out = z => Some(z |> Zipper.set_caret(Outer));
-let pop_move = (d, z) => z |> Zipper.set_caret(Outer) |> Zipper.move(d);
-let inner_incr = (delim, c, z) =>
-  Some(Zipper.set_caret(Inner(delim, c + 1), z));
-let inner_decr = z => Some(Zipper.update_caret(Zipper.Caret.decrement, z));
-let inner_start = (d_init, z) =>
-  Some(Zipper.set_caret(Inner(d_init, 0), z));
-let inner_end = (d, d_init, c_max, z) =>
-  z |> Zipper.set_caret(Inner(d_init, c_max)) |> Zipper.move(d);
+let nhbr = (d: Direction.t, r: Relatives.t): indexed =>
+  switch (Siblings.neighbor(d, r.siblings)) {
+  | Some(p) => piece_neighbor(d, p)
+  | None => ancestor_neighbor(d, r.ancestors)
+  };
+
+let move_by_char_left = (z: t): option(t) =>
+  switch (z.caret, Option.bind(nhbr(Left, z.relatives), indexes)) {
+  | (Outer, None) => z |> move(Left)
+  | (Outer, Some((delim_init, char_max))) =>
+    z |> set_caret(Inner(delim_init, char_max)) |> move(Left)
+  | (Inner(_, char), None | Some((_, _))) when char == 0 =>
+    z |> set_caret(Outer) |> Option.some
+  | (Inner(delim, char), None | Some(_)) =>
+    z |> set_caret(Inner(delim, char - 1)) |> Option.some
+  };
+
+let move_by_char_right = (z: t): option(t) =>
+  switch (z.caret, Option.bind(nhbr(Right, z.relatives), indexes)) {
+  | (Outer, None) => z |> move(Right)
+  | (Outer, Some((delim_init, _))) =>
+    z |> set_caret(Inner(delim_init, 0)) |> Option.some
+  | (Inner(_, char), Some((_, char_max))) when char == char_max =>
+    z |> set_caret(Outer) |> move(Right)
+  | (Inner(delim, char), None | Some(_)) =>
+    z |> set_caret(Inner(delim, char + 1)) |> Option.some
+  };
+
+let move_by_char = (d: Direction.t, z: t): option(t) =>
+  switch (d) {
+  | Left => move_by_char_left(z)
+  | Right => move_by_char_right(z)
+  };
+
+let move_by_token = (d: Direction.t, z: t): option(t) =>
+  switch (z.caret) {
+  | Outer => move(d, z)
+  | Inner(_) =>
+    let z = set_caret(Outer, z);
+    switch (d) {
+    | Left => Some(z)
+    | Right => move(Right, z)
+    };
+  };
 
 let primary = (chunkiness: chunkiness, d: Direction.t, z: t): option(t) => {
-  switch (d, z.caret, neighbor_movability(chunkiness, z)) {
-  /* this case maybe shouldn't be necessary but currently covers an edge
-     (select an open parens to left of a multichar token and press left) */
-  | _ when z.selection.content != [] => pop_move(d, z)
-  | (Left, Outer, (CanEnter(dlm, c_max), _)) => inner_end(d, dlm, c_max, z)
-  | (Left, Outer, _) => Zipper.move(d, z)
-  | (Left, Inner(_), _) when chunkiness == ByToken => pop_out(z)
-  | (Left, Inner(_), _) =>
-    Some(Zipper.update_caret(Zipper.Caret.decrement, z))
-  | (Right, Outer, (_, CanEnter(d_init, _))) => inner_start(d_init, z)
-  | (Right, Outer, _) => Zipper.move(d, z)
-  | (Right, Inner(_, c), (_, CanEnter(_, c_max))) when c == c_max =>
-    pop_move(d, z)
-  | (Right, Inner(_), _) when chunkiness == ByToken => pop_move(d, z)
-  | (Right, Inner(delim, c), _) => inner_incr(delim, c, z)
+  let z = unselect(z);
+  switch (chunkiness) {
+  | ByToken => move_by_token(d, z)
+  | ByChar => move_by_char(d, z)
   };
 };
 
@@ -97,6 +94,7 @@ module type S = {
 module Make = (M: S) => {
   let caret_point = Zipper.caret_point(M.measured);
   let primary = primary;
+
   let is_at_side_of_row = (d: Direction.t, z: Zipper.t) => {
     let Point.{row, col} = caret_point(z);
     switch (Zipper.move(d, z)) {

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -222,14 +222,11 @@ let go_z =
       | Some(ci) => Info.ctx_of(ci)
       | None => Ctx.empty
       };
-    print_endline("Inserting " ++ char);
-    let z =
-      z
-      |> Insert.go(char, ~ctx)
-      /* note: remolding here is done case-by-case */
-      |> Result.of_option(~error=Action.Failure.Cant_insert);
-    print_endline("Inserted " ++ char);
-    z;
+
+    z
+    |> Insert.go(char, ~ctx)
+    /* note: remolding here is done case-by-case */
+    |> Result.of_option(~error=Action.Failure.Cant_insert);
   | Pick_up => Ok(remold_regrout(Left, Zipper.pick_up(z)))
   | Put_down =>
     let z =

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -222,11 +222,14 @@ let go_z =
       | Some(ci) => Info.ctx_of(ci)
       | None => Ctx.empty
       };
-
-    z
-    |> Insert.go(char, ~ctx)
-    /* note: remolding here is done case-by-case */
-    |> Result.of_option(~error=Action.Failure.Cant_insert);
+    print_endline("Inserting " ++ char);
+    let z =
+      z
+      |> Insert.go(char, ~ctx)
+      /* note: remolding here is done case-by-case */
+      |> Result.of_option(~error=Action.Failure.Cant_insert);
+    print_endline("Inserted " ++ char);
+    z;
   | Pick_up => Ok(remold_regrout(Left, Zipper.pick_up(z)))
   | Put_down =>
     let z =

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -158,9 +158,7 @@ let go_z =
     )
     |> Result.of_option(~error=Action.Failure.Cant_move)
   | Unselect(Some(d)) => Ok(Zipper.directional_unselect(d, z))
-  | Unselect(None) =>
-    let z = Zipper.directional_unselect(z.selection.focus, z);
-    Ok(z);
+  | Unselect(None) => Ok(Zipper.unselect(z))
   | Select(All) =>
     let z =
       switch (Move.do_extreme(Move.primary(ByToken), Up, z)) {

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -208,13 +208,6 @@ let go_z =
   | Destruct(d) =>
     z
     |> Destruct.go(d)
-    |> Option.map(z => {
-         print_endline("z1: " ++ Printer.of_zipper(~caret="|", z));
-         //let z = remold_regrout(d, z);
-         print_endline("z2: " ++ Printer.of_zipper(~caret="|", z));
-         print_endline("z2': " ++ Zipper.show(z));
-         z;
-       })
     |> Result.of_option(~error=Action.Failure.Cant_destruct)
   | Insert(char) =>
     let id =

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -208,7 +208,13 @@ let go_z =
   | Destruct(d) =>
     z
     |> Destruct.go(d)
-    |> Option.map(remold_regrout(d))
+    |> Option.map(z => {
+         print_endline("z1: " ++ Printer.of_zipper(~caret="|", z));
+         //let z = remold_regrout(d, z);
+         print_endline("z2: " ++ Printer.of_zipper(~caret="|", z));
+         print_endline("z2': " ++ Zipper.show(z));
+         z;
+       })
     |> Result.of_option(~error=Action.Failure.Cant_destruct)
   | Insert(char) =>
     let id =

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -152,8 +152,8 @@ let go_z =
         let* idx = Indicated.index(z);
         let* ci = Id.Map.find_opt(idx, statics.info_map);
         let* binding_id = Language.Info.get_binding_site(ci);
-        Move.jump_to_id(z, binding_id);
-      | TileId(id) => Move.jump_to_id(z, id)
+        Move.jump_to_id_indicated(z, binding_id);
+      | TileId(id) => Move.jump_to_id_indicated(z, id)
       }
     )
     |> Result.of_option(~error=Action.Failure.Cant_move)

--- a/src/haz3lcore/zipper/action/Select.re
+++ b/src/haz3lcore/zipper/action/Select.re
@@ -37,13 +37,13 @@ module Make = (M: Move.S) => {
     };
 
   let range = (l: Id.t, r: Id.t, z: Zipper.t): option(Zipper.t) => {
-    let* z = Move.jump_to_id(z, l);
+    let* z = Move.jump_to_side_of_id(Left, z, l);
     let* Measured.{last, _} = Measured.find_by_id(r, M.measured);
     Move.do_towards(Zipper.select, last, z);
   };
 
   let tile = (id: Id.t, z: Zipper.t): option(Zipper.t) => {
-    let* z = Move.jump_to_id(z, id);
+    let* z = Move.jump_to_side_of_id(Left, z, id);
     let* Measured.{last, _} = Measured.find_by_id(id, M.measured);
     Move.do_towards(primary, last, z);
   };

--- a/src/language/builtins/Builtins.re
+++ b/src/language/builtins/Builtins.re
@@ -13,6 +13,13 @@ let builtins =
   @ List.map(fn_builtin, BuiltinsBase.numeric_fns)
   @ List.map(const_builtin, BuiltinsBase.numeric_constants);
 
+let builtins =
+  List.sort(
+    (a: builtin, b: builtin) =>
+      String.compare(name_of_builtin(b), name_of_builtin(a)),
+    builtins,
+  );
+
 /* Check for accidental duplicates */
 let _ = to_map(builtins);
 

--- a/src/language/statics/Elaborator.re
+++ b/src/language/statics/Elaborator.re
@@ -189,18 +189,14 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
     | Invalid(_)
     | Undefined
     | EmptyHole => uexp
-    | MultiHole(_) =>
-      /* I don't think there's a meaningful elaboration story here;
-       * currently it causes problems for case expressions containing
-       * multiholes so I'm disabling it */
-      // Any.map_term(
-      //   ~f_exp=(_, exp) => {elaborate(m, exp) |> fst},
-      //   ~f_pat=(_, pat) => {elaborate_pattern(m, pat, false) |> fst},
-      //   _,
-      // )
-      // |> List.map(_, stuff)
-      // |> (stuff => MultiHole(stuff) |> rewrap)
-      EmptyHole |> rewrap
+    | MultiHole(stuff) =>
+      Any.map_term(
+        ~f_exp=(_, exp) => {elaborate(m, exp) |> fst},
+        ~f_pat=(_, pat) => {elaborate_pattern(m, pat, false) |> fst},
+        _,
+      )
+      |> List.map(_, stuff)
+      |> (stuff => MultiHole(stuff) |> rewrap)
     | DynamicErrorHole(e, err) =>
       let (e', _) = elaborate(m, e);
       DynamicErrorHole(e', err) |> rewrap;

--- a/src/language/statics/Elaborator.re
+++ b/src/language/statics/Elaborator.re
@@ -189,14 +189,18 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
     | Invalid(_)
     | Undefined
     | EmptyHole => uexp
-    | MultiHole(stuff) =>
-      Any.map_term(
-        ~f_exp=(_, exp) => {elaborate(m, exp) |> fst},
-        ~f_pat=(_, pat) => {elaborate_pattern(m, pat, false) |> fst},
-        _,
-      )
-      |> List.map(_, stuff)
-      |> (stuff => MultiHole(stuff) |> rewrap)
+    | MultiHole(_) =>
+      /* I don't think there's a meaningful elaboration story here;
+       * currently it causes problems for case expressions containing
+       * multiholes so I'm disabling it */
+      // Any.map_term(
+      //   ~f_exp=(_, exp) => {elaborate(m, exp) |> fst},
+      //   ~f_pat=(_, pat) => {elaborate_pattern(m, pat, false) |> fst},
+      //   _,
+      // )
+      // |> List.map(_, stuff)
+      // |> (stuff => MultiHole(stuff) |> rewrap)
+      EmptyHole |> rewrap
     | DynamicErrorHole(e, err) =>
       let (e', _) = elaborate(m, e);
       DynamicErrorHole(e', err) |> rewrap;
@@ -440,8 +444,9 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
 let fix_typ_ids =
   Exp.map_term(~f_typ=(cont, e) => e |> IdTagged.new_ids |> cont);
 
-let uexp_elab = (m: Statics.Map.t, uexp: Exp.t): ElaborationResult.t =>
+let uexp_elab = (m: Statics.Map.t, uexp: Exp.t): ElaborationResult.t => {
   switch (elaborate(m, uexp)) {
   | exception MissingTypeInfo => DoesNotElaborate
   | (d, ty) => Elaborates(d |> fix_typ_ids, ty)
   };
+};

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -154,10 +154,32 @@ let rec any_to_info_map =
       CoCtx.empty,
       utyp_to_info_map(~ctx, ~ancestors, ty, m) |> snd,
     )
-  | Rul(_)
+  | Rul(rt) =>
+    switch (rt.term) {
+    | Rules(scrut, rules) =>
+      let tms =
+        rules
+        |> List.map(((p, e)) => (Grammar.Pat(p), Grammar.Exp(e)))
+        |> List.split
+        |> (((a, b)) => a @ b);
+      let tms = [Grammar.Exp(scrut), ...tms];
+      any_to_info_map(
+        ~ctx,
+        ~ancestors,
+        Exp({
+          term: MultiHole(tms),
+          annotation: rt.annotation,
+        }),
+        m,
+      );
+    | MultiHole(tms) =>
+      let (co_ctxs, m) = multi(~ctx, ~ancestors, m, tms);
+      (CoCtx.union(co_ctxs), m);
+    | Invalid(_) => (CoCtx.empty, m)
+    }
   | Any () => (CoCtx.empty, m)
   }
-and multi = (~ctx, ~ancestors, m, tms) =>
+and multi = (~ctx, ~ancestors, m, tms): (list(CoCtx.t), Map.t) =>
   List.fold_left(
     ((co_ctxs, m), any) => {
       let (co_ctx, m) = any_to_info_map(~ctx, ~ancestors, any, m);

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -154,21 +154,22 @@ let rec any_to_info_map =
       CoCtx.empty,
       utyp_to_info_map(~ctx, ~ancestors, ty, m) |> snd,
     )
-  | Rul(rt) =>
-    switch (rt.term) {
+  | Rul(r) =>
+    switch (r.term) {
     | Rules(scrut, rules) =>
+      /* Treat rules not properly positioned in cases as multiholes.
+       * Properly positioned rules would already have been removed
+       * in maketerm and became part of case expressions */
       let tms =
         rules
-        |> List.map(((p, e)) => (Grammar.Pat(p), Grammar.Exp(e)))
-        |> List.split
-        |> (((a, b)) => a @ b);
-      let tms = [Grammar.Exp(scrut), ...tms];
+        |> List.map(((p, e)) => [Grammar.Pat(p), Grammar.Exp(e)])
+        |> List.concat;
       any_to_info_map(
         ~ctx,
         ~ancestors,
         Exp({
-          term: MultiHole(tms),
-          annotation: rt.annotation,
+          term: MultiHole([Exp(scrut), ...tms]),
+          annotation: r.annotation,
         }),
         m,
       );

--- a/src/language/term/Grammar.re
+++ b/src/language/term/Grammar.re
@@ -133,7 +133,7 @@ and tpat_term('a) =
 and tpat_t('a) = Annotated.t(tpat_term('a), 'a)
 and rul_term('a) =
   | Invalid(string)
-  | Hole(list(any_t('a)))
+  | MultiHole(list(any_t('a)))
   | Rules(exp_t('a), list((pat_t('a), exp_t('a))))
 and rul_t('a) = Annotated.t(rul_term('a), 'a)
 and environment_t('a) = VarBstMap.Ordered.t_(exp_t('a))
@@ -367,7 +367,8 @@ and map_rul_annotation: 'a 'b. ('a => 'b, rul_t('a)) => rul_t('b) =
       term:
         switch (term) {
         | Invalid(s) => Invalid(s)
-        | Hole(l) => Hole(List.map(x => map_any_annotation(f, x), l))
+        | MultiHole(l) =>
+          MultiHole(List.map(x => map_any_annotation(f, x), l))
         | Rules(e, l) =>
           Rules(
             map_exp_annotation(f, e),
@@ -823,7 +824,7 @@ module Factory = (DefaultAnnotation: DefaultAnnotation) => {
       annotation: default_annotation(ann),
     };
     let rul_hole = (~ann=?, l): rul_t(DefaultAnnotation.t) => {
-      term: Hole(l),
+      term: MultiHole(l),
       annotation: default_annotation(ann),
     };
     let rul_rules = (~ann=?, e, l): rul_t(DefaultAnnotation.t) => {

--- a/src/language/term/Sort.re
+++ b/src/language/term/Sort.re
@@ -9,13 +9,6 @@ type t =
 
 let root = Exp;
 
-let consistent = (s, s') =>
-  switch (s, s') {
-  | (Any, _)
-  | (_, Any) => true
-  | _ => s == s'
-  };
-
 let to_string = show;
 
 let to_string_verbose =

--- a/src/language/term/Term.re
+++ b/src/language/term/Term.re
@@ -907,6 +907,8 @@ module Rul = {
     | [] => raise(Invalid_argument("Exp.rep_id"))
     | [id, ..._] => id
     };
+
+  let unwrap: t => (term, term => t) = IdTagged.unwrap;
 };
 
 module Any = {

--- a/src/language/term/Term.re
+++ b/src/language/term/Term.re
@@ -896,7 +896,7 @@ module Rul = {
     | [_, ..._] => ids
     | [] =>
       switch (term) {
-      | Hole([tm, ..._]) => any_ids(tm)
+      | MultiHole([tm, ..._]) => any_ids(tm)
       | Rules(scrut, []) => IdTagged.ids(scrut)
       | _ => []
       }

--- a/src/language/term/TermBase.re
+++ b/src/language/term/TermBase.re
@@ -836,7 +836,7 @@ and Rul: {
       term:
         switch (term) {
         | Invalid(_) => term
-        | Hole(things) => Hole(List.map(any_map_term, things))
+        | MultiHole(things) => MultiHole(List.map(any_map_term, things))
         | Rules(e, rls) =>
           Rules(
             exp_map_term(e),
@@ -853,7 +853,7 @@ and Rul: {
   let fast_equal = (r1: t, r2: t) =>
     switch (r1 |> Grammar.Annotated.term_of, r2 |> Grammar.Annotated.term_of) {
     | (Invalid(s1), Invalid(s2)) => s1 == s2
-    | (Hole(xs), Hole(ys)) =>
+    | (MultiHole(xs), MultiHole(ys)) =>
       List.length(xs) == List.length(ys)
       && List.equal(Any.fast_equal, xs, ys)
     | (Rules(e1, rls1), Rules(e2, rls2)) =>
@@ -866,7 +866,7 @@ and Rul: {
            rls2,
          )
     | (Invalid(_), _)
-    | (Hole(_), _)
+    | (MultiHole(_), _)
     | (Rules(_), _) => false
     };
   let equal = fast_equal;

--- a/src/util/StringUtil.re
+++ b/src/util/StringUtil.re
@@ -34,19 +34,17 @@ let match = (r: regexp, s: string): bool =>
 
 let replace = Js_of_ocaml.Regexp.global_replace;
 
-let split = Js_of_ocaml.Regexp.split;
-
 let search = Js_of_ocaml.Regexp.search;
 
 let plain_split: (string, string) => list(string) =
-  (str, sep) => split(Js_of_ocaml.Regexp.regexp_string(sep), str);
+  (str, sep) =>
+    Js_of_ocaml.Regexp.split(Js_of_ocaml.Regexp.regexp_string(sep), str);
 
 let plain_match: (string, string) => bool =
-  (regexp, str) => match(Js_of_ocaml.Regexp.regexp_string(regexp), str);
+  regexp => match(Js_of_ocaml.Regexp.regexp(regexp));
 
 let plain_replace: (string, string, string) => string =
-  (regexp, str, repl) =>
-    replace(Js_of_ocaml.Regexp.regexp_string(regexp), str, repl);
+  regexp => replace(Js_of_ocaml.Regexp.regexp(regexp));
 
 let plain_search: (string, string, int) => int =
   (regexp, str, idx) =>

--- a/src/web/Keyboard.re
+++ b/src/web/Keyboard.re
@@ -91,11 +91,15 @@ let handle_key_event = (k: Key.t): option(Action.t) => {
     | _ => None
     }
   | {key: D(key), sys: Mac, shift: Up, meta: Up, ctrl: Down, alt: Up} =>
+    print_endline("Mac Ctrl");
+    print_endline(key);
     switch (key) {
     | "a" => now(Move(Extreme(Left(ByToken))))
     | "e" => now(Move(Extreme(Right(ByToken))))
+    | "j" => now(Move(Local(Left(ByToken))))
+    | "k" => now(Move(Local(Right(ByToken))))
     | _ => None
-    }
+    };
   | {key: D("f"), sys: PC, shift: Up, meta: Up, ctrl: Up, alt: Down} =>
     Some(Project(SetIndicated(Specific(Fold))))
   | {key: D("ƒ"), sys: Mac, shift: Up, meta: Up, ctrl: Up, alt: Down} =>

--- a/src/web/Keyboard.re
+++ b/src/web/Keyboard.re
@@ -91,13 +91,11 @@ let handle_key_event = (k: Key.t): option(Action.t) => {
     | _ => None
     }
   | {key: D(key), sys: Mac, shift: Up, meta: Up, ctrl: Down, alt: Up} =>
-    print_endline("Mac Ctrl");
-    print_endline(key);
     switch (key) {
     | "a" => now(Move(Extreme(Left(ByToken))))
     | "e" => now(Move(Extreme(Right(ByToken))))
     | _ => None
-    };
+    }
   | {key: D("f"), sys: PC, shift: Up, meta: Up, ctrl: Up, alt: Down} =>
     Some(Project(SetIndicated(Specific(Fold))))
   | {key: D("ƒ"), sys: Mac, shift: Up, meta: Up, ctrl: Up, alt: Down} =>

--- a/src/web/Keyboard.re
+++ b/src/web/Keyboard.re
@@ -96,8 +96,6 @@ let handle_key_event = (k: Key.t): option(Action.t) => {
     switch (key) {
     | "a" => now(Move(Extreme(Left(ByToken))))
     | "e" => now(Move(Extreme(Right(ByToken))))
-    | "j" => now(Move(Local(Left(ByToken))))
-    | "k" => now(Move(Local(Right(ByToken))))
     | _ => None
     };
   | {key: D("f"), sys: PC, shift: Up, meta: Up, ctrl: Up, alt: Down} =>

--- a/src/web/app/editors/code/Code.re
+++ b/src/web/app/editors/code/Code.re
@@ -157,7 +157,15 @@ module Text =
           (child, l + 1 == r ? List.nth(t.mold.in_, i) : Sort.Any),
         Aba.aba_triples(Aba.mk(t.shards, t.children)),
       );
-    let is_consistent = Sort.consistent(t.mold.out, expected_sort);
+    let consistent = (s: Sort.t, s': Sort.t) =>
+      switch (s, s') {
+      | (Any, _)
+      | (_, Any) => true
+      | (Rul, Exp) => true
+      | (Exp, Rul) => true
+      | _ => s == s'
+      };
+    let is_consistent = consistent(t.mold.out, expected_sort);
     Aba.mk(t.shards, children_and_sorts)
     |> Aba.join(
          of_delim(is_consistent, m(Tile(t)).origin.col, t), ((seg, sort)) =>

--- a/src/web/app/editors/decoration/Deco.re
+++ b/src/web/app/editors/decoration/Deco.re
@@ -92,7 +92,7 @@ module HighlightSegment =
     let start_shape =
       switch (Piece.nibs(p)) {
       | None => start_shape
-      | Some((_, {shape, _})) => Some(shape)
+      | Some((_, {shape, _})) => Some(Nib.Shape.flip(shape))
       };
     (start_shape, shard_data);
   }

--- a/src/web/app/editors/decoration/Deco.re
+++ b/src/web/app/editors/decoration/Deco.re
@@ -6,7 +6,6 @@ type shard_data = (Measured.measurement, Nibs.shapes);
 
 let sel_shard_svg =
     (
-      ~index=?,
       ~start_shape: ShardDec.tip,
       measurement: Measured.measurement,
       p: Piece.t,
@@ -14,9 +13,8 @@ let sel_shard_svg =
     : (Measured.measurement, (ShardDec.tip, ShardDec.tip)) => (
   measurement,
   switch (p) {
-  | Tile(t) => Mold.nib_shapes(~index?, t.mold) |> ShardDec.tips_of_shapes
-  | Grout(g) =>
-    Mold.nib_shapes(Mold.of_grout(g, Any)) |> ShardDec.tips_of_shapes
+  | Tile(t) => t |> Tile.shapes |> ShardDec.tips_of_shapes
+  | Grout(g) => g |> Grout.shapes |> ShardDec.tips_of_shapes
   | Secondary(_) => (
       Option.map(
         (s: Nib.Shape.t) =>
@@ -105,7 +103,7 @@ module HighlightSegment =
       |> List.map(((index, m)) => {
            let token = List.nth(t.label, index);
            switch (StringUtil.num_linebreaks(token)) {
-           | 0 => [Some(sel_shard_svg(~start_shape, ~index, m, Tile(t)))]
+           | 0 => [Some(sel_shard_svg(~start_shape, m, Tile(t)))]
            | num_lb =>
              multiline_shard(num_lb, m, (Some(Convex), Some(Convex)))
            };

--- a/src/web/www/style/cursor-inspector.css
+++ b/src/web/www/style/cursor-inspector.css
@@ -131,10 +131,6 @@
   color: var(--token-label);
 }
 
-#cursor-inspector .ci-header.ok.Nul {
-  background-color: var(--shard-nul);
-  color: var(--shadow-nul);
-}
 #cursor-inspector .ci-header.ok.Any {
   background-color: var(--shard-any);
   color: var(--shadow-any);

--- a/src/web/www/style/editor.css
+++ b/src/web/www/style/editor.css
@@ -34,9 +34,6 @@
 
 /* TOKEN COLORS */
 
-.code .token.Nul {
-  color: var(--token-nul);
-}
 .code .token.Any {
   color: var(--token-any);
 }
@@ -109,9 +106,6 @@ svg.shard.indicated {
   --blur: 0;
 }
 
-svg.shard.indicated.Nul {
-  filter: drop-shadow(var(--off-x) var(--off-y) var(--blur) var(--shadow-nul));
-}
 svg.shard.indicated.Any {
   filter: drop-shadow(var(--off-x) var(--off-y) var(--blur) var(--shadow-any));
 }
@@ -135,9 +129,6 @@ svg.shard.indicated.TPat {
   filter: drop-shadow(var(--off-x) var(--off-y) var(--blur) var(--token-tpat));
 }
 
-svg.shard.indicated.Nul > path {
-  fill: var(--shard-nul);
-}
 svg.shard.indicated.Any > path {
   fill: var(--shard-any);
 }
@@ -172,7 +163,7 @@ svg.shard.indicated.caret.Typ > path {
 
 svg.shard.selected {
   z-index: var(--select-z);
-  filter: drop-shadow(1px 1px 0 var(--shadow-nul));
+  filter: drop-shadow(1px 1px 0 var(--shadow-selected));
 }
 svg.shard.indicated {
   z-index: var(--tile-z);
@@ -248,9 +239,6 @@ svg:has(.child-line) {
   z-index: var(--err-hole-arms-z);
 }
 
-.child-line.Nul {
-  stroke: var(--shadow-nul);
-}
 .child-line.Any {
   stroke: var(--shadow-any);
 }

--- a/src/web/www/style/explainthis.css
+++ b/src/web/www/style/explainthis.css
@@ -28,6 +28,10 @@
   background-color: var(--T2);
 }
 
+#explain-this .example .cell-item {
+  overflow: auto;
+}
+
 #explain-this .example .cell-result {
   border-radius: 0 0 0.4em 0.4em;
 }

--- a/src/web/www/style/projectors/proj-text.css
+++ b/src/web/www/style/projectors/proj-text.css
@@ -54,7 +54,7 @@
   );
 }
 .projector.text.selected > svg {
-  filter: drop-shadow(1px 1px 0 var(--shadow-nul));
+  filter: drop-shadow(1px 1px 0 var(--R0));
 }
 
 .projector.text textarea {

--- a/src/web/www/style/variables.css
+++ b/src/web/www/style/variables.css
@@ -87,14 +87,13 @@
   --token-string-lit: var(--Y3);
   --token-comment: var(--G2);
   --token-incomplete: var(--Y3);
-  --token-inconsistent: var(--BR2);
+  --token-inconsistent: var(--token-exp);
   --token-buffer: var(--BR1);
   --token-explicit-hole: var(--Y2);
   --token-explicit-hole-shadow: var(--BLACK);
   --token-secondary: var(--shard-exp);
   --token-rul: var(--token-exp);
-  --token-nul: var(--R2);
-  --token-any: var(--token-nul);
+  --token-any: var(--R2);
 
   /* CODE SHARDS */
 
@@ -112,10 +111,9 @@
   --shard_projector: var(--T2);
   --shard-rul: var(--shard-exp);
   --shard-lines-rul: var(--shard-lines-exp);
-  --shard-nul: var(--R0);
-  --shadow-nul: var(--R0);
-  --shard-any: var(--shard-nul);
-  --shadow-any: var(--shadow-nul);
+  --shadow-selected: var(--R0);
+  --shard-any: var(--shard-exp);
+  --shadow-any: var(--R0);
 
   /* EMPTY HOLE DECO */
 

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -139,6 +139,28 @@ let basic_tests = [
     ~acts=mk("¦") @ [Paste(String({|([)(|}))],
     ~goal={|([?)(¦?|},
   ),
+  test(
+    ~name="Split two prefix op !s into bin op !!",
+    ~acts=mk("--1¦") @ mv_l(2) @ [Insert(" ")],
+    // caret pos is invalid here in a way not represented in these tetesl
+    ~goal={|- ¦-1|},
+  ),
+  test(
+    ~name="Delete leading constructor in sum type with prefix plus",
+    ~acts=mk("1:(+A¦ +A)") @ [Destruct(Left)],
+    // suceeds but crashes later with split_kids
+    ~goal={|1:(+¦ +A)|},
+  ),
+  // test(
+  //   ~name="Merge two prefix op !s into bin op !!",
+  //   ~acts=mk("! ! X¦") @ mv_l(3) @ [Destruct(Left)],
+  //   ~goal={|?!¦! X|},
+  // ),
+  // test(
+  //   ~name="Split ++ op in type sort context",
+  //   ~acts=mk("1:(++A)¦") @ mv_l(3) @ [Insert(" ")],
+  //   ~goal={|1:(+?¦+A)|},
+  // ),
 ];
 
 let insertion_tests = [
@@ -227,6 +249,62 @@ let insertion_tests = [
     ~acts=mk({|if the¦else|}) @ [Insert("n"), Insert(" ")],
     ~goal={|if? then?¦else?|},
   ),
+  /* INSERTTION: AMPHIBIOUS PREFIX/INFIX OP */
+  test(
+    ~name="Amphibious Plus 0",
+    ~acts=mk({|type T = A ¦|}),
+    ~goal={|type T = A ¦|},
+  ),
+  test(
+    ~name="Amphibious Plus - At End - 1",
+    ~acts=mk({|type T = A ¦|}) @ [Insert("+")],
+    ~goal={|type T = A +¦?|},
+  ),
+  test(
+    ~name="Amphibious Plus - At End - 2",
+    ~acts=mk({|type T = A + B + ¦|}) @ [Insert("C")],
+    ~goal={|type T = A + B + C¦|},
+  ),
+  test(
+    ~name="Amphibious Plus - At End - 3",
+    ~acts=mk({|type T = + ¦|}),
+    ~goal={|type T = + ¦?|},
+  ),
+  test(
+    ~name="Amphibious Plus - At End - 4",
+    ~acts=mk({|type T = + ¦|}) @ [Insert("A")],
+    ~goal={|type T = + A¦|},
+  ),
+  test(
+    ~name="Amphibious Plus - At End - 5",
+    ~acts=mk({|type T = + A + B + C¦|}),
+    ~goal={|type T = + A + B + C¦|},
+  ),
+  test(
+    ~name="Amphibious Plus - Before - 1",
+    ~acts=mk({|type T = ¦A|}) @ [Insert("+")],
+    ~goal={|type T = +¦A|},
+  ),
+  test(
+    ~name="Amphibious Plus - Before - 2",
+    ~acts=mk({|type T = ¦+ B|}) @ [Insert("A")],
+    ~goal={|type T = A¦+ B|},
+  ),
+  test(
+    ~name="Amphibious Plus - Before - 3 (Prelude)",
+    ~acts=mk({|type T = A ¦ B|}),
+    ~goal={|type T = A~¦ B|},
+  ),
+  test(
+    ~name="Amphibious Plus - Before - 3",
+    ~acts=mk({|type T = A ¦ B|}) @ [Insert("+")],
+    ~goal={|type T = A+¦ B|},
+  ),
+  test(
+    ~name="Amphibious Plus - Before - 4",
+    ~acts=mk({|type T = ¦ + A + B|}) @ [Insert("+")],
+    ~goal={|type T = +¦ + A + B|},
+  ),
   /* DROPPING */
   test(
     ~name="Insert between non-leading delims when leading in backpack",
@@ -276,6 +354,64 @@ let destruct_tests = [
     ~name="Destruct leading delim in prefix 3-form",
     ~acts=mk({|if¦ 1 then 2 else 3|}) @ [Destruct(Left)],
     ~goal={|¦ 1 then 2 else 3|},
+  ),
+  /* DESTRUCTION: AMPHIBIOUS PREFIX/INFIX OP */
+  test(
+    ~name="Amphibious Plus Destruct 1",
+    ~acts=mk({|type T = A +¦|}) @ [Destruct(Left)],
+    ~goal={|type T = A ¦|},
+  ),
+  test(
+    ~name="Amphibious Plus Destruct 2",
+    ~acts=mk({|type T = A + B +¦|}) @ [Destruct(Left)],
+    ~goal={|type T = A + B ¦|},
+  ),
+  test(
+    ~name="Amphibious Plus Destruct 3",
+    ~acts=mk({|type T = A + B + C¦|}) @ [Destruct(Left)],
+    ~goal={|type T = A + B + ¦?|},
+  ),
+  test(
+    ~name="Amphibious Plus Destruct 4",
+    ~acts=mk({|type T = + A¦|}) @ [Destruct(Left)],
+    ~goal={|type T = + ¦?|},
+  ),
+  test(
+    ~name="Amphibious Plus Destruct 5",
+    ~acts=mk({|type T = + A +¦|}) @ [Destruct(Left)],
+    ~goal={|type T = + A ¦|},
+  ),
+  test(
+    ~name="Amphibious Plus Destruct 6",
+    ~acts=mk({|type T = + A + B¦|}) @ [Destruct(Left)],
+    ~goal={|type T = + A + ¦?|},
+  ),
+  test(
+    ~name="Amphibious Plus Destruct 7",
+    ~acts=mk({|type T = + A + B +¦|}) @ [Destruct(Left)],
+    ~goal={|type T = + A + B ¦|},
+  ),
+  test(
+    ~name="Amphibious Plus Destruct 8",
+    ~acts=mk({|type T = +¦ A + B + C|}) @ [Destruct(Left)],
+    ~goal={|type T = ¦ A + B + C|},
+  ),
+  test(
+    ~name="Amphibious Plus Destruct 8",
+    ~acts=mk({|type T = + A¦ + B + C|}) @ [Destruct(Left)],
+    /* Ideally this would have a hole but okay-ish */
+    ~goal={|type T = + ¦ + B + C|},
+  ),
+  test(
+    ~name="Amphibious Plus Destruct 9",
+    ~acts=mk({|type T = + A + B +¦ C|}) @ [Destruct(Left)],
+    ~goal={|type T = + A + B ¦~ C|},
+  ),
+  test(
+    ~name="Amphibious Plus Destruct 10",
+    ~acts=mk({|type T = + A + B¦ + C|}) @ [Destruct(Left)],
+    /* Ideally this would have a hole but okay-ish */
+    ~goal={|type T = + A + ¦ + C|},
   ),
 ];
 

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -327,6 +327,23 @@ let insertion_tests = [
       @ [Insert(" ")],
     ~goal={| 1 then  ¦2 else 3|},
   ),
+  test(
+    ~name="Insert let binding before prefix negation",
+    ~acts=
+      mk({|¦-1|})
+      @ [
+        Insert("l"),
+        Insert("e"),
+        Insert("t"),
+        Insert(" "),
+        Insert("x"),
+        Insert(" "),
+        Insert("="),
+        Insert(" "),
+        Move(Local(Right(ByChar))),
+      ],
+    ~goal={|let x = -¦1|},
+  ),
 ];
 
 let destruct_tests = [

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -208,11 +208,15 @@ let insertion_tests = [
     ~goal={|if? then?¦else?|},
   ),
   /* DROPPING */
-  // test(
-  //   ~name="Hint 1",
-  //   ~acts=mk({|hint 1¦|}) @ [Put_down],
-  //   ~goal={|hint 1¦|},
-  // ),
+  test(
+    ~name="Insert between non-leading delims when leading in backpack",
+    ~acts=
+      mk({|if¦ 1 then 2 else 3|})
+      @ [Destruct(Left)]
+      @ mv_r(8)
+      @ [Insert(" ")],
+    ~goal={| 1 then  ¦2 else 3|},
+  ),
 ];
 
 let destruct_tests = [
@@ -244,7 +248,12 @@ let destruct_tests = [
   ),
   /* DESTRUCTION: MATCHING */
   test(
-    ~name="Destruct leading delim",
+    ~name="Destruct leading delim in convex 2-form",
+    ~acts=mk({|(¦1)|}) @ [Destruct(Left)],
+    ~goal={|¦1)|},
+  ),
+  test(
+    ~name="Destruct leading delim in prefix 3-form",
     ~acts=mk({|if¦ 1 then 2 else 3|}) @ [Destruct(Left)],
     ~goal={|¦ 1 then 2 else 3|},
   ),

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -134,6 +134,11 @@ let basic_tests = [
     ~acts=mk("if¦then") @ [Paste(String({|"foo"|}))],
     ~goal={|if"foo"¦then?|},
   ),
+  test(
+    ~name="Paste string with a backpack barf false friend",
+    ~acts=mk("¦") @ [Paste(String({|([)(|}))],
+    ~goal={|([?)(¦?|},
+  ),
 ];
 
 let insertion_tests = [

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -119,6 +119,21 @@ let basic_tests = [
     ~acts=mk("¦foo"),
     ~goal="¦foo",
   ),
+  test(
+    ~name="Paste string duo-splitting empty tuple",
+    ~acts=mk("(¦)") @ [Paste(String({|"foo"|}))],
+    ~goal={|("foo"¦)|},
+  ),
+  test(
+    ~name="Paste string splitting token",
+    ~acts=mk("1¦1") @ [Paste(String({|"foo"|}))],
+    ~goal={|1~"foo"¦~1|},
+  ),
+  test(
+    ~name="Paste string splitting consecutive delimiters",
+    ~acts=mk("if¦then") @ [Paste(String({|"foo"|}))],
+    ~goal={|if"foo"¦then?|},
+  ),
 ];
 
 let insertion_tests = [

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -5,6 +5,7 @@
 open Util;
 open Alcotest;
 open Haz3lcore;
+open Action;
 module Fresh = Language.IdTagged.FreshGrammar;
 
 /* The following special characters are used in the tests to represent
@@ -66,8 +67,17 @@ let perform = (zip: Zipper.t, actions: list(Action.t)): Zipper.t => {
 let string_to_ltr_actions = (s: string): list(Action.t) =>
   s |> Util.StringUtil.to_list |> List.map(c => Action.Insert(c));
 
-let move_by_char_left_actions = (n: int): list(Action.t) =>
+let mv_l = (n: int): list(Action.t) =>
   List.init(n, _ => Action.Move(Local(Left(ByChar))));
+
+let mv_r = (n: int): list(Action.t) =>
+  List.init(n, _ => Action.Move(Local(Right(ByChar))));
+
+let mv_l_token = (n: int): list(Action.t) =>
+  List.init(n, _ => Action.Move(Local(Left(ByToken))));
+
+let mv_r_token = (n: int): list(Action.t) =>
+  List.init(n, _ => Action.Move(Local(Right(ByToken))));
 
 let mk = (init: string): list(Action.t) => {
   /* This harness uses a ¦ to represent caret position.
@@ -90,8 +100,7 @@ let mk = (init: string): list(Action.t) => {
    * of characters that come after the caret position */
   let chars_after_caret = String.length(init_without_caret) - caret_index;
 
-  string_to_ltr_actions(init_without_caret)
-  @ move_by_char_left_actions(chars_after_caret);
+  string_to_ltr_actions(init_without_caret) @ mv_l(chars_after_caret);
 };
 
 let test = (~name, ~acts, ~goal): test_case(_) =>
@@ -198,6 +207,12 @@ let insertion_tests = [
     ~acts=mk({|if the¦else|}) @ [Insert("n"), Insert(" ")],
     ~goal={|if? then?¦else?|},
   ),
+  /* DROPPING */
+  // test(
+  //   ~name="Hint 1",
+  //   ~acts=mk({|hint 1¦|}) @ [Put_down],
+  //   ~goal={|hint 1¦|},
+  // ),
 ];
 
 let destruct_tests = [
@@ -212,21 +227,194 @@ let destruct_tests = [
     ~acts=mk({|"¦"|}) @ [Destruct(Left)],
     ~goal={|¦?|},
   ),
-  /* DESTRUCTION: TOKEN MERGING */
   test(
-    ~name="`Merge to empty list by backspacing",
+    ~name="Merge to empty list by backspacing",
     ~acts=mk({|[1¦]|}) @ [Destruct(Left)],
     ~goal={|[¦]|},
   ),
   test(
-    ~name="`Merge to empty tuple by deleting",
+    ~name="Merge to empty tuple by deleting",
     ~acts=mk({|(¦1)|}) @ [Destruct(Right)],
     ~goal={|(¦)|},
   ),
   test(
-    ~name="`Merge number literals across bin op by backspacing",
+    ~name="Merge number literals across bin op by backspacing",
     ~acts=mk({|1+¦1|}) @ [Destruct(Left)],
     ~goal={|1¦1|},
+  ),
+  /* DESTRUCTION: MATCHING */
+  test(
+    ~name="Destruct leading delim",
+    ~acts=mk({|if¦ 1 then 2 else 3|}) @ [Destruct(Left)],
+    ~goal={|¦ 1 then 2 else 3|},
+  ),
+];
+
+let move_tests = [
+  // ByToken Right Complete Syntax
+  test(
+    ~name="Caret movement by token 1",
+    ~acts=mk({|¦let foo = 1 in foo|}) @ mv_r_token(1),
+    ~goal={|let¦ foo = 1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token 2",
+    ~acts=mk({|let¦ foo = 1 in foo|}) @ mv_r_token(1),
+    ~goal={|let ¦foo = 1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token 3",
+    ~acts=mk({|let ¦foo = 1 in foo|}) @ mv_r_token(1),
+    ~goal={|let foo¦ = 1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token 4",
+    ~acts=mk({|let foo¦ = 1 in foo|}) @ mv_r_token(1),
+    ~goal={|let foo ¦= 1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token 5",
+    ~acts=mk({|let foo ¦= 1 in foo|}) @ mv_r_token(1),
+    ~goal={|let foo =¦ 1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token 6",
+    ~acts=mk({|let foo =¦ 1 in foo|}) @ mv_r_token(1),
+    ~goal={|let foo = ¦1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token 7",
+    ~acts=mk({|let foo = ¦1 in foo|}) @ mv_r_token(1),
+    ~goal={|let foo = 1¦ in foo|},
+  ),
+  test(
+    ~name="Caret movement by token 8",
+    ~acts=mk({|let foo = 1¦ in foo|}) @ mv_r_token(1),
+    ~goal={|let foo = 1 ¦in foo|},
+  ),
+  test(
+    ~name="Caret movement by token 9",
+    ~acts=mk({|let foo = 1 ¦in foo|}) @ mv_r_token(1),
+    ~goal={|let foo = 1 in¦ foo|},
+  ),
+  test(
+    ~name="Caret movement by token 10",
+    ~acts=mk({|let foo = 1 in¦ foo|}) @ mv_r_token(1),
+    ~goal={|let foo = 1 in ¦foo|},
+  ),
+  test(
+    ~name="Caret movement by token 11",
+    ~acts=mk({|let foo = 1 in ¦foo|}) @ mv_r_token(1),
+    ~goal={|let foo = 1 in foo¦|},
+  ),
+  // ByToken Left Complete Syntax
+  test(
+    ~name="Caret movement by token Left 1",
+    ~acts=mk({|let foo = 1 in foo¦|}) @ mv_l_token(1),
+    ~goal={|let foo = 1 in ¦foo|},
+  ),
+  test(
+    ~name="Caret movement by token Left 2",
+    ~acts=mk({|let foo = 1 in ¦foo|}) @ mv_l_token(1),
+    ~goal={|let foo = 1 in¦ foo|},
+  ),
+  test(
+    ~name="Caret movement by token Left 3",
+    ~acts=mk({|let foo = 1 in¦ foo|}) @ mv_l_token(1),
+    ~goal={|let foo = 1 ¦in foo|},
+  ),
+  test(
+    ~name="Caret movement by token Left 4",
+    ~acts=mk({|let foo = 1 ¦in foo|}) @ mv_l_token(1),
+    ~goal={|let foo = 1¦ in foo|},
+  ),
+  test(
+    ~name="Caret movement by token Left 5",
+    ~acts=mk({|let foo = 1¦ in foo|}) @ mv_l_token(1),
+    ~goal={|let foo = ¦1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token Left 6",
+    ~acts=mk({|let foo = ¦1 in foo|}) @ mv_l_token(1),
+    ~goal={|let foo =¦ 1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token Left 7",
+    ~acts=mk({|let foo =¦ 1 in foo|}) @ mv_l_token(1),
+    ~goal={|let foo ¦= 1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token Left 8",
+    ~acts=mk({|let foo ¦= 1 in foo|}) @ mv_l_token(1),
+    ~goal={|let foo¦ = 1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token Left 9",
+    ~acts=mk({|let foo¦ = 1 in foo|}) @ mv_l_token(1),
+    ~goal={|let ¦foo = 1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token Left 10",
+    ~acts=mk({|let ¦foo = 1 in foo|}) @ mv_l_token(1),
+    ~goal={|let¦ foo = 1 in foo|},
+  ),
+  test(
+    ~name="Caret movement by token Left 11",
+    ~acts=mk({|let¦ foo = 1 in foo|}) @ mv_l_token(1),
+    ~goal={|¦let foo = 1 in foo|},
+  ),
+  // ByToken Escapes inside if starts inside token
+  test(
+    ~name="ByToken escapes token left",
+    ~acts=mk({|foo¦bar|}) @ mv_l_token(1),
+    ~goal={|¦foobar|},
+  ),
+  test(
+    ~name="ByToken escapes token right",
+    ~acts=mk({|foo¦bar|}) @ mv_r_token(1),
+    ~goal={|foobar¦|},
+  ),
+  // ByChar Complete Syntax
+  test(
+    ~name="Caret movement 3-delim R 1",
+    ~acts=mk({|¦if 1 then 2 else 3|}) @ mv_r(1),
+    ~goal={|i¦f 1 then 2 else 3|},
+  ),
+  test(
+    ~name="Caret movement 3-delim R 2",
+    ~acts=mk({|if 1 ¦then 2 else 3|}) @ mv_r(1),
+    ~goal={|if 1 t¦hen 2 else 3|},
+  ),
+  test(
+    ~name="Caret movement 3-delim R 3",
+    ~acts=mk({|if 1 the¦n 2 else 3|}) @ mv_r(1),
+    ~goal={|if 1 then¦ 2 else 3|},
+  ),
+  test(
+    ~name="Caret movement 3-delim L 1",
+    ~acts=mk({|if 1 then¦ 2 else 3|}) @ mv_l(1),
+    ~goal={|if 1 the¦n 2 else 3|},
+  ),
+  test(
+    ~name="Caret movement 3-delim L 2",
+    ~acts=mk({|if 1 th¦en 2 else 3|}) @ mv_l(1),
+    ~goal={|if 1 t¦hen 2 else 3|},
+  ),
+  test(
+    ~name="Caret movement 3-delim L 3",
+    ~acts=mk({|if 1 t¦hen 2 else 3|}) @ mv_l(1),
+    ~goal={|if 1 ¦then 2 else 3|},
+  ),
+  test(
+    ~name="Caret movement takes into account which shards are down - Right",
+    ~acts=mk({|if¦ 1 then 2 else 3|}) @ [Destruct(Left), ...mv_r(4)],
+    ~goal={| 1 t¦hen 2 else 3|},
+  ),
+  test(
+    ~name="Caret movement takes into account which shards are down - Left",
+    ~acts=
+      mk({|if¦ 1 then 2 else 3|}) @ [Destruct(Left)] @ mv_r(7) @ mv_l(1),
+    ~goal={| 1 the¦n 2 else 3|},
   ),
 ];
 
@@ -234,4 +422,5 @@ let tests = [
   ("Editing.Basic", basic_tests),
   ("Editing.Insertion", insertion_tests),
   ("Editing.Destruction", destruct_tests),
+  ("Editing.Move", move_tests),
 ];

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -151,16 +151,28 @@ let basic_tests = [
     // suceeds but crashes later with split_kids
     ~goal={|1:(+¦ +A)|},
   ),
-  // test(
-  //   ~name="Merge two prefix op !s into bin op !!",
-  //   ~acts=mk("! ! X¦") @ mv_l(3) @ [Destruct(Left)],
-  //   ~goal={|?!¦! X|},
-  // ),
-  // test(
-  //   ~name="Split ++ op in type sort context",
-  //   ~acts=mk("1:(++A)¦") @ mv_l(3) @ [Insert(" ")],
-  //   ~goal={|1:(+?¦+A)|},
-  // ),
+  test(
+    ~name="Split ++ op in type sort context",
+    ~acts=mk({|1:(++A)¦|}) @ mv_l(3) @ [Insert(" ")],
+    ~goal={|1:(+ ¦+A)|},
+  ),
+  test(
+    ~name="Split !! infix op !s into prefix ops !]",
+    ~acts=mk("!¦! X") @ [Insert(" ")],
+    ~goal={|! ¦! X|},
+  ),
+  //wrong caret placement (and its in weird escapee mode...)
+  test(
+    ~name="Merge 2 prefix ops ! into infix op !!",
+    ~acts=mk("! ! X¦") @ mv_l(3) @ [Destruct(Left)],
+    ~goal={|?!¦! X|},
+  ),
+  // wrong caret placement (and its in weird escapee mode...)
+  test(
+    ~name="Merge + + ops in type sort context",
+    ~acts=mk({|1:(+ ¦+A)|}) @ [Destruct(Left)],
+    ~goal={|1:(?+¦+A)|},
+  ),
 ];
 
 let insertion_tests = [

--- a/test/Test_Introduce.re
+++ b/test/Test_Introduce.re
@@ -38,7 +38,7 @@ let introduction_test = (before: string, expected: string) => {
     module S = (val Editor.Model.to_move_s(Editor.Model.mk(zip)));
     module Move = Move.Make(S);
     module Select = Select.Make(S);
-    let* zip = Move.jump_to_id(zip, hole_id);
+    let* zip = Move.jump_to_side_of_id(Left, zip, hole_id);
     let* zip = Move.go(Local(Right(ByChar)), zip); // To get on the hole itself
     let* zip =
       Select.current_term(~defs_exclude_bodies=false, ~case_rules=false, zip);

--- a/test/evaluator/Test_Evaluator_Builtins.re
+++ b/test/evaluator/Test_Evaluator_Builtins.re
@@ -90,23 +90,23 @@ let tests = (
     ),
     test_case("string_replace", `Quick, () =>
       evaluation_test(
-        {|string_replace(("hazel", "hazel hazel", "world"))|},
-        string("world world"),
+        {|string_replace(("ha+zel", "haazelhzel", "world"))|},
+        string("worldworld"),
         ap(
           Forward,
           builtin_fun("string_replace"),
-          tuple([string("hazel"), string("hazel hazel"), string("world")]),
+          tuple([string("ha*zel"), string("hazelhzel"), string("world")]),
         ),
       )
     ),
     test_case("string_search found", `Quick, () =>
       evaluation_test(
-        {|string_search(("haz", "hazel", 0))|},
+        {|string_search(("h.+z", "hazel", 0))|},
         int(0),
         ap(
           Forward,
           builtin_fun("string_search"),
-          tuple([string("haz"), string("hazel"), int(0)]),
+          tuple([string("h.+z"), string("hazel"), int(0)]),
         ),
       )
     ),


### PR DESCRIPTION
This PR fixes all outstanding syntax system issues which I've added or been assigned. Or at least the ones which are strictly bugs as opposed to design flaws.

Core Editing:
Closes #1753: Recently introduced bug which hard crashes on deleting any leading delimiter.
Closes #1724: Ancient and mysterious many-headed exception-throwing syntax bug dating back to pre haz3l tylr code. This should also fix the issue with the hinted tests form
Closes #1115: Longstanding movement edge case bug
Closes #1470: Remold bug
Closes #1354: 'Elaboration returns none' for incomplete case
Closes #1253: Bug when pasting string literal splits tokens
Closes #1259: Certain delimiters cannot be entered
Closes #1362: Selection decoration gets wrong shape on spaces near grout
Closes #1596: No longer suggest floating point exponentiation operator at the expense of multiplication
Closes #1759: Crashes on deleting/adding leading operands/operators in prefixed sum types
Closes #1767

Misc:
Closes #1755: String regexp builtins were broken
Closes #1727: Resolves the mold ambiguity warning in the console, and quiets a livelit warning
Closes #1702: ExplainThis embedded editors get horizontal scrolls if necessary
Closes #1564: Jump to id edge case fix

Others:
- Alphabetizes builtins (just functions, not types or constructors)
- Related to #1354 I made some adjustments to sort conflict styles aimed to reduce visual noise, mostly around entering case expressions. The angry red tile decoration when on unrecognized operators is reduced (it's annoying for freshly inserted rule bars in cases especially), and inconsistent-sorted tokens now just use the same color as expressions. This is less informative but less shouty, a good balance for now I think until we have a better experience around deferring yelling at the user during entry.
- Renames incorrectly-named Rul constructor Hole to MultiHole
- Editing movement tests
