### PR TITLE
Rewrite float negation as 0.0 -. e in ExpToSegment

### DIFF
--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -541,7 +541,17 @@ let rec parenthesize =
     |> rewrap
   | UnOp(Bool(Not), e) =>
     UnOp(Bool(Not), parenthesize(e) |> paren_at(Precedence.not_)) |> rewrap
-  | UnOp((Int(Minus) | Nat(Minus) | Float(Minus) | SInt(Minus)) as op, e) =>
+  | UnOp(Float(Minus), e) =>
+    /* Rewrite float negation as 0.0 -. e so that the segment round-trips
+       correctly through MakeTerm (which parses unary - as Int(Minus)) */
+    let zero = Exp.fresh(Atom(Float(0.0)));
+    BinOp(
+      Float(Minus),
+      parenthesize(zero) |> paren_assoc_at(Precedence.plus),
+      parenthesize(e) |> paren_at(Precedence.plus),
+    )
+    |> rewrap;
+  | UnOp((Int(Minus) | Nat(Minus) | SInt(Minus)) as op, e) =>
     UnOp(op, parenthesize(e) |> paren_at(Precedence.neg)) |> rewrap
   | BinOp(op, e1, e2) =>
     (
@@ -1646,10 +1656,14 @@ let rec exp_to_pretty = (~settings: Settings.t, exp: Exp.t): pretty => {
     let id = exp |> Exp.rep_id;
     let+ e = go(e);
     wrap(exp, [mk_form(Not, id, [])] @ e);
-  | UnOp(Int(Minus) | Nat(Minus) | Float(Minus) | SInt(Minus), e) =>
+  | UnOp(Int(Minus) | Nat(Minus) | SInt(Minus), e) =>
     let id = exp |> Exp.rep_id;
     let+ e = go(e);
     wrap(exp, [mk_form(UnaryMinus, id, [])] @ e);
+  | UnOp(Float(Minus), _) =>
+    failwith(
+      "ExpToSegment: UnOp(Float(Minus)) should have been rewritten by parenthesize",
+    )
   /* TODO: this isn't actually correct because we could the builtin
      could have been overriden in this scope; worth fixing when we fix
      closures. */

--- a/test/Test_ExpToSegment.re
+++ b/test/Test_ExpToSegment.re
@@ -356,6 +356,32 @@ let tests = (
         ),
       )
     }),
+    test_case(
+      "Float negation produces 0.0 -. e",
+      `Quick,
+      () => {
+        /* UnOp(Float(Minus), e) should be rewritten to 0.0 -. e
+           so it round-trips through MakeTerm correctly (MakeTerm
+           parses unary - as Int(Minus), breaking float evaluation) */
+        let seg =
+          exp_to_segment(
+            IdTagged.FreshGrammar.Exp.(un_op(Float(Minus), float(3.14))),
+          );
+        let serialized = print_seg(seg);
+        check(
+          string,
+          "Float negation text",
+          "0.000000 -. 3.140000",
+          serialized,
+        );
+        /* Verify round-trip: segment → term → segment preserves float minus */
+        switch (MakeTerm.for_projection(seg)) {
+        | Some(Exp({term: BinOp(Float(Minus), _, _), _})) => ()
+        | _ =>
+          Alcotest.fail("Expected BinOp(Float(Minus), ...) after round-trip")
+        };
+      },
+    ),
     test_case("Dot operator on float", `Quick, () => {
       check(
         string,


### PR DESCRIPTION
Terms support float-specific unary negation but tiles/segments don't at the moment. ExpToSegment sends both float negation and integer negation to the same UnaryMinus op, which means well-typed negative floats constructed as terms, serialized to segments, then parsed again as terms gain error holes. This modifies ExpToSegment so that it rewrites `-. f` in term form is serialized to `0.0 -. f` in segment form. Specifically, the parenthesize pass now rewrites UnOp(Float(Minus), e) to BinOp(Float(Minus), 0.0, e).