### PR TITLE
Use more beginner friendly `git clone` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ can also be accessed at:
 If you already have `ocaml` version 5.2.0, at least version 2.0 of `opam`, and `npm`
 installed, you can build Hazel by running the following commands.
 
-- `git clone git@github.com:hazelgrove/hazel.git`
+- `git clone https://github.com/hazelgrove/hazel.git`
 - `cd hazel`
 - `make deps`
 - `make dev`
@@ -147,7 +147,7 @@ To obtain an clean build, you may need to:
   enter the project root of your cloned Hazel project.
 
   ```sh
-  git clone git@github.com:hazelgrove/hazel.git
+  git clone https://github.com/hazelgrove/hazel.git
   cd hazel
   ```
 


### PR DESCRIPTION
My session trying to clone hazel after seeing the super impressive talk and web demo:

```
~/code/world
% git clone git@github.com:hazelgrove/hazel.git
Cloning into 'hazel'...
The authenticity of host 'github.com (140.82.112.3)' can't be established.
ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

~/code/world took 3s
128 % cd hazel
cd: no such file or directory: hazel

~/code/world
1 % ls

~/code/world
% git clone https://github.com/hazelgrove/hazel.git
Cloning into 'hazel'...
remote: Enumerating objects: 186865, done.
remote: Counting objects: 100% (3286/3286), done.
remote: Compressing objects: 100% (1031/1031), done.
remote: Total 186865 (delta 2783), reused 2351 (delta 2251), pack-reused 183579 (from 3)
Receiving objects: 100% (186865/186865), 178.48 MiB | 12.04 MiB/s, done.
Resolving deltas: 100% (140802/140802), done.
```


Cloning from the public URL means a beginner user doesn't have to have git ssh keys set up, though it may require `gh auth` to be able to push back seamlessly? I'm not sure.