### PR TITLE
fix: ExplainThis shows correct syntactic form for Int and SInt (#2234)

### DIFF
--- a/src/web/app/explainthis/ExplainThisForm.re
+++ b/src/web/app/explainthis/ExplainThisForm.re
@@ -385,6 +385,7 @@ type group_id =
   | EmptyHoleTyp
   | MultiHoleTyp
   | IntTyp
+  | SIntTyp
   | NatTyp
   | FloatTyp
   | BoolTyp

--- a/src/web/app/explainthis/data/TerminalTyp.re
+++ b/src/web/app/explainthis/data/TerminalTyp.re
@@ -5,7 +5,7 @@ let int_typ: form = {
   let explanation = "The `Int` type classifies (unbounded) integer values.";
   {
     id: IntTyp,
-    syntactic_form: [typ("SInt")],
+    syntactic_form: [typ("Int")],
     expandable_id: None,
     explanation,
     examples: [],
@@ -83,8 +83,8 @@ let int: group = {
   forms: [int_typ],
 };
 let sint: group = {
-  id: IntTyp,
-  forms: [int_typ],
+  id: SIntTyp,
+  forms: [sint_typ],
 };
 let nat: group = {
   id: NatTyp,


### PR DESCRIPTION
## Summary
- \`int_typ\`'s \`syntactic_form\` was incorrectly \`typ(\"SInt\")\`, so hovering on \`Int\` rendered \`SInt\` next to the (correct) \"The \`Int\` type\" explanation.
- The \`sint\` group also reused \`int_typ\`, so SInt users got the same buggy form.
- Give \`Int\` its own form rendering and route the SInt group through \`sint_typ\` (adding the corresponding \`SIntTyp\` group_id).

Closes #2234.

## Test plan
- [x] In ExplainThis sidebar, place caret on \`Int\` — explanation reads \"The \`Int\` type ...\" with \`Int\` (not \`SInt\`) as the syntactic form.
- [x] Place caret on \`SInt\` — explanation reads \"The \`SInt\` type ...\" with \`SInt\` as the syntactic form.
- [x] Other terminal types (\`Bool\`, \`Float\`, \`Nat\`, \`String\`) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)