### PR TITLE
ci: support slashes in branch names for deploy workflow

### DIFF
--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -71,7 +71,7 @@ jobs:
         run: if [ -d "${BRANCH_NAME}" ] ; then rm -rf "${BRANCH_NAME}" ; fi
         working-directory: ./server
       - name: Copy in the newly built source
-        run: mkdir "./server/${BRANCH_NAME}" && cp -r "./source/_build/default/src/web/www"/* "./server/${BRANCH_NAME}"
+        run: mkdir -p "./server/${BRANCH_NAME}" && cp -r "./source/_build/default/src/web/www"/* "./server/${BRANCH_NAME}"
       - name: Commit to the website aka deploy
         run: |
           git config user.name github-deploy-action


### PR DESCRIPTION
Use mkdir -p so parent directories are created when deploying branches with slashes (e.g., feature/my-fix).


I'm tired of fighting copilot on this https://github.com/hazelgrove/hazel/pull/2171