### PR TITLE
fix: treat 'module' as a keyword (#2239)

### DIFF
--- a/src/haz3lcore/lang/Token.re
+++ b/src/haz3lcore/lang/Token.re
@@ -131,6 +131,7 @@ let keywords = [
   "then",
   "else",
   "hint",
+  "module",
 ];
 
 let is_keyword = match(regexp("^(" ++ concat("|", keywords) ++ ")$"));


### PR DESCRIPTION
## Summary
- \`module\` was missing from \`Token.keywords\`, so \`is_ref\` (which excludes keywords) classified it as a variable reference and applied the \`.ref\` class.
- Cmd-hover then highlighted it like a go-to-definition target.

Closes #2239.

## Test plan
- [x] Hold Cmd and hover over the \`module\` keyword — it should not show the variable-reference highlight.
- [x] Other keywords (\`fun\`, \`let\`, \`if\`, etc.) continue to behave the same.
- [x] Variable references still highlight correctly under Cmd-hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)