### PR TITLE
Reforge: sort demotion (case bug)

### DIFF
--- a/src/haz3lcore/tiles/Segment.re
+++ b/src/haz3lcore/tiles/Segment.re
@@ -630,7 +630,37 @@ let presplit_orphans = (seg: t): t =>
        | p => [p],
      );
 
-let rescan = (seg: t): t => {
+/* Promote a complete singleton tile to an incomplete multi-token form
+ * if its expansion has a mold with out == sort. E.g., standalone `|`
+ * (label ["|"]) in Rul sort becomes ["|","=>"][0] (incomplete Rule). */
+let try_sort_expand = (sort: Sort.t, t: Tile.t): option(Tile.t) =>
+  if (sort == Any
+      || List.length(t.label) > 1
+      || !Tile.is_complete(t)
+      || List.length(t.shards) != 1) {
+    None;
+  } else {
+    let tok = List.hd(t.label);
+    let (label, _) = Form.Expansion.get(tok);
+    if (List.length(label) <= 1) {
+      None;
+    } else {
+      let molds = Form.Molds.get(label);
+      switch (List.find_opt((m: Mold.t) => m.out == sort, molds)) {
+      | None => None
+      | Some(mold) =>
+        Some({
+          ...t,
+          label,
+          mold,
+          shards: [0],
+          children: [],
+        })
+      };
+    };
+  };
+
+let rescan = (~sort: Sort.t=Any, seg: t): t => {
   let has_incomplete =
     List.exists(
       p =>
@@ -640,7 +670,9 @@ let rescan = (seg: t): t => {
         },
       seg,
     );
-  if (!has_incomplete) {
+  /* When sort is provided, we may need to promote tokens even if
+   * no incomplete tiles exist yet. Skip the fast path in that case. */
+  if (sort == Any && !has_incomplete) {
     seg;
   } else {
     /* Walk left-to-right with a STACK of backpack frames.
@@ -695,7 +727,16 @@ let rescan = (seg: t): t => {
                 let new_frame = missing_entries(t);
                 [hd, ...go(~frame=new_frame, ~stack=[frame, ...stack], tl)];
               } else {
-                [hd, ...go(~frame, ~stack, tl)];
+                /* Complete singleton: try sort-aware expansion */
+                switch (try_sort_expand(sort, t)) {
+                | Some(promoted) =>
+                  let new_frame = missing_entries(promoted);
+                  [
+                    Piece.Tile(promoted),
+                    ...go(~frame=new_frame, ~stack=[frame, ...stack], tl),
+                  ];
+                | None => [hd, ...go(~frame, ~stack, tl)]
+                };
               }
             };
           } else if (!Tile.is_complete(t)) {
@@ -710,6 +751,53 @@ let rescan = (seg: t): t => {
     go(seg);
   };
 };
+
+/* Like reassemble but reforges children of complete tiles when the
+ * child sort differs from the parent sort. This handles tokens that
+ * were created in one sort context but end up in a different sort
+ * after reassembly (e.g., standalone | and => becoming Rule tiles
+ * when they end up inside a case body in Rul sort). */
+let rec reassemble_reforge = (sort: Sort.t, seg: t): t =>
+  switch (incomplete_tiles(seg)) {
+  | [] => seg
+  | [t, ..._] =>
+    switch (Aba.trim(split_by_matching(t.id, seg))) {
+    | None => seg
+    | Some((seg_l, match, seg_r)) =>
+      let t = Tile.reassemble(match);
+      let children =
+        if (Tile.is_complete(t)) {
+          List.map2(
+            (child, child_sort) =>
+              if (child_sort != sort) {
+                reforge(child_sort, child);
+              } else {
+                reassemble_reforge(sort, child);
+              },
+            t.children,
+            t.mold.in_,
+          );
+        } else {
+          List.map(reassemble_reforge(sort), t.children);
+        };
+      let children = inner_regrout(children);
+      let p =
+        Tile.to_piece({
+          ...t,
+          children,
+        });
+      seg_l @ [p, ...reassemble_reforge(sort, seg_r)];
+    }
+  }
+/* Reforge: given a sort context, apply sort-aware rescan (promoting
+ * tokens to multi-token forms), reassemble with recursive reforging
+ * of children where sort changes, and remold. */
+and reforge = (sort: Sort.t, seg: t): t =>
+  seg
+  |> presplit_orphans
+  |> rescan(~sort)
+  |> reassemble_reforge(sort)
+  |> remold(_, sort);
 
 let rescan_and_reassemble = (seg: t): t => seg |> rescan |> reassemble;
 

--- a/src/haz3lcore/zipper/Relatives.re
+++ b/src/haz3lcore/zipper/Relatives.re
@@ -89,6 +89,16 @@ let remold = ({siblings, ancestors}: t): t => {
   };
 };
 
