### PR TITLE
Fix #1458

### DIFF
--- a/src/haz3lcore/lang/MakeTerm.re
+++ b/src/haz3lcore/lang/MakeTerm.re
@@ -708,19 +708,13 @@ and typ_term: unsorted => (Typ.term, list(Id.t)) = {
     }
   | Pre(tiles, Typ(t)) as tm =>
     switch (tiles) {
-    | ([(_, (["+"], []))], []) =>
-      ret(Sum([parse_sum_term(t)] |> ConstructorMap.mk(~mk_bad)))
+    | ([(_, (["+"], []))], []) => ret(Sum([parse_sum_term(t)]))
     | _ => ret(hole(tm))
     }
   | Bin(Typ(t1), tiles, Typ(t2)) as tm when is_typ_bsum(tiles) != None =>
     switch (is_typ_bsum(tiles)) {
     | Some(between_kids) =>
-      ret(
-        Sum(
-          List.map(parse_sum_term, [t1] @ between_kids @ [t2])
-          |> ConstructorMap.mk(~mk_bad),
-        ),
-      )
+      ret(Sum(List.map(parse_sum_term, [t1] @ between_kids @ [t2])))
     | None => ret(hole(tm))
     }
   | Bin(Typ(l), tiles, Typ(r)) as tm =>

--- a/src/language/statics/ConstructorMap.re
+++ b/src/language/statics/ConstructorMap.re
@@ -9,27 +9,6 @@ type variant('a) =
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t('a) = list(variant('a));
 
-let mk =
-    (
-      ~mk_bad: (Constructor.t, list(Id.t), option('a)) => 'a,
-      with_duplicates: list(variant('a)),
-    )
-    : t('a) => {
-  let rec go = (xs, seen: list(Constructor.t)) => {
-    switch (xs) {
-    | [] => []
-    | [BadEntry(x), ...xs] => [BadEntry(x), ...go(xs, seen)]
-    | [Variant(ctr, ids, value), ...xs] =>
-      if (List.mem(ctr, seen)) {
-        [BadEntry(mk_bad(ctr, ids, value)), ...go(xs, seen)];
-      } else {
-        [Variant(ctr, ids, value), ...go(xs, List.cons(ctr, seen))];
-      }
-    };
-  };
-  go(with_duplicates, []);
-};
-
 let equal_constructor =
     (eq: ('a, 'a) => bool, x: variant('a), y: variant('a)): bool =>
   switch (x, y) {

--- a/test/Test_MakeTerm.re
+++ b/test/Test_MakeTerm.re
@@ -70,6 +70,27 @@ let tests =
           "type x = Int in 1",
         )
       ),
+      test_case(
+        "Duplicate constructors in type alias don't become bad entries",
+        `Quick,
+        ()
+        // turning them into bad entries led to this regression
+        // https://github.com/hazelgrove/hazel/issues/1458
+        =>
+          exp_check(
+            ty_alias(
+              TPat.var("A2"),
+              Typ.(
+                sum([
+                  Variant("A", [Util.Id.mk()], None),
+                  Variant("A", [Util.Id.mk()], None),
+                ])
+              ),
+              empty_hole(),
+            ),
+            "type A2 = A + A in ?",
+          )
+        ),
       test_case("Singleton Labeled Tuple ascription in let", `Quick, () =>
         exp_check(
           let_(

--- a/test/statics/Test_Statics_Prelude.re
+++ b/test/statics/Test_Statics_Prelude.re
@@ -188,6 +188,7 @@ let skip_known_bug = (message: string, expression: string) =>
     }
   });
 
+// FactoryInfoError
 module FIError =
   Grammar.Factory({
     type t = option(Info.error);

--- a/test/statics/Test_Statics_Sums.re
+++ b/test/statics/Test_Statics_Sums.re
@@ -1,6 +1,10 @@
 open Test_Statics_Prelude;
 open FTemp;
 open Typ;
+open Util;
+
+let testable_id =
+  Alcotest.(testable(Fmt.using(Id.show, Fmt.string), Id.equal));
 
 let tests = (
   "Statics.Sums",
@@ -330,6 +334,40 @@ end
     let _ : +Yo = Yo("lol") in ?
     |} |> parse_exp,
     ),
+    Alcotest.test_case(
+      "Sum type duplicate constructor",
+      `Quick,
+      () => {
+        let id1 = Id.mk();
+        let id2 = Id.mk();
+        open Language;
+        let exp =
+          IdTagged.FreshGrammar.(
+            Exp.(
+              ty_alias(
+                TPat.var("A2"),
+                Typ.(
+                  sum([
+                    Variant("A", [id1], None),
+                    Variant("A", [id2], None),
+                  ])
+                ),
+                Exp.empty_hole(),
+              )
+            )
+          );
+
+        let error = Statics.Map.errors(statics(exp)) |> List.assoc(id2);
+        Alcotest.(
+          check(
+            testable_error,
+            "duplicate constructor present",
+            Typ(DuplicateConstructor("A")),
+            error,
+          )
+        );
+      },
+    ),
     // ======================== KNOWN BUGS ==============================
     skip_known_bug(
       // inconsistent_typecheck(
@@ -337,20 +375,6 @@ end
       // #err: invalid type name#
       {|
     type badTypeName = ? in ?
-    |},
-      // |> parse_exp,
-    ),
-    // Issue #1458
-    skip_known_bug(
-      // inconsistent_typecheck(
-      "duplicate constructors",
-      // #err: already used#
-      {|
-    type Dupes =
-      + Guy(Bool)
-      + Guy(Int)
-      + Guy
-    in ?
     |},
       // |> parse_exp,
     ),


### PR DESCRIPTION
Fixes https://github.com/hazelgrove/hazel/issues/1458. Problem was MakeTerm was prematurely detecting duplicate constructors and replacing them with BadEntry forms.

<img width="916" height="454" alt="image" src="https://github.com/user-attachments/assets/e3b5606e-bf18-4f0b-ab59-9624b943d248" />
