### PR TITLE
fix: restore Cmd/Ctrl+P shortcut for auto-probe mode (#2244)

### DIFF
--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -682,6 +682,29 @@ module View = {
             _,
           } =>
           Some(Update.Globals(Undo))
+        /* Cmd+P (Mac) / Ctrl+P (PC) toggles auto-probe mode.
+           Lost in the keyboard-handling refactor; re-added at the page
+           level since the toggle dispatches Globals(Set(AutoprobeMode)),
+           matching the deferral comment in ProbeProj.re. */
+        | {
+            key: D("P" | "p"),
+            sys: Mac,
+            shift: Up,
+            meta: Down,
+            ctrl: Up,
+            alt: Up,
+            _,
+          }
+        | {
+            key: D("P" | "p"),
+            sys: PC,
+            shift: Up,
+            meta: Up,
+            ctrl: Down,
+            alt: Up,
+            _,
+          } =>
+          Some(Update.Globals(Set(AutoprobeMode)))
         | _ => None
         };
       Effect.(


### PR DESCRIPTION
## Summary
- Cmd/Ctrl+P stopped toggling auto-probe mode after the keyboard-handling refactor.
- Re-add the binding at the page level since the toggle dispatches `Globals(Set(AutoprobeMode))`, matching the deferral comment in `ProbeProj.re`.
- **Solution taken from the `autofocus` branch** (commit 713d7a2d94 by @disconcision); applied here so it lands on \`dev\`.

Closes #2244.

## Test plan
- [x] On Mac, press Cmd+P in the editor — auto-probe mode toggles.
- [x] On Linux/Windows, press Ctrl+P — auto-probe mode toggles.
- [x] Cmd+Shift+P / Ctrl+Shift+P do not trigger the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)