### PR TITLE
Fix folds in printed programs for agent calls

### DIFF
--- a/src/haz3lcore/CompositionCore/CompositionView.re
+++ b/src/haz3lcore/CompositionCore/CompositionView.re
@@ -234,18 +234,21 @@ module Local = {
     };
   };
 
+  let projector_to_segment = (pr: Base.projector): Segment.t =>
+    switch (pr.kind) {
+    | Fold => [Piece.mk_tile(Form.mk_atom_op(Exp, {|⋱|}), [])]
+    | _ => Triggers.projector_to_invoke(pr)
+    };
+
   module Printer = {
-    let fold_abbrev_projector_to_segment = (pr: Base.projector): Segment.t =>
-      switch (pr.kind) {
-      | Fold => [Piece.mk_tile(Form.mk_atom_op(Exp, {|⋱|}), [])]
-      | _ => Triggers.projector_to_invoke(pr)
-      };
+    let print_segment = (segment: Segment.t): string =>
+      Printer.of_segment(~holes="?", ~projector_to_segment, segment);
 
     let print_zipper = (z: Zipper.t): string =>
       Printer.of_zipper(
         ~holes="?",
         ~concave_holes="~",
-        ~projector_to_segment=fold_abbrev_projector_to_segment,
+        ~projector_to_segment,
         z,
       );
 
@@ -263,7 +266,7 @@ module Local = {
       | None =>
         let has_probes = !List.is_empty(z.refractors.manuals);
         if (has_probes) {
-          ProbeText.of_zipper(~probe_map, z);
+          ProbeText.of_zipper(~projector_to_segment, ~probe_map, z);
         } else {
           print_zipper(z);
         };
@@ -281,7 +284,7 @@ module Local = {
           ViewUtils.collapse_definitions(~z, ~ids=ids_to_collapse, ~info_map);
         let has_probes = !List.is_empty(z'.refractors.manuals);
         if (has_probes) {
-          ProbeText.of_zipper(~probe_map, z');
+          ProbeText.of_zipper(~projector_to_segment, ~probe_map, z');
         } else {
           print_zipper(z');
         };
@@ -291,6 +294,7 @@ module Local = {
 };
 
 module Public = {
+  let print_segment = Local.Printer.print_segment;
   let print = Local.Printer.print;
   let print_zipper = Local.Printer.print_zipper;
 };

--- a/src/haz3lcore/projectors/ProbeText.re
+++ b/src/haz3lcore/projectors/ProbeText.re
@@ -125,16 +125,21 @@ let format_probe_values =
 /* Main entry point: generate text representation of program with probes */
 let of_segment =
     (
+      ~projector_to_segment: Base.projector => Segment.t=Triggers.projector_to_invoke,
       ~window: Sample.Window.mode=Single,
       ~probe_map: Sample.Map.t,
       ~refractors: Zipper.Refractor.RefractorList.t,
       segment: Segment.t,
     )
     : string => {
-  /* Convert segment to string using Printer, which uses Triggers to wrap
-   * probed expressions with ^^probe(...) notation */
   let base_text =
-    Printer.of_segment(~holes=" ", ~indent="  ", ~refractors, segment);
+    Printer.of_segment(
+      ~holes=" ",
+      ~indent="  ",
+      ~projector_to_segment,
+      ~refractors,
+      segment,
+    );
 
   /* If no refractors, just return the base text */
   if (List.is_empty(refractors)) {
@@ -178,6 +183,7 @@ let of_segment =
 /* Convenience function for use from zipper */
 let of_zipper =
     (
+      ~projector_to_segment: Base.projector => Segment.t=Triggers.projector_to_invoke,
       ~window: Sample.Window.mode=Single,
       ~probe_map: Sample.Map.t,
       zipper: Zipper.t,
@@ -185,5 +191,11 @@ let of_zipper =
     : string => {
   let segment = Zipper.unselect_and_zip(~erase_buffer=true, zipper);
   let refractors = zipper.refractors.manuals;
-  of_segment(~window, ~probe_map, ~refractors, segment);
+  of_segment(
+    ~projector_to_segment,
+    ~window,
+    ~probe_map,
+    ~refractors,
+    segment,
+  );
 };

--- a/src/web/view/AgentCore/Agent.re
+++ b/src/web/view/AgentCore/Agent.re
@@ -337,12 +337,16 @@ module Message = {
                       (
                         "old",
                         `String(
-                          Printer.of_segment(~holes="?", diff.old_segment),
+                          CompositionView.Public.print_segment(
+                            diff.old_segment,
+                          ),
                         ),
                       ),
                       (
                         "new",
-                        `String(Printer.of_segment(~holes="?", new_segment)),
+                        `String(
+                          CompositionView.Public.print_segment(new_segment),
+                        ),
                       ),
                     ])
                   | None => `Null
@@ -354,7 +358,9 @@ module Message = {
                 "before",
                 switch (tool_result.before_segment) {
                 | Some(before_segment) =>
-                  `String(Printer.of_segment(~holes="?", before_segment))
+                  `String(
+                    CompositionView.Public.print_segment(before_segment),
+                  )
                 | None => `Null
                 },
               ),
@@ -362,7 +368,9 @@ module Message = {
                 "after",
                 switch (tool_result.after_segment) {
                 | Some(after_segment) =>
-                  `String(Printer.of_segment(~holes="?", after_segment))
+                  `String(
+                    CompositionView.Public.print_segment(after_segment),
+                  )
                 | None => `Null
                 },
               ),


### PR DESCRIPTION
I've consolidated agent print calls to use the printer wrapper defined in CompositionView which prints folds as ⋱.