### PR TITLE
Handle function application in rewrite checker

### DIFF
--- a/src/web/app/editors/stepper/RewriteChecker.re
+++ b/src/web/app/editors/stepper/RewriteChecker.re
@@ -34,6 +34,37 @@ let rec print_exp_for_algebrite = (exp: Exp.t): string =>
     ++ "("
     ++ print_exp_for_algebrite(inner)
     ++ ")"
+  // Just return built-in functions using their exact name
+  | BuiltinFun(str) => str
+  // Handle functions
+  // TODO(nishant): need to handle more here
+  | Fun(pat, exp, _, var) =>
+    print_endline("pat: " ++ Pat.show(pat));
+    print_endline(print_exp_for_algebrite(exp));
+    switch (var) {
+    | Some(v) => print_endline(Var.show(v))
+    | None => print_endline("None")
+    };
+    print_exp_for_algebrite(exp);
+  // Handle lists
+  | ListLit(list) =>
+    "["
+    ++ String.concat(", ", List.map(print_exp_for_algebrite, list))
+    ++ "]"
+  | ListConcat(exp1, exp2) =>
+    "["
+    ++ String.sub(
+         print_exp_for_algebrite(exp1),
+         1,
+         String.length(print_exp_for_algebrite(exp1)) - 2,
+       )  // remove the [] brackets
+    ++ ", "
+    ++ String.sub(
+         print_exp_for_algebrite(exp2),
+         1,
+         String.length(print_exp_for_algebrite(exp2)) - 2,
+       )  // remove the [] brackets
+    ++ "]"
   // If we don't know how to print the expression, we can use a hash to create a unique string
   // Modulo keeps it short
   | _ =>

--- a/src/web/app/editors/stepper/RewriteChecker.re
+++ b/src/web/app/editors/stepper/RewriteChecker.re
@@ -27,11 +27,21 @@ let rec print_exp_for_algebrite = (exp: Exp.t): string =>
     "(" ++ "-" ++ print_exp_for_algebrite(exp) ++ ")"
   | Parens(exp) => "(" ++ print_exp_for_algebrite(exp) ++ ")"
   | Var(value) => value
-  // TODO: think harder about weird corner cases where we'd want to ensure the types in Cast are valid
+  // TODO(nishant): think harder about weird corner cases where we'd want to ensure the types in Cast are valid
   | Asc(exp, _) => print_exp_for_algebrite(exp)
+  | Ap(_, outer, inner) =>
+    print_exp_for_algebrite(outer)
+    ++ "("
+    ++ print_exp_for_algebrite(inner)
+    ++ ")"
   // If we don't know how to print the expression, we can use a hash to create a unique string
   // Modulo keeps it short
-  | _ => "unknown_" ++ string_of_int(Hashtbl.hash(exp) mod 100000)
+  | _ =>
+    print_endline(
+      "Algebrite rewrite checker received unknown value of type "
+      ++ Exp.show(exp),
+    );
+    "unknown_" ++ string_of_int(Hashtbl.hash(exp) mod 100000);
   };
 
 let checkEquality = (expr1, expr2): bool => {


### PR DESCRIPTION
Allows us to rewrite-check things like `f(x) + 1` being equivalent to `1 + f(x)`; all we have to do is unpack function application. Even works when `f, x` have not been defined: 
<img width="720" height="642" alt="image" src="https://github.com/user-attachments/assets/8b7a4620-a4b9-464b-9480-494c7dd9089a" />

Closes #1842.
