### PR TITLE
Make pretty printer treat folded functions like normal symbols

### DIFF
--- a/src/haz3lcore/pretty/PrettySegment.re
+++ b/src/haz3lcore/pretty/PrettySegment.re
@@ -423,6 +423,7 @@ let is_right_convex = (p: Piece.t): bool =>
     | _ => false
     }
   | Grout({shape: Convex, _}) => true
+  | Projector(_) => true
   | _ => false
   };
 


### PR DESCRIPTION
Before:
<img width="931" height="200" alt="image" src="https://github.com/user-attachments/assets/d02c3375-70fa-4b9c-939a-454556edfcd4" />

After:
<img width="665" height="179" alt="image" src="https://github.com/user-attachments/assets/ffc4194a-c5b0-489d-b483-c6323d768687" />
