### PR TITLE
Fix multiline paste behavior on Windows

### DIFF
--- a/src/util/StringUtil.re
+++ b/src/util/StringUtil.re
@@ -74,9 +74,9 @@ let unescape_linebreaks: string => string =
 
 let trim_leading = (s: string): string => {
   s
-  |> replace(regexp("\r\n"), _, "\n")  // Normalize Windows line breaks
-  |> replace(regexp("\r"), _, "\n")    // Normalize old Mac line breaks
-  |> replace(regexp("^[ ]*"), _, "")  // Remove leading spaces at start
+  |> replace(regexp("\r\n"), _, "\n") // Normalize Windows line breaks
+  |> replace(regexp("\r"), _, "\n") // Normalize old Mac line breaks
+  |> replace(regexp("^[ ]*"), _, "") // Remove leading spaces at start
   |> replace(regexp("\n[ ]*"), _, "\n"); // Remove leading spaces after newlines
 };
 

--- a/src/util/StringUtil.re
+++ b/src/util/StringUtil.re
@@ -74,9 +74,9 @@ let unescape_linebreaks: string => string =
 
 let trim_leading = (s: string): string => {
   s
-  |> replace(regexp("\r\n"), _, "\n") // Normalize Windows line breaks
-  |> replace(regexp("\r"), _, "\n") // Normalize old Mac line breaks
-  |> replace(regexp("^[ ]*"), _, "") // Remove leading spaces at start
+  |> replace(regexp("\r\n"), _, "\n")  // Normalize Windows line breaks
+  |> replace(regexp("\r"), _, "\n")  // Normalize old Mac line breaks
+  |> replace(regexp("^[ ]*"), _, "")  // Remove leading spaces at start
   |> replace(regexp("\n[ ]*"), _, "\n"); // Remove leading spaces after newlines
 };
 

--- a/src/util/StringUtil.re
+++ b/src/util/StringUtil.re
@@ -74,6 +74,8 @@ let unescape_linebreaks: string => string =
 
 let trim_leading = (s: string): string => {
   s
+  |> replace(regexp("\r\n"), _, "\n")  // Normalize Windows line breaks
+  |> replace(regexp("\r"), _, "\n")    // Normalize old Mac line breaks
   |> replace(regexp("^[ ]*"), _, "")  // Remove leading spaces at start
   |> replace(regexp("\n[ ]*"), _, "\n"); // Remove leading spaces after newlines
 };


### PR DESCRIPTION
## Summary
Normalize `\r\n` (Windows) and `\r` (old Mac) line breaks to `\n` in the trim_leading function to prevent parsing errors that appear as red error markers when pasting multiline code.

## Changes
- Modified `src/util/StringUtil.re` to normalize line breaks before trimming

Fixes #2090

Generated with [Claude Code](https://claude.ai/code)