### PR TITLE
Fix forall regrouting issue

### DIFF
--- a/src/haz3lcore/lang/Form.re
+++ b/src/haz3lcore/lang/Form.re
@@ -165,6 +165,7 @@ type compound_form =
   | ParensExp
   | ParensPat
   | ParensTyp
+  | ParensTPat
   | ApExpEmpty
   | ApExp
   | ApPat
@@ -252,6 +253,7 @@ let get: compound_form => t =
   | ParensExp => mk_parens(Exp)
   | ParensPat => mk_parens(Pat)
   | ParensTyp => mk_parens(Typ)
+  | ParensTPat => mk_parens(TPat) // HACk (Issue #1913)
   | ApExpEmpty => mk_post_c(LT, ["()"], P.ap, Exp, [])
   | ApExp => mk_post_c(LT, ["(", ")"], P.ap, Exp, [Exp])
   | ApPat => mk_post_c(LT, ["(", ")"], P.ap, Pat, [Pat])

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -436,6 +436,7 @@ let insertion_tests = [
     ~name="Forall regrouting edge case (non-debatable) (#1913)",
     ~acts=mk({|?:foral¦(?)|}) @ [Insert("l"), Insert("-"), Insert(">")],
     ~goal={|?:forall?->¦(?)|},
+  ),
   /* In below test, we first cause the two `=`s to merge, then split them.
      The first `=` should not get matched to the `let` because of the parens.
      If it does, then it will prevent the Put_down from dropping the parens.

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -427,6 +427,16 @@ let insertion_tests = [
     ~acts=mk({|f(g¦)|}) @ [Insert("("), Insert(")")],
     ~goal={|f(g()¦)|},
   ),
+  test(
+    ~name="Forall regrouting edge case (debatable behavior) (#1913)",
+    ~acts=mk({|?:foral¦(?)|}) @ [Insert("l")],
+    ~goal={|?:forall¦(?)|},
+  ),
+  test(
+    ~name="Forall regrouting edge case (non-debatable) (#1913)",
+    ~acts=mk({|?:foral¦(?)|}) @ [Insert("l"), Insert("-"), Insert(">")],
+    ~goal={|?:forall?->¦(?)|},
+  ),
 ];
 
 let destruct_tests = [


### PR DESCRIPTION
Closes #1913.

This is a hack, but is small and fairly isolated so I'm not terribly worried about it. I don't know how to fix it for real without deeper changes to how remolding works which are not at all obvious to me. See the indicated issue for a discussion. I believe the only non-fix behavioral consequence to this hack is that parens in TPat contexts, i.e. `type (T) = ...` will no longer be treated as a syntax error. However, they are still treated as a semantic error and will have a mark on them. Given that this is a pretty uncommon situation and the marking is still there, I think this is Good Enough (tm).