### PR TITLE
Fix ascription accumulation during evaluation

### DIFF
--- a/src/language/dynamics/transition/Ascriptions.re
+++ b/src/language/dynamics/transition/Ascriptions.re
@@ -99,7 +99,7 @@ let rec transition = (~recursive=false, d: DHExp.t): option(DHExp.t) => {
     | (If(e, e1, e2), t) =>
       Some(
         If(
-          recur(Asc(e, t |> Typ.temp) |> DHExp.fresh),
+          recur(e),
           recur(Asc(e1, t |> Typ.temp) |> DHExp.fresh),
           recur(Asc(e2, t |> Typ.temp) |> DHExp.fresh),
         )

--- a/src/language/dynamics/transition/Ascriptions.re
+++ b/src/language/dynamics/transition/Ascriptions.re
@@ -140,6 +140,59 @@ let rec transition = (~recursive=false, d: DHExp.t): option(DHExp.t) => {
         when Typ.is_consistent(Ctx.empty, Typ.unroll(t), t' |> Typ.temp) =>
       Some(e)
     | (Test(_), Prod([])) => Some(e)
+    // These are non-value cases we're handling to process ascriptions as early as possible
+    | (BinOp(bin_op, _, _), _) =>
+      switch (Operators.semantics_of_bin_op(bin_op)) {
+      | DefinedPoly(Equals | NotEquals)
+          when Typ.is_consistent(Ctx.empty, t, Atom(Bool) |> Typ.temp) =>
+        Some(e)
+      | Defined(_, _, ty_out, _)
+          when
+            Typ.is_consistent(
+              Ctx.empty,
+              t,
+              Atom(Atom.cls_of_kind(ty_out)) |> Typ.temp,
+            ) =>
+        Some(e)
+      | Undefined(_)
+      | DefinedPoly(_)
+      | Defined(_) => None
+      }
+    | (UnOp(un_op, _), _) =>
+      switch (Operators.semantics_of_un_op(un_op)) {
+      | Defined(_, ty_out, _)
+          when
+            Typ.is_consistent(
+              Ctx.empty,
+              t,
+              Atom(Atom.cls_of_kind(ty_out)) |> Typ.temp,
+            ) =>
+        Some(e)
+      | Undefined(_)
+      | Defined(_) => None
+      }
+    | (ListConcat(d1, d2), List(_)) =>
+      Some(
+        ListConcat(
+          recur(Asc(d1, t) |> DHExp.fresh),
+          recur(Asc(d2, t) |> DHExp.fresh),
+        )
+        |> DHExp.fresh,
+      )
+    | (Let(p, e1, e2), _) =>
+      Some(Let(p, e1, Asc(e2, t) |> DHExp.fresh) |> DHExp.fresh)
+    | (Seq(e1, e2), _) =>
+      Some(Seq(e1, Asc(e2, t) |> DHExp.fresh) |> DHExp.fresh)
+    | (Parens(e), _) =>
+      Some(Parens(Asc(e, t) |> DHExp.fresh) |> DHExp.fresh)
+    // We _could_ do this, but it would be a bit weird
+    | (Use(_), _) // I'm scaredto do Use because the type-directed literals might make this look weird in the stepper
+    | (BuiltinFun(_), _)
+    | (FixF(_), _)
+    | (TypAp(_), _)
+    | (Filter(_), _)
+    | (TyAlias(_), _)
+    | (Asc(_), _) => None
     // These are non-value cases we don't want to handle
     | (EmptyHole, _)
     | (DynamicErrorHole(_), _)
@@ -155,23 +208,10 @@ let rec transition = (~recursive=false, d: DHExp.t): option(DHExp.t) => {
     | (LivelitName(_), _)
     | (Probe(_, _), _)
     | (TupleExtension(_, _), _)
-    // We _could_ do this, but it would be a bit weird
-    | (Let(_), _)
-    | (Use(_), _)
-    | (BinOp(_), _)
-    | (UnOp(_), _)
-    | (BuiltinFun(_), _)
-    | (FixF(_), _)
-    | (TypAp(_), _)
-    | (Seq(_), _)
-    | (Filter(_), _)
-    | (Parens(_), _)
-    | (TyAlias(_), _)
-    | (ListConcat(_), _)
-    | (Asc(_), _) => None
     // These are handled above and must have the wrong type
     | (Atom(_), _)
     | (ListLit(_), _)
+    | (ListConcat(_), _)
     | (TupLabel(_), _)
     | (Tuple(_), _)
     | (Fun(_), _)

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -905,19 +905,31 @@ module Transition = (EV: EV_MODE) => {
       let. _ = otherwise(env, d);
       let.wrap_closure _ = env;
       Indet;
-    | Asc(d, t) =>
-      let. _ = otherwise(env, d => Asc(d, t) |> rewrap)
-      and. d' = req_final(req(state, env), d => Asc(d, t) |> wrap_ctx, d);
-      switch (Ascriptions.transition(Asc(d', t) |> rewrap)) {
-      | Some(d) =>
+    | Asc(d', t) =>
+      switch (Ascriptions.transition(d)) {
+      | Some(d') =>
+        let. _ = otherwise(env, d);
         Step({
-          expr: d,
+          expr: d',
           state_update,
           kind: Ascription,
           is_value: false,
-        })
-      | None => Constructor
-      };
+        });
+      | None =>
+        let. _ = otherwise(env, d => Asc(d, t) |> rewrap)
+        and. d' =
+          req_final(req(state, env), d => Asc(d, t) |> wrap_ctx, d');
+        switch (Ascriptions.transition(Asc(d', t) |> rewrap)) {
+        | Some(d) =>
+          Step({
+            expr: d,
+            state_update,
+            kind: Ascription,
+            is_value: false,
+          })
+        | None => Constructor
+        };
+      }
     | Undefined =>
       let. _ = otherwise(env, d);
       Indet;

--- a/test/evaluator/Test_Evaluator_List.re
+++ b/test/evaluator/Test_Evaluator_List.re
@@ -16,6 +16,18 @@ let tests = (
         {|[1,2,3] : [String]|},
       )
     ),
+    test_case("List ascription through indet cons", `Quick, () => {
+      parse_and_evaluate_test(
+        "(x : Int) :: (y : [Int])",
+        {|(x :: y) : [Int]|},
+      )
+    }),
+    test_case("Ascription through indet list concatenation", `Quick, () => {
+      parse_and_evaluate_test(
+        "(x : [Int]) @ (y : [Int])",
+        {|(x @ y) : [Int]|},
+      )
+    }),
     test_case("Inconsistent list ascription with alias", `Quick, () => {
       parse_and_evaluate_test(
         "[1 : String,2 : String,3 : String]",

--- a/test/evaluator/Test_Evaluator_Match.re
+++ b/test/evaluator/Test_Evaluator_Match.re
@@ -125,6 +125,12 @@ go(Var("yo"))|},
         ),
       )
     ),
+    test_case("Ascriptions collapse lazily through if", `Quick, () =>
+      parse_and_evaluate_test(
+        {|if ? then ? : String else ? : String|},
+        {|(if ? then ? else ?) : String : String|},
+      )
+    ),
     test_case("Indet case passes ascriptions through", `Quick, () => {
       parse_and_evaluate_test(
         {|(case ?

--- a/test/evaluator/Test_Evaluator_Operators.re
+++ b/test/evaluator/Test_Evaluator_Operators.re
@@ -15,5 +15,30 @@ let tests = (
     test_case("Inconsistent type ascription in subterm", `Quick, () =>
       parse_and_evaluate_test("1 + (4 : String)", {|1 + (4 : String)|})
     ),
+    test_case(
+      "Ascriptions around indet operators collapse",
+      `Quick,
+      () => {
+        parse_and_evaluate_test("x + y", "(x + y) : Int");
+        parse_and_evaluate_test("x - y", "(x - y) : Int");
+        parse_and_evaluate_test("x * y", "(x * y) : Int");
+        parse_and_evaluate_test("x ** y", "(x ** y) : Int");
+        parse_and_evaluate_test("x / y", "(x / y) : Int");
+        parse_and_evaluate_test("x < y", "(x < y) : Bool");
+        parse_and_evaluate_test("x <= y", "(x <= y) : Bool");
+        parse_and_evaluate_test("x > y", "(x > y) : Bool");
+        parse_and_evaluate_test("x >= y", "(x >= y) : Bool");
+        parse_and_evaluate_test("x == y", "(x == y) : Bool");
+        parse_and_evaluate_test("x != y", "(x != y) : Bool");
+        parse_and_evaluate_test("s1 ++ s2", "(s1 ++ s2) : String");
+        parse_and_evaluate_test("s1 +. s2", "(s1 +. s2) : Float");
+        parse_and_evaluate_test("s1 -. s2", "(s1 -. s2) : Float");
+        parse_and_evaluate_test("s1 *. s2", "(s1 *. s2) : Float");
+        parse_and_evaluate_test("s1 **. s2", "(s1 **. s2) : Float");
+        parse_and_evaluate_test("s1 /. s2", "(s1 /. s2) : Float");
+        parse_and_evaluate_test("b1 && b2", "(b1 && b2) : Bool");
+        parse_and_evaluate_test("b1 || b2", "(b1 || b2) : Bool");
+      },
+    ),
   ],
 );


### PR DESCRIPTION
## Overview

This PR addresses two related issues in Hazel's evaluation process concerning ascriptions:

1. **Redundant Ascriptions:**  
   Previously, ascriptions were not being collapsed properly, resulting in multiple redundant ascriptions stacking up instead of being unified.

2. **Overaccumulation of Ascriptions:**  
   The reduction of ascriptions was delayed until after the scrutinee finished evaluating. This led to excessive accumulation of ascriptions.

## Solution

- Ascriptions are now collapsed as soon as possible.
- Transition rules have been added for many forms to collapse ascriptions around indet forms with known types

## Sum Screenshot
**Before:**  
<img width="701" height="1076" alt="Screenshot From 2025-09-11 13-48-05" src="https://github.com/user-attachments/assets/43816104-ee4c-47b8-a5c9-9a01ab9b8705" />
**After:**  
<img width="433" height="1083" alt="Screenshot From 2025-09-11 13-47-55" src="https://github.com/user-attachments/assets/9e5203c1-6ec4-4a4f-a025-387bbe238582" />
