### PR TITLE
Fix type of sort function and make string_compare compatible

### DIFF
--- a/src/language/builtins/BuiltinsBase.re
+++ b/src/language/builtins/BuiltinsBase.re
@@ -1,7 +1,6 @@
 open Util;
 open OptUtil.Syntax;
 open BuiltinsUtil;
-
 module Fresh = IdTagged.FreshGrammar;
 
 open Fresh.Typ;
@@ -272,15 +271,19 @@ let string_fns: list(BuiltinsUtil.fn) = [
       Some(Exp.int(String.length(s)));
     },
   },
-  {
+  BuiltinsADT.{
     name: "string_compare",
     arg: Prod([string(), string()]),
-    ret: Atom(Int),
+    ret: Ord.t.term,
     imp:
       binary((d1, d2) => {
         let-unbox s1 = (Atom(String), d1);
         let-unbox s2 = (Atom(String), d2);
-        Some(Exp.int(String.compare(s1, s2)));
+        switch (String.compare(s1, s2)) {
+        | 0 => Some(Ord.eq)
+        | n when n < 0 => Some(Ord.lt)
+        | _ => Some(Ord.gt)
+        };
       }),
   },
   {

--- a/src/language/builtins/BuiltinsList.re
+++ b/src/language/builtins/BuiltinsList.re
@@ -2384,7 +2384,7 @@ let go: ([?], [?], [?]) -> [?] =
     name: "sort",
     arg:
       Prod([
-        arrow(prod([unknown(Internal), unknown(Internal)]), int()),
+        arrow(prod([unknown(Internal), unknown(Internal)]), Ord.t),
         list(unknown(Internal)),
       ]),
     ret: List(unknown(Internal)),

--- a/test/evaluator/Test_Evaluator_Builtins.re
+++ b/test/evaluator/Test_Evaluator_Builtins.re
@@ -17,7 +17,7 @@ let tests = (
     test_case("Multi-arg builtin with ascription", `Quick, () =>
       evaluation_test(
         {|string_compare(("Hello", "World"):(?, ?))|},
-        int(-1),
+        BuiltinsADT.Ord.lt,
         ap(
           Forward,
           builtin_fun("string_compare"),
@@ -37,7 +37,7 @@ let tests = (
     test_case("Multi arg builtin ascription", `Quick, () =>
       evaluation_test(
         {|string_compare(("Hello": ?, "World": ?):(?, ?))|},
-        int(-1),
+        BuiltinsADT.Ord.lt,
         ap(
           Forward,
           builtin_fun("string_compare"),


### PR DESCRIPTION
Fixes the type of the builtin sort to have a comparator that returns Ord.t as opposed to int to be compatible with it's dynamics. Also changed string_compare to return Ord.t so you can do:

```hazel
sort(string_compare,["ab", "", "ca","Al","T","c"])
```
Without converting between int and Ord.t