### PR TITLE
Stepper lists variable names in substitution

### DIFF
--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -246,7 +246,6 @@ module Transition = (EV: EV_MODE) => {
         is_value: false,
       });
     | Let(dp, d1, d2) =>
-      print_endline(Term.Pat.show(dp));
       let. _ = otherwise(env, d1 => Let(dp, d1, d2) |> rewrap)
       and. d1' =
         req_final(req(state, env), d1 => Let1(dp, d1, d2) |> wrap_ctx, d1);
@@ -257,7 +256,8 @@ module Transition = (EV: EV_MODE) => {
         | IndetMatch
         | DoesNotMatch => ""
         | Matches(env) =>
-          VarBstMap.Ordered.to_listk(env)
+          VarBstMap.Ordered.to_listo(env)
+          |> List.rev
           |> List.map(((s, _)) => s)
           |> String.concat(", ")
         };

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -50,7 +50,7 @@ type step_kind =
   | InvalidStep
   | VarLookup
   | Seq
-  | LetBind
+  | LetBind(string)
   | WrapClosure
   | FixUnwrap
   | FixClosure
@@ -246,16 +246,27 @@ module Transition = (EV: EV_MODE) => {
         is_value: false,
       });
     | Let(dp, d1, d2) =>
+      print_endline(Term.Pat.show(dp));
       let. _ = otherwise(env, d1 => Let(dp, d1, d2) |> rewrap)
       and. d1' =
         req_final(req(state, env), d1 => Let1(dp, d1, d2) |> wrap_ctx, d1);
       let.wrap_closure _ = env;
       let {matches, closures} = matches(dp, d1');
+      let matches_str = {
+        switch (matches) {
+        | IndetMatch
+        | DoesNotMatch => ""
+        | Matches(env) =>
+          VarBstMap.Ordered.to_listk(env)
+          |> List.map(((s, _)) => s)
+          |> String.concat(", ")
+        };
+      };
       let.match env' = (env, matches, env.call_stack);
       Step({
         expr: subst_env(env', d2),
         state_update: capture_closures(env, state, closures),
-        kind: LetBind,
+        kind: LetBind(matches_str),
         is_value: false,
       });
     | TypFun(_)
@@ -869,7 +880,7 @@ module Transition = (EV: EV_MODE) => {
 
 let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
   fun
-  | LetBind
+  | LetBind(_)
   | Seq
   | UpdateTest
   | TypFunAp
@@ -901,7 +912,7 @@ let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
 
 let stepper_justification: step_kind => string =
   fun
-  | LetBind => "substitution"
+  | LetBind(s) => String.cat("substitution for ", s)
   | Seq => "sequence"
   | FixUnwrap => "unroll fixpoint"
   | UpdateTest => "update test"


### PR DESCRIPTION
Added which variables are being substituted in justification for substitution in let expressions.

<img width="1077" height="124" alt="Screenshot 2025-07-15 at 1 12 19 PM" src="https://github.com/user-attachments/assets/4e541f57-fe6e-4e09-85f4-a8e4746e84ed" />
