### PR TITLE
Fixes #2166

### DIFF
--- a/src/language/term/Exp.re
+++ b/src/language/term/Exp.re
@@ -116,6 +116,8 @@ let rec cls_of_term: type a. Grammar.exp_term(a) => cls =
   | Filter(_) => Filter
   | Closure(_) => Closure
   | Parens(_) => Parens
+  // We're bypassing projectors from cls because they're breaking cursor inspector messages.
+  // Future work could be to specialize projectors in the cursor inspector.
   | Projector(_, e) => cls_of_term(e.term)
   | Cons(_) => Cons
   | ListConcat(_) => ListConcat

--- a/src/language/term/Exp.re
+++ b/src/language/term/Exp.re
@@ -75,7 +75,7 @@ let rep_id: t => Id.t = IdTagged.rep_id;
 let term_of: t => term = IdTagged.term_of;
 let unwrap: t => (term, term => t) = IdTagged.unwrap;
 
-let cls_of_term: type a. Grammar.exp_term(a) => cls =
+let rec cls_of_term: type a. Grammar.exp_term(a) => cls =
   fun
   | Invalid(_) => Invalid
   | EmptyHole => EmptyHole
@@ -116,7 +116,7 @@ let cls_of_term: type a. Grammar.exp_term(a) => cls =
   | Filter(_) => Filter
   | Closure(_) => Closure
   | Parens(_) => Parens
-  | Projector(_) => Projector
+  | Projector(_, e) => cls_of_term(e.term)
   | Cons(_) => Cons
   | ListConcat(_) => ListConcat
   | UnOp(op, _) => UnOp(op)

--- a/test/Test_Grammar.re
+++ b/test/Test_Grammar.re
@@ -214,13 +214,17 @@ let tests = (
         let cls_testable =
           testable(Fmt.using(Exp.show_cls, Fmt.string), Exp.equal_cls);
         List.iter(
-          cls =>
-            check(
-              cls_testable,
-              Exp.show_cls(cls) ++ " Equivalency",
-              cls,
-              Exp.cls_of_term(sample_expression(cls).term),
-            ),
+          (cls: Exp.cls) =>
+            switch (cls) {
+            | Projector => () // Excluding projectors from cls
+            | _ =>
+              check(
+                cls_testable,
+                Exp.show_cls(cls) ++ " Equivalency",
+                cls,
+                Exp.cls_of_term(sample_expression(cls).term),
+              )
+            },
           exp_classes,
         );
       },


### PR DESCRIPTION
- Exp.cls_of_term shows cls of underlying expression if projector
- Cursor inspector still shows projector info on left side