### PR TITLE
Don't serialize worker messages

### DIFF
--- a/src/language/term/Environment.re
+++ b/src/language/term/Environment.re
@@ -9,8 +9,7 @@ type t('a) =
       id: Id.t,
       binding: binding('a),
       prev_env: t('a),
-      cached_search_tree:
-        Core.Map.t(Var.t, 'a, Core.String.comparator_witness),
+      cached_search_tree: Maps.StringMap.t('a),
     });
 
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
@@ -28,14 +27,13 @@ let extend = (type a, ~id=Id.mk(), env: t(a), (v: Var.t, x: a)): t(a) => {
     binding: (v, x),
     prev_env: env,
     cached_search_tree:
-      Core.Map.update(
+      Maps.StringMap.add(
+        v,
+        x,
         switch (env) {
-        | Empty => Core.Map.empty((module Core.String))
+        | Empty => Maps.StringMap.empty
         | E(e) => e.cached_search_tree
         },
-        v,
-        ~f=_ =>
-        x
       ),
   });
 };
@@ -136,7 +134,8 @@ let rec fold = (f: ((Var.t, 'a), 'b) => 'b, init: 'b, env: t('a)): 'b =>
 let lookup = (env: t('a), v: Var.t): option('a) => {
   switch (env) {
   | Empty => None
-  | E({cached_search_tree, _}) => Core.Map.find(cached_search_tree, v)
+  | E({cached_search_tree, _}) =>
+    Maps.StringMap.find_opt(v, cached_search_tree)
   };
 };
 

--- a/src/web/util/WorkerClient.re
+++ b/src/web/util/WorkerClient.re
@@ -4,9 +4,10 @@ open WorkerServer;
 let name = "worker.js"; // Worker file name
 let timeoutDuration = 20000; // Worker timeout in ms
 
-let initWorker = () => Worker.create(name);
+let initWorker: unit => Js.t(Worker.worker(Request.t, Response.t)) =
+  () => Worker.create(name);
 
-let workerRef: ref(Js.t(Worker.worker(string, string))) =
+let workerRef: ref(Js.t(Worker.worker(Request.t, Response.t))) =
   ref(initWorker());
 
 let timeoutId = ref(None);
@@ -31,7 +32,7 @@ let request =
         | None => ()
         };
         timeoutId.contents = None; /* Clear timeout after response */
-        evt##.data |> Response.deserialize |> handler;
+        evt##.data |> handler;
         Js._true;
       });
   };
@@ -46,7 +47,7 @@ let request =
 
   setupWorkerMessageHandler(workerRef.contents);
 
-  workerRef.contents##postMessage(Request.serialize(req));
+  workerRef.contents##postMessage(req);
 
   let onTimeout = (): unit => {
     restart_worker();

--- a/src/web/util/WorkerServer.re
+++ b/src/web/util/WorkerServer.re
@@ -41,11 +41,9 @@ let work = (res: Request.value): Response.value =>
   | (result, state) => Ok((result, state))
   };
 
-let on_request = (req: string): unit =>
+let on_request = (req: Request.t): unit =>
   req
-  |> Request.deserialize
   |> List.map(((k, v)) => (k, work(v)))
-  |> Response.serialize
   |> Js_of_ocaml.Worker.post_message;
 
 let start = () => Js_of_ocaml.Worker.set_onmessage(on_request);


### PR DESCRIPTION
Changes:
- WorkerClient.re: Changed worker type to Worker.worker(Request.t, Response.t), removed serialize/deserialize calls
- WorkerServer.re: Removed sexp serialization, receives/sends OCaml values directly
- Environment.re: Changed cached_search_tree from Core.Map.t to Maps.StringMap.t (Core.Map embeds a comparator function that cannot be structured-cloned)