### PR TITLE
Fix exercise module export serialization for refractors

### DIFF
--- a/src/haz3lcore/zipper/Refractors.re
+++ b/src/haz3lcore/zipper/Refractors.re
@@ -74,6 +74,14 @@ let init = {
 let persist = (refractors: t): string =>
   refractors.manuals |> RefractorList.sexp_of_t |> Sexplib.Sexp.to_string;
 
+/* Prepares refractors for serialization by resetting non-persistable state.
+ * Only `manuals` is persisted - see state location docs at top of file.
+ * Used by both sexp serialization (persist) and show serialization (Exercise export). */
+let for_serialization = (refractors: t): t => {
+  ...init,
+  manuals: refractors.manuals,
+};
+
 /* Refractors store a simplified `entry` type in Zipper.Refractor.Map
  * (just kind + model), avoiding redundant id/syntax in serialization.
  * When the full Base.projector is needed for rendering, use `to_projector`. */

--- a/src/util/Id.re
+++ b/src/util/Id.re
@@ -109,11 +109,20 @@ module Map = {
     |> List.to_seq
     |> of_seq;
 
-  let pp = (pp_v, fmt, map) =>
-    bindings(map)
-    |> List.iter(((k, v)) =>
-         Format.fprintf(fmt, "%a -> %a\n", pp, k, pp_v, v)
-       );
+  /* Outputs valid OCaml code for empty maps only.
+   * Non-empty maps will fail - this is intentional. Currently only empty maps
+   * are serialized via show (see Refractors.for_serialization which resets
+   * autos to empty before serialization). If you need to persist non-empty
+   * Id.Map values, implement proper nested Id.Map.add output here. */
+  let pp = (_pp_v, fmt, map) =>
+    if (is_empty(map)) {
+      Format.fprintf(fmt, "Haz3lcore.Id.Map.empty");
+    } else {
+      failwith(
+        "Id.Map.pp: non-empty map serialization not implemented. "
+        ++ "See Refractors.for_serialization if you're seeing this during exercise export.",
+      );
+    };
 };
 let invalid: t =
   "00000000-0000-0000-0000-000000000000" |> Uuidm.of_string |> Option.get;

--- a/src/web/exercises/Exercise.re
+++ b/src/web/exercises/Exercise.re
@@ -837,8 +837,10 @@ let pos_of_key = (key: string): pos =>
 
 let editor_pp = (fmt, editor: Editor.t) => {
   let zipper = editor.state.zipper;
+  /* Reset non-persistable refractor state before serialization.
+   * See Refractors.for_serialization - keeps manuals, resets autos/sample_cursor. */
+  let zipper = Zipper.update_refractors(zipper, Refractors.for_serialization);
   let serialization = Zipper.show(zipper);
-  // let string_literal = "\"" ++ String.escaped(serialization) ++ "\"";
   Format.pp_print_string(fmt, serialization);
 };
 


### PR DESCRIPTION
Fixes #2099

The exercise module export was using Zipper.show() which tried to serialize refractors.autos containing Id.Map.t(unit). The Id.Map.pp function output debug-style text that was not valid OCaml syntax, resulting in blank fields like `ids = ;` in the exported .ml file.

Changes:
- Add Refractors.for_serialization to reset non-persistable fields (autos, sample_cursor) before serialization, keeping only manuals
- Update Id.Map.pp to output valid OCaml for empty maps, fail explicitly for non-empty maps with a helpful error message
- Use for_serialization in Exercise.editor_pp before calling Zipper.show()

This aligns with the existing design where only manuals is persisted (see state location docs in Refractors.re).