### PR TITLE
Silence warning 56

### DIFF
--- a/dune-workspace
+++ b/dune-workspace
@@ -4,11 +4,11 @@
 (env
  (dev
   (flags
-   (:standard -w -58 -warn-error +A-26-27-K-58))) ; Disable some unused warnings.
+   (:standard -w -56-58 -warn-error +A-26-27-K-58))) ; Disable some unused warnings.
  (release
   (flags
    (:standard -w
-  @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40-58
+  @1..3@5..28@31..39@43@46..47@49..55@57@61..62@67@69-40-58
   -strict-sequence
   -strict-formats
   -short-paths


### PR DESCRIPTION
Currently the below code produces a warning:

```
type empty = 
  | ;

type t = 
  | A(int)
  | B(empty);
,
switch (x) {
  | A(x) => x
  | B(x) => 4
}

```

this is because the compiler wants to encourage you not to implement this case and instead refute it like this:

```
switch (x) {
  | A(x) => x
  | B(x) => .
}
```

I think there are cases where you would want to implement that case as boilerplate. The derivers for sexp and yojson also currently automatically produce code that creates this warning, and there is no way to prevent it.