### PR TITLE
Fix INSTALL.md 'til next dep update

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -133,6 +133,11 @@ follow these instructions instead of the shorter instructions in the
   eval $(opam env --switch=5.2.0)
   ```
 
+- Add the opam archive (TODO Remove this at next release version bump)
+- ```sh
+  opam repo add archive git+https://github.com/ocaml/opam-repository-archive
+  ```
+
 ## Clone the Source Code
 
 - Pick a directory that you want to be the parent of the directory that contains


### PR DESCRIPTION
Necessary to avoid this err with current directions at least on Mac.

```
% make deps
opam update

<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><>  🐫
[default] no changes from https://opam.ocaml.org
opam install ./hazel.opam.locked --deps-only --with-test --with-doc
[ERROR] Package conflict!
  * Missing dependency:
    - deps-of-hazel → ppx_deriving_qcheck < 0.7
    no matching version

No solution found, exiting
make: *** [deps] Error 20
```

Ref:
https://github.com/ocaml/opam-repository/issues/28065#issuecomment-2995585882