### PR TITLE
Stop persisting unmodified doc slides

### DIFF
--- a/src/web/Export.re
+++ b/src/web/Export.re
@@ -62,4 +62,3 @@ let import_all = (~import_log: string => unit, data, ~specs) => {
   ExercisesMode.Store.import(all.exercise, ~specs, ~instructor_mode);
   import_log(all.log);
 };
-

--- a/src/web/Export.re
+++ b/src/web/Export.re
@@ -63,17 +63,3 @@ let import_all = (~import_log: string => unit, data, ~specs) => {
   import_log(all.log);
 };
 
-let export_persistent = () => {
-  let data: PersistentData.t = {
-    documentation: ScratchMode.StoreDocumentation.load(),
-    scratch: ScratchMode.Store.load(),
-  };
-  let contents =
-    "let startup : PersistentData.t = " ++ PersistentData.show(data);
-  JsUtil.download_string_file(
-    ~filename="Init.ml",
-    ~content_type="text/plain",
-    ~contents,
-  );
-  print_endline("INFO: Persistent data exported to Init.ml");
-};

--- a/src/web/app/helpful-assistant/prompts/InitPrompts.re
+++ b/src/web/app/helpful-assistant/prompts/InitPrompts.re
@@ -4,6 +4,19 @@ let get_documentation_as_text = () => {
   let (_, slides) = ScratchMode.StoreDocumentation.load();
   let documentation =
     slides
+    |> List.map(
+         ((s, optional_persisent)): (string, CellEditor.Model.persistent) => {
+         let p =
+           switch (optional_persisent) {
+           | Some(persistent) => persistent
+           | None =>
+             Init.startup.documentation
+             |> snd
+             |> List.find(((name, _)) => name == s)
+             |> snd
+           };
+         (s, p);
+       })
     |> List.map(((name, persistent)) => {
          let cell_model =
            CellEditor.Model.unpersist(

--- a/src/web/app/helpful-assistant/prompts/InitPrompts.re
+++ b/src/web/app/helpful-assistant/prompts/InitPrompts.re
@@ -5,17 +5,23 @@ let get_documentation_as_text = () => {
   let documentation =
     slides
     |> List.map(
-         ((s, optional_persisent)): (string, CellEditor.Model.persistent) => {
-         let p =
+         (
+           (
+             s: string,
+             optional_persisent: option(CellEditor.Model.persistent),
+           ),
+         ) => {
+         (
+           s,
            switch (optional_persisent) {
            | Some(persistent) => persistent
            | None =>
-             Init.startup.documentation
-             |> snd
-             |> List.find(((name, _)) => name == s)
-             |> snd
-           };
-         (s, p);
+             switch (Init.find_documentation_slide(s)) {
+             | Some(x) => x
+             | None => Init.empty_cell_editor_persistent()
+             }
+           },
+         )
        })
     |> List.map(((name, persistent)) => {
          let cell_model =

--- a/src/web/app/helpful-assistant/prompts/InitPrompts.re
+++ b/src/web/app/helpful-assistant/prompts/InitPrompts.re
@@ -15,11 +15,7 @@ let get_documentation_as_text = () => {
            s,
            switch (optional_persistent) {
            | Some(persistent) => persistent
-           | None =>
-             switch (Init.find_documentation_slide(s)) {
-             | Some(x) => x
-             | None => Init.empty_cell_editor_persistent()
-             }
+           | None => Init.default_documentation_slide_name(s)
            },
          )
        })

--- a/src/web/app/helpful-assistant/prompts/InitPrompts.re
+++ b/src/web/app/helpful-assistant/prompts/InitPrompts.re
@@ -4,19 +4,13 @@ let get_documentation_as_text = () => {
   let (_, slides) = ScratchMode.StoreDocumentation.load();
   let documentation =
     slides
-    |> List.map(
-         (
-           (
-             s: string,
-             optional_persistent: option(CellEditor.Model.persistent),
-           ),
-         ) => {
+    |> List.map(((s, optional_persistent)) => {
          (
            s,
-           switch (optional_persistent) {
-           | Some(persistent) => persistent
-           | None => Init.default_documentation_slide_name(s)
-           },
+           OptUtil.get(
+             () => Init.default_documentation_slide_name(s),
+             optional_persistent,
+           ),
          )
        })
     |> List.map(((name, persistent)) => {

--- a/src/web/app/helpful-assistant/prompts/InitPrompts.re
+++ b/src/web/app/helpful-assistant/prompts/InitPrompts.re
@@ -8,12 +8,12 @@ let get_documentation_as_text = () => {
          (
            (
              s: string,
-             optional_persisent: option(CellEditor.Model.persistent),
+             optional_persistent: option(CellEditor.Model.persistent),
            ),
          ) => {
          (
            s,
-           switch (optional_persisent) {
+           switch (optional_persistent) {
            | Some(persistent) => persistent
            | None =>
              switch (Init.find_documentation_slide(s)) {

--- a/src/web/init/Init.re
+++ b/src/web/init/Init.re
@@ -1,4 +1,5 @@
 open Haz3lcore;
+open Util;
 
 let empty_cell_editor_persistent: unit => CellEditor.Model.persistent =
   () => {
@@ -53,8 +54,8 @@ let find_documentation_slide = (name: string) => {
 
 let default_documentation_slide_name =
     (name: string): CellEditor.Model.persistent => {
-  switch (find_documentation_slide(name)) {
-  | Some(x) => x
-  | None => empty_cell_editor_persistent()
-  };
+  OptUtil.get(
+    () => empty_cell_editor_persistent(),
+    find_documentation_slide(name),
+  );
 };

--- a/src/web/init/Init.re
+++ b/src/web/init/Init.re
@@ -50,3 +50,11 @@ let find_documentation_slide = (name: string) => {
   |> List.find_opt(((n, _)) => n == name)
   |> Option.map(snd);
 };
+
+let default_documentation_slide_name =
+    (name: string): CellEditor.Model.persistent => {
+  switch (find_documentation_slide(name)) {
+  | Some(x) => x
+  | None => empty_cell_editor_persistent()
+  };
+};

--- a/src/web/init/Init.re
+++ b/src/web/init/Init.re
@@ -1,18 +1,13 @@
 open Haz3lcore;
 
+let empty_cell_editor_persistent: unit => CellEditor.Model.persistent =
+  () => {
+    editor: Zipper.init() |> PersistentZipper.persist,
+    result: EvalResult.Model.init |> EvalResult.Model.persist,
+  };
+
 let startup: PersistentData.t = {
-  scratch: (
-    0,
-    [
-      (
-        "Scratchpad 1",
-        {
-          editor: Zipper.init() |> PersistentZipper.persist,
-          result: EvalResult.Model.init |> EvalResult.Model.persist,
-        },
-      ),
-    ],
-  ),
+  scratch: (0, [("Scratchpad 1", empty_cell_editor_persistent())]),
   documentation: (
     0,
     [
@@ -47,4 +42,11 @@ let startup: PersistentData.t = {
          )
        ),
   ),
+};
+
+let find_documentation_slide = (name: string) => {
+  startup.documentation
+  |> snd
+  |> List.find_opt(((n, _)) => n == name)
+  |> Option.map(snd);
 };

--- a/src/web/view/ScratchMode.re
+++ b/src/web/view/ScratchMode.re
@@ -11,21 +11,59 @@ module Model = {
   };
 
   [@deriving (show({with_path: false}), sexp, yojson)]
-  type persistent = (int, list((string, CellEditor.Model.persistent)));
+  type persistent = (
+    int,
+    list((string, option(CellEditor.Model.persistent))),
+  );
 
-  let persist = model => (
+  let persist = (model: t): persistent => (
     model.current,
     List.map(
-      ((s, m)) => (s, CellEditor.Model.persist(m)),
+      ((s, m): (string, CellEditor.Model.t)) => {
+        let persisted: CellEditor.Model.persistent =
+          CellEditor.Model.persist(m);
+        let init_version: option(CellEditor.Model.persistent) =
+          Init.startup.documentation
+          |> snd
+          |> List.find_opt(((name, _)) => name == s)
+          |> Option.map(snd);
+
+        // Consider ignoring ids and/or caret position
+        if (Some(persisted) == init_version) {
+          print_endline(
+            "Not persisting scratchpad "
+            ++ s
+            ++ " because it matches the initial version.",
+          );
+          (s, None);
+        } else {
+          print_endline("Persisting scratchpad " ++ s ++ ".");
+          (s, Some(persisted));
+        };
+      },
       model.scratchpads,
     ),
   );
 
-  let unpersist = (~settings, (current, slides)) => {
+  let unpersist = (~settings, (current, slides): persistent): t => {
     current,
     scratchpads:
       List.map(
-        ((s, m)) => (s, CellEditor.Model.unpersist(~settings, m)),
+        ((s: string, m: option(CellEditor.Model.persistent))) =>
+          (
+            s,
+            {
+              switch (Option.map(CellEditor.Model.unpersist(~settings), m)) {
+              | Some(x) => x
+              | None =>
+                Init.startup.documentation
+                |> snd
+                |> List.find(((name, _)) => name == s)
+                |> snd
+                |> CellEditor.Model.unpersist(~settings)
+              };
+            },
+          ),
         slides,
       ),
   };
@@ -36,7 +74,9 @@ module StoreDocumentation =
     [@deriving (show({with_path: false}), sexp, yojson)]
     type t = Model.persistent;
     let key = Store.Documentation;
-    let default = () => Init.startup.documentation;
+    let default = (): t =>
+      Init.startup.documentation
+      |> PairUtil.map_snd(List.map(PairUtil.map_snd(_ => None)));
   });
 
 module Store = {
@@ -44,7 +84,9 @@ module Store = {
     [@deriving (show({with_path: false}), sexp, yojson)]
     type t = Model.persistent;
     let key = Store.Scratch;
-    let default = () => Init.startup.scratch;
+    let default = () =>
+      Init.startup.documentation
+      |> PairUtil.map_snd(List.map(PairUtil.map_snd(x => Some(x))));
   });
 
   let integrate_share = (model: t): t => {
@@ -66,7 +108,10 @@ module Store = {
         result: EvalResult.Model.init |> EvalResult.Model.persist,
       };
 
-      (List.length(scratchpads), scratchpads @ [(share_name, shared)]);
+      (
+        List.length(scratchpads),
+        scratchpads @ [(share_name, Some(shared))],
+      );
     };
   };
 };

--- a/src/web/view/ScratchMode.re
+++ b/src/web/view/ScratchMode.re
@@ -19,21 +19,24 @@ module Model = {
   let persist = (model: t): persistent => (
     model.current,
     List.map(
-      ((s, m): (string, CellEditor.Model.t)) => {
-        let current: CellEditor.Model.persistent =
-          CellEditor.Model.persist(m);
+      ((s: string, m: CellEditor.Model.t)) => {
+        let current_segment = Zipper.zip(m.editor.editor.state.zipper);
+        let original = Init.find_documentation_slide(s);
+        let original_segment =
+          original
+          |> Option.map((pce: CellEditor.Model.persistent) =>
+               PersistentZipper.unpersist(pce.editor)
+             )
+          |> Option.map(Zipper.zip);
 
-        // Consider ignoring ids and/or caret position
-        if (Some(current) == Init.find_documentation_slide(s)) {
-          print_endline(
-            "Not persisting scratchpad "
-            ++ s
-            ++ " because it matches the initial version.",
-          );
+        if (Option.equal(
+              Base.equal_segment,
+              original_segment,
+              Some(current_segment),
+            )) {
           (s, None);
         } else {
-          print_endline("Persisting scratchpad " ++ s ++ ".");
-          (s, Some(current));
+          (s, Some(CellEditor.Model.persist(m)));
         };
       },
       model.scratchpads,

--- a/src/web/view/ScratchMode.re
+++ b/src/web/view/ScratchMode.re
@@ -20,16 +20,11 @@ module Model = {
     model.current,
     List.map(
       ((s, m): (string, CellEditor.Model.t)) => {
-        let persisted: CellEditor.Model.persistent =
+        let current: CellEditor.Model.persistent =
           CellEditor.Model.persist(m);
-        let init_version: option(CellEditor.Model.persistent) =
-          Init.startup.documentation
-          |> snd
-          |> List.find_opt(((name, _)) => name == s)
-          |> Option.map(snd);
 
         // Consider ignoring ids and/or caret position
-        if (Some(persisted) == init_version) {
+        if (Some(current) == Init.find_documentation_slide(s)) {
           print_endline(
             "Not persisting scratchpad "
             ++ s
@@ -38,7 +33,7 @@ module Model = {
           (s, None);
         } else {
           print_endline("Persisting scratchpad " ++ s ++ ".");
-          (s, Some(persisted));
+          (s, Some(current));
         };
       },
       model.scratchpads,
@@ -56,11 +51,15 @@ module Model = {
               switch (Option.map(CellEditor.Model.unpersist(~settings), m)) {
               | Some(x) => x
               | None =>
-                Init.startup.documentation
-                |> snd
-                |> List.find(((name, _)) => name == s)
-                |> snd
-                |> CellEditor.Model.unpersist(~settings)
+                let default = Init.find_documentation_slide(s);
+
+                CellEditor.Model.unpersist(
+                  ~settings,
+                  switch (default) {
+                  | Some(x) => x
+                  | None => Init.empty_cell_editor_persistent()
+                  },
+                );
               };
             },
           ),

--- a/src/web/view/ScratchMode.re
+++ b/src/web/view/ScratchMode.re
@@ -288,10 +288,10 @@ module Update = {
           CellEditor.Model.mk(Editor.Model.mk(Zipper.init()))
           |> CellEditor.Model.persist
         | true =>
-          Init.startup.documentation
-          |> snd
-          |> List.map(snd)
-          |> List.nth(_, model.current)
+          switch (Init.find_documentation_slide(key)) {
+          | Some(x) => x
+          | None => Init.empty_cell_editor_persistent()
+          }
         };
       let* data =
         source

--- a/src/web/view/ScratchMode.re
+++ b/src/web/view/ScratchMode.re
@@ -50,16 +50,8 @@ module Model = {
         ((s: string, m: option(CellEditor.Model.persistent))) =>
           (
             s,
-            {
-              switch (Option.map(CellEditor.Model.unpersist(~settings), m)) {
-              | Some(x) => x
-              | None =>
-                CellEditor.Model.unpersist(
-                  ~settings,
-                  Init.default_documentation_slide_name(s),
-                )
-              };
-            },
+            OptUtil.get(() => Init.default_documentation_slide_name(s), m)
+            |> CellEditor.Model.unpersist(~settings),
           ),
         slides,
       ),

--- a/src/web/view/ScratchMode.re
+++ b/src/web/view/ScratchMode.re
@@ -54,15 +54,10 @@ module Model = {
               switch (Option.map(CellEditor.Model.unpersist(~settings), m)) {
               | Some(x) => x
               | None =>
-                let default = Init.find_documentation_slide(s);
-
                 CellEditor.Model.unpersist(
                   ~settings,
-                  switch (default) {
-                  | Some(x) => x
-                  | None => Init.empty_cell_editor_persistent()
-                  },
-                );
+                  Init.default_documentation_slide_name(s),
+                )
               };
             },
           ),
@@ -290,11 +285,7 @@ module Update = {
         | false =>
           CellEditor.Model.mk(Editor.Model.mk(Zipper.init()))
           |> CellEditor.Model.persist
-        | true =>
-          switch (Init.find_documentation_slide(key)) {
-          | Some(x) => x
-          | None => Init.empty_cell_editor_persistent()
-          }
+        | true => Init.default_documentation_slide_name(key)
         };
       let* data =
         source

--- a/src/web/view/ScratchMode.re
+++ b/src/web/view/ScratchMode.re
@@ -87,7 +87,7 @@ module Store = {
     type t = Model.persistent;
     let key = Store.Scratch;
     let default = () =>
-      Init.startup.documentation
+      Init.startup.scratch
       |> PairUtil.map_snd(List.map(PairUtil.map_snd(x => Some(x))));
   });
 


### PR DESCRIPTION
Closes #1904 

## Overview

This PR refines the persistence logic for documentation slides in Hazel. Instead of persisting all slides, we now only persist slides that have been modified by the user. Slides that remain unchanged from the initial shipped versions in `Init.re` are not saved in the browser.

## Changes

- Slides are matched with the initial versions using their names.
- Unmodified slides are identified by comparing the current slide’s segment structure (excluding IDs and caret position) with the initial version.
  - We use the `Segment` structure instead of the `Zipper` so that caret position and IDs are ignored in the comparison.
- Only modified slides are persisted; unmodified slides are omitted from client-side storage.
- The "Reset Current Slide" button now resets based on the slide’s name rather than its position. (Previously, there was a bug where a slide could reset to a different one based on position.)

## Rationale

This change directly addresses [Quota Exceeded when many documentation slides are added](https://github.com/hazelgrove/hazel/issues/1899), an issue where storing too many slides in browser localStorage exceeded the 5MB quota, causing exceptions in Firefox and Chrome.

Key points:
- **Persistence Limit Avoidance:** By skipping unmodified slides, we reduce storage demand and help avoid hitting browser quotas.
- **Accurate Slide Updates:** The equality check uses segment-wise comparison (ignoring IDs and caret position) to ensure only meaningful changes trigger persistence. We compare the current slide against the shipped initial version in the codebase.
- **Default Slide Updates:** Because default/initial slides are not persisted unless modified, any updates to them in the codebase will automatically appear for users (unless they have previously modified the slide).
- **Efficient Storage:** Persisting only what’s necessary keeps browser storage lean.
