### PR TITLE
Stop Indet forms evaluating to false with polymorphic equality

### DIFF
--- a/src/language/dynamics/DHExp.re
+++ b/src/language/dynamics/DHExp.re
@@ -5,6 +5,9 @@
    slightly as described in Elaborator.re.
    */
 
+open Util;
+open OptUtil.Syntax;
+
 include Exp;
 
 let term_of: t => term = IdTagged.term_of;
@@ -222,9 +225,11 @@ let rec ty_comparable = (d1, d2) => {
   };
 };
 
-let rec poly_equal = (d1, d2): bool => {
+/* Returns Some(true) if they are definitely equal, Some(false) if they are definitely not equal, and None if either d1 or d2 is indet or incomparable.*/
+let rec poly_equal = (d1, d2): option(bool) => {
   // With assumption that the types are consistent and have no arrow type
   switch (term_of(d1), term_of(d2)) {
+  // If either is indet or incomparable, return None
   | (Invalid(_), _)
   | (EmptyHole, _)
   | (MultiHole(_), _)
@@ -254,54 +259,65 @@ let rec poly_equal = (d1, d2): bool => {
   | (Fun(_), _)
   | (TypFun(_), _)
   | (Use(_), _)
-  | (BuiltinFun(_), _) => false
+  | (BuiltinFun(_), _) => None
+
+  // Wrapping forms: just look through them
   | (Probe(d1, _), _) => poly_equal(d1, d2)
   | (_, Probe(d2, _)) => poly_equal(d1, d2)
   | (Parens(d1), _) => poly_equal(d1, d2)
   | (_, Parens(d2)) => poly_equal(d1, d2)
   | (Asc(d1, _), _) => poly_equal(d1, d2)
   | (_, Asc(d2, _)) => poly_equal(d1, d2)
+
+  // Comparable forms
   | (Atom(t1), Atom(t2)) =>
-    switch (t1, t2) {
-    | (Int(n1), Int(n2)) => n1 == n2
-    | (Int(_), _) => false
-    | (SInt(n1), SInt(n2)) => n1 == n2
-    | (SInt(_), _) => false
-    | (Nat(n1), Nat(n2)) => n1 == n2
-    | (Nat(_), _) => false
-    | (Bool(b1), Bool(b2)) => b1 == b2
-    | (Bool(_), _) => false
-    | (String(s1), String(s2)) => s1 == s2
-    | (String(_), _) => false
-    | (Float(f1), Float(f2)) => f1 == f2
-    | (Float(_), _) => false
-    }
-  | (Atom(_), _) => false
-  | (Label(l1), Label(l2)) => l1 == l2
-  | (Label(_), _) => false
-  | (ExplicitNonlabel, ExplicitNonlabel) => true
-  | (ExplicitNonlabel, _) => false
+    (
+      switch (t1, t2) {
+      | (Int(n1), Int(n2)) => n1 == n2
+      | (Int(_), _) => false
+      | (SInt(n1), SInt(n2)) => n1 == n2
+      | (SInt(_), _) => false
+      | (Nat(n1), Nat(n2)) => n1 == n2
+      | (Nat(_), _) => false
+      | (Bool(b1), Bool(b2)) => b1 == b2
+      | (Bool(_), _) => false
+      | (String(s1), String(s2)) => s1 == s2
+      | (String(_), _) => false
+      | (Float(f1), Float(f2)) => f1 == f2
+      | (Float(_), _) => false
+      }
+    )
+    |> Option.some
+  | (Atom(_), _) => None
+  | (Label(l1), Label(l2)) => l1 == l2 ? Some(true) : None
+  | (Label(_), _) => None
+  | (ExplicitNonlabel, ExplicitNonlabel) => Some(true)
+  | (ExplicitNonlabel, _) => None
   | (TupLabel({term: ExplicitNonlabel, _}, d1), _) => poly_equal(d1, d2)
   | (_, TupLabel({term: ExplicitNonlabel, _}, d2)) => poly_equal(d1, d2)
   | (TupLabel(l1, d1), TupLabel(l2, d2)) =>
-    poly_equal(l1, l2) && poly_equal(d1, d2)
-  | (TupLabel(_), _) => false
-  | (ListLit(ds1), ListLit(ds2)) =>
-    List.length(ds1) == List.length(ds2)
-    && List.for_all2(poly_equal, ds1, ds2)
-  | (ListLit(_), _) => false
-  | (Tuple(ds1), Tuple(ds2)) =>
-    List.length(ds1) == List.length(ds2)
-    && List.for_all2(poly_equal, ds1, ds2)
-  | (Tuple(_), _) => false
-  | (Constructor(c1, _), Constructor(c2, _)) => c1 == c2
-  | (Constructor(_), _) => false
+    let* l_eq = poly_equal(l1, l2);
+    let* d_eq = poly_equal(d1, d2);
+    Some(l_eq && d_eq);
+  | (TupLabel(_), _) => None
+  | (ListLit(ds1), ListLit(ds2)) when List.length(ds1) == List.length(ds2) =>
+    ListUtil.forall2_opt(poly_equal, ds1, ds2)
+  | (ListLit(_), ListLit(_)) => Some(false)
+  | (ListLit(_), _) => None
+  | (Tuple(ds1), Tuple(ds2)) when List.length(ds1) == List.length(ds2) =>
+    ListUtil.forall2_opt(poly_equal, ds1, ds2)
+  | (Tuple(_), _) => None
+  | (Constructor(c1, _), Constructor(c2, _)) => Some(c1 == c2)
   // Note: Only Constructor Ap is comparable
   | (
       Ap(_, {term: Constructor(c1, _), _}, d1),
       Ap(_, {term: Constructor(c2, _), _}, d2),
     ) =>
-    c1 == c2 && poly_equal(d1, d2)
-  | (Ap(_), _) => false
+    let* d_eq = poly_equal(d1, d2);
+    Some(c1 == c2 && d_eq);
+  | (Constructor(_), Ap(_, {term: Constructor(_), _}, _))
+  | (Ap(_, {term: Constructor(_), _}, _), Constructor(_)) => Some(false)
+  | (Ap(_), _) => None
+  | (Constructor(_), _) => None
   };
 };

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -642,14 +642,23 @@ module Transition = (EV: EV_MODE) => {
             is_value: false,
           });
         } else {
-          let res = DHExp.poly_equal(d1, d2);
-          let expr = Atom(Bool(poly_op == Equals ? res : !res)) |> fresh;
-          Step({
-            expr,
-            state_update,
-            kind: BinOp(op),
-            is_value: false,
-          });
+          switch (DHExp.poly_equal(d1, d2)) {
+          | None => Indet
+          | Some(true) =>
+            Step({
+              expr: Atom(Bool(poly_op == Equals)) |> fresh,
+              state_update,
+              kind: BinOp(op),
+              is_value: false,
+            })
+          | Some(false) =>
+            Step({
+              expr: Atom(Bool(poly_op != Equals)) |> fresh,
+              state_update,
+              kind: BinOp(op),
+              is_value: false,
+            })
+          };
         }
       | Defined(in_ty1, in_ty2, out_ty, f) =>
         let-unbox n1 = (Atom(in_ty1), d1);

