### PR TITLE
fix: increase Node.js stack size to prevent test flakes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,11 @@ repl:
 test:
 	dune fmt --auto-promote || true
 	dune build @ocaml-index @src/fmt @test/fmt --auto-promote src test --profile dev
-	node $(TEST_DIR)/haz3ltest.bc.js
+	node --stack-size=8192 $(TEST_DIR)/haz3ltest.bc.js
 
 test-quick:
 	dune build @ocaml-index @src/fmt @test/fmt --auto-promote src test --profile dev
-	node $(TEST_DIR)/haz3ltest.bc.js -q
+	node --stack-size=8192 $(TEST_DIR)/haz3ltest.bc.js -q
 
 watch-test:
 	dune build @ocaml-index @fmt @runtest @default --profile dev --auto-promote --watch

--- a/test/dune
+++ b/test/dune
@@ -4,5 +4,9 @@
  (name haz3ltest)
  (libraries web menhirParser junit_alcotest bisect_ppx.runtime)
  (modes js)
+ ; Increase Node.js stack size to 8MB to prevent stack overflows
+ ; in deeply recursive tests (e.g., Pattern Coverage Checker).
+ (action
+  (run node --stack-size=8192 %{test}))
  (preprocess
   (pps ppx_deriving.show)))


### PR DESCRIPTION
- Adds `--stack-size=8192` (8MB) to Node.js when running the js_of_ocaml-compiled test binary, fixing stack overflow flakes in the Pattern Coverage Checker tests
- Updates `test/dune` with a custom `(action ...)` so `dune runtest` (used by CI) passes the flag
- Updates `Makefile` `test` and `test-quick` targets to pass the flag

test suite is compiled to JavaScript via js_of_ocaml and run with Node.js. Pattern Coverage Checker tests use deep recursion that overflows Node's default ~1MB stack. This system-dependent test failures (out of 61 in the Pattern Coverage group) with `Stack overflow` exceptions. The failures are flaky because they depend on the exact stack depth available at runtime.
