### PR TITLE
Add Petrinaut livelit

### DIFF
--- a/src/haz3lcore/projectors/Exo.re
+++ b/src/haz3lcore/projectors/Exo.re
@@ -4,7 +4,8 @@ open Util;
 type kind =
   | ExoSlider
   | ExoBuilder
-  | ExoNool;
+  | ExoNool
+  | Petrinaut;
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type size = {
@@ -74,6 +75,18 @@ let module_of_kind = (kind: kind): info =>
       size: {
         width: 680,
         height: 490,
+      },
+    }
+  | Petrinaut => {
+      kind,
+      prod: "https://hazel.petrinaut.org",
+      dev: "http://localhost:5173",
+      shape: Block,
+      // TODO: More specific syntax restriction
+      guard: _ => true,
+      size: {
+        width: 1050,
+        height: 590,
       },
     }
   };


### PR DESCRIPTION
## What this PR does

Adds Petrinaut as a livelit. 

Petrinaut is a very early prototype of a visual [Petri net](http://petrinet.org/) editor.

The key code for the livelit wrapper is [here](https://github.com/hashintel/labs/blob/main/pocs/petrinaut-hazel/src/main/app.tsx) and the code for Petrinaut itself is [here](https://github.com/hashintel/hash/tree/cm/extract-petri-net-editor-into-package/libs/%40hashintel/petrinaut).

## Caveats

This is a POC rather than anything which will be directly useful. The Petrinaut execution logic should not be relied on and the extensions it has UI for (e.g. colours, conditional outputs) are an arbitrary selection and do not represent correct implementation of any semantics.

Petrinaut itself will be further developed and new versions pushed to make it more useful (this can happen without further modifying Hazel code).

## Testing

Petrinaut can be invoked via `^^Petrinaut("{}")`. 