--- a/src/util/ListUtil.re
+++ b/src/util/ListUtil.re
@@ -490,3 +490,24 @@ let rec fold_left2_opt =
   | _ => None
   };
 };
+
+/**
+ * Similar to List.for_all2 but for functions that return option(bool)
+ * Returns None if any call returns None
+ * Returns Some(false) if any call returns Some(false)
+ * Returns Some(true) if all calls return Some(true)
+ */
+let rec forall2_opt =
+        (f: ('a, 'b) => option(bool), l1: list('a), l2: list('b))
+        : option(bool) => {
+  switch (l1, l2) {
+  | ([], []) => Some(true)
+  | ([x1, ...rest1], [x2, ...rest2]) =>
+    switch (f(x1, x2)) {
+    | None => None
+    | Some(false) => Some(false)
+    | Some(true) => forall2_opt(f, rest1, rest2)
+    }
+  | _ => Some(false) // Different lengths
+  };
+};

--- a/test/evaluator/Test_Evaluator_Poly_Equal.re
+++ b/test/evaluator/Test_Evaluator_Poly_Equal.re
@@ -88,6 +88,12 @@ let tests = (
           bool(false),
           elaborate(parse_exp("type T = +A+B(Int) in B(2) == B(1)")),
         );
+        evaluation_test(
+          "Indet Variables in sum constructors",
+          ~ignore_constructor_types=true,
+          parse_exp("C(x) == C(x)"),
+          elaborate(parse_exp("type T = +C(Int) in C(x) == C(x)")),
+        );
       },
     ),
     test_case(


### PR DESCRIPTION
This stops

<img width="366" height="137" alt="image" src="https://github.com/user-attachments/assets/ef0fd32b-18f3-4299-9ff3-346841571316" />

from evaluating to false, (allowing us to use reflexivity in proofs)