### PR TITLE
Remove Dynamic Typing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,17 @@ release-student: setup-student
 echo-html-dir:
 	@echo $(HTML_DIR)
 
-serve:
-	cd $(HTML_DIR); python3 -m http.server 8000 --bind 0.0.0.0
+unserve:
+	@pids=$$(lsof -t -i:8000 -sTCP:LISTEN); \
+	if [ $$(echo $$pids | wc -w) -eq 1 ]; then \
+		echo "Killing process on port 8000 with PID $$pids"; \
+		kill -9 $$pids; \
+	else \
+		echo "Not killing: found $$(echo $$pids | wc -w) processes on port 8000"; \
+	fi
+
+serve:  unserve
+	cd $(HTML_DIR); python3 -m http.server 8000 --bind 0.0.0.0 &
 
 hot:
 	npx vite

--- a/src/haz3lcore/TyDi/ErrorPrint.re
+++ b/src/haz3lcore/TyDi/ErrorPrint.re
@@ -37,6 +37,7 @@ module Print = {
   };
 
   let typ = (ty: Typ.t): string => term(Typ(ty));
+  let prov = (prov: Typ.provenance): string => Typ.show_provenance(prov); // TODO: Pretty
 };
 
 let prn = Printf.sprintf;
@@ -62,8 +63,13 @@ let common_error: Info.error_common => string =
       Print.typ(ana),
       Print.typ(syn),
     )
-  | AsymmetricUnknown(ty, _) =>
-    prn("Unfilled type hole. Fill with %s", Print.typ(ty));
+  | AsymmetricUnknown(ty, h, p) =>
+    prn(
+      "Unfilled type hole (id: %s) in sub-part %s. Fill with %s",
+      Hole.rep_id(h) |> Uuidm.to_string,
+      Print.prov(p),
+      Print.typ(ty),
+    );
 
 let exp_error: Info.error_exp => string =
   fun

--- a/src/haz3lcore/TyDi/ErrorPrint.re
+++ b/src/haz3lcore/TyDi/ErrorPrint.re
@@ -62,7 +62,7 @@ let common_error: Info.error_common => string =
       Print.typ(ana),
       Print.typ(syn),
     )
-  | AsymmetricUnknown(ty) =>
+  | AsymmetricUnknown(ty, _) =>
     prn("Unfilled type hole. Fill with %s", Print.typ(ty));
 
 let exp_error: Info.error_exp => string =

--- a/src/haz3lcore/TyDi/ErrorPrint.re
+++ b/src/haz3lcore/TyDi/ErrorPrint.re
@@ -61,7 +61,9 @@ let common_error: Info.error_common => string =
       "Expecting type %s but got inconsistent type %s",
       Print.typ(ana),
       Print.typ(syn),
-    );
+    )
+  | AsymmetricUnknown(ty) =>
+    prn("Unfilled type hole. Fill with %s", Print.typ(ty));
 
 let exp_error: Info.error_exp => string =
   fun

--- a/src/haz3lcore/TyDi/TyDiForms.re
+++ b/src/haz3lcore/TyDi/TyDiForms.re
@@ -10,7 +10,7 @@ let leading_expander = " ";
  * running Statics, but for now, new forms e.g. operators must be added
  * below manually.  */
 module Typ = {
-  let unk: Typ.t = Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh;
+  let unk: Typ.t = Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.fresh;
 
   let of_const_mono_delim: list((Token.t, Typ.t)) = [
     ("true", Atom(Bool) |> Typ.fresh),

--- a/src/haz3lcore/TyDi/TyDiForms.re
+++ b/src/haz3lcore/TyDi/TyDiForms.re
@@ -10,7 +10,7 @@ let leading_expander = " ";
  * running Statics, but for now, new forms e.g. operators must be added
  * below manually.  */
 module Typ = {
-  let unk: Typ.t = Unknown(Internal) |> Typ.fresh;
+  let unk: Typ.t = Unknown(Ana) |> Typ.fresh;
 
   let of_const_mono_delim: list((Token.t, Typ.t)) = [
     ("true", Atom(Bool) |> Typ.fresh),
@@ -33,10 +33,10 @@ module Typ = {
 
   let of_infix_delim: list((Token.t, Typ.term)) = [
     //("|>", Unknown(Internal)), /* annoying during case rules */
-    (",", Prod([unk, unk])), /* NOTE: Current approach doesn't work for this, but irrelevant as 1-char */
+    (",", Prod([Typ.fresh(Unknown(Ana)), Typ.fresh(Unknown(Ana))])), /* NOTE: Current approach doesn't work for this, but irrelevant as 1-char */
     //("::", List(unk)), /* annoying in patterns. TODO: add codepath to show only if Ana(List(_)) */
-    ("@", List(unk)),
-    (";", Unknown(Internal)),
+    ("@", List(Typ.fresh(Unknown(Ana)))),
+    (";", Unknown(Ana)),
     ("&&", Atom(Bool)),
     ("\\/", Atom(Bool)),
     //("||", Atom(Bool)),
@@ -71,7 +71,7 @@ module Typ = {
     fun
     | InfoExp({ana, _})
     | InfoPat({ana, _}) => ana
-    | _ => Unknown(Internal) |> Typ.fresh;
+    | _ => Unknown(Ana) |> Typ.fresh;
 
   let filter_by =
       (

--- a/src/haz3lcore/TyDi/TyDiForms.re
+++ b/src/haz3lcore/TyDi/TyDiForms.re
@@ -10,7 +10,7 @@ let leading_expander = " ";
  * running Statics, but for now, new forms e.g. operators must be added
  * below manually.  */
 module Typ = {
-  let unk: Typ.t = Unknown(Ana) |> Typ.fresh;
+  let unk: Typ.t = Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh;
 
   let of_const_mono_delim: list((Token.t, Typ.t)) = [
     ("true", Atom(Bool) |> Typ.fresh),
@@ -33,10 +33,10 @@ module Typ = {
 
   let of_infix_delim: list((Token.t, Typ.term)) = [
     //("|>", Unknown(Internal)), /* annoying during case rules */
-    (",", Prod([Typ.fresh(Unknown(Ana)), Typ.fresh(Unknown(Ana))])), /* NOTE: Current approach doesn't work for this, but irrelevant as 1-char */
+    (",", Prod([unk, unk])), /* NOTE: Current approach doesn't work for this, but irrelevant as 1-char */
     //("::", List(unk)), /* annoying in patterns. TODO: add codepath to show only if Ana(List(_)) */
-    ("@", List(Typ.fresh(Unknown(Ana)))),
-    (";", Unknown(Ana)),
+    ("@", List(unk)),
+    (";", unk.term),
     ("&&", Atom(Bool)),
     ("\\/", Atom(Bool)),
     //("||", Atom(Bool)),
@@ -71,7 +71,7 @@ module Typ = {
     fun
     | InfoExp({ana, _})
     | InfoPat({ana, _}) => ana
-    | _ => Unknown(Ana) |> Typ.fresh;
+    | _ => unk;
 
   let filter_by =
       (

--- a/src/haz3lcore/lang/MakeTerm.re
+++ b/src/haz3lcore/lang/MakeTerm.re
@@ -602,7 +602,7 @@ and typ = unsorted => {
 }
 and typ_term: unsorted => (Typ.term, list(Id.t)) = {
   let ret = (term: Typ.term) => (term, []);
-  let hole = unsorted => Typ.hole_syn(kids_of_unsorted(unsorted));
+  let hole = unsorted => Typ.hole_typ(kids_of_unsorted(unsorted));
   fun
   | Op(tiles) as tm =>
     switch (tiles) {
@@ -623,7 +623,7 @@ and typ_term: unsorted => (Typ.term, list(Id.t)) = {
         | ([t], []) when is_hole_label(t) => hole(tm)
         | ([t], []) =>
           Unknown(
-            Syn,
+            Type,
             {
               term: Invalid(t),
               annotation: {

--- a/src/haz3lcore/lang/MakeTerm.re
+++ b/src/haz3lcore/lang/MakeTerm.re
@@ -602,11 +602,11 @@ and typ = unsorted => {
 }
 and typ_term: unsorted => (Typ.term, list(Id.t)) = {
   let ret = (term: Typ.term) => (term, []);
-  let hole = unsorted => Typ.hole(kids_of_unsorted(unsorted));
+  let hole = unsorted => Typ.hole_syn(kids_of_unsorted(unsorted));
   fun
   | Op(tiles) as tm =>
     switch (tiles) {
-    | ([(_id, tile)], []) =>
+    | ([(id, tile)], []) =>
       ret(
         switch (tile) {
         | ([t], []) when Form.is_empty_tuple(t) => Prod([])
@@ -621,7 +621,17 @@ and typ_term: unsorted => (Typ.term, list(Id.t)) = {
         | (label, [Typ(body)]) when is_probe_wrap(label) => body.term
         | (["[", "]"], [Typ(body)]) => List(body)
         | ([t], []) when is_hole_label(t) => hole(tm)
-        | ([t], []) => Unknown(Hole(Invalid(t)))
+        | ([t], []) =>
+          Unknown(
+            Syn,
+            {
+              term: Invalid(t),
+              annotation: {
+                ids: [id],
+              },
+            },
+            Atom,
+          )
         | _ => hole(tm)
         },
       )

--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -128,7 +128,7 @@ let external_precedence_pat = (dp: Pat.t) =>
 let external_precedence_typ = (tp: Typ.t) =>
   switch (Typ.term_of(tp)) {
   // Matt: I think multiholes are min because we don't know the precedence of the `⟩?⟨`s
-  | Unknown(Hole(MultiHole(_))) => Precedence.min
+  | Unknown(_, {term: MultiHole(_), _}, _) => Precedence.min
 
   // Indivisible forms never need parentheses around them
   | Unknown(_)
@@ -461,9 +461,14 @@ and parenthesize_typ =
   let (term, rewrap) = Typ.unwrap(typ);
   switch (term) {
   // Other forms
-  | Unknown(Hole(MultiHole(xs))) =>
+  | Unknown(m, {term: MultiHole(xs), annotation}, p) =>
     Unknown(
-      Hole(MultiHole(List.map(parenthesize_any(~show_filters), xs))),
+      m,
+      {
+        term: MultiHole(List.map(parenthesize_any(~show_filters), xs)),
+        annotation,
+      },
+      p,
     )
     |> rewrap
   | Parens(t) =>
@@ -1229,9 +1234,9 @@ and typ_to_pretty = (~settings: Settings.t, typ: Typ.t): pretty => {
       }
     | BadEntry(x) => go(x);
   switch (typ |> Typ.term_of) {
-  | Unknown(Hole(Invalid(s))) =>
+  | Unknown(_, {term: Invalid(s), _}, _) =>
     text_to_pretty(typ |> Typ.rep_id, Sort.Typ, s)
-  | Unknown(Hole(MultiHole(es))) =>
+  | Unknown(_, {term: MultiHole(es), _}, _) =>
     let id = typ |> Typ.rep_id;
     let+ es = es |> List.map(any_to_pretty(~settings: Settings.t)) |> all;
     ListUtil.flat_intersperse(

--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -127,11 +127,11 @@ let external_precedence_pat = (dp: Pat.t) =>
 
 let external_precedence_typ = (tp: Typ.t) =>
   switch (Typ.term_of(tp)) {
+  // Matt: I think multiholes are min because we don't know the precedence of the `⟩?⟨`s
+  | Unknown(Hole(MultiHole(_))) => Precedence.min
+
   // Indivisible forms never need parentheses around them
-  | Unknown(Hole(Invalid(_)))
-  | Unknown(Internal)
-  | Unknown(SynSwitch)
-  | Unknown(Hole(EmptyHole))
+  | Unknown(_)
   | Var(_)
   | Atom(_)
   | Label(_)
@@ -148,9 +148,6 @@ let external_precedence_typ = (tp: Typ.t) =>
   | Sum(_) => Precedence.type_plus
   | Rec(_, _) => Precedence.let_
   | Forall(_, _) => Precedence.let_
-
-  // Matt: I think multiholes are min because we don't know the precedence of the `⟩?⟨`s
-  | Unknown(Hole(MultiHole(_))) => Precedence.min
   };
 
 let paren_at = (internal_precedence: Precedence.t, exp: Exp.t): Exp.t =>
@@ -463,15 +460,12 @@ and parenthesize_typ =
   let parenthesize_typ = parenthesize_typ(~show_filters);
   let (term, rewrap) = Typ.unwrap(typ);
   switch (term) {
-  // Indivisible forms dont' change
-  | Var(_)
-  | Unknown(Hole(Invalid(_)))
-  | Unknown(Internal)
-  | Unknown(SynSwitch)
-  | Unknown(Hole(EmptyHole))
-  | Atom(_) => typ
-
   // Other forms
+  | Unknown(Hole(MultiHole(xs))) =>
+    Unknown(
+      Hole(MultiHole(List.map(parenthesize_any(~show_filters), xs))),
+    )
+    |> rewrap
   | Parens(t) =>
     Parens(
       parenthesize_typ(~already_paren=true, t)
@@ -529,11 +523,10 @@ and parenthesize_typ =
       ),
     )
     |> rewrap
-  | Unknown(Hole(MultiHole(xs))) =>
-    Unknown(
-      Hole(MultiHole(List.map(parenthesize_any(~show_filters), xs))),
-    )
-    |> rewrap
+  // Indivisible forms dont' change
+  | Var(_)
+  | Unknown(_)
+  | Atom(_) => typ
   };
 }
 
@@ -1238,9 +1231,17 @@ and typ_to_pretty = (~settings: Settings.t, typ: Typ.t): pretty => {
   switch (typ |> Typ.term_of) {
   | Unknown(Hole(Invalid(s))) =>
     text_to_pretty(typ |> Typ.rep_id, Sort.Typ, s)
-  | Unknown(Internal)
-  | Unknown(SynSwitch)
-  | Unknown(Hole(EmptyHole)) =>
+  | Unknown(Hole(MultiHole(es))) =>
+    let id = typ |> Typ.rep_id;
+    let+ es = es |> List.map(any_to_pretty(~settings: Settings.t)) |> all;
+    ListUtil.flat_intersperse(
+      Grout({
+        id,
+        shape: Concave,
+      }),
+      es,
+    );
+  | Unknown(_) =>
     if (settings.show_unknown_as_hole) {
       let id = typ |> Typ.rep_id;
       p_just([
@@ -1252,16 +1253,6 @@ and typ_to_pretty = (~settings: Settings.t, typ: Typ.t): pretty => {
     } else {
       text_to_pretty(typ |> Typ.rep_id, Sort.Typ, "?");
     }
-  | Unknown(Hole(MultiHole(es))) =>
-    let id = typ |> Typ.rep_id;
-    let+ es = es |> List.map(any_to_pretty(~settings: Settings.t)) |> all;
-    ListUtil.flat_intersperse(
-      Grout({
-        id,
-        shape: Concave,
-      }),
-      es,
-    );
 
   | Var(v) => text_to_pretty(typ |> Typ.rep_id, Sort.Typ, v)
   | Atom(Int) => text_to_pretty(typ |> Typ.rep_id, Sort.Typ, "Int")

--- a/src/haz3lcore/projectors/implementations/TypeProj.re
+++ b/src/haz3lcore/projectors/implementations/TypeProj.re
@@ -20,7 +20,7 @@ let self_ty = (info: option(Info.t)): option(Typ.t) =>
 let totalize_ty = (expected_ty: option(Typ.t)): Typ.t =>
   switch (expected_ty) {
   | Some(expected_ty) => expected_ty
-  | None => Typ.fresh(Unknown(Ana))
+  | None => Typ.fresh(Unknown(Syn, Hole.temp(EmptyHole), Atom))
   };
 
 module M: Projector = {
@@ -47,7 +47,7 @@ module M: Projector = {
 
   let display_ty = (model, statics): option(Typ.t) =>
     switch (model) {
-    | _ when expected_ty(statics) |> totalize_ty |> Typ.is_syn =>
+    | _ when expected_ty(statics) |> totalize_ty |> Typ.is_synswitch =>
       statics |> self_ty
     | Self => statics |> self_ty
     | Expected => statics |> expected_ty
@@ -56,7 +56,7 @@ module M: Projector = {
   let display_mode = (model: model, statics: option(Language.Info.t)): string =>
     switch (model) {
     | _ when self_ty(statics) == expected_ty(statics) => "⇔"
-    | _ when expected_ty(statics) |> totalize_ty |> Typ.is_syn => "⇒"
+    | _ when expected_ty(statics) |> totalize_ty |> Typ.is_synswitch => "⇒"
     | Self => "⇒"
     | Expected => "⇐"
     };

--- a/src/haz3lcore/projectors/implementations/TypeProj.re
+++ b/src/haz3lcore/projectors/implementations/TypeProj.re
@@ -20,7 +20,7 @@ let self_ty = (info: option(Info.t)): option(Typ.t) =>
 let totalize_ty = (expected_ty: option(Typ.t)): Typ.t =>
   switch (expected_ty) {
   | Some(expected_ty) => expected_ty
-  | None => Typ.fresh(Unknown(Syn, Hole.temp(EmptyHole), Atom))
+  | None => Typ.fresh(Unknown(Type, Hole.temp(EmptyHole), Atom))
   };
 
 module M: Projector = {

--- a/src/haz3lcore/projectors/implementations/TypeProj.re
+++ b/src/haz3lcore/projectors/implementations/TypeProj.re
@@ -20,7 +20,7 @@ let self_ty = (info: option(Info.t)): option(Typ.t) =>
 let totalize_ty = (expected_ty: option(Typ.t)): Typ.t =>
   switch (expected_ty) {
   | Some(expected_ty) => expected_ty
-  | None => Typ.fresh(Unknown(Internal))
+  | None => Typ.fresh(Unknown(Ana))
   };
 
 module M: Projector = {

--- a/src/haz3lcore/proof/ProofHacks.re
+++ b/src/haz3lcore/proof/ProofHacks.re
@@ -144,6 +144,7 @@ let dhpat_extend_ctx = (dhpat: DHPat.t, ty: Typ.t, ctx: Ctx.t): option(Ctx.t) =>
             term: ErrorHole,
             annotation: ty.annotation,
           },
+          Expr,
         );
       let* l =
         List.map2((dhp, typ) => {dhpat_var_entry(dhp, typ)}, l1, ts)

--- a/src/haz3lcore/proof/ProofHacks.re
+++ b/src/haz3lcore/proof/ProofHacks.re
@@ -134,8 +134,16 @@ let dhpat_extend_ctx = (dhpat: DHPat.t, ty: Typ.t, ctx: Ctx.t): option(Ctx.t) =>
       }
     | Tuple(l1) =>
       let (l1, ts) =
-        Typ.matched_prod(ctx, l1, Pat.match_tup_label, ty, (name, b) =>
-          TupLabel(Label(name) |> Pat.fresh, b) |> Pat.fresh
+        Typ.matched_prod(
+          ctx,
+          l1,
+          Pat.match_tup_label,
+          ty,
+          (name, b) => TupLabel(Label(name) |> Pat.fresh, b) |> Pat.fresh,
+          {
+            term: ErrorHole,
+            annotation: ty.annotation,
+          },
         );
       let* l =
         List.map2((dhp, typ) => {dhpat_var_entry(dhp, typ)}, l1, ts)

--- a/src/language/builtins/BuiltinsADT.re
+++ b/src/language/builtins/BuiltinsADT.re
@@ -29,11 +29,11 @@ module Either = {
     sum_type([
       (
         "Left",
-        Some(Unknown(Syn, Hole.fresh(EmptyHole), Atom) |> Typ.fresh),
+        Some(Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.fresh),
       ),
       (
         "Right",
-        Some(Unknown(Syn, Hole.fresh(EmptyHole), Atom) |> Typ.fresh),
+        Some(Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.fresh),
       ),
     ]);
 
@@ -41,23 +41,23 @@ module Either = {
   let left =
     Exp.constructor(
       "Left",
-      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+      Some(Some(arrow(unknown(Type, Hole.temp(EmptyHole), Atom), t))),
     );
   let right =
     Exp.constructor(
       "Right",
-      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+      Some(Some(arrow(unknown(Type, Hole.temp(EmptyHole), Atom), t))),
     );
 
   let pat_left =
     Pat.constructor(
       "Left",
-      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+      Some(Some(arrow(unknown(Type, Hole.temp(EmptyHole), Atom), t))),
     );
   let pat_right =
     Pat.constructor(
       "Right",
-      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+      Some(Some(arrow(unknown(Type, Hole.temp(EmptyHole), Atom), t))),
     );
 };
 
@@ -67,7 +67,7 @@ module Option = {
       ("None", None),
       (
         "Some",
-        Some(Unknown(Syn, Hole.fresh(EmptyHole), Atom) |> Typ.fresh),
+        Some(Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.fresh),
       ),
     ]);
 
@@ -79,7 +79,7 @@ module Option = {
   let some =
     Exp.constructor(
       "Some",
-      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+      Some(Some(arrow(unknown(Type, Hole.temp(EmptyHole), Atom), t))),
     );
 
   let pat_none = Pat.constructor("None", Some(Some(t)));
@@ -87,7 +87,7 @@ module Option = {
   let pat_some =
     Pat.constructor(
       "Some",
-      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+      Some(Some(arrow(unknown(Type, Hole.temp(EmptyHole), Atom), t))),
     );
 
   let builtins: list(hazel_fn) = [
@@ -101,11 +101,11 @@ module Option = {
         Prod([
           t,
           arrow(
-            unknown(Syn, Hole.fresh(EmptyHole), Atom),
-            unknown(Syn, Hole.fresh(EmptyHole), Atom),
+            unknown(Type, Hole.temp(EmptyHole), Atom),
+            unknown(Type, Hole.temp(EmptyHole), Atom),
           ),
         ]),
-      ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+      ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
       imp: {
         Fresh.(
           Exp.(
@@ -138,11 +138,11 @@ module Option = {
         Prod([
           t,
           arrow(
-            unknown(Syn, Hole.fresh(EmptyHole), Atom),
-            unknown(Syn, Hole.fresh(EmptyHole), Atom),
+            unknown(Type, Hole.temp(EmptyHole), Atom),
+            unknown(Type, Hole.temp(EmptyHole), Atom),
           ),
         ]),
-      ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+      ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
       imp: {
         Fresh.(
           Exp.(
@@ -168,7 +168,7 @@ module Option = {
     {
       name: "option_to_list",
       arg: t.term,
-      ret: List(unknown(Syn, Hole.fresh(EmptyHole), Atom)),
+      ret: List(unknown(Type, Hole.temp(EmptyHole), Atom)),
       str: {|fun opt -> case opt
                | None => []
                | Some x => [x]

--- a/src/language/builtins/BuiltinsADT.re
+++ b/src/language/builtins/BuiltinsADT.re
@@ -23,11 +23,12 @@ module Ord = {
   let gt_pat = Pat.constructor("Gt", Some(Some(t)));
 };
 
+// This form of polymorphism is not allowed under asymmetric unknown types, these should error!
 module Either = {
   let t: Typ.t =
     sum_type([
-      ("Left", Some(Unknown(Internal) |> Typ.fresh)),
-      ("Right", Some(Unknown(Internal) |> Typ.fresh)),
+      ("Left", Some(Unknown(Ana) |> Typ.fresh)),
+      ("Right", Some(Unknown(Ana) |> Typ.fresh)),
     ]);
 
   open IdTagged.FreshGrammar;
@@ -44,10 +45,7 @@ module Either = {
 
 module Option = {
   let t: Typ.t =
-    sum_type([
-      ("None", None),
-      ("Some", Some(Unknown(Internal) |> Typ.fresh)),
-    ]);
+    sum_type([("None", None), ("Some", Some(Unknown(Ana) |> Typ.fresh))]);
 
   open IdTagged.FreshGrammar;
 
@@ -69,8 +67,8 @@ module Option = {
                | Some(x) => Some(f(x))
              end|},
       name: "option_map",
-      arg: Prod([t, arrow(unknown(Internal), unknown(Internal))]),
-      ret: Unknown(Internal),
+      arg: Prod([t, arrow(unknown(Ana), unknown(Ana))]),
+      ret: Unknown(Ana),
       imp: {
         Fresh.(
           Exp.(
@@ -99,8 +97,8 @@ module Option = {
                | Some x => f(x)
              end|},
       name: "option_bind",
-      arg: Prod([t, arrow(unknown(Internal), unknown(Internal))]),
-      ret: Unknown(Internal),
+      arg: Prod([t, arrow(unknown(Ana), unknown(Ana))]),
+      ret: Unknown(Ana),
       imp: {
         Fresh.(
           Exp.(
@@ -126,7 +124,7 @@ module Option = {
     {
       name: "option_to_list",
       arg: t.term,
-      ret: List(unknown(Internal)),
+      ret: List(unknown(Ana)),
       str: {|fun opt -> case opt
                | None => []
                | Some x => [x]

--- a/src/language/builtins/BuiltinsADT.re
+++ b/src/language/builtins/BuiltinsADT.re
@@ -23,29 +23,53 @@ module Ord = {
   let gt_pat = Pat.constructor("Gt", Some(Some(t)));
 };
 
-// This form of polymorphism is not allowed under asymmetric unknown types, these should error!
+// This form of polymorphism is not allowed under asymmetric unknown types, these would error!
 module Either = {
   let t: Typ.t =
     sum_type([
-      ("Left", Some(Unknown(Ana) |> Typ.fresh)),
-      ("Right", Some(Unknown(Ana) |> Typ.fresh)),
+      (
+        "Left",
+        Some(Unknown(Syn, Hole.fresh(EmptyHole), Atom) |> Typ.fresh),
+      ),
+      (
+        "Right",
+        Some(Unknown(Syn, Hole.fresh(EmptyHole), Atom) |> Typ.fresh),
+      ),
     ]);
 
   open IdTagged.FreshGrammar;
   let left =
-    Exp.constructor("Left", Some(Some(arrow(unknown(SynSwitch), t))));
+    Exp.constructor(
+      "Left",
+      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+    );
   let right =
-    Exp.constructor("Right", Some(Some(arrow(unknown(SynSwitch), t))));
+    Exp.constructor(
+      "Right",
+      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+    );
 
   let pat_left =
-    Pat.constructor("Left", Some(Some(arrow(unknown(SynSwitch), t))));
+    Pat.constructor(
+      "Left",
+      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+    );
   let pat_right =
-    Pat.constructor("Right", Some(Some(arrow(unknown(SynSwitch), t))));
+    Pat.constructor(
+      "Right",
+      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+    );
 };
 
 module Option = {
   let t: Typ.t =
-    sum_type([("None", None), ("Some", Some(Unknown(Ana) |> Typ.fresh))]);
+    sum_type([
+      ("None", None),
+      (
+        "Some",
+        Some(Unknown(Syn, Hole.fresh(EmptyHole), Atom) |> Typ.fresh),
+      ),
+    ]);
 
   open IdTagged.FreshGrammar;
 
@@ -53,12 +77,18 @@ module Option = {
   let none = Exp.constructor("None", Some(Some(t)));
 
   let some =
-    Exp.constructor("Some", Some(Some(arrow(unknown(SynSwitch), t))));
+    Exp.constructor(
+      "Some",
+      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+    );
 
   let pat_none = Pat.constructor("None", Some(Some(t)));
 
   let pat_some =
-    Pat.constructor("Some", Some(Some(arrow(unknown(SynSwitch), t))));
+    Pat.constructor(
+      "Some",
+      Some(Some(arrow(unknown(Syn, Hole.fresh(EmptyHole), Atom), t))),
+    );
 
   let builtins: list(hazel_fn) = [
     {
@@ -67,8 +97,15 @@ module Option = {
                | Some(x) => Some(f(x))
              end|},
       name: "option_map",
-      arg: Prod([t, arrow(unknown(Ana), unknown(Ana))]),
-      ret: Unknown(Ana),
+      arg:
+        Prod([
+          t,
+          arrow(
+            unknown(Syn, Hole.fresh(EmptyHole), Atom),
+            unknown(Syn, Hole.fresh(EmptyHole), Atom),
+          ),
+        ]),
+      ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
       imp: {
         Fresh.(
           Exp.(
@@ -97,8 +134,15 @@ module Option = {
                | Some x => f(x)
              end|},
       name: "option_bind",
-      arg: Prod([t, arrow(unknown(Ana), unknown(Ana))]),
-      ret: Unknown(Ana),
+      arg:
+        Prod([
+          t,
+          arrow(
+            unknown(Syn, Hole.fresh(EmptyHole), Atom),
+            unknown(Syn, Hole.fresh(EmptyHole), Atom),
+          ),
+        ]),
+      ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
       imp: {
         Fresh.(
           Exp.(
@@ -124,7 +168,7 @@ module Option = {
     {
       name: "option_to_list",
       arg: t.term,
-      ret: List(unknown(Ana)),
+      ret: List(unknown(Syn, Hole.fresh(EmptyHole), Atom)),
       str: {|fun opt -> case opt
                | None => []
                | Some x => [x]

--- a/src/language/builtins/BuiltinsBase.re
+++ b/src/language/builtins/BuiltinsBase.re
@@ -451,11 +451,12 @@ let string_fns: list(BuiltinsUtil.fn) = [
   },
 ];
 
+// Note: With asymmetric unknown types this form of polymorphism is disallowed, these funs shoulder
 let pair_fns: list(BuiltinsUtil.fn) = [
   {
     name: "fst",
-    arg: Prod([unknown(Internal), unknown(Internal)]),
-    ret: Unknown(Internal),
+    arg: Prod([unknown(Ana), unknown(Ana)]),
+    ret: Unknown(Ana),
     imp: d => {
       let-unbox t = (Tuple(2), d);
       switch (t) {
@@ -466,8 +467,8 @@ let pair_fns: list(BuiltinsUtil.fn) = [
   },
   {
     name: "snd",
-    arg: Prod([unknown(Internal), unknown(Internal)]),
-    ret: Unknown(Internal),
+    arg: Prod([unknown(Ana), unknown(Ana)]),
+    ret: Unknown(Ana),
     imp: d => {
       let-unbox t = (Tuple(2), d);
       switch (t) {

--- a/src/language/builtins/BuiltinsBase.re
+++ b/src/language/builtins/BuiltinsBase.re
@@ -455,8 +455,8 @@ let string_fns: list(BuiltinsUtil.fn) = [
 let pair_fns: list(BuiltinsUtil.fn) = [
   {
     name: "fst",
-    arg: Prod([unknown(Ana), unknown(Ana)]),
-    ret: Unknown(Ana),
+    arg: Prod([empty_hole_ana(), empty_hole_ana()]),
+    ret: empty_hole_ana().term,
     imp: d => {
       let-unbox t = (Tuple(2), d);
       switch (t) {
@@ -467,8 +467,8 @@ let pair_fns: list(BuiltinsUtil.fn) = [
   },
   {
     name: "snd",
-    arg: Prod([unknown(Ana), unknown(Ana)]),
-    ret: Unknown(Ana),
+    arg: Prod([empty_hole_ana(), empty_hole_ana()]),
+    ret: empty_hole_ana().term,
     imp: d => {
       let-unbox t = (Tuple(2), d);
       switch (t) {

--- a/src/language/builtins/BuiltinsBase.re
+++ b/src/language/builtins/BuiltinsBase.re
@@ -455,8 +455,8 @@ let string_fns: list(BuiltinsUtil.fn) = [
 let pair_fns: list(BuiltinsUtil.fn) = [
   {
     name: "fst",
-    arg: Prod([empty_hole_ana(), empty_hole_ana()]),
-    ret: empty_hole_ana().term,
+    arg: Prod([empty_hole_typ(), empty_hole_typ()]),
+    ret: empty_hole_typ().term,
     imp: d => {
       let-unbox t = (Tuple(2), d);
       switch (t) {
@@ -467,8 +467,8 @@ let pair_fns: list(BuiltinsUtil.fn) = [
   },
   {
     name: "snd",
-    arg: Prod([empty_hole_ana(), empty_hole_ana()]),
-    ret: empty_hole_ana().term,
+    arg: Prod([empty_hole_typ(), empty_hole_typ()]),
+    ret: empty_hole_typ().term,
     imp: d => {
       let-unbox t = (Tuple(2), d);
       switch (t) {

--- a/src/language/builtins/BuiltinsList.re
+++ b/src/language/builtins/BuiltinsList.re
@@ -11,7 +11,7 @@ let builtins = [
                | x :: xs => 1 + length(xs)
              end|},
     name: "length",
-    arg: List(unknown(Internal)),
+    arg: List(unknown(Ana)),
     ret: Atom(Int),
     imp: {
       Fresh.(
@@ -51,12 +51,8 @@ let builtins = [
                | x :: xs => f(x) :: map(f, xs)
              end|},
     name: "map",
-    arg:
-      Prod([
-        list(unknown(Internal)),
-        arrow(unknown(Internal), unknown(Internal)),
-      ]),
-    ret: List(unknown(Internal)),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), unknown(Ana))]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -100,9 +96,8 @@ let builtins = [
              | x :: xs => if f(x) then x :: filter(f, xs) else filter(f, xs)
            end|},
     name: "filter",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
-    ret: List(unknown(Internal)),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -152,14 +147,11 @@ let builtins = [
     name: "fold_left",
     arg:
       Prod([
-        list(unknown(Internal)),
-        arrow(
-          prod([unknown(Internal), unknown(Internal)]),
-          unknown(Internal),
-        ),
-        unknown(Internal),
+        list(unknown(Ana)),
+        arrow(prod([unknown(Ana), unknown(Ana)]), unknown(Ana)),
+        unknown(Ana),
       ]),
-    ret: Typ.term_of(unknown(Internal)),
+    ret: Typ.term_of(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -203,10 +195,10 @@ let builtins = [
     name: "flat_map",
     arg:
       Prod([
-        list(unknown(Internal)),
-        arrow(unknown(Internal), list(unknown(Internal))),
+        list(unknown(Ana)),
+        arrow(unknown(Ana), list(unknown(Ana))),
       ]),
-    ret: List(unknown(Internal)),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -247,8 +239,8 @@ let builtins = [
              | (x :: xs, y :: ys) => (x,y) :: zip(xs,ys)
            end|},
     name: "zip",
-    arg: Prod([list(unknown(Internal)), list(unknown(Internal))]),
-    ret: List(prod([unknown(Internal), unknown(Internal)])),
+    arg: Prod([list(unknown(Ana)), list(unknown(Ana))]),
+    ret: List(prod([unknown(Ana), unknown(Ana)])),
     imp: {
       Fresh.(
         Exp.(
@@ -295,8 +287,8 @@ let builtins = [
              | ((a,b) :: xs) => let (as, bs) = unzip(xs) in ((a :: as), (b ::bs))
            end|},
     name: "unzip",
-    arg: List(prod([unknown(Internal), unknown(Internal)])),
-    ret: Prod([list(unknown(Internal)), list(unknown(Internal))]),
+    arg: List(prod([unknown(Ana), unknown(Ana)])),
+    ret: Prod([list(unknown(Ana)), list(unknown(Ana))]),
     imp: {
       Fresh.(
         Exp.(
@@ -340,8 +332,8 @@ let builtins = [
            end|},
     /* Faster (possibly) than tail-rec variant in medium-length cases since @ is builtin */
     name: "reverse",
-    arg: List(unknown(Internal)),
-    ret: List(unknown(Internal)),
+    arg: List(unknown(Ana)),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -379,8 +371,8 @@ let builtins = [
              | x :: xs => x :: take(xs, n - 1)
            end|},
     name: "take",
-    arg: Prod([list(unknown(Internal)), int()]),
-    ret: List(unknown(Internal)),
+    arg: Prod([list(unknown(Ana)), int()]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -428,8 +420,8 @@ let builtins = [
              | x :: xs => drop(xs, n - 1)
            end|},
     name: "drop",
-    arg: Prod([list(unknown(Internal)), int()]),
-    ret: List(unknown(Internal)),
+    arg: Prod([list(unknown(Ana)), int()]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -511,8 +503,8 @@ let builtins = [
            end)((xs, 0))
            |},
     name: "enumerate",
-    arg: List(unknown(Internal)),
-    ret: List(prod([int(), unknown(Internal)])),
+    arg: List(unknown(Ana)),
+    ret: List(prod([int(), unknown(Ana)])),
     imp: {
       Fresh.(
         Exp.(
@@ -568,8 +560,7 @@ let builtins = [
              | x :: xs => if pred(x) then true else any(xs, pred)
            end|},
     name: "any",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -611,8 +602,7 @@ let builtins = [
              | x :: xs => if pred(x) then all(xs, pred) else false
            end|},
     name: "all",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -655,8 +645,8 @@ let builtins = [
              | x :: xs => x :: sep :: intersperse(xs, sep)
            end|},
     name: "intersperse",
-    arg: Prod([list(unknown(Internal)), unknown(Internal)]),
-    ret: List(unknown(Internal)),
+    arg: Prod([list(unknown(Ana)), unknown(Ana)]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -697,8 +687,8 @@ let builtins = [
   {
     str: {|fix cons -> fun (x, xs) -> x :: xs|},
     name: "cons",
-    arg: Prod([unknown(Internal), list(unknown(Internal))]),
-    ret: List(unknown(Internal)),
+    arg: Prod([unknown(Ana), list(unknown(Ana))]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -722,8 +712,8 @@ let builtins = [
              | x :: _ => x
            end|},
     name: "hd",
-    arg: List(unknown(Internal)),
-    ret: Unknown(Internal),
+    arg: List(unknown(Ana)),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -753,8 +743,8 @@ let builtins = [
              | _ :: xs => xs
            end|},
     name: "tl",
-    arg: List(unknown(Internal)),
-    ret: List(unknown(Internal)),
+    arg: List(unknown(Ana)),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -784,7 +774,7 @@ let builtins = [
              | _ => false
            end|},
     name: "is_empty",
-    arg: List(unknown(Internal)),
+    arg: List(unknown(Ana)),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -815,8 +805,8 @@ let builtins = [
              | x :: xs => if n == 0 then x else nth(xs, n - 1)
            end|},
     name: "nth",
-    arg: Prod([list(unknown(Internal)), int()]),
-    ret: Unknown(Internal),
+    arg: Prod([list(unknown(Ana)), int()]),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -862,14 +852,11 @@ let builtins = [
     name: "fold_right",
     arg:
       Prod([
-        list(unknown(Internal)),
-        arrow(
-          prod([unknown(Internal), unknown(Internal)]),
-          unknown(Internal),
-        ),
-        unknown(Internal),
+        list(unknown(Ana)),
+        arrow(prod([unknown(Ana), unknown(Ana)]), unknown(Ana)),
+        unknown(Ana),
       ]),
-    ret: Unknown(Internal),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -910,8 +897,8 @@ let builtins = [
   {
     str: {|fix append -> fun (xs, ys) -> xs @ ys|},
     name: "append",
-    arg: Prod([list(unknown(Internal)), list(unknown(Internal))]),
-    ret: List(unknown(Internal)),
+    arg: Prod([list(unknown(Ana)), list(unknown(Ana))]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -935,8 +922,8 @@ let builtins = [
              | xs :: xss => xs @ concat(xss)
            end|},
     name: "concat",
-    arg: List(list(unknown(Internal))),
-    ret: List(unknown(Internal)),
+    arg: List(list(unknown(Ana))),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -975,10 +962,10 @@ let builtins = [
     name: "mapi",
     arg:
       Prod([
-        list(unknown(Internal)),
-        arrow(prod([int(), unknown(Internal)]), unknown(Internal)),
+        list(unknown(Ana)),
+        arrow(prod([int(), unknown(Ana)]), unknown(Ana)),
       ]),
-    ret: List(unknown(Internal)),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -1042,10 +1029,10 @@ let builtins = [
     name: "filteri",
     arg:
       Prod([
-        list(unknown(Internal)),
-        arrow(prod([int(), unknown(Internal)]), bool()),
+        list(unknown(Ana)),
+        arrow(prod([int(), unknown(Ana)]), bool()),
       ]),
-    ret: List(unknown(Internal)),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -1115,7 +1102,7 @@ let builtins = [
   {
     str: {|fun (xs, x) -> any(xs, fun t -> x == t)|},
     name: "mem",
-    arg: Prod([list(unknown(Internal)), unknown(Internal)]),
+    arg: Prod([list(unknown(Ana)), unknown(Ana)]),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -1149,9 +1136,8 @@ let builtins = [
                if pred(x) then (x :: trues, falses) else (trues, x :: falses)
            end|},
     name: "partition",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
-    ret: Prod([list(unknown(Internal)), list(unknown(Internal))]),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    ret: Prod([list(unknown(Ana)), list(unknown(Ana))]),
     imp: {
       Fresh.(
         Exp.(
@@ -1202,8 +1188,8 @@ let builtins = [
              | x :: xs => rev_append(xs, x :: ys)
            end|},
     name: "rev_append",
-    arg: Prod([list(unknown(Internal)), list(unknown(Internal))]),
-    ret: List(unknown(Internal)),
+    arg: Prod([list(unknown(Ana)), list(unknown(Ana))]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -1243,15 +1229,15 @@ let builtins = [
     name: "fold_left2",
     arg:
       Prod([
-        list(unknown(Internal)),
-        list(unknown(Internal)),
+        list(unknown(Ana)),
+        list(unknown(Ana)),
         arrow(
-          prod([unknown(Internal), unknown(Internal), unknown(Internal)]),
-          unknown(Internal),
+          prod([unknown(Ana), unknown(Ana), unknown(Ana)]),
+          unknown(Ana),
         ),
-        unknown(Internal),
+        unknown(Ana),
       ]),
-    ret: Unknown(Internal),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -1309,15 +1295,15 @@ let builtins = [
     name: "fold_right2",
     arg:
       Prod([
-        list(unknown(Internal)),
-        list(unknown(Internal)),
+        list(unknown(Ana)),
+        list(unknown(Ana)),
         arrow(
-          prod([unknown(Internal), unknown(Internal), unknown(Internal)]),
-          unknown(Internal),
+          prod([unknown(Ana), unknown(Ana), unknown(Ana)]),
+          unknown(Ana),
         ),
-        unknown(Internal),
+        unknown(Ana),
       ]),
-    ret: Unknown(Internal),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -1379,14 +1365,11 @@ let builtins = [
     name: "map2",
     arg:
       Prod([
-        list(unknown(Internal)),
-        list(unknown(Internal)),
-        arrow(
-          prod([unknown(Internal), unknown(Internal)]),
-          unknown(Internal),
-        ),
+        list(unknown(Ana)),
+        list(unknown(Ana)),
+        arrow(prod([unknown(Ana), unknown(Ana)]), unknown(Ana)),
       ]),
-    ret: List(unknown(Internal)),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -1436,9 +1419,9 @@ let builtins = [
     name: "all2",
     arg:
       Prod([
-        list(unknown(Internal)),
-        list(unknown(Internal)),
-        arrow(prod([unknown(Internal), unknown(Internal)]), bool()),
+        list(unknown(Ana)),
+        list(unknown(Ana)),
+        arrow(prod([unknown(Ana), unknown(Ana)]), bool()),
       ]),
     ret: Atom(Bool),
     imp: {
@@ -1492,9 +1475,9 @@ let builtins = [
     name: "any2",
     arg:
       Prod([
-        list(unknown(Internal)),
-        list(unknown(Internal)),
-        arrow(prod([unknown(Internal), unknown(Internal)]), bool()),
+        list(unknown(Ana)),
+        list(unknown(Ana)),
+        arrow(prod([unknown(Ana), unknown(Ana)]), bool()),
       ]),
     ret: Atom(Bool),
     imp: {
@@ -1545,9 +1528,8 @@ let builtins = [
              | x :: xs => if pred(x) then x else find(xs, pred)
            end|},
     name: "find",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
-    ret: Unknown(Internal),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -1588,9 +1570,8 @@ let builtins = [
              | x :: xs => if pred(x) then x :: take_while(xs, pred) else []
            end|},
     name: "take_while",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
-    ret: List(unknown(Internal)),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -1634,9 +1615,8 @@ let builtins = [
              | x :: xs => if pred(x) then drop_while(xs, pred) else xs
            end|},
     name: "drop_while",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
-    ret: List(unknown(Internal)),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -1680,12 +1660,8 @@ let builtins = [
              end
            end|},
     name: "filter_map",
-    arg:
-      Prod([
-        list(unknown(Internal)),
-        arrow(unknown(Internal), unknown(Internal)),
-      ]),
-    ret: List(unknown(Internal)),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), unknown(Ana))]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -1741,8 +1717,8 @@ let builtins = [
              | x :: xs => if n == 0 then Some(x) else nth_opt(xs, n - 1)
            end|},
     name: "nth_opt",
-    arg: Prod([list(unknown(Internal)), int()]),
-    ret: Unknown(Internal),
+    arg: Prod([list(unknown(Ana)), int()]),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -1786,9 +1762,8 @@ let builtins = [
              | x :: xs => if pred(x) then Some(x) else find_opt(xs, pred)
            end|},
     name: "find_opt",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
-    ret: Unknown(Internal),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -1830,9 +1805,8 @@ let builtins = [
              | x :: xs => if pred(x) then Some(i) else find_index_helper(xs, pred, i + 1)
            end|},
     name: "find_index",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
-    ret: Unknown(Internal),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -1897,12 +1871,8 @@ let builtins = [
              end
            end|},
     name: "find_map",
-    arg:
-      Prod([
-        list(unknown(Internal)),
-        arrow(unknown(Internal), unknown(Internal)),
-      ]),
-    ret: Unknown(Internal),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), unknown(Ana))]),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -1957,10 +1927,10 @@ let builtins = [
     name: "find_mapi",
     arg:
       Prod([
-        list(unknown(Internal)),
-        arrow(prod([int(), unknown(Internal)]), unknown(Internal)),
+        list(unknown(Ana)),
+        arrow(prod([int(), unknown(Ana)]), unknown(Ana)),
       ]),
-    ret: Unknown(Internal),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -2029,8 +1999,8 @@ let builtins = [
            fix init_helper -> fun (n, f, i) -> if i >= n then [] else f(i) :: init_helper(n, f, i + 1)
            end|},
     name: "init",
-    arg: Prod([int(), arrow(int(), unknown(Internal))]),
-    ret: List(unknown(Internal)),
+    arg: Prod([int(), arrow(int(), unknown(Ana))]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -2082,12 +2052,8 @@ let builtins = [
              | (k, v) :: xs => if k == key then v else assoc(xs, key)
            end|},
     name: "assoc",
-    arg:
-      Prod([
-        list(prod([unknown(Internal), unknown(Internal)])),
-        unknown(Internal),
-      ]),
-    ret: Unknown(Internal),
+    arg: Prod([list(prod([unknown(Ana), unknown(Ana)])), unknown(Ana)]),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -2131,12 +2097,8 @@ let builtins = [
              | (k, v) :: xs => if k == key then Some(v) else assoc_opt(xs, key)
            end|},
     name: "assoc_opt",
-    arg:
-      Prod([
-        list(prod([unknown(Internal), unknown(Internal)])),
-        unknown(Internal),
-      ]),
-    ret: Unknown(Internal),
+    arg: Prod([list(prod([unknown(Ana), unknown(Ana)])), unknown(Ana)]),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -2180,11 +2142,7 @@ let builtins = [
              | (k, _) :: xs => if k == key then true else mem_assoc(xs, key)
            end|},
     name: "mem_assoc",
-    arg:
-      Prod([
-        list(prod([unknown(Internal), unknown(Internal)])),
-        unknown(Internal),
-      ]),
+    arg: Prod([list(prod([unknown(Ana), unknown(Ana)])), unknown(Ana)]),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -2229,12 +2187,8 @@ let builtins = [
              | (k, v) :: xs => if k == key then remove_assoc(xs, key) else (k, v) :: remove_assoc(xs, key)
            end|},
     name: "remove_assoc",
-    arg:
-      Prod([
-        list(prod([unknown(Internal), unknown(Internal)])),
-        unknown(Internal),
-      ]),
-    ret: List(prod([unknown(Internal), unknown(Internal)])),
+    arg: Prod([list(prod([unknown(Ana), unknown(Ana)])), unknown(Ana)]),
+    ret: List(prod([unknown(Ana), unknown(Ana)])),
     imp: {
       Fresh.(
         Exp.(
@@ -2289,12 +2243,8 @@ let builtins = [
              end
            end|},
     name: "partition_map",
-    arg:
-      Prod([
-        list(unknown(Internal)),
-        arrow(unknown(Internal), unknown(Internal)),
-      ]),
-    ret: Prod([list(unknown(Internal)), list(unknown(Internal))]),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), unknown(Ana))]),
+    ret: Prod([list(unknown(Ana)), list(unknown(Ana))]),
     imp: {
       Fresh.(
         Exp.(
@@ -2384,10 +2334,10 @@ let go: ([?], [?], [?]) -> [?] =
     name: "sort",
     arg:
       Prod([
-        arrow(prod([unknown(Internal), unknown(Internal)]), int()),
-        list(unknown(Internal)),
+        arrow(prod([unknown(Ana), unknown(Ana)]), int()),
+        list(unknown(Ana)),
       ]),
-    ret: List(unknown(Internal)),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -2597,8 +2547,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|fix slice -> fun (start, end, xs) -> take(drop(xs, start), end - start)|},
     name: "slice",
-    arg: Prod([int(), int(), list(unknown(Internal))]),
-    ret: List(unknown(Internal)),
+    arg: Prod([int(), int(), list(unknown(Ana))]),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(
         Exp.(
@@ -2633,8 +2583,8 @@ let go: ([?], [?], [?]) -> [?] =
              | x :: _ => Some(x)
            end|},
     name: "hd_opt",
-    arg: List(unknown(Internal)),
-    ret: Unknown(Internal),
+    arg: List(unknown(Ana)),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -2667,8 +2617,8 @@ let go: ([?], [?], [?]) -> [?] =
              | _ :: xs => Some(xs)
            end|},
     name: "tl_opt",
-    arg: List(unknown(Internal)),
-    ret: Unknown(Internal),
+    arg: List(unknown(Ana)),
+    ret: Unknown(Ana),
     imp: {
       Fresh.(
         Exp.(
@@ -2698,8 +2648,7 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|any|}, //alias
     name: "contains",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(Exp.(var("any")));
@@ -2708,8 +2657,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|concat|}, //alias
     name: "flatten",
-    arg: List(list(unknown(Internal))),
-    ret: List(unknown(Internal)),
+    arg: List(list(unknown(Ana))),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(Exp.(var("concat")));
     },
@@ -2717,8 +2666,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|reverse|}, //alias
     name: "rev",
-    arg: List(unknown(Internal)),
-    ret: List(unknown(Internal)),
+    arg: List(unknown(Ana)),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(Exp.(var("reverse")));
     },
@@ -2726,8 +2675,7 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|any|}, //alias
     name: "exists",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(Exp.(var("any")));
@@ -2736,8 +2684,7 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|all|}, //alias
     name: "for_all",
-    arg:
-      Prod([list(unknown(Internal)), arrow(unknown(Internal), bool())]),
+    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(Exp.(var("all")));
@@ -2748,9 +2695,9 @@ let go: ([?], [?], [?]) -> [?] =
     name: "exists2",
     arg:
       Prod([
-        list(unknown(Internal)),
-        list(unknown(Internal)),
-        arrow(prod([unknown(Internal), unknown(Internal)]), bool()),
+        list(unknown(Ana)),
+        list(unknown(Ana)),
+        arrow(prod([unknown(Ana), unknown(Ana)]), bool()),
       ]),
     ret: Atom(Bool),
     imp: {
@@ -2762,9 +2709,9 @@ let go: ([?], [?], [?]) -> [?] =
     name: "for_all2",
     arg:
       Prod([
-        list(unknown(Internal)),
-        list(unknown(Internal)),
-        arrow(prod([unknown(Internal), unknown(Internal)]), bool()),
+        list(unknown(Ana)),
+        list(unknown(Ana)),
+        arrow(prod([unknown(Ana), unknown(Ana)]), bool()),
       ]),
     ret: Atom(Bool),
     imp: {
@@ -2776,10 +2723,10 @@ let go: ([?], [?], [?]) -> [?] =
     name: "concat_map",
     arg:
       Prod([
-        list(unknown(Internal)),
-        arrow(unknown(Internal), list(unknown(Internal))),
+        list(unknown(Ana)),
+        arrow(unknown(Ana), list(unknown(Ana))),
       ]),
-    ret: List(unknown(Internal)),
+    ret: List(unknown(Ana)),
     imp: {
       Fresh.(Exp.(var("flat_map")));
     },
@@ -2787,8 +2734,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|unzip|}, //alias
     name: "split",
-    arg: List(prod([unknown(Internal), unknown(Internal)])),
-    ret: Prod([list(unknown(Internal)), list(unknown(Internal))]),
+    arg: List(prod([unknown(Ana), unknown(Ana)])),
+    ret: Prod([list(unknown(Ana)), list(unknown(Ana))]),
     imp: {
       Fresh.(Exp.(var("unzip")));
     },
@@ -2796,8 +2743,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|zip|}, //alias
     name: "combine",
-    arg: Prod([list(unknown(Internal)), list(unknown(Internal))]),
-    ret: List(prod([unknown(Internal), unknown(Internal)])),
+    arg: Prod([list(unknown(Ana)), list(unknown(Ana))]),
+    ret: List(prod([unknown(Ana), unknown(Ana)])),
     imp: {
       Fresh.(Exp.(var("zip")));
     },

--- a/src/language/builtins/BuiltinsList.re
+++ b/src/language/builtins/BuiltinsList.re
@@ -3,7 +3,7 @@ open Fresh.Typ;
 open BuiltinsUtil;
 open BuiltinsADT;
 
-let unk = unknown(Syn, Hole.fresh(EmptyHole), Atom);
+let unk = unknown(Type, Hole.temp(EmptyHole), Atom);
 let builtins = [
   {
     str: {|fix length -> fun xs -> case xs
@@ -705,7 +705,7 @@ let builtins = [
            end|},
     name: "hd",
     arg: List(unk),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -798,7 +798,7 @@ let builtins = [
            end|},
     name: "nth",
     arg: Prod([list(unk), int()]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -843,7 +843,7 @@ let builtins = [
            end|},
     name: "fold_right",
     arg: Prod([list(unk), arrow(prod([unk, unk]), unk), unk]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1213,7 +1213,7 @@ let builtins = [
         arrow(prod([unk, unk, unk]), unk),
         unk,
       ]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1276,7 +1276,7 @@ let builtins = [
         arrow(prod([unk, unk, unk]), unk),
         unk,
       ]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1487,7 +1487,7 @@ let builtins = [
            end|},
     name: "find",
     arg: Prod([list(unk), arrow(unk, bool())]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1676,7 +1676,7 @@ let builtins = [
            end|},
     name: "nth_opt",
     arg: Prod([list(unk), int()]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1721,7 +1721,7 @@ let builtins = [
            end|},
     name: "find_opt",
     arg: Prod([list(unk), arrow(unk, bool())]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1764,7 +1764,7 @@ let builtins = [
            end|},
     name: "find_index",
     arg: Prod([list(unk), arrow(unk, bool())]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1830,7 +1830,7 @@ let builtins = [
            end|},
     name: "find_map",
     arg: Prod([list(unk), arrow(unk, unk)]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1884,7 +1884,7 @@ let builtins = [
            end|},
     name: "find_mapi",
     arg: Prod([list(unk), arrow(prod([int(), unk]), unk)]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -2007,7 +2007,7 @@ let builtins = [
            end|},
     name: "assoc",
     arg: Prod([list(prod([unk, unk])), unk]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -2052,7 +2052,7 @@ let builtins = [
            end|},
     name: "assoc_opt",
     arg: Prod([list(prod([unk, unk])), unk]),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -2534,7 +2534,7 @@ let go: ([?], [?], [?]) -> [?] =
            end|},
     name: "hd_opt",
     arg: List(unk),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -2568,7 +2568,7 @@ let go: ([?], [?], [?]) -> [?] =
            end|},
     name: "tl_opt",
     arg: List(unk),
-    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
+    ret: Unknown(Type, Hole.temp(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(

--- a/src/language/builtins/BuiltinsList.re
+++ b/src/language/builtins/BuiltinsList.re
@@ -3,6 +3,7 @@ open Fresh.Typ;
 open BuiltinsUtil;
 open BuiltinsADT;
 
+let unk = unknown(Syn, Hole.fresh(EmptyHole), Atom);
 let builtins = [
   {
     str: {|fix length -> fun xs -> case xs
@@ -11,7 +12,7 @@ let builtins = [
                | x :: xs => 1 + length(xs)
              end|},
     name: "length",
-    arg: List(unknown(Ana)),
+    arg: List(unk),
     ret: Atom(Int),
     imp: {
       Fresh.(
@@ -51,8 +52,8 @@ let builtins = [
                | x :: xs => f(x) :: map(f, xs)
              end|},
     name: "map",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), unknown(Ana))]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), arrow(unk, unk)]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -96,8 +97,8 @@ let builtins = [
              | x :: xs => if f(x) then x :: filter(f, xs) else filter(f, xs)
            end|},
     name: "filter",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), arrow(unk, bool())]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -145,13 +146,8 @@ let builtins = [
              | x :: xs => fold_left(xs, f, f(acc, x))
            end|},
     name: "fold_left",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        arrow(prod([unknown(Ana), unknown(Ana)]), unknown(Ana)),
-        unknown(Ana),
-      ]),
-    ret: Typ.term_of(unknown(Ana)),
+    arg: Prod([list(unk), arrow(prod([unk, unk]), unk), unk]),
+    ret: Typ.term_of(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -193,12 +189,8 @@ let builtins = [
   {
     str: {|fix flat_map -> fun (xs, f) -> fold_left(xs, fun (acc,x) -> acc @ f(x), []))|},
     name: "flat_map",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        arrow(unknown(Ana), list(unknown(Ana))),
-      ]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), arrow(unk, list(unk))]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -239,8 +231,8 @@ let builtins = [
              | (x :: xs, y :: ys) => (x,y) :: zip(xs,ys)
            end|},
     name: "zip",
-    arg: Prod([list(unknown(Ana)), list(unknown(Ana))]),
-    ret: List(prod([unknown(Ana), unknown(Ana)])),
+    arg: Prod([list(unk), list(unk)]),
+    ret: List(prod([unk, unk])),
     imp: {
       Fresh.(
         Exp.(
@@ -287,8 +279,8 @@ let builtins = [
              | ((a,b) :: xs) => let (as, bs) = unzip(xs) in ((a :: as), (b ::bs))
            end|},
     name: "unzip",
-    arg: List(prod([unknown(Ana), unknown(Ana)])),
-    ret: Prod([list(unknown(Ana)), list(unknown(Ana))]),
+    arg: List(prod([unk, unk])),
+    ret: Prod([list(unk), list(unk)]),
     imp: {
       Fresh.(
         Exp.(
@@ -332,8 +324,8 @@ let builtins = [
            end|},
     /* Faster (possibly) than tail-rec variant in medium-length cases since @ is builtin */
     name: "reverse",
-    arg: List(unknown(Ana)),
-    ret: List(unknown(Ana)),
+    arg: List(unk),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -371,8 +363,8 @@ let builtins = [
              | x :: xs => x :: take(xs, n - 1)
            end|},
     name: "take",
-    arg: Prod([list(unknown(Ana)), int()]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), int()]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -420,8 +412,8 @@ let builtins = [
              | x :: xs => drop(xs, n - 1)
            end|},
     name: "drop",
-    arg: Prod([list(unknown(Ana)), int()]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), int()]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -503,8 +495,8 @@ let builtins = [
            end)((xs, 0))
            |},
     name: "enumerate",
-    arg: List(unknown(Ana)),
-    ret: List(prod([int(), unknown(Ana)])),
+    arg: List(unk),
+    ret: List(prod([int(), unk])),
     imp: {
       Fresh.(
         Exp.(
@@ -560,7 +552,7 @@ let builtins = [
              | x :: xs => if pred(x) then true else any(xs, pred)
            end|},
     name: "any",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    arg: Prod([list(unk), arrow(unk, bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -602,7 +594,7 @@ let builtins = [
              | x :: xs => if pred(x) then all(xs, pred) else false
            end|},
     name: "all",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    arg: Prod([list(unk), arrow(unk, bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -645,8 +637,8 @@ let builtins = [
              | x :: xs => x :: sep :: intersperse(xs, sep)
            end|},
     name: "intersperse",
-    arg: Prod([list(unknown(Ana)), unknown(Ana)]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), unk]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -687,8 +679,8 @@ let builtins = [
   {
     str: {|fix cons -> fun (x, xs) -> x :: xs|},
     name: "cons",
-    arg: Prod([unknown(Ana), list(unknown(Ana))]),
-    ret: List(unknown(Ana)),
+    arg: Prod([unk, list(unk)]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -712,8 +704,8 @@ let builtins = [
              | x :: _ => x
            end|},
     name: "hd",
-    arg: List(unknown(Ana)),
-    ret: Unknown(Ana),
+    arg: List(unk),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -743,8 +735,8 @@ let builtins = [
              | _ :: xs => xs
            end|},
     name: "tl",
-    arg: List(unknown(Ana)),
-    ret: List(unknown(Ana)),
+    arg: List(unk),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -774,7 +766,7 @@ let builtins = [
              | _ => false
            end|},
     name: "is_empty",
-    arg: List(unknown(Ana)),
+    arg: List(unk),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -805,8 +797,8 @@ let builtins = [
              | x :: xs => if n == 0 then x else nth(xs, n - 1)
            end|},
     name: "nth",
-    arg: Prod([list(unknown(Ana)), int()]),
-    ret: Unknown(Ana),
+    arg: Prod([list(unk), int()]),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -850,13 +842,8 @@ let builtins = [
              | x :: xs => f(x, fold_right(xs, f, acc))
            end|},
     name: "fold_right",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        arrow(prod([unknown(Ana), unknown(Ana)]), unknown(Ana)),
-        unknown(Ana),
-      ]),
-    ret: Unknown(Ana),
+    arg: Prod([list(unk), arrow(prod([unk, unk]), unk), unk]),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -897,8 +884,8 @@ let builtins = [
   {
     str: {|fix append -> fun (xs, ys) -> xs @ ys|},
     name: "append",
-    arg: Prod([list(unknown(Ana)), list(unknown(Ana))]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), list(unk)]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -922,8 +909,8 @@ let builtins = [
              | xs :: xss => xs @ concat(xss)
            end|},
     name: "concat",
-    arg: List(list(unknown(Ana))),
-    ret: List(unknown(Ana)),
+    arg: List(list(unk)),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -960,12 +947,8 @@ let builtins = [
              | x :: xs => f(i, x) :: mapi_helper(xs, f, i + 1)
            end|},
     name: "mapi",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        arrow(prod([int(), unknown(Ana)]), unknown(Ana)),
-      ]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), arrow(prod([int(), unk]), unk)]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -1027,12 +1010,8 @@ let builtins = [
              | x :: xs => if f(i, x) then x :: filteri_helper(xs, f, i + 1) else filteri_helper(xs, f, i + 1)
            end|},
     name: "filteri",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        arrow(prod([int(), unknown(Ana)]), bool()),
-      ]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), arrow(prod([int(), unk]), bool())]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -1102,7 +1081,7 @@ let builtins = [
   {
     str: {|fun (xs, x) -> any(xs, fun t -> x == t)|},
     name: "mem",
-    arg: Prod([list(unknown(Ana)), unknown(Ana)]),
+    arg: Prod([list(unk), unk]),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -1136,8 +1115,8 @@ let builtins = [
                if pred(x) then (x :: trues, falses) else (trues, x :: falses)
            end|},
     name: "partition",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
-    ret: Prod([list(unknown(Ana)), list(unknown(Ana))]),
+    arg: Prod([list(unk), arrow(unk, bool())]),
+    ret: Prod([list(unk), list(unk)]),
     imp: {
       Fresh.(
         Exp.(
@@ -1188,8 +1167,8 @@ let builtins = [
              | x :: xs => rev_append(xs, x :: ys)
            end|},
     name: "rev_append",
-    arg: Prod([list(unknown(Ana)), list(unknown(Ana))]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), list(unk)]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -1229,15 +1208,12 @@ let builtins = [
     name: "fold_left2",
     arg:
       Prod([
-        list(unknown(Ana)),
-        list(unknown(Ana)),
-        arrow(
-          prod([unknown(Ana), unknown(Ana), unknown(Ana)]),
-          unknown(Ana),
-        ),
-        unknown(Ana),
+        list(unk),
+        list(unk),
+        arrow(prod([unk, unk, unk]), unk),
+        unk,
       ]),
-    ret: Unknown(Ana),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1295,15 +1271,12 @@ let builtins = [
     name: "fold_right2",
     arg:
       Prod([
-        list(unknown(Ana)),
-        list(unknown(Ana)),
-        arrow(
-          prod([unknown(Ana), unknown(Ana), unknown(Ana)]),
-          unknown(Ana),
-        ),
-        unknown(Ana),
+        list(unk),
+        list(unk),
+        arrow(prod([unk, unk, unk]), unk),
+        unk,
       ]),
-    ret: Unknown(Ana),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1363,13 +1336,8 @@ let builtins = [
              | (x :: xs, y :: ys) => f(x, y) :: map2(xs, ys, f)
            end|},
     name: "map2",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        list(unknown(Ana)),
-        arrow(prod([unknown(Ana), unknown(Ana)]), unknown(Ana)),
-      ]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), list(unk), arrow(prod([unk, unk]), unk)]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -1417,12 +1385,7 @@ let builtins = [
              | (x :: xs, y :: ys) => if pred(x, y) then all2(xs, ys, pred) else false
            end|},
     name: "all2",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        list(unknown(Ana)),
-        arrow(prod([unknown(Ana), unknown(Ana)]), bool()),
-      ]),
+    arg: Prod([list(unk), list(unk), arrow(prod([unk, unk]), bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -1473,12 +1436,7 @@ let builtins = [
              | (x :: xs, y :: ys) => if pred(x, y) then true else any2(xs, ys, pred)
            end|},
     name: "any2",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        list(unknown(Ana)),
-        arrow(prod([unknown(Ana), unknown(Ana)]), bool()),
-      ]),
+    arg: Prod([list(unk), list(unk), arrow(prod([unk, unk]), bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -1528,8 +1486,8 @@ let builtins = [
              | x :: xs => if pred(x) then x else find(xs, pred)
            end|},
     name: "find",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
-    ret: Unknown(Ana),
+    arg: Prod([list(unk), arrow(unk, bool())]),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1570,8 +1528,8 @@ let builtins = [
              | x :: xs => if pred(x) then x :: take_while(xs, pred) else []
            end|},
     name: "take_while",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), arrow(unk, bool())]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -1615,8 +1573,8 @@ let builtins = [
              | x :: xs => if pred(x) then drop_while(xs, pred) else xs
            end|},
     name: "drop_while",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), arrow(unk, bool())]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -1660,8 +1618,8 @@ let builtins = [
              end
            end|},
     name: "filter_map",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), unknown(Ana))]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), arrow(unk, unk)]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -1717,8 +1675,8 @@ let builtins = [
              | x :: xs => if n == 0 then Some(x) else nth_opt(xs, n - 1)
            end|},
     name: "nth_opt",
-    arg: Prod([list(unknown(Ana)), int()]),
-    ret: Unknown(Ana),
+    arg: Prod([list(unk), int()]),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1762,8 +1720,8 @@ let builtins = [
              | x :: xs => if pred(x) then Some(x) else find_opt(xs, pred)
            end|},
     name: "find_opt",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
-    ret: Unknown(Ana),
+    arg: Prod([list(unk), arrow(unk, bool())]),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1805,8 +1763,8 @@ let builtins = [
              | x :: xs => if pred(x) then Some(i) else find_index_helper(xs, pred, i + 1)
            end|},
     name: "find_index",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
-    ret: Unknown(Ana),
+    arg: Prod([list(unk), arrow(unk, bool())]),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1871,8 +1829,8 @@ let builtins = [
              end
            end|},
     name: "find_map",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), unknown(Ana))]),
-    ret: Unknown(Ana),
+    arg: Prod([list(unk), arrow(unk, unk)]),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1925,12 +1883,8 @@ let builtins = [
              end
            end|},
     name: "find_mapi",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        arrow(prod([int(), unknown(Ana)]), unknown(Ana)),
-      ]),
-    ret: Unknown(Ana),
+    arg: Prod([list(unk), arrow(prod([int(), unk]), unk)]),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -1999,8 +1953,8 @@ let builtins = [
            fix init_helper -> fun (n, f, i) -> if i >= n then [] else f(i) :: init_helper(n, f, i + 1)
            end|},
     name: "init",
-    arg: Prod([int(), arrow(int(), unknown(Ana))]),
-    ret: List(unknown(Ana)),
+    arg: Prod([int(), arrow(int(), unk)]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -2052,8 +2006,8 @@ let builtins = [
              | (k, v) :: xs => if k == key then v else assoc(xs, key)
            end|},
     name: "assoc",
-    arg: Prod([list(prod([unknown(Ana), unknown(Ana)])), unknown(Ana)]),
-    ret: Unknown(Ana),
+    arg: Prod([list(prod([unk, unk])), unk]),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -2097,8 +2051,8 @@ let builtins = [
              | (k, v) :: xs => if k == key then Some(v) else assoc_opt(xs, key)
            end|},
     name: "assoc_opt",
-    arg: Prod([list(prod([unknown(Ana), unknown(Ana)])), unknown(Ana)]),
-    ret: Unknown(Ana),
+    arg: Prod([list(prod([unk, unk])), unk]),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -2142,7 +2096,7 @@ let builtins = [
              | (k, _) :: xs => if k == key then true else mem_assoc(xs, key)
            end|},
     name: "mem_assoc",
-    arg: Prod([list(prod([unknown(Ana), unknown(Ana)])), unknown(Ana)]),
+    arg: Prod([list(prod([unk, unk])), unk]),
     ret: Atom(Bool),
     imp: {
       Fresh.(
@@ -2187,8 +2141,8 @@ let builtins = [
              | (k, v) :: xs => if k == key then remove_assoc(xs, key) else (k, v) :: remove_assoc(xs, key)
            end|},
     name: "remove_assoc",
-    arg: Prod([list(prod([unknown(Ana), unknown(Ana)])), unknown(Ana)]),
-    ret: List(prod([unknown(Ana), unknown(Ana)])),
+    arg: Prod([list(prod([unk, unk])), unk]),
+    ret: List(prod([unk, unk])),
     imp: {
       Fresh.(
         Exp.(
@@ -2243,8 +2197,8 @@ let builtins = [
              end
            end|},
     name: "partition_map",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), unknown(Ana))]),
-    ret: Prod([list(unknown(Ana)), list(unknown(Ana))]),
+    arg: Prod([list(unk), arrow(unk, unk)]),
+    ret: Prod([list(unk), list(unk)]),
     imp: {
       Fresh.(
         Exp.(
@@ -2332,12 +2286,8 @@ let go: ([?], [?], [?]) -> [?] =
         end in
         merge_sort(xs)|},
     name: "sort",
-    arg:
-      Prod([
-        arrow(prod([unknown(Ana), unknown(Ana)]), int()),
-        list(unknown(Ana)),
-      ]),
-    ret: List(unknown(Ana)),
+    arg: Prod([arrow(prod([unk, unk]), int()), list(unk)]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -2547,8 +2497,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|fix slice -> fun (start, end, xs) -> take(drop(xs, start), end - start)|},
     name: "slice",
-    arg: Prod([int(), int(), list(unknown(Ana))]),
-    ret: List(unknown(Ana)),
+    arg: Prod([int(), int(), list(unk)]),
+    ret: List(unk),
     imp: {
       Fresh.(
         Exp.(
@@ -2583,8 +2533,8 @@ let go: ([?], [?], [?]) -> [?] =
              | x :: _ => Some(x)
            end|},
     name: "hd_opt",
-    arg: List(unknown(Ana)),
-    ret: Unknown(Ana),
+    arg: List(unk),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -2617,8 +2567,8 @@ let go: ([?], [?], [?]) -> [?] =
              | _ :: xs => Some(xs)
            end|},
     name: "tl_opt",
-    arg: List(unknown(Ana)),
-    ret: Unknown(Ana),
+    arg: List(unk),
+    ret: Unknown(Syn, Hole.fresh(EmptyHole), Atom),
     imp: {
       Fresh.(
         Exp.(
@@ -2648,7 +2598,7 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|any|}, //alias
     name: "contains",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    arg: Prod([list(unk), arrow(unk, bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(Exp.(var("any")));
@@ -2657,8 +2607,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|concat|}, //alias
     name: "flatten",
-    arg: List(list(unknown(Ana))),
-    ret: List(unknown(Ana)),
+    arg: List(list(unk)),
+    ret: List(unk),
     imp: {
       Fresh.(Exp.(var("concat")));
     },
@@ -2666,8 +2616,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|reverse|}, //alias
     name: "rev",
-    arg: List(unknown(Ana)),
-    ret: List(unknown(Ana)),
+    arg: List(unk),
+    ret: List(unk),
     imp: {
       Fresh.(Exp.(var("reverse")));
     },
@@ -2675,7 +2625,7 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|any|}, //alias
     name: "exists",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    arg: Prod([list(unk), arrow(unk, bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(Exp.(var("any")));
@@ -2684,7 +2634,7 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|all|}, //alias
     name: "for_all",
-    arg: Prod([list(unknown(Ana)), arrow(unknown(Ana), bool())]),
+    arg: Prod([list(unk), arrow(unk, bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(Exp.(var("all")));
@@ -2693,12 +2643,7 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|any2|}, //alias
     name: "exists2",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        list(unknown(Ana)),
-        arrow(prod([unknown(Ana), unknown(Ana)]), bool()),
-      ]),
+    arg: Prod([list(unk), list(unk), arrow(prod([unk, unk]), bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(Exp.(var("any2")));
@@ -2707,12 +2652,7 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|all2|}, //alias
     name: "for_all2",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        list(unknown(Ana)),
-        arrow(prod([unknown(Ana), unknown(Ana)]), bool()),
-      ]),
+    arg: Prod([list(unk), list(unk), arrow(prod([unk, unk]), bool())]),
     ret: Atom(Bool),
     imp: {
       Fresh.(Exp.(var("all2")));
@@ -2721,12 +2661,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|flat_map|}, //alias
     name: "concat_map",
-    arg:
-      Prod([
-        list(unknown(Ana)),
-        arrow(unknown(Ana), list(unknown(Ana))),
-      ]),
-    ret: List(unknown(Ana)),
+    arg: Prod([list(unk), arrow(unk, list(unk))]),
+    ret: List(unk),
     imp: {
       Fresh.(Exp.(var("flat_map")));
     },
@@ -2734,8 +2670,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|unzip|}, //alias
     name: "split",
-    arg: List(prod([unknown(Ana), unknown(Ana)])),
-    ret: Prod([list(unknown(Ana)), list(unknown(Ana))]),
+    arg: List(prod([unk, unk])),
+    ret: Prod([list(unk), list(unk)]),
     imp: {
       Fresh.(Exp.(var("unzip")));
     },
@@ -2743,8 +2679,8 @@ let go: ([?], [?], [?]) -> [?] =
   {
     str: {|zip|}, //alias
     name: "combine",
-    arg: Prod([list(unknown(Ana)), list(unknown(Ana))]),
-    ret: List(prod([unknown(Ana), unknown(Ana)])),
+    arg: Prod([list(unk), list(unk)]),
+    ret: List(prod([unk, unk])),
     imp: {
       Fresh.(Exp.(var("zip")));
     },

--- a/src/language/dynamics/transition/Ascriptions.re
+++ b/src/language/dynamics/transition/Ascriptions.re
@@ -86,7 +86,7 @@ let rec transition = (~recursive=false, d: DHExp.t): option(DHExp.t) => {
       let new_ty: Typ.t =
         switch (TPat.tyvar_of_utpat(tp)) {
         | Some(tyvar) => Var(tyvar) |> Typ.temp
-        | None => Unknown(Internal) |> Typ.temp
+        | None => Unknown(SynSwitch) |> Typ.temp
         };
       Some(
         TypFun(

--- a/src/language/dynamics/transition/Ascriptions.re
+++ b/src/language/dynamics/transition/Ascriptions.re
@@ -87,7 +87,7 @@ let rec transition = (~recursive=false, d: DHExp.t): option(DHExp.t) => {
         switch (TPat.tyvar_of_utpat(tp)) {
         | Some(tyvar) => Var(tyvar) |> Typ.temp
         | None =>
-          Unknown(Syn, Hole.fresh(Invalid("Invalid tyvar")), Atom)
+          Unknown(Expr, Hole.fresh(Invalid("Invalid tyvar")), Atom)
           |> Typ.temp // TODO: Provenances for dynamic errors?
         };
       Some(

--- a/src/language/dynamics/transition/Ascriptions.re
+++ b/src/language/dynamics/transition/Ascriptions.re
@@ -86,7 +86,9 @@ let rec transition = (~recursive=false, d: DHExp.t): option(DHExp.t) => {
       let new_ty: Typ.t =
         switch (TPat.tyvar_of_utpat(tp)) {
         | Some(tyvar) => Var(tyvar) |> Typ.temp
-        | None => Unknown(SynSwitch) |> Typ.temp
+        | None =>
+          Unknown(Syn, Hole.fresh(Invalid("Invalid tyvar")), Atom)
+          |> Typ.temp // TODO: Provenances for dynamic errors?
         };
       Some(
         TypFun(

--- a/src/language/statics/CoCtx.re
+++ b/src/language/statics/CoCtx.re
@@ -72,9 +72,9 @@ let join: (Ctx.t, list(entry)) => Typ.t =
   (ctx, entries) => {
     let expected_tys = List.map(entry => entry.expected_ty, entries);
     switch (
-      Typ.join_all(~empty=Unknown(Internal) |> Typ.fresh, ctx, expected_tys)
+      Typ.join_all(~empty=Unknown(SynSwitch) |> Typ.fresh, ctx, expected_tys)
     ) {
-    | None => Unknown(Internal) |> Typ.fresh
+    | None => Unknown(Ana) |> Typ.fresh
     | Some(ty) => ty
     };
   };

--- a/src/language/statics/CoCtx.re
+++ b/src/language/statics/CoCtx.re
@@ -73,12 +73,12 @@ let join: (Ctx.t, list(entry)) => Typ.t =
     let expected_tys = List.map(entry => entry.expected_ty, entries);
     switch (
       Typ.join_all(
-        ~empty=Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh,
+        ~empty=Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.fresh,
         ctx,
         expected_tys // Note, no need for hole provenances as this is only used in TyDi
       )
     ) {
-    | None => Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh
+    | None => Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.fresh
     | Some(ty) => ty
     };
   };

--- a/src/language/statics/CoCtx.re
+++ b/src/language/statics/CoCtx.re
@@ -72,9 +72,13 @@ let join: (Ctx.t, list(entry)) => Typ.t =
   (ctx, entries) => {
     let expected_tys = List.map(entry => entry.expected_ty, entries);
     switch (
-      Typ.join_all(~empty=Unknown(SynSwitch) |> Typ.fresh, ctx, expected_tys)
+      Typ.join_all(
+        ~empty=Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh,
+        ctx,
+        expected_tys // Note, no need for hole provenances as this is only used in TyDi
+      )
     ) {
-    | None => Unknown(Ana) |> Typ.fresh
+    | None => Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh
     | Some(ty) => ty
     };
   };

--- a/src/language/statics/Coverage.re
+++ b/src/language/statics/Coverage.re
@@ -85,18 +85,18 @@ module Ctr = {
     switch (all_ctrs) {
     | Unknown =>
       List.init(ctr.num_args, _ =>
-        Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp
-      ) // TODO: Check Ana works here
+        Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.temp
+      )
     | Infinite =>
       List.init(ctr.num_args, _ =>
-        Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp
+        Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.temp
       )
     | Finite(all_ctrs) =>
       switch (Map.find_opt(ctr, all_ctrs)) {
       | Some(arity) => arity
       | None =>
         List.init(ctr.num_args, _ =>
-          Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp
+          Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.temp
         )
       }
     };

--- a/src/language/statics/Coverage.re
+++ b/src/language/statics/Coverage.re
@@ -83,12 +83,12 @@ module Ctr = {
 
   let arity_of = (ctr, all_ctrs: all_ctrs): arity =>
     switch (all_ctrs) {
-    | Unknown => List.init(ctr.num_args, _ => Unknown(Internal) |> Typ.temp)
-    | Infinite => List.init(ctr.num_args, _ => Unknown(Internal) |> Typ.temp)
+    | Unknown => List.init(ctr.num_args, _ => Unknown(Ana) |> Typ.temp) // TODO: Provenances here
+    | Infinite => List.init(ctr.num_args, _ => Unknown(Ana) |> Typ.temp)
     | Finite(all_ctrs) =>
       switch (Map.find_opt(ctr, all_ctrs)) {
       | Some(arity) => arity
-      | None => List.init(ctr.num_args, _ => Unknown(Internal) |> Typ.temp)
+      | None => List.init(ctr.num_args, _ => Unknown(Ana) |> Typ.temp)
       }
     };
 

--- a/src/language/statics/Coverage.re
+++ b/src/language/statics/Coverage.re
@@ -83,12 +83,21 @@ module Ctr = {
 
   let arity_of = (ctr, all_ctrs: all_ctrs): arity =>
     switch (all_ctrs) {
-    | Unknown => List.init(ctr.num_args, _ => Unknown(Ana) |> Typ.temp) // TODO: Provenances here
-    | Infinite => List.init(ctr.num_args, _ => Unknown(Ana) |> Typ.temp)
+    | Unknown =>
+      List.init(ctr.num_args, _ =>
+        Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp
+      ) // TODO: Check Ana works here
+    | Infinite =>
+      List.init(ctr.num_args, _ =>
+        Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp
+      )
     | Finite(all_ctrs) =>
       switch (Map.find_opt(ctr, all_ctrs)) {
       | Some(arity) => arity
-      | None => List.init(ctr.num_args, _ => Unknown(Ana) |> Typ.temp)
+      | None =>
+        List.init(ctr.num_args, _ =>
+          Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp
+        )
       }
     };
 

--- a/src/language/statics/Ctx.re
+++ b/src/language/statics/Ctx.re
@@ -134,13 +134,20 @@ let is_abstract = (ctx: t, name: string): bool =>
   | None => false
   };
 
-let lookup_alias = (ctx: t, name: string): option(TermBase.Typ.t) =>
+let lookup_alias = (ctx: t, name: string, var_ids): option(TermBase.Typ.t) =>
   switch (lookup_tvar(ctx, name)) {
   | Some(Singleton(ty)) => Some(ty)
   | Some(Abstract) => None
   | None =>
     Some(
-      (Unknown(Hole(Invalid(name))): TermBase.Typ.term) |> IdTagged.fresh,
+      (
+        Unknown(
+          Syn,
+          (Invalid(name): TermBase.Hole.term) |> IdTagged.tag(var_ids),
+          Atom,
+        ): TermBase.Typ.term
+      )
+      |> IdTagged.fresh,
     )
   };
 

--- a/src/language/statics/Ctx.re
+++ b/src/language/statics/Ctx.re
@@ -142,7 +142,7 @@ let lookup_alias = (ctx: t, name: string, var_ids): option(TermBase.Typ.t) =>
     Some(
       (
         Unknown(
-          Syn,
+          Expr,
           (Invalid(name): TermBase.Hole.term) |> IdTagged.tag(var_ids),
           Atom,
         ): TermBase.Typ.term

--- a/src/language/statics/Elaborator.re
+++ b/src/language/statics/Elaborator.re
@@ -16,7 +16,7 @@ module ElaborationResult = {
 let fresh_ascription = (d: Exp.t, t: Typ.t, t': option(Typ.t)) => {
   IdTagged.FreshGrammar.Exp.(
     switch (t') {
-    | Some({term: Unknown(Internal), _}) => d
+    | Some({term: Unknown(Ana), _}) => d
     | Some(ty) when !Typ.fast_equal(ty, t) => asc(d, ty)
     | _ => d
     }
@@ -220,7 +220,7 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
     | ListLit(es) =>
       let (ds, tys) = List.map(elaborate(m), es) |> ListUtil.unzip;
       let joined_ty =
-        Typ.join_all(~empty=Unknown(Internal) |> Typ.temp, ctx, tys);
+        Typ.join_all(~empty=Unknown(SynSwitch) |> Typ.temp, ctx, tys);
 
       let ds' =
         List.map2((d, t) => fresh_ascription(d, t, joined_ty), ds, tys);
@@ -400,10 +400,10 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
       switch (e.term) {
       // TODO: confirm whether these types are correct
       | Var("e") =>
-        Constructor("$e", Some(Some(Unknown(Internal) |> Typ.fresh)))
+        Constructor("$e", Some(Some(Unknown(SynSwitch) |> Typ.fresh)))
         |> rewrap
       | Var("v") =>
-        Constructor("$v", Some(Some(Unknown(Internal) |> Typ.fresh)))
+        Constructor("$v", Some(Some(Unknown(SynSwitch) |> Typ.fresh)))
         |> rewrap
       | _ => EmptyHole |> rewrap
       }

--- a/src/language/statics/Elaborator.re
+++ b/src/language/statics/Elaborator.re
@@ -16,7 +16,7 @@ module ElaborationResult = {
 let fresh_ascription = (d: Exp.t, t: Typ.t, t': option(Typ.t)) => {
   IdTagged.FreshGrammar.Exp.(
     switch (t') {
-    | Some({term: Unknown(Ana), _}) => d
+    | Some({term: Unknown(Ana, _, _), _}) => d
     | Some(ty) when !Typ.fast_equal(ty, t) => asc(d, ty)
     | _ => d
     }
@@ -220,7 +220,11 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
     | ListLit(es) =>
       let (ds, tys) = List.map(elaborate(m), es) |> ListUtil.unzip;
       let joined_ty =
-        Typ.join_all(~empty=Unknown(SynSwitch) |> Typ.temp, ctx, tys);
+        Typ.join_all(
+          ~empty=Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+          ctx,
+          tys,
+        );
 
       let ds' =
         List.map2((d, t) => fresh_ascription(d, t, joined_ty), ds, tys);
@@ -400,10 +404,16 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
       switch (e.term) {
       // TODO: confirm whether these types are correct
       | Var("e") =>
-        Constructor("$e", Some(Some(Unknown(SynSwitch) |> Typ.fresh)))
+        Constructor(
+          "$e",
+          Some(Some(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp)),
+        )
         |> rewrap
       | Var("v") =>
-        Constructor("$v", Some(Some(Unknown(SynSwitch) |> Typ.fresh)))
+        Constructor(
+          "$v",
+          Some(Some(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp)),
+        )
         |> rewrap
       | _ => EmptyHole |> rewrap
       }

--- a/src/language/statics/Elaborator.re
+++ b/src/language/statics/Elaborator.re
@@ -16,7 +16,7 @@ module ElaborationResult = {
 let fresh_ascription = (d: Exp.t, t: Typ.t, t': option(Typ.t)) => {
   IdTagged.FreshGrammar.Exp.(
     switch (t') {
-    | Some({term: Unknown(Ana, _, _), _}) => d
+    | Some({term: Unknown(Expr | Type, _, _), _}) => d
     | Some(ty) when !Typ.fast_equal(ty, t) => asc(d, ty)
     | _ => d
     }
@@ -221,7 +221,7 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
       let (ds, tys) = List.map(elaborate(m), es) |> ListUtil.unzip;
       let joined_ty =
         Typ.join_all(
-          ~empty=Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+          ~empty=Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.temp,
           ctx,
           tys,
         );
@@ -406,13 +406,17 @@ let rec elaborate = (m: Statics.Map.t, uexp: Exp.t): (DHExp.t, Typ.t) => {
       | Var("e") =>
         Constructor(
           "$e",
-          Some(Some(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp)),
+          Some(
+            Some(Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.temp),
+          ),
         )
         |> rewrap
       | Var("v") =>
         Constructor(
           "$v",
-          Some(Some(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp)),
+          Some(
+            Some(Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.temp),
+          ),
         )
         |> rewrap
       | _ => EmptyHole |> rewrap

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -112,15 +112,7 @@ type ok_ana =
       ana: Typ.t,
       syn: Typ.t,
       join: Typ.t,
-    })
-  /* A match expression or list literal which, in synthetic position,
-     would be marked as internally inconsistent, but is considered
-     fine as the expected type provides a consistent lower bound
-     (often Unknown) for the types of the branches/elements */
-  | InternallyInconsistent({
-      ana: Typ.t,
-      nojoin: list(Typ.t),
-    }); // TODO: remove
+    });
 
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
 type ok_common =
@@ -501,41 +493,29 @@ let status_common =
     ) // TODO: track multihole, or just remove arg entirely
   | (NoJoin(_, tys), {term: Unknown(SynSwitch, _, _), _}) =>
     InHole(Inconsistent(Internal(Typ.of_source(tys))))
-  | (NoJoin(wrap, tys), ana) =>
+  | (NoJoin(wrap, _), ana) =>
     let syn: Typ.t =
       Self.join_of(
         wrap,
         Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp,
       );
-    switch (Typ.join(ctx, ana, syn)) {
-    | None =>
-      switch (ana.term, syn.term) {
-      | (Label(_), Label(_)) =>
-        InHole(
-          Inconsistent(
-            Expectation({
-              ana,
-              syn,
-            }),
-          ),
-        )
-      | (Label(_), _) => InHole(NoType(BadLabel(Typ(syn))))
-      | _ =>
-        InHole(
-          Inconsistent(
-            Expectation({
-              ana,
-              syn,
-            }),
-          ),
-        )
-      }
-    | Some(_) =>
-      NotInHole(
-        Ana(
-          InternallyInconsistent({
+    switch (ana.term, syn.term) {
+    | (Label(_), Label(_)) =>
+      InHole(
+        Inconsistent(
+          Expectation({
             ana,
-            nojoin: Typ.of_source(tys),
+            syn,
+          }),
+        ),
+      )
+    | (Label(_), _) => InHole(NoType(BadLabel(Typ(syn))))
+    | _ =>
+      InHole(
+        Inconsistent(
+          Expectation({
+            ana,
+            syn,
           }),
         ),
       )
@@ -797,8 +777,7 @@ let is_error = (ci: t): bool => {
 let fixed_typ_ok: ok_pat => Typ.t =
   fun
   | Syn(syn) => syn
-  | Ana(Consistent({join, _})) => join
-  | Ana(InternallyInconsistent({ana, _})) => ana;
+  | Ana(Consistent({join, _})) => join;
 
 let fixed_typ_err_common = (error_common, ids) =>
   switch (error_common) {

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -120,7 +120,7 @@ type ok_ana =
   | InternallyInconsistent({
       ana: Typ.t,
       nojoin: list(Typ.t),
-    });
+    }); // TODO: remove
 
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
 type ok_common =

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -394,7 +394,9 @@ let status_common =
   switch (self, ty_ana) {
   | (Just(ty), {term: Unknown(SynSwitch, _, _), _}) => NotInHole(Syn(ty))
   | (Just(ty), {term: Unknown(Type, h, p), _}) when !Typ.is_unknown(ty) =>
-    InHole(AsymmetricUnknown(ty, h, p)) /* Disallow analysing against ?_t except for terms synthesising ? */
+    InHole(AsymmetricUnknown(ty, h, p)) /* Disallow analysing ty against ?_t except for ty = ? */
+  | (Just({term: Unknown(Type, h, p), _}), ty) when !Typ.is_unknown(ty) =>
+    InHole(AsymmetricUnknown(ty, h, p)) /* Disallow analysing ?_t against ty except for ty = ? */
   | (Just(syn), ana) =>
     switch (
       Typ.join(

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -465,12 +465,12 @@ let status_common = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.t): status_common =>
     )
   | (Duplicate(lab, Just(ty)), _) => InHole(DuplicateLabel(lab, ty))
   | (Duplicate(lab, _), _) =>
-    InHole(DuplicateLabel(lab, Unknown(Internal) |> Typ.temp))
-  | (IsMulti, _) => NotInHole(Syn(Unknown(Internal) |> Typ.temp))
+    InHole(DuplicateLabel(lab, Unknown(Ana) |> Typ.temp))
+  | (IsMulti, _) => NotInHole(Syn(Unknown(SynSwitch) |> Typ.temp))
   | (NoJoin(_, tys), {term: Unknown(SynSwitch), _}) =>
     InHole(Inconsistent(Internal(Typ.of_source(tys))))
   | (NoJoin(wrap, tys), ana) =>
-    let syn: Typ.t = Self.join_of(wrap, Unknown(Internal) |> Typ.temp);
+    let syn: Typ.t = Self.join_of(wrap, Unknown(SynSwitch) |> Typ.temp);
     switch (Typ.join(ctx, ana, syn)) {
     | None =>
       switch (ana.term, syn.term) {
@@ -594,7 +594,7 @@ let rec status_exp = (ctx: Ctx.t, ty_ana, self: Self.exp): status_exp =>
     switch (ll) {
     | None => InHole(UnboundLivelit(name))
     | Some(_livelit) =>
-      NotInHole(Common(Syn(Unknown(Internal) |> Typ.temp)))
+      NotInHole(Common(Syn(Unknown(SynSwitch) |> Typ.temp)))
     };
   | BadTrivAp(ty) => InHole(BadTrivAp(ty))
   | BadOperator(op) => InHole(BadOperator(op))
@@ -761,17 +761,20 @@ let fixed_typ_err_common: error_common => Typ.t =
   | NoType(FreeConstructor(c)) =>
     Sum([
       ConstructorMap.Variant(c, [Id.invalid], None),
-      ConstructorMap.BadEntry(Unknown(Internal) |> Typ.temp),
+      ConstructorMap.BadEntry(Unknown(SynSwitch) |> Typ.temp),
     ])
     |> Typ.temp
   | NoType(BadToken(_) | BadLabel(_) | InvalidLabel(_))
-  | AsymmetricUnknown(_) => Unknown(Internal) |> Typ.temp
+  | AsymmetricUnknown(_) => Unknown(SynSwitch) |> Typ.temp
   | TupleLabelError({typ, _})
   | DuplicateLabel(_, typ) => typ
   | Inconsistent(Expectation({ana, _})) => ana
-  | Inconsistent(Internal(_)) => Unknown(Internal) |> Typ.temp // Should this be some sort of meet?
+  | Inconsistent(Internal(_)) => Unknown(SynSwitch) |> Typ.temp // Should this be some sort of meet?
   | Inconsistent(WithArrow(_)) =>
-    Arrow(Unknown(Internal) |> Typ.temp, Unknown(Internal) |> Typ.temp)
+    Arrow(
+      Unknown(ArrowL(SynSwitch)) |> Typ.temp,
+      Unknown(ArrowR(SynSwitch)) |> Typ.temp,
+    )
     |> Typ.temp;
 
 let fixed_typ_err: error_exp => Typ.t =
@@ -784,7 +787,7 @@ let fixed_typ_err: error_exp => Typ.t =
   | WantTuple
   | BadOperator(_)
   | LabelNotFound(_, _)
-  | BadTrivAp(_) => Unknown(Internal) |> Typ.temp
+  | BadTrivAp(_) => Unknown(SynSwitch) |> Typ.temp
   | Common(err) => fixed_typ_err_common(err)
   | InvalidUseMode({inner_typ, _}) => inner_typ
   | BadLivelitModel(ana) => ana;
@@ -792,7 +795,7 @@ let fixed_typ_err: error_exp => Typ.t =
 let fixed_typ_err_pat: error_pat => Typ.t =
   fun
   | ExpectedConstructor
-  | Redundant(_) => Unknown(Internal) |> Typ.temp
+  | Redundant(_) => Unknown(SynSwitch) |> Typ.temp
   | Common(err) => fixed_typ_err_common(err);
 
 let fixed_typ_pat = (ctx, ty_ana: Typ.t, self: Self.pat): Typ.t => {

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -62,8 +62,8 @@ type error_common =
   | NoType(error_no_type)
   /* Overdetermined: Conflicting type expectations */
   | Inconsistent(error_inconsistent)
-  /* Syn is more specific than analysed unknown: Type hole should be filled */
-  | AsymmetricUnknown(Typ.t)
+  /* Syn is more specific than analysed unknown: Type hole of given id should be filled */
+  | AsymmetricUnknown(Typ.t, Id.t)
   /* The error on a specific duplicate label */
   | DuplicateLabel(LabeledTuple.label, Typ.t)
   /* Tuple/TupLabel contains malformed labels, duplicate labels, and/or invalid labels */
@@ -374,6 +374,22 @@ let error_of: t => option(error) =
   | InfoTPat({status: InHole(err), _}) => Some(TPat(err))
   | Secondary(_) => None;
 
+/* May include non-local error ids for asymmetric unknown type errors */
+let error_ids_of: t => list(Id.t) =
+  i =>
+    [id_of(i)]
+    @ (
+      switch (error_of(i)) {
+      | Some(
+          Exp(Common(AsymmetricUnknown(_, hole_id))) |
+          Pat(Common(AsymmetricUnknown(_, hole_id))),
+        ) => [
+          hole_id,
+        ]
+      | _ => []
+      }
+    );
+
 let exp_co_ctx: exp => CoCtx.t = ({co_ctx, _}) => co_ctx;
 let exp_ty: exp => Typ.t = ({ty, _}) => ty;
 let pat_ctx: pat => Ctx.t = ({ctx, _}) => ctx;
@@ -384,8 +400,8 @@ let pat_constraint: pat => Coverage.Constraint.t =
 let status_common = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.t): status_common =>
   switch (self, ty_ana) {
   | (Just(ty), {term: Unknown(SynSwitch), _}) => NotInHole(Syn(ty))
-  | (Just(ty), {term: Unknown(_), _}) when !Typ.is_unknown(ty) =>
-    InHole(AsymmetricUnknown(ty)) /* Disallow analysing against ? except for terms synthesising ? */
+  | (Just(ty), ana) when !Typ.is_unknown(ty) && Typ.is_unknown(ana) =>
+    InHole(AsymmetricUnknown(ty, Typ.rep_id(ana))) /* Disallow analysing against ? except for terms synthesising ? */
   | (Just(syn), ana) =>
     switch (
       Typ.join(

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -62,6 +62,8 @@ type error_common =
   | NoType(error_no_type)
   /* Overdetermined: Conflicting type expectations */
   | Inconsistent(error_inconsistent)
+  /* Syn is more specific than analysed unknown: Type hole should be filled */
+  | AsymmetricUnknown(Typ.t)
   /* The error on a specific duplicate label */
   | DuplicateLabel(LabeledTuple.label, Typ.t)
   /* Tuple/TupLabel contains malformed labels, duplicate labels, and/or invalid labels */
@@ -382,6 +384,8 @@ let pat_constraint: pat => Coverage.Constraint.t =
 let status_common = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.t): status_common =>
   switch (self, ty_ana) {
   | (Just(ty), {term: Unknown(SynSwitch), _}) => NotInHole(Syn(ty))
+  | (Just(ty), {term: Unknown(_), _}) when !Typ.is_unknown(ty) =>
+    InHole(AsymmetricUnknown(ty)) /* Disallow analysing against ? except for terms synthesising ? */
   | (Just(syn), ana) =>
     switch (
       Typ.join(
@@ -492,7 +496,10 @@ let rec status_pat = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.pat): status_pat =>
     let additional_err =
       switch (status_pat(ctx, ty_ana, self)) {
       | InHole(
-          Common(Inconsistent(Internal(_) | Expectation(_)) | NoType(_)) as err,
+          Common(
+            Inconsistent(Internal(_) | Expectation(_)) | NoType(_) |
+            AsymmetricUnknown(_),
+          ) as err,
         ) =>
         Some(err)
       | NotInHole(_) => None
@@ -531,7 +538,12 @@ let rec status_exp = (ctx: Ctx.t, ty_ana, self: Self.exp): status_exp =>
       | InHole(Common(Inconsistent(Internal(_)) as inconsistent_err)) =>
         Some(inconsistent_err)
       | NotInHole(_)
-      | InHole(Common(Inconsistent(Expectation(_) | WithArrow(_)))) => None /* Type checking should fail and these errors would be nullified */
+      | InHole(
+          Common(
+            Inconsistent(Expectation(_) | WithArrow(_)) | AsymmetricUnknown(_),
+          ),
+        ) =>
+        None /* Type checking should fail and these errors would be nullified */
       | InHole(
           Common(NoType(_) | TupleLabelError(_) | DuplicateLabel(_)) |
           FreeVariable(_) |
@@ -736,8 +748,8 @@ let fixed_typ_err_common: error_common => Typ.t =
       ConstructorMap.BadEntry(Unknown(Internal) |> Typ.temp),
     ])
     |> Typ.temp
-  | NoType(BadToken(_) | BadLabel(_) | InvalidLabel(_)) =>
-    Unknown(Internal) |> Typ.temp
+  | NoType(BadToken(_) | BadLabel(_) | InvalidLabel(_))
+  | AsymmetricUnknown(_) => Unknown(Internal) |> Typ.temp
   | TupleLabelError({typ, _})
   | DuplicateLabel(_, typ) => typ
   | Inconsistent(Expectation({ana, _})) => ana

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -63,7 +63,7 @@ type error_common =
   /* Overdetermined: Conflicting type expectations */
   | Inconsistent(error_inconsistent)
   /* Syn is more specific than analysed unknown: Type hole of given id should be filled */
-  | AsymmetricUnknown(Typ.t, Id.t)
+  | AsymmetricUnknown(Typ.t, Hole.t, Typ.provenance)
   /* The error on a specific duplicate label */
   | DuplicateLabel(LabeledTuple.label, Typ.t)
   /* Tuple/TupLabel contains malformed labels, duplicate labels, and/or invalid labels */
@@ -381,10 +381,10 @@ let error_ids_of: t => list(Id.t) =
     @ (
       switch (error_of(i)) {
       | Some(
-          Exp(Common(AsymmetricUnknown(_, hole_id))) |
-          Pat(Common(AsymmetricUnknown(_, hole_id))),
+          Exp(Common(AsymmetricUnknown(_, hole, _))) |
+          Pat(Common(AsymmetricUnknown(_, hole, _))),
         ) => [
-          hole_id,
+          Hole.rep_id(hole),
         ]
       | _ => []
       }
@@ -397,11 +397,13 @@ let pat_ty: pat => Typ.t = ({ty, _}) => ty;
 let pat_constraint: pat => Coverage.Constraint.t =
   ({constraint_, _}) => constraint_;
 
-let status_common = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.t): status_common =>
+let status_common =
+    (ctx: Ctx.t, ty_ana: Typ.t, self: Self.t, ids: list(Id.t)): status_common =>
   switch (self, ty_ana) {
-  | (Just(ty), {term: Unknown(SynSwitch), _}) => NotInHole(Syn(ty))
-  | (Just(ty), ana) when !Typ.is_unknown(ty) && Typ.is_unknown(ana) =>
-    InHole(AsymmetricUnknown(ty, Typ.rep_id(ana))) /* Disallow analysing against ? except for terms synthesising ? */
+  | (Just(ty), {term: Unknown(Syn | SynSwitch, _, _), _}) =>
+    NotInHole(Syn(ty))
+  | (Just(ty), {term: Unknown(Ana, h, p), _}) when !Typ.is_unknown_syn(ty) =>
+    InHole(AsymmetricUnknown(ty, h, p)) /* Disallow analysing against ? except for terms synthesising ? */
   | (Just(syn), ana) =>
     switch (
       Typ.join(
@@ -465,12 +467,46 @@ let status_common = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.t): status_common =>
     )
   | (Duplicate(lab, Just(ty)), _) => InHole(DuplicateLabel(lab, ty))
   | (Duplicate(lab, _), _) =>
-    InHole(DuplicateLabel(lab, Unknown(Ana) |> Typ.temp))
-  | (IsMulti, _) => NotInHole(Syn(Unknown(SynSwitch) |> Typ.temp))
-  | (NoJoin(_, tys), {term: Unknown(SynSwitch), _}) =>
+    InHole(
+      DuplicateLabel(
+        lab,
+        Unknown(
+          Syn,
+          {
+            term: ErrorHole,
+            annotation: {
+              ids: ids,
+            },
+          },
+          Atom,
+        )
+        |> Typ.temp,
+      ),
+    )
+  | (IsMulti, _) =>
+    NotInHole(
+      Syn(
+        Unknown(
+          Syn,
+          {
+            term: MultiHole([]),
+            annotation: {
+              ids: ids,
+            },
+          },
+          Atom,
+        )
+        |> Typ.temp,
+      ),
+    ) // TODO: track multihole, or just remove arg entirely
+  | (NoJoin(_, tys), {term: Unknown(SynSwitch, _, _), _}) =>
     InHole(Inconsistent(Internal(Typ.of_source(tys))))
   | (NoJoin(wrap, tys), ana) =>
-    let syn: Typ.t = Self.join_of(wrap, Unknown(SynSwitch) |> Typ.temp);
+    let syn: Typ.t =
+      Self.join_of(
+        wrap,
+        Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+      );
     switch (Typ.join(ctx, ana, syn)) {
     | None =>
       switch (ana.term, syn.term) {
@@ -506,11 +542,12 @@ let status_common = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.t): status_common =>
     };
   };
 
-let rec status_pat = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.pat): status_pat =>
+let rec status_pat =
+        (ctx: Ctx.t, ty_ana: Typ.t, self: Self.pat, ids): status_pat =>
   switch (self) {
   | Redundant(self) =>
     let additional_err =
-      switch (status_pat(ctx, ty_ana, self)) {
+      switch (status_pat(ctx, ty_ana, self, ids)) {
       | InHole(
           Common(
             Inconsistent(Internal(_) | Expectation(_)) | NoType(_) |
@@ -535,7 +572,7 @@ let rec status_pat = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.pat): status_pat =>
     InHole(Common(NoType(FreeConstructor(name))))
   | ExpectedConstructor(_) => InHole(ExpectedConstructor)
   | Common(self_pat) =>
-    switch (status_common(ctx, ty_ana, self_pat)) {
+    switch (status_common(ctx, ty_ana, self_pat, ids)) {
     | NotInHole(ok_pat) => NotInHole(ok_pat)
     | InHole(err_pat) => InHole(Common(err_pat))
     }
@@ -545,12 +582,12 @@ let rec status_pat = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.pat): status_pat =>
    depending on the mode, which represents the expectations of the
    surrounding syntactic context, and the self which represents the
    makeup of the expression / pattern itself. */
-let rec status_exp = (ctx: Ctx.t, ty_ana, self: Self.exp): status_exp =>
+let rec status_exp = (ctx: Ctx.t, ty_ana, self: Self.exp, ids): status_exp =>
   switch (self) {
   | Free(name) => InHole(FreeVariable(name))
   | InexhaustiveMatch(self) =>
     let additional_err =
-      switch (status_exp(ctx, ty_ana, self)) {
+      switch (status_exp(ctx, ty_ana, self, ids)) {
       | InHole(Common(Inconsistent(Internal(_)) as inconsistent_err)) =>
         Some(inconsistent_err)
       | NotInHole(_)
@@ -577,7 +614,8 @@ let rec status_exp = (ctx: Ctx.t, ty_ana, self: Self.exp): status_exp =>
         failwith("InHole(InexhaustiveMatch(impossible_err))")
       };
     InHole(InexhaustiveMatch(additional_err));
-  | IsDeferral(_) when Typ.is_syn_plus(ty_ana) => InHole(UnusedDeferral)
+  | IsDeferral(_) when Typ.is_synswitch_plus(ty_ana) =>
+    InHole(UnusedDeferral)
   | IsDeferral(InAp) => NotInHole(AnaDeferralConsistent(ty_ana))
   | IsDeferral(_) => InHole(UnusedDeferral)
   | IsBadPartialAp(_ as info) => InHole(BadPartialAp(info))
@@ -594,14 +632,16 @@ let rec status_exp = (ctx: Ctx.t, ty_ana, self: Self.exp): status_exp =>
     switch (ll) {
     | None => InHole(UnboundLivelit(name))
     | Some(_livelit) =>
-      NotInHole(Common(Syn(Unknown(SynSwitch) |> Typ.temp)))
+      NotInHole(
+        Common(Syn(Unknown(Syn, Hole.fresh(EmptyHole), Atom) |> Typ.temp)),
+      )
     };
   | BadTrivAp(ty) => InHole(BadTrivAp(ty))
   | BadOperator(op) => InHole(BadOperator(op))
   | LabelNotFound(label, labels) => InHole(LabelNotFound(label, labels))
   | BadLivelitModel(typ) => InHole(BadLivelitModel(typ))
   | Common(self_exp) =>
-    switch (status_common(ctx, ty_ana, self_exp)) {
+    switch (status_common(ctx, ty_ana, self_exp, ids)) {
     | NotInHole(ok_exp) => NotInHole(Common(ok_exp))
     | InHole(err_exp) => InHole(Common(err_exp))
     }
@@ -616,8 +656,8 @@ let rec status_exp = (ctx: Ctx.t, ty_ana, self: Self.exp): status_exp =>
    free, and whether a ctr name is a dupe. */
 let status_typ = (ctx: Ctx.t, expects: typ_expects, ty: Typ.t): status_typ =>
   switch (ty.term) {
-  | Unknown(Hole(Invalid(token))) => InHole(BadToken(token))
-  | Unknown(Hole(EmptyHole)) =>
+  | Unknown(_, {term: Invalid(token), _}, _) => InHole(BadToken(token))
+  | Unknown(_, {term: EmptyHole, _}, _) =>
     switch (expects) {
     | LabelExpected(_) => NotInHole(EmptyLabel)
     | _ => NotInHole(Type(ty))
@@ -631,13 +671,17 @@ let status_typ = (ctx: Ctx.t, expects: typ_expects, ty: Typ.t): status_typ =>
     | ConstructorExpected(Duplicate, _) =>
       InHole(DuplicateConstructor(name))
     | TupleExpected =>
-      switch (Ctx.lookup_alias(ctx, name)) {
+      switch (
+        Ctx.lookup_alias(ctx, name, IdTagged.IdTag.of_id(Typ.rep_id(ty)))
+      ) {
       | Some({term: Prod(_), _}) =>
         NotInHole(TypeAlias(name, Typ.weak_head_normalize(ctx, ty)))
       | _ => InHole(WantTuple)
       }
     | LabelExpected(_) =>
-      switch (Ctx.lookup_alias(ctx, name)) {
+      switch (
+        Ctx.lookup_alias(ctx, name, IdTagged.IdTag.of_id(Typ.rep_id(ty)))
+      ) {
       | Some({term: Label(_), _}) =>
         NotInHole(TypeAlias(name, Typ.weak_head_normalize(ctx, ty)))
       | _ => InHole(WantLabel)
@@ -756,29 +800,84 @@ let fixed_typ_ok: ok_pat => Typ.t =
   | Ana(Consistent({join, _})) => join
   | Ana(InternallyInconsistent({ana, _})) => ana;
 
-let fixed_typ_err_common: error_common => Typ.t =
-  fun
+let fixed_typ_err_common = (error_common, ids) =>
+  switch (error_common) {
   | NoType(FreeConstructor(c)) =>
     Sum([
       ConstructorMap.Variant(c, [Id.invalid], None),
-      ConstructorMap.BadEntry(Unknown(SynSwitch) |> Typ.temp),
+      ConstructorMap.BadEntry(
+        Unknown(
+          Syn,
+          {
+            term: ErrorHole,
+            annotation: {
+              ids: ids,
+            },
+          },
+          Sum(Ctr(c, Atom)),
+        )
+        |> Typ.temp,
+      ),
     ])
     |> Typ.temp
-  | NoType(BadToken(_) | BadLabel(_) | InvalidLabel(_))
-  | AsymmetricUnknown(_) => Unknown(SynSwitch) |> Typ.temp
+  | NoType(BadToken(_) | BadLabel(_) | InvalidLabel(_)) =>
+    Unknown(
+      Syn,
+      {
+        term: ErrorHole,
+        annotation: {
+          ids: ids,
+        },
+      },
+      Atom,
+    )
+    |> Typ.temp
+  | AsymmetricUnknown(_, h, p) => Unknown(Syn, h, p) |> Typ.temp
   | TupleLabelError({typ, _})
   | DuplicateLabel(_, typ) => typ
   | Inconsistent(Expectation({ana, _})) => ana
-  | Inconsistent(Internal(_)) => Unknown(SynSwitch) |> Typ.temp // Should this be some sort of meet?
+  | Inconsistent(Internal(_)) =>
+    Unknown(
+      Syn,
+      {
+        term: ErrorHole,
+        annotation: {
+          ids: ids,
+        },
+      },
+      Atom,
+    )
+    |> Typ.temp // Should this be some sort of meet?
   | Inconsistent(WithArrow(_)) =>
     Arrow(
-      Unknown(ArrowL(SynSwitch)) |> Typ.temp,
-      Unknown(ArrowR(SynSwitch)) |> Typ.temp,
+      Unknown(
+        Syn,
+        {
+          term: ErrorHole,
+          annotation: {
+            ids: ids,
+          },
+        },
+        ArrowL(Atom),
+      )
+      |> Typ.temp,
+      Unknown(
+        Syn,
+        {
+          term: ErrorHole,
+          annotation: {
+            ids: ids,
+          },
+        },
+        ArrowR(Atom),
+      )
+      |> Typ.temp,
     )
-    |> Typ.temp;
+    |> Typ.temp
+  };
 
-let fixed_typ_err: error_exp => Typ.t =
-  fun
+let fixed_typ_err = (error_typ, ids) =>
+  switch (error_typ) {
   | UnboundLivelit(_)
   | FreeVariable(_)
   | UnusedDeferral
@@ -787,33 +886,57 @@ let fixed_typ_err: error_exp => Typ.t =
   | WantTuple
   | BadOperator(_)
   | LabelNotFound(_, _)
-  | BadTrivAp(_) => Unknown(SynSwitch) |> Typ.temp
-  | Common(err) => fixed_typ_err_common(err)
+  | BadTrivAp(_) =>
+    Unknown(
+      Syn,
+      {
+        term: ErrorHole,
+        annotation: {
+          ids: ids,
+        },
+      },
+      Atom,
+    )
+    |> Typ.temp
+  | Common(err) => fixed_typ_err_common(err, ids)
   | InvalidUseMode({inner_typ, _}) => inner_typ
-  | BadLivelitModel(ana) => ana;
+  | BadLivelitModel(ana) => ana
+  };
 
-let fixed_typ_err_pat: error_pat => Typ.t =
-  fun
+let fixed_typ_err_pat = (error_pat, ids) =>
+  switch (error_pat) {
   | ExpectedConstructor
-  | Redundant(_) => Unknown(SynSwitch) |> Typ.temp
-  | Common(err) => fixed_typ_err_common(err);
+  | Redundant(_) =>
+    Unknown(
+      Syn,
+      {
+        term: ErrorHole,
+        annotation: {
+          ids: ids,
+        },
+      },
+      Atom,
+    )
+    |> Typ.temp
+  | Common(err) => fixed_typ_err_common(err, ids)
+  };
 
-let fixed_typ_pat = (ctx, ty_ana: Typ.t, self: Self.pat): Typ.t => {
+let fixed_typ_pat = (ctx, ty_ana: Typ.t, self: Self.pat, ids): Typ.t => {
   // TODO: get rid of unwrapping (probably by changing the implementation of error_exp.Redundant)
   let self =
     switch (self) {
     | Redundant(self) => self
     | _ => self
     };
-  switch (status_pat(ctx, ty_ana, self)) {
-  | InHole(err) => fixed_typ_err_pat(err)
+  switch (status_pat(ctx, ty_ana, self, ids)) {
+  | InHole(err) => fixed_typ_err_pat(err, ids)
   | NotInHole(ok) => fixed_typ_ok(ok)
   };
 };
 
-let fixed_typ_exp = (ctx, ty_ana: Typ.t, self: Self.exp): Typ.t =>
-  switch (status_exp(ctx, ty_ana, self)) {
-  | InHole(err) => fixed_typ_err(err)
+let fixed_typ_exp = (ctx, ty_ana: Typ.t, self: Self.exp, ids): Typ.t =>
+  switch (status_exp(ctx, ty_ana, self, ids)) {
+  | InHole(err) => fixed_typ_err(err, ids)
   | NotInHole(AnaDeferralConsistent(ana)) => ana
   | NotInHole(Common(ok)) => fixed_typ_ok(ok)
   };
@@ -833,8 +956,8 @@ let derived_exp =
     )
     : exp => {
   let cls = Cls.Exp(Exp.cls_of_term(uexp.term));
-  let status = status_exp(ctx, ana, self);
-  let ty = fixed_typ_exp(ctx, ana, self);
+  let status = status_exp(ctx, ana, self, uexp.annotation.ids);
+  let ty = fixed_typ_exp(ctx, ana, self, uexp.annotation.ids);
   {
     cls,
     self,
@@ -868,8 +991,8 @@ let derived_pat =
     )
     : pat => {
   let cls = Cls.Pat(Pat.cls_of_term(upat.term));
-  let status = status_pat(ctx, ana, self);
-  let ty = fixed_typ_pat(ctx, ana, self);
+  let status = status_pat(ctx, ana, self, upat.annotation.ids);
+  let ty = fixed_typ_pat(ctx, ana, self, upat.annotation.ids);
   {
     cls,
     self,

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -392,10 +392,9 @@ let pat_constraint: pat => Coverage.Constraint.t =
 let status_common =
     (ctx: Ctx.t, ty_ana: Typ.t, self: Self.t, ids: list(Id.t)): status_common =>
   switch (self, ty_ana) {
-  | (Just(ty), {term: Unknown(Syn | SynSwitch, _, _), _}) =>
-    NotInHole(Syn(ty))
-  | (Just(ty), {term: Unknown(Ana, h, p), _}) when !Typ.is_unknown_syn(ty) =>
-    InHole(AsymmetricUnknown(ty, h, p)) /* Disallow analysing against ? except for terms synthesising ? */
+  | (Just(ty), {term: Unknown(SynSwitch, _, _), _}) => NotInHole(Syn(ty))
+  | (Just(ty), {term: Unknown(Type, h, p), _}) when !Typ.is_unknown(ty) =>
+    InHole(AsymmetricUnknown(ty, h, p)) /* Disallow analysing against ?_t except for terms synthesising ? */
   | (Just(syn), ana) =>
     switch (
       Typ.join(
@@ -463,7 +462,7 @@ let status_common =
       DuplicateLabel(
         lab,
         Unknown(
-          Syn,
+          Expr,
           {
             term: ErrorHole,
             annotation: {
@@ -479,7 +478,7 @@ let status_common =
     NotInHole(
       Syn(
         Unknown(
-          Syn,
+          Expr,
           {
             term: MultiHole([]),
             annotation: {
@@ -497,7 +496,7 @@ let status_common =
     let syn: Typ.t =
       Self.join_of(
         wrap,
-        Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+        Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.temp,
       );
     switch (ana.term, syn.term) {
     | (Label(_), Label(_)) =>
@@ -613,7 +612,9 @@ let rec status_exp = (ctx: Ctx.t, ty_ana, self: Self.exp, ids): status_exp =>
     | None => InHole(UnboundLivelit(name))
     | Some(_livelit) =>
       NotInHole(
-        Common(Syn(Unknown(Syn, Hole.fresh(EmptyHole), Atom) |> Typ.temp)),
+        Common(
+          Syn(Unknown(Expr, Hole.fresh(EmptyHole), Atom) |> Typ.temp),
+        ),
       )
     };
   | BadTrivAp(ty) => InHole(BadTrivAp(ty))
@@ -786,7 +787,7 @@ let fixed_typ_err_common = (error_common, ids) =>
       ConstructorMap.Variant(c, [Id.invalid], None),
       ConstructorMap.BadEntry(
         Unknown(
-          Syn,
+          Expr,
           {
             term: ErrorHole,
             annotation: {
@@ -801,7 +802,7 @@ let fixed_typ_err_common = (error_common, ids) =>
     |> Typ.temp
   | NoType(BadToken(_) | BadLabel(_) | InvalidLabel(_)) =>
     Unknown(
-      Syn,
+      Expr,
       {
         term: ErrorHole,
         annotation: {
@@ -811,13 +812,13 @@ let fixed_typ_err_common = (error_common, ids) =>
       Atom,
     )
     |> Typ.temp
-  | AsymmetricUnknown(_, h, p) => Unknown(Syn, h, p) |> Typ.temp
+  | AsymmetricUnknown(_, h, p) => Unknown(Expr, h, p) |> Typ.temp
   | TupleLabelError({typ, _})
   | DuplicateLabel(_, typ) => typ
   | Inconsistent(Expectation({ana, _})) => ana
   | Inconsistent(Internal(_)) =>
     Unknown(
-      Syn,
+      Expr,
       {
         term: ErrorHole,
         annotation: {
@@ -830,7 +831,7 @@ let fixed_typ_err_common = (error_common, ids) =>
   | Inconsistent(WithArrow(_)) =>
     Arrow(
       Unknown(
-        Syn,
+        Expr,
         {
           term: ErrorHole,
           annotation: {
@@ -841,7 +842,7 @@ let fixed_typ_err_common = (error_common, ids) =>
       )
       |> Typ.temp,
       Unknown(
-        Syn,
+        Expr,
         {
           term: ErrorHole,
           annotation: {
@@ -867,7 +868,7 @@ let fixed_typ_err = (error_typ, ids) =>
   | LabelNotFound(_, _)
   | BadTrivAp(_) =>
     Unknown(
-      Syn,
+      Expr,
       {
         term: ErrorHole,
         annotation: {
@@ -887,7 +888,7 @@ let fixed_typ_err_pat = (error_pat, ids) =>
   | ExpectedConstructor
   | Redundant(_) =>
     Unknown(
-      Syn,
+      Expr,
       {
         term: ErrorHole,
         annotation: {

--- a/src/language/statics/Self.re
+++ b/src/language/statics/Self.re
@@ -96,7 +96,10 @@ let typ_of: t => option(Typ.t) =
     Some(
       Sum([
         ConstructorMap.Variant(name, [Id.invalid], None),
-        ConstructorMap.BadEntry(Unknown(Sum(Ana)) |> Typ.temp),
+        ConstructorMap.BadEntry(
+          Unknown(Syn, Hole.fresh(Invalid("Free Constructor")), Atom)
+          |> Typ.temp,
+        ) // TODO: Correctly track IDs/provenances for free constructor
       ])
       |> Typ.temp,
     )
@@ -226,8 +229,10 @@ let add_source =
     }
   );
 
-let match = (ctx: Ctx.t, tys: list(Typ.t), ids: list(Id.t)): t =>
-  switch (Typ.join_all(~empty=Unknown(SynSwitch) |> Typ.fresh, ctx, tys)) {
+let match = (ctx: Ctx.t, tys: list(Typ.t), ids: list(Id.t), error): t =>
+  switch (
+    Typ.join_all(~empty=Unknown(Syn, error, Atom) |> Typ.fresh, ctx, tys)
+  ) {
   | None => NoJoin(Id, add_source(ids, tys))
   | Some(ty) => Just(ty)
   };
@@ -239,7 +244,13 @@ let listlit = (~empty, ctx: Ctx.t, tys: list(Typ.t), ids: list(Id.t)): t =>
   };
 
 let list_concat = (ctx: Ctx.t, tys: list(Typ.t), ids: list(Id.t)): t =>
-  switch (Typ.join_all(~empty=Unknown(SynSwitch) |> Typ.fresh, ctx, tys)) {
+  switch (
+    Typ.join_all(
+      ~empty=Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh,
+      ctx,
+      tys,
+    )
+  ) {
   | None => NoJoin(List, add_source(ids, tys))
   | Some(ty) => Just(ty)
   };

--- a/src/language/statics/Self.re
+++ b/src/language/statics/Self.re
@@ -96,7 +96,7 @@ let typ_of: t => option(Typ.t) =
     Some(
       Sum([
         ConstructorMap.Variant(name, [Id.invalid], None),
-        ConstructorMap.BadEntry(Unknown(Internal) |> Typ.temp),
+        ConstructorMap.BadEntry(Unknown(Sum(Ana)) |> Typ.temp),
       ])
       |> Typ.temp,
     )
@@ -227,7 +227,7 @@ let add_source =
   );
 
 let match = (ctx: Ctx.t, tys: list(Typ.t), ids: list(Id.t)): t =>
-  switch (Typ.join_all(~empty=Unknown(Internal) |> Typ.fresh, ctx, tys)) {
+  switch (Typ.join_all(~empty=Unknown(SynSwitch) |> Typ.fresh, ctx, tys)) {
   | None => NoJoin(Id, add_source(ids, tys))
   | Some(ty) => Just(ty)
   };
@@ -239,7 +239,7 @@ let listlit = (~empty, ctx: Ctx.t, tys: list(Typ.t), ids: list(Id.t)): t =>
   };
 
 let list_concat = (ctx: Ctx.t, tys: list(Typ.t), ids: list(Id.t)): t =>
-  switch (Typ.join_all(~empty=Unknown(Internal) |> Typ.fresh, ctx, tys)) {
+  switch (Typ.join_all(~empty=Unknown(SynSwitch) |> Typ.fresh, ctx, tys)) {
   | None => NoJoin(List, add_source(ids, tys))
   | Some(ty) => Just(ty)
   };

--- a/src/language/statics/Self.re
+++ b/src/language/statics/Self.re
@@ -97,7 +97,7 @@ let typ_of: t => option(Typ.t) =
       Sum([
         ConstructorMap.Variant(name, [Id.invalid], None),
         ConstructorMap.BadEntry(
-          Unknown(Syn, Hole.fresh(Invalid("Free Constructor")), Atom)
+          Unknown(Expr, Hole.fresh(Invalid("Free Constructor")), Atom)
           |> Typ.temp,
         ) // TODO: Correctly track IDs/provenances for free constructor
       ])
@@ -231,7 +231,7 @@ let add_source =
 
 let match = (ctx: Ctx.t, tys: list(Typ.t), ids: list(Id.t), error): t =>
   switch (
-    Typ.join_all(~empty=Unknown(Syn, error, Atom) |> Typ.fresh, ctx, tys)
+    Typ.join_all(~empty=Unknown(Expr, error, Atom) |> Typ.fresh, ctx, tys)
   ) {
   | None => NoJoin(Id, add_source(ids, tys))
   | Some(ty) => Just(ty)
@@ -246,7 +246,7 @@ let listlit = (~empty, ctx: Ctx.t, tys: list(Typ.t), ids: list(Id.t)): t =>
 let list_concat = (ctx: Ctx.t, tys: list(Typ.t), ids: list(Id.t)): t =>
   switch (
     Typ.join_all(
-      ~empty=Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh,
+      ~empty=Unknown(Expr, Hole.temp(List), Atom) |> Typ.fresh,
       ctx,
       tys,
     )

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -342,14 +342,14 @@ and uexp_to_info_map =
       add(~self=IsMulti, ~co_ctx=CoCtx.union(co_ctxs), m);
     | Asc(e, t2) =>
       let (t, m) = go_typ(t2, ~expects=Info.TypeExpected, m);
-      let (e, m) = go'(~ana=Typ.make_ana(t.term), ~ctx=t.ctx, e, m);
+      let (e, m) = go'(~ana=t.term, ~ctx=t.ctx, e, m);
       add(~self=Just(t.term), ~co_ctx=e.co_ctx, m);
     | Invalid(token) => atomic(BadToken(token))
     | EmptyHole =>
       atomic(
         Just(
           Unknown(
-            Syn,
+            Expr,
             {
               term: EmptyHole,
               annotation: {
@@ -367,7 +367,7 @@ and uexp_to_info_map =
       atomic(
         Just(
           Unknown(
-            Syn,
+            Expr,
             {
               term: EmptyHole,
               annotation: {
@@ -397,14 +397,14 @@ and uexp_to_info_map =
       )
     | ListLit(es) =>
       let ids = List.map(Exp.rep_id, es);
-      let inner_ana_ty = Typ.matched_list(ctx, ana, errorhole);
+      let inner_ana_ty = Typ.matched_list(ctx, ana, errorhole, Expr);
       let anas = List.init(List.length(es), _ => inner_ana_ty);
       let (es, m) = map_m_go(m, anas, es);
       let tys = List.map(Info.exp_ty, es);
       add(
         ~self=
           Self.listlit(
-            ~empty=Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+            ~empty=Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.temp,
             ctx,
             tys,
             ids,
@@ -413,7 +413,7 @@ and uexp_to_info_map =
         m,
       );
     | Cons(hd, tl) =>
-      let inner_ana_ty = Typ.matched_list(ctx, ana, errorhole);
+      let inner_ana_ty = Typ.matched_list(ctx, ana, errorhole, Expr);
       let (hd, m) = go(~ana=inner_ana_ty, hd, m);
       let (tl, m) = go(~ana=List(inner_ana_ty) |> Typ.temp, tl, m);
       add(
@@ -423,7 +423,7 @@ and uexp_to_info_map =
       );
     | ListConcat(e1, e2) =>
       let inner_ana_ty =
-        List(Typ.matched_list(ctx, ana, errorhole)) |> Typ.temp;
+        List(Typ.matched_list(ctx, ana, errorhole, Expr)) |> Typ.temp;
       let ids = List.map(Exp.rep_id, [e1, e2]);
       let (e1, m) = go(~ana=inner_ana_ty, e1, m);
       let (e2, m) = go(~ana=inner_ana_ty, e2, m);
@@ -455,21 +455,25 @@ and uexp_to_info_map =
             Constructor(
               "$e",
               Some(
-                Some(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh),
+                Some(
+                  Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.fresh,
+                ),
               ),
             )
           | Var("v") =>
             Constructor(
               "$v",
               Some(
-                Some(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh),
+                Some(
+                  Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.fresh,
+                ),
               ),
             )
           | _ => e.term
           },
       };
       let ty_in = Var("$Meta") |> Typ.temp;
-      let ty_out = Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp;
+      let ty_out = Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.temp;
       let (e, m) = go(~ana=ty_in, e, m);
       add(~self=Just(ty_out), ~co_ctx=e.co_ctx, m);
     | UnOp(Meta(Unquote), e) =>
@@ -540,7 +544,8 @@ and uexp_to_info_map =
               Some(name),
               TupLabel(Label(name) |> Exp.fresh, e) |> Exp.fresh,
             ),
-          errorhole // TODO: Check
+          errorhole,
+          Expr,
         );
       let es = List.map(snd, inferred_es);
       let inferred = List.map(fst, inferred_es);
@@ -641,7 +646,7 @@ and uexp_to_info_map =
         | _ =>
           let (lab, m) =
             go(
-              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp, // TODO: use SynSwitch here if it doesn't break anything. (To avoid unfilled temporary holes)
+              ~ana=Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.temp, // TODO: use SynSwitch here if it doesn't break anything. (To avoid unfilled temporary holes)
               ~override_self=?
                 switch (label.term, expected_labels) {
                 | (Label(name), Some(expected_labels))
@@ -659,7 +664,7 @@ and uexp_to_info_map =
 
           let (e, m) =
             go(
-              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+              ~ana=Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.temp,
               ~inferred_label?,
               e,
               m,
@@ -697,7 +702,7 @@ and uexp_to_info_map =
             typ:
               TupLabel(
                 Unknown(
-                  Syn,
+                  Expr,
                   {
                     term: ErrorHole,
                     annotation: lab.term.annotation,
@@ -733,7 +738,7 @@ and uexp_to_info_map =
             Prod([
               TupLabel(
                 Label(name) |> Typ.temp,
-                Unknown(Syn, errorhole, Atom) |> Typ.temp // TODO: Check
+                Unknown(Expr, errorhole, Atom) |> Typ.temp,
               )
               |> Typ.temp,
             ])
@@ -768,7 +773,7 @@ and uexp_to_info_map =
             ~self=
               Just(
                 Unknown(
-                  Syn,
+                  Expr,
                   {
                     term: EmptyHole,
                     annotation: e2.annotation,
@@ -822,7 +827,7 @@ and uexp_to_info_map =
         switch (Ctx.lookup_livelit(ctx, s)) {
         | Some({expansion_t, model_t, expand, _}) =>
           let (fn, m) = go(~ana=expansion_t, fn, m);
-          let (arg, m) = go(~ana=Typ.make_ana(model_t), arg, m);
+          let (arg, m) = go(~ana=model_t, arg, m);
 
           // try to expand
           switch (expand(arg.term)) {
@@ -845,13 +850,13 @@ and uexp_to_info_map =
           // TODO: Hole provenances?
           let (fn, m) =
             go(
-              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+              ~ana=Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.temp,
               fn,
               m,
             );
           let (arg, m) =
             go(
-              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+              ~ana=Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.temp,
               arg,
               m,
             );
@@ -859,7 +864,7 @@ and uexp_to_info_map =
             ~self=
               Just(
                 Unknown(
-                  Syn,
+                  Expr,
                   {
                     term: ErrorHole,
                     annotation: fn.term.annotation,
@@ -897,9 +902,10 @@ and uexp_to_info_map =
               term: ErrorHole,
               annotation: fn.ty.annotation,
             },
+            Expr,
           );
 
-        let (arg, m) = go(~ana=Typ.make_ana(ty_in), arg, m);
+        let (arg, m) = go(~ana=ty_in, arg, m);
         let self: Self.exp =
           Id.is_nullary_ap_flag(IdTagged.ids(arg.term))
           && !Typ.is_consistent(ctx, ty_in, Prod([]) |> Typ.temp)
@@ -918,6 +924,7 @@ and uexp_to_info_map =
             term: ErrorHole,
             annotation: fn.ty.annotation,
           },
+          Expr,
         );
       switch (option_name) {
       | Some(name) =>
@@ -953,6 +960,7 @@ and uexp_to_info_map =
             term: ErrorHole,
             annotation: fn.ty.annotation,
           },
+          Expr,
         );
       let num_args = List.length(args);
       switch (Typ.matched_args_strict(ctx, ty_in, num_args)) {
@@ -977,7 +985,7 @@ and uexp_to_info_map =
         let ty_ins =
           List.init(num_args, i =>
             Unknown(
-              Ana,
+              Expr,
               {
                 term: ErrorHole,
                 annotation: fn.term.annotation,
@@ -1001,7 +1009,8 @@ and uexp_to_info_map =
         );
       };
     | Fun(p, e, typ, _) =>
-      let (mode_pat, mode_body) = Typ.matched_arrow(ctx, ana, errorhole);
+      let (mode_pat, mode_body) =
+        Typ.matched_arrow(ctx, ana, errorhole, Expr);
       let mode_pat = Option.value(~default=mode_pat, typ);
       let (p', _) =
         go_pat(~is_synswitch=false, ~co_ctx=CoCtx.empty, ~ana=mode_pat, p, m);
@@ -1019,7 +1028,7 @@ and uexp_to_info_map =
       add'(~self, ~co_ctx=CoCtx.mk(ctx, p.ctx, e.co_ctx), m);
     | TypFun(utpat, body, _) =>
       let (name_expected_opt, item) =
-        Typ.matched_forall(ctx, ana, errorhole);
+        Typ.matched_forall(ctx, ana, errorhole, Expr);
       let (mode_body, ctx_body) =
         switch (TPat.tyvar_of_utpat(utpat)) {
         | Some(name) when !Ctx.shadows_typ(ctx, name) =>
@@ -1055,7 +1064,7 @@ and uexp_to_info_map =
         go_pat(~is_synswitch=true, ~co_ctx=CoCtx.empty, ~ana=synswitch, p, m);
       let (def, p_ana_ctx, m, ty_p_ana) =
         if (!is_recursive(ctx, p, def, p_syn.ty)) {
-          let (def, m) = go(~ana=Typ.make_ana(p_syn.ty), def, m);
+          let (def, m) = go(~ana=p_syn.ty, def, m);
           let ty_p_ana = def.ty;
           let (p_ana', _) =
             go_pat(
@@ -1067,8 +1076,7 @@ and uexp_to_info_map =
             );
           (def, p_ana'.ctx, m, ty_p_ana);
         } else {
-          let (def_base, _) =
-            go'(~ctx=p_syn.ctx, ~ana=Typ.make_ana(p_syn.ty), def, m);
+          let (def_base, _) = go'(~ctx=p_syn.ctx, ~ana=p_syn.ty, def, m);
           let ty_p_ana = def_base.ty;
           /* Analyze pattern to incorporate def type into ctx */
           let (p_ana', _) =
@@ -1080,13 +1088,10 @@ and uexp_to_info_map =
               m,
             );
           let def_ctx = p_ana'.ctx;
-          let (def_base2, _) =
-            go'(~ctx=def_ctx, ~ana=Typ.make_ana(p_syn.ty), def, m);
+          let (def_base2, _) = go'(~ctx=def_ctx, ~ana=p_syn.ty, def, m);
           let ana_ty_fn = ((ty_fn1, ty_fn2), ty_p) => {
-            Typ.make_ana(
-              ty_p |> Typ.is_synswitch && !Typ.equal(ty_fn1, ty_fn2)
-                ? ty_fn1 : ty_p,
-            );
+            ty_p |> Typ.is_synswitch && !Typ.equal(ty_fn1, ty_fn2)
+              ? ty_fn1 : ty_p;
           };
           let ana =
             switch (
@@ -1333,7 +1338,7 @@ and upat_to_info_map =
       ~ancestors: Info.ancestors,
       ~duplicates: list(string),
       ~expected_labels=?,
-      ~ana: Typ.t=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+      ~ana: Typ.t=Unknown(Type, Hole.temp(EmptyHole), Atom) |> Typ.temp,
       ~under_ascription: bool=false,
       ~override_self: option(Self.t)=?,
       ~inferred_label=?,
@@ -1410,7 +1415,7 @@ and upat_to_info_map =
   let go = (~under_ascription=false) =>
     upat_to_info_map(~under_ascription, ~is_synswitch, ~ancestors, ~co_ctx);
   let unknown =
-    Unknown(is_synswitch ? SynSwitch : Syn, Hole.temp(EmptyHole), Atom)
+    Unknown(is_synswitch ? SynSwitch : Type, Hole.temp(EmptyHole), Atom)
     |> Typ.temp;
   let ctx_fold = (ctx: Ctx.t, m, ~duplicates=[]) =>
     List.fold_left2(
@@ -1500,7 +1505,7 @@ and upat_to_info_map =
       hole(
         Just(
           Unknown(
-            Syn,
+            Expr,
             {
               term: EmptyHole,
               annotation: {
@@ -1547,7 +1552,7 @@ and upat_to_info_map =
       };
     | ListLit(ps) =>
       let ids = List.map(Pat.rep_id, ps);
-      let mode = Typ.matched_list(ctx, ana, errorhole);
+      let mode = Typ.matched_list(ctx, ana, errorhole, Expr);
       let modes = List.init(List.length(ps), _ => mode);
       let (ctx, tys, cons, m, _) = ctx_fold(ctx, m, ps, modes);
       let rec cons_fold_list = cs =>
@@ -1562,7 +1567,7 @@ and upat_to_info_map =
         m,
       );
     | Cons(hd, tl) =>
-      let inner_ty = Typ.matched_list(ctx, ana, errorhole);
+      let inner_ty = Typ.matched_list(ctx, ana, errorhole, Expr);
       let (hd, m) = go(~ctx, ~ana=inner_ty, hd, m);
       let (tl, m) =
         go(~ctx=hd.ctx, ~ana=List(inner_ty) |> Typ.fresh, tl, m);
@@ -1582,7 +1587,7 @@ and upat_to_info_map =
           ctx,
           ana,
           Common(
-            Just(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp),
+            Just(Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.temp),
           ),
           ids,
         );
@@ -1625,7 +1630,7 @@ and upat_to_info_map =
           let (lab, m) =
             go(
               ~ctx,
-              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+              ~ana=Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.temp,
               ~label_sort=true,
               ~override_self=?
                 switch (label.term, expected_labels) {
@@ -1644,7 +1649,7 @@ and upat_to_info_map =
           let (p, m) =
             go(
               ~ctx,
-              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+              ~ana=Unknown(Expr, Hole.temp(EmptyHole), Atom) |> Typ.temp,
               ~inferred_label?,
               p,
               m,
@@ -1682,7 +1687,7 @@ and upat_to_info_map =
             typ:
               TupLabel(
                 Unknown(
-                  Syn,
+                  Expr,
                   {
                     term: ErrorHole,
                     annotation: lab.term.annotation,
@@ -1732,6 +1737,7 @@ and upat_to_info_map =
               TupLabel(Label(name) |> Pat.fresh, p) |> Pat.fresh,
             ),
           errorhole,
+          Expr,
         );
       let ps = List.map(snd, inferred_ps);
       let inferred = List.map(fst, inferred_ps);
@@ -1855,8 +1861,9 @@ and upat_to_info_map =
             term: ErrorHole,
             annotation: fn'.term.annotation,
           },
+          Expr,
         );
-      let (arg, m) = go(~ctx, ~ana=Typ.make_ana(ty_in), arg, m);
+      let (arg, m) = go(~ctx, ~ana=ty_in, arg, m);
       let constraint_ =
         switch (ctr) {
         | Some(ctr) => Coverage.Constraint.Ap(ctr, Some(arg.constraint_))
@@ -1865,10 +1872,8 @@ and upat_to_info_map =
       add(~self=Just(ty_out), ~ctx=arg.ctx, ~constraint_, m);
     | Asc(p, ann) =>
       let (ann, m) = utyp_to_info_map(~ctx, ~ancestors, ann, m);
-      let (p, m) =
-        go(~ctx, ~under_ascription=true, ~ana=Typ.make_ana(ann.term), p, m);
-      add(~self=Just(Typ.make_ana(ann.term)),
-       ~ctx=p.ctx, ~constraint_=p.constraint_, m);
+      let (p, m) = go(~ctx, ~under_ascription=true, ~ana=ann.term, p, m);
+      add(~self=Just(ann.term), ~ctx=p.ctx, ~constraint_=p.constraint_, m);
     };
 
   // This is to allow lifting single values into a singleton labeled tuple when the label is not present
@@ -1956,7 +1961,7 @@ and utyp_to_info_map =
           Unique,
           Arrow(
             t2,
-            Unknown(Syn, Hole.temp(EmptyHole), ArrowR(Atom)) |> Typ.temp,
+            Unknown(Type, Hole.temp(EmptyHole), ArrowR(Atom)) |> Typ.temp,
           )
           |> Typ.temp,
         )

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -342,7 +342,7 @@ and uexp_to_info_map =
       add(~self=IsMulti, ~co_ctx=CoCtx.union(co_ctxs), m);
     | Asc(e, t2) =>
       let (t, m) = go_typ(t2, ~expects=Info.TypeExpected, m);
-      let (e, m) = go'(~ana=t.term, ~ctx=t.ctx, e, m);
+      let (e, m) = go'(~ana=Typ.make_ana(t.term), ~ctx=t.ctx, e, m);
       add(~self=Just(t.term), ~co_ctx=e.co_ctx, m);
     | Invalid(token) => atomic(BadToken(token))
     | EmptyHole =>
@@ -641,7 +641,7 @@ and uexp_to_info_map =
         | _ =>
           let (lab, m) =
             go(
-              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp, // TODO: Replace with synswitch?
+              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp, // TODO: use SynSwitch here if it doesn't break anything. (To avoid unfilled temporary holes)
               ~override_self=?
                 switch (label.term, expected_labels) {
                 | (Label(name), Some(expected_labels))
@@ -663,7 +663,7 @@ and uexp_to_info_map =
               ~inferred_label?,
               e,
               m,
-            ); // TODO: Replace with synswitch?
+            );
           (lab, e, m);
         };
 
@@ -822,7 +822,7 @@ and uexp_to_info_map =
         switch (Ctx.lookup_livelit(ctx, s)) {
         | Some({expansion_t, model_t, expand, _}) =>
           let (fn, m) = go(~ana=expansion_t, fn, m);
-          let (arg, m) = go(~ana=model_t, arg, m);
+          let (arg, m) = go(~ana=Typ.make_ana(model_t), arg, m);
 
           // try to expand
           switch (expand(arg.term)) {
@@ -842,7 +842,7 @@ and uexp_to_info_map =
           };
 
         | None =>
-          // TODO: Hole provenances
+          // TODO: Hole provenances?
           let (fn, m) =
             go(
               ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
@@ -899,7 +899,7 @@ and uexp_to_info_map =
             },
           );
 
-        let (arg, m) = go(~ana=ty_in, arg, m);
+        let (arg, m) = go(~ana=Typ.make_ana(ty_in), arg, m);
         let self: Self.exp =
           Id.is_nullary_ap_flag(IdTagged.ids(arg.term))
           && !Typ.is_consistent(ctx, ty_in, Prod([]) |> Typ.temp)
@@ -1055,7 +1055,7 @@ and uexp_to_info_map =
         go_pat(~is_synswitch=true, ~co_ctx=CoCtx.empty, ~ana=synswitch, p, m);
       let (def, p_ana_ctx, m, ty_p_ana) =
         if (!is_recursive(ctx, p, def, p_syn.ty)) {
-          let (def, m) = go(~ana=p_syn.ty, def, m);
+          let (def, m) = go(~ana=Typ.make_ana(p_syn.ty), def, m);
           let ty_p_ana = def.ty;
           let (p_ana', _) =
             go_pat(
@@ -1067,7 +1067,8 @@ and uexp_to_info_map =
             );
           (def, p_ana'.ctx, m, ty_p_ana);
         } else {
-          let (def_base, _) = go'(~ctx=p_syn.ctx, ~ana=p_syn.ty, def, m);
+          let (def_base, _) =
+            go'(~ctx=p_syn.ctx, ~ana=Typ.make_ana(p_syn.ty), def, m);
           let ty_p_ana = def_base.ty;
           /* Analyze pattern to incorporate def type into ctx */
           let (p_ana', _) =
@@ -1079,10 +1080,13 @@ and uexp_to_info_map =
               m,
             );
           let def_ctx = p_ana'.ctx;
-          let (def_base2, _) = go'(~ctx=def_ctx, ~ana=p_syn.ty, def, m);
+          let (def_base2, _) =
+            go'(~ctx=def_ctx, ~ana=Typ.make_ana(p_syn.ty), def, m);
           let ana_ty_fn = ((ty_fn1, ty_fn2), ty_p) => {
-            ty_p |> Typ.is_synswitch && !Typ.equal(ty_fn1, ty_fn2)
-              ? ty_fn1 : ty_p;
+            Typ.make_ana(
+              ty_p |> Typ.is_synswitch && !Typ.equal(ty_fn1, ty_fn2)
+                ? ty_fn1 : ty_p // TODO: Check make_ana makes sense in both situations here
+            );
           };
           let ana =
             switch (
@@ -1329,7 +1333,7 @@ and upat_to_info_map =
       ~ancestors: Info.ancestors,
       ~duplicates: list(string),
       ~expected_labels=?,
-      ~ana: Typ.t=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp, // TODO: Switch to synswitch?
+      ~ana: Typ.t=Unknown(SynSwitch, Hole.temp(EmptyHole), Atom) |> Typ.temp,
       ~under_ascription: bool=false,
       ~override_self: option(Self.t)=?,
       ~inferred_label=?,
@@ -1405,6 +1409,9 @@ and upat_to_info_map =
   let ancestors = [Pat.rep_id(upat)] @ ancestors;
   let go = (~under_ascription=false) =>
     upat_to_info_map(~under_ascription, ~is_synswitch, ~ancestors, ~co_ctx);
+  let unknown =
+    Unknown(is_synswitch ? SynSwitch : Syn, Hole.temp(EmptyHole), Atom)
+    |> Typ.temp;
   let ctx_fold = (ctx: Ctx.t, m, ~duplicates=[]) =>
     List.fold_left2(
       ((ctx, tys, cons, m, info_all), e, ana) =>
@@ -1549,13 +1556,7 @@ and upat_to_info_map =
         | [hd, ...tl] => Coverage.Constraint.cons(hd, cons_fold_list(tl))
         };
       add(
-        ~self=
-          Self.listlit(
-            ~empty=Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp,
-            ctx,
-            tys,
-            ids,
-          ),
+        ~self=Self.listlit(~empty=unknown, ctx, tys, ids),
         ~ctx,
         ~constraint_=cons_fold_list(cons),
         m,
@@ -1571,15 +1572,11 @@ and upat_to_info_map =
         ~constraint_=Coverage.Constraint.cons(hd.constraint_, tl.constraint_),
         m,
       );
-    | Wild =>
-      atomic(
-        Just(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp),
-        Coverage.Constraint.Truth,
-      )
+    | Wild => atomic(Just(unknown), Coverage.Constraint.Truth)
     | Var(name) =>
       /* NOTE: The self type assigned to pattern variables (Unknown)
          may be SynSwitch, but SynSwitch is never added to the context;
-         Unknown(Internal) is used in this case */
+         Unknown(Syn, ...) is used in this case */
       let ctx_typ =
         Info.fixed_typ_pat(
           ctx,
@@ -1596,7 +1593,7 @@ and upat_to_info_map =
           typ: ctx_typ,
         });
       add(
-        ~self=Just(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp),
+        ~self=Just(unknown),
         ~ctx=Ctx.extend(ctx, entry),
         ~constraint_=Coverage.Constraint.Truth,
         m,
@@ -1859,7 +1856,7 @@ and upat_to_info_map =
             annotation: fn'.term.annotation,
           },
         );
-      let (arg, m) = go(~ctx, ~ana=ty_in, arg, m);
+      let (arg, m) = go(~ctx, ~ana=Typ.make_ana(ty_in), arg, m);
       let constraint_ =
         switch (ctr) {
         | Some(ctr) => Coverage.Constraint.Ap(ctr, Some(arg.constraint_))
@@ -1868,7 +1865,8 @@ and upat_to_info_map =
       add(~self=Just(ty_out), ~ctx=arg.ctx, ~constraint_, m);
     | Asc(p, ann) =>
       let (ann, m) = utyp_to_info_map(~ctx, ~ancestors, ann, m);
-      let (p, m) = go(~ctx, ~under_ascription=true, ~ana=ann.term, p, m);
+      let (p, m) =
+        go(~ctx, ~under_ascription=true, ~ana=Typ.make_ana(ann.term), p, m);
       add(~self=Just(ann.term), ~ctx=p.ctx, ~constraint_=p.constraint_, m);
     };
 

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -338,7 +338,7 @@ and uexp_to_info_map =
       let (e, m) = go'(~ana=t.term, ~ctx=t.ctx, e, m);
       add(~self=Just(t.term), ~co_ctx=e.co_ctx, m);
     | Invalid(token) => atomic(BadToken(token))
-    | EmptyHole => atomic(Just(Unknown(Internal) |> Typ.temp))
+    | EmptyHole => atomic(Just(Unknown(SynSwitch) |> Typ.temp))
     | Deferral(position) =>
       add'(~self=IsDeferral(position), ~co_ctx=CoCtx.empty, m)
     | Undefined => atomic(Just(Unknown(Hole(EmptyHole)) |> Typ.temp))
@@ -366,7 +366,7 @@ and uexp_to_info_map =
       let tys = List.map(Info.exp_ty, es);
       add(
         ~self=
-          Self.listlit(~empty=Unknown(Internal) |> Typ.temp, ctx, tys, ids),
+          Self.listlit(~empty=Unknown(SynSwitch) |> Typ.temp, ctx, tys, ids),
         ~co_ctx=CoCtx.union(List.map(Info.exp_co_ctx, es)),
         m,
       );
@@ -408,14 +408,14 @@ and uexp_to_info_map =
         term:
           switch (e.term) {
           | Var("e") =>
-            Constructor("$e", Some(Some(Unknown(Internal) |> Typ.fresh)))
+            Constructor("$e", Some(Some(Unknown(SynSwitch) |> Typ.fresh)))
           | Var("v") =>
-            Constructor("$v", Some(Some(Unknown(Internal) |> Typ.fresh)))
+            Constructor("$v", Some(Some(Unknown(SynSwitch) |> Typ.fresh)))
           | _ => e.term
           },
       };
       let ty_in = Var("$Meta") |> Typ.temp;
-      let ty_out = Unknown(Internal) |> Typ.temp;
+      let ty_out = Unknown(SynSwitch) |> Typ.temp;
       let (e, m) = go(~ana=ty_in, e, m);
       add(~self=Just(ty_out), ~co_ctx=e.co_ctx, m);
     | UnOp(Meta(Unquote), e) =>
@@ -586,7 +586,7 @@ and uexp_to_info_map =
         | _ =>
           let (lab, m) =
             go(
-              ~ana=Unknown(Internal) |> Typ.temp,
+              ~ana=Unknown(Ana) |> Typ.temp,
               ~override_self=?
                 switch (label.term, expected_labels) {
                 | (Label(name), Some(expected_labels))
@@ -603,7 +603,7 @@ and uexp_to_info_map =
             );
 
           let (e, m) =
-            go(~ana=Unknown(Internal) |> Typ.temp, ~inferred_label?, e, m);
+            go(~ana=Unknown(Ana) |> Typ.temp, ~inferred_label?, e, m);
           (lab, e, m);
         };
 
@@ -634,7 +634,9 @@ and uexp_to_info_map =
             malformed_labels: [Exp(label)],
             duplicate_labels: [],
             invalid_labels: [],
-            typ: TupLabel(Unknown(Internal) |> Typ.temp, e.ty) |> Typ.temp,
+            typ:
+              TupLabel(Unknown(Label(SynSwitch)) |> Typ.temp, e.ty)
+              |> Typ.temp,
           })
         };
       add(~self, ~co_ctx=CoCtx.union([lab.co_ctx, e.co_ctx]), m);
@@ -655,12 +657,12 @@ and uexp_to_info_map =
       let (ty, m) = {
         switch (info_e1.ty.term, info_e2.ty.term) {
         | (Unknown(_), Label(name)) =>
-          // This is so that the statics will result in Unknown(Internal)
+          // This is so that the statics will result in Unknown(Syn)
           let ty =
             Prod([
               TupLabel(
                 Label(name) |> Typ.temp,
-                Unknown(Internal) |> Typ.temp,
+                Unknown(SynSwitch) |> Typ.temp,
               )
               |> Typ.temp,
             ])
@@ -692,7 +694,7 @@ and uexp_to_info_map =
           };
         | EmptyHole =>
           add(
-            ~self=Just(Unknown(Internal) |> Typ.temp),
+            ~self=Just(Unknown(SynSwitch) |> Typ.temp),
             ~co_ctx=info_e2.co_ctx,
             m,
           )
@@ -759,10 +761,10 @@ and uexp_to_info_map =
           };
 
         | None =>
-          let (fn, m) = go(~ana=Unknown(Internal) |> Typ.temp, fn, m);
-          let (arg, m) = go(~ana=Unknown(Internal) |> Typ.temp, arg, m);
+          let (fn, m) = go(~ana=Unknown(SynSwitch) |> Typ.temp, fn, m);
+          let (arg, m) = go(~ana=Unknown(SynSwitch) |> Typ.temp, arg, m);
           add(
-            ~self=Just(Unknown(Internal) |> Typ.temp),
+            ~self=Just(Unknown(SynSwitch) |> Typ.temp),
             ~co_ctx=CoCtx.union([fn.co_ctx, arg.co_ctx]),
             m,
           );
@@ -847,7 +849,7 @@ and uexp_to_info_map =
           m,
         );
       | R(expected) =>
-        let ty_ins = List.init(num_args, _ => Unknown(Internal) |> Typ.temp);
+        let ty_ins = List.init(num_args, _ => Unknown(SynSwitch) |> Typ.temp);
         let (args, m) = map_m_go(m, ty_ins, args);
         let arg_co_ctx = CoCtx.union(List.map(Info.exp_co_ctx, args));
         add'(
@@ -1156,8 +1158,7 @@ and uexp_to_info_map =
       let self: Self.exp =
         switch (use_mode) {
         | Some(_) => Common(Just(body.ty))
-        | None when Typ.fast_equal(Unknown(Internal) |> Typ.temp, typ.term) =>
-          Common(Just(body.ty))
+        | None when Typ.is_unknown(typ.term) => Common(Just(body.ty))
         | None =>
           InvalidUseMode({
             bad_typ: typ.term,
@@ -1192,7 +1193,7 @@ and upat_to_info_map =
       ~ancestors: Info.ancestors,
       ~duplicates: list(string),
       ~expected_labels=?,
-      ~ana: Typ.t=Unknown(Internal) |> Typ.temp,
+      ~ana: Typ.t=Unknown(Ana) |> Typ.temp,
       ~under_ascription: bool=false,
       ~override_self: option(Self.t)=?,
       ~inferred_label=?,
@@ -1262,7 +1263,7 @@ and upat_to_info_map =
   let ancestors = [Pat.rep_id(upat)] @ ancestors;
   let go = (~under_ascription=false) =>
     upat_to_info_map(~under_ascription, ~is_synswitch, ~ancestors, ~co_ctx);
-  let unknown = Unknown(is_synswitch ? SynSwitch : Internal) |> Typ.temp;
+  let unknown = Unknown(SynSwitch) |> Typ.temp;
   let ctx_fold = (ctx: Ctx.t, m, ~duplicates=[]) =>
     List.fold_left2(
       ((ctx, tys, cons, m, info_all), e, ana) =>
@@ -1417,7 +1418,7 @@ and upat_to_info_map =
         Info.fixed_typ_pat(
           ctx,
           ana,
-          Common(Just(Unknown(Internal) |> Typ.temp)),
+          Common(Just(Unknown(SynSwitch) |> Typ.temp)),
         );
       let entry =
         Ctx.VarEntry({
@@ -1458,7 +1459,7 @@ and upat_to_info_map =
           let (lab, m) =
             go(
               ~ctx,
-              ~ana=Unknown(Internal) |> Typ.temp,
+              ~ana=Unknown(Ana) |> Typ.temp,
               ~label_sort=true,
               ~override_self=?
                 switch (label.term, expected_labels) {
@@ -1475,13 +1476,7 @@ and upat_to_info_map =
             );
 
           let (p, m) =
-            go(
-              ~ctx,
-              ~ana=Unknown(Internal) |> Typ.temp,
-              ~inferred_label?,
-              p,
-              m,
-            );
+            go(~ctx, ~ana=Unknown(Ana) |> Typ.temp, ~inferred_label?, p, m);
           (lab, p, m);
         };
 
@@ -1512,7 +1507,9 @@ and upat_to_info_map =
             malformed_labels: [Pat(label)],
             duplicate_labels: [],
             invalid_labels: [],
-            typ: TupLabel(Unknown(Internal) |> Typ.temp, p.ty) |> Typ.temp,
+            typ:
+              TupLabel(Unknown(Label(SynSwitch)) |> Typ.temp, p.ty)
+              |> Typ.temp,
           })
         };
       add(
@@ -1763,7 +1760,7 @@ and utyp_to_info_map =
       | _ =>
         ConstructorExpected(
           Unique,
-          Arrow(t2, Unknown(Internal) |> Typ.temp) |> Typ.temp,
+          Arrow(t2, Unknown(ArrowR(SynSwitch)) |> Typ.temp) |> Typ.temp,
         )
       };
     let m = go'(~expects=t1_mode, t1, m) |> snd;

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -117,7 +117,8 @@ let is_recursive = (ctx, p, def, syn: Typ.t) => {
   };
 };
 
-let syn = Unknown(SynSwitch) |> Typ.temp;
+// TODO: Factor out SynSwitch from Unknown, it does not come from holes (it is purely an implementation technicality).
+let synswitch = Unknown(SynSwitch, Hole.temp(EmptyHole), Atom) |> Typ.temp;
 
 let rec any_to_info_map =
         (~ctx: Ctx.t, ~ancestors, any: Any.t, m: Map.t): (CoCtx.t, Map.t) =>
@@ -193,7 +194,7 @@ and multi = (~ctx, ~ancestors, m, tms): (list(CoCtx.t), Map.t) =>
 and uexp_to_info_map =
     (
       ~ctx: Ctx.t,
-      ~ana=Unknown(SynSwitch) |> Typ.temp,
+      ~ana=synswitch,
       ~is_in_filter=false,
       ~ancestors,
       ~duplicates: list(string),
@@ -205,6 +206,12 @@ and uexp_to_info_map =
       m: Map.t,
     )
     : (Info.exp, Map.t) => {
+  let errorhole: Hole.t = {
+    term: ErrorHole,
+    annotation: {
+      ids: ids,
+    },
+  };
   let add' = (~label_inference=?, ~self, ~co_ctx, m) => {
     let info =
       Info.derived_exp(
@@ -228,7 +235,7 @@ and uexp_to_info_map =
   let uexp_to_info_map =
       (
         ~ctx,
-        ~ana=Unknown(SynSwitch) |> Typ.temp,
+        ~ana=synswitch,
         ~is_in_filter=is_in_filter,
         ~ancestors=ancestors,
         ~duplicates=[],
@@ -338,10 +345,40 @@ and uexp_to_info_map =
       let (e, m) = go'(~ana=t.term, ~ctx=t.ctx, e, m);
       add(~self=Just(t.term), ~co_ctx=e.co_ctx, m);
     | Invalid(token) => atomic(BadToken(token))
-    | EmptyHole => atomic(Just(Unknown(SynSwitch) |> Typ.temp))
+    | EmptyHole =>
+      atomic(
+        Just(
+          Unknown(
+            Syn,
+            {
+              term: EmptyHole,
+              annotation: {
+                ids: ids,
+              },
+            },
+            Atom,
+          )
+          |> Typ.temp,
+        ),
+      )
     | Deferral(position) =>
       add'(~self=IsDeferral(position), ~co_ctx=CoCtx.empty, m)
-    | Undefined => atomic(Just(Unknown(Hole(EmptyHole)) |> Typ.temp))
+    | Undefined =>
+      atomic(
+        Just(
+          Unknown(
+            Syn,
+            {
+              term: EmptyHole,
+              annotation: {
+                ids: ids,
+              },
+            },
+            Atom,
+          )
+          |> Typ.temp,
+        ),
+      )
     | Atom(c) =>
       let c =
         Operators.replace_literal(c, Typ.is_ana_atom(ana), ctx.use_mode); // Replace literal if necessary due to `use`
@@ -360,18 +397,23 @@ and uexp_to_info_map =
       )
     | ListLit(es) =>
       let ids = List.map(Exp.rep_id, es);
-      let inner_ana_ty = Typ.matched_list(ctx, ana);
+      let inner_ana_ty = Typ.matched_list(ctx, ana, errorhole);
       let anas = List.init(List.length(es), _ => inner_ana_ty);
       let (es, m) = map_m_go(m, anas, es);
       let tys = List.map(Info.exp_ty, es);
       add(
         ~self=
-          Self.listlit(~empty=Unknown(SynSwitch) |> Typ.temp, ctx, tys, ids),
+          Self.listlit(
+            ~empty=Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+            ctx,
+            tys,
+            ids,
+          ),
         ~co_ctx=CoCtx.union(List.map(Info.exp_co_ctx, es)),
         m,
       );
     | Cons(hd, tl) =>
-      let inner_ana_ty = Typ.matched_list(ctx, ana);
+      let inner_ana_ty = Typ.matched_list(ctx, ana, errorhole);
       let (hd, m) = go(~ana=inner_ana_ty, hd, m);
       let (tl, m) = go(~ana=List(inner_ana_ty) |> Typ.temp, tl, m);
       add(
@@ -380,7 +422,8 @@ and uexp_to_info_map =
         m,
       );
     | ListConcat(e1, e2) =>
-      let inner_ana_ty = List(Typ.matched_list(ctx, ana)) |> Typ.temp;
+      let inner_ana_ty =
+        List(Typ.matched_list(ctx, ana, errorhole)) |> Typ.temp;
       let ids = List.map(Exp.rep_id, [e1, e2]);
       let (e1, m) = go(~ana=inner_ana_ty, e1, m);
       let (e2, m) = go(~ana=inner_ana_ty, e2, m);
@@ -401,6 +444,7 @@ and uexp_to_info_map =
       let (e, m) = go(~ana, e, m);
       add(~self=Just(e.ty), ~co_ctx=e.co_ctx, m);
     | UnOp(Meta(Unquote), e) when is_in_filter =>
+      // TODO: Hole provenances for this case...
       let e: Exp.t = {
         annotation: {
           ids: IdTagged.ids(e),
@@ -408,25 +452,35 @@ and uexp_to_info_map =
         term:
           switch (e.term) {
           | Var("e") =>
-            Constructor("$e", Some(Some(Unknown(SynSwitch) |> Typ.fresh)))
+            Constructor(
+              "$e",
+              Some(
+                Some(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh),
+              ),
+            )
           | Var("v") =>
-            Constructor("$v", Some(Some(Unknown(SynSwitch) |> Typ.fresh)))
+            Constructor(
+              "$v",
+              Some(
+                Some(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.fresh),
+              ),
+            )
           | _ => e.term
           },
       };
       let ty_in = Var("$Meta") |> Typ.temp;
-      let ty_out = Unknown(SynSwitch) |> Typ.temp;
+      let ty_out = Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp;
       let (e, m) = go(~ana=ty_in, e, m);
       add(~self=Just(ty_out), ~co_ctx=e.co_ctx, m);
     | UnOp(Meta(Unquote), e) =>
-      let (e, m) = go(~ana=syn, e, m);
+      let (e, m) = go(~ana=synswitch, e, m);
       add'(~self=BadOperator("Unquote not in filter"), ~co_ctx=e.co_ctx, m);
     | UnOp(op, e) =>
       let op = Operators.replace_un_op(op, ctx.use_mode); // Replace op if necessary due to `use`
       let op_semantics = Operators.semantics_of_un_op(op);
       switch (op_semantics) {
       | Undefined(msg) =>
-        let (_, m) = go(~ana=syn, e, m);
+        let (_, m) = go(~ana=synswitch, e, m);
         add'(~self=BadOperator(msg), ~co_ctx=CoCtx.empty, m);
       | Defined(ty_in, ty_out, _) =>
         let ty_in = Atom(Atom.cls_of_kind(ty_in)) |> Typ.temp;
@@ -439,8 +493,8 @@ and uexp_to_info_map =
       let op_semantics = Operators.semantics_of_bin_op(op);
       switch (op_semantics) {
       | Undefined(msg) =>
-        let (_, m) = go(~ana=syn, e1, m);
-        let (_, m) = go(~ana=syn, e2, m);
+        let (_, m) = go(~ana=synswitch, e1, m);
+        let (_, m) = go(~ana=synswitch, e2, m);
         add'(~self=BadOperator(msg), ~co_ctx=CoCtx.empty, m);
       | Defined(ty1, ty2, ty_out, _) =>
         let ty1 = Atom(Atom.cls_of_kind(ty1)) |> Typ.temp;
@@ -486,6 +540,7 @@ and uexp_to_info_map =
               Some(name),
               TupLabel(Label(name) |> Exp.fresh, e) |> Exp.fresh,
             ),
+          errorhole // TODO: Check
         );
       let es = List.map(snd, inferred_es);
       let inferred = List.map(fst, inferred_es);
@@ -586,7 +641,7 @@ and uexp_to_info_map =
         | _ =>
           let (lab, m) =
             go(
-              ~ana=Unknown(Ana) |> Typ.temp,
+              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp, // TODO: Replace with synswitch?
               ~override_self=?
                 switch (label.term, expected_labels) {
                 | (Label(name), Some(expected_labels))
@@ -603,7 +658,12 @@ and uexp_to_info_map =
             );
 
           let (e, m) =
-            go(~ana=Unknown(Ana) |> Typ.temp, ~inferred_label?, e, m);
+            go(
+              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+              ~inferred_label?,
+              e,
+              m,
+            ); // TODO: Replace with synswitch?
           (lab, e, m);
         };
 
@@ -635,7 +695,18 @@ and uexp_to_info_map =
             duplicate_labels: [],
             invalid_labels: [],
             typ:
-              TupLabel(Unknown(Label(SynSwitch)) |> Typ.temp, e.ty)
+              TupLabel(
+                Unknown(
+                  Syn,
+                  {
+                    term: ErrorHole,
+                    annotation: lab.term.annotation,
+                  },
+                  Atom,
+                )
+                |> Typ.temp,
+                e.ty,
+              )
               |> Typ.temp,
           })
         };
@@ -652,17 +723,17 @@ and uexp_to_info_map =
       )
 
     | Dot(e1, e2) =>
-      let (info_e1, m) = go(~ana=Unknown(SynSwitch) |> Typ.temp, e1, m);
+      let (info_e1, m) = go(~ana=synswitch, e1, m);
       let (info_e2, m) = go(~ana=Label("") |> Typ.temp, e2, m);
       let (ty, m) = {
         switch (info_e1.ty.term, info_e2.ty.term) {
         | (Unknown(_), Label(name)) =>
-          // This is so that the statics will result in Unknown(Syn)
+          // This is so that the statics will result in Unknown(Syn, ...)
           let ty =
             Prod([
               TupLabel(
                 Label(name) |> Typ.temp,
-                Unknown(SynSwitch) |> Typ.temp,
+                Unknown(Syn, errorhole, Atom) |> Typ.temp // TODO: Check
               )
               |> Typ.temp,
             ])
@@ -694,7 +765,18 @@ and uexp_to_info_map =
           };
         | EmptyHole =>
           add(
-            ~self=Just(Unknown(SynSwitch) |> Typ.temp),
+            ~self=
+              Just(
+                Unknown(
+                  Syn,
+                  {
+                    term: EmptyHole,
+                    annotation: e2.annotation,
+                  },
+                  Atom,
+                )
+                |> Typ.temp,
+              ),
             ~co_ctx=info_e2.co_ctx,
             m,
           )
@@ -714,8 +796,7 @@ and uexp_to_info_map =
         m,
       );
     | Filter(Filter({pat: cond, _}), body) =>
-      let (cond, m) =
-        go(~ana=Unknown(SynSwitch) |> Typ.temp, cond, m, ~is_in_filter=true);
+      let (cond, m) = go(~ana=synswitch, cond, m, ~is_in_filter=true);
       let (body, m) = go(~ana, body, m);
       add(
         ~self=Just(body.ty),
@@ -726,7 +807,7 @@ and uexp_to_info_map =
       let (body, m) = go(~ana, body, m);
       add(~self=Just(body.ty), ~co_ctx=CoCtx.union([body.co_ctx]), m);
     | Seq(e1, e2) =>
-      let (e1, m) = go(~ana=Unknown(SynSwitch) |> Typ.temp, e1, m);
+      let (e1, m) = go(~ana=synswitch, e1, m);
       let (e2, m) = go(~ana, e2, m);
       add(
         ~self=Just(e2.ty),
@@ -761,10 +842,32 @@ and uexp_to_info_map =
           };
 
         | None =>
-          let (fn, m) = go(~ana=Unknown(SynSwitch) |> Typ.temp, fn, m);
-          let (arg, m) = go(~ana=Unknown(SynSwitch) |> Typ.temp, arg, m);
+          // TODO: Hole provenances
+          let (fn, m) =
+            go(
+              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+              fn,
+              m,
+            );
+          let (arg, m) =
+            go(
+              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+              arg,
+              m,
+            );
           add(
-            ~self=Just(Unknown(SynSwitch) |> Typ.temp),
+            ~self=
+              Just(
+                Unknown(
+                  Syn,
+                  {
+                    term: ErrorHole,
+                    annotation: fn.term.annotation,
+                  },
+                  Atom,
+                )
+                |> Typ.temp,
+              ),
             ~co_ctx=CoCtx.union([fn.co_ctx, arg.co_ctx]),
             m,
           );
@@ -779,14 +882,22 @@ and uexp_to_info_map =
             | Some(ty_ana) =>
               switch (Typ.matched_arrow_strict(ctx, ty_ana)) {
               | Some((ty1, ty2)) => Arrow(ty1, ty2) |> Typ.temp
-              | None => Arrow(syn, syn) |> Typ.temp
+              | None => Arrow(synswitch, synswitch) |> Typ.temp
               }
-            | None => Arrow(syn, syn) |> Typ.temp
+            | None => Arrow(synswitch, synswitch) |> Typ.temp
             }
-          | None => Arrow(syn, syn) |> Typ.temp
+          | None => Arrow(synswitch, synswitch) |> Typ.temp
           };
         let (fn, m) = go(~ana=fn_ana, fn, m);
-        let (ty_in, ty_out) = Typ.matched_arrow(ctx, fn.ty);
+        let (ty_in, ty_out) =
+          Typ.matched_arrow(
+            ctx,
+            fn.ty,
+            {
+              term: ErrorHole,
+              annotation: fn.ty.annotation,
+            },
+          );
 
         let (arg, m) = go(~ana=ty_in, arg, m);
         let self: Self.exp =
@@ -796,12 +907,18 @@ and uexp_to_info_map =
         add'(~self, ~co_ctx=CoCtx.union([fn.co_ctx, arg.co_ctx]), m);
       }
     | TypAp(fn, utyp) =>
-      let typfn_ana =
-        Forall(EmptyHole |> TPat.fresh, Unknown(SynSwitch) |> Typ.temp)
-        |> Typ.temp;
+      let typfn_ana = Forall(EmptyHole |> TPat.fresh, synswitch) |> Typ.temp;
       let (fn, m) = go(~ana=typfn_ana, fn, m);
       let (_, m) = utyp_to_info_map(~ctx, ~ancestors, utyp, m);
-      let (option_name, ty_body) = Typ.matched_forall(ctx, fn.ty);
+      let (option_name, ty_body) =
+        Typ.matched_forall(
+          ctx,
+          fn.ty,
+          {
+            term: ErrorHole,
+            annotation: fn.ty.annotation,
+          },
+        );
       switch (option_name) {
       | Some(name) =>
         add(
@@ -821,14 +938,22 @@ and uexp_to_info_map =
           | Some(ty_ana) =>
             switch (Typ.matched_arrow_strict(ctx, ty_ana)) {
             | Some((ty1, ty2)) => Arrow(ty1, ty2) |> Typ.temp
-            | None => Arrow(syn, syn) |> Typ.temp
+            | None => Arrow(synswitch, synswitch) |> Typ.temp
             }
-          | None => Arrow(syn, syn) |> Typ.temp
+          | None => Arrow(synswitch, synswitch) |> Typ.temp
           }
-        | None => Arrow(syn, syn) |> Typ.temp
+        | None => Arrow(synswitch, synswitch) |> Typ.temp
         };
       let (fn, m) = go(~ana=fn_ana, fn, m);
-      let (ty_in, ty_out) = Typ.matched_arrow(ctx, fn.ty);
+      let (ty_in, ty_out) =
+        Typ.matched_arrow(
+          ctx,
+          fn.ty,
+          {
+            term: ErrorHole,
+            annotation: fn.ty.annotation,
+          },
+        );
       let num_args = List.length(args);
       switch (Typ.matched_args_strict(ctx, ty_in, num_args)) {
       | L(ty_ins) =>
@@ -849,7 +974,18 @@ and uexp_to_info_map =
           m,
         );
       | R(expected) =>
-        let ty_ins = List.init(num_args, _ => Unknown(SynSwitch) |> Typ.temp);
+        let ty_ins =
+          List.init(num_args, i =>
+            Unknown(
+              Ana,
+              {
+                term: ErrorHole,
+                annotation: fn.term.annotation,
+              },
+              Prod(i, Atom),
+            )
+            |> Typ.fresh
+          );
         let (args, m) = map_m_go(m, ty_ins, args);
         let arg_co_ctx = CoCtx.union(List.map(Info.exp_co_ctx, args));
         add'(
@@ -865,7 +1001,7 @@ and uexp_to_info_map =
         );
       };
     | Fun(p, e, typ, _) =>
-      let (mode_pat, mode_body) = Typ.matched_arrow(ctx, ana);
+      let (mode_pat, mode_body) = Typ.matched_arrow(ctx, ana, errorhole);
       let mode_pat = Option.value(~default=mode_pat, typ);
       let (p', _) =
         go_pat(~is_synswitch=false, ~co_ctx=CoCtx.empty, ~ana=mode_pat, p, m);
@@ -882,7 +1018,8 @@ and uexp_to_info_map =
         is_exhaustive ? unwrapped_self : InexhaustiveMatch(unwrapped_self);
       add'(~self, ~co_ctx=CoCtx.mk(ctx, p.ctx, e.co_ctx), m);
     | TypFun(utpat, body, _) =>
-      let (name_expected_opt, item) = Typ.matched_forall(ctx, ana);
+      let (name_expected_opt, item) =
+        Typ.matched_forall(ctx, ana, errorhole);
       let (mode_body, ctx_body) =
         switch (TPat.tyvar_of_utpat(utpat)) {
         | Some(name) when !Ctx.shadows_typ(ctx, name) =>
@@ -915,7 +1052,7 @@ and uexp_to_info_map =
       );
     | Let(p, def, body) =>
       let (p_syn, _) =
-        go_pat(~is_synswitch=true, ~co_ctx=CoCtx.empty, ~ana=syn, p, m);
+        go_pat(~is_synswitch=true, ~co_ctx=CoCtx.empty, ~ana=synswitch, p, m);
       let (def, p_ana_ctx, m, ty_p_ana) =
         if (!is_recursive(ctx, p, def, p_syn.ty)) {
           let (def, m) = go(~ana=p_syn.ty, def, m);
@@ -944,8 +1081,7 @@ and uexp_to_info_map =
           let def_ctx = p_ana'.ctx;
           let (def_base2, _) = go'(~ctx=def_ctx, ~ana=p_syn.ty, def, m);
           let ana_ty_fn = ((ty_fn1, ty_fn2), ty_p) => {
-            Typ.term_of(ty_p) == Unknown(SynSwitch)
-            && !Typ.equal(ty_fn1, ty_fn2)
+            ty_p |> Typ.is_synswitch && !Typ.equal(ty_fn1, ty_fn2)
               ? ty_fn1 : ty_p;
           };
           let ana =
@@ -999,12 +1135,12 @@ and uexp_to_info_map =
       let (cons, m) = go(~ana, e1, m);
       let (alt, m) = go(~ana, e2, m);
       add(
-        ~self=Self.match(ctx, [cons.ty, alt.ty], branch_ids),
+        ~self=Self.match(ctx, [cons.ty, alt.ty], branch_ids, errorhole),
         ~co_ctx=CoCtx.union([cond.co_ctx, cons.co_ctx, alt.co_ctx]),
         m,
       );
     | Match(scrut, rules) =>
-      let (scrut, m) = go(~ana=syn, scrut, m);
+      let (scrut, m) = go(~ana=synswitch, scrut, m);
       let (ps, es) = List.split(rules);
       let branch_ids = List.map(Exp.rep_id, es);
       let (ps', _) =
@@ -1026,7 +1162,7 @@ and uexp_to_info_map =
       let e_co_ctxs =
         List.map2(CoCtx.mk(ctx), p_ctxs, List.map(Info.exp_co_ctx, es));
       let unwrapped_self: Self.exp =
-        Common(Self.match(ctx, e_tys, branch_ids));
+        Common(Self.match(ctx, e_tys, branch_ids, errorhole));
       let (constraints, m) =
         List.fold_left(
           (
@@ -1175,7 +1311,7 @@ and uexp_to_info_map =
   | Prod([{term: TupLabel({term: Label(l1), _}, ana_ty), _}]) =>
     // We can flatten this by pulling it up on the case match but since OCaml is strict it'll be evaluated.
     // So for performance reasons we'll just do it here.
-    let (e, m) = go(~ana=syn, uexp, m);
+    let (e, m) = go(~ana=synswitch, uexp, m);
 
     switch (Typ.weak_head_normalize(ctx, e.ty).term) {
     | Prod([{term: TupLabel({term: Label(l2), _}, _), _}]) when l1 == l2 =>
@@ -1193,7 +1329,7 @@ and upat_to_info_map =
       ~ancestors: Info.ancestors,
       ~duplicates: list(string),
       ~expected_labels=?,
-      ~ana: Typ.t=Unknown(Ana) |> Typ.temp,
+      ~ana: Typ.t=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp, // TODO: Switch to synswitch?
       ~under_ascription: bool=false,
       ~override_self: option(Self.t)=?,
       ~inferred_label=?,
@@ -1205,7 +1341,7 @@ and upat_to_info_map =
   let add = (~self, ~ctx, ~constraint_, ~label_inference=?, m) => {
     let prev_synswitch =
       switch (Id.Map.find_opt(Pat.rep_id(upat), m)) {
-      | Some(Info.InfoPat({ana, ty, _})) when Typ.is_syn_plus(ana) =>
+      | Some(Info.InfoPat({ana, ty, _})) when Typ.is_synswitch_plus(ana) =>
         Some(ty)
       | Some(Info.InfoPat({prev_synswitch, _})) => prev_synswitch
       | Some(_)
@@ -1259,11 +1395,16 @@ and upat_to_info_map =
       m: Map.t,
     );
   };
+  let errorhole: Hole.t = {
+    term: ErrorHole,
+    annotation: {
+      ids: ids,
+    },
+  };
   let atomic = (self, constraint_) => add(~self, ~ctx, ~constraint_, m);
   let ancestors = [Pat.rep_id(upat)] @ ancestors;
   let go = (~under_ascription=false) =>
     upat_to_info_map(~under_ascription, ~is_synswitch, ~ancestors, ~co_ctx);
-  let unknown = Unknown(SynSwitch) |> Typ.temp;
   let ctx_fold = (ctx: Ctx.t, m, ~duplicates=[]) =>
     List.fold_left2(
       ((ctx, tys, cons, m, info_all), e, ana) =>
@@ -1348,7 +1489,22 @@ and upat_to_info_map =
       let (_, m) = multi(~ctx, ~ancestors, m, tms);
       add(~self=IsMulti, ~ctx, ~constraint_=Coverage.Constraint.Hole, m);
     | Invalid(token) => hole(BadToken(token))
-    | EmptyHole => hole(Just(unknown))
+    | EmptyHole =>
+      hole(
+        Just(
+          Unknown(
+            Syn,
+            {
+              term: EmptyHole,
+              annotation: {
+                ids: ids,
+              },
+            },
+            Atom,
+          )
+          |> Typ.fresh,
+        ),
+      )
     | Atom(c) =>
       let c =
         Operators.replace_literal(c, Typ.is_ana_atom(ana), ctx.use_mode); // Replace literal if necessary due to `use`
@@ -1384,7 +1540,7 @@ and upat_to_info_map =
       };
     | ListLit(ps) =>
       let ids = List.map(Pat.rep_id, ps);
-      let mode = Typ.matched_list(ctx, ana);
+      let mode = Typ.matched_list(ctx, ana, errorhole);
       let modes = List.init(List.length(ps), _ => mode);
       let (ctx, tys, cons, m, _) = ctx_fold(ctx, m, ps, modes);
       let rec cons_fold_list = cs =>
@@ -1393,13 +1549,19 @@ and upat_to_info_map =
         | [hd, ...tl] => Coverage.Constraint.cons(hd, cons_fold_list(tl))
         };
       add(
-        ~self=Self.listlit(~empty=unknown, ctx, tys, ids),
+        ~self=
+          Self.listlit(
+            ~empty=Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+            ctx,
+            tys,
+            ids,
+          ),
         ~ctx,
         ~constraint_=cons_fold_list(cons),
         m,
       );
     | Cons(hd, tl) =>
-      let inner_ty = Typ.matched_list(ctx, ana);
+      let inner_ty = Typ.matched_list(ctx, ana, errorhole);
       let (hd, m) = go(~ctx, ~ana=inner_ty, hd, m);
       let (tl, m) =
         go(~ctx=hd.ctx, ~ana=List(inner_ty) |> Typ.fresh, tl, m);
@@ -1409,7 +1571,11 @@ and upat_to_info_map =
         ~constraint_=Coverage.Constraint.cons(hd.constraint_, tl.constraint_),
         m,
       );
-    | Wild => atomic(Just(unknown), Coverage.Constraint.Truth)
+    | Wild =>
+      atomic(
+        Just(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp),
+        Coverage.Constraint.Truth,
+      )
     | Var(name) =>
       /* NOTE: The self type assigned to pattern variables (Unknown)
          may be SynSwitch, but SynSwitch is never added to the context;
@@ -1418,7 +1584,10 @@ and upat_to_info_map =
         Info.fixed_typ_pat(
           ctx,
           ana,
-          Common(Just(Unknown(SynSwitch) |> Typ.temp)),
+          Common(
+            Just(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp),
+          ),
+          ids,
         );
       let entry =
         Ctx.VarEntry({
@@ -1427,7 +1596,7 @@ and upat_to_info_map =
           typ: ctx_typ,
         });
       add(
-        ~self=Just(unknown),
+        ~self=Just(Unknown(Syn, Hole.temp(EmptyHole), Atom) |> Typ.temp),
         ~ctx=Ctx.extend(ctx, entry),
         ~constraint_=Coverage.Constraint.Truth,
         m,
@@ -1459,7 +1628,7 @@ and upat_to_info_map =
           let (lab, m) =
             go(
               ~ctx,
-              ~ana=Unknown(Ana) |> Typ.temp,
+              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
               ~label_sort=true,
               ~override_self=?
                 switch (label.term, expected_labels) {
@@ -1476,7 +1645,13 @@ and upat_to_info_map =
             );
 
           let (p, m) =
-            go(~ctx, ~ana=Unknown(Ana) |> Typ.temp, ~inferred_label?, p, m);
+            go(
+              ~ctx,
+              ~ana=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+              ~inferred_label?,
+              p,
+              m,
+            );
           (lab, p, m);
         };
 
@@ -1508,7 +1683,18 @@ and upat_to_info_map =
             duplicate_labels: [],
             invalid_labels: [],
             typ:
-              TupLabel(Unknown(Label(SynSwitch)) |> Typ.temp, p.ty)
+              TupLabel(
+                Unknown(
+                  Syn,
+                  {
+                    term: ErrorHole,
+                    annotation: lab.term.annotation,
+                  },
+                  Atom,
+                )
+                |> Typ.temp,
+                p.ty,
+              )
               |> Typ.temp,
           })
         };
@@ -1548,6 +1734,7 @@ and upat_to_info_map =
               Some(name),
               TupLabel(Label(name) |> Pat.fresh, p) |> Pat.fresh,
             ),
+          errorhole,
         );
       let ps = List.map(snd, inferred_ps);
       let inferred = List.map(fst, inferred_ps);
@@ -1640,7 +1827,7 @@ and upat_to_info_map =
       atomic(self, Coverage.Constraint.Ap(ctr, None));
     | Ap(fn, arg) =>
       let ctr = Pat.ctr_name(fn);
-      let fn_ana = Arrow(Unknown(SynSwitch) |> Typ.temp, ana) |> Typ.temp;
+      let fn_ana = Arrow(synswitch, ana) |> Typ.temp;
       let (fn', m) = go(~ctx, ~ana=fn_ana, fn, m);
       let m = {
         switch (fn |> Pat.term_of) {
@@ -1663,7 +1850,15 @@ and upat_to_info_map =
           add_info(IdTagged.ids(fn), InfoPat(info), m);
         };
       };
-      let (ty_in, ty_out) = Typ.matched_arrow(ctx, fn'.ty);
+      let (ty_in, ty_out) =
+        Typ.matched_arrow(
+          ctx,
+          fn'.ty,
+          {
+            term: ErrorHole,
+            annotation: fn'.term.annotation,
+          },
+        );
       let (arg, m) = go(~ctx, ~ana=ty_in, arg, m);
       let constraint_ =
         switch (ctr) {
@@ -1685,7 +1880,7 @@ and upat_to_info_map =
     | Prod([{term: TupLabel({term: Label(l1), _}, ana_ty), _}]) =>
       // We can flatten this by pulling it up on the case match but since OCaml is strict it'll be evaluated.
       // So for performance reasons we'll just do it here.
-      let (e, m) = go(~ana=syn, ~ctx, upat, m);
+      let (e, m) = go(~ana=synswitch, ~ctx, upat, m);
 
       switch (Typ.weak_head_normalize(ctx, e.ty).term) {
       | Prod([{term: TupLabel({term: Label(l2), _}, _), _}]) when l1 == l2 =>
@@ -1714,7 +1909,7 @@ and utyp_to_info_map =
   let go' = utyp_to_info_map(~ctx, ~ancestors);
   let go = go'(~expects=TypeExpected);
   switch (term) {
-  | Unknown(Hole(MultiHole(tms))) =>
+  | Unknown(_, {term: MultiHole(tms), _}, _) =>
     let (_, m) = multi(~ctx, ~ancestors, m, tms);
     add(m);
   | Unknown(_)
@@ -1760,7 +1955,11 @@ and utyp_to_info_map =
       | _ =>
         ConstructorExpected(
           Unique,
-          Arrow(t2, Unknown(ArrowR(SynSwitch)) |> Typ.temp) |> Typ.temp,
+          Arrow(
+            t2,
+            Unknown(Syn, Hole.temp(EmptyHole), ArrowR(Atom)) |> Typ.temp,
+          )
+          |> Typ.temp,
         )
       };
     let m = go'(~expects=t1_mode, t1, m) |> snd;

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -45,7 +45,8 @@ module Map = {
       (id, info, acc) =>
         /* Second clause is to eliminate non-representative ids,
          * which will not be found in the measurements map */
-        Info.is_error(info) && id == Info.id_of(info) ? [id, ...acc] : acc,
+        Info.is_error(info) && id == Info.id_of(info)
+          ? Info.error_ids_of(info) @ acc : acc,
       info_map,
       [],
     );

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -1581,7 +1581,7 @@ and upat_to_info_map =
     | Var(name) =>
       /* NOTE: The self type assigned to pattern variables (Unknown)
          may be SynSwitch, but SynSwitch is never added to the context;
-         Unknown(Syn, ...) is used in this case */
+         Unknown(Expr, ...) is used in this case */
       let ctx_typ =
         Info.fixed_typ_pat(
           ctx,

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -1085,7 +1085,7 @@ and uexp_to_info_map =
           let ana_ty_fn = ((ty_fn1, ty_fn2), ty_p) => {
             Typ.make_ana(
               ty_p |> Typ.is_synswitch && !Typ.equal(ty_fn1, ty_fn2)
-                ? ty_fn1 : ty_p // TODO: Check make_ana makes sense in both situations here
+                ? ty_fn1 : ty_p,
             );
           };
           let ana =
@@ -1333,7 +1333,7 @@ and upat_to_info_map =
       ~ancestors: Info.ancestors,
       ~duplicates: list(string),
       ~expected_labels=?,
-      ~ana: Typ.t=Unknown(SynSwitch, Hole.temp(EmptyHole), Atom) |> Typ.temp,
+      ~ana: Typ.t=Unknown(Ana, Hole.temp(EmptyHole), Atom) |> Typ.temp,
       ~under_ascription: bool=false,
       ~override_self: option(Self.t)=?,
       ~inferred_label=?,
@@ -1867,7 +1867,8 @@ and upat_to_info_map =
       let (ann, m) = utyp_to_info_map(~ctx, ~ancestors, ann, m);
       let (p, m) =
         go(~ctx, ~under_ascription=true, ~ana=Typ.make_ana(ann.term), p, m);
-      add(~self=Just(ann.term), ~ctx=p.ctx, ~constraint_=p.constraint_, m);
+      add(~self=Just(Typ.make_ana(ann.term)),
+       ~ctx=p.ctx, ~constraint_=p.constraint_, m);
     };
 
   // This is to allow lifting single values into a singleton labeled tuple when the label is not present

--- a/src/language/term/Abbreviate.re
+++ b/src/language/term/Abbreviate.re
@@ -44,7 +44,7 @@ let abbreviate_str = (min_len: int, s: string): string => {
 };
 
 let indet_term: Exp.term = Invalid("?");
-let indet_term_typ: Typ.term = Unknown(Ana);
+let indet_term_typ: Typ.term = Unknown(Syn, Hole.fresh(EmptyHole), Atom);
 let indet_term_pat: Pat.term = Invalid("?");
 let indet_term_rul: Rul.term = Invalid("?");
 let indet_term_tpat: TPat.term = Invalid("?");
@@ -774,7 +774,7 @@ and abbreviate_typ = (typ: Typ.t): Typ.t => {
 
   let term: Typ.term =
     switch (typ |> Typ.term_of) {
-    | Unknown(prov) => Unknown(prov)
+    | Unknown(m, h, p) => Unknown(m, h, p)
     | Atom(Int) =>
       if (available^ < 3) {
         indet_term_typ;

--- a/src/language/term/Abbreviate.re
+++ b/src/language/term/Abbreviate.re
@@ -44,7 +44,7 @@ let abbreviate_str = (min_len: int, s: string): string => {
 };
 
 let indet_term: Exp.term = Invalid("?");
-let indet_term_typ: Typ.term = Unknown(Syn, Hole.fresh(EmptyHole), Atom);
+let indet_term_typ: Typ.term = Unknown(Type, Hole.fresh(EmptyHole), Atom);
 let indet_term_pat: Pat.term = Invalid("?");
 let indet_term_rul: Rul.term = Invalid("?");
 let indet_term_tpat: TPat.term = Invalid("?");

--- a/src/language/term/Abbreviate.re
+++ b/src/language/term/Abbreviate.re
@@ -44,7 +44,7 @@ let abbreviate_str = (min_len: int, s: string): string => {
 };
 
 let indet_term: Exp.term = Invalid("?");
-let indet_term_typ: Typ.term = Unknown(Internal);
+let indet_term_typ: Typ.term = Unknown(Ana);
 let indet_term_pat: Pat.term = Invalid("?");
 let indet_term_rul: Rul.term = Invalid("?");
 let indet_term_tpat: TPat.term = Invalid("?");

--- a/src/language/term/Grammar.re
+++ b/src/language/term/Grammar.re
@@ -112,7 +112,9 @@ and pat_term('a) =
   | Asc(pat_t('a), typ_t('a))
 and pat_t('a) = Annotated.t(pat_term('a), 'a)
 and typ_term('a) =
-  | Unknown(type_provenance('a))
+  // Asymmetric Unknown type of Mode: Syn/Ana. Pointing to a hole of some sort. With a type provenance to track matching function usage.
+  // The hole pointed to _should_ be a type or exp hole for Syn mode. But can only be a type hole for Ana mode.
+  | Unknown(unknown_mode, hole_t('a), type_provenance)
   | Atom(Atom.cls)
   | Var(string)
   | List(typ_t('a))
@@ -146,26 +148,30 @@ and closure_environment_t('a) = {
 and stepper_filter_kind_t('a) =
   | Filter(filter('a))
   | Residue(int, FilterAction.t)
-and type_hole('a) =
+and unknown_mode =
+  // Note: Ideally SynSwitch should be removed somehow. Analysing against Syn-Unknown could represent synthesis
+  | SynSwitch
+  | Syn
+  | Ana
+and hole_term('a) =
   | Invalid(string)
+  | ErrorHole
   | EmptyHole
   | MultiHole(list(any_t('a)))
+and hole_t('a) = Annotated.t(hole_term('a), 'a)
 // TODO: Refactor type provenances to always include hole/error ID. Separate Syn/Ana from provenance
-and type_provenance('a) =
-  | SynSwitch
-  | Hole(type_hole('a))
-  /* Internal Type Provenances */
-  | Ana
-  | ArrowL(type_provenance('a))
-  | ArrowR(type_provenance('a))
-  | List(type_provenance('a))
-  | Sum(type_provenance('a))
-  | Ctr(Constructor.t, type_provenance('a))
-  | Prod(int, type_provenance('a))
-  | Label(type_provenance('a))
-  | TupLabel(type_provenance('a))
-  | Forall(type_provenance('a))
-  | Arg(int, type_provenance('a))
+and type_provenance =
+  | Atom
+  | ArrowL(type_provenance)
+  | ArrowR(type_provenance)
+  | List(type_provenance)
+  | Sum(type_provenance)
+  | Ctr(Constructor.t, type_provenance)
+  | Prod(int, type_provenance)
+  | Label(type_provenance)
+  | TupLabel(type_provenance)
+  | Forall(type_provenance)
+  | Arg(int, type_provenance)
 and filter('a) = {
   pat: exp_t('a),
   act: FilterAction.t,
@@ -335,7 +341,7 @@ and map_typ_annotation: 'a 'b. ('a => 'b, typ_t('a)) => typ_t('b) =
     {
       term:
         switch (term) {
-        | Unknown(p) => Unknown(map_type_provenance_annotation(f, p))
+        | Unknown(m, h, p) => Unknown(m, map_type_hole_annotation(f, h), p)
         | Atom(c) => Atom(c)
         | Var(s) => Var(s)
         | List(t) => List(map_typ_annotation(f, t))
@@ -419,36 +425,20 @@ and map_closure_environment_annotation:
     call_stack,
   }
 
-and map_type_provenance_annotation:
-  'a 'b.
-  ('a => 'b, type_provenance('a)) => type_provenance('b)
- =
+and map_type_hole_annotation: 'a 'b. ('a => 'b, hole_t('a)) => hole_t('b) =
   (f, e) => {
-    switch (e) {
-    | SynSwitch => SynSwitch
-    | Hole(h) => Hole(map_type_hole_annotation(f, h))
-    | Ana => Ana
-    | ArrowL(p) => ArrowL(map_type_provenance_annotation(f, p))
-    | ArrowR(p) => ArrowR(map_type_provenance_annotation(f, p))
-    | List(p) => List(map_type_provenance_annotation(f, p))
-    | Prod(i, p) => Prod(i, map_type_provenance_annotation(f, p))
-    | Forall(p) => Forall(map_type_provenance_annotation(f, p))
-    | Arg(i, p) => Arg(i, map_type_provenance_annotation(f, p))
-    | Label(p) => Label(map_type_provenance_annotation(f, p))
-    | TupLabel(p) => TupLabel(map_type_provenance_annotation(f, p))
-    | Sum(p) => Sum(map_type_provenance_annotation(f, p))
-    | Ctr(name, p) => Ctr(name, map_type_provenance_annotation(f, p))
-    };
-  }
-and map_type_hole_annotation:
-  'a 'b.
-  ('a => 'b, type_hole('a)) => type_hole('b)
- =
-  (f, e) => {
-    switch (e) {
-    | Invalid(s) => Invalid(s)
-    | EmptyHole => EmptyHole
-    | MultiHole(l) => MultiHole(List.map(x => map_any_annotation(f, x), l))
+    let (term, annotation) = (e.term, e.annotation);
+    let new_annotation = f(annotation);
+    {
+      term:
+        switch (term) {
+        | Invalid(s) => Invalid(s)
+        | EmptyHole => EmptyHole
+        | ErrorHole => ErrorHole
+        | MultiHole(l) =>
+          MultiHole(List.map(x => map_any_annotation(f, x), l))
+        },
+      annotation: new_annotation,
     };
   };
 
@@ -462,7 +452,7 @@ module Factory = (DefaultAnnotation: DefaultAnnotation) => {
   type pat = pat_t(DefaultAnnotation.t);
   type typ = typ_t(DefaultAnnotation.t);
   type tpat = tpat_t(DefaultAnnotation.t);
-  type typ_provenance = type_provenance(DefaultAnnotation.t);
+  type hole = hole_t(DefaultAnnotation.t);
 
   let default_annotation = ann =>
     Option.value(~default=DefaultAnnotation.default_value(), ann);
@@ -749,9 +739,39 @@ module Factory = (DefaultAnnotation: DefaultAnnotation) => {
     };
   };
 
+  module TypeHole = {
+    let invalid = (~ann=?, s): hole_t(DefaultAnnotation.t) => {
+      {
+        term: Invalid(s),
+        annotation: default_annotation(ann),
+      };
+    };
+    let empty_hole = (~ann=?, ()): hole_t(DefaultAnnotation.t) => {
+      {
+        term: EmptyHole,
+        annotation: default_annotation(ann),
+      };
+    };
+    let multi_hole = (~ann=?, l): hole_t(DefaultAnnotation.t) => {
+      {
+        term: MultiHole(l),
+        annotation: default_annotation(ann),
+      };
+    };
+  };
+
+  module UnknownMode = {
+    let syn = (): unknown_mode => {
+      Syn;
+    };
+    let ana = (): unknown_mode => {
+      Ana;
+    };
+  };
+
   module Typ = {
-    let unknown = (~ann=?, p): typ_t(DefaultAnnotation.t) => {
-      term: Unknown(p),
+    let unknown = (~ann=?, m, h, p): typ_t(DefaultAnnotation.t) => {
+      term: Unknown(m, h, p),
       annotation: default_annotation(ann),
     };
     let int = (~ann=?, ()): typ_t(DefaultAnnotation.t) => {
@@ -822,8 +842,12 @@ module Factory = (DefaultAnnotation: DefaultAnnotation) => {
       term: Forall(tp, t),
       annotation: default_annotation(ann),
     };
-    let empty_hole = (~ann=?, ()): typ_t(DefaultAnnotation.t) => {
-      term: Unknown(Hole(EmptyHole)),
+    let empty_hole_syn = (~ann=?, ()): typ_t(DefaultAnnotation.t) => {
+      term: Unknown(Syn, TypeHole.empty_hole(~ann?, ()), Atom),
+      annotation: default_annotation(ann),
+    };
+    let empty_hole_ana = (~ann=?, ()): typ_t(DefaultAnnotation.t) => {
+      term: Unknown(Ana, TypeHole.empty_hole(~ann?, ()), Atom),
       annotation: default_annotation(ann),
     };
   };
@@ -882,30 +906,6 @@ module Factory = (DefaultAnnotation: DefaultAnnotation) => {
     };
     let residue = (i, act): stepper_filter_kind_t(DefaultAnnotation.t) => {
       Residue(i, act);
-    };
-  };
-
-  module TypeHole = {
-    let invalid = (s): type_hole(DefaultAnnotation.t) => {
-      Invalid(s);
-    };
-    let empty_hole = (): type_hole(DefaultAnnotation.t) => {
-      EmptyHole;
-    };
-    let multi_hole = (l): type_hole(DefaultAnnotation.t) => {
-      MultiHole(l);
-    };
-  };
-
-  module TypeProvenance = {
-    let syn_switch = (): type_provenance(DefaultAnnotation.t) => {
-      SynSwitch;
-    };
-    let hole = (h): type_provenance(DefaultAnnotation.t) => {
-      Hole(h);
-    };
-    let ana = (): type_provenance(DefaultAnnotation.t) => {
-      Ana;
     };
   };
 };

--- a/src/language/term/Grammar.re
+++ b/src/language/term/Grammar.re
@@ -150,10 +150,22 @@ and type_hole('a) =
   | Invalid(string)
   | EmptyHole
   | MultiHole(list(any_t('a)))
+// TODO: Refactor type provenances to always include hole/error ID. Separate Syn/Ana from provenance
 and type_provenance('a) =
   | SynSwitch
   | Hole(type_hole('a))
-  | Internal
+  /* Internal Type Provenances */
+  | Ana
+  | ArrowL(type_provenance('a))
+  | ArrowR(type_provenance('a))
+  | List(type_provenance('a))
+  | Sum(type_provenance('a))
+  | Ctr(Constructor.t, type_provenance('a))
+  | Prod(int, type_provenance('a))
+  | Label(type_provenance('a))
+  | TupLabel(type_provenance('a))
+  | Forall(type_provenance('a))
+  | Arg(int, type_provenance('a))
 and filter('a) = {
   pat: exp_t('a),
   act: FilterAction.t,
@@ -415,7 +427,17 @@ and map_type_provenance_annotation:
     switch (e) {
     | SynSwitch => SynSwitch
     | Hole(h) => Hole(map_type_hole_annotation(f, h))
-    | Internal => Internal
+    | Ana => Ana
+    | ArrowL(p) => ArrowL(map_type_provenance_annotation(f, p))
+    | ArrowR(p) => ArrowR(map_type_provenance_annotation(f, p))
+    | List(p) => List(map_type_provenance_annotation(f, p))
+    | Prod(i, p) => Prod(i, map_type_provenance_annotation(f, p))
+    | Forall(p) => Forall(map_type_provenance_annotation(f, p))
+    | Arg(i, p) => Arg(i, map_type_provenance_annotation(f, p))
+    | Label(p) => Label(map_type_provenance_annotation(f, p))
+    | TupLabel(p) => TupLabel(map_type_provenance_annotation(f, p))
+    | Sum(p) => Sum(map_type_provenance_annotation(f, p))
+    | Ctr(name, p) => Ctr(name, map_type_provenance_annotation(f, p))
     };
   }
 and map_type_hole_annotation:
@@ -882,8 +904,8 @@ module Factory = (DefaultAnnotation: DefaultAnnotation) => {
     let hole = (h): type_provenance(DefaultAnnotation.t) => {
       Hole(h);
     };
-    let internal = (): type_provenance(DefaultAnnotation.t) => {
-      Internal;
+    let ana = (): type_provenance(DefaultAnnotation.t) => {
+      Ana;
     };
   };
 };

--- a/src/language/term/Grammar.re
+++ b/src/language/term/Grammar.re
@@ -40,6 +40,15 @@ type deferral_position_t =
   | InAp
   | OutsideAp;
 
+// Class of unknown type, derived from expression hole or type hole.
+// Use "Type" when in doubt
+[@deriving (show({with_path: false}), sexp, yojson, enumerate, eq)]
+type unknown_mode =
+  // Note: Ideally SynSwitch should be factored out of Unknown (does not point to a hole)
+  | SynSwitch
+  | Type
+  | Expr; // (Also includes pattern holes)
+
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
 type any_t('a) =
   | Exp(exp_t('a))
@@ -112,8 +121,9 @@ and pat_term('a) =
   | Asc(pat_t('a), typ_t('a))
 and pat_t('a) = Annotated.t(pat_term('a), 'a)
 and typ_term('a) =
-  // Asymmetric Unknown type of Mode: Syn/Ana. Pointing to a hole of some sort. With a type provenance to track matching function usage.
-  // The hole pointed to _should_ be a type or exp hole for Syn mode. But can only be a type hole for Ana mode.
+  // Asymmetric Unknown type of pointing to a type or expression hole of some sort. With a type provenance to track matching function usage.
+  // Invariant: In Analysis mode, the hole pointed to must be a type hole (except for those arising from matching functions).
+  //            Use "Type" mode and a dummy temp empty hole when in doubt to preserve this invariant
   | Unknown(unknown_mode, hole_t('a), type_provenance)
   | Atom(Atom.cls)
   | Var(string)
@@ -148,12 +158,8 @@ and closure_environment_t('a) = {
 and stepper_filter_kind_t('a) =
   | Filter(filter('a))
   | Residue(int, FilterAction.t)
-and unknown_mode =
-  // Note: Ideally SynSwitch should be removed somehow. Analysing against Syn-Unknown could represent synthesis
-  | SynSwitch
-  | Syn
-  | Ana
 and hole_term('a) =
+  | List // Hack: Allow polymorphic empty list [] : [?]
   | Invalid(string)
   | ErrorHole
   | EmptyHole
@@ -434,6 +440,7 @@ and map_type_hole_annotation: 'a 'b. ('a => 'b, hole_t('a)) => hole_t('b) =
         switch (term) {
         | Invalid(s) => Invalid(s)
         | EmptyHole => EmptyHole
+        | List => List
         | ErrorHole => ErrorHole
         | MultiHole(l) =>
           MultiHole(List.map(x => map_any_annotation(f, x), l))
@@ -761,11 +768,11 @@ module Factory = (DefaultAnnotation: DefaultAnnotation) => {
   };
 
   module UnknownMode = {
-    let syn = (): unknown_mode => {
-      Syn;
+    let typ = (): unknown_mode => {
+      Type;
     };
-    let ana = (): unknown_mode => {
-      Ana;
+    let exp = (): unknown_mode => {
+      Expr;
     };
   };
 
@@ -842,12 +849,12 @@ module Factory = (DefaultAnnotation: DefaultAnnotation) => {
       term: Forall(tp, t),
       annotation: default_annotation(ann),
     };
-    let empty_hole_syn = (~ann=?, ()): typ_t(DefaultAnnotation.t) => {
-      term: Unknown(Syn, TypeHole.empty_hole(~ann?, ()), Atom),
+    let empty_hole_typ = (~ann=?, ()): typ_t(DefaultAnnotation.t) => {
+      term: Unknown(Type, TypeHole.empty_hole(~ann?, ()), Atom),
       annotation: default_annotation(ann),
     };
-    let empty_hole_ana = (~ann=?, ()): typ_t(DefaultAnnotation.t) => {
-      term: Unknown(Ana, TypeHole.empty_hole(~ann?, ()), Atom),
+    let empty_hole_expr = (~ann=?, ()): typ_t(DefaultAnnotation.t) => {
+      term: Unknown(Expr, TypeHole.empty_hole(~ann?, ()), Atom),
       annotation: default_annotation(ann),
     };
   };

--- a/src/language/term/Hole.re
+++ b/src/language/term/Hole.re
@@ -1,5 +1,6 @@
 [@deriving (show({with_path: false}), sexp, yojson, enumerate, eq)]
 type cls =
+  | List
   | Invalid
   | EmptyHole
   | MultiHole;
@@ -18,6 +19,7 @@ let hole = (tms: list(TermBase.Any.t)): TermBase.Hole.term =>
 
 let cls_of_term: Grammar.hole_term('a) => cls =
   fun
+  | List => List
   | Invalid(_) => Invalid
   | EmptyHole => EmptyHole
   | ErrorHole
@@ -25,6 +27,7 @@ let cls_of_term: Grammar.hole_term('a) => cls =
 
 let show_cls: cls => string =
   fun
+  | List => "List"
   | Invalid => "Invalid term"
   | MultiHole => "Error term"
   | EmptyHole => "Empty hole";

--- a/src/language/term/Hole.re
+++ b/src/language/term/Hole.re
@@ -1,0 +1,38 @@
+[@deriving (show({with_path: false}), sexp, yojson, enumerate, eq)]
+type cls =
+  | Invalid
+  | EmptyHole
+  | MultiHole;
+
+include TermBase.Hole;
+
+let rep_id: t => Id.t = IdTagged.rep_id;
+
+let fresh: term => t = IdTagged.fresh;
+
+let hole = (tms: list(TermBase.Any.t)): TermBase.Hole.term =>
+  switch (tms) {
+  | [] => EmptyHole
+  | [_, ..._] => MultiHole(tms)
+  };
+
+let cls_of_term: Grammar.hole_term('a) => cls =
+  fun
+  | Invalid(_) => Invalid
+  | EmptyHole => EmptyHole
+  | ErrorHole
+  | MultiHole(_) => MultiHole;
+
+let show_cls: cls => string =
+  fun
+  | Invalid => "Invalid term"
+  | MultiHole => "Error term"
+  | EmptyHole => "Empty hole";
+
+let temp: term => t =
+  term => {
+    term,
+    annotation: {
+      ids: [Id.invalid],
+    },
+  };

--- a/src/language/term/IdTagged.re
+++ b/src/language/term/IdTagged.re
@@ -3,7 +3,7 @@ open Util;
 module IdTag = {
   [@deriving (show({with_path: false}), sexp, yojson, eq)]
   type t = {
-    [@show.opaque]
+    //[@show.opaque]
     ids: list(Id.t),
   };
 

--- a/src/language/term/IdTagged.re
+++ b/src/language/term/IdTagged.re
@@ -1,13 +1,14 @@
 open Util;
 
 module IdTag = {
-  [@deriving (show({with_path: false}), sexp, yojson)]
+  [@deriving (show({with_path: false}), sexp, yojson, eq)]
   type t = {
     [@show.opaque]
     ids: list(Id.t),
   };
 
   let fresh = (): t => {ids: [Id.mk()]};
+  let of_id = (id): t => {ids: [id]};
 };
 
 [@deriving (show({with_path: false}), sexp, yojson)]
@@ -64,6 +65,11 @@ let replace_temp = ({term, annotation: {ids}}: t('a)): t('a) => {
   annotation: {
     ids: ids == [Id.invalid] ? [Id.mk()] : ids,
   },
+};
+
+let tag = (ids, term): Grammar.Annotated.t('a, IdTag.t) => {
+  term,
+  annotation: ids,
 };
 
 module FreshGrammar =

--- a/src/language/term/TermBase.re
+++ b/src/language/term/TermBase.re
@@ -74,7 +74,7 @@ type hole_term = Grammar.hole_term(IdTagged.IdTag.t);
 type hole_t = Grammar.hole_t(IdTagged.IdTag.t);
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
 type type_provenance = Grammar.type_provenance;
-[@deriving (show({with_path: false}), sexp, yojson, eq)]
+[@deriving (show({with_path: false}), sexp, yojson, enumerate, eq)]
 type unknown_mode = Grammar.unknown_mode;
 [@deriving (show({with_path: false}), sexp, yojson)]
 type filter = Grammar.filter(IdTagged.IdTag.t);
@@ -912,7 +912,8 @@ and Hole: {
         switch (term) {
         | EmptyHole
         | ErrorHole
-        | Invalid(_) => term
+        | Invalid(_)
+        | List => term
         | MultiHole(things) => MultiHole(List.map(any_map_term, things))
         },
     };
@@ -926,6 +927,7 @@ and Hole: {
     ) {
     | (EmptyHole, EmptyHole) => true
     | (ErrorHole, ErrorHole) => true
+    | (List, List) => true
     | (Invalid(s1), Invalid(s2)) => s1 == s2
     | (MultiHole(xs), MultiHole(ys)) =>
       List.length(xs) == List.length(ys)
@@ -933,7 +935,8 @@ and Hole: {
     | (EmptyHole, _)
     | (ErrorHole, _)
     | (Invalid(_), _)
-    | (MultiHole(_), _) => false
+    | (MultiHole(_), _)
+    | (List, _) => false
     };
   let equal = fast_equal;
 }

--- a/src/language/term/TermBase.re
+++ b/src/language/term/TermBase.re
@@ -69,9 +69,13 @@ type closure_environment_t = Grammar.closure_environment_t(IdTagged.IdTag.t);
 [@deriving (show({with_path: false}), sexp, yojson)]
 type stepper_filter_kind_t = Grammar.stepper_filter_kind_t(IdTagged.IdTag.t);
 [@deriving (show({with_path: false}), sexp, yojson)]
-type type_hole = Grammar.type_hole(IdTagged.IdTag.t);
+type hole_term = Grammar.hole_term(IdTagged.IdTag.t);
 [@deriving (show({with_path: false}), sexp, yojson)]
-type type_provenance = Grammar.type_provenance(IdTagged.IdTag.t);
+type hole_t = Grammar.hole_t(IdTagged.IdTag.t);
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type type_provenance = Grammar.type_provenance;
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type unknown_mode = Grammar.unknown_mode;
 [@deriving (show({with_path: false}), sexp, yojson)]
 type filter = Grammar.filter(IdTagged.IdTag.t);
 [@deriving (show({with_path: false}), sexp, yojson)]
@@ -88,6 +92,7 @@ module rec Any: {
       ~f_exp: (Exp.t => Exp.t, Exp.t) => Exp.t=?,
       ~f_pat: (Pat.t => Pat.t, Pat.t) => Pat.t=?,
       ~f_typ: (Typ.t => Typ.t, Typ.t) => Typ.t=?,
+      ~f_hole: (Hole.t => Hole.t, Hole.t) => Hole.t=?,
       ~f_tpat: (TPat.t => TPat.t, TPat.t) => TPat.t=?,
       ~f_rul: (Rul.t => Rul.t, Rul.t) => Rul.t=?,
       ~f_any: (Any.t => Any.t, Any.t) => Any.t=?,
@@ -116,6 +121,7 @@ module rec Any: {
         ~f_exp=continue,
         ~f_pat=continue,
         ~f_typ=continue,
+        ~f_hole=continue,
         ~f_tpat=continue,
         ~f_rul=continue,
         ~f_any=continue,
@@ -124,17 +130,70 @@ module rec Any: {
     let rec_call = (y: any_t): any_t =>
       switch (y) {
       | Exp(x) =>
-        Exp(Exp.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any, x))
+        Exp(
+          Exp.map_term(
+            ~f_exp,
+            ~f_pat,
+            ~f_typ,
+            ~f_hole,
+            ~f_tpat,
+            ~f_rul,
+            ~f_any,
+            x,
+          ),
+        )
       | Pat(x) =>
-        Pat(Pat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any, x))
+        Pat(
+          Pat.map_term(
+            ~f_exp,
+            ~f_pat,
+            ~f_typ,
+            ~f_hole,
+            ~f_tpat,
+            ~f_rul,
+            ~f_any,
+            x,
+          ),
+        )
       | Typ(x) =>
-        Typ(Typ.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any, x))
+        Typ(
+          Typ.map_term(
+            ~f_exp,
+            ~f_pat,
+            ~f_typ,
+            ~f_hole,
+            ~f_tpat,
+            ~f_rul,
+            ~f_any,
+            x,
+          ),
+        )
       | TPat(x) =>
         TPat(
-          TPat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any, x),
+          TPat.map_term(
+            ~f_exp,
+            ~f_pat,
+            ~f_typ,
+            ~f_hole,
+            ~f_tpat,
+            ~f_rul,
+            ~f_any,
+            x,
+          ),
         )
       | Rul(x) =>
-        Rul(Rul.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any, x))
+        Rul(
+          Rul.map_term(
+            ~f_exp,
+            ~f_pat,
+            ~f_typ,
+            ~f_hole,
+            ~f_tpat,
+            ~f_rul,
+            ~f_any,
+            x,
+          ),
+        )
       | Any () => Any()
       };
     x |> f_any(rec_call);
@@ -170,6 +229,7 @@ and Exp: {
       ~f_exp: (Exp.t => Exp.t, Exp.t) => Exp.t=?,
       ~f_pat: (Pat.t => Pat.t, Pat.t) => Pat.t=?,
       ~f_typ: (Typ.t => Typ.t, Typ.t) => Typ.t=?,
+      ~f_hole: (Hole.t => Hole.t, Hole.t) => Hole.t=?,
       ~f_tpat: (TPat.t => TPat.t, TPat.t) => TPat.t=?,
       ~f_rul: (Rul.t => Rul.t, Rul.t) => Rul.t=?,
       ~f_any: (Any.t => Any.t, Any.t) => Any.t=?,
@@ -192,21 +252,22 @@ and Exp: {
         ~f_exp=continue,
         ~f_pat=continue,
         ~f_typ=continue,
+        ~f_hole=continue,
         ~f_tpat=continue,
         ~f_rul=continue,
         ~f_any=continue,
         x,
       ) => {
     let exp_map_term =
-      Exp.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Exp.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let pat_map_term =
-      Pat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Pat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let typ_map_term =
-      Typ.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Typ.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let tpat_map_term =
-      TPat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      TPat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let any_map_term =
-      Any.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Any.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let flt_map_term =
       StepperFilterKind.map_term(
         ~f_exp,
@@ -428,6 +489,7 @@ and Pat: {
       ~f_exp: (Exp.t => Exp.t, Exp.t) => Exp.t=?,
       ~f_pat: (Pat.t => Pat.t, Pat.t) => Pat.t=?,
       ~f_typ: (Typ.t => Typ.t, Typ.t) => Typ.t=?,
+      ~f_hole: (Hole.t => Hole.t, Hole.t) => Hole.t=?,
       ~f_tpat: (TPat.t => TPat.t, TPat.t) => TPat.t=?,
       ~f_rul: (Rul.t => Rul.t, Rul.t) => Rul.t=?,
       ~f_any: (Any.t => Any.t, Any.t) => Any.t=?,
@@ -448,17 +510,18 @@ and Pat: {
         ~f_exp=continue,
         ~f_pat=continue,
         ~f_typ=continue,
+        ~f_hole=continue,
         ~f_tpat=continue,
         ~f_rul=continue,
         ~f_any=continue,
         x,
       ) => {
     let pat_map_term =
-      Pat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Pat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let typ_map_term =
-      Typ.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Typ.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let any_map_term =
-      Any.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Any.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let rec_call = ({term, _} as exp: t) => {
       ...exp,
       term:
@@ -540,6 +603,11 @@ and Typ: {
   [@deriving (show({with_path: false}), sexp, yojson)]
   type t = typ_t;
 
+  [@deriving (show({with_path: false}), sexp, yojson, eq)]
+  type provenance = type_provenance;
+  [@deriving (show({with_path: false}), sexp, yojson, eq)]
+  type mode = unknown_mode;
+
   type sum_map = ConstructorMap.t(t);
 
   let map_term:
@@ -547,6 +615,7 @@ and Typ: {
       ~f_exp: (Exp.t => Exp.t, Exp.t) => Exp.t=?,
       ~f_pat: (Pat.t => Pat.t, Pat.t) => Pat.t=?,
       ~f_typ: (Typ.t => Typ.t, Typ.t) => Typ.t=?,
+      ~f_hole: (Hole.t => Hole.t, Hole.t) => Hole.t=?,
       ~f_tpat: (TPat.t => TPat.t, TPat.t) => TPat.t=?,
       ~f_rul: (Rul.t => Rul.t, Rul.t) => Rul.t=?,
       ~f_any: (Any.t => Any.t, Any.t) => Any.t=?,
@@ -564,6 +633,11 @@ and Typ: {
   [@deriving (show({with_path: false}), sexp, yojson)]
   type t = typ_t;
 
+  [@deriving (show({with_path: false}), sexp, yojson, eq)]
+  type provenance = type_provenance;
+  [@deriving (show({with_path: false}), sexp, yojson, eq)]
+  type mode = unknown_mode;
+
   type sum_map = ConstructorMap.t(t);
 
   let map_term =
@@ -571,25 +645,24 @@ and Typ: {
         ~f_exp=continue,
         ~f_pat=continue,
         ~f_typ=continue,
+        ~f_hole=continue,
         ~f_tpat=continue,
         ~f_rul=continue,
         ~f_any=continue,
         x,
       ) => {
     let typ_map_term =
-      Typ.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
-    let any_map_term =
-      Any.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Typ.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
+    let hole_map_term =
+      Hole.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let tpat_map_term =
-      TPat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      TPat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let rec_call: t => t =
       ({term, _} as exp: t) => {
         ...exp,
         term:
           switch (term) {
-          | Unknown(Hole(MultiHole(things))) =>
-            Unknown(Hole(MultiHole(List.map(any_map_term, things))))
-          | Unknown(_)
+          | Unknown(m, h, p) => Unknown(m, hole_map_term(h), p)
           | Atom(_)
           | Label(_)
           | Var(_) => term
@@ -623,11 +696,11 @@ and Typ: {
     | Some(str) =>
       let (term, rewrap) = Grammar.Annotated.unwrap(ty);
       switch (term) {
-      | Atom(_) => ty
-      | Label(name) => (Grammar.Label(name): typ_term) |> rewrap
-      | Unknown(prov) => Unknown(prov) |> rewrap
+      | Atom(_)
+      | Label(_)
+      | Unknown(_) => ty
       | Arrow(ty1, ty2) =>
-        Arrow(subst(s, x, ty1), subst(s, x, ty2)) |> rewrap
+        (Arrow(subst(s, x, ty1), subst(s, x, ty2)): term) |> rewrap
       | Prod(tys) => Prod(List.map(subst(s, x), tys)) |> rewrap
       | TupLabel(label, ty) => TupLabel(label, subst(s, x, ty)) |> rewrap
       | Sum(sm) =>
@@ -725,6 +798,7 @@ and TPat: {
       ~f_exp: (Exp.t => Exp.t, Exp.t) => Exp.t=?,
       ~f_pat: (Pat.t => Pat.t, Pat.t) => Pat.t=?,
       ~f_typ: (Typ.t => Typ.t, Typ.t) => Typ.t=?,
+      ~f_hole: (Hole.t => Hole.t, Hole.t) => Hole.t=?,
       ~f_tpat: (TPat.t => TPat.t, TPat.t) => TPat.t=?,
       ~f_rul: (Rul.t => Rul.t, Rul.t) => Rul.t=?,
       ~f_any: (Any.t => Any.t, Any.t) => Any.t=?,
@@ -747,13 +821,14 @@ and TPat: {
         ~f_exp=continue,
         ~f_pat=continue,
         ~f_typ=continue,
+        ~f_hole=continue,
         ~f_tpat=continue,
         ~f_rul=continue,
         ~f_any=continue,
         x,
       ) => {
     let any_map_term =
-      Any.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Any.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let rec_call = ({term, _} as exp: t) => {
       ...exp,
       term:
@@ -791,6 +866,77 @@ and TPat: {
     };
   let equal = fast_equal;
 }
+and Hole: {
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type term = hole_term;
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type t = hole_t;
+
+  let map_term:
+    (
+      ~f_exp: (Exp.t => Exp.t, Exp.t) => Exp.t=?,
+      ~f_pat: (Pat.t => Pat.t, Pat.t) => Pat.t=?,
+      ~f_typ: (Typ.t => Typ.t, Typ.t) => Typ.t=?,
+      ~f_hole: (Hole.t => Hole.t, Hole.t) => Hole.t=?,
+      ~f_tpat: (TPat.t => TPat.t, TPat.t) => TPat.t=?,
+      ~f_rul: (Rul.t => Rul.t, Rul.t) => Rul.t=?,
+      ~f_any: (Any.t => Any.t, Any.t) => Any.t=?,
+      t
+    ) =>
+    t;
+
+  let fast_equal: (t, t) => bool;
+  let equal: (t, t) => bool;
+} = {
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type term = hole_term;
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type t = hole_t;
+
+  let map_term =
+      (
+        ~f_exp=continue,
+        ~f_pat=continue,
+        ~f_typ=continue,
+        ~f_hole=continue,
+        ~f_tpat=continue,
+        ~f_rul=continue,
+        ~f_any=continue,
+        x,
+      ) => {
+    let any_map_term =
+      Any.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+    let rec_call = ({term, _} as exp: t) => {
+      ...exp,
+      term:
+        switch (term) {
+        | EmptyHole
+        | ErrorHole
+        | Invalid(_) => term
+        | MultiHole(things) => MultiHole(List.map(any_map_term, things))
+        },
+    };
+    x |> f_hole(rec_call);
+  };
+
+  let fast_equal = (tp1: t, tp2: t) =>
+    switch (
+      tp1 |> Grammar.Annotated.term_of,
+      tp2 |> Grammar.Annotated.term_of,
+    ) {
+    | (EmptyHole, EmptyHole) => true
+    | (ErrorHole, ErrorHole) => true
+    | (Invalid(s1), Invalid(s2)) => s1 == s2
+    | (MultiHole(xs), MultiHole(ys)) =>
+      List.length(xs) == List.length(ys)
+      && List.equal(Any.fast_equal, xs, ys)
+    | (EmptyHole, _)
+    | (ErrorHole, _)
+    | (Invalid(_), _)
+    | (MultiHole(_), _) => false
+    };
+  let equal = fast_equal;
+}
 and Rul: {
   [@deriving (show({with_path: false}), sexp, yojson)]
   type term = rul_term;
@@ -802,6 +948,7 @@ and Rul: {
       ~f_exp: (Exp.t => Exp.t, Exp.t) => Exp.t=?,
       ~f_pat: (Pat.t => Pat.t, Pat.t) => Pat.t=?,
       ~f_typ: (Typ.t => Typ.t, Typ.t) => Typ.t=?,
+      ~f_hole: (Hole.t => Hole.t, Hole.t) => Hole.t=?,
       ~f_tpat: (TPat.t => TPat.t, TPat.t) => TPat.t=?,
       ~f_rul: (Rul.t => Rul.t, Rul.t) => Rul.t=?,
       ~f_any: (Any.t => Any.t, Any.t) => Any.t=?,
@@ -822,15 +969,16 @@ and Rul: {
         ~f_exp=continue,
         ~f_pat=continue,
         ~f_typ=continue,
+        ~f_hole=continue,
         ~f_tpat=continue,
         ~f_rul=continue,
         ~f_any=continue,
         x,
       ) => {
     let exp_map_term =
-      Exp.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Exp.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let pat_map_term =
-      Pat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
+      Pat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_hole, ~f_tpat, ~f_rul, ~f_any);
     let any_map_term =
       Any.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
     let rec_call = ({term, _} as exp: t) => {

--- a/src/language/term/TermBase.re
+++ b/src/language/term/TermBase.re
@@ -582,41 +582,39 @@ and Typ: {
       Any.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
     let tpat_map_term =
       TPat.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any);
-    let rec_call = ({term, _} as exp: t) => {
-      ...exp,
-      term:
-        switch (term) {
-        | Unknown(Hole(EmptyHole))
-        | Unknown(Hole(Invalid(_)))
-        | Unknown(SynSwitch)
-        | Unknown(Internal)
-        | Atom(_)
-        | Label(_)
-        | Var(_) => term
-        | List(t) => List(typ_map_term(t))
-        | Unknown(Hole(MultiHole(things))) =>
-          Unknown(Hole(MultiHole(List.map(any_map_term, things))))
-        | Ap(e1, e2) => Ap(typ_map_term(e1), typ_map_term(e2))
-        | Prod(xs) => Prod(List.map(typ_map_term, xs))
-        | TupLabel(label, e) =>
-          TupLabel(typ_map_term(label), typ_map_term(e))
-        | Parens(e) => Parens(typ_map_term(e))
-        | Arrow(t1, t2) => Arrow(typ_map_term(t1), typ_map_term(t2))
-        | Sum(variants) =>
-          Sum(
-            List.map(
-              fun
-              | ConstructorMap.Variant(c, ids, t) =>
-                ConstructorMap.Variant(c, ids, Option.map(typ_map_term, t))
-              | ConstructorMap.BadEntry(t) =>
-                ConstructorMap.BadEntry(typ_map_term(t)),
-              variants,
-            ),
-          )
-        | Rec(tp, t) => Rec(tpat_map_term(tp), typ_map_term(t))
-        | Forall(tp, t) => Forall(tpat_map_term(tp), typ_map_term(t))
-        },
-    };
+    let rec_call: t => t =
+      ({term, _} as exp: t) => {
+        ...exp,
+        term:
+          switch (term) {
+          | Unknown(Hole(MultiHole(things))) =>
+            Unknown(Hole(MultiHole(List.map(any_map_term, things))))
+          | Unknown(_)
+          | Atom(_)
+          | Label(_)
+          | Var(_) => term
+          | List(t) => List(typ_map_term(t))
+          | Ap(e1, e2) => Ap(typ_map_term(e1), typ_map_term(e2))
+          | Prod(xs) => Prod(List.map(typ_map_term, xs))
+          | TupLabel(label, e) =>
+            TupLabel(typ_map_term(label), typ_map_term(e))
+          | Parens(e) => Parens(typ_map_term(e))
+          | Arrow(t1, t2) => Arrow(typ_map_term(t1), typ_map_term(t2))
+          | Sum(variants) =>
+            Sum(
+              List.map(
+                fun
+                | ConstructorMap.Variant(c, ids, t) =>
+                  ConstructorMap.Variant(c, ids, Option.map(typ_map_term, t))
+                | ConstructorMap.BadEntry(t) =>
+                  ConstructorMap.BadEntry(typ_map_term(t)),
+                variants,
+              ),
+            )
+          | Rec(tp, t) => Rec(tpat_map_term(tp), typ_map_term(t))
+          | Forall(tp, t) => Forall(tpat_map_term(tp), typ_map_term(t))
+          },
+      };
     x |> f_typ(rec_call);
   };
 
@@ -626,7 +624,7 @@ and Typ: {
       let (term, rewrap) = Grammar.Annotated.unwrap(ty);
       switch (term) {
       | Atom(_) => ty
-      | Label(name) => Grammar.Label(name) |> rewrap
+      | Label(name) => (Grammar.Label(name): typ_term) |> rewrap
       | Unknown(prov) => Unknown(prov) |> rewrap
       | Arrow(ty1, ty2) =>
         Arrow(subst(s, x, ty1), subst(s, x, ty2)) |> rewrap

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -186,21 +186,25 @@ type source = {
 /* Strip location information from a list of sources */
 let of_source = List.map((source: source) => source.ty);
 
-/* How type provenance information should be collated when
-   joining unknown types. This probably requires more thought,
-   but right now TypeHole strictly predominates over Internal
-   which strictly predominates over SynSwitch. */
+/* Internal > Hole(_) > SynSwitch  and  Invalid > MultiHole > EmptyHole
+   Note: Important for asymmetric unknown type checking that Internal > SynSwitch */
 let join_type_provenance =
     (p1: TermBase.type_provenance, p2: TermBase.type_provenance)
     : TermBase.type_provenance =>
   switch (p1, p2) {
-  | (Hole(h1), Hole(h2)) when h1 == h2 => Hole(h1)
-  | (Hole(EmptyHole), Hole(EmptyHole) | SynSwitch)
-  | (SynSwitch, Hole(EmptyHole)) => Hole(EmptyHole)
-  | (SynSwitch, Internal)
-  | (Internal, SynSwitch) => SynSwitch
-  | (Internal | Hole(_), _)
-  | (_, Hole(_)) => Internal
+  /* Internal > x */
+  | (Internal, Internal | SynSwitch | Hole(_))
+  | (SynSwitch | Hole(_), Internal) => Internal
+  /* Invalid > x */
+  | (Hole(Invalid(s)), Hole(_))
+  | (Hole(_), Hole(Invalid(s))) => Hole(Invalid(s))
+  /* MultiHole > EmptyHole */
+  | (Hole(MultiHole(e)), Hole(_))
+  | (Hole(_), Hole(MultiHole(e))) => Hole(MultiHole(e))
+  | (Hole(EmptyHole), Hole(EmptyHole)) => Hole(EmptyHole)
+  /* Hole(_) > SynSwitch */
+  | (Hole(h), SynSwitch)
+  | (SynSwitch, Hole(h)) => Hole(h)
   | (SynSwitch, SynSwitch) => SynSwitch
   };
 

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -199,12 +199,12 @@ type source = {
 /* Strip location information from a list of sources */
 let of_source = List.map((source: source) => source.ty);
 
-/* Expr > Type > SynSwitch
+/* Type > Expr > SynSwitch
 
    Note: Joining SynSwitches does NOT make semantic sense, we do not yet know if such a join is possible,
          it is dependent on how the SynSwitches are matched.
 
-         SynSwitch > Expr > Type makes more intuitive sense as it _might_ contain more type info when synswitch
+         SynSwitch > Type > Expr makes more intuitive sense as it _might_ contain more type info when synswitch
          is matched.
 
          But, the current logic uses join to match SynSwitches during Info.status_common.
@@ -212,10 +212,10 @@ let of_source = List.map((source: source) => source.ty);
          match_synswitch where required */
 let join_unknown_mode: ((mode, mode)) => mode =
   fun
-  | (Expr, _)
-  | (_, Expr) => Expr
   | (Type, _)
   | (_, Type) => Type
+  | (Expr, _)
+  | (_, Expr) => Expr
   | (SynSwitch, SynSwitch) => SynSwitch;
 
 /* TODO: Think about joining provenances. (may not be required) */

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -196,14 +196,24 @@ type source = {
 /* Strip location information from a list of sources */
 let of_source = List.map((source: source) => source.ty);
 
-/* Ana > SynSwitch > Syn */
+/* Ana > Syn > SynSwitch
+
+   Note: Joining SynSwitches does NOT make semantic sense, we do not yet know if such a join is possible,
+         it is dependent on how the SynSwitches are matched.
+
+         SynSwitch > Syn makes more intuitive sense as it _might_ contain more type info when synswitch
+         is matched.
+
+         But, the current logic uses join to match SynSwitches during Info.status_common.
+         Consider refactoring this to disallow joins with SynSwitch and explicitly use
+         match_synswitch where required */
 let join_unknown_mode: ((mode, mode)) => mode =
   fun
   | (Ana, _)
   | (_, Ana) => Ana
-  | (SynSwitch, _)
-  | (_, SynSwitch) => SynSwitch
-  | (Syn, Syn) => Syn;
+  | (Syn, _)
+  | (_, Syn) => Syn
+  | (SynSwitch, SynSwitch) => SynSwitch;
 
 /* TODO: Think about joining provenances. (may not be required) */
 let join_type_provenance = ((p1, _p2)) => p1;
@@ -821,6 +831,20 @@ let rec is_synswitch = (ty: t): bool =>
   | Prod(_)
   | Sum(_) => false
   };
+
+// Note: Does not remove synswitch
+let make_ana =
+  map_term(~f_typ=(cont, ty: t) => {
+    let (term, rewrap) = IdTagged.unwrap(ty);
+    (
+      switch (term) {
+      | Unknown(Syn, h, p) => (Unknown(Ana, h, p): term)
+      | x => x
+      }
+    )
+    |> rewrap
+    |> cont;
+  });
 
 let rec is_ana_atom = (ty: t) =>
   switch (ty |> term_of) {

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -4,11 +4,12 @@ open OptUtil.Syntax;
 [@deriving (show({with_path: false}), sexp, yojson, enumerate, eq)]
 type cls =
   | Atom(Atom.cls)
-  | Invalid
-  | EmptyHole
-  | MultiHole
-  | SynSwitch
-  | Internal
+  | UnkInvalidSyn
+  | UnkInvalidAna
+  | UnkEmptyHoleSyn
+  | UnkEmptyHoleAna
+  | UnkMultiHoleSyn
+  | UnkMultiHoleAna
   | Arrow
   | Prod
   | TupLabel
@@ -68,19 +69,27 @@ let (replace_temp, replace_temp_exp) = {
   );
 };
 
-let hole = (tms: list(TermBase.Any.t)): TermBase.Typ.term =>
+let hole_syn = (tms: list(TermBase.Any.t)): TermBase.Typ.term =>
   switch (tms) {
-  | [] => Unknown(Hole(EmptyHole))
-  | [_, ..._] => Unknown(Hole(MultiHole(tms)))
+  | [] => Unknown(Syn, Hole.fresh(EmptyHole), Atom)
+  | [_, ..._] => Unknown(Syn, Hole.fresh(MultiHole(tms)), Atom)
+  };
+
+let hole_ana = (tms: list(TermBase.Any.t)): TermBase.Typ.term =>
+  switch (tms) {
+  | [] => Unknown(Ana, Hole.fresh(EmptyHole), Atom)
+  | [_, ..._] => Unknown(Ana, Hole.fresh(MultiHole(tms)), Atom)
   };
 
 let cls_of_term: Grammar.typ_term('a) => cls =
   fun
-  | Unknown(Hole(Invalid(_))) => Invalid
-  | Unknown(Hole(EmptyHole)) => EmptyHole
-  | Unknown(Hole(MultiHole(_))) => MultiHole
-  | Unknown(SynSwitch) => SynSwitch
-  | Unknown(_) => Internal // Note: might need classes for provenances
+  | Unknown(Syn | SynSwitch, {term: Invalid(_), _}, _) => UnkInvalidSyn
+  | Unknown(Ana, {term: Invalid(_), _}, _) => UnkInvalidAna
+  | Unknown(Syn | SynSwitch, {term: EmptyHole, _}, _) => UnkEmptyHoleSyn
+  | Unknown(Ana, {term: EmptyHole, _}, _) => UnkEmptyHoleAna
+  | Unknown(Syn | SynSwitch, {term: MultiHole(_) | ErrorHole, _}, _) =>
+    UnkMultiHoleSyn
+  | Unknown(Ana, {term: MultiHole(_) | ErrorHole, _}, _) => UnkMultiHoleAna
   | Atom(c) => Atom(c)
   | List(_) => List
   | Arrow(_) => Arrow
@@ -96,11 +105,12 @@ let cls_of_term: Grammar.typ_term('a) => cls =
 
 let show_cls: cls => string =
   fun
-  | Invalid => "Invalid type"
-  | MultiHole => "Broken type"
-  | EmptyHole => "Empty type hole"
-  | SynSwitch => "Synthetic type"
-  | Internal => "Internal type"
+  | UnkInvalidSyn
+  | UnkInvalidAna => "Invalid type"
+  | UnkMultiHoleSyn
+  | UnkMultiHoleAna => "Broken type"
+  | UnkEmptyHoleSyn => "Synthesising unknown type (from expression hole or partially annotated variable)"
+  | UnkEmptyHoleAna => "Analysing unknown type (from partial annotation)"
   | Atom(_) => "Base type"
   | Var => "Type variable"
   | Constructor => "Sum constructor"
@@ -186,29 +196,29 @@ type source = {
 /* Strip location information from a list of sources */
 let of_source = List.map((source: source) => source.ty);
 
-/* Internal type provenances > Hole(_) > SynSwitch  and  Invalid > MultiHole > EmptyHole
-   Note: Important for asymmetric unknown type checking that Internal > SynSwitch */
-let join_type_provenance =
-    (p1: TermBase.type_provenance, p2: TermBase.type_provenance)
-    : TermBase.type_provenance =>
-  switch (p1, p2) {
-  /* Invalid > x */
-  | (Hole(Invalid(s)), Hole(_))
-  | (Hole(_), Hole(Invalid(s))) => Hole(Invalid(s))
-  /* MultiHole > EmptyHole */
-  | (Hole(MultiHole(e)), Hole(_))
-  | (Hole(_), Hole(MultiHole(e))) => Hole(MultiHole(e))
-  | (Hole(EmptyHole), Hole(EmptyHole)) => Hole(EmptyHole)
-  /* Hole(_) > SynSwitch */
-  | (Hole(h), SynSwitch)
-  | (SynSwitch, Hole(h)) => Hole(h)
-  | (SynSwitch, SynSwitch) => SynSwitch
-  /* Internal > x */
-  | (p, SynSwitch | Hole(_))
-  | (SynSwitch | Hole(_), p) => p // Should joining Internal with Hole even make sense?
-  | (p1, p2) when p1 == p2 => p1
-  | (_p1, _p2) => Ana // TODO: THink about this case
-  };
+/* Ana > SynSwitch > Syn */
+let join_unknown_mode: ((mode, mode)) => mode =
+  fun
+  | (Ana, _)
+  | (_, Ana) => Ana
+  | (SynSwitch, _)
+  | (_, SynSwitch) => SynSwitch
+  | (Syn, Syn) => Syn;
+
+/* TODO: Think about joining provenances. (may not be required) */
+let join_type_provenance = ((p1, _p2)) => p1;
+
+/* TODO: Think about joining holes.
+   Currently: Invalid > ErrorHole > MultiHole > Hole*/
+let join_hole: ((Hole.t, Hole.t)) => Hole.t =
+  fun
+  | ({term: Invalid(_), _} as h, _)
+  | (_, {term: Invalid(_), _} as h)
+  | ({term: ErrorHole, _} as h, _)
+  | (_, {term: ErrorHole, _} as h)
+  | ({term: MultiHole(_), _} as h, _)
+  | (_, {term: MultiHole(_), _} as h)
+  | ({term: EmptyHole, _} as h, _) => h;
 
 let rec match_tup_label = ty =>
   switch (term_of(ty)) {
@@ -272,9 +282,16 @@ let rec aliases_deep = (ctx: Ctx.t, ty: t): list((string, t)) => {
   let defs =
     ListUtil.flat_map(
       var =>
-        switch (Ctx.lookup_alias(ctx, var)) {
+        switch (
+          Ctx.lookup_alias(ctx, var, IdTagged.IdTag.of_id(rep_id(ty)))
+        ) {
         | Some(ty) => [(var, ty)]
-        | None => [(var, fresh(Unknown(Ana)))]
+        | None => [
+            (
+              var,
+              fresh(Unknown(Syn, Hole.fresh(Invalid("Abstract")), Atom)),
+            ),
+          ] // TODO: Handle hole provenances of abstract ctx lookups correctly
         },
       vars(ty),
     )
@@ -389,25 +406,36 @@ let rec join = (~resolve=false, ctx: Ctx.t, ty1: t, ty2: t): option(t) => {
   switch (term_of(ty1), term_of(ty2)) {
   | (_, Parens(ty2)) => join'(ty1, ty2)
   | (Parens(ty1), _) => join'(ty1, ty2)
-  | (Unknown(p1), Unknown(p2)) =>
-    Some(Unknown(join_type_provenance(p1, p2)) |> temp)
+  | (Unknown(m1, h1, p1), Unknown(m2, h2, p2)) =>
+    Some(
+      Unknown(
+        join_unknown_mode((m1, m2)),
+        join_hole((h1, h2)),
+        join_type_provenance((p1, p2)),
+      )
+      |> temp,
+    )
   | (Unknown(_), _) => Some(ty2)
   | (_, Unknown(_)) => Some(ty1)
   | (Var(n1), Var(n2)) =>
     if (n1 == n2) {
       Some(ty1);
     } else {
-      let* ty1 = Ctx.lookup_alias(ctx, n1);
-      let* ty2 = Ctx.lookup_alias(ctx, n2);
+      let* ty1 =
+        Ctx.lookup_alias(ctx, n1, IdTagged.IdTag.of_id(rep_id(ty1)));
+      let* ty2 =
+        Ctx.lookup_alias(ctx, n2, IdTagged.IdTag.of_id(rep_id(ty2)));
       let+ ty_join = join'(ty1, ty2);
       !resolve && equal(ty1, ty_join) ? ty1 : ty_join;
     }
   | (Var(name), _) =>
-    let* ty_name = Ctx.lookup_alias(ctx, name);
+    let* ty_name =
+      Ctx.lookup_alias(ctx, name, IdTagged.IdTag.of_id(rep_id(ty1)));
     let+ ty_join = join'(ty_name, ty2);
     !resolve && equal(ty_name, ty_join) ? ty1 : ty_join;
   | (_, Var(name)) =>
-    let* ty_name = Ctx.lookup_alias(ctx, name);
+    let* ty_name =
+      Ctx.lookup_alias(ctx, name, IdTagged.IdTag.of_id(rep_id(ty2)));
     let+ ty_join = join'(ty_name, ty1);
     !resolve && equal(ty_name, ty_join) ? ty2 : ty_join;
   /* Note: Ordering of Unknown, Var, and Rec above is load-bearing! */
@@ -482,7 +510,7 @@ let rec match_synswitch = (t1: t, t2: t) => {
   let (term1, rewrap1) = unwrap(t1);
   switch (term1, term_of(t2)) {
   | (Parens(t1), _) => Parens(match_synswitch(t1, t2)) |> rewrap1
-  | (Unknown(SynSwitch), _) => t2
+  | (Unknown(SynSwitch, _, _), _) => t2
   // These cases can't have a synswitch inside
   | (Unknown(_), _)
   | (Atom(_), _)
@@ -545,7 +573,7 @@ let rec weak_head_normalize = (~rec_counter=0, ctx: Ctx.t, ty: t): t => {
   switch (term_of(ty)) {
   | Parens(t) => weak_head_normalize(~rec_counter=rec_counter + 1, ctx, t)
   | Var(x) =>
-    switch (Ctx.lookup_alias(ctx, x)) {
+    switch (Ctx.lookup_alias(ctx, x, IdTagged.IdTag.of_id(rep_id(ty)))) {
     | Some(ty) => weak_head_normalize(~rec_counter=rec_counter + 1, ctx, ty)
     | None => ty
     }
@@ -561,7 +589,7 @@ let rec normalize = (~rec_counter=0, ctx: Ctx.t, ty: t): t => {
   let (term, rewrap) = unwrap(ty);
   switch (term) {
   | Var(x) =>
-    switch (Ctx.lookup_alias(ctx, x)) {
+    switch (Ctx.lookup_alias(ctx, x, IdTagged.IdTag.of_id(rep_id(ty)))) {
     | Some(ty) => normalize(ctx, ty)
     | None => ty
     }
@@ -592,17 +620,20 @@ let rec matched_arrow_strict = (ctx, ty) =>
   switch (term_of(weak_head_normalize(ctx, ty))) {
   | Parens(ty) => matched_arrow_strict(ctx, ty)
   | Arrow(ty_in, ty_out) => Some((ty_in, ty_out))
-  | Unknown(p) =>
-    Some((Unknown(ArrowL(p)) |> temp, Unknown(ArrowR(p)) |> temp))
+  | Unknown(m, h, p) =>
+    Some((
+      Unknown(m, h, ArrowL(p)) |> temp,
+      Unknown(m, h, ArrowR(p)) |> temp,
+    ))
   | _ => None
   };
 
-let matched_arrow = (ctx, ty) =>
+let matched_arrow = (ctx, ty, error) =>
   matched_arrow_strict(ctx, ty)
   |> Option.value(
        ~default=(
-         Unknown(ArrowL(Ana)) |> temp,
-         Unknown(ArrowR(Ana)) |> temp,
+         Unknown(Syn, error, ArrowL(Atom)) |> temp,
+         Unknown(Syn, error, ArrowR(Atom)) |> temp,
        ),
      );
 
@@ -610,13 +641,15 @@ let rec matched_forall_strict = (ctx, ty) =>
   switch (term_of(weak_head_normalize(ctx, ty))) {
   | Parens(ty) => matched_forall_strict(ctx, ty)
   | Forall(t, ty) => Some((Some(t), ty))
-  | Unknown(p) => Some((None, Unknown(Forall(p)) |> temp))
+  | Unknown(m, h, p) => Some((None, Unknown(m, h, Forall(p)) |> temp))
   | _ => None
   };
 
-let matched_forall = (ctx, ty) =>
+let matched_forall = (ctx, ty, error) =>
   matched_forall_strict(ctx, ty)
-  |> Option.value(~default=(None, Unknown(Ana) |> temp));
+  |> Option.value(
+       ~default=(None, Unknown(Syn, error, Forall(Atom)) |> temp),
+     );
 
 let rec get_labels = (ctx, ty): list(option(string)) => {
   let ty = weak_head_normalize(ctx, ty);
@@ -650,15 +683,19 @@ let rec matched_prod_strict:
           Some(tys),
         );
       }
-    | Unknown(p) => (
+    | Unknown(m, h, p) => (
         es,
-        Some(List.init(List.length(es), i => Unknown(Prod(i, p)) |> temp)),
+        Some(
+          List.init(List.length(es), i =>
+            Unknown(m, h, Prod(i, p)) |> temp
+          ),
+        ),
       )
     | _ => (es, None)
     };
   };
 
-let matched_prod = (ctx, es, get_label_es, ty, constructor) => {
+let matched_prod = (ctx, es, get_label_es, ty, constructor, error) => {
   let (es, tys_opt) =
     matched_prod_strict(ctx, es, get_label_es, ty, constructor);
   (
@@ -666,7 +703,9 @@ let matched_prod = (ctx, es, get_label_es, ty, constructor) => {
     tys_opt
     |> Option.value(
          ~default=
-           List.init(List.length(es), i => Unknown(Prod(i, Ana)) |> temp),
+           List.init(List.length(es), i =>
+             Unknown(Syn, error, Prod(i, Atom)) |> temp
+           ),
        ),
   );
 };
@@ -675,13 +714,13 @@ let rec matched_list_strict = (ctx, ty) =>
   switch (term_of(weak_head_normalize(ctx, ty))) {
   | Parens(ty) => matched_list_strict(ctx, ty)
   | List(ty) => Some(ty)
-  | Unknown(p) => Some(Unknown(List(p)) |> temp)
+  | Unknown(m, h, p) => Some(Unknown(m, h, List(p)) |> temp)
   | _ => None
   };
 
-let matched_list = (ctx, ty) =>
+let matched_list = (ctx, ty, error) =>
   matched_list_strict(ctx, ty)
-  |> Option.value(~default=Unknown(List(Ana)) |> temp);
+  |> Option.value(~default=Unknown(Syn, error, List(Atom)) |> temp);
 
 let rec matched_args_strict = (ctx, ty, arity): Either.t('a, int) => {
   switch (term_of(weak_head_normalize(ctx, ty))) {
@@ -689,22 +728,26 @@ let rec matched_args_strict = (ctx, ty, arity): Either.t('a, int) => {
   | Prod(tys) when List.length(tys) == arity => L(tys)
   | Prod(tys) => R(List.length(tys))
   | _ when arity == 1 => L([ty])
-  | Unknown(p) => L(List.init(arity, i => Unknown(Arg(i, p)) |> temp))
+  | Unknown(m, h, p) =>
+    L(List.init(arity, i => Unknown(m, h, Arg(i, p)) |> temp))
   | _ => R(1)
   };
 };
 
-let matched_args = (ctx, ty, arity) =>
+let matched_args = (ctx, ty, arity, error) =>
   switch (matched_args_strict(ctx, ty, arity)) {
   | L(tys) => tys
-  | R(_) => List.init(arity, i => Unknown(Arg(i, Ana)) |> temp)
+  | R(_) => List.init(arity, i => Unknown(Syn, error, Arg(i, Atom)) |> temp)
   };
 
 let matched_label = (ctx, ty): option((t, t)) =>
   switch (term_of(weak_head_normalize(ctx, ty))) {
   | TupLabel({term: Label(ml), _}, ty) => Some((Label(ml) |> temp, ty))
-  | Unknown(p) =>
-    Some((Unknown(Label(p)) |> temp, Unknown(TupLabel(p)) |> temp))
+  | Unknown(m, h, p) =>
+    Some((
+      Unknown(m, h, Label(p)) |> temp,
+      Unknown(m, h, TupLabel(p)) |> temp,
+    ))
   | _ => None
   };
 
@@ -726,11 +769,7 @@ let rec get_sum_constructors = (ctx: Ctx.t, ty: t): option(sum_map) => {
        the below code will be incorrect! */
     let ty =
       switch (ty |> term_of) {
-      | Rec({term: Var(x), _}, _ty_body) =>
-        switch (Ctx.lookup_alias(ctx, x)) {
-        | None => unroll(ty)
-        | Some(_) => unroll(ty)
-        }
+      | Rec({term: Var(_), _}, _ty_body) => unroll(ty)
       | _ => ty
       };
     switch (ty |> term_of) {
@@ -749,27 +788,28 @@ let rec is_unknown = (ty: t): bool =>
   | _ => false
   };
 
-let rec is_syn_prov: Grammar.type_provenance('a) => bool =
-  fun
-  | SynSwitch => true
-  | Hole(_)
-  | Ana => false
-  | ArrowL(p)
-  | ArrowR(p)
-  | List(p)
-  | Prod(_, p)
-  | Arg(_, p)
-  | Label(p)
-  | TupLabel(p)
-  | Forall(p)
-  | Sum(p)
-  | Ctr(_, p) => is_syn_prov(p);
-
-let rec is_syn = (ty: t): bool =>
+let rec is_unknown_syn = (ty: t): bool =>
   switch (ty |> term_of) {
   | TupLabel(_, x)
-  | Parens(x) => is_syn(x)
-  | Unknown(p) => is_syn_prov(p)
+  | Parens(x) => is_unknown_syn(x)
+  | Unknown(Syn, _, _) => true
+  | _ => false
+  };
+
+let rec is_unknown_ana = (ty: t): bool =>
+  switch (ty |> term_of) {
+  | TupLabel(_, x)
+  | Parens(x) => is_unknown_ana(x)
+  | Unknown(Ana, _, _) => true
+  | _ => false
+  };
+
+let rec is_synswitch = (ty: t): bool =>
+  switch (ty |> term_of) {
+  | TupLabel(_, x)
+  | Parens(x) => is_synswitch(x)
+  | Unknown(SynSwitch, _, _) => true
+  | Unknown(_)
   | Atom(_)
   | Label(_)
   | Var(_)
@@ -799,11 +839,11 @@ let rec is_ana_atom = (ty: t) =>
   | Sum(_) => None
   };
 
-let rec is_syn_fun = (ty: t): bool =>
+let rec is_synswitch_fun = (ty: t): bool =>
   switch (ty |> term_of) {
   | TupLabel(_, x)
-  | Parens(x) => is_syn_fun(x)
-  | Arrow(t1, t2) => is_syn(t1) && is_syn_fun(t2)
+  | Parens(x) => is_synswitch_fun(x)
+  | Arrow(t1, t2) => is_synswitch(t1) && is_synswitch_fun(t2)
   | Unknown(_)
   | Atom(_)
   | Label(_)
@@ -816,13 +856,14 @@ let rec is_syn_fun = (ty: t): bool =>
   | Sum(_) => false
   };
 
-let rec is_syn_plus = (ty: t): bool =>
+let rec is_synswitch_plus = (ty: t): bool =>
   switch (ty |> term_of) {
   | TupLabel(_, x)
-  | Parens(x) => is_syn_plus(x)
-  | Unknown(p) => is_syn_prov(p)
-  | Arrow(t1, t2) => is_syn(t1) && is_syn_plus(t2)
-  | Forall(_, t) => is_syn(t)
+  | Parens(x) => is_synswitch_plus(x)
+  | Unknown(SynSwitch | Syn, _, _) => true
+  | Arrow(t1, t2) => is_synswitch(t1) && is_synswitch_plus(t2)
+  | Forall(_, t) => is_synswitch(t)
+  | Unknown(_)
   | Atom(_)
   | Label(_)
   | Var(_)
@@ -941,7 +982,11 @@ let remove_duplicate_labels =
             [l] @ seen_duplicates,
             deduplicated_types
             @ [
-              TupLabel(Label(l) |> temp, Unknown(TupLabel(Ana)) |> temp)
+              TupLabel(
+                Label(l) |> temp,
+                Unknown(Syn, Hole.fresh(Invalid("Duplicate Label")), Atom)
+                |> temp,
+              )  // TODO: Correctly track ids for duplicate labels
               |> temp,
             ],
           )

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -209,10 +209,10 @@ let of_source = List.map((source: source) => source.ty);
          match_synswitch where required */
 let join_unknown_mode: ((mode, mode)) => mode =
   fun
-  | (Ana, _)
-  | (_, Ana) => Ana
   | (Syn, _)
   | (_, Syn) => Syn
+  | (Ana, _)
+  | (_, Ana) => Ana
   | (SynSwitch, SynSwitch) => SynSwitch;
 
 /* TODO: Think about joining provenances. (may not be required) */

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -80,7 +80,7 @@ let cls_of_term: Grammar.typ_term('a) => cls =
   | Unknown(Hole(EmptyHole)) => EmptyHole
   | Unknown(Hole(MultiHole(_))) => MultiHole
   | Unknown(SynSwitch) => SynSwitch
-  | Unknown(Internal) => Internal
+  | Unknown(_) => Internal // Note: might need classes for provenances
   | Atom(c) => Atom(c)
   | List(_) => List
   | Arrow(_) => Arrow
@@ -186,15 +186,12 @@ type source = {
 /* Strip location information from a list of sources */
 let of_source = List.map((source: source) => source.ty);
 
-/* Internal > Hole(_) > SynSwitch  and  Invalid > MultiHole > EmptyHole
+/* Internal type provenances > Hole(_) > SynSwitch  and  Invalid > MultiHole > EmptyHole
    Note: Important for asymmetric unknown type checking that Internal > SynSwitch */
 let join_type_provenance =
     (p1: TermBase.type_provenance, p2: TermBase.type_provenance)
     : TermBase.type_provenance =>
   switch (p1, p2) {
-  /* Internal > x */
-  | (Internal, Internal | SynSwitch | Hole(_))
-  | (SynSwitch | Hole(_), Internal) => Internal
   /* Invalid > x */
   | (Hole(Invalid(s)), Hole(_))
   | (Hole(_), Hole(Invalid(s))) => Hole(Invalid(s))
@@ -206,6 +203,11 @@ let join_type_provenance =
   | (Hole(h), SynSwitch)
   | (SynSwitch, Hole(h)) => Hole(h)
   | (SynSwitch, SynSwitch) => SynSwitch
+  /* Internal > x */
+  | (p, SynSwitch | Hole(_))
+  | (SynSwitch | Hole(_), p) => p // Should joining Internal with Hole even make sense?
+  | (p1, p2) when p1 == p2 => p1
+  | (_p1, _p2) => Ana // TODO: THink about this case
   };
 
 let rec match_tup_label = ty =>
@@ -272,7 +274,7 @@ let rec aliases_deep = (ctx: Ctx.t, ty: t): list((string, t)) => {
       var =>
         switch (Ctx.lookup_alias(ctx, var)) {
         | Some(ty) => [(var, ty)]
-        | None => [(var, fresh(Unknown(Internal)))]
+        | None => [(var, fresh(Unknown(Ana)))]
         },
       vars(ty),
     )
@@ -590,28 +592,31 @@ let rec matched_arrow_strict = (ctx, ty) =>
   switch (term_of(weak_head_normalize(ctx, ty))) {
   | Parens(ty) => matched_arrow_strict(ctx, ty)
   | Arrow(ty_in, ty_out) => Some((ty_in, ty_out))
-  | Unknown(SynSwitch) =>
-    Some((Unknown(SynSwitch) |> temp, Unknown(SynSwitch) |> temp))
+  | Unknown(p) =>
+    Some((Unknown(ArrowL(p)) |> temp, Unknown(ArrowR(p)) |> temp))
   | _ => None
   };
 
 let matched_arrow = (ctx, ty) =>
   matched_arrow_strict(ctx, ty)
   |> Option.value(
-       ~default=(Unknown(Internal) |> temp, Unknown(Internal) |> temp),
+       ~default=(
+         Unknown(ArrowL(Ana)) |> temp,
+         Unknown(ArrowR(Ana)) |> temp,
+       ),
      );
 
 let rec matched_forall_strict = (ctx, ty) =>
   switch (term_of(weak_head_normalize(ctx, ty))) {
   | Parens(ty) => matched_forall_strict(ctx, ty)
   | Forall(t, ty) => Some((Some(t), ty))
-  | Unknown(SynSwitch) => Some((None, Unknown(SynSwitch) |> temp))
+  | Unknown(p) => Some((None, Unknown(Forall(p)) |> temp))
   | _ => None
   };
 
 let matched_forall = (ctx, ty) =>
   matched_forall_strict(ctx, ty)
-  |> Option.value(~default=(None, Unknown(Internal) |> temp));
+  |> Option.value(~default=(None, Unknown(Ana) |> temp));
 
 let rec get_labels = (ctx, ty): list(option(string)) => {
   let ty = weak_head_normalize(ctx, ty);
@@ -645,9 +650,9 @@ let rec matched_prod_strict:
           Some(tys),
         );
       }
-    | Unknown(SynSwitch) => (
+    | Unknown(p) => (
         es,
-        Some(List.init(List.length(es), _ => Unknown(SynSwitch) |> temp)),
+        Some(List.init(List.length(es), i => Unknown(Prod(i, p)) |> temp)),
       )
     | _ => (es, None)
     };
@@ -660,7 +665,8 @@ let matched_prod = (ctx, es, get_label_es, ty, constructor) => {
     es,
     tys_opt
     |> Option.value(
-         ~default=List.init(List.length(es), _ => Unknown(Internal) |> temp),
+         ~default=
+           List.init(List.length(es), i => Unknown(Prod(i, Ana)) |> temp),
        ),
   );
 };
@@ -669,13 +675,13 @@ let rec matched_list_strict = (ctx, ty) =>
   switch (term_of(weak_head_normalize(ctx, ty))) {
   | Parens(ty) => matched_list_strict(ctx, ty)
   | List(ty) => Some(ty)
-  | Unknown(SynSwitch) => Some(Unknown(SynSwitch) |> temp)
+  | Unknown(p) => Some(Unknown(List(p)) |> temp)
   | _ => None
   };
 
 let matched_list = (ctx, ty) =>
   matched_list_strict(ctx, ty)
-  |> Option.value(~default=Unknown(Internal) |> temp);
+  |> Option.value(~default=Unknown(List(Ana)) |> temp);
 
 let rec matched_args_strict = (ctx, ty, arity): Either.t('a, int) => {
   switch (term_of(weak_head_normalize(ctx, ty))) {
@@ -683,8 +689,7 @@ let rec matched_args_strict = (ctx, ty, arity): Either.t('a, int) => {
   | Prod(tys) when List.length(tys) == arity => L(tys)
   | Prod(tys) => R(List.length(tys))
   | _ when arity == 1 => L([ty])
-  | Unknown((SynSwitch | Internal) as p) =>
-    L(List.init(arity, _ => Unknown(p) |> temp))
+  | Unknown(p) => L(List.init(arity, i => Unknown(Arg(i, p)) |> temp))
   | _ => R(1)
   };
 };
@@ -692,14 +697,14 @@ let rec matched_args_strict = (ctx, ty, arity): Either.t('a, int) => {
 let matched_args = (ctx, ty, arity) =>
   switch (matched_args_strict(ctx, ty, arity)) {
   | L(tys) => tys
-  | R(_) => List.init(arity, _ => Unknown(Internal) |> temp)
+  | R(_) => List.init(arity, i => Unknown(Arg(i, Ana)) |> temp)
   };
 
 let matched_label = (ctx, ty): option((t, t)) =>
   switch (term_of(weak_head_normalize(ctx, ty))) {
   | TupLabel({term: Label(ml), _}, ty) => Some((Label(ml) |> temp, ty))
-  | Unknown(SynSwitch) =>
-    Some((Unknown(SynSwitch) |> temp, Unknown(SynSwitch) |> temp))
+  | Unknown(p) =>
+    Some((Unknown(Label(p)) |> temp, Unknown(TupLabel(p)) |> temp))
   | _ => None
   };
 
@@ -744,12 +749,27 @@ let rec is_unknown = (ty: t): bool =>
   | _ => false
   };
 
+let rec is_syn_prov: Grammar.type_provenance('a) => bool =
+  fun
+  | SynSwitch => true
+  | Hole(_)
+  | Ana => false
+  | ArrowL(p)
+  | ArrowR(p)
+  | List(p)
+  | Prod(_, p)
+  | Arg(_, p)
+  | Label(p)
+  | TupLabel(p)
+  | Forall(p)
+  | Sum(p)
+  | Ctr(_, p) => is_syn_prov(p);
+
 let rec is_syn = (ty: t): bool =>
   switch (ty |> term_of) {
   | TupLabel(_, x)
   | Parens(x) => is_syn(x)
-  | Unknown(SynSwitch) => true
-  | Unknown(_)
+  | Unknown(p) => is_syn_prov(p)
   | Atom(_)
   | Label(_)
   | Var(_)
@@ -800,10 +820,9 @@ let rec is_syn_plus = (ty: t): bool =>
   switch (ty |> term_of) {
   | TupLabel(_, x)
   | Parens(x) => is_syn_plus(x)
-  | Unknown(SynSwitch) => true
+  | Unknown(p) => is_syn_prov(p)
   | Arrow(t1, t2) => is_syn(t1) && is_syn_plus(t2)
   | Forall(_, t) => is_syn(t)
-  | Unknown(_)
   | Atom(_)
   | Label(_)
   | Var(_)
@@ -922,7 +941,8 @@ let remove_duplicate_labels =
             [l] @ seen_duplicates,
             deduplicated_types
             @ [
-              TupLabel(Label(l) |> temp, Unknown(Internal) |> temp) |> temp,
+              TupLabel(Label(l) |> temp, Unknown(TupLabel(Ana)) |> temp)
+              |> temp,
             ],
           )
         | Some(_) => (seen_duplicates, deduplicated_types @ [ty])

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -2,14 +2,20 @@ open Util;
 open OptUtil.Syntax;
 
 [@deriving (show({with_path: false}), sexp, yojson, enumerate, eq)]
+type unknown_cls =
+  | List
+  | Invalid
+  | EmptyHole
+  | MultiHole;
+
+include TermBase.Typ;
+[@deriving (show({with_path: false}), sexp, yojson, enumerate, eq)]
+type mode = TermBase.unknown_mode; // WHY can't I put ppx_enumerate in TermBase.Typ >:(
+
+[@deriving (show({with_path: false}), sexp, yojson, enumerate, eq)]
 type cls =
   | Atom(Atom.cls)
-  | UnkInvalidSyn
-  | UnkInvalidAna
-  | UnkEmptyHoleSyn
-  | UnkEmptyHoleAna
-  | UnkMultiHoleSyn
-  | UnkMultiHoleAna
+  | Unknown(mode, unknown_cls)
   | Arrow
   | Prod
   | TupLabel
@@ -22,8 +28,6 @@ type cls =
   | Ap
   | Rec
   | Forall;
-
-include TermBase.Typ;
 
 let term_of: t => term = IdTagged.term_of;
 let unwrap: t => (term, term => t) = IdTagged.unwrap;
@@ -69,27 +73,26 @@ let (replace_temp, replace_temp_exp) = {
   );
 };
 
-let hole_syn = (tms: list(TermBase.Any.t)): TermBase.Typ.term =>
+// TODO: IDs?
+let hole_typ = (tms: list(TermBase.Any.t)): TermBase.Typ.term =>
   switch (tms) {
-  | [] => Unknown(Syn, Hole.fresh(EmptyHole), Atom)
-  | [_, ..._] => Unknown(Syn, Hole.fresh(MultiHole(tms)), Atom)
+  | [] => Unknown(Type, Hole.fresh(EmptyHole), Atom)
+  | [_, ..._] => Unknown(Type, Hole.fresh(MultiHole(tms)), Atom)
   };
 
 let hole_ana = (tms: list(TermBase.Any.t)): TermBase.Typ.term =>
   switch (tms) {
-  | [] => Unknown(Ana, Hole.fresh(EmptyHole), Atom)
-  | [_, ..._] => Unknown(Ana, Hole.fresh(MultiHole(tms)), Atom)
+  | [] => Unknown(Expr, Hole.fresh(EmptyHole), Atom)
+  | [_, ..._] => Unknown(Expr, Hole.fresh(MultiHole(tms)), Atom)
   };
 
 let cls_of_term: Grammar.typ_term('a) => cls =
   fun
-  | Unknown(Syn | SynSwitch, {term: Invalid(_), _}, _) => UnkInvalidSyn
-  | Unknown(Ana, {term: Invalid(_), _}, _) => UnkInvalidAna
-  | Unknown(Syn | SynSwitch, {term: EmptyHole, _}, _) => UnkEmptyHoleSyn
-  | Unknown(Ana, {term: EmptyHole, _}, _) => UnkEmptyHoleAna
-  | Unknown(Syn | SynSwitch, {term: MultiHole(_) | ErrorHole, _}, _) =>
-    UnkMultiHoleSyn
-  | Unknown(Ana, {term: MultiHole(_) | ErrorHole, _}, _) => UnkMultiHoleAna
+  | Unknown(m, {term: Invalid(_), _}, _) => Unknown(m, Invalid)
+  | Unknown(m, {term: EmptyHole, _}, _) => Unknown(m, EmptyHole)
+  | Unknown(m, {term: MultiHole(_) | ErrorHole, _}, _) =>
+    Unknown(m, MultiHole)
+  | Unknown(m, {term: List, _}, _) => Unknown(m, List)
   | Atom(c) => Atom(c)
   | List(_) => List
   | Arrow(_) => Arrow
@@ -105,12 +108,12 @@ let cls_of_term: Grammar.typ_term('a) => cls =
 
 let show_cls: cls => string =
   fun
-  | UnkInvalidSyn
-  | UnkInvalidAna => "Invalid type"
-  | UnkMultiHoleSyn
-  | UnkMultiHoleAna => "Broken type"
-  | UnkEmptyHoleSyn => "Synthesising unknown type (from expression hole or partially annotated variable)"
-  | UnkEmptyHoleAna => "Analysing unknown type (from partial annotation)"
+  | Unknown(SynSwitch, _) => "SynSwitch"
+  | Unknown(_, Invalid) => "Invalid type"
+  | Unknown(_, MultiHole) => "Broken type"
+  | Unknown(_, List) => "Unknown type (from list)"
+  | Unknown(Expr, EmptyHole) => "Unknown type (from expression hole)"
+  | Unknown(Type, EmptyHole) => "Unknown type (from partial annotation)"
   | Atom(_) => "Base type"
   | Var => "Type variable"
   | Constructor => "Sum constructor"
@@ -196,12 +199,12 @@ type source = {
 /* Strip location information from a list of sources */
 let of_source = List.map((source: source) => source.ty);
 
-/* Ana > Syn > SynSwitch
+/* Expr > Type > SynSwitch
 
    Note: Joining SynSwitches does NOT make semantic sense, we do not yet know if such a join is possible,
          it is dependent on how the SynSwitches are matched.
 
-         SynSwitch > Syn makes more intuitive sense as it _might_ contain more type info when synswitch
+         SynSwitch > Expr > Type makes more intuitive sense as it _might_ contain more type info when synswitch
          is matched.
 
          But, the current logic uses join to match SynSwitches during Info.status_common.
@@ -209,17 +212,17 @@ let of_source = List.map((source: source) => source.ty);
          match_synswitch where required */
 let join_unknown_mode: ((mode, mode)) => mode =
   fun
-  | (Syn, _)
-  | (_, Syn) => Syn
-  | (Ana, _)
-  | (_, Ana) => Ana
+  | (Expr, _)
+  | (_, Expr) => Expr
+  | (Type, _)
+  | (_, Type) => Type
   | (SynSwitch, SynSwitch) => SynSwitch;
 
 /* TODO: Think about joining provenances. (may not be required) */
 let join_type_provenance = ((p1, _p2)) => p1;
 
 /* TODO: Think about joining holes.
-   Currently: Invalid > ErrorHole > MultiHole > Hole*/
+   Currently: Invalid > ErrorHole > MultiHole > Hole > List*/
 let join_hole: ((Hole.t, Hole.t)) => Hole.t =
   fun
   | ({term: Invalid(_), _} as h, _)
@@ -228,7 +231,9 @@ let join_hole: ((Hole.t, Hole.t)) => Hole.t =
   | (_, {term: ErrorHole, _} as h)
   | ({term: MultiHole(_), _} as h, _)
   | (_, {term: MultiHole(_), _} as h)
-  | ({term: EmptyHole, _} as h, _) => h;
+  | ({term: EmptyHole, _} as h, _)
+  | (_, {term: EmptyHole, _} as h)
+  | ({term: List, _} as h, _) => h;
 
 let rec match_tup_label = ty =>
   switch (term_of(ty)) {
@@ -299,9 +304,9 @@ let rec aliases_deep = (ctx: Ctx.t, ty: t): list((string, t)) => {
         | None => [
             (
               var,
-              fresh(Unknown(Syn, Hole.fresh(Invalid("Abstract")), Atom)),
+              fresh(Unknown(Type, Hole.fresh(Invalid("Abstract")), Atom)),
             ),
-          ] // TODO: Handle hole provenances of abstract ctx lookups correctly
+          ]
         },
       vars(ty),
     )
@@ -638,12 +643,12 @@ let rec matched_arrow_strict = (ctx, ty) =>
   | _ => None
   };
 
-let matched_arrow = (ctx, ty, error) =>
+let matched_arrow = (ctx, ty, error, mode) =>
   matched_arrow_strict(ctx, ty)
   |> Option.value(
        ~default=(
-         Unknown(Syn, error, ArrowL(Atom)) |> temp,
-         Unknown(Syn, error, ArrowR(Atom)) |> temp,
+         Unknown(mode, error, ArrowL(Atom)) |> temp,
+         Unknown(mode, error, ArrowR(Atom)) |> temp,
        ),
      );
 
@@ -655,10 +660,10 @@ let rec matched_forall_strict = (ctx, ty) =>
   | _ => None
   };
 
-let matched_forall = (ctx, ty, error) =>
+let matched_forall = (ctx, ty, error, mode) =>
   matched_forall_strict(ctx, ty)
   |> Option.value(
-       ~default=(None, Unknown(Syn, error, Forall(Atom)) |> temp),
+       ~default=(None, Unknown(mode, error, Forall(Atom)) |> temp),
      );
 
 let rec get_labels = (ctx, ty): list(option(string)) => {
@@ -705,7 +710,7 @@ let rec matched_prod_strict:
     };
   };
 
-let matched_prod = (ctx, es, get_label_es, ty, constructor, error) => {
+let matched_prod = (ctx, es, get_label_es, ty, constructor, error, mode) => {
   let (es, tys_opt) =
     matched_prod_strict(ctx, es, get_label_es, ty, constructor);
   (
@@ -714,7 +719,7 @@ let matched_prod = (ctx, es, get_label_es, ty, constructor, error) => {
     |> Option.value(
          ~default=
            List.init(List.length(es), i =>
-             Unknown(Syn, error, Prod(i, Atom)) |> temp
+             Unknown(mode, error, Prod(i, Atom)) |> temp
            ),
        ),
   );
@@ -728,9 +733,9 @@ let rec matched_list_strict = (ctx, ty) =>
   | _ => None
   };
 
-let matched_list = (ctx, ty, error) =>
+let matched_list = (ctx, ty, error, mode) =>
   matched_list_strict(ctx, ty)
-  |> Option.value(~default=Unknown(Syn, error, List(Atom)) |> temp);
+  |> Option.value(~default=Unknown(mode, error, List(Atom)) |> temp);
 
 let rec matched_args_strict = (ctx, ty, arity): Either.t('a, int) => {
   switch (term_of(weak_head_normalize(ctx, ty))) {
@@ -744,10 +749,10 @@ let rec matched_args_strict = (ctx, ty, arity): Either.t('a, int) => {
   };
 };
 
-let matched_args = (ctx, ty, arity, error) =>
+let matched_args = (ctx, ty, arity, error, mode) =>
   switch (matched_args_strict(ctx, ty, arity)) {
   | L(tys) => tys
-  | R(_) => List.init(arity, i => Unknown(Syn, error, Arg(i, Atom)) |> temp)
+  | R(_) => List.init(arity, i => Unknown(mode, error, Arg(i, Atom)) |> temp)
   };
 
 let matched_label = (ctx, ty): option((t, t)) =>
@@ -798,19 +803,19 @@ let rec is_unknown = (ty: t): bool =>
   | _ => false
   };
 
-let rec is_unknown_syn = (ty: t): bool =>
+let rec is_unknown_expr = (ty: t): bool =>
   switch (ty |> term_of) {
   | TupLabel(_, x)
-  | Parens(x) => is_unknown_syn(x)
-  | Unknown(Syn, _, _) => true
+  | Parens(x) => is_unknown_expr(x)
+  | Unknown(Expr, _, _) => true
   | _ => false
   };
 
-let rec is_unknown_ana = (ty: t): bool =>
+let rec is_unknown_type = (ty: t): bool =>
   switch (ty |> term_of) {
   | TupLabel(_, x)
-  | Parens(x) => is_unknown_ana(x)
-  | Unknown(Ana, _, _) => true
+  | Parens(x) => is_unknown_type(x)
+  | Unknown(Type, _, _) => true
   | _ => false
   };
 
@@ -831,20 +836,6 @@ let rec is_synswitch = (ty: t): bool =>
   | Prod(_)
   | Sum(_) => false
   };
-
-// Note: Does not remove synswitch
-let make_ana =
-  map_term(~f_typ=(cont, ty: t) => {
-    let (term, rewrap) = IdTagged.unwrap(ty);
-    (
-      switch (term) {
-      | Unknown(Syn, h, p) => (Unknown(Ana, h, p): term)
-      | x => x
-      }
-    )
-    |> rewrap
-    |> cont;
-  });
 
 let rec is_ana_atom = (ty: t) =>
   switch (ty |> term_of) {
@@ -884,7 +875,7 @@ let rec is_synswitch_plus = (ty: t): bool =>
   switch (ty |> term_of) {
   | TupLabel(_, x)
   | Parens(x) => is_synswitch_plus(x)
-  | Unknown(SynSwitch | Syn, _, _) => true
+  | Unknown(SynSwitch, _, _) => true
   | Arrow(t1, t2) => is_synswitch(t1) && is_synswitch_plus(t2)
   | Forall(_, t) => is_synswitch(t)
   | Unknown(_)
@@ -1008,7 +999,7 @@ let remove_duplicate_labels =
             @ [
               TupLabel(
                 Label(l) |> temp,
-                Unknown(Syn, Hole.fresh(Invalid("Duplicate Label")), Atom)
+                Unknown(Expr, Hole.fresh(Invalid("Duplicate Label")), Atom)
                 |> temp,
               )  // TODO: Correctly track ids for duplicate labels
               |> temp,

--- a/src/menhirParser/Conversion.re
+++ b/src/menhirParser/Conversion.re
@@ -399,7 +399,7 @@ and Typ: {
     switch (typ) {
     | InvalidTyp(s) =>
       unknown(
-        Syn,
+        Type,
         {
           term: Invalid(s),
           annotation: true,
@@ -416,7 +416,7 @@ and Typ: {
       switch (p) {
       | Internal =>
         unknown(
-          Syn,
+          Type,
           {
             term: EmptyHole,
             annotation: true,
@@ -425,7 +425,7 @@ and Typ: {
         )
       | EmptyHole =>
         unknown(
-          Syn,
+          Type,
           {
             term: EmptyHole,
             annotation: true,

--- a/src/menhirParser/Conversion.re
+++ b/src/menhirParser/Conversion.re
@@ -397,7 +397,15 @@ and Typ: {
   open IndicatedG.Typ;
   let rec of_menhir_ast = (typ: AST.typ): IndicatedG.typ => {
     switch (typ) {
-    | InvalidTyp(s) => unknown(Hole(Invalid(s)))
+    | InvalidTyp(s) =>
+      unknown(
+        Syn,
+        {
+          term: Invalid(s),
+          annotation: true,
+        },
+        Atom,
+      )
     | IntType => int()
     | SIntType => sint()
     | FloatType => float()
@@ -406,8 +414,24 @@ and Typ: {
     | NatType => nat()
     | UnknownType(p) =>
       switch (p) {
-      | Internal => unknown(Ana)
-      | EmptyHole => unknown(Hole(EmptyHole))
+      | Internal =>
+        unknown(
+          Syn,
+          {
+            term: EmptyHole,
+            annotation: true,
+          },
+          Atom,
+        )
+      | EmptyHole =>
+        unknown(
+          Syn,
+          {
+            term: EmptyHole,
+            annotation: true,
+          },
+          Atom,
+        )
       }
     | TypVar(s) => var(s)
     | TupleType([t]) => parens(of_menhir_ast(t))
@@ -442,11 +466,9 @@ and Typ: {
     };
   };
 
-  let of_core_type_provenance =
-      (p: IndicatedG.typ_provenance): AST.typ_provenance => {
-    switch (p) {
-    | Hole(EmptyHole) => EmptyHole
-    | SynSwitch => raise(Failure("Unknown type_provenance"))
+  let of_core_type_provenance = (h: IndicatedG.hole): AST.typ_provenance => {
+    switch (h.term) {
+    | EmptyHole => EmptyHole
     | _ => Internal
     };
   };
@@ -462,7 +484,7 @@ and Typ: {
     | Prod(ts) => TupleType(List.map(of_core, ts))
     | List(t) => ArrayType(of_core(t))
     | Arrow(t1, t2) => ArrowType(of_core(t1), of_core(t2))
-    | Unknown(p) => UnknownType(of_core_type_provenance(p))
+    | Unknown(_, h, _) => UnknownType(of_core_type_provenance(h)) // TODO: Asymmetric unknown type provenances
     | Forall(tp, t) => ForallType(TPat.of_core(tp), of_core(t))
     | Rec(tp, t) => RecType(TPat.of_core(tp), of_core(t))
     | Parens(t) => of_core(t)

--- a/src/menhirParser/Conversion.re
+++ b/src/menhirParser/Conversion.re
@@ -406,7 +406,7 @@ and Typ: {
     | NatType => nat()
     | UnknownType(p) =>
       switch (p) {
-      | Internal => unknown(Internal)
+      | Internal => unknown(Ana)
       | EmptyHole => unknown(Hole(EmptyHole))
       }
     | TypVar(s) => var(s)
@@ -445,9 +445,9 @@ and Typ: {
   let of_core_type_provenance =
       (p: IndicatedG.typ_provenance): AST.typ_provenance => {
     switch (p) {
-    | Internal => Internal
     | Hole(EmptyHole) => EmptyHole
-    | _ => raise(Failure("Unknown type_provenance"))
+    | SynSwitch => raise(Failure("Unknown type_provenance"))
+    | _ => Internal
     };
   };
   let rec of_core = (typ: IndicatedG.typ): AST.typ => {

--- a/src/web/app/editors/stepper/StepperBase.re
+++ b/src/web/app/editors/stepper/StepperBase.re
@@ -870,7 +870,7 @@ module Update = {
           | Fun(p, d1, t, _) =>
             let t =
               OptUtil.get(
-                () => Typ.fresh(Unknown(Syn, Hole.temp(EmptyHole), Atom)),
+                () => Typ.fresh(Unknown(Type, Hole.temp(EmptyHole), Atom)),
                 t,
               );
             let* bindings = ProofHacks.dhpat_extend_ctx(p, t, ctx);
@@ -894,7 +894,7 @@ module Update = {
               Fun(
                 Pat.fresh(EmptyHole),
                 last,
-                Some(Typ.fresh(Unknown(Syn, Hole.temp(EmptyHole), Atom))),
+                Some(Typ.fresh(Unknown(Type, Hole.temp(EmptyHole), Atom))),
                 None,
               ),
             )

--- a/src/web/app/editors/stepper/StepperBase.re
+++ b/src/web/app/editors/stepper/StepperBase.re
@@ -868,7 +868,11 @@ module Update = {
           and.calc ctx = ctx;
           switch (exp |> Exp.term_of) {
           | Fun(p, d1, t, _) =>
-            let t = OptUtil.get(() => Typ.fresh(Unknown(SynSwitch)), t);
+            let t =
+              OptUtil.get(
+                () => Typ.fresh(Unknown(Syn, Hole.temp(EmptyHole), Atom)),
+                t,
+              );
             let* bindings = ProofHacks.dhpat_extend_ctx(p, t, ctx);
             Some((bindings, d1));
           | _ => None
@@ -890,7 +894,7 @@ module Update = {
               Fun(
                 Pat.fresh(EmptyHole),
                 last,
-                Some(Typ.fresh(Unknown(SynSwitch))),
+                Some(Typ.fresh(Unknown(Syn, Hole.temp(EmptyHole), Atom))),
                 None,
               ),
             )

--- a/src/web/app/editors/stepper/StepperBase.re
+++ b/src/web/app/editors/stepper/StepperBase.re
@@ -868,7 +868,7 @@ module Update = {
           and.calc ctx = ctx;
           switch (exp |> Exp.term_of) {
           | Fun(p, d1, t, _) =>
-            let t = OptUtil.get(() => Typ.fresh(Unknown(Internal)), t);
+            let t = OptUtil.get(() => Typ.fresh(Unknown(SynSwitch)), t);
             let* bindings = ProofHacks.dhpat_extend_ctx(p, t, ctx);
             Some((bindings, d1));
           | _ => None
@@ -890,7 +890,7 @@ module Update = {
               Fun(
                 Pat.fresh(EmptyHole),
                 last,
-                Some(Typ.fresh(Unknown(Internal))),
+                Some(Typ.fresh(Unknown(SynSwitch))),
                 None,
               ),
             )

--- a/src/web/app/explainthis/ExplainThis.re
+++ b/src/web/app/explainthis/ExplainThis.re
@@ -2402,10 +2402,9 @@ let get_doc =
     }
   | Some(InfoTyp({term, _} as typ_info)) =>
     switch (bypass_parens_typ(term).term) {
-    | Unknown(SynSwitch)
-    | Unknown(Internal)
-    | Unknown(Hole(EmptyHole)) => get_message(HoleTyp.empty_hole)
+    | Unknown(Hole(Invalid(_))) => simple("Not a type or type operator")
     | Unknown(Hole(MultiHole(_))) => get_message(HoleTyp.multi_hole)
+    | Unknown(_) => get_message(HoleTyp.empty_hole)
     | Atom(Int) => get_message(TerminalTyp.int)
     | Atom(SInt) => get_message(TerminalTyp.sint)
     | Atom(Float) => get_message(TerminalTyp.float)
@@ -2616,7 +2615,6 @@ let get_doc =
     | Sum(_) => get_message(SumTyp.labelled_sum_typs)
     | Ap({term: Var(c), _}, _) =>
       get_message(SumTyp.sum_typ_unary_constructor_defs(c))
-    | Unknown(Hole(Invalid(_))) => simple("Not a type or type operator")
     | Ap(_)
     | Parens(_) => default // Shouldn't be hit?
     }

--- a/src/web/app/explainthis/ExplainThis.re
+++ b/src/web/app/explainthis/ExplainThis.re
@@ -2402,8 +2402,10 @@ let get_doc =
     }
   | Some(InfoTyp({term, _} as typ_info)) =>
     switch (bypass_parens_typ(term).term) {
-    | Unknown(Hole(Invalid(_))) => simple("Not a type or type operator")
-    | Unknown(Hole(MultiHole(_))) => get_message(HoleTyp.multi_hole)
+    | Unknown(_, {term: Invalid(_), _}, _) =>
+      simple("Not a type or type operator")
+    | Unknown(_, {term: MultiHole(_), _}, _) =>
+      get_message(HoleTyp.multi_hole)
     | Unknown(_) => get_message(HoleTyp.empty_hole)
     | Atom(Int) => get_message(TerminalTyp.int)
     | Atom(SInt) => get_message(TerminalTyp.sint)

--- a/src/web/app/helpful-assistant/CompletionExamples.re
+++ b/src/web/app/helpful-assistant/CompletionExamples.re
@@ -94,7 +94,7 @@ fun c ->
     ),
     (
       "let f = " ++ hole_label ++ " in f(5)",
-      expected_type(Unknown(Internal)),
+      expected_type(Unknown(Ana)),
       advanced_reasoning
         ? {|
 Discussion:
@@ -133,7 +133,7 @@ x
       "let num_or_zero = fun maybe_num ->\n case maybe_num\n | Some(num) => "
       ++ hole_label
       ++ " \n| None => 0 end in",
-      expected_type(Unknown(Internal)),
+      expected_type(Unknown(Ana)),
       advanced_reasoning
         ? {|
 Discussion:
@@ -212,7 +212,7 @@ in merge_sort_helper(list)
 in
 test 2 == List.nth(List.sort(fun a, b -> a<b, [4,1,3,2]), 1) end
     |},
-      expected_type(List(Typ.fresh(Unknown(Internal)))),
+      expected_type(List(Typ.fresh(Unknown(Ana)))),
       advanced_reasoning
         ? {|
 Discussion:

--- a/src/web/app/helpful-assistant/CompletionExamples.re
+++ b/src/web/app/helpful-assistant/CompletionExamples.re
@@ -94,7 +94,7 @@ fun c ->
     ),
     (
       "let f = " ++ hole_label ++ " in f(5)",
-      expected_type(Unknown(Ana)),
+      expected_type(Unknown(Syn, Hole.temp(EmptyHole), Atom)),
       advanced_reasoning
         ? {|
 Discussion:
@@ -133,7 +133,7 @@ x
       "let num_or_zero = fun maybe_num ->\n case maybe_num\n | Some(num) => "
       ++ hole_label
       ++ " \n| None => 0 end in",
-      expected_type(Unknown(Ana)),
+      expected_type(Unknown(Syn, Hole.temp(EmptyHole), Atom)),
       advanced_reasoning
         ? {|
 Discussion:
@@ -212,7 +212,9 @@ in merge_sort_helper(list)
 in
 test 2 == List.nth(List.sort(fun a, b -> a<b, [4,1,3,2]), 1) end
     |},
-      expected_type(List(Typ.fresh(Unknown(Ana)))),
+      expected_type(
+        List(Typ.fresh(Unknown(Syn, Hole.temp(EmptyHole), Atom))),
+      ),
       advanced_reasoning
         ? {|
 Discussion:

--- a/src/web/app/helpful-assistant/CompletionExamples.re
+++ b/src/web/app/helpful-assistant/CompletionExamples.re
@@ -94,7 +94,7 @@ fun c ->
     ),
     (
       "let f = " ++ hole_label ++ " in f(5)",
-      expected_type(Unknown(Syn, Hole.temp(EmptyHole), Atom)),
+      expected_type(Unknown(Type, Hole.temp(EmptyHole), Atom)),
       advanced_reasoning
         ? {|
 Discussion:
@@ -133,7 +133,7 @@ x
       "let num_or_zero = fun maybe_num ->\n case maybe_num\n | Some(num) => "
       ++ hole_label
       ++ " \n| None => 0 end in",
-      expected_type(Unknown(Syn, Hole.temp(EmptyHole), Atom)),
+      expected_type(Unknown(Type, Hole.temp(EmptyHole), Atom)),
       advanced_reasoning
         ? {|
 Discussion:
@@ -213,7 +213,7 @@ in
 test 2 == List.nth(List.sort(fun a, b -> a<b, [4,1,3,2]), 1) end
     |},
       expected_type(
-        List(Typ.fresh(Unknown(Syn, Hole.temp(EmptyHole), Atom))),
+        List(Typ.fresh(Unknown(Type, Hole.temp(EmptyHole), Atom))),
       ),
       advanced_reasoning
         ? {|

--- a/src/web/app/helpful-assistant/RelevantValues.re
+++ b/src/web/app/helpful-assistant/RelevantValues.re
@@ -61,8 +61,10 @@ let filter_ctx = (ctx: Ctx.t, ty_expect: Typ.t): list(filtered_entry) =>
 
 let primary_goal = (ctx: Ctx.t, ana: Typ.t): Typ.t =>
   switch (ana) {
-  | {term: Var(name), _} when Ctx.lookup_alias(ctx, name) != None =>
-    let ty_expanded = Ctx.lookup_alias(ctx, name) |> Option.get;
+  | {term: Var(name), _}
+      when Ctx.lookup_alias(ctx, name, {ids: [Typ.rep_id(ana)]}) != None =>
+    let ty_expanded =
+      Ctx.lookup_alias(ctx, name, {ids: [Typ.rep_id(ana)]}) |> Option.get;
     ty_expanded |> Typ.normalize(ctx);
   | _ => ana |> Typ.normalize(ctx)
   };

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -189,7 +189,7 @@ let common_err_view =
         text(h |> Hole.rep_id |> Id.to_string),
         text(" should be (partially annotated) in location "),
         text(Typ.show_provenance(p)),
-        text("with type: "),
+        text(" with type: "),
         view_type(ty),
       ]
     }

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -307,12 +307,6 @@ let common_ok_view =
         | true => [text(" after reordering by labels ")]
         }
       )
-    | (_, Ana(InternallyInconsistent({ana, nojoin: tys}))) =>
-      [
-        text(elements_noun(cls) ++ " have inconsistent types:"),
-        ...ListUtil.join(text(","), List.map(view_type, tys)),
-      ]
-      @ [text("but consistent with expected"), view_type(ana)]
     }
   )
   @ (

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -184,6 +184,10 @@ let common_err_view =
         text(elements_noun(cls) ++ " have inconsistent types:"),
         ...ListUtil.join(text(","), List.map(view_type, tys)),
       ]
+    | AsymmetricUnknown(ty) => [
+        text(": Unfilled type hole should have type: "),
+        view_type(ty),
+      ]
     }
   )
   @ (

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -22,7 +22,7 @@ let cls_view = (ci: Info.t): Node.t => {
     [
       text(
         switch (cls) {
-        | Typ(UnkEmptyHoleAna | UnkEmptyHoleSyn)
+        | Typ(Unknown(_, EmptyHole))
         | Exp(EmptyHole)
         | Pat(EmptyHole) =>
           Info.is_label(ci) ? "Empty Label" : Cls.show(cls)
@@ -321,7 +321,10 @@ let typ_ok_view = (~globals, cls: Cls.t, ok: Info.ok_typ) => {
   let view_type = view_type(~globals);
   switch (ok) {
   | EmptyLabel => []
-  | Type(_) when cls == Typ(UnkEmptyHoleAna) || cls == Typ(UnkEmptyHoleSyn) => [
+  | Type(_)
+      when
+        cls == Typ(Unknown(Expr, EmptyHole))
+        || cls == Typ(Unknown(Type, EmptyHole)) => [
       text("Fillable by any type"),
     ]
   | Type(ty) =>

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -184,7 +184,7 @@ let common_err_view =
         text(elements_noun(cls) ++ " have inconsistent types:"),
         ...ListUtil.join(text(","), List.map(view_type, tys)),
       ]
-    | AsymmetricUnknown(ty) => [
+    | AsymmetricUnknown(ty, _) => [
         text(": Unfilled type hole should have type: "),
         view_type(ty),
       ]

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -22,7 +22,7 @@ let cls_view = (ci: Info.t): Node.t => {
     [
       text(
         switch (cls) {
-        | Typ(EmptyHole)
+        | Typ(UnkEmptyHoleAna | UnkEmptyHoleSyn)
         | Exp(EmptyHole)
         | Pat(EmptyHole) =>
           Info.is_label(ci) ? "Empty Label" : Cls.show(cls)
@@ -184,8 +184,12 @@ let common_err_view =
         text(elements_noun(cls) ++ " have inconsistent types:"),
         ...ListUtil.join(text(","), List.map(view_type, tys)),
       ]
-    | AsymmetricUnknown(ty, _) => [
-        text(": Unfilled type hole should have type: "),
+    | AsymmetricUnknown(ty, h, p) => [
+        text(": Unfilled type hole (id: "),
+        text(h |> Hole.rep_id |> Id.to_string),
+        text(" should be (partially annotated) in location "),
+        text(Typ.show_provenance(p)),
+        text("with type: "),
         view_type(ty),
       ]
     }
@@ -323,7 +327,9 @@ let typ_ok_view = (~globals, cls: Cls.t, ok: Info.ok_typ) => {
   let view_type = view_type(~globals);
   switch (ok) {
   | EmptyLabel => []
-  | Type(_) when cls == Typ(EmptyHole) => [text("Fillable by any type")]
+  | Type(_) when cls == Typ(UnkEmptyHoleAna) || cls == Typ(UnkEmptyHoleSyn) => [
+      text("Fillable by any type"),
+    ]
   | Type(ty) =>
     [view_type(ty)]
     @ (

--- a/src/web/exercises/Exercise.re
+++ b/src/web/exercises/Exercise.re
@@ -648,7 +648,12 @@ let wrap_filter =
           term:
             Constructor(
               "$e",
-              Some(Some(Unknown(SynSwitch) |> Language.Typ.fresh)),
+              Some(
+                Some(
+                  Unknown(Syn, Language.Hole.temp(EmptyHole), Atom)
+                  |> Language.Typ.fresh,
+                ),
+              ),
             ),
           annotation: {
             ids: [Id.mk()],

--- a/src/web/exercises/Exercise.re
+++ b/src/web/exercises/Exercise.re
@@ -650,7 +650,7 @@ let wrap_filter =
               "$e",
               Some(
                 Some(
-                  Unknown(Syn, Language.Hole.temp(EmptyHole), Atom)
+                  Unknown(Type, Language.Hole.temp(EmptyHole), Atom)
                   |> Language.Typ.fresh,
                 ),
               ),

--- a/src/web/exercises/Exercise.re
+++ b/src/web/exercises/Exercise.re
@@ -648,7 +648,7 @@ let wrap_filter =
           term:
             Constructor(
               "$e",
-              Some(Some(Unknown(Internal) |> Language.Typ.fresh)),
+              Some(Some(Unknown(SynSwitch) |> Language.Typ.fresh)),
             ),
           annotation: {
             ids: [Id.mk()],

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -593,9 +593,7 @@ module PlainTests = {
             fn(
               Pat.(tuple([tup_label(label("a"), var("x"))])),
               var("x"),
-              Some(
-                Typ.(prod([tup_label(label("a"), unknown(Internal))])),
-              ),
+              Some(Typ.(prod([tup_label(label("a"), unknown(Ana))]))),
               None,
             ),
             tuple([tup_label(label("a"), int(1))]),

--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -77,7 +77,7 @@ module PlainTests = {
       fn(
         Pat.var("x"),
         bin_op(Int(Plus), int(4), int(5)),
-        Some(Typ.unknown(Hole(EmptyHole))),
+        Some(Typ.var("Hole TODO")),
         None,
       )
     );
@@ -593,7 +593,9 @@ module PlainTests = {
             fn(
               Pat.(tuple([tup_label(label("a"), var("x"))])),
               var("x"),
-              Some(Typ.(prod([tup_label(label("a"), unknown(Ana))]))),
+              Some(
+                Typ.(prod([tup_label(label("a"), Typ.var("Hole TODO"))])),
+              ),
               None,
             ),
             tuple([tup_label(label("a"), int(1))]),

--- a/test/Test_Grammar.re
+++ b/test/Test_Grammar.re
@@ -57,14 +57,10 @@ let sample_expression = (cls_exp: Exp.cls): Grammar.UnitGrammar.exp => {
       | Let => let_(Pat.empty_hole(), empty_hole(), empty_hole())
       | FixF => fix_f(Pat.empty_hole(), empty_hole(), None)
       | TyAlias =>
-        ty_alias(
-          TPat.empty_hole(),
-          Typ.unknown(Hole(EmptyHole)),
-          empty_hole(),
-        )
-      | Use => use(Typ.unknown(Hole(EmptyHole)), empty_hole())
+        ty_alias(TPat.empty_hole(), Typ.var("Hole TODO"), empty_hole())
+      | Use => use(Typ.var("Hole TODO"), empty_hole())
       | Ap => ap(Forward, empty_hole(), empty_hole())
-      | TypAp => typ_ap(empty_hole(), Typ.unknown(Hole(EmptyHole)))
+      | TypAp => typ_ap(empty_hole(), Typ.var("Hole TODO"))
       | DeferredAp => deferred_ap(empty_hole(), [empty_hole()])
       | If => if_(empty_hole(), empty_hole(), empty_hole())
       | Seq => seq(empty_hole(), empty_hole())
@@ -129,28 +125,28 @@ let sample_type = (cls_typ: Typ.cls): Grammar.UnitGrammar.typ => {
   Grammar.UnitGrammar.(
     Typ.(
       switch (cls_typ) {
-      | Invalid => unknown(Hole(Invalid("invalid")))
+      | UnkInvalidAna
+      | UnkInvalidSyn => Typ.var("Hole TODO")
       | Atom(Bool) => bool()
       | Atom(Int) => int()
       | Atom(SInt) => sint()
       | Atom(Float) => float()
       | Atom(String) => string()
       | Atom(Nat) => nat()
-      | List => list(unknown(Hole(EmptyHole)))
-      | Arrow => arrow(unknown(Hole(EmptyHole)), unknown(Hole(EmptyHole)))
+      | List => list(Typ.var("Hole TODO"))
+      | Arrow => arrow(Typ.var("Hole TODO"), Typ.var("Hole TODO"))
       | Var => var("x")
       | Prod => prod([])
-      | TupLabel =>
-        tup_label(unknown(Hole(EmptyHole)), unknown(Hole(EmptyHole)))
-      | Parens => parens(unknown(Hole(EmptyHole)))
-      | Ap => ap(unknown(Hole(EmptyHole)), unknown(Hole(EmptyHole)))
-      | Rec => rec_(TPat.var("x"), unknown(Hole(EmptyHole)))
-      | Forall => forall(TPat.var("x"), unknown(Hole(EmptyHole)))
-      | EmptyHole => unknown(Hole(EmptyHole))
-      | SynSwitch => unknown(SynSwitch)
-      | Internal => unknown(Ana)
+      | TupLabel => tup_label(Typ.var("Hole TODO"), Typ.var("Hole TODO"))
+      | Parens => parens(Typ.var("Hole TODO"))
+      | Ap => ap(Typ.var("Hole TODO"), Typ.var("Hole TODO"))
+      | Rec => rec_(TPat.var("x"), Typ.var("Hole TODO"))
+      | Forall => forall(TPat.var("x"), Typ.var("Hole TODO"))
+      | UnkEmptyHoleAna
+      | UnkEmptyHoleSyn => Typ.var("Hole TODO")
       | Label => label("label")
-      | MultiHole => unknown(Hole(MultiHole([])))
+      | UnkMultiHoleAna
+      | UnkMultiHoleSyn => Typ.var("Hole TODO")
       | Sum => sum([])
       | Constructor => assert(false) // Excluded because there is no Typ constructor
       }

--- a/test/Test_Grammar.re
+++ b/test/Test_Grammar.re
@@ -148,7 +148,7 @@ let sample_type = (cls_typ: Typ.cls): Grammar.UnitGrammar.typ => {
       | Forall => forall(TPat.var("x"), unknown(Hole(EmptyHole)))
       | EmptyHole => unknown(Hole(EmptyHole))
       | SynSwitch => unknown(SynSwitch)
-      | Internal => unknown(Internal)
+      | Internal => unknown(Ana)
       | Label => label("label")
       | MultiHole => unknown(Hole(MultiHole([])))
       | Sum => sum([])

--- a/test/Test_Grammar.re
+++ b/test/Test_Grammar.re
@@ -125,8 +125,7 @@ let sample_type = (cls_typ: Typ.cls): Grammar.UnitGrammar.typ => {
   Grammar.UnitGrammar.(
     Typ.(
       switch (cls_typ) {
-      | UnkInvalidAna
-      | UnkInvalidSyn => Typ.var("Hole TODO")
+      | Unknown(_) => Typ.var("Hole TODO")
       | Atom(Bool) => bool()
       | Atom(Int) => int()
       | Atom(SInt) => sint()
@@ -142,11 +141,7 @@ let sample_type = (cls_typ: Typ.cls): Grammar.UnitGrammar.typ => {
       | Ap => ap(Typ.var("Hole TODO"), Typ.var("Hole TODO"))
       | Rec => rec_(TPat.var("x"), Typ.var("Hole TODO"))
       | Forall => forall(TPat.var("x"), Typ.var("Hole TODO"))
-      | UnkEmptyHoleAna
-      | UnkEmptyHoleSyn => Typ.var("Hole TODO")
       | Label => label("label")
-      | UnkMultiHoleAna
-      | UnkMultiHoleSyn => Typ.var("Hole TODO")
       | Sum => sum([])
       | Constructor => assert(false) // Excluded because there is no Typ constructor
       }

--- a/test/Test_Menhir.re
+++ b/test/Test_Menhir.re
@@ -367,8 +367,8 @@ let tests =
             Typ.(
               parens(
                 arrow(
-                  unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
-                  unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                  unknown(Type, Language.Hole.temp(EmptyHole), Atom),
+                  unknown(Type, Language.Hole.temp(EmptyHole), Atom),
                 ),
               )
             ),

--- a/test/Test_Menhir.re
+++ b/test/Test_Menhir.re
@@ -367,8 +367,8 @@ let tests =
             Typ.(
               parens(
                 arrow(
-                  unknown(TypeProvenance.hole(EmptyHole)),
-                  unknown(TypeProvenance.hole(EmptyHole)),
+                  unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                  unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
                 ),
               )
             ),

--- a/test/Test_Unboxing.re
+++ b/test/Test_Unboxing.re
@@ -82,7 +82,7 @@ let tests = (
         "Ascribed Hole to ListLit",
         list(dhexp_typ),
         ListLit,
-        asc(empty_hole(), Typ.(list(empty_hole()))),
+        asc(empty_hole(), Typ.(list(empty_hole_syn()))),
       ),
       // ListLitn requests
       test_matches(
@@ -115,7 +115,7 @@ let tests = (
         "Ascribed Hole to ListLitn",
         list(dhexp_typ),
         ListLitn(0),
-        asc(empty_hole(), Typ.(list(empty_hole()))),
+        asc(empty_hole(), Typ.(list(empty_hole_syn()))),
       ),
       // Cons requests
       test_matches(
@@ -149,7 +149,7 @@ let tests = (
         "Ascribed Hole to Cons",
         pair(dhexp_typ, dhexp_typ),
         Cons,
-        asc(empty_hole(), Typ.(list(empty_hole()))),
+        asc(empty_hole(), Typ.(list(empty_hole_syn()))),
       ),
     ]
   ),

--- a/test/Test_Unboxing.re
+++ b/test/Test_Unboxing.re
@@ -82,7 +82,7 @@ let tests = (
         "Ascribed Hole to ListLit",
         list(dhexp_typ),
         ListLit,
-        asc(empty_hole(), Typ.(list(empty_hole_syn()))),
+        asc(empty_hole(), Typ.(list(empty_hole_typ()))),
       ),
       // ListLitn requests
       test_matches(
@@ -115,7 +115,7 @@ let tests = (
         "Ascribed Hole to ListLitn",
         list(dhexp_typ),
         ListLitn(0),
-        asc(empty_hole(), Typ.(list(empty_hole_syn()))),
+        asc(empty_hole(), Typ.(list(empty_hole_typ()))),
       ),
       // Cons requests
       test_matches(
@@ -149,7 +149,7 @@ let tests = (
         "Ascribed Hole to Cons",
         pair(dhexp_typ, dhexp_typ),
         Cons,
-        asc(empty_hole(), Typ.(list(empty_hole_syn()))),
+        asc(empty_hole(), Typ.(list(empty_hole_typ()))),
       ),
     ]
   ),

--- a/test/evaluator/Test_Evaluator_Builtins.re
+++ b/test/evaluator/Test_Evaluator_Builtins.re
@@ -23,7 +23,12 @@ let tests = (
           builtin_fun("string_compare"),
           asc(
             tuple([string("Hello"), string("World")]),
-            Typ.(prod([Typ.unknown(Ana), Typ.unknown(Ana)])),
+            Typ.(
+              prod([
+                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+              ])
+            ),
           ),
         ),
       )
@@ -43,10 +48,21 @@ let tests = (
           builtin_fun("string_compare"),
           asc(
             tuple([
-              asc(string("Hello"), Typ.unknown(Ana)),
-              asc(string("World"), Typ.unknown(Ana)),
+              asc(
+                string("Hello"),
+                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+              ),
+              asc(
+                string("World"),
+                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+              ),
             ]),
-            Typ.(prod([Typ.unknown(Ana), Typ.unknown(Ana)])),
+            Typ.(
+              prod([
+                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+              ])
+            ),
           ),
         ),
       )

--- a/test/evaluator/Test_Evaluator_Builtins.re
+++ b/test/evaluator/Test_Evaluator_Builtins.re
@@ -25,8 +25,8 @@ let tests = (
             tuple([string("Hello"), string("World")]),
             Typ.(
               prod([
-                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
-                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                Typ.unknown(Type, Language.Hole.temp(EmptyHole), Atom),
+                Typ.unknown(Type, Language.Hole.temp(EmptyHole), Atom),
               ])
             ),
           ),
@@ -50,17 +50,17 @@ let tests = (
             tuple([
               asc(
                 string("Hello"),
-                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                Typ.unknown(Type, Language.Hole.temp(EmptyHole), Atom),
               ),
               asc(
                 string("World"),
-                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                Typ.unknown(Type, Language.Hole.temp(EmptyHole), Atom),
               ),
             ]),
             Typ.(
               prod([
-                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
-                Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                Typ.unknown(Type, Language.Hole.temp(EmptyHole), Atom),
+                Typ.unknown(Type, Language.Hole.temp(EmptyHole), Atom),
               ])
             ),
           ),

--- a/test/evaluator/Test_Evaluator_Builtins.re
+++ b/test/evaluator/Test_Evaluator_Builtins.re
@@ -23,7 +23,7 @@ let tests = (
           builtin_fun("string_compare"),
           asc(
             tuple([string("Hello"), string("World")]),
-            Typ.(prod([Typ.unknown(Internal), Typ.unknown(Internal)])),
+            Typ.(prod([Typ.unknown(Ana), Typ.unknown(Ana)])),
           ),
         ),
       )
@@ -43,10 +43,10 @@ let tests = (
           builtin_fun("string_compare"),
           asc(
             tuple([
-              asc(string("Hello"), Typ.unknown(Internal)),
-              asc(string("World"), Typ.unknown(Internal)),
+              asc(string("Hello"), Typ.unknown(Ana)),
+              asc(string("World"), Typ.unknown(Ana)),
             ]),
-            Typ.(prod([Typ.unknown(Internal), Typ.unknown(Internal)])),
+            Typ.(prod([Typ.unknown(Ana), Typ.unknown(Ana)])),
           ),
         ),
       )

--- a/test/evaluator/Test_Evaluator_Sum_Types.re
+++ b/test/evaluator/Test_Evaluator_Sum_Types.re
@@ -72,7 +72,7 @@ let tests = (
                   Typ.sum([
                     Variant("T", [], None),
                     BadEntry(
-                      Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                      Typ.unknown(Type, Language.Hole.temp(EmptyHole), Atom),
                     ),
                   ]),
                 ),
@@ -102,14 +102,14 @@ let tests = (
                     Some(
                       Typ.(
                         arrow(
-                          unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                          unknown(Type, Language.Hole.temp(EmptyHole), Atom),
                           sum([
                             Variant(
                               "B",
                               [],
                               Some(
                                 unknown(
-                                  Syn,
+                                  Type,
                                   Language.Hole.temp(EmptyHole),
                                   Atom,
                                 ),
@@ -127,7 +127,7 @@ let tests = (
                       "B",
                       [],
                       Some(
-                        unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                        unknown(Type, Language.Hole.temp(EmptyHole), Atom),
                       ),
                     ),
                   ])
@@ -148,7 +148,7 @@ let tests = (
               Some(
                 Some(
                   Typ.(
-                    list(unknown(Syn, Language.Hole.temp(EmptyHole), Atom))
+                    list(unknown(Type, Language.Hole.temp(EmptyHole), Atom))
                   ),
                 ),
               ),
@@ -166,7 +166,7 @@ let tests = (
               Some(
                 Some(
                   Typ.(
-                    list(unknown(Syn, Language.Hole.temp(EmptyHole), Atom))
+                    list(unknown(Type, Language.Hole.temp(EmptyHole), Atom))
                   ),
                 ),
               ),
@@ -205,13 +205,13 @@ let tests = (
                   Typ.(
                     forall(
                       TPat.empty_hole(),
-                      unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                      unknown(Type, Language.Hole.temp(EmptyHole), Atom),
                     )
                   ),
                 ),
               ),
             ),
-            Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+            Typ.unknown(Type, Language.Hole.temp(EmptyHole), Atom),
           ),
           elaborate(
             parse_exp("type y = + B in case true | a => B end @<?>"),

--- a/test/evaluator/Test_Evaluator_Sum_Types.re
+++ b/test/evaluator/Test_Evaluator_Sum_Types.re
@@ -71,7 +71,9 @@ let tests = (
                 Some(
                   Typ.sum([
                     Variant("T", [], None),
-                    BadEntry(Typ.unknown(SynSwitch)),
+                    BadEntry(
+                      Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                    ),
                   ]),
                 ),
               ),
@@ -100,12 +102,18 @@ let tests = (
                     Some(
                       Typ.(
                         arrow(
-                          unknown(Hole(EmptyHole)),
+                          unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
                           sum([
                             Variant(
                               "B",
                               [],
-                              Some(unknown(Hole(EmptyHole))),
+                              Some(
+                                unknown(
+                                  Syn,
+                                  Language.Hole.temp(EmptyHole),
+                                  Atom,
+                                ),
+                              ),
                             ),
                           ]),
                         )
@@ -114,7 +122,15 @@ let tests = (
                   ),
                 ),
                 Typ.(
-                  sum([Variant("B", [], Some(unknown(Hole(EmptyHole))))])
+                  sum([
+                    Variant(
+                      "B",
+                      [],
+                      Some(
+                        unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                      ),
+                    ),
+                  ])
                 ),
               )
             ),
@@ -127,7 +143,16 @@ let tests = (
           "Indet when unboxing constructor as list",
           let_(
             Pat.list_lit([]),
-            constructor("On", Some(Some(Typ.(list(unknown(SynSwitch)))))), // This type on the constructor can't be right
+            constructor(
+              "On",
+              Some(
+                Some(
+                  Typ.(
+                    list(unknown(Syn, Language.Hole.temp(EmptyHole), Atom))
+                  ),
+                ),
+              ),
+            ), // This type on the constructor can't be right
             empty_hole(),
           ),
           elaborate(parse_exp("type g = + On in let [] = On in")),
@@ -136,7 +161,16 @@ let tests = (
           "Indet when unboxing constructor as cons",
           let_(
             Pat.(cons(wild(), list_lit([]))),
-            constructor("B", Some(Some(Typ.(list(unknown(SynSwitch)))))), // This type on the constructor can't be right
+            constructor(
+              "B",
+              Some(
+                Some(
+                  Typ.(
+                    list(unknown(Syn, Language.Hole.temp(EmptyHole), Atom))
+                  ),
+                ),
+              ),
+            ), // This type on the constructor can't be right
             empty_hole(),
           ),
           elaborate(parse_exp("let (_:: []) = type y = + B in B in ?")),
@@ -167,10 +201,17 @@ let tests = (
             constructor(
               "B",
               Some(
-                Some(Typ.(forall(TPat.empty_hole(), unknown(SynSwitch)))),
+                Some(
+                  Typ.(
+                    forall(
+                      TPat.empty_hole(),
+                      unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                    )
+                  ),
+                ),
               ),
             ),
-            Typ.unknown(Hole(EmptyHole)),
+            Typ.unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
           ),
           elaborate(
             parse_exp("type y = + B in case true | a => B end @<?>"),

--- a/test/evaluator/Test_Evaluator_Sum_Types.re
+++ b/test/evaluator/Test_Evaluator_Sum_Types.re
@@ -71,7 +71,7 @@ let tests = (
                 Some(
                   Typ.sum([
                     Variant("T", [], None),
-                    BadEntry(Typ.unknown(Internal)),
+                    BadEntry(Typ.unknown(SynSwitch)),
                   ]),
                 ),
               ),

--- a/test/statics/Test_Statics_Fixpoint.re
+++ b/test/statics/Test_Statics_Fixpoint.re
@@ -17,7 +17,7 @@ let tests = [
                         Inconsistent(
                           Expectation({
                             ana: prod([]),
-                            syn: list(unknown(Internal)),
+                            syn: list(unknown(Ana)),
                           }),
                         )
                       ),

--- a/test/statics/Test_Statics_Fixpoint.re
+++ b/test/statics/Test_Statics_Fixpoint.re
@@ -20,7 +20,7 @@ let tests = [
                             syn:
                               list(
                                 unknown(
-                                  Syn,
+                                  Type,
                                   Language.Hole.temp(EmptyHole),
                                   Atom,
                                 ),

--- a/test/statics/Test_Statics_Fixpoint.re
+++ b/test/statics/Test_Statics_Fixpoint.re
@@ -17,7 +17,14 @@ let tests = [
                         Inconsistent(
                           Expectation({
                             ana: prod([]),
-                            syn: list(unknown(Ana)),
+                            syn:
+                              list(
+                                unknown(
+                                  Syn,
+                                  Language.Hole.temp(EmptyHole),
+                                  Atom,
+                                ),
+                              ),
                           }),
                         )
                       ),

--- a/test/statics/Test_Statics_Functions.re
+++ b/test/statics/Test_Statics_Functions.re
@@ -6,7 +6,7 @@ let tests = [
   fully_consistent_typecheck(
     "Function with unknown param",
     "fun x -> 4 + 5",
-    Some(Typ.(arrow(unknown(Internal), int()))),
+    Some(Typ.(arrow(unknown(Ana), int()))),
   ),
   fully_consistent_typecheck(
     "Function with known param",
@@ -16,7 +16,7 @@ let tests = [
   fully_consistent_typecheck(
     "Function with labeled param",
     "fun (a=x) -> 4",
-    Some(arrow(prod([tup_label(label("a"), unknown(Internal))]), int())),
+    Some(arrow(prod([tup_label(label("a"), unknown(Ana))]), int())),
   ),
   fully_consistent_typecheck(
     "bifunction",

--- a/test/statics/Test_Statics_Functions.re
+++ b/test/statics/Test_Statics_Functions.re
@@ -7,7 +7,9 @@ let tests = [
     "Function with unknown param",
     "fun x -> 4 + 5",
     Some(
-      Typ.(arrow(unknown(Syn, Language.Hole.temp(EmptyHole), Atom), int())),
+      Typ.(
+        arrow(unknown(Type, Language.Hole.temp(EmptyHole), Atom), int())
+      ),
     ),
   ),
   fully_consistent_typecheck(
@@ -23,7 +25,7 @@ let tests = [
         prod([
           tup_label(
             label("a"),
-            unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+            unknown(Type, Language.Hole.temp(EmptyHole), Atom),
           ),
         ]),
         int(),

--- a/test/statics/Test_Statics_Functions.re
+++ b/test/statics/Test_Statics_Functions.re
@@ -6,7 +6,9 @@ let tests = [
   fully_consistent_typecheck(
     "Function with unknown param",
     "fun x -> 4 + 5",
-    Some(Typ.(arrow(unknown(Ana), int()))),
+    Some(
+      Typ.(arrow(unknown(Syn, Language.Hole.temp(EmptyHole), Atom), int())),
+    ),
   ),
   fully_consistent_typecheck(
     "Function with known param",
@@ -16,7 +18,17 @@ let tests = [
   fully_consistent_typecheck(
     "Function with labeled param",
     "fun (a=x) -> 4",
-    Some(arrow(prod([tup_label(label("a"), unknown(Ana))]), int())),
+    Some(
+      arrow(
+        prod([
+          tup_label(
+            label("a"),
+            unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+          ),
+        ]),
+        int(),
+      ),
+    ),
   ),
   fully_consistent_typecheck(
     "bifunction",

--- a/test/statics/Test_Statics_Labeled_Tuple.re
+++ b/test/statics/Test_Statics_Labeled_Tuple.re
@@ -183,7 +183,7 @@ let tests = [
   fully_consistent_typecheck(
     "Reconstructed labeled tuple without values",
     {|let x : (l=|},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "Singleton labeled argument let with unknown type",
@@ -192,7 +192,7 @@ let tests = [
       prod([
         tup_label(
           label("a"),
-          unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+          unknown(Type, Language.Hole.temp(EmptyHole), Atom),
         ),
       ]),
     ),
@@ -219,7 +219,7 @@ let tests = [
               prod([
                 tup_label(
                   label("c"),
-                  unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                  unknown(Type, Language.Hole.temp(EmptyHole), Atom),
                 ),
               ]),
             ),
@@ -231,12 +231,12 @@ let tests = [
   fully_consistent_typecheck(
     "Singleton labeled argument function application with unknown type",
     {|(fun a=x->x)(a=1)|},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "Singleton labeled argument function application with no labeled param",
     {|(fun a=x->x)(1)|},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "Singleton labeled argument not labeled in pattern",
@@ -359,7 +359,7 @@ let tests = [
                               tup_label(
                                 label("a"),
                                 unknown(
-                                  Syn,
+                                  Type,
                                   Language.Hole.temp(EmptyHole),
                                   Atom,
                                 ),
@@ -480,7 +480,7 @@ let tests = [
                               prod([
                                 tup_label(
                                   unknown(
-                                    Syn,
+                                    Type,
                                     Language.Hole.temp(EmptyHole),
                                     Atom,
                                   ),
@@ -510,7 +510,7 @@ let tests = [
                                 Typ.(
                                   tup_label(
                                     unknown(
-                                      Syn,
+                                      Type,
                                       Language.Hole.temp(EmptyHole),
                                       Atom,
                                     ),
@@ -571,7 +571,7 @@ let tests = [
                               prod([
                                 tup_label(
                                   unknown(
-                                    Syn,
+                                    Type,
                                     Language.Hole.temp(EmptyHole),
                                     Atom,
                                   ),
@@ -602,7 +602,7 @@ let tests = [
                                 Typ.(
                                   tup_label(
                                     unknown(
-                                      Syn,
+                                      Type,
                                       Language.Hole.temp(EmptyHole),
                                       Atom,
                                     ),

--- a/test/statics/Test_Statics_Labeled_Tuple.re
+++ b/test/statics/Test_Statics_Labeled_Tuple.re
@@ -183,12 +183,19 @@ let tests = [
   fully_consistent_typecheck(
     "Reconstructed labeled tuple without values",
     {|let x : (l=|},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "Singleton labeled argument let with unknown type",
     {|let x : (a=?) = (a=1) in x|},
-    Some(prod([tup_label(label("a"), unknown(Hole(EmptyHole)))])),
+    Some(
+      prod([
+        tup_label(
+          label("a"),
+          unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+        ),
+      ]),
+    ),
   ),
   fully_consistent_typecheck(
     "nested different singleton labeled arguments",
@@ -209,7 +216,12 @@ let tests = [
           prod([
             tup_label(
               label("b"),
-              prod([tup_label(label("c"), unknown(Hole(EmptyHole)))]),
+              prod([
+                tup_label(
+                  label("c"),
+                  unknown(Syn, Language.Hole.temp(EmptyHole), Atom),
+                ),
+              ]),
             ),
           ]),
         ),
@@ -219,12 +231,12 @@ let tests = [
   fully_consistent_typecheck(
     "Singleton labeled argument function application with unknown type",
     {|(fun a=x->x)(a=1)|},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "Singleton labeled argument function application with no labeled param",
     {|(fun a=x->x)(1)|},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "Singleton labeled argument not labeled in pattern",
@@ -342,7 +354,17 @@ let tests = [
                           malformed_labels: [],
                           duplicate_labels: ["a", "a"],
                           invalid_labels: [],
-                          typ: prod([tup_label(label("a"), unknown(Ana))]),
+                          typ:
+                            prod([
+                              tup_label(
+                                label("a"),
+                                unknown(
+                                  Syn,
+                                  Language.Hole.temp(EmptyHole),
+                                  Atom,
+                                ),
+                              ),
+                            ]),
                         }),
                       ),
                     )
@@ -454,7 +476,18 @@ let tests = [
                           duplicate_labels: [],
                           invalid_labels: [],
                           typ:
-                            Typ.(prod([tup_label(unknown(Ana), string())])),
+                            Typ.(
+                              prod([
+                                tup_label(
+                                  unknown(
+                                    Syn,
+                                    Language.Hole.temp(EmptyHole),
+                                    Atom,
+                                  ),
+                                  string(),
+                                ),
+                              ])
+                            ),
                         }),
                       ),
                     )
@@ -473,7 +506,17 @@ let tests = [
                               ],
                               duplicate_labels: [],
                               invalid_labels: [],
-                              typ: Typ.(tup_label(unknown(Ana), string())),
+                              typ:
+                                Typ.(
+                                  tup_label(
+                                    unknown(
+                                      Syn,
+                                      Language.Hole.temp(EmptyHole),
+                                      Atom,
+                                    ),
+                                    string(),
+                                  )
+                                ),
                             }),
                           ),
                         )
@@ -526,7 +569,14 @@ let tests = [
                           typ:
                             Typ.(
                               prod([
-                                tup_label(unknown(Ana), string()),
+                                tup_label(
+                                  unknown(
+                                    Syn,
+                                    Language.Hole.temp(EmptyHole),
+                                    Atom,
+                                  ),
+                                  string(),
+                                ),
                                 tup_label(label("a"), int()),
                               ])
                             ),
@@ -548,7 +598,17 @@ let tests = [
                               ],
                               duplicate_labels: [],
                               invalid_labels: [],
-                              typ: Typ.(tup_label(unknown(Ana), string())),
+                              typ:
+                                Typ.(
+                                  tup_label(
+                                    unknown(
+                                      Syn,
+                                      Language.Hole.temp(EmptyHole),
+                                      Atom,
+                                    ),
+                                    string(),
+                                  )
+                                ),
                             }),
                           ),
                         )

--- a/test/statics/Test_Statics_Labeled_Tuple.re
+++ b/test/statics/Test_Statics_Labeled_Tuple.re
@@ -183,7 +183,7 @@ let tests = [
   fully_consistent_typecheck(
     "Reconstructed labeled tuple without values",
     {|let x : (l=|},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   fully_consistent_typecheck(
     "Singleton labeled argument let with unknown type",
@@ -219,12 +219,12 @@ let tests = [
   fully_consistent_typecheck(
     "Singleton labeled argument function application with unknown type",
     {|(fun a=x->x)(a=1)|},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   fully_consistent_typecheck(
     "Singleton labeled argument function application with no labeled param",
     {|(fun a=x->x)(1)|},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   fully_consistent_typecheck(
     "Singleton labeled argument not labeled in pattern",
@@ -342,10 +342,7 @@ let tests = [
                           malformed_labels: [],
                           duplicate_labels: ["a", "a"],
                           invalid_labels: [],
-                          typ:
-                            prod([
-                              tup_label(label("a"), unknown(Internal)),
-                            ]),
+                          typ: prod([tup_label(label("a"), unknown(Ana))]),
                         }),
                       ),
                     )
@@ -457,9 +454,7 @@ let tests = [
                           duplicate_labels: [],
                           invalid_labels: [],
                           typ:
-                            Typ.(
-                              prod([tup_label(unknown(Internal), string())])
-                            ),
+                            Typ.(prod([tup_label(unknown(Ana), string())])),
                         }),
                       ),
                     )
@@ -478,8 +473,7 @@ let tests = [
                               ],
                               duplicate_labels: [],
                               invalid_labels: [],
-                              typ:
-                                Typ.(tup_label(unknown(Internal), string())),
+                              typ: Typ.(tup_label(unknown(Ana), string())),
                             }),
                           ),
                         )
@@ -532,7 +526,7 @@ let tests = [
                           typ:
                             Typ.(
                               prod([
-                                tup_label(unknown(Internal), string()),
+                                tup_label(unknown(Ana), string()),
                                 tup_label(label("a"), int()),
                               ])
                             ),
@@ -554,8 +548,7 @@ let tests = [
                               ],
                               duplicate_labels: [],
                               invalid_labels: [],
-                              typ:
-                                Typ.(tup_label(unknown(Internal), string())),
+                              typ: Typ.(tup_label(unknown(Ana), string())),
                             }),
                           ),
                         )

--- a/test/statics/Test_Statics_Sums.re
+++ b/test/statics/Test_Statics_Sums.re
@@ -18,28 +18,28 @@ end
     {|
     type ? = ? in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "single null sum type",
     {|
     type SingleNull = +One in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "single sum type",
     {|
     type Single = +F(Int) in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "partial sum type",
     {|
     type Partial = Ok(?) + ? in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "double alias",
@@ -47,7 +47,7 @@ end
     type GoodSum = A + B + C(Int) in
     type DoubleAlias = GoodSum in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "vertical leading",
@@ -59,7 +59,7 @@ end
       + C(Bool->Bool)
     in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "tuple as type name",
@@ -142,7 +142,7 @@ end
     type CompoundAlias = (Int, Anonymous + Sum) in
     let _: CompoundAlias = (1, Sum) in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "unbound type var in function",
@@ -159,7 +159,7 @@ end
     type Yorp = Int -> (Inside + Ouside) in
     let _: Yorp = fun _ -> Inside in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "unbound type var in sum",
@@ -176,7 +176,7 @@ end
     type Gargs = [BigGuy + Small] in
     let _: Gargs = [BigGuy] in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "analytic sum types in sum with cons",
@@ -184,7 +184,7 @@ end
     type Gargs = [BigGuy + Small] in
     let _: Gargs = BigGuy :: [BigGuy] in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "unbound type var in sum with cons",
@@ -207,7 +207,7 @@ end
     type Tork2 = +Blob in
     let x:Tork1 = Blob in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "exp tests: happy",
@@ -221,7 +221,7 @@ end
     let _ : (Yo + Dawg, Int) = (Dawg,5) in
     let _ : DoubleAlias = C(4) in ?
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "inconsistent type with arrow",
@@ -267,7 +267,7 @@ end
     case Yo(1):(+Yo(Int)) | Yo(1) => ? | _ => ? end;
     case Yo :(+Yo) | Yo : +Yo => ? end;
     |},
-    Some(unknown(Ana)),
+    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "pattern constructor tests: errors",

--- a/test/statics/Test_Statics_Sums.re
+++ b/test/statics/Test_Statics_Sums.re
@@ -18,28 +18,28 @@ end
     {|
     type ? = ? in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   fully_consistent_typecheck(
     "single null sum type",
     {|
     type SingleNull = +One in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   fully_consistent_typecheck(
     "single sum type",
     {|
     type Single = +F(Int) in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   fully_consistent_typecheck(
     "partial sum type",
     {|
     type Partial = Ok(?) + ? in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   fully_consistent_typecheck(
     "double alias",
@@ -47,7 +47,7 @@ end
     type GoodSum = A + B + C(Int) in
     type DoubleAlias = GoodSum in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   fully_consistent_typecheck(
     "vertical leading",
@@ -59,7 +59,7 @@ end
       + C(Bool->Bool)
     in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   inconsistent_typecheck(
     "tuple as type name",
@@ -142,7 +142,7 @@ end
     type CompoundAlias = (Int, Anonymous + Sum) in
     let _: CompoundAlias = (1, Sum) in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   inconsistent_typecheck(
     "unbound type var in function",
@@ -159,7 +159,7 @@ end
     type Yorp = Int -> (Inside + Ouside) in
     let _: Yorp = fun _ -> Inside in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   inconsistent_typecheck(
     "unbound type var in sum",
@@ -176,7 +176,7 @@ end
     type Gargs = [BigGuy + Small] in
     let _: Gargs = [BigGuy] in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   fully_consistent_typecheck(
     "analytic sum types in sum with cons",
@@ -184,7 +184,7 @@ end
     type Gargs = [BigGuy + Small] in
     let _: Gargs = BigGuy :: [BigGuy] in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   inconsistent_typecheck(
     "unbound type var in sum with cons",
@@ -207,7 +207,7 @@ end
     type Tork2 = +Blob in
     let x:Tork1 = Blob in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   fully_consistent_typecheck(
     "exp tests: happy",
@@ -221,7 +221,7 @@ end
     let _ : (Yo + Dawg, Int) = (Dawg,5) in
     let _ : DoubleAlias = C(4) in ?
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   inconsistent_typecheck(
     "inconsistent type with arrow",
@@ -267,7 +267,7 @@ end
     case Yo(1):(+Yo(Int)) | Yo(1) => ? | _ => ? end;
     case Yo :(+Yo) | Yo : +Yo => ? end;
     |},
-    Some(unknown(Internal)),
+    Some(unknown(Ana)),
   ),
   inconsistent_typecheck(
     "pattern constructor tests: errors",

--- a/test/statics/Test_Statics_Sums.re
+++ b/test/statics/Test_Statics_Sums.re
@@ -18,28 +18,28 @@ end
     {|
     type ? = ? in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "single null sum type",
     {|
     type SingleNull = +One in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "single sum type",
     {|
     type Single = +F(Int) in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "partial sum type",
     {|
     type Partial = Ok(?) + ? in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "double alias",
@@ -47,7 +47,7 @@ end
     type GoodSum = A + B + C(Int) in
     type DoubleAlias = GoodSum in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "vertical leading",
@@ -59,7 +59,7 @@ end
       + C(Bool->Bool)
     in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "tuple as type name",
@@ -142,7 +142,7 @@ end
     type CompoundAlias = (Int, Anonymous + Sum) in
     let _: CompoundAlias = (1, Sum) in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "unbound type var in function",
@@ -159,7 +159,7 @@ end
     type Yorp = Int -> (Inside + Ouside) in
     let _: Yorp = fun _ -> Inside in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "unbound type var in sum",
@@ -176,7 +176,7 @@ end
     type Gargs = [BigGuy + Small] in
     let _: Gargs = [BigGuy] in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "analytic sum types in sum with cons",
@@ -184,7 +184,7 @@ end
     type Gargs = [BigGuy + Small] in
     let _: Gargs = BigGuy :: [BigGuy] in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "unbound type var in sum with cons",
@@ -207,7 +207,7 @@ end
     type Tork2 = +Blob in
     let x:Tork1 = Blob in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   fully_consistent_typecheck(
     "exp tests: happy",
@@ -221,7 +221,7 @@ end
     let _ : (Yo + Dawg, Int) = (Dawg,5) in
     let _ : DoubleAlias = C(4) in ?
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "inconsistent type with arrow",
@@ -267,7 +267,7 @@ end
     case Yo(1):(+Yo(Int)) | Yo(1) => ? | _ => ? end;
     case Yo :(+Yo) | Yo : +Yo => ? end;
     |},
-    Some(unknown(Syn, Language.Hole.temp(EmptyHole), Atom)),
+    Some(unknown(Type, Language.Hole.temp(EmptyHole), Atom)),
   ),
   inconsistent_typecheck(
     "pattern constructor tests: errors",


### PR DESCRIPTION
Hazel is not aiming to be a dynamically typed language. Holes should have a single _unknown_ but _uniform_ type.

I am exploring changing the notion of the unknown type to an two-class version that more closely represent this idea. It also lends itself well to a more interactive error system that could 'imitate' global inference without using a constraint solver.

## Classes
Split the unknown type into two variants $?_e$ and $?_t$, classified by if they are derived from expression holes or type holes. With $?_e \sim ?_t$ but $?_t \not \sim u$ for any other type u
## Important Properties
- Every unknown type must trace back to a hole (or error, treated as a hole).

These do not currently hold for lists constructed using :: or @. But, it should be possible to treat these more like list literals (joining the constraints); similar solutions could be applicable to future parameterised type aliases.

Technically, $?_t$ can also come from an unannotated function argument. But these are functionally equivalent to having a single type hole annotation, so should be treated the same way.

## Examples:
<img width="536" height="79" alt="image" src="https://github.com/user-attachments/assets/4cd92860-4020-4207-b652-6a6a9db969fe" />
(Note: the type hole would be highlighted in the below 2 examples)
<img width="536" height="79" alt="image" src="https://github.com/user-attachments/assets/f540e9b7-1a16-493f-9466-575f8d4225d2" />
<img width="536" height="79" alt="image" src="https://github.com/user-attachments/assets/bdb4eedb-29e2-4f78-8100-22ab88df7ddd" />

As a consequence of this, expressions which are allowed in dynamic typing but do not make sense with the interpretation of holes being _uniform_ can be disallowed e.g.:
<img width="812" height="80" alt="image" src="https://github.com/user-attachments/assets/4fbfb156-ee55-483d-8cf4-4e966fa89ed5" />
vs. (when selecting the integer 0)
<img width="535" height="80" alt="image" src="https://github.com/user-attachments/assets/30e9c471-6e51-43cf-b38a-341c48add6e1" />


## vs Inference
This has parallels to global inference: the errors non-locally point to a type hole and required constraints on the hole can be suggested. But, instead of inferring automatically and using a constraint solver, it would take the more interactive approach suggesting constraints on type holes (as in the Type Hole Inference paper), even when a valid type is inferrable. 

I think this should get you most the way there in terms of usability without needing to deal with constraint solving.

## Checklist:
- [x] Type Checking
- [ ] Error Highlighting - (Partially Implemented)
- [ ] Disallow non-monomorphic lists
- [x] Disallow internally inconsistent branches/lists
- [ ] Collate non-local errors involving a type hole at the site of the hole. Suggest hole candidate fillings
- [ ] 'Missing annotation' errors
- [x] Track matching functions (unknown type provenance)
- [x] Principled type provenance joins & synswitch vs ana
- [ ] Debatable: Classify more casts as failures/inconsistent (upcasts to ?). Possibly still useful to allow dynamic evaluation for debugging purposes.
- [ ] Tests