### PR TITLE
Fix issue when pasting code with linebreaks in windows

### DIFF
--- a/src/util/StringUtil.re
+++ b/src/util/StringUtil.re
@@ -74,9 +74,9 @@ let unescape_linebreaks: string => string =
 
 let trim_leading = (s: string): string => {
   s
-  |> replace(regexp("\r\n"), _, "\n")  // Normalize Windows line breaks
-  |> replace(regexp("\r"), _, "\n")    // Normalize old Mac line breaks
-  |> replace(regexp("^[ ]*"), _, "")  // Remove leading spaces at start
+  |> replace(regexp("\r\n"), _, "\n") // Normalize Windows line breaks
+  |> replace(regexp("\r"), _, "\n") // Normalize old Mac line breaks
+  |> replace(regexp("^[ ]*"), _, "") // Remove leading spaces at start
   |> replace(regexp("\n[ ]*"), _, "\n"); // Remove leading spaces after newlines
 };
 

--- a/src/util/StringUtil.re
+++ b/src/util/StringUtil.re
@@ -74,9 +74,9 @@ let unescape_linebreaks: string => string =
 
 let trim_leading = (s: string): string => {
   s
-  |> replace(regexp("\r\n"), _, "\n") // Normalize Windows line breaks
-  |> replace(regexp("\r"), _, "\n") // Normalize old Mac line breaks
-  |> replace(regexp("^[ ]*"), _, "") // Remove leading spaces at start
+  |> replace(regexp("\r\n"), _, "\n")  // Normalize Windows line breaks
+  |> replace(regexp("\r"), _, "\n")  // Normalize old Mac line breaks
+  |> replace(regexp("^[ ]*"), _, "")  // Remove leading spaces at start
   |> replace(regexp("\n[ ]*"), _, "\n"); // Remove leading spaces after newlines
 };
 

--- a/src/util/StringUtil.re
+++ b/src/util/StringUtil.re
@@ -74,6 +74,8 @@ let unescape_linebreaks: string => string =
 
 let trim_leading = (s: string): string => {
   s
+  |> replace(regexp("\r\n"), _, "\n")  // Normalize Windows line breaks
+  |> replace(regexp("\r"), _, "\n")    // Normalize old Mac line breaks
   |> replace(regexp("^[ ]*"), _, "")  // Remove leading spaces at start
   |> replace(regexp("\n[ ]*"), _, "\n"); // Remove leading spaces after newlines
 };

--- a/test/Test_ExpToSegment.re
+++ b/test/Test_ExpToSegment.re
@@ -1041,11 +1041,7 @@ let roundtrip_grout_text_test = (name: string, input: string) =>
          This achieves true string round-tripping since grout is internally
          inserted, not explicitly typed by users. */
       let print_seg_grout =
-        Printer.of_segment(
-          ~holes="",
-          ~concave_holes="",
-          ~refractors=Id.Map.empty,
-        );
+        Printer.of_segment(~holes="", ~concave_holes="", ~refractors=[]);
       let seg' = exp_to_segment_roundtrip(term);
       let output = print_seg_grout(seg');
       check(string, {|Round-trip text|}, input, output);


### PR DESCRIPTION
Normalize \r\n (Windows) and \r (old Mac) line breaks to \n in the trim_leading function to prevent parsing errors that appear as red error markers when pasting multiline code.

Closes #2090 