### PR TITLE
Add failing test for inserting let binding before prefix negation

### DIFF
--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -198,6 +198,22 @@ let insertion_tests = [
     ~acts=mk({|if the¦else|}) @ [Insert("n"), Insert(" ")],
     ~goal={|if? then?¦else?|},
   ),
+    test(
+    ~name="Insert let binding before prefix negation",
+    ~acts=
+      mk({|¦-_|})
+      @ [
+        Insert("l"),
+        Insert("e"),
+        Insert("t"),
+        Insert(" "),
+        Insert("x"),
+        Insert("="),
+        Insert(" "),
+        Move(Local(Right(ByChar))),
+      ],
+    ~goal={|let x = -¦_|},
+  ),
 ];
 
 let destruct_tests = [


### PR DESCRIPTION
Just adding the failing test here to track the issue. I'm not sure how to address it yet.