+let reforge_siblings =
+    (sort: Sort.t, {siblings: (pre, suf), ancestors}: t): t => {
+  let pre = Segment.reforge(sort, pre);
+  let suf = Segment.reforge(sort, suf);
+  {
+    siblings: (pre, suf),
+    ancestors,
+  };
+};
+
 let regrout = (d: Direction.t, {siblings, ancestors}: t): t => {
   /* Direction is side of grout caret will end up on */
 

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -65,23 +65,36 @@ let remold = (z: t): t => {
 let remold_regrout = (d: Direction.t, z: t): t => z |> remold |> regrout(d);
 
 /* Rescan siblings for label-based shard conversion, then
- * reassemble + remold + regrout. This handles the case where
- * a standalone monotile should retroactively become a shard
+ * reassemble + reforge + remold + regrout. This handles the case
+ * where a standalone monotile should retroactively become a shard
  * of an incomplete tile (e.g. standalone `->` matching `fun`).
+ * After reassembly, reforge handles sort-aware re-expansion of
+ * tokens that end up in a new sort context (e.g. standalone `|`
+ * and `=>` becoming Rule tiles inside a case body).
  * Should be called after edits, not during cursor movement. */
 let rescan_reassemble = (d: Direction.t, z: t): t => {
   let siblings = Siblings.rescan(z.relatives.siblings);
   if (siblings == z.relatives.siblings) {
     z;
   } else {
+    let old_sort = Ancestors.sort(z.relatives.ancestors);
     let relatives =
       {
         ...z.relatives,
         siblings,
       }
-      |> Relatives.reassemble
-      |> Relatives.remold
-      |> Relatives.regrout(d);
+      |> Relatives.reassemble;
+    /* If reassembly created a new ancestor (changing the sort context),
+     * reforge the siblings in the new sort to handle tokens that need
+     * re-expansion (e.g., | and => inside a case body). */
+    let new_sort = Ancestors.sort(relatives.ancestors);
+    let relatives =
+      if (new_sort != old_sort) {
+        Relatives.reforge_siblings(new_sort, relatives);
+      } else {
+        relatives;
+      };
+    let relatives = relatives |> Relatives.remold |> Relatives.regrout(d);
     {
       ...z,
       relatives,

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -1165,6 +1165,58 @@ let rescan_tests = [
       };
     },
   ),
+  /* TODO: Sort demotion — the reverse of Phase 3's sort-aware expansion.
+   * When a case expression breaks, Rule tiles (|,=>) should be demoted
+   * to standalone tokens since they have no valid mold in Exp sort.
+   * Requires deciding when/how to trigger reforge after edits;
+   * see delimiter-reassociation-case branch for exploration. */
+  test_case(
+    "Reforge: breaking case demotes Rule tiles to standalone tokens",
+    `Quick,
+    () => {
+      let _ = Alcotest.skip();
+      let z =
+        mk({|¦case x | a => 0 end|})
+        @ [Destruct(Right)]
+        |> perform(Zipper.init());
+      if (seg_has_tile(["|", "=>"], Zipper.zip(z))) {
+        Alcotest.fail(
+          "Complete Rule tile [|, =>] still exists — "
+          ++ "should have been demoted to standalone tokens",
+        );
+      };
+    },
+  ),
+  /* TODO: Round-trip — breaking and reforming case should be reversible.
+   * Currently Insert and Destruct have asymmetric reforge behavior,
+   * so this round-trip doesn't work yet. */
+  test_case(
+    "Reforge: breaking and reforming case round-trips Rule tiles",
+    `Quick,
+    () => {
+      let _ = Alcotest.skip();
+      /* Start with complete syntax, caret before x */
+      let z = mk({|case ¦x | a => 0 end|}) |> perform(Zipper.init());
+      /* Verify Rule tile exists initially */
+      if (!seg_has_tile(["|", "=>"], Zipper.zip(z))) {
+        Alcotest.fail("Rule tile [|, =>] should exist in initial state");
+      };
+      /* Backspace: delete space, merges case+x, breaks tile */
+      let z = [Destruct(Left)] |> perform(z);
+      if (seg_has_tile(["|", "=>"], Zipper.zip(z))) {
+        Alcotest.fail(
+          "Rule tile [|, =>] should be demoted after breaking case",
+        );
+      };
+      /* Reinsert space: should split casex, reform case tile + rules */
+      let z = [Insert(" ")] |> perform(z);
+      if (!seg_has_tile(["|", "=>"], Zipper.zip(z))) {
+        Alcotest.fail(
+          "Rule tile [|, =>] should reform after reinserting space",
+        );
+      };
+    },
+  ),
 ];
 
 let tests = [

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -1030,6 +1030,19 @@ let rec seg_has_incomplete = (seg: Segment.t): bool =>
 let zip_has_incomplete = (z: Zipper.t): bool =>
   seg_has_incomplete(Zipper.zip(z));
 
+/* Check that a tile with the given label exists (complete) anywhere
+ * in the segment, recursing into children. */
+let rec seg_has_tile = (label: Label.t, seg: Segment.t): bool =>
+  List.exists(
+    fun
+    | Piece.Tile(t) =>
+      t.label == label
+      && Tile.is_complete(t)
+      || List.exists(seg_has_tile(label), t.children)
+    | _ => false,
+    seg,
+  );
+
 /* Test helper that checks printer output AND absence of incomplete tiles. */
 let test_complete = (~name, ~acts, ~goal): test_case(_) =>
   test_case(
@@ -1120,6 +1133,37 @@ let rescan_tests = [
       @ mv_r(6)  /* fun (a, b) -> )¦ */
       @ [Destruct(Left)], /* delete old ) */
     ~goal={|fun (a, b) -> a¦|},
+  ),
+  /* PHASE 3 (reforge): Sort-aware child normalization.
+   * Type `x | a => 0 end` (no case context, so | and => stay standalone),
+   * then type `case ` before. Rescan matches case with end, but the
+   * child segment has standalone | and => that should form a Rule tile.
+   * This requires reforge to re-expand tokens in the new Rul sort. */
+  test_case(
+    "Reforge: case/end child remolding creates Rule tiles",
+    `Quick,
+    () => {
+      let z =
+        mk({|¦x | a => 0 end|})
+        @ string_to_ltr_actions("case ")
+        |> perform(Zipper.init());
+      let printed = printer(z);
+      check(
+        testable(Fmt.string, String.equal),
+        "printer output",
+        {|case ¦x | a => 0 end|},
+        printed,
+      );
+      if (zip_has_incomplete(z)) {
+        Alcotest.fail("Incomplete tiles remain");
+      };
+      if (!seg_has_tile(["|", "=>"], Zipper.zip(z))) {
+        Alcotest.fail(
+          "No complete Rule tile [|, =>] found — "
+          ++ "| and => are standalone tokens instead of a Rule form",
+        );
+      };
+    },
   ),
 ];
 


### PR DESCRIPTION
## Summary
- Sort-aware child normalization after reforge (Phase 3): when rescan matches delimiters and creates tiles, children get reforged in their new sort context (e.g., standalone `|` and `=>` inside a case body form Rule tiles)
- Two skipped tests documenting the reverse (demotion): breaking a case expression should demote Rule tiles to standalone tokens, and reforming it should bring them back

## Status
Phase 3 (promotion into children) works. Demotion (the reverse) is not yet implemented — the skipped tests document the expected behavior. The main open question is when/how to trigger reforge after edits, since Insert and Destruct currently have asymmetric behavior.

## Test plan
- [x] Phase 3 test passes (case/end child remolding creates Rule tiles)
- [ ] Demotion test (skipped): breaking case demotes Rule tiles
- [ ] Round-trip test (skipped): break + reform case round-trips Rule tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)