### PR TITLE
Stepper shows variable substitution dropdowns

### DIFF
--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -50,13 +50,13 @@ type step_kind =
   | InvalidStep
   | VarLookup
   | Seq
-  | LetBind(string)
+  | LetBind(list(string))
   | WrapClosure
   | FixUnwrap
   | FixClosure
   | UpdateTest
   | TypFunAp
-  | FunAp
+  | FunAp(list(string))
   | DeferredAp
   | AscriptionTypAp
   | AscriptionAp
@@ -69,7 +69,7 @@ type step_kind =
   | Projection
   | ListCons
   | ListConcat
-  | CaseApply
+  | CaseApply(list(string))
   | CompleteClosure
   | CompleteFilter
   | Ascription
@@ -163,6 +163,13 @@ module Transition = (EV: EV_MODE) => {
       r;
     };
 
+  let str_from_matches = (matches: match_result) =>
+    switch (matches) {
+    | IndetMatch
+    | DoesNotMatch => []
+    | Matches(env) =>
+      VarBstMap.Ordered.to_listo(env) |> List.rev |> List.map(((s, _)) => s)
+    };
   /* Note[Matt]: For IDs, I'm currently using a fresh id
      if anything about the current node changes, if only its
      children change, we use rewrap */
@@ -251,22 +258,11 @@ module Transition = (EV: EV_MODE) => {
         req_final(req(state, env), d1 => Let1(dp, d1, d2) |> wrap_ctx, d1);
       let.wrap_closure _ = env;
       let {matches, closures} = matches(dp, d1');
-      let matches_str = {
-        switch (matches) {
-        | IndetMatch
-        | DoesNotMatch => ""
-        | Matches(env) =>
-          VarBstMap.Ordered.to_listo(env)
-          |> List.rev
-          |> List.map(((s, _)) => s)
-          |> String.concat(", ")
-        };
-      };
       let.match env' = (env, matches, env.call_stack);
       Step({
         expr: subst_env(env', d2),
         state_update: capture_closures(env, state, closures),
-        kind: LetBind(matches_str),
+        kind: LetBind(str_from_matches(matches)),
         is_value: false,
       });
     | TypFun(_)
@@ -432,7 +428,7 @@ module Transition = (EV: EV_MODE) => {
           Step({
             expr: subst_env(env'', d3),
             state_update: capture_closures(env'', state, matches.closures),
-            kind: FunAp,
+            kind: FunAp(str_from_matches(matches.matches)),
             is_value: false,
           });
         };
@@ -454,7 +450,7 @@ module Transition = (EV: EV_MODE) => {
                 state,
                 matches.closures,
               ),
-            kind: FunAp,
+            kind: FunAp(str_from_matches(matches.matches)),
             is_value: false,
           })
         };
@@ -777,7 +773,12 @@ module Transition = (EV: EV_MODE) => {
             ),
 
           state_update: capture_closures(env, state, closures),
-          kind: CaseApply,
+          kind:
+            CaseApply(
+              VarBstMap.Ordered.to_listo(env')
+              |> List.rev
+              |> List.map(((s, _)) => s),
+            ),
           is_value: false,
         })
       | None =>
@@ -899,7 +900,7 @@ let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
   | Seq
   | UpdateTest
   | TypFunAp
-  | FunAp
+  | FunAp(_)
   | DeferredAp
   | BuiltinAp(_)
   | BinOp(_)
@@ -907,7 +908,7 @@ let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
   | UnOp(_)
   | ListCons
   | ListConcat
-  | CaseApply
+  | CaseApply(_)
   | Projection // TODO(Matt): We don't want to show projection to the user
   | Conditional(_)
   | RemoveTypeAlias
@@ -924,15 +925,52 @@ let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
   | WrapClosure
   | FixClosure
   | RemoveParens => true;
