### PR TITLE
Fix duplicate probe samples from Dot projection and Asc distribution

### DIFF
--- a/src/language/dynamics/state/EvaluatorState.re
+++ b/src/language/dynamics/state/EvaluatorState.re
@@ -60,8 +60,32 @@ let add_test = (state: t, instance_report: TestMap.instance_report) => {
     ),
 };
 let add_sample = (state: t, sample: Sample.t) => {
-  ...state,
-  probes: Sample.Map.extend(sample.syntax_id, sample, state.probes),
+  /* Deduplicate: skip recording if a sample at the top level (empty
+   * call_stack) already exists for this syntax_id. This prevents
+   * duplicate samples caused by ascription distribution: when a value
+   * with a probe target ID flows through a typed function, the Asc
+   * transition distributes type annotations into compound values
+   * (tuples, lists), creating Asc wrappers that force re-evaluation
+   * of the inner values with a deeper call_stack. The top-level
+   * sample (from the original definition-site evaluation) is always
+   * the authoritative one. */
+  let dominated =
+    sample.call_stack != []
+    && (
+      switch (Id.Map.find_opt(sample.syntax_id, state.probes)) {
+      | Some(existing) =>
+        List.exists((s: Sample.t) => s.call_stack == [], existing)
+      | None => false
+      }
+    );
+  if (dominated) {
+    state;
+  } else {
+    {
+      ...state,
+      probes: Sample.Map.extend(sample.syntax_id, sample, state.probes),
+    };
+  };
 };
 
 let add_theorem = ({theorems, _} as es, id, name, env, goal) => {

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -744,7 +744,11 @@ module Transition = (EV: EV_MODE) => {
                 expr: exp,
                 side_effects: [],
                 kind: Dot,
-                is_value: false,
+                /* d1 is req_final so all tuple elements are already values.
+                   Must be true to avoid re-entering evaluate on the projected
+                   value, which would trigger duplicate probe samples when the
+                   value carries a probe target ID. */
+                is_value: true,
               })
             | _ => Indet
             };
@@ -757,7 +761,7 @@ module Transition = (EV: EV_MODE) => {
                   expr: d,
                   side_effects: [],
                   kind: Dot,
-                  is_value: false,
+                  is_value: true,
                 })
               : Indet
           | ListLit(ds) =>

--- a/test/evaluator/Test_Evaluator_Probes.re
+++ b/test/evaluator/Test_Evaluator_Probes.re
@@ -801,6 +801,75 @@ in f(1)|},
   ),
 ];
 
+/* Tests that probe samples are not duplicated when values flow through
+ * typed functions or are projected with dot access. Two independent
+ * mechanisms caused duplicates:
+ * 1. Dot projection with is_value:false re-evaluated already-final values
+ * 2. Ascription distribution through typed functions re-evaluated inner
+ *    compound elements at a deeper call_stack */
+let duplicate_prevention_tests = [
+  /* Dot projection: extracting from a probed tuple must not duplicate.
+   * Without is_value:true on the Dot transition, the projected value
+   * gets re-evaluated, recording a second sample at the same call_stack. */
+  probe_line_test(
+    "Dot on probed labeled tuple field",
+    {|let x = (a = ^^probe(1),
+b = ^^probe(2)) in x.a|},
+    [(0, ["1"]), (1, ["2"])],
+  ),
+  /* Typed identity function with labeled tuple.
+   * Without Asc distribution dedup, each field gets a duplicate sample
+   * at the function's call_stack when the ascription distributes. */
+  probe_line_test(
+    "Probed labeled tuple through typed identity",
+    {|let x = (a = ^^probe(1),
+b = ^^probe(2)) in
+let f: (a = Int, b = Int) -> (a = Int, b = Int) =
+  fun t -> t
+in
+f(x)|},
+    [(0, ["1"]), (1, ["2"])],
+  ),
+  /* User-suggested: unlabeled tuple through typed identity with ? types */
+  probe_line_test(
+    "Probed unlabeled tuple through typed identity with holes",
+    {|let f: ? -> (?, ?) = fun t -> t in
+f((?, ^^probe(1)))|},
+    [(1, ["1"])],
+  ),
+  /* User-suggested: labeled tuple through typed identity with ? types */
+  probe_line_test(
+    "Probed labeled tuple through typed identity with holes",
+    {|let f: ? -> (a = ?, b = ?) = fun t -> t in
+f((a = ?, b = ^^probe(1)))|},
+    [(1, ["1"])],
+  ),
+  /* User-suggested: list through typed identity with ? types */
+  probe_line_test(
+    "Probed list through typed identity with holes",
+    {|let f: ? -> [?] = fun t -> t in
+f([?, ^^probe(1)])|},
+    [(1, ["1"])],
+  ),
+  /* Chained typed functions: value passes through two Asc distributions */
+  probe_line_test(
+    "Probed tuple through two chained typed functions",
+    {|let x = (^^probe(1),
+^^probe(2)) in
+let f: (Int, Int) -> (Int, Int) = fun t -> t in
+let g: (Int, Int) -> (Int, Int) = fun t -> t in
+g(f(x))|},
+    [(0, ["1"]), (1, ["2"])],
+  ),
+  /* Multi-call: legitimate multiple samples must still work */
+  probe_line_test(
+    "Multi-call function probe still produces multiple samples",
+    {|let f: Int -> Int = fun x -> ^^probe(x) in
+[f(1), f(2), f(3)]|},
+    [(0, ["1", "2", "3"])],
+  ),
+];
+
 let tests = [
   ("Evaluator.Probes.Basic", basic_tests),
   ("Evaluator.Probes.Operators", operator_tests),
@@ -809,4 +878,5 @@ let tests = [
   ("Evaluator.Probes.Nested", nested_probe_tests),
   ("Evaluator.Probes.Recursion", recursion_tests),
   ("Evaluator.Probes.Ascription", ascription_tests),
+  ("Evaluator.Probes.DuplicatePrevention", duplicate_prevention_tests),
 ];


### PR DESCRIPTION
Closes #2142.

## Summary

- **Dot projection** on Tuple/TupLabel incorrectly set `is_value: false`, causing re-evaluation of already-final projected values. Fixed by setting `is_value: true`, consistent with other value-extracting transitions (Cons, ListConcat, BinOp, UnOp, TupleExtension).
- **Ascription distribution** through typed functions re-evaluated inner compound elements at a deeper call_stack, creating duplicate samples. Fixed by deduplicating in `add_sample`: if a top-level (empty call_stack) sample already exists for a syntax_id, skip recording deeper samples from the same definition site.
- Added 7 regression tests covering both mechanisms.

**Repro**: `let x = (a = ^^probe(1), b = ^^probe(2)) in let f: (a=Int,b=Int) -> (a=Int,b=Int) = fun t -> t in f(x)` — showed 2 samples per field instead of 1.

## Test plan

- [x] All 328 Evaluator tests pass
- [x] New `Evaluator.Probes.DuplicatePrevention` group: Dot projection, typed identity (labeled/unlabeled tuples, lists), chained functions, multi-call legitimacy

🤖 Generated with [Claude Code](https://claude.com/claude-code)