### PR TITLE
Disable culling to fix #2702

### DIFF
--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -706,7 +706,7 @@ module View = {
       let culling_enabled =
         switch (editors) {
         | Scratch(_)
-        | Documentation(_) => true
+        | Documentation(_) => false /* Disabled for now due to layout issues */
         | Tutorial(_)
         | Exercises(_) => false
         };


### PR DESCRIPTION
Temporarily removes culling to fix a layout bug; (https://github.com/hazelgrove/hazel/issues/2072).

Proper fix will take time to figure out how to adjust the culling to know the positions of the functions on screen.