### PR TITLE
fix(statics): correct self parameter in uexp_to_info_map for Parens and Probe

### DIFF
--- a/src/haz3lcore/TyDi/ErrorPrint.re
+++ b/src/haz3lcore/TyDi/ErrorPrint.re
@@ -49,8 +49,6 @@ let common_error: Info.error_common => string =
   | TupleLabelError(_) => "Invalid tuple label"
   | NoType(UnexpectedLabelSort(_)) => "Unexpected label sort"
   | NoType(BadToken(token)) => prn("\"%s\" isn't a valid token", token)
-  | Inconsistent(WithArrow(ty)) =>
-    prn("type %s is not consistent with arrow type", Print.typ(ty))
   | Inconsistent(CompareFun(ty)) =>
     prn("values of type %s cannot be compared", Print.typ(ty))
   | NoType(FreeConstructor(_name)) => prn("Constructor is not defined")

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -796,31 +796,36 @@ let fixed_typ_ok: ok_pat => Typ.t =
   | Ana(InternallyInconsistent({ana, _})) => ana;
 
 let fixed_typ_err_common: (error_common, Typ.t) => Typ.t =
-  (err, ana) =>
+  (err, ana) => {
+    let typ_or_ana = ty =>
+      if (Typ.is_syn_plus(ana)) {
+        ty;
+      } else {
+        ana;
+      };
     switch (err) {
     | NoType(FreeConstructor(c)) =>
-      if (Typ.is_syn_plus(ana)) {
+      typ_or_ana(
         Sum([
           ConstructorMap.Variant(c, [Id.invalid], None),
           ConstructorMap.BadEntry(Unknown(Internal) |> Typ.temp),
         ])
-        |> Typ.temp;
-      } else {
-        ana;
-      }
+        |> Typ.temp,
+      )
     | NoType(BadToken(_))
     | NoType(BadLabel(_))
     | NoType(InvalidLabel(_))
     | NoType(UnexpectedLabelSort(_)) => Unknown(Internal) |> Typ.temp
     | TupleLabelError({typ, _})
-    | DuplicateLabel(_, typ) => typ
+    | DuplicateLabel(_, typ) => typ_or_ana(typ)
     | Inconsistent(Expectation({ana, _})) => ana
     | Inconsistent(Internal(_)) => Unknown(Internal) |> Typ.temp // Should this be some sort of meet?
-    | Inconsistent(CompareFun(_)) => Atom(Bool) |> Typ.temp
+    | Inconsistent(CompareFun(_)) => typ_or_ana(Atom(Bool) |> Typ.temp)
     | Inconsistent(WithArrow(_)) =>
       Arrow(Unknown(Internal) |> Typ.temp, Unknown(Internal) |> Typ.temp)
       |> Typ.temp
     };
+  };
 
 let fixed_typ_err: (error_exp, Typ.t) => Typ.t =
   (err, ana) =>

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -205,7 +205,6 @@ type underdetermined_typ =
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
 type ok_typ =
   | Variant(Constructor.t, Typ.t)
-  | VariantIncomplete(Typ.t)
   | TypeAlias(string, Typ.t)
   | WHNormalizedTo({
       unnormalized: Typ.t,

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -530,17 +530,15 @@ let rec status_pat = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.pat): status_pat =>
       | InHole(
           Common(
             Inconsistent(Internal(_) | Expectation(_) | CompareFun(_)) |
-            NoType(_),
+            NoType(_) |
+            DuplicateLabel(_) |
+            TupleLabelError(_),
           ) as err,
         ) =>
         Some(err)
       | NotInHole(_) => None
       | InHole(
-          Common(
-            DuplicateLabel(_) | TupleLabelError(_) |
-            Inconsistent(WithArrow(_)),
-          ) |
-          ExpectedConstructor |
+          Common(Inconsistent(WithArrow(_))) | ExpectedConstructor |
           Redundant(_),
         ) =>
         // ExpectedConstructor cannot be a reason to hole-wrap the entire pattern

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -42,9 +42,7 @@ type error_inconsistent =
   /* Inconsistent match or listlit */
   | Internal(list(Typ.t))
   /* Bad type equality due to function inside */
-  | CompareFun(Typ.t)
-  /* Bad function position */
-  | WithArrow(Typ.t);
+  | CompareFun(Typ.t);
 
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
 type error_no_type =
@@ -537,10 +535,7 @@ let rec status_pat = (ctx: Ctx.t, ty_ana: Typ.t, self: Self.pat): status_pat =>
         ) =>
         Some(err)
       | NotInHole(_) => None
-      | InHole(
-          Common(Inconsistent(WithArrow(_))) | ExpectedConstructor |
-          Redundant(_),
-        ) =>
+      | InHole(ExpectedConstructor | Redundant(_)) =>
         // ExpectedConstructor cannot be a reason to hole-wrap the entire pattern
         failwith("InHole(Redundant(impossible_err))")
       };
@@ -568,12 +563,7 @@ let rec status_exp = (ctx: Ctx.t, ty_ana, self: Self.exp): status_exp =>
       | InHole(Common(Inconsistent(Internal(_)) as inconsistent_err)) =>
         Some(inconsistent_err)
       | NotInHole(_)
-      | InHole(
-          Common(
-            Inconsistent(Expectation(_) | WithArrow(_) | CompareFun(_)),
-          ),
-        ) =>
-        None /* Type checking should fail and these errors would be nullified */
+      | InHole(Common(Inconsistent(Expectation(_) | CompareFun(_)))) => None /* Type checking should fail and these errors would be nullified */
       | InHole(Common(NoType(_)))
       | InHole(Common(TupleLabelError(_)))
       | InHole(Common(DuplicateLabel(_)))
@@ -821,9 +811,6 @@ let fixed_typ_err_common: (error_common, Typ.t) => Typ.t =
     | Inconsistent(Expectation({ana, _})) => ana
     | Inconsistent(Internal(_)) => Unknown(Internal) |> Typ.temp // Should this be some sort of meet?
     | Inconsistent(CompareFun(_)) => typ_or_ana(Atom(Bool) |> Typ.temp)
