### PR TITLE
Move agent data from localStorage to IndexedDB

### DIFF
--- a/src/web/StoreIDB.re
+++ b/src/web/StoreIDB.re
@@ -1,0 +1,80 @@
+/* IndexedDB-backed key-value store.
+   Async counterpart to Store.F (which uses localStorage).
+   Each store instance gets its own IndexedDB database to avoid
+   version-coordination issues between independent stores. */
+
+module F =
+       (
+         STORE_KIND: {
+           [@deriving (show({with_path: false}), sexp, yojson)]
+           type t;
+           let default: unit => t;
+           let db_name: string;
+         },
+       ) => {
+  include STORE_KIND;
+
+  open Ezjs_idb;
+  module IDBStore = Ezjs_idb.Store(StringTr, StringTr);
+
+  type db = Ezjs_min.t(Types.iDBDatabase);
+
+  let table_name = "kv";
+
+  let kv_store = (db: db): IDBStore.store =>
+    IDBStore.store(~mode=READWRITE, db, table_name);
+
+  let with_db = (f): unit => {
+    let error = _: unit =>
+      print_endline("ERROR: StoreIDB(" ++ db_name ++ ").open");
+    let upgrade = (db: db, e: db_upgrade): unit =>
+      e.new_version >= 1 && e.old_version == 0
+        ? ignore(IDBStore.create(db, table_name)) : ();
+    openDB(~upgrade, ~error, ~version=1, db_name, db => f(db));
+  };
+
+  let serialize = (data: t): string =>
+    data |> sexp_of_t |> Sexplib.Sexp.to_string;
+
+  let deserialize = (data: string): option(t) =>
+    try(Some(data |> Sexplib.Sexp.of_string |> t_of_sexp)) {
+    | _ =>
+      print_endline("StoreIDB(" ++ db_name ++ "): deserialization error");
+      None;
+    };
+
+  let save = (key: string, data: t): unit =>
+    with_db(db =>
+      IDBStore.put(~key, ~callback=_ => (), kv_store(db), serialize(data))
+    );
+
+  let load = (key: string, callback: option(t) => unit): unit =>
+    with_db(db => {
+      let error = _ =>
+        print_endline("ERROR: StoreIDB(" ++ db_name ++ ").get");
+      IDBStore.get(
+        ~error,
+        kv_store(db),
+        fun
+        | None => callback(None)
+        | Some(data) => callback(deserialize(data)),
+        K(key),
+      );
+    });
+
+  let delete = (key: string): unit =>
+    with_db(db =>
+      IDBStore.delete(
+        ~error=_ => (),
+        ~callback=_ => (),
+        kv_store(db),
+        K(key),
+      )
+    );
+
+  let clear = (~callback=() => (), ()): unit => {
+    let error = _ =>
+      print_endline("ERROR: StoreIDB(" ++ db_name ++ ").clear");
+    with_db(db => IDBStore.clear(~error, ~callback, kv_store(db)));
+  };
+};

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -321,7 +321,25 @@ module Update = {
     | Benchmark(Finish) =>
       Benchmark.finish();
       model |> Updated.return_quiet;
-    | Start => model |> return // Triggers recalculation at the start
+    | Start =>
+      /* Trigger async IndexedDB load for agent data */
+      switch (model.editors) {
+      | Scratch(m) =>
+        ScratchMode.load_agents_from_idb(
+          "scratch", ScratchMode.Model.scratchpad_names(m), (name, agent) =>
+          schedule_action(Editors(Scratch(LoadAgentData(name, agent))))
+        )
+      | Documentation(m) =>
+        ScratchMode.load_agents_from_idb(
+          "documentation",
+          ScratchMode.Model.scratchpad_names(m),
+          (name, agent) =>
+          schedule_action(Editors(Scratch(LoadAgentData(name, agent))))
+        )
+      | Tutorial(_)
+      | Exercises(_) => ()
+      };
+      model |> return; // Triggers recalculation at the start
     | Save =>
       print_endline("Saving...");
       Store.save(model);

--- a/src/web/app/editors/Editors.re
+++ b/src/web/app/editors/Editors.re
@@ -78,9 +78,25 @@ module Store = {
     switch (model) {
     | Model.Scratch(m) =>
       StoreMode.save(Scratch);
+      /* Save agent data to IndexedDB, then persist editors to localStorage
+         (persist writes empty agent stubs to keep localStorage small) */
+      ScratchMode.save_agents_to_idb(
+        "scratch",
+        List.map(
+          (s: ScratchMode.Scratchpad.t) => (s.name, s.agent),
+          m.scratchpads,
+        ),
+      );
       ScratchMode.Store.save(ScratchMode.Model.persist(m));
     | Model.Documentation(m) =>
       StoreMode.save(Documentation);
+      ScratchMode.save_agents_to_idb(
+        "documentation",
+        List.map(
+          (s: ScratchMode.Scratchpad.t) => (s.name, s.agent),
+          m.scratchpads,
+        ),
+      );
       ScratchMode.StoreDocumentation.save(ScratchMode.Model.persist(m));
     | Model.Tutorial(m) =>
       StoreMode.save(Tutorial);
@@ -180,17 +196,23 @@ module Update = {
     | (SwitchMode(Documentation), Documentation(_))
     | (SwitchMode(Exercises), Exercises(_)) => model |> return_quiet
     | (SwitchMode(Scratch), _) =>
-      Model.Scratch(
+      let m =
         ScratchMode.Store.load()
-        |> ScratchMode.Model.unpersist(~settings=globals.settings.core),
-      )
-      |> return
+        |> ScratchMode.Model.unpersist(~settings=globals.settings.core);
+      ScratchMode.load_agents_from_idb(
+        "scratch", ScratchMode.Model.scratchpad_names(m), (name, agent) =>
+        schedule_action(Scratch(LoadAgentData(name, agent)))
+      );
+      Model.Scratch(m) |> return;
     | (SwitchMode(Documentation), _) =>
-      Model.Documentation(
+      let m =
         ScratchMode.StoreDocumentation.load()
-        |> ScratchMode.Model.unpersist(~settings=globals.settings.core),
-      )
-      |> return
+        |> ScratchMode.Model.unpersist(~settings=globals.settings.core);
+      ScratchMode.load_agents_from_idb(
+        "documentation", ScratchMode.Model.scratchpad_names(m), (name, agent) =>
+        schedule_action(Scratch(LoadAgentData(name, agent)))
+      );
+      Model.Documentation(m) |> return;
     | (SwitchMode(Tutorial), Tutorial(_)) => model |> raise_invalid_action
     | (SwitchMode(Tutorial), _) =>
       Model.Tutorial(

--- a/src/web/view/AgentCore/Agent.re
+++ b/src/web/view/AgentCore/Agent.re
@@ -1124,6 +1124,25 @@ module Agent = {
         tools_view_expanded: [],
       };
     };
+
+    /* Minimal stub for localStorage. Contains no system prompt, tools,
+       or chat history — just enough to deserialize without error.
+       Real agent data is stored in IndexedDB. */
+    let empty = (): t => {
+      chat_system: ChatSystem.Utils.init(~system_prompt="", ~dev_notes=""),
+      prompting: {
+        system_prompt: "",
+        dev_notes: "",
+        tools: [],
+        disabled_tool_names: [],
+      },
+      active_timeline_node: None,
+      awaiting_response: None,
+      restore_editor_state: None,
+      last_empty_retry_attempt: None,
+      last_active_task_nudge_attempt: None,
+      tools_view_expanded: [],
+    };
   };
 
   module ToolUtils = {

--- a/src/web/view/ScratchMode.re
+++ b/src/web/view/ScratchMode.re
@@ -3,6 +3,58 @@ open Util;
 
 /* This file follows conventions in [docs/ui-architecture.md] */
 
+/* IndexedDB store for agent chat data. Each scratchpad's agent state
+   is stored here, keyed by "mode:scratchpad_name". This avoids
+   bloating localStorage with large system prompts and chat history. */
+module AgentIDB =
+  StoreIDB.F({
+    [@deriving (show({with_path: false}), sexp, yojson)]
+    type t = Agent.Agent.Persistent.t;
+    let default = Agent.Agent.Persistent.empty;
+    let db_name = "hazel_agent_db";
+  });
+
+let agent_idb_key = (mode_prefix: string, name: string): string =>
+  mode_prefix ++ ":" ++ name;
+
+/* Save all scratchpad agents to IndexedDB */
+let save_agents_to_idb =
+    (mode_prefix: string, scratchpads: list((string, Agent.Agent.Model.t)))
+    : unit =>
+  List.iter(
+    ((name, agent)) => {
+      let key = agent_idb_key(mode_prefix, name);
+      AgentIDB.save(key, Agent.Agent.Persistent.persist(agent));
+    },
+    scratchpads,
+  );
+
+/* Load all scratchpad agents from IndexedDB, dispatching results */
+let load_agents_from_idb =
+    (
+      mode_prefix: string,
+      names: list(string),
+      on_load: (string, Agent.Agent.Model.t) => unit,
+    )
+    : unit =>
+  List.iter(
+    name => {
+      let key = agent_idb_key(mode_prefix, name);
+      AgentIDB.load(
+        key,
+        data => {
+          let agent =
+            switch (data) {
+            | Some(p) => Agent.Agent.Persistent.unpersist(p)
+            | None => Agent.Agent.Utils.init()
+            };
+          on_load(name, agent);
+        },
+      );
+    },
+    names,
+  );
+
 module Scratchpad = {
   [@deriving (show({with_path: false}), sexp, yojson)]
   type t = {
@@ -18,6 +70,8 @@ module Scratchpad = {
     agent: Agent.Agent.Persistent.t,
   };
 
+  /* Persist for localStorage: writes an empty agent stub.
+     Real agent data is saved to IndexedDB separately. */
   let persist = (s: t): persistent => {
     let current_segment = Zipper.zip(s.editor.editor.editor.state.zipper);
     let original = Init.find_documentation_slide(s.name);
@@ -40,10 +94,13 @@ module Scratchpad = {
     {
       name: s.name,
       editor,
-      agent: Agent.Agent.Persistent.persist(s.agent),
+      /* Write empty stub to localStorage — agent data lives in IndexedDB */
+      agent: Agent.Agent.Persistent.empty(),
     };
   };
 
+  /* Unpersist from localStorage: ignores agent stub, starts with
+     fresh agent. IndexedDB load will populate real data async. */
   let unpersist = (~settings, p: persistent): t => {
     name: p.name,
     editor:
@@ -52,7 +109,7 @@ module Scratchpad = {
         p.editor,
       )
       |> CellEditor.Model.unpersist(~settings),
-    agent: Agent.Agent.Persistent.unpersist(p.agent),
+    agent: Agent.Agent.Utils.init(),
   };
 
   let mk = (~name, ~editor, ()): t => {
@@ -82,6 +139,9 @@ module Model = {
     scratchpads:
       List.map(sp => Scratchpad.unpersist(~settings, sp), scratchpads),
   };
+
+  let scratchpad_names = (model: t): list(string) =>
+    List.map((s: Scratchpad.t) => s.name, model.scratchpads);
 };
 
 let scratchpad_persistent_of_init =
@@ -89,7 +149,7 @@ let scratchpad_persistent_of_init =
     : Scratchpad.persistent => {
   name,
   editor,
-  agent: Agent.Agent.Utils.init() |> Agent.Agent.Persistent.persist,
+  agent: Agent.Agent.Persistent.empty(),
 };
 
 module StoreDocumentation =
@@ -155,6 +215,7 @@ module Update = {
   type t =
     | CellAction(CellEditor.Update.t)
     | AgentAction(Agent.Agent.Update.Action.t)
+    | LoadAgentData(string, Agent.Agent.Model.t)
     | SwitchSlide(int)
     | ResetCurrent
     | InitImportScratchpad([@opaque] Js_of_ocaml.Js.t(Js_of_ocaml.File.file))
@@ -169,6 +230,7 @@ module Update = {
     switch (action) {
     | CellAction(action) => CellEditor.Update.can_undo(action)
     | AgentAction(_) => true
+    | LoadAgentData(_, _) => false
     | SwitchSlide(_) => false
     | ResetCurrent => true
     | InitImportScratchpad(_) => true
@@ -316,6 +378,26 @@ module Update = {
         ...model,
         scratchpads: new_sp,
       };
+    | LoadAgentData(name, agent) =>
+      /* Async callback from IndexedDB load — populate agent data */
+      let scratchpads =
+        List.map(
+          (s: Scratchpad.t) =>
+            if (s.name == name) {
+              {
+                ...s,
+                agent,
+              };
+            } else {
+              s;
+            },
+          model.scratchpads,
+        );
+      {
+        ...model,
+        scratchpads,
+      }
+      |> Updated.return_quiet;
     | CellAction(a) =>
       let scratchpad = List.nth(model.scratchpads, model.current);
       let* new_ed = CellEditor.Update.update(~settings, a, scratchpad.editor);
@@ -690,6 +772,7 @@ module View = {
             );
           if (confirmed) {
             JsUtil.clear_localstore();
+            AgentIDB.clear();
             Js_of_ocaml.Dom_html.window##.location##reload;
           };
           Virtual_dom.Vdom.Effect.Ignore;


### PR DESCRIPTION
Closes #2188

This is a triage change for the QuotaExceededError issue; it introduces a new db for simplicity rather than using the one used for logging. I'll follow it up with a broader migration away from localstorage which will use a more consolidated/structured storage approach.

- Fixes the `QuotaExceededError` caused by agent data (system prompts + tool definitions ~60KB per scratchpad) filling localStorage when serialized across 52 documentation slides
- Agent chat data now stored in IndexedDB (`hazel_agent_db` database), localStorage gets a minimal empty stub (~few hundred bytes)