+// Returns an empty list if stepper should not display a dropdown in justification.
+
+// Meaning if a let bind only binds one variable, this function returns an empty list.
+
+let substitution_vars: step_kind => list(string) =
+  fun
+  | LetBind(matches) => List.length(matches) > 1 ? matches : []
+  | CaseApply(matches)
+  | FunAp(matches) => matches
+  | Seq
+  | UpdateTest
+  | TypFunAp
+  | DeferredAp
+  | BuiltinAp(_)
+  | BinOp(_)
+  | Dot
+  | UnOp(_)
+  | ListCons
+  | ListConcat
+  | Projection
+  | Conditional(_)
+  | RemoveTypeAlias
+  | RemoveUse
+  | InvalidStep
+  | VarLookup
+  | AscriptionTypAp
+  | AscriptionAp
+  | Ascription
+  | FixUnwrap
+  | CompleteClosure
+  | CompleteFilter
+  | BuiltinWrap
+  | WrapClosure
+  | FixClosure
+  | RemoveParens => [];
 
 let stepper_justification: step_kind => string =
   fun
-  | LetBind(s) => String.cat("substitution for ", s)
+  | LetBind(vars) =>
+    List.length(vars) == 1
+      ? "substitution for " ++ List.hd(vars) : "substitution"
   | Seq => "sequence"
   | FixUnwrap => "unroll fixpoint"
   | UpdateTest => "update test"
   | TypFunAp => "apply type function"
-  | FunAp => "apply function"
+  | FunAp(_) => "apply function"
   | DeferredAp => "deferred application"
   | BuiltinWrap => "wrap builtin"
   | BuiltinAp(s) => "evaluate " ++ s
@@ -958,7 +996,7 @@ let stepper_justification: step_kind => string =
   | Conditional(_) => "conditional"
   | ListCons => "list manipulation"
   | ListConcat => "list manipulation"
-  | CaseApply => "case selection"
+  | CaseApply(_) => "case selection"
   | Projection => "projection" // TODO(Matt): We don't want to show projection to the user
   | InvalidStep => "error"
   | VarLookup => "variable lookup"

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -965,7 +965,7 @@ let stepper_justification: step_kind => string =
   fun
   | LetBind(vars) =>
     List.length(vars) == 1
-      ? "substitution for " ++ List.hd(vars) : "substitution"
+      ? "substitution for " ++ List.hd(vars) : "substitution for ..."
   | Seq => "sequence"
   | FixUnwrap => "unroll fixpoint"
   | UpdateTest => "update test"

--- a/src/web/app/editors/stepper/SingleStep.re
+++ b/src/web/app/editors/stepper/SingleStep.re
@@ -119,12 +119,32 @@ module F =
         ~undo as _: option(Ui_effect.t(unit)),
         ~is_toplevel as _: bool,
         m: model,
-      ) =>
-    WebUtil.Node.text(
-      m.evalobj
-      |> EvaluatorStep.get_step_kind
-      |> Transition.stepper_justification,
-    );
+      ) => {
+    let step_kind = m.evalobj |> EvaluatorStep.get_step_kind;
+    let justification_text = step_kind |> Transition.stepper_justification;
+    let substitution_vars = Transition.substitution_vars(step_kind);
+    if (!List.is_empty(substitution_vars)) {
+      WebUtil.Node.div(
+        [WebUtil.Node.text(justification_text)]
+        @ [
+          WebUtil.div_c(
+            "stepper-justification-sub-vars",
+            [WebUtil.Node.text("Variables substituted:")],
+          ),
+        ]
+        @ List.map(
+            var =>
+              WebUtil.div_c(
+                "stepper-justification-sub-vars",
+                [WebUtil.Node.text(var)],
+              ),
+            substitution_vars,
+          ),
+      );
+    } else {
+      WebUtil.Node.text(justification_text);
+    };
+  };
 
   let view_content =
       (

--- a/src/web/app/editors/stepper/SingleStep.re
+++ b/src/web/app/editors/stepper/SingleStep.re
@@ -129,17 +129,23 @@ module F =
         @ [
           WebUtil.div_c(
             "stepper-justification-sub-vars",
-            [WebUtil.Node.text("Variables substituted:")],
-          ),
-        ]
-        @ List.map(
-            var =>
-              WebUtil.div_c(
-                "stepper-justification-sub-vars",
-                [WebUtil.Node.text(var)],
+            [
+              WebUtil.Node.span([
+                WebUtil.Node.text("Variables substituted:"),
+              ]),
+            ]
+            @ List.flatten(
+                List.map(
+                  var =>
+                    [
+                      WebUtil.Node.br(),
+                      WebUtil.Node.span([WebUtil.Node.text(var)]),
+                    ],
+                  substitution_vars,
+                ),
               ),
-            substitution_vars,
           ),
+        ],
       );
     } else {
       WebUtil.Node.text(justification_text);

--- a/src/web/app/editors/stepper/StepperBase.re
+++ b/src/web/app/editors/stepper/StepperBase.re
@@ -838,7 +838,7 @@ and Stepper: {
                 [
                   div_c("equiv", [Node.text("≡")]),
                   div_c("step-output", [editor]),
-                  justification,
+                  div_c("stepper-justification", [justification]),
                 ],
               ),
             ]

