### PR TITLE
clean up evalresult

### DIFF
--- a/src/language/CoreSettings.re
+++ b/src/language/CoreSettings.re
@@ -57,3 +57,19 @@ let on: t = {
   flip_animations: true,
   evaluation: Evaluation.init,
 };
+
+let eq_ignoring_stepper_modals = (a: t, b: t) =>
+  {
+    ...a,
+    evaluation: {
+      ...a.evaluation,
+      stepper_history: false,
+    },
+  }
+  == {
+       ...b,
+       evaluation: {
+         ...b.evaluation,
+         stepper_history: false,
+       },
+     };

--- a/src/language/dynamics/Dynamics.re
+++ b/src/language/dynamics/Dynamics.re
@@ -142,3 +142,9 @@ module Map = {
   let mk: t => t = Fun.id;
   let lookup = Probe.Map.lookup;
 };
+
+[@deriving (show({with_path: false}), sexp, yojson)]
+type t = {
+  probe_map: Probe.Map.t,
+  test_results: TestResults.t,
+};

--- a/src/language/dynamics/ProgramResult.re
+++ b/src/language/dynamics/ProgramResult.re
@@ -1,26 +1,5 @@
 open Util;
 
-// TODO[Matt]: combine into one module
-
-module Result = {
-  [@deriving (show({with_path: false}), sexp, yojson)]
-  type t =
-    | BoxedValue(DHExp.t)
-    | Indet(DHExp.t);
-
-  let unbox =
-    fun
-    | BoxedValue(d)
-    | Indet(d) => d;
-
-  let fast_equal = (r1, r2) =>
-    switch (r1, r2) {
-    | (BoxedValue(d1), BoxedValue(d2))
-    | (Indet(d1), Indet(d2)) => DHExp.fast_equal(d1, d2)
-    | _ => false
-    };
-};
-
 /**
   The result of a program evaluation. Includes the {!type:EvaluatorResult.t},
   the {!type:EvaluatorState}, and the tracked hole instance information
@@ -40,7 +19,6 @@ type error =
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t('a) =
-  | Off(DHExp.t) // Elaboration
   | ResultOk('a)
   | ResultFail(error)
   | ResultPending;
@@ -50,7 +28,6 @@ let get_state = (r: inner) => r.state;
 
 let map = (f: 'a => 'b, r: t('a)) =>
   switch (r) {
-  | Off(elab) => Off(elab)
   | ResultOk(a) => ResultOk(f(a))
   | ResultFail(e) => ResultFail(e)
   | ResultPending => ResultPending

--- a/src/language/dynamics/state/TestResults.re
+++ b/src/language/dynamics/state/TestResults.re
@@ -23,9 +23,6 @@ let mk_results = (~descriptions=[], test_map: TestMap.t): t => {
   unfinished: TestMap.count_status(Indet, test_map),
 };
 
-let of_state = (state: EvaluatorState.t): t =>
-  state |> EvaluatorState.get_tests |> mk_results;
-
 let result_summary_str =
     (~n, ~p, ~q, ~n_str, ~ns_str, ~p_str, ~q_str, ~r_str): string => {
   let one_p = "one is " ++ p_str ++ " ";

--- a/src/util/Calc.re
+++ b/src/util/Calc.re
@@ -1,7 +1,6 @@
 /*
-     A helper module for making things that look incremental (but aren't
-     because we haven't integrated incrementality yet). Eventually this module
-     will hopefully be made redundant by the Bonsai tree.
+     A helper module for making things calculate incrementally. Eventually
+     this module will hopefully be made redundant by the Bonsai tree.
  */
 
 // ================================================================================
