### PR TITLE
Fix make test/test-quick failing with IDBKeyRange not defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,11 @@ repl:
 test:
 	dune fmt --auto-promote || true
 	dune build @ocaml-index @src/fmt @test/fmt --auto-promote src test --profile dev
-	node --stack-size=8192 $(TEST_DIR)/haz3ltest.bc.js
+	node --stack-size=8192 --require $(TEST_DIR)/idb_stub.js $(TEST_DIR)/haz3ltest.bc.js
 
 test-quick:
 	dune build @ocaml-index @src/fmt @test/fmt --auto-promote src test --profile dev
-	node --stack-size=8192 $(TEST_DIR)/haz3ltest.bc.js -q
+	node --stack-size=8192 --require $(TEST_DIR)/idb_stub.js $(TEST_DIR)/haz3ltest.bc.js -q
 
 watch-test:
 	dune build @ocaml-index @fmt @runtest @default --profile dev --auto-promote --watch


### PR DESCRIPTION
The Makefile test targets ran node without --require idb_stub.js, causing IDBKeyRange ReferenceError in Node.js. The dune test action already included this flag, which is why CI (dune runtest) passed.