### PR TITLE
Fix text projector line height

### DIFF
--- a/src/web/www/style/projectors/proj-text.css
+++ b/src/web/www/style/projectors/proj-text.css
@@ -39,18 +39,18 @@
   color: var(--SAND);
   background: repeating-linear-gradient(
     var(--NONE),
-    var(--NONE) 1.41em,
-    var(--textarea-h-stripe) 1.41em,
-    var(--textarea-h-stripe) 1.47em /* line-height */
+    var(--NONE) calc((var(--line-height) - 0.06) * 1em),
+    var(--textarea-h-stripe) calc((var(--line-height) - 0.06) * 1em),
+    var(--textarea-h-stripe) calc(var(--line-height) * 1em) /* line-height */
   );
 }
 
 .projector.text.selected .cols {
   background: repeating-linear-gradient(
     var(--NONE),
-    var(--NONE) 1.41em,
-    var(--textarea-h-strip-selected) 1.41em,
-    var(--textarea-h-strip-selected) 1.47em /* line-height */
+    var(--NONE) calc((var(--line-height) - 0.06) * 1em),
+    var(--textarea-h-strip-selected) calc((var(--line-height) - 0.06) * 1em),
+    var(--textarea-h-strip-selected) calc(var(--line-height) * 1em) /* line-height */
   );
 }
 .projector.text.selected > svg {


### PR DESCRIPTION
The text alignment of the lines was off


Before:
<img width="1343" height="1322" alt="Lines overlap text" src="https://github.com/user-attachments/assets/538df69a-7db4-472f-879d-c7f8981baf8d" />
After:
<img width="1343" height="1322" alt="Lines between text" src="https://github.com/user-attachments/assets/59684cbd-7664-40a9-87f8-dc4725aa4249" />