-    | Inconsistent(WithArrow(_)) =>
-      Arrow(Unknown(Internal) |> Typ.temp, Unknown(Internal) |> Typ.temp)
-      |> Typ.temp
     };
   };
 

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -633,7 +633,7 @@ let rec status_exp = (ctx: Ctx.t, ty_ana, self: Self.exp): status_exp =>
    separate sort. It also determines semantic properties
    such as whether or not a type variable reference is
    free, and whether a ctr name is a dupe. */
-let status_typ = (ctx: Ctx.t, expects: typ_expects, ty: Typ.t): status_typ => {
+let rec status_typ = (ctx: Ctx.t, expects: typ_expects, ty: Typ.t): status_typ => {
   switch (expects, ty.term) {
   | (_, Unknown(Hole(Invalid(token)))) => InHole(BadToken(token))
   | (LabelExpected(_), Unknown(Hole(EmptyHole))) => NotInHole(EmptyLabel)
@@ -734,11 +734,13 @@ let status_typ = (ctx: Ctx.t, expects: typ_expects, ty: Typ.t): status_typ => {
     NotInHole(Type(Unknown(Internal) |> Typ.temp)) // Unknown type because the product is unknown
   | (ConstructorExpected(_), Label(_))
   | (VariantExpected(_), Label(_)) => InHole(WantConstructorFoundType(ty))
-  | (TypeExpected, _) => NotInHole(Type(ty))
+
   | (LabelExpected(_), _)
   | (LabelProjectionExpected(_), _) => InHole(WantLabel)
   | (ConstructorExpected(_), _)
   | (VariantExpected(_), _) => InHole(WantConstructorFoundType(ty))
+  | (_, Parens(t)) => status_typ(ctx, expects, t)
+  | (TypeExpected, _) => NotInHole(Type(ty))
   };
 };
 

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -1374,7 +1374,15 @@ and upat_to_info_map =
       m: Map.t,
     )
     : (Info.pat, Map.t) => {
-  let add = (~self, ~ctx, ~constraint_, ~label_inference=?, m) => {
+  let add' =
+      (
+        ~self: Self.pat,
+        ~ctx: Ctx.t,
+        ~constraint_: Coverage.Constraint.t,
+        ~label_inference: option(Info.label_inference(Info.pat))=?,
+        m: Id.Map.t(Info.t),
+      )
+      : (Info.pat, Map.t) => {
     let prev_synswitch =
       switch (Id.Map.find_opt(Pat.rep_id(upat), m)) {
       | Some(Info.InfoPat({ana, ty, _})) when Typ.is_syn_plus(ana) =>
@@ -1391,7 +1399,11 @@ and upat_to_info_map =
         ~co_ctx,
         ~ana,
         ~ancestors,
-        ~self=Common(Option.value(~default=self, override_self)),
+        ~self=
+          Option.value(
+            ~default=self,
+            override_self |> Option.map((s): Self.pat => Common(s)),
+          ),
         ~constraint_,
         ~label_inference,
         ~inferred_label,
@@ -1399,6 +1411,17 @@ and upat_to_info_map =
       );
 
     (info, add_info(ids, InfoPat(info), m));
+  };
+  let add =
+      (
+        ~self: Self.t,
+        ~ctx: Ctx.t,
+        ~constraint_: Coverage.Constraint.t,
+        ~label_inference: option(Info.label_inference(Info.pat))=?,
+        m: Id.Map.t(Info.t),
+      )
+      : (Info.pat, Map.t) => {
+    add'(~self=Common(self), ~ctx, ~constraint_, ~label_inference?, m);
   };
   let upat_to_info_map =
       (
@@ -1774,15 +1797,18 @@ and upat_to_info_map =
       let (malformed_labels, duplicate_labels, invalid_labels) =
         List.fold_left(
           ((a, b, c), e: Info.pat) => {
-            switch (e.status) {
-            | InHole(
-                Common(
-                  TupleLabelError({
-                    malformed_labels,
-                    duplicate_labels,
-                    invalid_labels,
-                    _,
-                  }),
+            switch (e.term.term, e.status) {
+            | (
+                TupLabel(_, _),
+                InHole(
+                  Common(
+                    TupleLabelError({
+                      malformed_labels,
+                      duplicate_labels,
+                      invalid_labels,
+                      _,
+                    }),
+                  ),
                 ),
               ) => (
                 a @ malformed_labels,
@@ -1823,7 +1849,7 @@ and upat_to_info_map =
     | Parens(p)
     | Probe(p, _) =>
       let (p, m) = go(~ctx, ~ana, p, m);
-      add(~self=Just(p.ty), ~ctx=p.ctx, ~constraint_=p.constraint_, m);
+      add'(~self=p.self, ~ctx=p.ctx, ~constraint_=p.constraint_, m);
     | Constructor(ctr, ty) =>
       let self = Self.of_ctr(ctx, ctr, ana, ty);
       atomic(self, Coverage.Constraint.Ap(ctr, None));

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -388,7 +388,7 @@ and uexp_to_info_map =
     | Parens(e)
     | Probe(e, _) =>
       let (e, m) = go(~ana, e, m);
-      add(~self=Just(e.ty), ~co_ctx=e.co_ctx, m);
+      add'(~self=e.self, ~co_ctx=e.co_ctx, m);
     | UnOp(Meta(Unquote), e) when is_in_filter =>
       let e: Exp.t = {
         annotation: {

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -1821,16 +1821,19 @@ and upat_to_info_map =
           ([], [], []),
           info_pats,
         );
+
+      let ty_list = Typ.remove_duplicate_labels(~duplicate_labels, tys);
+
       let self =
         List.is_empty(malformed_labels)
         && List.is_empty(duplicate_labels)
         && List.is_empty(invalid_labels)
-          ? Self.Just(Prod(tys) |> Typ.temp)
+          ? Self.Just(Prod(ty_list) |> Typ.temp)
           : Self.TupleLabelError({
               malformed_labels,
               duplicate_labels,
               invalid_labels,
-              typ: Prod(tys) |> Typ.temp,
+              typ: Prod(ty_list) |> Typ.temp,
             });
 
       add(

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -388,7 +388,7 @@ and uexp_to_info_map =
     | Parens(e)
     | Probe(e, _) =>
       let (e, m) = go(~ana, e, m);
-      add'(~self=e.self, ~co_ctx=e.co_ctx, m);
+      add'(~self=Just(e.ty), ~co_ctx=e.co_ctx, m);
     | UnOp(Meta(Unquote), e) when is_in_filter =>
       let e: Exp.t = {
         annotation: {

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -586,17 +586,21 @@ and uexp_to_info_map =
       let ty_list = List.map(Info.exp_ty, es');
 
       let (malformed_labels, duplicate_labels, invalid_labels) =
-        List.fold_left(
-          ((a, b, c), e: Info.exp) => {
-            switch (e.status) {
-            | InHole(
-                Common(
-                  TupleLabelError({
-                    malformed_labels,
-                    duplicate_labels,
-                    invalid_labels,
-                    _,
-                  }),
+        List.fold_left2(
+          ((a, b, c), e: Exp.t, e_info: Info.exp) => {
+            // Only collect errors from TupLabel elements
+            switch (e.term, e_info.status) {
+            | (
+                TupLabel(_, _),
+                InHole(
+                  Common(
+                    TupleLabelError({
+                      malformed_labels,
+                      duplicate_labels,
+                      invalid_labels,
+                      _,
+                    }),
+                  ),
                 ),
               ) => (
                 a @ malformed_labels,
@@ -607,6 +611,7 @@ and uexp_to_info_map =
             }
           },
           ([], [], []),
+          es,
           es',
         );
 

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -388,7 +388,7 @@ and uexp_to_info_map =
     | Parens(e)
     | Probe(e, _) =>
       let (e, m) = go(~ana, e, m);
-      add'(~self=Just(e.ty), ~co_ctx=e.co_ctx, m);
+      add'(~self=e.self, ~co_ctx=e.co_ctx, m);
     | UnOp(Meta(Unquote), e) when is_in_filter =>
       let e: Exp.t = {
         annotation: {

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -421,10 +421,6 @@ let typ_ok_view = (~globals, cls: Cls.t, ok: Info.ok_typ) => {
       text("is a sum type constuctor of type"),
       view_type(sum_ty),
     ]
-  | VariantIncomplete(sum_ty) => [
-      text("An incomplete sum type constuctor of type"),
-      view_type(sum_ty),
-    ]
   | TypeUnderdetermined(underdetermined) =>
     underdetermined_typ_view(~globals, underdetermined)
   };

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -169,11 +169,6 @@ let common_err_view =
         text("values cannot be compared:"),
         view_type(ty),
       ]
-    | Inconsistent(WithArrow(typ)) => [
-        text(":"),
-        view_type(typ) |> code_box_container,
-        text("inconsistent with arrow type"),
-      ]
     | Inconsistent(Expectation({ana, syn})) =>
       switch (syn.term, ana.term) {
       | (Label(syn_l), Label(an_label)) => [

--- a/test/Test_Coverage.re
+++ b/test/Test_Coverage.re
@@ -1074,6 +1074,114 @@ in ?|},
     ],
   );
 
+let labeled_tuple_additional_error =
+  has_errors(
+    "Labeled Tuple Additional Error Test",
+    {|case () | _ => ""| {{{([], a=?)}}} => "" end|},
+    [
+      Info.Pat(
+        Redundant(
+          Some(
+            Common(
+              TupleLabelError({
+                malformed_labels: [],
+                duplicate_labels: ["a"],
+                invalid_labels: [],
+                typ:
+                  Test_Statics_Prelude.FTemp.Typ.(
+                    prod([list(unknown(Internal)), unknown(Internal)])
+                  ),
+              }),
+            ),
+          ),
+        ),
+      ),
+    ],
+  );
+
+let labeled_tuple_additional_error = {
+  test_case("Labeled Tuple Additional Error Test", `Quick, () => {
+    Test_Statics_Prelude.(
+      annotated_tree_test(
+        {|case () | _ => ""| {{{([], a=?)}}} => "" end|},
+        FTemp.Typ.(string()),
+        FIError.(
+          Exp.(
+            match(
+              tuple([]),
+              [
+                (Pat.wild(), string("")),
+                (
+                  Pat.(
+                    tuple(
+                      ~ann=
+                        Some(
+                          Pat(
+                            Redundant(
+                              Some(
+                                Common(
+                                  TupleLabelError({
+                                    malformed_labels: [],
+                                    duplicate_labels: [],
+                                    invalid_labels: ["a"],
+                                    typ:
+                                      FTemp.Typ.(
+                                        prod([
+                                          list(unknown(Internal)),
+                                          unknown(Internal),
+                                        ])
+                                      ),
+                                  }),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      [
+                        list_lit([]),
+                        tup_label(
+                          ~ann=
+                            Some(
+                              Pat(
+                                Common(
+                                  TupleLabelError({
+                                    malformed_labels: [],
+                                    duplicate_labels: [],
+                                    invalid_labels: ["a"],
+                                    typ:
+                                      FTemp.Typ.(
+                                        tup_label(
+                                          label("a"),
+                                          unknown(Internal),
+                                        )
+                                      ),
+                                  }),
+                                ),
+                              ),
+                            ),
+                          label(
+                            ~ann=
+                              Some(
+                                Pat(Common(NoType(InvalidLabel("a", [])))),
+                              ),
+                            "a",
+                          ),
+                          empty_hole(),
+                        ),
+                      ],
+                    )
+                  ),
+                  string(""),
+                ),
+              ],
+            )
+          )
+        ),
+      )
+    )
+  });
+};
+
 let function_scrutinee =
   has_errors(
     "Function Scrutinee",
@@ -1205,6 +1313,7 @@ let tests = (
     labeled_tuple_exhaustiveness,
     labeled_tuple_inexhaustiveness,
     labeled_tuple_redundancy,
+    labeled_tuple_additional_error,
     function_scrutinee,
     fun_labeled_tuple,
     exhaustive_ints_with_wilds,

--- a/test/Test_Coverage.re
+++ b/test/Test_Coverage.re
@@ -1074,7 +1074,6 @@ in ?|},
     ],
   );
 
-
 let labeled_tuple_additional_error = {
   test_case("Labeled Tuple Additional Error Test", `Quick, () => {
     Test_Statics_Prelude.(

--- a/test/Test_Coverage.re
+++ b/test/Test_Coverage.re
@@ -1074,30 +1074,6 @@ in ?|},
     ],
   );
 
-let labeled_tuple_additional_error =
-  has_errors(
-    "Labeled Tuple Additional Error Test",
-    {|case () | _ => ""| {{{([], a=?)}}} => "" end|},
-    [
-      Info.Pat(
-        Redundant(
-          Some(
-            Common(
-              TupleLabelError({
-                malformed_labels: [],
-                duplicate_labels: ["a"],
-                invalid_labels: [],
-                typ:
-                  Test_Statics_Prelude.FTemp.Typ.(
-                    prod([list(unknown(Internal)), unknown(Internal)])
-                  ),
-              }),
-            ),
-          ),
-        ),
-      ),
-    ],
-  );
 
 let labeled_tuple_additional_error = {
   test_case("Labeled Tuple Additional Error Test", `Quick, () => {

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -1081,9 +1081,12 @@ let tests = (
                         Common(
                           TupleLabelError({
                             malformed_labels: [],
-                            duplicate_labels: ["a"],
+                            duplicate_labels: ["a", "a"],
                             invalid_labels: [],
-                            typ: tup_label(label("a"), string()),
+                            typ:
+                              prod([
+                                tup_label(label("a"), unknown(Internal)),
+                              ]),
                           }),
                         ),
                       )
@@ -1100,7 +1103,7 @@ let tests = (
                                 malformed_labels: [],
                                 duplicate_labels: ["a"],
                                 invalid_labels: [],
-                                typ: tup_label(label("a"), string()),
+                                typ: tup_label(label("a"), int()),
                               }),
                             ),
                           )
@@ -1127,7 +1130,7 @@ let tests = (
                                 malformed_labels: [],
                                 duplicate_labels: ["a"],
                                 invalid_labels: [],
-                                typ: tup_label(label("a"), string()),
+                                typ: tup_label(label("a"), int()),
                               }),
                             ),
                           )

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -1166,7 +1166,25 @@ let tests = (
                 parens(
                   ~ann=
                     Some(
-                      FTemp.Typ.(
+                      Pat(
+                        Common(
+                          TupleLabelError({
+                            malformed_labels: [],
+                            duplicate_labels: ["a", "a"],
+                            invalid_labels: [],
+                            typ:
+                              FTemp.Typ.(
+                                prod([
+                                  tup_label(label("a"), unknown(Internal)),
+                                ])
+                              ),
+                          }),
+                        ),
+                      ),
+                    ),
+                  tuple(
+                    ~ann=
+                      Some(
                         Pat(
                           Common(
                             TupleLabelError({
@@ -1184,31 +1202,6 @@ let tests = (
                                 ),
                             }),
                           ),
-                        )
-                      ),
-                    ),
-                  tuple(
-                    ~ann=
-                      Some(
-                        FTemp.Typ.(
-                          Pat(
-                            Common(
-                              TupleLabelError({
-                                malformed_labels: [],
-                                duplicate_labels: ["a", "a"],
-                                invalid_labels: [],
-                                typ:
-                                  FTemp.Typ.(
-                                    prod([
-                                      tup_label(
-                                        label("a"),
-                                        unknown(Internal),
-                                      ),
-                                    ])
-                                  ),
-                              }),
-                            ),
-                          )
                         ),
                       ),
                     [
@@ -1248,23 +1241,21 @@ let tests = (
                       tup_label(
                         ~ann=
                           Some(
-                            FTemp.Typ.(
-                              Pat(
-                                Common(
-                                  TupleLabelError({
-                                    malformed_labels: [],
-                                    duplicate_labels: ["a"],
-                                    invalid_labels: [],
-                                    typ:
-                                      FTemp.Typ.(
-                                        tup_label(
-                                          label("a"),
-                                          unknown(Internal),
-                                        )
-                                      ),
-                                  }),
-                                ),
-                              )
+                            Pat(
+                              Common(
+                                TupleLabelError({
+                                  malformed_labels: [],
+                                  duplicate_labels: ["a"],
+                                  invalid_labels: [],
+                                  typ:
+                                    FTemp.Typ.(
+                                      tup_label(
+                                        label("a"),
+                                        unknown(Internal),
+                                      )
+                                    ),
+                                }),
+                              ),
                             ),
                           ),
                         label(

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -931,6 +931,25 @@ let tests = (
           Exp.(
             asc(
               parens(
+                ~ann=
+                  Some(
+                    Exp(
+                      Common(
+                        Inconsistent(
+                          FTemp.Typ.(
+                            Expectation({
+                              ana: int(),
+                              syn:
+                                prod([
+                                  tup_label(label("a"), int()),
+                                  tup_label(label("b"), int()),
+                                ]),
+                            })
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
                 tuple(
                   ~ann=
                     Some(

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -1155,6 +1155,143 @@ let tests = (
         ),
       )
     }),
+    test_case("Duplicate labels in patterns collapse duplicates", `Quick, () => {
+      annotated_tree_test(
+        {|fun (a=a, a=b) -> 1|},
+        arrow(prod([tup_label(label("a"), unknown(Internal))]), int()),
+        FIError.(
+          Exp.(
+            fn(
+              Pat.(
+                parens(
+                  ~ann=
+                    Some(
+                      FTemp.Typ.(
+                        Pat(
+                          Common(
+                            TupleLabelError({
+                              malformed_labels: [],
+                              duplicate_labels: ["a", "a"],
+                              invalid_labels: [],
+                              typ:
+                                FTemp.Typ.(
+                                  prod([
+                                    tup_label(
+                                      label("a"),
+                                      unknown(Internal),
+                                    ),
+                                  ])
+                                ),
+                            }),
+                          ),
+                        )
+                      ),
+                    ),
+                  tuple(
+                    ~ann=
+                      Some(
+                        FTemp.Typ.(
+                          Pat(
+                            Common(
+                              TupleLabelError({
+                                malformed_labels: [],
+                                duplicate_labels: ["a", "a"],
+                                invalid_labels: [],
+                                typ:
+                                  FTemp.Typ.(
+                                    prod([
+                                      tup_label(
+                                        label("a"),
+                                        unknown(Internal),
+                                      ),
+                                    ])
+                                  ),
+                              }),
+                            ),
+                          )
+                        ),
+                      ),
+                    [
+                      tup_label(
+                        ~ann=
+                          Some(
+                            Pat(
+                              Common(
+                                TupleLabelError({
+                                  malformed_labels: [],
+                                  duplicate_labels: ["a"],
+                                  invalid_labels: [],
+                                  typ:
+                                    FTemp.Typ.(
+                                      tup_label(
+                                        label("a"),
+                                        unknown(Internal),
+                                      )
+                                    ),
+                                }),
+                              ),
+                            ),
+                          ),
+                        label(
+                          ~ann=
+                            Some(
+                              Pat(
+                                Common(
+                                  DuplicateLabel("a", FTemp.Typ.label("a")),
+                                ),
+                              ),
+                            ),
+                          "a",
+                        ),
+                        var("a"),
+                      ),
+                      tup_label(
+                        ~ann=
+                          Some(
+                            FTemp.Typ.(
+                              Pat(
+                                Common(
+                                  TupleLabelError({
+                                    malformed_labels: [],
+                                    duplicate_labels: ["a"],
+                                    invalid_labels: [],
+                                    typ:
+                                      FTemp.Typ.(
+                                        tup_label(
+                                          label("a"),
+                                          unknown(Internal),
+                                        )
+                                      ),
+                                  }),
+                                ),
+                              )
+                            ),
+                          ),
+                        label(
+                          ~ann=
+                            Some(
+                              Pat(
+                                Common(
+                                  DuplicateLabel("a", FTemp.Typ.label("a")),
+                                ),
+                              ),
+                            ),
+                          "a",
+                        ),
+                        var("b"),
+                      ),
+                    ],
+                  ),
+                )
+              ),
+              int(1),
+              None,
+              None,
+            )
+          )
+        ),
+      )
+    }),
   ]
   @ TupleExtension.tests
   @ ProductProjection.tests

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -1066,6 +1066,92 @@ let tests = (
       {|([(a=1) : ?]).a|},
       Some(list(unknown(Internal))),
     ),
+    test_case("Nested tuple with duplicate labels", `Quick, () => {
+      annotated_tree_test(
+        {|((a=1,a=2), 3)|},
+        prod([prod([tup_label(label("a"), unknown(Internal))]), int()]),
+        FIError.(
+          Exp.(
+            tuple([
+              tuple(
+                ~ann=
+                  Some(
+                    FTemp.Typ.(
+                      Exp(
+                        Common(
+                          TupleLabelError({
+                            malformed_labels: [],
+                            duplicate_labels: ["a"],
+                            invalid_labels: [],
+                            typ: tup_label(label("a"), string()),
+                          }),
+                        ),
+                      )
+                    ),
+                  ),
+                [
+                  tup_label(
+                    ~ann=
+                      Some(
+                        FTemp.Typ.(
+                          Exp(
+                            Common(
+                              TupleLabelError({
+                                malformed_labels: [],
+                                duplicate_labels: ["a"],
+                                invalid_labels: [],
+                                typ: tup_label(label("a"), string()),
+                              }),
+                            ),
+                          )
+                        ),
+                      ),
+                    label(
+                      ~ann=
+                        Some(
+                          FTemp.Typ.(
+                            Exp(Common(DuplicateLabel("a", label("a"))))
+                          ),
+                        ),
+                      "a",
+                    ),
+                    int(1),
+                  ),
+                  tup_label(
+                    ~ann=
+                      Some(
+                        FTemp.Typ.(
+                          Exp(
+                            Common(
+                              TupleLabelError({
+                                malformed_labels: [],
+                                duplicate_labels: ["a"],
+                                invalid_labels: [],
+                                typ: tup_label(label("a"), string()),
+                              }),
+                            ),
+                          )
+                        ),
+                      ),
+                    label(
+                      ~ann=
+                        Some(
+                          FTemp.Typ.(
+                            Exp(Common(DuplicateLabel("a", label("a"))))
+                          ),
+                        ),
+                      "a",
+                    ),
+                    int(2),
+                  ),
+                ],
+              ),
+              int(3),
+            ])
+          )
+        ),
+      )
+    }),
   ]
   @ TupleExtension.tests
   @ ProductProjection.tests

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -832,6 +832,31 @@ let tests = (
             let_(
               Pat.(
                 asc(
+                  ~ann=
+                    Some(
+                      Pat(
+                        Common(
+                          Inconsistent(
+                            FTemp.Typ.(
+                              Expectation({
+                                ana:
+                                  prod([
+                                    tup_label(label("c"), int()),
+                                    tup_label(label("a"), string()),
+                                  ]),
+                                syn:
+                                  parens(
+                                    prod([
+                                      int(),
+                                      tup_label(label("a"), string()),
+                                    ]),
+                                  ),
+                              })
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
                   var("extra_label"),
                   Typ.(
                     parens(prod([int(), tup_label(label("a"), string())]))

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -1,3 +1,4 @@
+open Language;
 open Alcotest;
 open Test_Statics_Prelude;
 open FTemp;
@@ -529,112 +530,71 @@ let tests = (
         ),
       )
     }),
-    test_case("Duplicate label synthesis", `Quick, () => {
-      annotated_tree_test(
-        {|(a="hello", a=3)|},
-        prod([tup_label(label("a"), unknown(Internal))]),
-        FIError.(
-          Exp.(
-            parens(
-              ~ann=
-                Some(
-                  FTemp.Typ.(
-                    Exp(
-                      Common(
-                        TupleLabelError({
-                          malformed_labels: [],
-                          duplicate_labels: ["a", "a"],
-                          invalid_labels: [],
-                          typ:
-                            prod([
-                              tup_label(label("a"), unknown(Internal)),
-                            ]),
-                        }),
-                      ),
-                    )
-                  ),
-                ),
-              tuple(
-                ~ann=
-                  Some(
+    test_case(
+      "Duplicate label synthesis",
+      `Quick,
+      () => {
+        let duplicate_a_tuple_exp_ann: option(Info.error) =
+          Some(
+            Exp(
+              Common(
+                TupleLabelError({
+                  malformed_labels: [],
+                  duplicate_labels: ["a", "a"],
+                  invalid_labels: [],
+                  typ:
                     FTemp.Typ.(
-                      Exp(
-                        Common(
-                          TupleLabelError({
-                            malformed_labels: [],
-                            duplicate_labels: ["a", "a"],
-                            invalid_labels: [],
-                            typ:
-                              prod([
-                                tup_label(label("a"), unknown(Internal)),
-                              ]),
-                          }),
-                        ),
-                      )
+                      prod([tup_label(label("a"), unknown(Internal))])
                     ),
-                  ),
-                [
-                  tup_label(
-                    ~ann=
-                      Some(
-                        FTemp.Typ.(
-                          Exp(
-                            Common(
-                              TupleLabelError({
-                                malformed_labels: [],
-                                duplicate_labels: ["a"],
-                                invalid_labels: [],
-                                typ: tup_label(label("a"), string()),
-                              }),
-                            ),
-                          )
-                        ),
-                      ),
-                    label(
-                      ~ann=
-                        Some(
-                          FTemp.Typ.(
-                            Exp(Common(DuplicateLabel("a", label("a"))))
-                          ),
-                        ),
-                      "a",
-                    ),
-                    string("hello"),
-                  ),
-                  tup_label(
-                    ~ann=
-                      Some(
-                        FTemp.Typ.(
-                          Exp(
-                            Common(
-                              TupleLabelError({
-                                malformed_labels: [],
-                                duplicate_labels: ["a"],
-                                invalid_labels: [],
-                                typ: tup_label(label("a"), int()),
-                              }),
-                            ),
-                          )
-                        ),
-                      ),
-                    label(
-                      ~ann=
-                        Some(
-                          FTemp.Typ.(
-                            Exp(Common(DuplicateLabel("a", label("a"))))
-                          ),
-                        ),
-                      "a",
-                    ),
-                    int(3),
-                  ),
-                ],
+                }),
               ),
+            ),
+          );
+        let label_error: option(Info.error) =
+          Some(Exp(Common(DuplicateLabel("a", FTemp.Typ.label("a")))));
+        let tup_label_error = (typ): option(Info.error) =>
+          Some(
+            FTemp.Typ.(
+              Exp(
+                Common(
+                  TupleLabelError({
+                    malformed_labels: [],
+                    duplicate_labels: ["a"],
+                    invalid_labels: [],
+                    typ: tup_label(label("a"), typ),
+                  }),
+                ),
+              )
+            ),
+          );
+        annotated_tree_test(
+          {|(a="hello", a=3)|},
+          prod([tup_label(label("a"), unknown(Internal))]),
+          FIError.(
+            Exp.(
+              parens(
+                ~ann=duplicate_a_tuple_exp_ann,
+                tuple(
+                  ~ann=duplicate_a_tuple_exp_ann,
+                  [
+                    tup_label(
+                      ~ann=tup_label_error(FTemp.Typ.string()),
+                      label(~ann=label_error, "a"),
+                      string("hello"),
+                    ),
+                    tup_label(
+                      ~ann=tup_label_error(FTemp.Typ.int()),
+                      label(~ann=label_error, "a"),
+                      int(3),
+                    ),
+                  ],
+                ),
+              )
             )
-          )
-        ),
-      )
-    }),
+          ),
+        );
+      },
+    ),
     test_case("Bad label projection", `Quick, () => {
       annotated_tree_test(
         {|(1, 2) . 1|},
@@ -1066,223 +1026,142 @@ let tests = (
       {|([(a=1) : ?]).a|},
       Some(list(unknown(Internal))),
     ),
-    test_case("Nested tuple with duplicate labels", `Quick, () => {
-      annotated_tree_test(
-        {|((a=1,a=2), 3)|},
-        prod([prod([tup_label(label("a"), unknown(Internal))]), int()]),
-        FIError.(
-          Exp.(
-            tuple([
-              tuple(
-                ~ann=
-                  Some(
-                    FTemp.Typ.(
-                      Exp(
-                        Common(
-                          TupleLabelError({
-                            malformed_labels: [],
-                            duplicate_labels: ["a", "a"],
-                            invalid_labels: [],
-                            typ:
-                              prod([
-                                tup_label(label("a"), unknown(Internal)),
-                              ]),
-                          }),
-                        ),
-                      )
-                    ),
-                  ),
-                [
-                  tup_label(
-                    ~ann=
-                      Some(
-                        FTemp.Typ.(
-                          Exp(
-                            Common(
-                              TupleLabelError({
-                                malformed_labels: [],
-                                duplicate_labels: ["a"],
-                                invalid_labels: [],
-                                typ: tup_label(label("a"), int()),
-                              }),
-                            ),
-                          )
-                        ),
-                      ),
-                    label(
-                      ~ann=
-                        Some(
-                          FTemp.Typ.(
-                            Exp(Common(DuplicateLabel("a", label("a"))))
-                          ),
-                        ),
-                      "a",
-                    ),
-                    int(1),
-                  ),
-                  tup_label(
-                    ~ann=
-                      Some(
-                        FTemp.Typ.(
-                          Exp(
-                            Common(
-                              TupleLabelError({
-                                malformed_labels: [],
-                                duplicate_labels: ["a"],
-                                invalid_labels: [],
-                                typ: tup_label(label("a"), int()),
-                              }),
-                            ),
-                          )
-                        ),
-                      ),
-                    label(
-                      ~ann=
-                        Some(
-                          FTemp.Typ.(
-                            Exp(Common(DuplicateLabel("a", label("a"))))
-                          ),
-                        ),
-                      "a",
-                    ),
-                    int(2),
-                  ),
-                ],
-              ),
-              int(3),
-            ])
-          )
-        ),
-      )
-    }),
-    test_case("Duplicate labels in patterns collapse duplicates", `Quick, () => {
-      annotated_tree_test(
-        {|fun (a=a, a=b) -> 1|},
-        arrow(prod([tup_label(label("a"), unknown(Internal))]), int()),
-        FIError.(
-          Exp.(
-            fn(
-              Pat.(
-                parens(
+    test_case(
+      "Nested tuple with duplicate labels",
+      `Quick,
+      () => {
+        let duplicate_a_label_exp_ann: option(Info.error) =
+          Some(Exp(Common(DuplicateLabel("a", FTemp.Typ.label("a")))));
+        let tup_label_error: option(Info.error) =
+          Some(
+            Typ.(
+              Exp(
+                Common(
+                  TupleLabelError({
+                    malformed_labels: [],
+                    duplicate_labels: ["a"],
+                    invalid_labels: [],
+                    typ: tup_label(label("a"), int()),
+                  }),
+                ),
+              )
+            ),
+          );
+        annotated_tree_test(
+          {|((a=1,a=2), 3)|},
+          prod([prod([tup_label(label("a"), unknown(Internal))]), int()]),
+          FIError.(
+            Exp.(
+              tuple([
+                tuple(
                   ~ann=
                     Some(
-                      Pat(
-                        Common(
-                          TupleLabelError({
-                            malformed_labels: [],
-                            duplicate_labels: ["a", "a"],
-                            invalid_labels: [],
-                            typ:
-                              FTemp.Typ.(
-                                prod([
-                                  tup_label(label("a"), unknown(Internal)),
-                                ])
-                              ),
-                          }),
-                        ),
-                      ),
-                    ),
-                  tuple(
-                    ~ann=
-                      Some(
-                        Pat(
+                      FTemp.Typ.(
+                        Exp(
                           Common(
                             TupleLabelError({
                               malformed_labels: [],
                               duplicate_labels: ["a", "a"],
                               invalid_labels: [],
                               typ:
-                                FTemp.Typ.(
-                                  prod([
-                                    tup_label(
-                                      label("a"),
-                                      unknown(Internal),
-                                    ),
-                                  ])
-                                ),
+                                prod([
+                                  tup_label(label("a"), unknown(Internal)),
+                                ]),
                             }),
                           ),
-                        ),
+                        )
                       ),
-                    [
-                      tup_label(
-                        ~ann=
-                          Some(
-                            Pat(
-                              Common(
-                                TupleLabelError({
-                                  malformed_labels: [],
-                                  duplicate_labels: ["a"],
-                                  invalid_labels: [],
-                                  typ:
-                                    FTemp.Typ.(
-                                      tup_label(
-                                        label("a"),
-                                        unknown(Internal),
-                                      )
-                                    ),
-                                }),
-                              ),
-                            ),
-                          ),
-                        label(
-                          ~ann=
-                            Some(
-                              Pat(
-                                Common(
-                                  DuplicateLabel("a", FTemp.Typ.label("a")),
-                                ),
-                              ),
-                            ),
-                          "a",
-                        ),
-                        var("a"),
-                      ),
-                      tup_label(
-                        ~ann=
-                          Some(
-                            Pat(
-                              Common(
-                                TupleLabelError({
-                                  malformed_labels: [],
-                                  duplicate_labels: ["a"],
-                                  invalid_labels: [],
-                                  typ:
-                                    FTemp.Typ.(
-                                      tup_label(
-                                        label("a"),
-                                        unknown(Internal),
-                                      )
-                                    ),
-                                }),
-                              ),
-                            ),
-                          ),
-                        label(
-                          ~ann=
-                            Some(
-                              Pat(
-                                Common(
-                                  DuplicateLabel("a", FTemp.Typ.label("a")),
-                                ),
-                              ),
-                            ),
-                          "a",
-                        ),
-                        var("b"),
-                      ),
-                    ],
-                  ),
-                )
-              ),
-              int(1),
-              None,
-              None,
+                    ),
+                  [
+                    tup_label(
+                      ~ann=tup_label_error,
+                      label(~ann=duplicate_a_label_exp_ann, "a"),
+                      int(1),
+                    ),
+                    tup_label(
+                      ~ann=tup_label_error,
+                      label(~ann=duplicate_a_label_exp_ann, "a"),
+                      int(2),
+                    ),
+                  ],
+                ),
+                int(3),
+              ])
             )
-          )
-        ),
-      )
-    }),
+          ),
+        );
+      },
+    ),
+    test_case(
+      "Duplicate labels in patterns collapse duplicates",
+      `Quick,
+      () => {
+        let duplicate_a_tuple_pat_ann: option(Info.error) =
+          Some(
+            Pat(
+              Common(
+                TupleLabelError({
+                  malformed_labels: [],
+                  duplicate_labels: ["a", "a"],
+                  invalid_labels: [],
+                  typ:
+                    FTemp.Typ.(
+                      prod([tup_label(label("a"), unknown(Internal))])
+                    ),
+                }),
+              ),
+            ),
+          );
+        let single_duplicate_a_pat_ann: option(Info.error) =
+          Some(
+            Pat(
+              Common(
+                TupleLabelError({
+                  malformed_labels: [],
+                  duplicate_labels: ["a"],
+                  invalid_labels: [],
+                  typ: FTemp.Typ.(tup_label(label("a"), unknown(Internal))),
+                }),
+              ),
+            ),
+          );
+        let duplicate_a_label_pat_ann: option(Info.error) =
+          Some(Pat(Common(DuplicateLabel("a", FTemp.Typ.label("a")))));
+        annotated_tree_test(
+          {|fun (a=a, a=b) -> 1|},
+          arrow(prod([tup_label(label("a"), unknown(Internal))]), int()),
+          FIError.(
+            Exp.(
+              fn(
+                Pat.(
+                  parens(
+                    ~ann=duplicate_a_tuple_pat_ann,
+                    tuple(
+                      ~ann=duplicate_a_tuple_pat_ann,
+                      [
+                        tup_label(
+                          ~ann=single_duplicate_a_pat_ann,
+                          label(~ann=duplicate_a_label_pat_ann, "a"),
+                          var("a"),
+                        ),
+                        tup_label(
+                          ~ann=single_duplicate_a_pat_ann,
+                          label(~ann=duplicate_a_label_pat_ann, "a"),
+                          var("b"),
+                        ),
+                      ],
+                    ),
+                  )
+                ),
+                int(1),
+                None,
+                None,
+              )
+            )
+          ),
+        );
+      },
+    ),
   ]
   @ TupleExtension.tests
   @ ProductProjection.tests

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -441,29 +441,22 @@ let tests = (
               parens(
                 ~ann=
                   Some(
-                    FTemp.Typ.(
-                      Exp(
-                        Common(
-                          Inconsistent(
-                            Expectation({
-                              ana:
-                                parens(
-                                  prod([
-                                    tup_label(label("a"), int()),
-                                    tup_label(label("b"), float()),
-                                    string(),
-                                  ]),
-                                ),
-                              syn:
-                                prod([
-                                  tup_label(label("a"), int()),
-                                  tup_label(label("b"), float()),
-                                  tup_label(label("z"), string()),
-                                ]),
-                            }),
-                          ),
-                        ),
-                      )
+                    Exp(
+                      Common(
+                        TupleLabelError({
+                          malformed_labels: [],
+                          duplicate_labels: [],
+                          invalid_labels: ["z"],
+                          typ:
+                            FTemp.Typ.(
+                              prod([
+                                tup_label(label("a"), int()),
+                                tup_label(label("b"), float()),
+                                string(),
+                              ])
+                            ),
+                        }),
+                      ),
                     ),
                   ),
                 tuple(
@@ -480,7 +473,7 @@ let tests = (
                                 prod([
                                   tup_label(label("a"), int()),
                                   tup_label(label("b"), float()),
-                                  tup_label(label("z"), string()),
+                                  string(),
                                 ])
                               ),
                           }),
@@ -557,8 +550,8 @@ let tests = (
                               tup_label(label("a"), unknown(Internal)),
                             ]),
                         }),
-                      )
-                    ),
+                      ),
+                    )
                   ),
                 ),
               tuple(
@@ -688,12 +681,10 @@ let tests = (
                           invalid_labels: [],
                           typ:
                             Typ.(
-                              prod([
-                                tup_label(unknown(Internal), string()),
-                              ])
+                              prod([tup_label(unknown(Internal), string())])
                             ),
                         }),
-                      )
+                      ),
                     )
                   ),
                 ),
@@ -809,7 +800,7 @@ let tests = (
                               ])
                             ),
                         }),
-                      )
+                      ),
                     )
                   ),
                 ),
@@ -895,31 +886,6 @@ let tests = (
             let_(
               Pat.(
                 asc(
-                  ~ann=
-                    Some(
-                      Pat(
-                        Common(
-                          Inconsistent(
-                            FTemp.Typ.(
-                              Expectation({
-                                ana:
-                                  prod([
-                                    tup_label(label("c"), int()),
-                                    tup_label(label("a"), string()),
-                                  ]),
-                                syn:
-                                  parens(
-                                    prod([
-                                      int(),
-                                      tup_label(label("a"), string()),
-                                    ]),
-                                  ),
-                              })
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
                   var("extra_label"),
                   Typ.(
                     parens(prod([int(), tup_label(label("a"), string())]))
@@ -931,24 +897,15 @@ let tests = (
                   Some(
                     Exp(
                       Common(
-                        Inconsistent(
-                          FTemp.Typ.(
-                            Expectation({
-                              ana:
-                                parens(
-                                  prod([
-                                    int(),
-                                    tup_label(label("a"), string()),
-                                  ]),
-                                ),
-                              syn:
-                                prod([
-                                  tup_label(label("c"), int()),
-                                  tup_label(label("a"), string()),
-                                ]),
-                            })
-                          ),
-                        ),
+                        TupleLabelError({
+                          malformed_labels: [],
+                          duplicate_labels: [],
+                          invalid_labels: ["c"],
+                          typ:
+                            FTemp.Typ.(
+                              prod([int(), tup_label(label("a"), string())])
+                            ),
+                        }),
                       ),
                     ),
                   ),
@@ -964,7 +921,7 @@ let tests = (
                             typ:
                               FTemp.Typ.(
                                 prod([
-                                  tup_label(label("c"), int()),
+                                  int(),
                                   tup_label(label("a"), string()),
                                 ])
                               ),

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -543,6 +543,24 @@ let tests = (
         FIError.(
           Exp.(
             parens(
+              ~ann=
+                Some(
+                  FTemp.Typ.(
+                    Exp(
+                      Common(
+                        TupleLabelError({
+                          malformed_labels: [],
+                          duplicate_labels: ["a", "a"],
+                          invalid_labels: [],
+                          typ:
+                            prod([
+                              tup_label(label("a"), unknown(Internal)),
+                            ]),
+                        }),
+                      )
+                    ),
+                  ),
+                ),
               tuple(
                 ~ann=
                   Some(
@@ -657,6 +675,28 @@ let tests = (
         FIError.(
           Exp.(
             parens(
+              ~ann=
+                Some(
+                  FTemp.(
+                    Exp(
+                      Common(
+                        TupleLabelError({
+                          malformed_labels: [
+                            Exp.(Exp(multi_hole([Exp(label("1"))]))),
+                          ],
+                          duplicate_labels: [],
+                          invalid_labels: [],
+                          typ:
+                            Typ.(
+                              prod([
+                                tup_label(unknown(Internal), string()),
+                              ])
+                            ),
+                        }),
+                      )
+                    )
+                  ),
+                ),
               tuple(
                 ~ann=
                   Some(
@@ -750,6 +790,29 @@ let tests = (
         FIError.(
           Exp.(
             parens(
+              ~ann=
+                Some(
+                  FTemp.(
+                    Exp(
+                      Common(
+                        TupleLabelError({
+                          malformed_labels: [
+                            Exp.(Exp(multi_hole([Exp(int(1))]))),
+                          ],
+                          duplicate_labels: [],
+                          invalid_labels: [],
+                          typ:
+                            Typ.(
+                              prod([
+                                tup_label(unknown(Internal), string()),
+                                tup_label(label("a"), int()),
+                              ])
+                            ),
+                        }),
+                      )
+                    )
+                  ),
+                ),
               tuple(
                 ~ann=
                   Some(


### PR DESCRIPTION
Parens and probe now mirror the info of their enclosed expression/pattern/type. Cursor inspector messages and marks appear on the parens themselves, and the parens’ self type matches the inner node’s self type (important for the type projector).

Fixes uncovered while enabling this:
-  Redundant patterns can carry tuple errors; these are no longer thrown or hidden by parentheses. #2014 
-  Duplicate pattern labels were synthesizing the wrong type; this is corrected. #2012 
-  Certain type-preserving errors in lets were incorrectly moving diagnostics from the expression to the pattern because the analytical type on the expression wasn’t preserved; this now stays on the expression. #2011 
- Remove `WithArrow` and `IncompleteVariant` errors that are never used

Behavioral impact
- Diagnostics (messages and marks) now show up on parentheses/probes exactly as on their contents.
- Type projection over parentheses reflects the same self type as the enclosed node.