### PR TITLE
Replace legacy color highlighting with selection-based highlighting deco

### DIFF
--- a/src/web/app/editors/decoration/Deco.re
+++ b/src/web/app/editors/decoration/Deco.re
@@ -337,69 +337,17 @@ module Deco =
       : Node.div([]);
   };
 
-  let term_decoration =
-      (~id: Id.t, deco: ((Point.t, Point.t, SvgUtil.Path.t)) => Node.t) => {
-    let (l, r) =
-      TermData.extreme_measures(id, term_data, measured) |> Option.get;
-    open SvgUtil.Path;
-    let r_edge =
-      ListUtil.range(~lo=l.row, r.row + 1)
-      |> List.concat_map(i => {
-           let row = Measured.Rows.find(i, measured.rows);
-           [h(~x=i == r.row ? r.col : row.max_col), v_(~dy=1)];
-         });
-    let l_edge =
-      ListUtil.range(~lo=l.row, r.row + 1)
-      |> List.rev_map(i => {
-           let row = Measured.Rows.find(i, measured.rows);
-           [h(~x=i == l.row ? l.col : row.indent), v_(~dy=-1)];
-         })
-      |> List.concat;
-    let path =
-      [m(~x=l.col, ~y=l.row), ...r_edge]
-      @ l_edge
-      @ [Z]
-      |> translate({
-           dx: Float.of_int(- l.col),
-           dy: Float.of_int(- l.row),
-         });
-    (l, r, path) |> deco;
-  };
-
-  let term_highlight = (~clss: list(string), id: Id.t) =>
-    try(
-      term_decoration(~id, ((origin, last, path)) =>
-        DecUtil.code_svg_sized(
-          ~font_metrics,
-          ~measurement={
-            origin,
-            last,
-          },
-          ~base_cls=clss,
-          path,
-        )
-      )
-    ) {
-    | _ =>
-      /* This is caused by the statics overloading for exercise mode. The overriding
-       * Exercise mode statics maps are calculated based on splicing together multiple
-       * editors, but error_ids are extracted generically from the statics map, so
-       * there may be error holes that don't occur in the editor being rendered.
-       * Additionally, when showing color highlights when the backpack is non-empty,
-       * the prospective completion may have different ids than the displayed code.
-       * Additionally additionally, this is crashing with an Option.get exception on
-       * typfuns when they are indicated with ExplainThis open, also due to the
-       * color_highting codepath; unsure if related to previous; color highlighting
-       * shows up fine though... */
-      Node.div([])
+  let color_highlight = (clss: list(string), id: Id.t) =>
+    switch (TermData.segment(id, term_data)) {
+    | Some(segment) => Highlight.go(segment, Some(Convex), clss)
+    | None => []
     };
 
   let color_highlights = () =>
     div_c(
       "color-highlights",
-      List.map(
-        ((id, color)) =>
-          term_highlight(~clss=["highlight-code-" ++ color], id),
+      List.concat_map(
+        ((id, color)) => color_highlight(["highlight-code-" ++ color], id),
         switch (color_highlights) {
         | Some(colorMap) => ColorSteps.to_list(colorMap)
         | _ => []

--- a/src/web/app/explainthis/ExplainThis.re
+++ b/src/web/app/explainthis/ExplainThis.re
@@ -239,96 +239,94 @@ let expander_deco =
       let globals = globals;
       let statics = CachedStatics.empty;
     });
+
   switch (doc.expandable_id, List.length(options)) {
   | (None, _)
   | (_, 0 | 1) => div([])
-  | (Some((expandable, _)), _) =>
-    Deco.term_decoration(
-      ~id=expandable,
-      ((origin, _, path)) => {
-        let specificity_pos =
-          Printf.sprintf(
-            "position: absolute; top: %fpx;",
-            font_metrics.row_height,
-          );
+  | (Some((id, _)), _) =>
+    let origin =
+      switch (TermData.extreme_measures(id, Deco.term_data, Deco.measured)) {
+      | Some((origin, _)) => origin
+      | None => {
+          row: 0,
+          col: 0,
+        }
+      };
+    let specificity_pos =
+      Printf.sprintf(
+        "position: absolute; top: %fpx;",
+        font_metrics.row_height,
+      );
 
-        let specificity_style =
-          Attr.create(
-            "style",
-            specificity_pos
-            ++ (docs.specificity_open ? "transform: scaleY(1);" : ""),
-          );
+    let specificity_style =
+      Attr.create(
+        "style",
+        specificity_pos
+        ++ (docs.specificity_open ? "transform: scaleY(1);" : ""),
+      );
 
-        let get_clss = segment =>
-          switch (List.nth(segment, 0)) {
-          | Base.Tile({mold, _}) => [
-              "ci-header-" ++ Sort.to_string(mold.out) // TODO the brown on brown isn't the greatest... but okay
-            ]
-          | _ => []
-          };
+    let get_clss = segment =>
+      switch (List.nth(segment, 0)) {
+      | Base.Tile({mold, _}) => [
+          "ci-header-" ++ Sort.to_string(mold.out) // TODO the brown on brown isn't the greatest... but okay
+        ]
+      | _ => []
+      };
 
-        let specificity_menu =
-          Node.div(
-            ~attrs=[
-              clss(["specificity-options-menu", "expandable"]),
-              specificity_style,
-            ],
-            List.map(
-              ((id: ExplainThisForm.form_id, segment: Segment.t)): Node.t => {
-                let code_view =
-                  CodeViewable.view_segment(
-                    ~globals,
-                    ~sort=Exp,
-                    ~shape_map=ProjectorCore.Shape.Map.empty, // Assume no projectors
-                    segment,
-                  );
-                let classes =
-                  id == doc.id
-                    ? ["selected"] @ get_clss(segment) : get_clss(segment);
-                let update_group_selection = _ =>
-                  inject(
-                    ExplainThisUpdate.UpdateGroupSelection(group.id, id),
-                  );
-                Node.div(
-                  ~attrs=[
-                    clss(classes),
-                    Attr.on_click(update_group_selection),
-                  ],
-                  [code_view],
-                );
-              },
-              options,
-            ),
-          );
+    let specificity_menu =
+      Node.div(
+        ~attrs=[
+          clss(["specificity-options-menu", "expandable"]),
+          specificity_style,
+        ],
+        List.map(
+          ((id: ExplainThisForm.form_id, segment: Segment.t)): Node.t => {
+            let code_view =
+              CodeViewable.view_segment(
+                ~globals,
+                ~sort=Exp,
+                ~shape_map=ProjectorCore.Shape.Map.empty, // Assume no projectors
+                segment,
+              );
+            let classes =
+              id == doc.id
+                ? ["selected"] @ get_clss(segment) : get_clss(segment);
+            let update_group_selection = _ =>
+              inject(ExplainThisUpdate.UpdateGroupSelection(group.id, id));
+            Node.div(
+              ~attrs=[clss(classes), Attr.on_click(update_group_selection)],
+              [code_view],
+            );
+          },
+          options,
+        ),
+      );
 
-        let expand_arrow_style = Attr.create("style", specificity_pos);
-        let expand_arrow =
-          Node.div(~attrs=[clss(["arrow"]), expand_arrow_style], []);
+    let expand_arrow_style = Attr.create("style", specificity_pos);
+    let expand_arrow =
+      Node.div(~attrs=[clss(["arrow"]), expand_arrow_style], []);
 
-        let expandable_deco =
-          DecUtil.code_svg(
-            ~font_metrics,
-            ~origin,
-            ~base_cls=["expandable"],
-            ~abs_pos=false,
-            path,
-          );
+    let expandable_deco =
+      div_c("color-highlights", Deco.color_highlight(["expandable"], id));
 
-        Node.div(
-          ~attrs=[
-            clss(["expandable-target"]),
-            DecUtil.abs_position(~font_metrics, origin),
-            Attr.on_click(_ => {
-              inject(
-                ExplainThisUpdate.SpecificityOpen(!docs.specificity_open),
-              )
-            }),
-          ],
-          [expandable_deco, specificity_menu]
-          @ (docs.specificity_open ? [] : [expand_arrow]),
-        );
-      },
-    )
+    let expander =
+      div(
+        ~attrs=[
+          clss(["expandable-target"]),
+          DecUtil.abs_position(~font_metrics, origin),
+        ],
+        [specificity_menu] @ (docs.specificity_open ? [] : [expand_arrow]),
+      );
+
+    Node.div(
+      ~attrs=[
+        clss(["expandable-target"]),
+        Attr.on_click(_ =>
+          inject(ExplainThisUpdate.SpecificityOpen(!docs.specificity_open))
+        ),
+      ],
+      [expandable_deco, expander],
+    );
   };
 };
 


### PR DESCRIPTION
Non-hackified version of #1926. Color highlighting now uses the same hexagonal decoration style (and same codepath) as selection decorations