### PR TITLE
Make CSV projector show up in context menu for empty list

### DIFF
--- a/src/haz3lcore/projectors/ProjectorCore.re
+++ b/src/haz3lcore/projectors/ProjectorCore.re
@@ -34,9 +34,9 @@ module Kind = {
     Slider,
     SliderF,
     TextArea,
-    Card,
+    Csv, /* Competes with Card for empty list */
+    Card, /* Competes with Csv for empty list */
     Livelit,
-    Csv,
   ];
 
   /* Note: Probe intentionally excluded - probes use separate action path */


### PR DESCRIPTION
Closes #2100. Could be better; there's less of a reason to pick a default value for this now instead of showing all applicable ones but wanted to put a basic fix up.