### PR TITLE
fix(stepper): tweak equality settings

### DIFF
--- a/src/language/dynamics/stepper/FilterMatcher.re
+++ b/src/language/dynamics/stepper/FilterMatcher.re
@@ -3,6 +3,7 @@ let matches_exp = (~denv, d, ~fenv, f) => {
     equality({
       ...semantic_settings,
       ignore_fixpoints: true,
+      ignore_ascriptions: true,
       use_expr_wildcards:
         Some((env, exp) => ValueChecker.check_value(env, exp) != Expr),
       env1: Some(fenv),


### PR DESCRIPTION
This PR fixes the bad case in #1835. Note that the settings might need to be tuned further to cover all stepper-irrelevant language constructs. This PR only sets `ignore_ascriptions` to true, so that when pattern-matching a expression against a pattern, the ascription wraps around the function parameter and other expressions will not cause the pattern-matching to fail.

Note that when recursive function is defined without type-annotation, there is no ascriptions, hence a correct trajectory when stepper through the program.