--- a/src/web/www/style/dynamics.css
+++ b/src/web/www/style/dynamics.css
@@ -180,15 +180,24 @@
 
 .stepper-justification {
     width: fit-content;
+    position:relative
 }
 .stepper-justification-sub-vars {
     display: none;
-    position: relative;
-    filter: drop-shadow(3px 3px 2px #00000010);
+    position: absolute;
+    right: 0;
+    width: max-content;
+    text-align: right;
+    z-index: var(--projector-hover-z);
+}
+.stepper-justification-sub-vars span{
+  display:inline-block;
+  background-color: var(--shard-any);
+  padding: 2px;
+
 }
 .stepper-justification:hover .stepper-justification-sub-vars{
     display: block;
-    background-color: var(--shard-any);
 }
 
 .step-expand,

--- a/src/web/www/style/dynamics.css
+++ b/src/web/www/style/dynamics.css
@@ -179,7 +179,16 @@
 /* STEPPER */
 
 .stepper-justification {
-  width: 260px;
+    width: fit-content;
+}
+.stepper-justification-sub-vars {
+    display: none;
+    position: relative;
+    filter: drop-shadow(3px 3px 2px #00000010);
+}
+.stepper-justification:hover .stepper-justification-sub-vars{
+    display: block;
+    background-color: var(--shard-any);
 }
 
 .step-expand,

--- a/src/web/www/style/stepper.css
+++ b/src/web/www/style/stepper.css
@@ -168,35 +168,6 @@
 }
 
 
-/* STEPPER (OLD) */
-/*
-.stepper-justification {
-  width: 260px;
-}*/
-
-.step-expand,
-.step-back {
-  cursor: pointer;
-}
-
-.step-expand:hover span,
-.step-back:hover span {
-  display: none;
-}
-
-.step-expand:hover:before {
-  content: "↕";
-}
-
-.step-back:hover:before {
-  content: "←";
-}
-
-.substituted {
-  text-decoration: line-through;
-  color: var(--STONE);
-}
-
 
 /* TILES */
 

--- a/src/web/www/style/stepper.css
+++ b/src/web/www/style/stepper.css
@@ -169,10 +169,10 @@
 
 
 /* STEPPER (OLD) */
-
+/*
 .stepper-justification {
   width: 260px;
-}
+}*/
 
 .step-expand,
 .step-back {


### PR DESCRIPTION
On let binds with only one variable, shows "substitution for (variable name)"
<img width="1477" height="597" alt="Screenshot 2025-08-15 at 5 09 58 PM" src="https://github.com/user-attachments/assets/ba4ffa0d-8edb-401f-a692-b87d7c8b8f74" />

On let binds with more than one variable, function application, and case selection, shows variables substituted when hovered over.

<img width="1479" height="692" alt="Screenshot 2025-08-15 at 5 10 36 PM" src="https://github.com/user-attachments/assets/68aadd29-d428-40c3-91a6-3ef8d77db3fa" />