### PR TITLE
ci: per-branch deploy concurrency + larger retry budget

### DIFF
--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -93,12 +93,13 @@ jobs:
             exit 0
           fi
           git commit -m "github-deploy-action-${BRANCH_NAME}"
-          for i in 1 2 3; do
+          for i in $(seq 1 10); do
             git push && exit 0
             echo "Push failed (attempt $i), pulling and retrying..."
+            sleep $((RANDOM % 3 + 1))
             git pull --rebase --no-edit
           done
-          echo "Push failed after 3 attempts"
+          echo "Push failed after 10 attempts"
           exit 1
         working-directory: ./server
       - name: Run Tests

--- a/.github/workflows/deploy_branches.yml
+++ b/.github/workflows/deploy_branches.yml
@@ -3,8 +3,14 @@
 name: Build and Deploy Hazel
 on: [push]
 concurrency:
-  group: deploy-to-build-repo
-  cancel-in-progress: false
+  # Per-branch group so cross-branch deploys don't evict each other from
+  # the queue (a global group has queue depth 1, so a third concurrent
+  # run cancels whichever was queued). The push-retry loop in the deploy
+  # step handles the cross-branch race on hazelgrove/build's main ref.
+  # cancel-in-progress: true so a newer commit on the same branch
+  # supersedes an older in-flight build rather than deploying stale output.
+  group: deploy-to-build-repo-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   Deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

Cross-branch deploy runs were being cancelled with \`Canceling since a higher priority waiting request for deploy-to-build-repo exists\`, even though the runs were for unrelated branches. Examples:

- https://github.com/hazelgrove/hazel/actions/runs/25442149188
- https://github.com/hazelgrove/hazel/actions/runs/25442149151

## What was going wrong

#2205 added a global concurrency group \`deploy-to-build-repo\` with \`cancel-in-progress: false\` to serialize pushes to \`hazelgrove/build\` and avoid the \`cannot lock ref 'refs/heads/main'\` race.

The PR description framed this as \"queued deploys wait rather than get canceled,\" but GitHub Actions concurrency has a rule that wasn't accounted for: **the queue depth per group is 1**.

- \`cancel-in-progress: false\` only protects the *running* job from cancellation.
- It does **not** protect the *queued* job. When a third run arrives, the currently-queued one is evicted with the \"higher priority waiting request\" message, and the new arrival takes the queue slot.

So with three or more roughly-concurrent pushes across branches, the middle ones were silently dropped and never deployed.

## The fix

Two small changes to \`.github/workflows/deploy_branches.yml\`:

1. **Per-branch concurrency group** (\`deploy-to-build-repo-\${{ github.ref }}\`) with \`cancel-in-progress: true\`. Cross-branch deploys no longer share a queue slot, so they can't evict each other. Same-branch double-pushes still serialize: a newer commit supersedes an older in-flight build instead of deploying stale output.

2. **Retry budget bumped from 3 to 10**, with a 1-3s jittered sleep between attempts. The original retry-with-rebase loop now becomes load-bearing for the cross-branch ref race (rather than defense-in-depth behind the global serialization). 3 attempts covered ~4 concurrent branches worst-case; 10 gives generous headroom for bursty pushes.

The cross-branch ref race itself is still resolved correctly by the existing \`git pull --rebase --no-edit\` retry loop: each branch deploys to its own directory \`./server/\${BRANCH_NAME}\`, so the rebase is conflict-free, and after the rebase the next push has the correct parent.

## Alternatives considered

- **Drop the concurrency group entirely.** Simplest, but allows same-branch races where an older commit's build finishes after a newer one's and overwrites it. Rejected — stale-deploy risk.
- **Per-branch group with \`cancel-in-progress: false\`.** Every commit deploys in order, no stale-deploy risk, but slower and pointless for branches where only the latest build matters. Rejected as the default; \`true\` matches typical desired behavior.
- **Split into two jobs (build/test per-branch, deploy globally serialized) using upload-artifact/download-artifact.** Strongest guarantee — only one push to \`hazelgrove/build\` is ever in flight. But artifact upload/download adds latency and complexity, and the retry loop already handles the race correctly. Rejected as overkill given expected concurrency levels.