### PR TITLE
allowed partial matches in pattern matching

### DIFF
--- a/src/language/dynamics/Substitution.re
+++ b/src/language/dynamics/Substitution.re
@@ -22,6 +22,97 @@ let rec binds_var = (x: Var.t, dp: DHPat.t): bool =>
     List.fold_left((||), false, new_list);
   | Ap(_, _) => false
   };
+let rec expr_contains_var = (d: DHExp.t, x: Var.t): bool => {
+  let (term, _) = DHExp.unwrap(d);
+  switch (term) {
+  | Var(y) => Var.equal(x, y)
+  | Invalid(_) => false
+  | Undefined => false
+  | Seq(d3, d4) => expr_contains_var(d3, x) || expr_contains_var(d4, x)
+  | Filter(_, _) =>
+    //unimplemented
+    false
+  | Let(dp, d3, d4) =>
+    if (expr_contains_var(d3, x)) {
+      true;
+    } else if (binds_var(x, dp)) {
+      false;
+    } else {
+      expr_contains_var(d4, x);
+    }
+  | FixF(_, _, _) =>
+    //unimplemnted
+    false
+  | Fun(dp, d3, _, _) =>
+    if (binds_var(x, dp)) {
+      false;
+    } else {
+      expr_contains_var(d3, x);
+    }
+  | TypFun(_, d3, _) => expr_contains_var(d3, x)
+  | Closure(_, d3) =>
+    /* Closure shouldn't appear during substitution (which
+       only is called from elaboration currently) */
+    expr_contains_var(d3, x)
+  | Ap(_, d3, d4) => expr_contains_var(d3, x) || expr_contains_var(d4, x)
+  | BuiltinFun(_) => false
+  | Test(d)
+  | HintedTest(d, _) => expr_contains_var(d, x)
+  | Atom(_)
+  | Label(_)
+  | LivelitName(_)
+  | Constructor(_) => false
+  | ListLit(ds) =>
+    List.fold_left((acc, d) => acc || expr_contains_var(d, x), false, ds)
+  | Cons(d3, d4) => expr_contains_var(d3, x) || expr_contains_var(d4, x)
+  | ListConcat(d3, d4) =>
+    expr_contains_var(d3, x) || expr_contains_var(d4, x)
+  | TupLabel(_, d) => expr_contains_var(d, x)
+  | Dot(d3, d4) => expr_contains_var(d3, x) || expr_contains_var(d4, x)
+  | Tuple(ds) =>
+    List.fold_left((acc, d) => acc || expr_contains_var(d, x), false, ds)
+  | TupleExtension(d3, d4) =>
+    expr_contains_var(d3, x) || expr_contains_var(d4, x)
+  | UnOp(_, d3) => expr_contains_var(d3, x)
+  | BinOp(_, d3, d4) => expr_contains_var(d3, x) || expr_contains_var(d4, x)
+  | Match(_, _) => false
+  /* Unimplemented
+     let ds = subst_var(d1, x, ds);
+     let rules =
+       List.map(
+         ((p, v)) =>
+           if (binds_var(x, p)) {
+             (p, v);
+           } else {
+             (p, subst_var(d1, x, v));
+           },
+         rules,
+       );
+     Match(ds, rules) |> rewrap;*/
+  | EmptyHole => false
+  // TODO: handle multihole
+  | MultiHole(_d2) => false //MultiHole(List.map(subst_var(m, d1, x), ds)) |> rewrap
+  | Asc(d, _) => expr_contains_var(d, x)
+  | DynamicErrorHole(d, _) => expr_contains_var(d, x)
+  | If(d4, d5, d6) =>
+    expr_contains_var(d4, x)
+    || expr_contains_var(d5, x)
+    || expr_contains_var(d6, x)
+  | TyAlias(_, _, d4) => expr_contains_var(d4, x)
+  | Use(_, d) => expr_contains_var(d, x)
+  | Parens(d4) => expr_contains_var(d4, x)
+  | Probe(d4, _) => expr_contains_var(d4, x)
+  | Deferral(_) => false
+  | DeferredAp(d3, d4s) =>
+    expr_contains_var(d3, x)
+    || List.fold_left(
+         (acc, d) => acc || expr_contains_var(d, x),
+         false,
+         d4s,
+       )
+  | TypAp(d3, _) => expr_contains_var(d3, x)
+  };
+};
 
 /* closed substitution [d1/x]d2 */
 let rec subst_var = (d1: DHExp.t, x: Var.t, d2: DHExp.t): DHExp.t => {

--- a/src/language/dynamics/transition/PatternMatch.re
+++ b/src/language/dynamics/transition/PatternMatch.re
@@ -12,9 +12,25 @@ let combine_result = (r1: match_result, r2: match_result): match_result =>
     Matches(Environment.union(env1, env2))
   };
 
