### PR TITLE
fix: propagate co-contexts through TupleExtension (#2157)

### DIFF
--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -630,6 +630,7 @@ and uexp_to_info_map =
         | _ => replace_self(m, t2, TupleExtensionRequiresTuples)
         };
       };
+      let co_ctx = CoCtx.union([t1.co_ctx, t2.co_ctx]);
 
       switch (
         Typ.normalize(ctx, t1.ty).term,
@@ -662,20 +663,20 @@ and uexp_to_info_map =
 
         add(
           ~self=Just(ty), // TODO: fix this
-          ~co_ctx=CoCtx.empty,
+          ~co_ctx,
           m,
         );
       | (Unknown(_), _)
       | (_, Unknown(_)) =>
         add(
           ~self=Just(IdTagged.FreshGrammar.Typ.unknown(Internal)),
-          ~co_ctx=CoCtx.empty,
+          ~co_ctx,
           m,
         )
       | _ =>
         add(
           ~self=Just(IdTagged.FreshGrammar.Typ.unknown(Internal)),
-          ~co_ctx=CoCtx.empty,
+          ~co_ctx,
           m,
         )
       };

--- a/test/Test_UnusedWarnings.re
+++ b/test/Test_UnusedWarnings.re
@@ -203,5 +203,25 @@ let tests = (
       "let m : { let x : Int } = { let x = 1 } in 5",
       ["m"],
     ),
+    /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+       TUPLE EXTENSION: CO-CONTEXT PROPAGATION
+       The ... operator should propagate co-contexts
+       from both operands.
+       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+    check_unused(
+      "tuple extension: variable used in base of spread",
+      "let x = (a=1, b=2) in x ... (a=3)",
+      [],
+    ),
+    check_unused(
+      "tuple extension: variable used in extension of spread",
+      "let x = 1 in (a=1, b=2) ... (a=x)",
+      [],
+    ),
+    check_unused(
+      "tuple extension: fun param used in spread",
+      "fun e -> e ... (a=1)",
+      [],
+    ),
   ],
 );

--- a/test/Test_UnusedWarnings.re
+++ b/test/Test_UnusedWarnings.re
@@ -223,5 +223,20 @@ let tests = (
       "fun e -> e ... (a=1)",
       [],
     ),
+    check_unused(
+      "tuple extension: unused variable not in spread",
+      "let x = 1 in (a=1, b=2) ... (a=3)",
+      ["x"],
+    ),
+    check_unused(
+      "tuple extension: one used one unused",
+      "let x = (a=1, b=2) in let y = 1 in x ... (a=3)",
+      ["y"],
+    ),
+    check_unused(
+      "tuple extension: both operands use different variables",
+      "let x = (a=1, b=2) in let y = 3 in x ... (a=y)",
+      [],
+    ),
   ],
 );


### PR DESCRIPTION
The tuple spread operator (...) was discarding co-contexts from both operands, causing variables used inside spread expressions to be incorrectly flagged as unused.