### PR TITLE
Move proof internals into Language

### DIFF
--- a/src/language/proof/Axioms.re
+++ b/src/language/proof/Axioms.re
@@ -1,5 +1,3 @@
-open Language;
-
 let v: ProofCtx.t =
   []
   |> ProofCtx.add_entry(

--- a/src/language/proof/MatchExp.re
+++ b/src/language/proof/MatchExp.re
@@ -1,6 +1,5 @@
 open Util;
 open OptUtil.Syntax;
-open Language;
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type match_ctx = list((string, option(Exp.t)));

--- a/src/language/proof/ProofCtx.re
+++ b/src/language/proof/ProofCtx.re
@@ -1,5 +1,3 @@
-open Language;
-
 type entry = {
   name: string,
   exp: Exp.t,

--- a/src/language/proof/ProofHacks.re
+++ b/src/language/proof/ProofHacks.re
@@ -1,6 +1,5 @@
 open Util;
 open OptUtil.Syntax;
-open Language;
 // Find exp with id using ugly exception route
 
 exception Found(Exp.t);

--- a/src/language/proof/ProofRule.re
+++ b/src/language/proof/ProofRule.re
@@ -1,5 +1,4 @@
 open Util;
-open Language;
 type conclusion =
   | Equality(Exp.t, Exp.t)
   | Other(Exp.t);


### PR DESCRIPTION
Moves the files that deal with exps in proof steps into the language folder where they belong.