### PR TITLE
Hide case steps by default

### DIFF
--- a/src/language/CoreSettings.re
+++ b/src/language/CoreSettings.re
@@ -7,6 +7,7 @@ module Evaluation = {
     show_fn_bodies: bool,
     show_fixpoints: bool,
     show_ascription_steps: bool,
+    show_case_steps: bool,
     show_lookup_steps: bool,
     show_stepper_filters: bool,
     // TODO[Matt]: Move this to somewhere where it is a per-scratch setting
@@ -21,6 +22,7 @@ module Evaluation = {
     show_fn_bodies: false,
     show_fixpoints: false,
     show_ascription_steps: false,
+    show_case_steps: false,
     show_lookup_steps: false,
     show_stepper_filters: false,
     stepper_history: false,

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -997,8 +997,8 @@ let should_hide_step_kind = (~settings: CoreSettings.Evaluation.t) =>
   | UnOp(_)
   | ListCons
   | ListConcat
-  | TupleExtension
-  | CaseApply
+  | TupleExtension => false
+  | CaseApply => !settings.show_case_steps
   | Projection // TODO(Matt): We don't want to show projection to the user
   | Conditional(_)
   | RemoveTypeAlias

--- a/src/web/Settings.re
+++ b/src/web/Settings.re
@@ -29,6 +29,7 @@ module Model = {
         show_fn_bodies: false,
         show_fixpoints: false,
         show_ascription_steps: false,
+        show_case_steps: false,
         show_lookup_steps: false,
         show_stepper_filters: false,
         stepper_history: false,
@@ -92,6 +93,7 @@ module Update = {
     | ShowCaseClauses
     | ShowFnBodies
     | ShowAscriptionSteps
+    | ShowCaseSteps
     | ShowFixpoints
     | ShowLookups
     | ShowFilters
@@ -192,6 +194,10 @@ module Update = {
           | ShowAscriptionSteps => {
               ...evaluation,
               show_ascription_steps: !evaluation.show_ascription_steps,
+            }
+          | ShowCaseSteps => {
+              ...evaluation,
+              show_case_steps: !evaluation.show_case_steps,
             }
           | ShowFixpoints => {
               ...evaluation,

--- a/src/web/view/NutMenu.re
+++ b/src/web/view/NutMenu.re
@@ -95,6 +95,12 @@ let stepper_group = (~globals: Globals.t) => {
         Evaluation(ShowAscriptionSteps),
       ),
       (
+        "⇨",
+        "Show Case Steps",
+        s.show_case_steps,
+        Evaluation(ShowCaseSteps),
+      ),
+      (
         "π",
         "Proof Steps (experimental)",
         s.enable_proof,


### PR DESCRIPTION
Skip case-selection steps in the stepper by default - this cleans up a lot of the examples we use in the prover