### PR TITLE
Retain UUIDs during insert/destruct actions involving monotiles

### DIFF
--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -303,7 +303,14 @@ let put_down_regrout_remold_tok =
 };
 
 let rec construct =
-        (~caret: Direction.t, ~backpack: Direction.t, label: Label.t, z: t): t => {
+        (
+          ~id: Id.t=Id.mk(),
+          ~caret: Direction.t,
+          ~backpack: Direction.t,
+          label: Label.t,
+          z: t,
+        )
+        : t => {
   switch (label) {
   | [t] when Form.is_string_delim(t) =>
     /* Special case for constructing string literals.
@@ -312,12 +319,10 @@ let rec construct =
   | [content] when Form.is_comment(content) =>
     /* Special case for comments, can't rely on the last branch to construct */
     let content = Secondary.construct_comment(content);
-    let id = Id.mk();
     let z = destruct(z);
     put_down_seg(caret, Base.mk_secondary(id, content), z);
   | [content] when Form.is_secondary(content) =>
     let content = Secondary.Whitespace(content);
-    let id = Id.mk();
     z
     |> update_siblings(((l, r)) =>
          (
@@ -337,7 +342,6 @@ let rec construct =
     assert(molds != []);
     // initial mold to typecheck, will be remolded
     let mold = List.hd(molds);
-    let id = Id.mk();
     let selections =
       Tile.split_shards(id, label, mold, List.mapi((i, _) => i, label))
       |> List.map(Segment.of_tile)
@@ -346,8 +350,8 @@ let rec construct =
   };
 };
 
-let construct_mono = (d: Direction.t, t: Token.t, z: t): t =>
-  construct(~caret=d, ~backpack=Left, [t], z);
+let construct_mono = (~id, d: Direction.t, t: Token.t, z: t): t =>
+  construct(~id, ~caret=d, ~backpack=Left, [t], z);
 
 let rec get_leaf_pieces =
         (syntaxNode: Piece.t, ~ignored_labels: list(list(string)))
@@ -397,10 +401,11 @@ let delete = (d: Direction.t, z: t): option(t) => {
 };
 
 let replace =
-    (~caret: Direction.t, ~backpack: Direction.t, l: Label.t, z: t)
-    : option(t) =>
+    (~id: Id.t, ~caret: Direction.t, ~backpack: Direction.t, l: Label.t, z: t)
+    : option(t) => {
   /* i.e. select and construct, overwriting the selection */
-  z |> delete(caret) |> Option.map(construct(~caret, ~backpack, l));
+  z |> delete(caret) |> Option.map(construct(~id, ~caret, ~backpack, l));
+};
 
 let match_prev = (z: t) =>
   switch (neighbor_monotiles(z.relatives.siblings)) {
@@ -412,8 +417,22 @@ let match_prev = (z: t) =>
   | _ => None
   };
 
-let replace_mono = (d: Direction.t, t: Token.t, z: t): option(t) =>
-  replace(~caret=d, ~backpack=Left, [t], z);
+let adjacent_monotile_id = (d: Direction.t, z: t): option(Id.t) =>
+  switch (Siblings.neighbors(z.relatives.siblings)) {
+  | (Some(Tile({id, label: [_], _})), _) when d == Left => Some(id)
+  | (_, Some(Tile({id, label: [_], _}))) when d == Right => Some(id)
+  | _ => None
+  };
+
+let replace_mono = (d: Direction.t, t: Token.t, z: t): option(t) => {
+  /* Re-use existing monotile id where appropriate */
+  let id =
+    switch (adjacent_monotile_id(d, z)) {
+    | Some(id) => id
+    | None => Id.mk()
+    };
+  replace(~id, ~caret=d, ~backpack=Left, [t], z);
+};
 
 let representative_piece = (z: t): option((Piece.t, Direction.t)) => {
   /* The piece to the left of the caret, or if none exists, the piece to the right */

--- a/src/haz3lcore/zipper/action/Destruct.re
+++ b/src/haz3lcore/zipper/action/Destruct.re
@@ -90,11 +90,11 @@ let merge = ((l, r): (Token.t, Token.t), z: t): option(t) => {
   Some(z);
 };
 
-let parent_merge = (lbl: Label.t, z: t): t => {
+let parent_merge = (~id: Id.t, lbl: Label.t, z: t): t => {
   z
   |> Zipper.delete_parent
   |> Zipper.set_caret(Inner(0, 0))  /* Note 2-token assumption */
-  |> Zipper.construct(~caret=Right, ~backpack=Left, lbl)
+  |> Zipper.construct(~id, ~caret=Right, ~backpack=Left, lbl)
   /* Below regrouting important for parens/ap positioning */
   |> remold_regrout(Right);
 };
@@ -103,7 +103,8 @@ let parent_merge = (lbl: Label.t, z: t): t => {
 let parent_duomerges = (z: Zipper.t) => {
   let* parent = Relatives.parent(z.relatives);
   let* lbl = Piece.label(parent);
-  Form.duomerges(lbl);
+  let+ res = Form.duomerges(lbl);
+  (res, Piece.id(parent));
 };
 
 let go = (d: Direction.t, z: t): option(t) => {
@@ -113,12 +114,12 @@ let go = (d: Direction.t, z: t): option(t) => {
     z.caret,
     neighbor_monotiles(z.relatives.siblings),
   ) {
-  | (Some(lbl), Outer, (None, None))
+  | (Some((lbl, id)), Outer, (None, None))
       when Siblings.no_siblings(z.relatives.siblings) =>
     /* Note: we must do the no_siblings check, it does not suffice
        to check no monotile neighbors as there could be other neighbors
        for example edge case: "((|))" */
-    z |> parent_merge(lbl) |> Option.some
+    z |> parent_merge(~id, lbl) |> Option.some
   | (_, Outer, (Some(l), Some(r))) when Molds.allow_merge(l, r) =>
     z |> merge((l, r))
   | _ => Some(z) |> Option.map(remold_regrout(d))

--- a/src/haz3lcore/zipper/action/Destruct.re
+++ b/src/haz3lcore/zipper/action/Destruct.re
@@ -76,10 +76,15 @@ let destruct =
 };
 
 let merge = ((l, r): (Token.t, Token.t), z: t): option(t) => {
+  let left_monotile_id =
+    switch (Zipper.adjacent_monotile_id(Left, z)) {
+    | Some(id) => id
+    | None => Id.mk()
+    };
   let z = Zipper.set_caret(Inner(0, Token.length(l) - 1), z); /* Note monotile assumption */
   let* z = Zipper.delete(Left, z);
   let* z = Zipper.delete(Right, z);
-  let z = Zipper.construct_mono(Right, l ++ r, z);
+  let z = Zipper.construct_mono(~id=left_monotile_id, Right, l ++ r, z);
   /* Regrouting direction needed to merge prefixs into infix eg ! */
   let z = remold_regrout(Right, z);
   Some(z);

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -42,8 +42,14 @@ let delayed_expand = (t: Token.t, caret: Direction.t, z: t): option(t) => {
     | _ when t == "|" => ([t], Direction.Left)
     | _ => (new_label, backpack)
     };
+  /* Retain monotile id for new polytile (Just for fun) */
+  let id =
+    switch (adjacent_monotile_id(caret, z)) {
+    | Some(id) => id
+    | None => Id.mk()
+    };
   let+ z = delete(caret, z);
-  construct(~backpack, ~caret, new_label, z);
+  construct(~id, ~backpack, ~caret, new_label, z);
 };
 
 let expand_or_barf_left_neighbor = (z as s: t): option(t) =>
@@ -72,7 +78,7 @@ let get_duo_shard = ({label, shards, _}: Tile.t) =>
   };
 
 let neighbor_can_duomerge =
-    (t: Token.t, s: Siblings.t): option((Label.t, Direction.t)) =>
+    (t: Token.t, s: Siblings.t): option((Label.t, Direction.t, Id.t)) =>
   /* Checks if a neighbor, preferentially the left neighbor, is
      a shard of a duotile which can be merged to form a monotile.
      It returns the resulting (mono)label, and the direction of
@@ -81,28 +87,28 @@ let neighbor_can_duomerge =
   | (Some(Tile(tile)), _) =>
     let* start = get_duo_shard(tile);
     let+ mono_lbl = Form.duomerges([start, t]);
-    (mono_lbl, Direction.Left);
+    (mono_lbl, Direction.Left, tile.id);
   | (_, Some(Tile(tile))) =>
     let* last = get_duo_shard(tile);
     let+ mono_lbl = Form.duomerges([t, last]);
-    (mono_lbl, Direction.Right);
+    (mono_lbl, Direction.Right, tile.id);
   | _ => None
   };
 
-let make_new_tile = (t: Token.t, caret: Direction.t, z: t): t =>
+let make_new_tile = (~id, t: Token.t, caret: Direction.t, z: t): t =>
   /* Adds a new tile at the caret. If the new token matches the top
      of the backpack, the backpack shard is dropped. Otherwise, we
      construct a new tile, which may immediately expand. */
   switch (neighbor_can_duomerge(t, z.relatives.siblings)) {
-  | Some((lbl, d)) =>
-    Zipper.replace(~caret=d, ~backpack=d, lbl, z) |> Option.get
+  | Some((lbl, d, id)) =>
+    Zipper.replace(~id, ~caret=d, ~backpack=d, lbl, z) |> Option.get
   | None =>
     /* e.g. closing parens are put down without further ceremony */
     Zipper.will_barf(t, z) && Form.is_instant_putdown(t)
       ? put_down_regrout_remold_tok(caret, t, z) |> Option.get
       : {
         let (lbl, backpack) = Molds.instant_expansion(t);
-        construct(~caret, ~backpack, lbl, z);
+        construct(~id, ~caret, ~backpack, lbl, z);
       }
   };
 
@@ -122,14 +128,19 @@ let expand_neighbors_and_make_new_tile = (char: Token.t, state: t): option(t) =>
   let* z = expand_or_barf_left_neighbor(state);
   let+ z = expand_or_barf_right_neighbor(z);
   let z = remold_regrout_prev(z);
-  let z = make_new_tile(char, Left, z);
+  let z = make_new_tile(~id=Id.mk(), char, Left, z);
   let z = remold_regrout_prev(z);
   z;
 };
 
 let replace_tile = (t: Token.t, d: Direction.t, z: t): option(t) => {
+  let id =
+    switch (adjacent_monotile_id(d, z)) {
+    | Some(id) => id
+    | None => Id.mk()
+    };
   let+ z = delete(d, z);
-  make_new_tile(t, d, z);
+  make_new_tile(~id, t, d, z);
 };
 
 [@deriving (show({with_path: false}), sexp, yojson)]
@@ -166,10 +177,10 @@ let insert_duo = (lbl: Label.t, z: option(t)): option(t) =>
        |> OptUtil.and_then(Zipper.move(Left))
      });
 
-let insert_monos = (l: Token.t, r: Token.t, z: option(t)): option(t) =>
+let insert_monos = (~id, l: Token.t, r: Token.t, z: option(t)): option(t) =>
   z
-  |> Option.map(Zipper.construct_mono(Right, r))
-  |> Option.map(Zipper.construct_mono(Left, l));
+  |> Option.map(Zipper.construct_mono(~id=Id.mk(), Right, r))
+  |> Option.map(Zipper.construct_mono(~id, Left, l));
 
 let should_supress_space = (z: t): bool => {
   /* Figure out if we should avoid inserting a space because a grout
@@ -204,6 +215,11 @@ let split = (z: t, char: string, idx: int, t: Token.t): option(t) => {
    * to append the new char to the left half, and then the right half,
    * and only if those fail creating a new center token. */
   let (l, r) = Token.split_nth(idx, t);
+  let right_monotile_id =
+    switch (adjacent_monotile_id(Right, z)) {
+    | Some(id) => id
+    | None => Id.mk()
+    };
   /* overwrite selection */
   let z = z |> Zipper.set_caret(Outer) |> Zipper.select(Right);
   switch (Form.duomerges([l, r])) {
@@ -212,7 +228,7 @@ let split = (z: t, char: string, idx: int, t: Token.t): option(t) => {
     /* If we're inserting a space, don't bother to insert it;
      * we'll get a convex grout anyway from regrouting */
 
-    (Form.space != char ? make_new_tile(char, Left, z) : z)
+    (Form.space != char ? make_new_tile(~id=Id.mk(), char, Left, z) : z)
     |> remold_regrout(Right)
     |> move_into_if_stringlit_or_comment(char);
 
@@ -225,7 +241,7 @@ let split = (z: t, char: string, idx: int, t: Token.t): option(t) => {
      * `1|1` (needs concave grout by caret in current seg)
      * `if|if` (no grout needed by caret, and later)
      * `case|end` */
-    let* z = insert_monos(l, r, z);
+    let* z = insert_monos(~id=right_monotile_id, l, r, z);
     let* z = expand_or_barf_left_neighbor(z);
     let+ z = expand_or_barf_right_neighbor(z);
     if (Form.space == char && should_supress_space(z)) {
@@ -241,7 +257,8 @@ let split = (z: t, char: string, idx: int, t: Token.t): option(t) => {
       };
     } else {
       let z = remold(z);
-      let z = z |> remold_regrout_prev |> make_new_tile(char, Left);
+      let z =
+        z |> remold_regrout_prev |> make_new_tile(~id=Id.mk(), char, Left);
       let z = z |> remold_regrout(Right);
       let z = z |> move_into_if_stringlit_or_comment(char);
       z;

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -166,9 +166,11 @@ let insert_outer = (char: string, z as state: t): option(t) =>
   | AppendRight(t) => replace_tile(t, Right, state)
   };
 
-let insert_duo = (lbl: Label.t, z: option(t)): option(t) =>
+let insert_duo = (~id, lbl: Label.t, z: option(t)): option(t) =>
   z
-  |> Option.map(z => Zipper.construct(~caret=Left, ~backpack=Left, lbl, z))
+  |> Option.map(z =>
+       Zipper.construct(~id, ~caret=Left, ~backpack=Left, lbl, z)
+     )
   |> OptUtil.and_then(z => {
        //NOTE: regrout to put e.g. ap(1|) back together
        z
@@ -224,7 +226,7 @@ let split = (z: t, char: string, idx: int, t: Token.t): option(t) => {
   let z = z |> Zipper.set_caret(Outer) |> Zipper.select(Right);
   switch (Form.duomerges([l, r])) {
   | Some(_) =>
-    let+ z = insert_duo([l, r], z);
+    let+ z = insert_duo(~id=right_monotile_id, [l, r], z);
     /* If we're inserting a space, don't bother to insert it;
      * we'll get a convex grout anyway from regrouting */
 


### PR DESCRIPTION
This reuses existing UUIDs where possible during basic editor actions.

This is intended to help with:

- Cleaner automerge/patchwork diffs
- Retaining reflector placements during editing

Specifically, UUIDs are now retained in the following cases:

1. Insert character actions taking a monotile to a monotile (original ID retained)
2. Delete character actions taking a monotile to a monotile (original ID retained)
3. Insert character actions which split one monotile into two (left half gets original ID)
4. Delete character actions which merge two monotiles into one (gets original ID of left half)
5. Insert character actions which split a monotile into a duotile (original ID retained)
6. Delete character actions which merge a duotile into a monotile (original ID retained)
7. Insert character actions which keyword-expand (new polytile gets keyword ID)

I think this covers just about every primitive character-level action in which its reasonable to retain ids. Note that polytile IDs are always already retained. Some of these are less obviously desirable than others... I'm debating whether 7 is particularly meaningful, and 5 and 6 are strictly edge cases. But maybe easier to go maximalist and we can pull back if necessary.

