### PR TITLE
Fix pivot_table type signature

### DIFF
--- a/src/language/builtins/BuiltinsList.re
+++ b/src/language/builtins/BuiltinsList.re
@@ -2946,7 +2946,7 @@ let go: ([?], [?], [?]) -> [?] =
           list(unknown(Internal)),
           arrow(unknown(Internal), string()),
           arrow(unknown(Internal), string()),
-          arrow(unknown(Internal), unknown(Internal)),
+          arrow(list(unknown(Internal)), unknown(Internal)),
         ]),
       ret: List(unknown(Internal)),
       imp: {

--- a/src/language/builtins/BuiltinsList.re
+++ b/src/language/builtins/BuiltinsList.re
@@ -2945,7 +2945,7 @@ let go: ([?], [?], [?]) -> [?] =
         Prod([
           list(unknown(Internal)),
           arrow(unknown(Internal), string()),
-          arrow(unknown(Internal), string()),
+          arrow(unknown(Internal), unknown(Internal)),
           arrow(list(unknown(Internal)), unknown(Internal)),
         ]),
       ret: List(unknown(Internal)),

--- a/src/language/builtins/BuiltinsList.re
+++ b/src/language/builtins/BuiltinsList.re
@@ -2944,8 +2944,8 @@ let go: ([?], [?], [?]) -> [?] =
       arg:
         Prod([
           list(unknown(Internal)),
-          arrow(unknown(Internal), unknown(Internal)),
-          arrow(unknown(Internal), unknown(Internal)),
+          arrow(unknown(Internal), string()),
+          arrow(unknown(Internal), string()),
           arrow(unknown(Internal), unknown(Internal)),
         ]),
       ret: List(unknown(Internal)),

--- a/test/evaluator/Test_Evaluator_Builtins_Lists.re
+++ b/test/evaluator/Test_Evaluator_Builtins_Lists.re
@@ -458,20 +458,20 @@ let tests = (
     test_case("pivot_table", `Quick, () =>
       parse_and_evaluate_test(
         {|
-      [(index="x", `A`=2, `B`=1, `C`=0), (index="y", `A`=1, `B`=1, `C`=1)]
+      [(index=true, `A`=60, `B`=30, `C`=0), (index=false, `A`=20, `B`=40, `C`=60)]
       |},
         {|pivot_table(
   [
-    ("A", "x"),
-    ("A", "y"),
-    ("B", "x"),
-    ("B", "y"),
-    ("A", "x"),
-    ("C", "y")
+    ("A", true, 10),
+    ("A", false, 20),
+    ("B", true, 30),
+    ("B", false, 40),
+    ("A", true, 50),
+    ("C", false, 60)
   ],
-  fun (r, _) -> r,
-  fun (_, c) -> c,
-  length
+  fun (r, _, _) -> r,
+  fun (_, c, _) -> c,
+  fold_left(_, fun (acc, (_, _, v)) -> acc + v, 0)
 )
 |},
       )


### PR DESCRIPTION
## Summary

- Require `String` for column labels in `pivot_table`, but allow any type for row labels
- Require the reduce/aggregation argument to take a `List`

## Example

Given weather observations as `(city: String, sunny: Bool)` tuples, count sunny vs not-sunny days per city:

```
pivot_table(
  [
    ("NYC", true),
    ("NYC", false),
    ("NYC", true),
    ("LA", true),
    ("LA", true),
    ("LA", true),
    ("Chicago", false),
    ("Chicago", false)
  ],
  fun (r, _) -> r,
  fun (_, c) -> c,
  length
)
```

Produces:

```
[(index=true, `NYC`=2, `LA`=3, `Chicago`=0),
 (index=false, `NYC`=1, `LA`=0, `Chicago`=2)]
```

Column labels (`"NYC"`, `"LA"`, `"Chicago"`) must be strings since they become label names in the output tuples. Row labels (`true`/`false`) can be any type since they are stored as values.

## Test plan

- [x] `make dev` compiles
- [x] `make test-quick` passes (1394 tests)
- [x] pivot_table test updated to use `(String, Bool, Int)` tuples with `fold_left` sum aggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)