### PR TITLE
Duplicate labels in product types cause introduce and typechecking to check against invalid types

### DIFF
--- a/src/haz3lcore/zipper/action/Introduce.re
+++ b/src/haz3lcore/zipper/action/Introduce.re
@@ -246,8 +246,8 @@ let introduce = (ci: option(Info.t), z: Zipper.t) => {
         _,
       }),
     ) =>
-    module IP = Make(IntroduceExp);
-    IP.introduce(z, Typ.weak_head_normalize(ctx, ana), ctx);
+    module IE = Make(IntroduceExp);
+    IE.introduce(z, Typ.weak_head_normalize(ctx, ana), ctx);
 
   | Some(
       InfoPat({

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -1919,7 +1919,17 @@ and utyp_to_info_map =
       List.is_empty(duplicate_labels)
         ? map_m(go, ts, m) |> snd
         : map_m(
-            go'(~expects=LabelExpected(Duplicate, duplicate_labels)),
+            (t: Typ.t) =>
+              go'(
+                ~expects=
+                  switch (t.term) {
+                  | Label(_)
+                  | TupLabel(_, _) =>
+                    LabelExpected(Duplicate, duplicate_labels)
+                  | _ => TypeExpected
+                  },
+                t,
+              ),
             ts,
             m,
           )

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -487,12 +487,13 @@ let product_extension = (tys1: list(t), tys2: list(t)): term => {
 /**
  * Removes duplicate labels from a given list of types inside a tuple.
  *
- * This function takes a list of types and returns a new list with all
- * duplicate labels replaced with their first occurence and the unknown type.
+ * For each label in the list of duplicate labels, keeps only the first occurrence,
+ * replacing its type with Unknown(Internal), and removes all subsequent occurrences.
  *
  * @param duplicate_labels - The list of duplicate labels.
  * @param tys - The list of types to remove duplicates from.
- * @return A new list of types with duplicates removed.
+ * @return A new list of types where, for each duplicate label, only the first occurrence
+ *         is kept (with type Unknown(Internal)), and all subsequent occurrences are removed.
  */
 let remove_duplicate_labels =
     (~duplicate_labels: list(LabeledTuple.label), tys: list(t)): list(t) => {

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -497,32 +497,32 @@ let product_extension = (tys1: list(t), tys2: list(t)): term => {
  */
 let remove_duplicate_labels =
     (~duplicate_labels: list(LabeledTuple.label), tys: list(t)): list(t) => {
-  snd(
+  let (_, rev_deduplicated) =
     List.fold_left(
-      ((seen_duplicates, deduplicated_types), ty) => {
+      ((seen_duplicates, rev_deduplicated_types), ty) => {
         let tup_label = match_tup_label(ty);
         switch (tup_label) {
         | Some((l, _))
             when
               List.mem(l, duplicate_labels) && List.mem(l, seen_duplicates) => (
             seen_duplicates,
-            deduplicated_types,
+            rev_deduplicated_types,
           )
         | Some((l, _)) when List.mem(l, duplicate_labels) => (
             [l, ...seen_duplicates],
-            deduplicated_types
-            @ [
+            [
               TupLabel(Label(l) |> temp, Unknown(Internal) |> temp) |> temp,
+              ...rev_deduplicated_types,
             ],
           )
-        | Some(_) => (seen_duplicates, deduplicated_types @ [ty])
-        | None => (seen_duplicates, deduplicated_types @ [ty])
+        | Some(_) => (seen_duplicates, [ty, ...rev_deduplicated_types])
+        | None => (seen_duplicates, [ty, ...rev_deduplicated_types])
         };
       },
       ([], []),
       tys,
-    ),
-  );
+    );
+  List.rev(rev_deduplicated);
 };
 
 let rec weak_head_normalize = (~rec_counter=0, ctx: Ctx.t, ty: t): t => {

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -484,6 +484,46 @@ let product_extension = (tys1: list(t), tys2: list(t)): term => {
   Prod(new_tys);
 };
 
+/**
+ * Removes duplicate labels from a given list of types inside a tuple.
+ *
+ * This function takes a list of types and returns a new list with all
+ * duplicate labels replaced with their first occurence and the unknown type.
+ *
+ * @param duplicate_labels - The list of duplicate labels.
+ * @param tys - The list of types to remove duplicates from.
+ * @return A new list of types with duplicates removed.
+ */
+let remove_duplicate_labels =
+    (~duplicate_labels: list(LabeledTuple.label), tys: list(t)): list(t) => {
+  snd(
+    List.fold_left(
+      ((seen_duplicates, deduplicated_types), ty) => {
+        let tup_label = match_tup_label(ty);
+        switch (tup_label) {
+        | Some((l, _))
+            when
+              List.mem(l, duplicate_labels) && List.mem(l, seen_duplicates) => (
+            seen_duplicates,
+            deduplicated_types,
+          )
+        | Some((l, _)) when List.mem(l, duplicate_labels) => (
+            [l] @ seen_duplicates,
+            deduplicated_types
+            @ [
+              TupLabel(Label(l) |> temp, Unknown(Internal) |> temp) |> temp,
+            ],
+          )
+        | Some(_) => (seen_duplicates, deduplicated_types @ [ty])
+        | None => (seen_duplicates, deduplicated_types @ [ty])
+        };
+      },
+      ([], []),
+      tys,
+    ),
+  );
+};
+
 let rec weak_head_normalize = (~rec_counter=0, ctx: Ctx.t, ty: t): t => {
   if (rec_counter > 1000) {
     failwith("weak_head_normalize exceeded 1000 recursive calls");
@@ -510,6 +550,16 @@ let rec weak_head_normalize = (~rec_counter=0, ctx: Ctx.t, ty: t): t => {
       }
     )
     |> Option.value(~default=Unknown(Internal) |> rewrap);
+  | Prod(ts) =>
+    let (_, rewrap) = unwrap(ty);
+    let duplicate_labels =
+      LabeledTuple.get_duplicate_labels(match_tup_label, ts);
+    if (List.is_empty(duplicate_labels)) {
+      ty;
+    } else {
+      let cleaned_ts = remove_duplicate_labels(~duplicate_labels, ts);
+      Prod(cleaned_ts) |> rewrap;
+    };
   | ProdExtension(t1, t2) =>
     let (_, rewrap) = unwrap(ty);
 
@@ -645,13 +695,26 @@ let rec join = (~resolve=false, ctx: Ctx.t, ty1: t, ty2: t): option(t) => {
     TupLabel(lab, ty) |> temp;
   | (TupLabel(_), _) => None
   | (Prod(tys1), Prod(tys2)) =>
+    let tys1 =
+      remove_duplicate_labels(
+        ~duplicate_labels=
+          LabeledTuple.get_duplicate_labels(match_tup_label, tys1),
+        tys1,
+      );
+    let tys2 =
+      remove_duplicate_labels(
+        ~duplicate_labels=
+          LabeledTuple.get_duplicate_labels(match_tup_label, tys2),
+        tys2,
+      );
+
     if (List.length(tys1) != List.length(tys2)) {
       None;
     } else {
       let* tys = ListUtil.map2_opt(join', tys1, tys2);
       let+ tys = OptUtil.sequence(tys);
       Prod(tys) |> temp;
-    }
+    };
   | (Prod(_), _) => None
   | (Sum(sm1), Sum(sm2)) =>
     let+ sm' = ConstructorMap.join(equal, join(~resolve, ctx), sm1, sm2);
@@ -1019,46 +1082,6 @@ and paren_pretty_print = typ =>
   } else {
     pretty_print(typ);
   };
-
-/**
- * Removes duplicate labels from a given list of types inside a tuple.
- *
- * This function takes a list of types and returns a new list with all
- * duplicate labels replaced with their first occurence and the unknown type.
- *
- * @param duplicate_labels - The list of duplicate labels.
- * @param tys - The list of types to remove duplicates from.
- * @return A new list of types with duplicates removed.
- */
-let remove_duplicate_labels =
-    (~duplicate_labels: list(LabeledTuple.label), tys: list(t)): list(t) => {
-  snd(
-    List.fold_left(
-      ((seen_duplicates, deduplicated_types), ty) => {
-        let tup_label = match_tup_label(ty);
-        switch (tup_label) {
-        | Some((l, _))
-            when
-              List.mem(l, duplicate_labels) && List.mem(l, seen_duplicates) => (
-            seen_duplicates,
-            deduplicated_types,
-          )
-        | Some((l, _)) when List.mem(l, duplicate_labels) => (
-            [l] @ seen_duplicates,
-            deduplicated_types
-            @ [
-              TupLabel(Label(l) |> temp, Unknown(Internal) |> temp) |> temp,
-            ],
-          )
-        | Some(_) => (seen_duplicates, deduplicated_types @ [ty])
-        | None => (seen_duplicates, deduplicated_types @ [ty])
-        };
-      },
-      ([], []),
-      tys,
-    ),
-  );
-};
 
 /**
  * Converts a list of types (`tys`) into a product type.

--- a/src/language/term/Typ.re
+++ b/src/language/term/Typ.re
@@ -509,7 +509,7 @@ let remove_duplicate_labels =
             deduplicated_types,
           )
         | Some((l, _)) when List.mem(l, duplicate_labels) => (
-            [l] @ seen_duplicates,
+            [l, ...seen_duplicates],
             deduplicated_types
             @ [
               TupLabel(Label(l) |> temp, Unknown(Internal) |> temp) |> temp,

--- a/test/Test_Introduce.re
+++ b/test/Test_Introduce.re
@@ -58,7 +58,12 @@ let introduction_test = (before: string, expected: string) => {
 };
 
 let introduce_expression = (x: Typ.t): option(Exp.t) =>
-  Haz3lcore.Introduce.IntroduceExp.introduce(x)
+  Haz3lcore.Introduce.IntroduceExp.introduce(
+    Typ.weak_head_normalize(
+      Builtins.ctx_init(Some(Operators.default_mode)),
+      x,
+    ),
+  )
   |> Option.map(((a, _b, _c)) => a);
 
 let tests =
@@ -197,6 +202,25 @@ let tests =
             introduce_expression(Typ.(list(int()))),
           )
         }),
+        test_case(
+          "Duplicate labels in product",
+          `Quick,
+          () => {
+            let duplicate_prod =
+              Typ.(
+                prod([
+                  tup_label(label("a"), int()),
+                  tup_label(label("a"), string()),
+                ])
+              );
+            check(
+              option(exp),
+              "Duplicate labels should introduce single label",
+              Some(Exp.(tuple([tup_label(label("a"), empty_hole())]))),
+              introduce_expression(duplicate_prod),
+            );
+          },
+        ),
       ],
     ),
     (

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -1036,7 +1036,7 @@ let tests = (
         ),
       )
     }),
-    test_case("Duplicat label leaves non-labeled unaffected", `Quick, () => {
+    test_case("Duplicate label leaves non-labeled unaffected", `Quick, () => {
       annotated_tree_test(
         "? : (a=Int, a=String, Float)",
         Typ.prod([

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -1036,6 +1036,42 @@ let tests = (
         ),
       )
     }),
+    test_case("Duplicat label leaves non-labeled unaffected", `Quick, () => {
+      annotated_tree_test(
+        "? : (a=Int, a=String, Float)",
+        Typ.prod([
+          tup_label(label("a"), int()),
+          tup_label(label("a"), string()),
+          float(),
+        ]),
+        FIError.(
+          Exp.(
+            asc(
+              empty_hole(),
+              Typ.(
+                prod([
+                  tup_label(
+                    label(
+                      ~ann=Some(Typ(Duplicate("a", FTemp.Typ.label("a")))),
+                      "a",
+                    ),
+                    int(),
+                  ),
+                  tup_label(
+                    label(
+                      ~ann=Some(Typ(Duplicate("a", FTemp.Typ.label("a")))),
+                      "a",
+                    ),
+                    string(),
+                  ),
+                  float(),
+                ])
+              ),
+            )
+          )
+        ),
+      )
+    }),
   ]
   @ TupleExtension.tests
   @ ProductProjection.tests

--- a/test/statics/Test_Statics_Tuples.re
+++ b/test/statics/Test_Statics_Tuples.re
@@ -1002,6 +1002,40 @@ let tests = (
       {|([(a=1) : ?]).a|},
       Some(list(unknown(Internal))),
     ),
+    test_case("Duplicate labels in type", `Quick, () => {
+      annotated_tree_test(
+        "(a=?) : (a=Int, a=String)",
+        Typ.prod([
+          tup_label(label("a"), int()),
+          tup_label(label("a"), string()),
+        ]),
+        FIError.(
+          Exp.(
+            asc(
+              tuple([tup_label(label("a"), empty_hole())]),
+              Typ.(
+                prod([
+                  tup_label(
+                    label(
+                      ~ann=Some(Typ(Duplicate("a", FTemp.Typ.label("a")))),
+                      "a",
+                    ),
+                    int(),
+                  ),
+                  tup_label(
+                    label(
+                      ~ann=Some(Typ(Duplicate("a", FTemp.Typ.label("a")))),
+                      "a",
+                    ),
+                    string(),
+                  ),
+                ])
+              ),
+            )
+          )
+        ),
+      )
+    }),
   ]
   @ TupleExtension.tests
   @ ProductProjection.tests


### PR DESCRIPTION
Fixes #2013 

Also fixes issue with unlabeled product entries getting marked in the presence of duplicates like `? : (a=Int, a=String, Float)`