-let rec matches = (capture, dp: Pat.t, d: DHExp.t): match_result => {
-  let matches = matches(capture);
+let combine_partial_result =
+    (r1: match_result, r2: match_result): match_result =>
+  switch (r1, r2) {
+  | (DoesNotMatch, DoesNotMatch)
+  | (IndetMatch, DoesNotMatch)
+  | (DoesNotMatch, IndetMatch) => DoesNotMatch
+  | (IndetMatch, IndetMatch) => IndetMatch
+  | (Matches(env1), Matches(env2)) =>
+    Matches(Environment.union(env1, env2))
+  | (Matches(env), _) => Matches(env)
+  | (_, Matches(env)) => Matches(env)
+  };
+let rec matches =
+        (~force_partial_match=?, capture, dp: Pat.t, d: DHExp.t): match_result => {
+  let matches = matches(capture, ~force_partial_match?);
   let d = Ascriptions.transition_multiple(d);
+  let combine_result =
+    Option.is_none(force_partial_match)
+      ? combine_result : combine_partial_result;
   switch (DHPat.term_of(dp)) {
   | Invalid(_)
   | EmptyHole
@@ -70,7 +86,8 @@ type matches_and_closures = {
   closures: closure_closures,
 };
 
-let matches = (dp: Pat.t, d: DHExp.t): matches_and_closures => {
+let matches =
+    (~force_partial_match=?, dp: Pat.t, d: DHExp.t): matches_and_closures => {
   /* Closure capture for Probe instrumentation */
   let closure_closures: ref(closure_closures) = ref([]);
   let capture =
@@ -86,7 +103,8 @@ let matches = (dp: Pat.t, d: DHExp.t): matches_and_closures => {
           closure_closures^,
         )
     };
-  let res = matches(capture, dp, d);
+  let res = matches(capture, dp, d, ~force_partial_match?);
+  print_endline("MATCH RESULT: " ++ show_match_result(res));
   {
     matches: res,
     closures: closure_closures^,

--- a/src/language/dynamics/transition/PatternMatch.re
+++ b/src/language/dynamics/transition/PatternMatch.re
@@ -41,9 +41,17 @@ let rec matches =
     let* d' = Unboxing.unbox(Atom(kind), d);
     value == d' ? Matches(Environment.empty) : DoesNotMatch;
   | ListLit(xs) =>
-    let* s' = Unboxing.unbox(ListLitn(List.length(xs)), d);
-    List.map2(matches, xs, s')
-    |> List.fold_left(combine_result, Matches(Environment.empty));
+    switch (d |> DHExp.term_of) {
+    | EmptyHole when force_partial_match == Some(true) =>
+      let* ds =
+        Matches(List.init(List.length(xs), _ => EmptyHole |> DHExp.fresh));
+      List.map2(matches, xs, ds)
+      |> List.fold_left(combine_result, Matches(Environment.empty));
+    | _ =>
+      let* s' = Unboxing.unbox(ListLitn(List.length(xs)), d);
+      List.map2(matches, xs, s')
+      |> List.fold_left(combine_result, Matches(Environment.empty));
+    }
   | Cons(x, xs) =>
     let* (x', xs') = Unboxing.unbox(Cons, d);
     let* m_x = matches(x, x');

--- a/src/language/dynamics/transition/PatternMatch.re
+++ b/src/language/dynamics/transition/PatternMatch.re
@@ -66,9 +66,17 @@ let rec matches =
     let* x' = Unboxing.unbox(TupLabel(dp), d);
     matches(x, x');
   | Tuple(ps) =>
-    let* ds = Unboxing.unbox(Tuple(List.length(ps)), d);
-    List.map2(matches, ps, ds)
-    |> List.fold_left(combine_result, Matches(Environment.empty));
+    switch (d |> DHExp.term_of) {
+    | EmptyHole when force_partial_match == Some(true) =>
+      let* ds =
+        Matches(List.init(List.length(ps), _ => EmptyHole |> DHExp.fresh));
+      List.map2(matches, ps, ds)
+      |> List.fold_left(combine_result, Matches(Environment.empty));
+    | _ =>
+      let* ds = Unboxing.unbox(Tuple(List.length(ps)), d);
+      List.map2(matches, ps, ds)
+      |> List.fold_left(combine_result, Matches(Environment.empty));
+    }
   | Parens(p) => matches(p, d)
   | Probe(p, pr) =>
     let inner_match = matches(p, d);
@@ -89,6 +97,9 @@ type matches_and_closures = {
 let matches =
     (~force_partial_match=?, dp: Pat.t, d: DHExp.t): matches_and_closures => {
   /* Closure capture for Probe instrumentation */
+  if (force_partial_match == Some(true)) {
+    print_endline("Indet match -> partial pattern match");
+  };
   let closure_closures: ref(closure_closures) = ref([]);
   let capture =
       (pr: Probe.t, dp: Term.Pat.t, d: DHExp.t, inner_match: match_result)

--- a/src/language/dynamics/transition/PatternMatch.re
+++ b/src/language/dynamics/transition/PatternMatch.re
@@ -104,7 +104,6 @@ let matches =
         )
     };
   let res = matches(capture, dp, d, ~force_partial_match?);
-  print_endline("MATCH RESULT: " ++ show_match_result(res));
   {
     matches: res,
     closures: closure_closures^,

--- a/src/language/dynamics/transition/PatternMatch.re
+++ b/src/language/dynamics/transition/PatternMatch.re
@@ -94,6 +94,59 @@ let rec matches =
     matches(p, Ascriptions.transition_multiple(Asc(d, t1) |> DHExp.fresh))
   };
 };
+let rec failed_matches = (dp: Pat.t, d: DHExp.t): list(string) => {
+  let d = Ascriptions.transition_multiple(d);
+  switch (DHPat.term_of(dp)) {
+  | Invalid(_)
+  | EmptyHole
+  | MultiHole(_)
+  | Wild
+  | Atom(_) => []
+  | ListLit(xs) =>
+    switch (d |> DHExp.term_of) {
+    | EmptyHole => Pat.bound_vars(dp)
+    | _ =>
+      let s' = Unboxing.unbox(ListLitn(List.length(xs)), d);
+      switch (s') {
+      | DoesNotMatch
+      | IndetMatch => []
+      | Matches(s') =>
+        List.map2(failed_matches, xs, s')
+        |> List.fold_left((a, b) => a @ b, [])
+      };
+    }
+  | Cons(_, _) =>
+    //TODO: Implement all of these cases
+    []
+  | Constructor(_, _) => []
+  | Ap({term: Constructor(_, _), _}, _) => []
+  | Ap(_, _) => []
+  | Var(_) => []
+  /* Labels are a special case */
+  | Label(_) => []
+  | TupLabel(_, _) => []
+  | Tuple(ps) =>
+    switch (d |> DHExp.term_of) {
+    | EmptyHole => Pat.bound_vars(dp)
+    | _ =>
+      let s' = Unboxing.unbox(Tuple(List.length(ps)), d);
+      switch (s') {
+      | DoesNotMatch
+      | IndetMatch => []
+      | Matches(s') =>
+        List.map2(failed_matches, ps, s')
+        |> List.fold_left((a, b) => a @ b, [])
+      };
+    }
+  | Parens(p) => failed_matches(p, d)
+  | Probe(p, _) => failed_matches(p, d)
+  | Asc(p, t1) =>
+    failed_matches(
+      p,
+      Ascriptions.transition_multiple(Asc(d, t1) |> DHExp.fresh),
+    )
+  };
+};
 
 type closure_closures = list(Probe.call_stack => Dynamics.Probe.Closure.t);
 

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -263,6 +263,23 @@ module Transition = (EV: EV_MODE) => {
             closures,
           };
       // If no matches found in let expression body, just say indeterminate match
+      let matches' =
+        switch (matches') {
+        | DoesNotMatch => Unboxing.DoesNotMatch
+        | IndetMatch => Unboxing.IndetMatch
+        | Matches(env) =>
+          let matches_in_body =
+            List.fold_left(
+              (acc, v) => acc || Substitution.expr_contains_var(d2, v),
+              false,
+              VarBstMap.Ordered.to_listo(env) |> List.map(((var, _)) => var),
+            );
+          if (matches_in_body) {
+            Matches(env);
+          } else {
+            IndetMatch;
+          };
+        };
       // Else, find vars in dp that couldn't match in d1 (aren't in matches')
       let failed_matches =
         switch (matches') {

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -48,7 +48,7 @@ open PatternMatch;
 [@deriving (show({with_path: false}), sexp, yojson)]
 type step_kind =
   | InvalidStep
-  | PartialStep(list(string))
+  | PartialStep(step_kind, list(string))
   | VarLookup
   | Seq
   | LetBind(string)
@@ -281,7 +281,9 @@ module Transition = (EV: EV_MODE) => {
         expr: subst_env(env', d2),
         state_update: capture_closures(env, state, closures),
         kind:
-          force_match ? PartialStep(failed_matches) : LetBind(matches_str),
+          force_match
+            ? PartialStep(LetBind(matches_str), failed_matches)
+            : LetBind(matches_str),
         is_value: false,
       });
     | TypFun(_)
@@ -445,8 +447,29 @@ module Transition = (EV: EV_MODE) => {
         | FunEnv(dp, d3, function_lexical_env) =>
           let matches' = matches(dp, d2');
           switch (matches'.matches) {
-          | DoesNotMatch
-          | IndetMatch => Indet
+          | DoesNotMatch => Indet
+          | IndetMatch =>
+            let partial_matches = matches(~force_partial_match=true, dp, d2');
+            let failed_matches = failed_matches(dp, d2');
+            switch (partial_matches.matches) {
+            | IndetMatch
+            | DoesNotMatch => Indet
+            | Matches(function_arg_env) =>
+              let env'' =
+                evaluate_extend_env(
+                  ~ap_id=Term.Exp.rep_id(d),
+                  ~call_stack=env.call_stack,
+                  function_arg_env,
+                  function_lexical_env,
+                );
+              Step({
+                expr: subst_env(env'', d3),
+                state_update:
+                  capture_closures(env'', state, matches'.closures),
+                kind: PartialStep(FunAp, failed_matches),
+                is_value: false,
+              });
+            };
           | Matches(function_arg_env) =>
             let env'' =
               evaluate_extend_env(
@@ -484,7 +507,7 @@ module Transition = (EV: EV_MODE) => {
                     state,
                     matches'.closures,
                   ),
-                kind: PartialStep(failed_matches),
+                kind: PartialStep(FunAp, failed_matches),
                 is_value: false,
               })
             };
@@ -1049,11 +1072,12 @@ let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
   | MarkIncomparable
   | RemoveParens => true;
 
-let stepper_justification: step_kind => string =
+let rec stepper_justification: step_kind => string =
   fun
   | LetBind(s) => String.cat("substitution for ", s)
-  | PartialStep(failed_matches) =>
-    "partial pattern match (failed to match: "
+  | PartialStep(step, failed_matches) =>
+    stepper_justification(step)
+    ++ " (failed to match: "
     ++ String.concat(", ", failed_matches)
     ++ ")"
   | Seq => "sequence"

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -48,6 +48,7 @@ open PatternMatch;
 [@deriving (show({with_path: false}), sexp, yojson)]
 type step_kind =
   | InvalidStep
+  | PartialStep
   | VarLookup
   | Seq
   | LetBind(string)
@@ -252,9 +253,17 @@ module Transition = (EV: EV_MODE) => {
       and. d1' =
         req_final(req(state, env), d1 => Let1(dp, d1, d2) |> wrap_ctx, d1);
       let.wrap_closure _ = env;
-      let {matches, closures} = matches(~force_partial_match=true, dp, d1');
+      let {matches: matches', closures} = matches(dp, d1');
+      let force_match = matches' == IndetMatch;
+      let {matches: matches', closures} =
+        force_match
+          ? matches(~force_partial_match=true, dp, d1')
+          : {
+            matches: matches',
+            closures,
+          };
       let matches_str = {
-        switch (matches) {
+        switch (matches') {
         | IndetMatch
         | DoesNotMatch => ""
         | Matches(env) =>
@@ -264,11 +273,11 @@ module Transition = (EV: EV_MODE) => {
           |> String.concat(", ")
         };
       };
-      let.match env' = (env, matches, env.call_stack);
+      let.match env' = (env, matches', env.call_stack);
       Step({
         expr: subst_env(env', d2),
         state_update: capture_closures(env, state, closures),
-        kind: LetBind(matches_str),
+        kind: force_match ? PartialStep : LetBind(matches_str),
         is_value: false,
       });
     | TypFun(_)
@@ -983,6 +992,7 @@ let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
   | LetBind(_)
   | Seq
   | UpdateTest
+  | PartialStep
   | TypFunAp
   | FunAp
   | DeferredAp
@@ -1015,6 +1025,7 @@ let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
 let stepper_justification: step_kind => string =
   fun
   | LetBind(s) => String.cat("substitution for ", s)
+  | PartialStep => "Partial pattern match"
   | Seq => "sequence"
   | FixUnwrap => "unroll fixpoint"
   | UpdateTest => "update test"

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -252,7 +252,7 @@ module Transition = (EV: EV_MODE) => {
       and. d1' =
         req_final(req(state, env), d1 => Let1(dp, d1, d2) |> wrap_ctx, d1);
       let.wrap_closure _ = env;
-      let {matches, closures} = matches(dp, d1');
+      let {matches, closures} = matches(~force_partial_match=true, dp, d1');
       let matches_str = {
         switch (matches) {
         | IndetMatch

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -48,7 +48,7 @@ open PatternMatch;
 [@deriving (show({with_path: false}), sexp, yojson)]
 type step_kind =
   | InvalidStep
-  | PartialStep
+  | PartialStep(list(string))
   | VarLookup
   | Seq
   | LetBind(string)
@@ -262,6 +262,17 @@ module Transition = (EV: EV_MODE) => {
             matches: matches',
             closures,
           };
+      // If no matches found in let expression body, just say indeterminate match
+      // Else, find vars in dp that couldn't match in d1 (aren't in matches')
+      let failed_matches =
+        switch (matches') {
+        | IndetMatch
+        | DoesNotMatch => []
+        | Matches(env) =>
+          Pat.bound_vars(dp)
+          |> List.filter(x => !VarBstMap.Ordered.contains(env, x))
+        };
+      List.iter(print_endline, failed_matches);
       let matches_str = {
         switch (matches') {
         | IndetMatch
@@ -277,7 +288,8 @@ module Transition = (EV: EV_MODE) => {
       Step({
         expr: subst_env(env', d2),
         state_update: capture_closures(env, state, closures),
-        kind: force_match ? PartialStep : LetBind(matches_str),
+        kind:
+          force_match ? PartialStep(failed_matches) : LetBind(matches_str),
         is_value: false,
       });
     | TypFun(_)
@@ -992,7 +1004,7 @@ let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
   | LetBind(_)
   | Seq
   | UpdateTest
-  | PartialStep
+  | PartialStep(_)
   | TypFunAp
   | FunAp
   | DeferredAp
@@ -1025,7 +1037,10 @@ let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
 let stepper_justification: step_kind => string =
   fun
   | LetBind(s) => String.cat("substitution for ", s)
-  | PartialStep => "Partial pattern match"
+  | PartialStep(failed_matches) =>
+    "partial pattern match (failed to match: "
+    ++ String.concat(", ", failed_matches)
+    ++ ")"
   | Seq => "sequence"
   | FixUnwrap => "unroll fixpoint"
   | UpdateTest => "update test"

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -264,22 +264,27 @@ module Transition = (EV: EV_MODE) => {
           };
       // If no matches found in let expression body, just say indeterminate match
       let matches' =
-        switch (matches') {
-        | DoesNotMatch => Unboxing.DoesNotMatch
-        | IndetMatch => Unboxing.IndetMatch
-        | Matches(env) =>
-          let matches_in_body =
-            List.fold_left(
-              (acc, v) => acc || Substitution.expr_contains_var(d2, v),
-              false,
-              VarBstMap.Ordered.to_listo(env) |> List.map(((var, _)) => var),
-            );
-          if (matches_in_body) {
-            Matches(env);
-          } else {
-            IndetMatch;
-          };
-        };
+        !force_match
+          ? matches'
+          : (
+            switch (matches') {
+            | DoesNotMatch => Unboxing.DoesNotMatch
+            | IndetMatch => Unboxing.IndetMatch
+            | Matches(env) =>
+              let matches_in_body =
+                List.fold_left(
+                  (acc, v) => acc || Substitution.expr_contains_var(d2, v),
+                  false,
+                  VarBstMap.Ordered.to_listo(env)
+                  |> List.map(((var, _)) => var),
+                );
+              if (matches_in_body) {
+                Matches(env);
+              } else {
+                IndetMatch;
+              };
+            }
+          );
       // Else, find vars in dp that couldn't match in d1 (aren't in matches')
       let failed_matches =
         switch (matches') {

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -255,6 +255,7 @@ module Transition = (EV: EV_MODE) => {
       let.wrap_closure _ = env;
       let {matches: matches', closures} = matches(dp, d1');
       let force_match = matches' == IndetMatch;
+      let failed_matches = failed_matches(dp, d1');
       let {matches: matches', closures} =
         force_match
           ? matches(~force_partial_match=true, dp, d1')
@@ -262,38 +263,8 @@ module Transition = (EV: EV_MODE) => {
             matches: matches',
             closures,
           };
-      // If no matches found in let expression body, just say indeterminate match
-      let matches' =
-        !force_match
-          ? matches'
-          : (
-            switch (matches') {
-            | DoesNotMatch => Unboxing.DoesNotMatch
-            | IndetMatch => Unboxing.IndetMatch
-            | Matches(env) =>
-              let matches_in_body =
-                List.fold_left(
-                  (acc, v) => acc || Substitution.expr_contains_var(d2, v),
-                  false,
-                  VarBstMap.Ordered.to_listo(env)
-                  |> List.map(((var, _)) => var),
-                );
-              if (matches_in_body) {
-                Matches(env);
-              } else {
-                IndetMatch;
-              };
-            }
-          );
-      // Else, find vars in dp that couldn't match in d1 (aren't in matches')
-      let failed_matches =
-        switch (matches') {
-        | IndetMatch
-        | DoesNotMatch => []
-        | Matches(env) =>
-          Pat.bound_vars(dp)
-          |> List.filter(x => !VarBstMap.Ordered.contains(env, x))
-        };
+      // find vars in dp that couldn't match in d1 (aren't in matches')
+
       let matches_str = {
         switch (matches') {
         | IndetMatch
@@ -474,28 +445,8 @@ module Transition = (EV: EV_MODE) => {
         | FunEnv(dp, d3, function_lexical_env) =>
           let matches' = matches(dp, d2');
           switch (matches'.matches) {
-          | DoesNotMatch => Indet
-          | IndetMatch =>
-            let matches' = matches(~force_partial_match=true, dp, d2');
-            switch (matches'.matches) {
-            | IndetMatch
-            | DoesNotMatch => Indet
-            | Matches(function_arg_env) =>
-              let env'' =
-                evaluate_extend_env(
-                  ~ap_id=Term.Exp.rep_id(d),
-                  ~call_stack=env.call_stack,
-                  function_arg_env,
-                  function_lexical_env,
-                );
-              Step({
-                expr: subst_env(env'', d3),
-                state_update:
-                  capture_closures(env'', state, matches'.closures),
-                kind: PartialStep(["test"]),
-                is_value: false,
-              });
-            };
+          | DoesNotMatch
+          | IndetMatch => Indet
           | Matches(function_arg_env) =>
             let env'' =
               evaluate_extend_env(
@@ -516,16 +467,11 @@ module Transition = (EV: EV_MODE) => {
           switch (matches'.matches) {
           | IndetMatch =>
             let partial_matches = matches(~force_partial_match=true, dp, d2');
+            let failed_matches = failed_matches(dp, d2');
             switch (partial_matches.matches) {
             | IndetMatch
             | DoesNotMatch => Indet
             | Matches(function_arg_env) =>
-              let failed_matches =
-                switch (partial_matches.matches) {
-                | IndetMatch
-                | DoesNotMatch => []
-                | Matches(_) => ["placeholder"]
-                };
               Step({
                 expr:
                   subst_env(
@@ -540,7 +486,7 @@ module Transition = (EV: EV_MODE) => {
                   ),
                 kind: PartialStep(failed_matches),
                 is_value: false,
-              });
+              })
             };
 
           | DoesNotMatch => Indet

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -294,7 +294,6 @@ module Transition = (EV: EV_MODE) => {
           Pat.bound_vars(dp)
           |> List.filter(x => !VarBstMap.Ordered.contains(env, x))
         };
-      List.iter(print_endline, failed_matches);
       let matches_str = {
         switch (matches') {
         | IndetMatch
@@ -473,10 +472,30 @@ module Transition = (EV: EV_MODE) => {
         switch (unboxed_fun) {
         | Constructor(_) => Constructor
         | FunEnv(dp, d3, function_lexical_env) =>
-          let matches = matches(dp, d2');
-          switch (matches.matches) {
-          | IndetMatch
+          let matches' = matches(dp, d2');
+          switch (matches'.matches) {
           | DoesNotMatch => Indet
+          | IndetMatch =>
+            let matches' = matches(~force_partial_match=true, dp, d2');
+            switch (matches'.matches) {
+            | IndetMatch
+            | DoesNotMatch => Indet
+            | Matches(function_arg_env) =>
+              let env'' =
+                evaluate_extend_env(
+                  ~ap_id=Term.Exp.rep_id(d),
+                  ~call_stack=env.call_stack,
+                  function_arg_env,
+                  function_lexical_env,
+                );
+              Step({
+                expr: subst_env(env'', d3),
+                state_update:
+                  capture_closures(env'', state, matches'.closures),
+                kind: PartialStep(["test"]),
+                is_value: false,
+              });
+            };
           | Matches(function_arg_env) =>
             let env'' =
               evaluate_extend_env(
@@ -487,15 +506,43 @@ module Transition = (EV: EV_MODE) => {
               );
             Step({
               expr: subst_env(env'', d3),
-              state_update: capture_closures(env'', state, matches.closures),
+              state_update: capture_closures(env'', state, matches'.closures),
               kind: FunAp,
               is_value: false,
             });
           };
         | FunNoEnv(dp, d3) when mode == `Substitution =>
-          let matches = matches(dp, d2');
-          switch (matches.matches) {
-          | IndetMatch
+          let matches' = matches(dp, d2');
+          switch (matches'.matches) {
+          | IndetMatch =>
+            let partial_matches = matches(~force_partial_match=true, dp, d2');
+            switch (partial_matches.matches) {
+            | IndetMatch
+            | DoesNotMatch => Indet
+            | Matches(function_arg_env) =>
+              let failed_matches =
+                switch (partial_matches.matches) {
+                | IndetMatch
+                | DoesNotMatch => []
+                | Matches(_) => ["placeholder"]
+                };
+              Step({
+                expr:
+                  subst_env(
+                    function_arg_env |> ClosureEnvironment.of_environment,
+                    d3,
+                  ),
+                state_update:
+                  capture_closures(
+                    function_arg_env |> ClosureEnvironment.of_environment,
+                    state,
+                    matches'.closures,
+                  ),
+                kind: PartialStep(failed_matches),
+                is_value: false,
+              });
+            };
+
           | DoesNotMatch => Indet
           | Matches(function_arg_env) =>
             Step({
@@ -508,7 +555,7 @@ module Transition = (EV: EV_MODE) => {
                 capture_closures(
                   function_arg_env |> ClosureEnvironment.of_environment,
                   state,
-                  matches.closures,
+                  matches'.closures,
                 ),
               kind: FunAp,
               is_value: false,


### PR DESCRIPTION
instead of ```let (a,b,(c,d)) = (1,2,?) in
a``` resulting in an indeterminate match, it now allows a and b to match to 1 and 2.

<img width="988" height="227" alt="Screenshot 2025-08-28 at 5 42 30 PM" src="https://github.com/user-attachments/assets/8179bc5e-eec5-477f-954c-f15195eb497e" />
