### PR TITLE
run dynamics on startup

### DIFF
--- a/src/web/Main.re
+++ b/src/web/Main.re
@@ -57,7 +57,11 @@ let apply =
   // ---------- CALCULATE PHASE ----------
   let model' =
     updated.model
-    |> History.Update.calculate(~schedule_action, ~is_edited=updated.is_edit);
+    |> History.Update.calculate(
+         ~schedule_action,
+         ~is_edited=updated.is_edit,
+         ~dynamics=true,
+       );
 
   if (updated.is_edit) {
     schedule_autosave(
@@ -97,7 +101,11 @@ let start = {
         },
       ~default_model=
         History.Model.init()
-        |> History.Update.calculate(~schedule_action=_ => (), ~is_edited=true),
+        |> History.Update.calculate(
+             ~schedule_action=_ => (),
+             ~is_edited=true,
+             ~dynamics=false,
+           ),
       save_scheduler,
     );
 

--- a/src/web/app/History.re
+++ b/src/web/app/History.re
@@ -114,9 +114,16 @@ module Update = {
     };
 
   let calculate =
-      (~schedule_action: t => unit, ~is_edited: bool, model: Model.t): Model.t => {
+      (
+        ~schedule_action: t => unit,
+        ~is_edited: bool,
+        ~dynamics,
+        model: Model.t,
+      )
+      : Model.t => {
     current:
-      model.current |> Page.Update.calculate(~schedule_action, ~is_edited),
+      model.current
+      |> Page.Update.calculate(~schedule_action, ~is_edited, ~dynamics),
     undo_stack: model.undo_stack,
     redo_stack: model.redo_stack,
   };

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -312,10 +312,17 @@ module Update = {
     };
   };
 
-  let calculate = (~schedule_action, ~is_edited, model: Model.t) => {
+  let calculate =
+      (~schedule_action, ~is_edited, ~dynamics: bool, model: Model.t) => {
     let editors =
       Editors.Update.calculate(
-        ~settings=model.globals.settings.core,
+        ~settings=
+          dynamics
+            ? model.globals.settings.core
+            : {
+              ...model.globals.settings.core,
+              dynamics: false,
+            },
         ~schedule_action=a => schedule_action(Editors(a)),
         ~is_edited,
         model.editors,


### PR DESCRIPTION
Fixes the issue where the dynamics don't run when you load Hazel.

This version still waits until after the first autosave to run dynamics, I would like to come up with a more immediate way to run it.