@@ -62,6 +61,12 @@ let get_saved = (default, x: saved('a)): 'a =>
   | Calculated(x) => x
   };
 
+let get_saved_opt = (x: saved('a)): option('a) =>
+  switch (x) {
+  | Pending => None
+  | Calculated(x) => Some(x)
+  };
+
 exception PendingValue;
 
 let get_saved_exc = (~print=?, x: saved('a)): 'a =>
@@ -94,6 +99,12 @@ let update = (x: t('a), f: 'a => 'b, y: saved('b)): t('b) =>
   | (Calculated(y), OldValue(_)) => OldValue(y)
   };
 
+let update' = (x: t('a), f: 'a => 'b, y: t('b)): t('b) =>
+  switch (x) {
+  | OldValue(_) => y
+  | NewValue(x) => NewValue(f(x))
+  };
+
 /* Using set, we can compare some value to the previously saved value, and create
    a new t('a) that indicates whether the value has changed. */
 let set = (~eq: ('a, 'a) => bool=(==), x: 'a, y: saved('a)) =>
@@ -118,11 +129,7 @@ let save = (x: t('a)): saved('a) =>
   | NewValue(x) => Calculated(x)
   };
 
-let saved_to_option = (x: saved('a)): option('a) =>
-  switch (x) {
-  | Pending => None
-  | Calculated(x) => Some(x)
-  };
+let saved_to_option = get_saved_opt;
 
 // ================================================================================
 // Helper functions:
@@ -152,5 +159,6 @@ let pair_saved = (x: saved('a), y: saved('b)): saved(('a, 'b)) =>
 
 module Syntax = {
   let (let.calc) = update;
+  let (let.calc_t) = update';
   let (and.calc) = combine;
 };

--- a/src/web/Main.re
+++ b/src/web/Main.re
@@ -56,13 +56,8 @@ let apply =
     };
   // ---------- CALCULATE PHASE ----------
   let model' =
-    updated.recalculate
-      ? updated.model
-        |> History.Update.calculate(
-             ~schedule_action,
-             ~is_edited=updated.is_edit,
-           )
-      : updated.model;
+    updated.model
+    |> History.Update.calculate(~schedule_action, ~is_edited=updated.is_edit);
 
   if (updated.is_edit) {
     schedule_autosave(
@@ -100,7 +95,12 @@ let start = {
             };
           apply(~schedule_action, ~schedule_autosave);
         },
-      ~default_model=History.Model.init(),
+      ~default_model=
+        History.Model.init()
+        |> History.Update.calculate(
+             ~schedule_action=_ => (),
+             ~is_edited=false,
+           ),
       save_scheduler,
     );
 

--- a/src/web/app/editors/result/EvalResult.re
+++ b/src/web/app/editors/result/EvalResult.re
@@ -1,4 +1,5 @@
 open Util;
+open Calc.Syntax;
 open Language;
 
 /* The result box at the bottom of a cell. This is either the TestResutls
@@ -14,66 +15,36 @@ module type Model = {
 
 module Model = {
   [@deriving (show({with_path: false}), sexp, yojson)]
-  type result =
-    | NoElab
-    | Evaluation({
-        elab: Exp.t,
-        result: Calc.t(ProgramResult.t((Exp.t, EvaluatorState.t))),
-        cached_settings: Calc.saved(CoreSettings.t),
-        editor: Calc.saved((Exp.t, CodeSelectable.Model.t)),
-      })
+  type display =
+    | Evaluation(Calc.saved(option((Exp.t, CodeSelectable.Model.t))))
     | Stepper(StepperView.Model.t);
 
   [@deriving (show({with_path: false}), sexp, yojson)]
-  type kind =
-    | Evaluation
-    | Stepper;
-
-  [@deriving (show({with_path: false}), sexp, yojson)]
   type t = {
-    kind,
-    result,
-    previous_tests: option(TestResults.t), // Stops test results from being cleared on update
-    previous_probes: option(Dynamics.Probe.Map.t) // As above
+    cached_settings: Calc.saved(CoreSettings.t),
+    elab: Calc.saved(Exp.t),
+    result: Calc.t(ProgramResult.t(ProgramResult.inner)),
+    dynamics: Calc.saved(option(Dynamics.t)),
+    display,
   };
 
   let init = {
-    kind: Evaluation,
-    result: NoElab,
-    previous_tests: None,
-    previous_probes: None,
+    cached_settings: Calc.Pending,
+    elab: Calc.Pending,
+    result: Calc.NewValue(ProgramResult.ResultPending),
+    dynamics: Calc.Pending,
+    display: Evaluation(Calc.Pending),
   };
 
-  let eval_state = (result: result): option(EvaluatorState.t) =>
-    switch (result) {
-    | Evaluation(e) =>
-      switch (e.result) {
-      | OldValue(ResultOk((_, state)))
-      | NewValue(ResultOk((_, state))) => Some(state)
-      | OldValue(ResultFail(_) | ResultPending | Off(_))
-      | NewValue(ResultFail(_) | ResultPending | Off(_)) => None
-      }
-    | Stepper(s) => Some(s |> StepperView.Model.get_state)
-    | NoElab => None
-    };
-
   let probe_results = (model: t): option(Dynamics.Probe.Map.t) =>
-    switch (eval_state(model.result)) {
-    | None => model.previous_probes
-    | Some(eval_state) => Some(EvaluatorState.get_probes(eval_state))
-    };
+    model.dynamics
+    |> Calc.get_saved(None)
+    |> Option.map((d: Dynamics.t) => d.probe_map);
 
   let test_results = (model: t): option(TestResults.t) =>
-    switch (eval_state(model.result)) {
-    | None => model.previous_tests
-    | Some(eval_state) => Some(TestResults.of_state(eval_state))
-    };
-
-  let make_test_report = (model: t): option(TestResults.t) =>
-    switch (eval_state(model.result)) {
-    | None => None
-    | Some(_) => test_results(model)
-    };
+    model.dynamics
+    |> Calc.get_saved(None)
+    |> Option.map((d: Dynamics.t) => d.test_results);
 
   let dynamics = (model: t): Dynamics.Map.t =>
     switch (probe_results(model)) {
@@ -82,11 +53,7 @@ module Model = {
     };
 
   let get_elaboration = (model: t): option(Exp.t) =>
-    switch (model.result) {
-    | Evaluation({elab, _}) => Some(elab)
-    | Stepper(s) => StepperView.Model.get_elaboration(s)
-    | _ => None
-    };
+    model.elab |> Calc.get_saved_opt;
 };
 
 module Update = {
@@ -111,81 +78,41 @@ module Update = {
   // Update is meant to make minimal changes to the model, and calculate will do the rest.
   let update = (~settings, action, model: Model.t): Updated.t(Model.t) =>
     switch (action, model) {
-    | (ToggleStepper, {kind: Stepper, _}) =>
+    | (ToggleStepper, {display: Stepper(_), _}) =>
       {
         ...model,
-        kind: Evaluation,
+        display: Evaluation(Calc.Pending),
       }
       |> Updated.return
-    | (ToggleStepper, {kind: Evaluation, _}) =>
+    | (ToggleStepper, {display: Evaluation(_), _}) =>
       {
         ...model,
-        kind: Stepper,
+        display: Stepper(StepperView.Model.init),
       }
       |> Updated.return
-    | (StepperAction(a), {result: Stepper(s), _}) =>
-      let* stepper = StepperView.Update.update(~settings, a, s);
+    | (StepperAction(a), {display: Stepper(stepper), _}) =>
+      let* stepper = StepperView.Update.update(~settings, a, stepper);
       {
         ...model,
-        result: Stepper(stepper),
+        display: Stepper(stepper),
       };
     | (StepperAction(_), _) => model |> Updated.return_quiet
     | (
         EvalEditorAction(a),
-        {
-          result:
-            Evaluation({
-              elab,
-              result,
-              cached_settings,
-              editor: Calculated((exp, editor)),
-            }),
-          _,
-        },
+        {display: Evaluation(Calculated(Some((exp, editor)))), _},
       ) =>
       let* editor = CodeSelectable.Update.update(~settings, a, editor);
       {
         ...model,
-        result:
-          Evaluation({
-            elab,
-            result,
-            cached_settings,
-            editor: Calculated((exp, editor)),
-          }),
+        display: Evaluation(Calculated(Some((exp, editor)))),
       };
     | (EvalEditorAction(_), _) => model |> Updated.return_quiet
-    | (
-        UpdateResult(update),
-        {result: Evaluation({elab, editor, cached_settings, _}), _},
-      ) =>
+    | (UpdateResult(result), _) =>
       {
         ...model,
-        result:
-          Evaluation({
-            elab,
-            result:
-              NewValue(
-                ProgramResult.map(
-                  ({result: exp, state: s}: ProgramResult.inner) => {
-                    (exp, s)
-                  },
-                  update,
-                ),
-              ),
-            editor,
-            cached_settings,
-          }),
+        result: Calc.NewValue(result),
       }
-      |> (
-        x => {
-          ...x,
-          previous_tests: Model.test_results(x),
-          previous_probes: Model.probe_results(x),
-        }
-      )
-      |> Updated.return
-    | (UpdateResult(_), _) => model |> Updated.return_quiet
+      |> Updated.return_quiet
     };
 
   let calculate =
@@ -194,127 +121,107 @@ module Update = {
         ~queue_worker: option(Exp.t => unit),
         ~is_edited: bool,
         statics: Haz3lcore.CachedStatics.t,
-        model: Model.t,
+        {cached_settings, elab, result, dynamics, display}: Model.t,
       ) => {
-    let elab = statics.elaborated;
-    let model =
-      switch (model.kind, model.result) {
-      // If elab hasn't changed, don't recalculate
-      | (
-          Evaluation,
-          Evaluation({elab: elab', result, cached_settings, editor}),
-        )
-          when Exp.fast_equal(elab, elab') => {
-          ...model,
-          result:
-            Evaluation({
-              elab,
-              result,
-              cached_settings,
-              editor,
-            }),
-        }
-      // If elab has changed, recalculate
-      | (Evaluation, _) when settings.dynamics =>
-        switch (queue_worker) {
-        | None => {
-            ...model,
-            result:
-              Evaluation({
-                elab,
-                result: {
-                  switch (WorkerServer.work(elab)) {
-                  | Ok((exp, state)) =>
-                    NewValue(ProgramResult.ResultOk((exp, state)))
-                  | Error(e) => NewValue(ProgramResult.ResultFail(e))
-                  };
-                },
-                cached_settings: Pending,
-                editor: Pending,
-              }),
-          }
+    // Check whether settings / elab have changed
+    let settings =
+      cached_settings
+      |> Calc.set(settings, ~eq=CoreSettings.eq_ignoring_stepper_modals);
+    let elab = Calc.set(~eq=Exp.fast_equal, statics.elaborated, elab);
 
+    // Calculate the result
+    let result =
+      result
+      |> {
+        let.calc_t elab = elab
+        and.calc settings = settings; // TODO[Matt]: We could make this more fine-grained, we only care about one setting
+        switch (queue_worker) {
+        // Dynamics is off:
+        | _ when !settings.dynamics => ProgramResult.ResultPending
+        // Using the webworker:
         | Some(queue_worker) =>
           queue_worker(elab);
-          {
-            ...model,
-            result:
-              Evaluation({
-                elab,
-                result: NewValue(ProgramResult.ResultPending),
-                cached_settings: Pending,
-                editor: Pending,
-              }),
-          };
-        }
-      | (Evaluation, _) => {
-          ...model,
-          result: NoElab,
-        }
-      | (Stepper, Stepper(s)) =>
-        let s' = StepperView.Update.calculate(~settings, elab, s);
-        {
-          ...model,
-          result: Stepper(s'),
-        };
-      | (Stepper, _) =>
-        let s =
-          StepperView.Model.init
-          |> StepperView.Update.calculate(~settings, elab);
-        {
-          ...model,
-          result: Stepper(s),
+          ProgramResult.ResultPending;
+        // Using the main thread:
+        | None =>
+          switch (WorkerServer.work(elab)) {
+          | Ok((exp, state)) =>
+            ProgramResult.ResultOk(
+              ProgramResult.{
+                result: exp,
+                state,
+              },
+            )
+          | Error(e) => ProgramResult.ResultFail(e)
+          }
         };
       };
 
-    // Calculate evaluation editor
-    switch (model.result) {
-    | Evaluation({elab, result, cached_settings, editor}) =>
-      open Calc.Syntax;
-      let cached_settings = Calc.set(~eq=(==), settings, cached_settings);
-      let editor =
-        editor
-        |> Calc.map_saved(x => Calc.Calculated(x))
+    // Turn state into dynamics map
+    let dynamics =
+      dynamics
+      |> {
+        let.calc result = result;
+        switch (result) {
+        | ProgramResult.ResultPending => dynamics |> Calc.get_saved(None)
+        | ProgramResult.ResultFail(_) => dynamics |> Calc.get_saved(None)
+        | ProgramResult.ResultOk({state, _}) =>
+          Some(
+            Dynamics.{
+              probe_map: state |> EvaluatorState.get_probes,
+              test_results:
+                state |> EvaluatorState.get_tests |> TestResults.mk_results,
+            },
+          )
+        };
+      };
+
+    // Calculate the display
+    let display =
+      switch (display) {
+      | Evaluation(ev_display) =>
+        ev_display
         |> {
-          let.calc settings = cached_settings
+          let.calc settings = settings
           and.calc result = result;
           switch (result) {
-          | ResultOk((exp, _state)) =>
-            exp
-            |> CodeSelectable.Model.mk_from_exp(~settings)
-            |> (x => Calc.Calculated((exp, x)))
-          | ResultFail(_) => Pending
-          | ResultPending => Pending
-          | Off(_) => Pending
+          | ResultOk({result: exp, _}) =>
+            Some((exp, exp |> CodeSelectable.Model.mk_from_exp(~settings)))
+          | ResultFail(_)
+          | ResultPending => ev_display |> Calc.get_saved_opt |> Option.join
           };
-        };
-      let editor =
-        editor
-        |> Calc.get_value
-        |> Calc.map_saved(((exp, editor)) =>
-             CodeSelectable.Update.calculate(
-               ~settings,
-               ~is_dynamic_term=true,
-               ~stitch=_ => exp,
-               ~is_edited,
-               ~dynamics=Model.dynamics(model),
-               editor,
-             )
-             |> (x => (exp, x))
+        }
+        |> Calc.make_new  // TODO[Matt]: Could eventually replace this by keeping track of whether the editor selection has changed
+        |> Calc.map_if_new(
+             Option.map(((exp, editor)) =>
+               (
+                 exp,
+                 CodeSelectable.Update.calculate(
+                   ~settings=settings |> Calc.get_value,
+                   ~is_dynamic_term=true,
+                   ~stitch=_ => exp,
+                   ~dynamics=Dynamics.Map.empty,
+                   ~is_edited,
+                   editor,
+                 ),
+               )
+             ),
            )
-        |> (x => Calc.OldValue(x));
-      {
-        ...model,
-        result:
-          Evaluation({
-            elab,
-            result: Calc.make_old(result),
-            cached_settings: Calc.save(cached_settings),
-            editor: Calc.get_value(editor),
-          }),
+        |> Calc.save
+        |> (x => Model.Evaluation(x))
+      | Stepper(stepper) =>
+        Model.Stepper(StepperView.Update.calculate(~settings, elab, stepper))
       };
-    | _ => model
-    };
+
+    (
+      {
+        cached_settings: settings |> Calc.save,
+        elab: elab |> Calc.save,
+        result: result |> Calc.make_old,
+        dynamics: dynamics |> Calc.save,
+        display,
+      }: Model.t
+    );
   };
 };
 
@@ -326,11 +233,9 @@ module Selection = {
     | Stepper(StepperView.Focus.t);
 
   let get_cursor_info = (~selection: t, mr: Model.t): cursor(Update.t) =>
-    switch (selection, mr.result) {
-    | (_, NoElab) => empty
-    | (Evaluation(selection), Evaluation({editor: Calculated(editor), _})) =>
-      let+ ci =
-        CodeSelectable.Selection.get_cursor_info(~selection, editor |> snd);
+    switch (selection, mr.display) {
+    | (Evaluation(selection), Evaluation(Calculated(Some((_, editor))))) =>
+      let+ ci = CodeSelectable.Selection.get_cursor_info(~selection, editor);
       Update.EvalEditorAction(ci);
     | (Stepper(focus), Stepper(s)) =>
       let+ ci = StepperView.Focus.get_cursor_info(~focus, s);
@@ -341,14 +246,9 @@ module Selection = {
 
   let handle_key_event =
       (~selection: t, ~event, mr: Model.t): option(Update.t) =>
-    switch (selection, mr.result) {
-    | (_, NoElab) => None
-    | (Evaluation(selection), Evaluation({editor: Calculated(editor), _})) =>
-      CodeSelectable.Selection.handle_key_event(
-        ~selection,
-        editor |> snd,
-        event,
-      )
+    switch (selection, mr.display) {
+    | (Evaluation(selection), Evaluation(Calculated(Some((_, editor))))) =>
+      CodeSelectable.Selection.handle_key_event(~selection, editor, event)
       |> Option.map(x => Update.EvalEditorAction(x))
     | (Stepper(focus), Stepper(s)) =>
       StepperView.Focus.handle_key_event(~focus, s, ~event)
@@ -377,8 +277,7 @@ module View = {
     fun
     | ResultPending => "pending"
     | ResultOk(_) => "ok"
-    | ResultFail(_) => "fail"
-    | Off(_) => "off";
+    | ResultFail(_) => "fail";
 
   let live_eval =
       (
@@ -387,26 +286,21 @@ module View = {
         ~inject: Update.t => Ui_effect.t(unit),
         ~selected,
         ~locked,
-        elab: Exp.t,
-        result: ProgramResult.t((Exp.t, EvaluatorState.t)),
-        editor: Calc.saved(('a, CodeSelectable.Model.t)),
+        result: ProgramResult.t(ProgramResult.inner),
+        editor: option(('a, CodeSelectable.Model.t)),
       ) => {
-    let editor =
-      switch (editor) {
-      | Calculated(editor) => editor |> snd
-      | _ =>
-        elab
-        |> CodeSelectable.Model.mk_from_exp(~settings=globals.settings.core)
-      };
+    let editor = Option.map(snd, editor);
     let code_view =
-      CodeSelectable.View.view(
-        ~signal=
-          fun
-          | MakeActive => signal(MakeActive(Evaluation())),
-        ~inject=a => inject(EvalEditorAction(a)),
-        ~globals,
-        ~selected,
-        ~sort=Sort.root,
+      Option.map(
+        CodeSelectable.View.view(
+          ~signal=
+            fun
+            | MakeActive => signal(MakeActive(Evaluation())),
+          ~inject=a => inject(EvalEditorAction(a)),
+          ~globals,
+          ~selected,
+          ~sort=Sort.root,
+        ),
         editor,
       );
     let exn_view =
@@ -433,7 +327,7 @@ module View = {
           ),
           div(
             ~attrs=[Attr.classes(["result", status_of(result)])],
-            [code_view],
+            Option.to_list(code_view),
           ),
         ]
         @ (
@@ -454,23 +348,21 @@ module View = {
         ~globals: Globals.t,
         ~signal,
         ~inject,
-        ~result: Model.t,
         ~selected: option(Selection.t),
         ~locked,
+        model: Model.t,
       ) =>
-    switch (result.result) {
+    switch (model.display) {
     | _ when !globals.settings.core.dynamics => []
-    | NoElab => []
-    | Evaluation({elab, result, editor, _}) => [
+    | Evaluation(editor) => [
         live_eval(
           ~globals,
           ~signal,
           ~inject,
           ~selected=selected == Some(Evaluation()),
           ~locked,
-          elab,
-          result |> Calc.get_value,
-          editor,
+          model.result |> Calc.get_value,
+          editor |> Calc.get_saved_exc(~print="result editor missing"),
         ),
       ]
     | Stepper(s) =>
@@ -521,27 +413,26 @@ module View = {
       ),
     );
 
-  type result_kind =
-    | NoResults
-    | TestResults
-    | EvalResults
-    | Custom(Node.t);
-
   let view =
       (
         ~globals: Globals.t,
         ~signal: event => Ui_effect.t(unit),
         ~inject: Update.t => Ui_effect.t(unit),
         ~selected: option(Selection.t),
-        ~result_kind=EvalResults,
+        ~result_kind: [
+           | `NoResults
+           | `TestResults
+           | `EvalResults
+           | `Custom(Node.t)
+         ]=`EvalResults,
         ~locked: bool,
         model: Model.t,
       ) =>
     switch (result_kind) {
     // Normal case:
-    | EvalResults when globals.settings.core.dynamics =>
+    | `EvalResults when globals.settings.core.dynamics =>
       let result =
-        footer(~globals, ~signal, ~inject, ~result=model, ~selected, ~locked);
+        footer(~globals, ~signal, ~inject, ~selected, ~locked, model);
       let test_overlay = (editor: Haz3lcore.Editor.t) =>
         switch (Model.test_results(model)) {
         | Some(result) => [
@@ -556,7 +447,7 @@ module View = {
       (result, test_overlay);
 
     // Just showing elaboration because evaluation is off:
-    | EvalResults when globals.settings.core.elaborate =>
+    | `EvalResults when globals.settings.core.elaborate =>
       let result = [
         text("Evaluation disabled, showing elaboration:"),
         switch (Model.get_elaboration(model)) {
@@ -576,10 +467,10 @@ module View = {
       (result, (_ => []));
 
     // Not showing any results:
-    | EvalResults
-    | NoResults => ([], (_ => []))
+    | `EvalResults
+    | `NoResults => ([], (_ => []))
 
-    | Custom(node) => (
+    | `Custom(node) => (
         [node],
         (
           (editor: Haz3lcore.Editor.t) =>
@@ -597,7 +488,7 @@ module View = {
       )
 
     // Just showing test results (school mode)
-    | TestResults =>
+    | `TestResults =>
       let test_results = Model.test_results(model);
       let test_overlay = (editor: Haz3lcore.Editor.t) =>
         switch (Model.test_results(model)) {

--- a/src/web/util/WorkerClient.re
+++ b/src/web/util/WorkerClient.re
@@ -62,3 +62,9 @@ let request =
       ),
     );
 };
+
+let request = (req, ~handler, ~timeout) =>
+  switch (req) {
+  | [] => ()
+  | _ => request(req, ~handler, ~timeout)
+  };

--- a/src/web/view/ExerciseMode.re
+++ b/src/web/view/ExerciseMode.re
@@ -378,44 +378,40 @@ module Update = {
         model.cells,
       );
 
-    if (List.length(worker_request^) > 0) {
-      WorkerClient.request(
-        worker_request^,
-        ~handler=
-          List.iter(((pos, result)) => {
-            let pos' = Exercise.pos_of_key(pos);
-            let result':
-              Language.ProgramResult.t(Language.ProgramResult.inner) =
-              switch (result) {
-              | Ok((r, s)) =>
-                ResultOk({
-                  result: r,
-                  state: s,
-                })
-              | Error(e) => ResultFail(e)
-              };
-            schedule_action(
-              Editor(pos', ResultAction(UpdateResult(result'))),
-            );
-          }),
-        ~timeout=_ => {
-          let _ =
-            Exercise.map_stitched(
-              (pos, _) =>
-                schedule_action(
-                  Editor(
-                    pos,
-                    ResultAction(UpdateResult(ResultFail(Timeout))),
-                  ),
+    WorkerClient.request(
+      worker_request^,
+      ~handler=
+        List.iter(((pos, result)) => {
+          let pos' = Exercise.pos_of_key(pos);
+          let result': Language.ProgramResult.t(Language.ProgramResult.inner) =
+            switch (result) {
+            | Ok((r, s)) =>
+              ResultOk({
+                result: r,
+                state: s,
+              })
+            | Error(e) => ResultFail(e)
+            };
+          schedule_action(
+            Editor(pos', ResultAction(UpdateResult(result'))),
+          );
+        }),
+      ~timeout=_ => {
+        let _ =
+          Exercise.map_stitched(
+            (pos, _) =>
+              schedule_action(
+                Editor(
+                  pos,
+                  ResultAction(UpdateResult(ResultFail(Timeout))),
                 ),
-              model.cells,
-            );
-          ();
-        },
-      );
-    } else {
-      ();
-    };
+              ),
+            model.cells,
+          );
+        ();
+      },
+    );
+
     /* The following section pulls statics back from cells into the editors
        There are many ad-hoc things about this code, including the fact that
        one of the editors is shown in two cells, so we arbitrarily choose which

--- a/src/web/view/ExerciseMode.re
+++ b/src/web/view/ExerciseMode.re
@@ -377,39 +377,45 @@ module Update = {
         stitched_elabs,
         model.cells,
       );
-    WorkerClient.request(
-      worker_request^,
-      ~handler=
-        List.iter(((pos, result)) => {
-          let pos' = Exercise.pos_of_key(pos);
-          let result': Language.ProgramResult.t(Language.ProgramResult.inner) =
-            switch (result) {
-            | Ok((r, s)) =>
-              ResultOk({
-                result: r,
-                state: s,
-              })
-            | Error(e) => ResultFail(e)
-            };
-          schedule_action(
-            Editor(pos', ResultAction(UpdateResult(result'))),
-          );
-        }),
-      ~timeout=_ => {
-        let _ =
-          Exercise.map_stitched(
-            (pos, _) =>
-              schedule_action(
-                Editor(
-                  pos,
-                  ResultAction(UpdateResult(ResultFail(Timeout))),
+
+    if (List.length(worker_request^) > 0) {
+      WorkerClient.request(
+        worker_request^,
+        ~handler=
+          List.iter(((pos, result)) => {
+            let pos' = Exercise.pos_of_key(pos);
+            let result':
+              Language.ProgramResult.t(Language.ProgramResult.inner) =
+              switch (result) {
+              | Ok((r, s)) =>
+                ResultOk({
+                  result: r,
+                  state: s,
+                })
+              | Error(e) => ResultFail(e)
+              };
+            schedule_action(
+              Editor(pos', ResultAction(UpdateResult(result'))),
+            );
+          }),
+        ~timeout=_ => {
+          let _ =
+            Exercise.map_stitched(
+              (pos, _) =>
+                schedule_action(
+                  Editor(
+                    pos,
+                    ResultAction(UpdateResult(ResultFail(Timeout))),
+                  ),
                 ),
-              ),
-            model.cells,
-          );
-        ();
-      },
-    );
+              model.cells,
+            );
+          ();
+        },
+      );
+    } else {
+      ();
+    };
     /* The following section pulls statics back from cells into the editors
        There are many ad-hoc things about this code, including the fact that
        one of the editors is shown in two cells, so we arbitrarily choose which
@@ -594,7 +600,7 @@ module View = {
     let stitched_tests =
       Exercise.map_stitched(
         (_, cell_editor: CellEditor.Model.t) =>
-          cell_editor.result |> EvalResult.Model.make_test_report,
+          cell_editor.result |> EvalResult.Model.test_results,
         model.cells,
       );
 
@@ -606,7 +612,7 @@ module View = {
         (
           ~caption: string,
           ~subcaption: option(string)=?,
-          ~result_kind=EvalResult.View.NoResults,
+          ~result_kind=`NoResults,
           this_pos: Exercise.pos,
           cell: CellEditor.Model.t,
         ) => {
@@ -962,7 +968,7 @@ module View = {
           ~caption="Test Validation",
           ~subcaption,
           ~result_kind=
-            Custom(
+            `Custom(
               Grading.TestValidationReport.view(
                 ~globals,
                 ~signal_jump=
@@ -1054,7 +1060,7 @@ module View = {
         globals.settings.instructor_mode
           ? "Student's Implementation" : "Your Implementation";
       Always(
-        editor_view(YourImpl, user_impl, ~caption, ~result_kind=EvalResults),
+        editor_view(YourImpl, user_impl, ~caption, ~result_kind=`EvalResults),
       );
     };
 
@@ -1083,7 +1089,7 @@ module View = {
           user_tests,
           ~caption="Implementation Validation",
           ~subcaption,
-          ~result_kind=TestResults,
+          ~result_kind=`TestResults,
         ),
       );
     };

--- a/src/web/view/StepperView.re
+++ b/src/web/view/StepperView.re
@@ -6,24 +6,18 @@ open Language;
 module Model = {
   [@deriving (show({with_path: false}), sexp, yojson)]
   type t = {
-    cached_settings: Calc.saved(CoreSettings.t),
-    cached_elab: Calc.saved(Exp.t),
     cached_elab_subst: Calc.saved(Exp.t),
     ctx: Calc.saved(Ctx.t),
     root: StepperBase.step_model,
   };
 
   let init = {
-    cached_settings: Calc.Pending,
-    cached_elab: Calc.Pending,
     cached_elab_subst: Calc.Pending,
     ctx: Calc.Pending,
     root: StepperBase.init_step,
   };
 
   let get_state = (m: t) => StepperBase.Stepper.get_state(m.root);
-
-  let get_elaboration = (m: t) => m.cached_elab |> Calc.saved_to_option;
 };
 
 module Update = {
@@ -41,32 +35,11 @@ module Update = {
 
   let calculate =
       (
-        ~settings,
-        elab: Exp.t,
-        {ctx, cached_settings, cached_elab, cached_elab_subst, root}: Model.t,
+        ~settings: Calc.t(CoreSettings.t),
+        elab: Calc.t(Exp.t),
+        {ctx, cached_elab_subst, root}: Model.t,
       )
       : Model.t => {
-    let settings =
-      cached_settings
-      |> Calc.set(settings, ~eq=(a, b) => {
-           CoreSettings.{
-             ...a,
-             evaluation: {
-               ...a.evaluation,
-               show_settings: true,
-               stepper_history: true,
-             },
-           }
-           == CoreSettings.{
-                ...b,
-                evaluation: {
-                  ...b.evaluation,
-                  show_settings: true,
-                  stepper_history: true,
-                },
-              }
-         });
-    let elab = cached_elab |> Calc.set(~eq=Exp.fast_equal, elab);
     let ctx = ctx |> Calc.const(() => Builtins.ctx_init(None));
     let elab_subst =
       cached_elab_subst
@@ -86,8 +59,6 @@ module Update = {
       )
       |> fst;
     {
-      cached_settings: settings |> Calc.save,
-      cached_elab: elab |> Calc.save,
       cached_elab_subst: elab_subst |> Calc.save,
       ctx: ctx |> Calc.save,
       root,


### PR DESCRIPTION
Tidies up the eval result code and fixes a couple perf issues.

* Delete dead code
* Stop showing elaboration while running code for perf reasons
* Stop recalculating whole editor with dynamic data (we still redraw after dynamic data)
* Always run evaluator in the background, even when stepper is open

Later:

- [ ] Abbreviate results