### PR TITLE
Clean up b2t2 slides: string_eq, unused vars, prettify (#2057)

### DIFF
--- a/src/b2t2/slides/B2T2ExampleTables.ml
+++ b/src/b2t2/slides/B2T2ExampleTables.ml
@@ -5,35 +5,39 @@ let out : string * Haz3lcore.PersistentSegment.t =
         "((Secondary((id \
          17762656-f10f-4636-ac4e-449d6d37e7b0)(content(Comment\"# Example \
          Tables from B2T2 #\"))))(Secondary((id \
-         89ac1f7c-c7c7-43d7-8c9b-26172dbc6c30)(content(Whitespace\"\\n\"))))(Secondary((id \
+         7ebfd4aa-b8f3-4b62-ae83-5b44894ad101)(content(Whitespace\"\\n\"))))(Secondary((id \
          bbf0ade1-8682-4f32-9023-1b1155d33730)(content(Comment\"# Tables \
          copied from \
          https://github.com/brownplt/B2T2/blob/main/ExampleTables.md \
          #\"))))(Secondary((id \
-         285ecb4f-f916-4a50-811c-b993385ef4b2)(content(Whitespace\"\\n\"))))(Tile((id \
+         83bcbc53-a26a-4adc-8629-cc1eda9607a1)(content(Whitespace\"\\n\"))))(Tile((id \
          7108d949-ca81-4d19-82fd-c99d265740e9)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         d72858d0-900e-4ebd-817d-2bf3aea0cc3d)(content(Whitespace\" \
+         b550bf9d-ffd6-4425-931e-4ba0bb08a176)(content(Whitespace\" \
          \"))))(Tile((id \
          effbc320-bb77-495f-ab4f-11b900a79597)(label(OptInt))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         2889d279-0dc2-45d5-ba8d-06cc75cf02db)(content(Whitespace\" \
+         e6d241f1-1870-4024-8b50-00fd78a6d105)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3f432e7f-1956-4b43-9083-88002e8aa80e)(content(Whitespace\" \
+         6dcbb996-fe13-4006-9efc-7990256219b6)(content(Whitespace\" \
          \"))))(Tile((id \
          76e928f4-3d40-44f6-8b3c-1963c1f5ebb0)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1f908fb4-530f-4ce3-91b9-4241bcee5ef7)(content(Whitespace\" \
+         \"))))(Tile((id \
          87097230-80dd-4082-a29e-edadc98996de)(label(None))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         b719bd87-f3a8-4c3e-b99b-49b6973a7b7c)(content(Whitespace\" \
+         88050a57-9431-42b2-95d3-c740dac17d3c)(content(Whitespace\" \
          \"))))(Tile((id \
          f9777460-41fa-45cd-af76-7e989242f87e)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
-         12))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         12))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         63354932-ad19-4c23-9203-649a98e108ac)(content(Whitespace\" \
+         \"))))(Tile((id \
          db8bcc76-72da-41a3-9193-b4a99395ff79)(label(Some))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
@@ -43,32 +47,36 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d463b4a3-3daf-4c62-9f11-21fa81d82ebd)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         3a139109-a3f8-4dae-9f14-5e417fa17084)(content(Whitespace\" \
+         91f31039-3a5d-4ce7-9aee-6eb2ae94cb1a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4f129aed-a032-48ac-89d2-a094118afe91)(content(Whitespace\"\\n\"))))(Tile((id \
+         e33e48ca-ea0d-4639-8baf-8489483f00a1)(content(Whitespace\"\\n\"))))(Tile((id \
          e4fc813f-9689-4339-9614-160ae653fad8)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         88423219-edc2-41b4-bfb8-892a53c5a903)(content(Whitespace\" \
+         31d73432-fb11-4530-8806-c3cfcf3fc5d6)(content(Whitespace\" \
          \"))))(Tile((id \
          a8d13c27-87a6-40ae-88b7-27472dcca78b)(label(OptString))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         8c0f12af-f600-41f2-9415-1c5955119d79)(content(Whitespace\" \
+         fce9450e-2d7a-4a26-a184-aa3d3ef2ad3a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         98b15f10-6832-4f91-9763-70d35675c259)(content(Whitespace\" \
+         5bfd9db7-d2d3-4730-861a-330d3e234754)(content(Whitespace\" \
          \"))))(Tile((id \
          af4a76d7-b357-47cf-80aa-167f2d6d999c)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e5b490a8-7f61-4e94-8fcb-7195f93b6c37)(content(Whitespace\" \
+         \"))))(Tile((id \
          1e6f85a8-cc34-4140-ae5f-4137f7c0def6)(label(None))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         31907c7e-eea8-432c-a1ff-fe02e8e2d894)(content(Whitespace\" \
+         763df9a6-a731-440c-ac73-59943f089c33)(content(Whitespace\" \
          \"))))(Tile((id \
          fd0289e7-a3d5-4d49-8a92-255651f3960f)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
-         12))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         12))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         97af7ed7-4fca-4e4f-a89e-9239557b02cc)(content(Whitespace\" \
+         \"))))(Tile((id \
          1a7f49b7-65ca-4aa7-8a84-43d06e0afc5c)(label(Some))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
@@ -78,91 +86,102 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cf9699ca-736e-4866-9c00-fdb1a9b60d56)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         2d2b5ec1-4945-4cc0-a038-7443aa6d9241)(content(Whitespace\" \
+         424fab0b-692b-4a94-b11b-7afe3d72cb4c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f91fb3d1-d0b8-4539-b8c1-790e4114cca6)(content(Whitespace\"\\n\"))))(Tile((id \
+         a18ae4d9-5caa-4513-aa43-1f52781681dd)(content(Whitespace\"\\n\"))))(Tile((id \
          86db3c8f-faf9-4935-8f65-a10afb13a373)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c9e0bbb2-2294-4769-a40b-4ac1b19a8b4f)(content(Whitespace\" \
+         babaffdc-eaed-473d-89c7-3440b66da7ec)(content(Whitespace\" \
          \"))))(Tile((id \
          aa563991-93d5-4c17-8afb-6ff5dab55c28)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         af926383-0565-4a81-8e3b-fa0a3e31353b)(content(Whitespace\" \
+         cea293cb-1518-49cd-afde-8e9e843c8e7f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9ec674c2-d18f-45de-9c6d-9f6f3705c27e)(content(Whitespace\" \
+         889aae2c-d95e-4466-b020-ad7b76db4082)(content(Whitespace\" \
          \"))))(Tile((id \
          7ca03d56-f0fe-4508-a145-b0341f351cd8)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          74229617-51fe-4f2b-b2e1-c02ee03f98ee)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e8a78624-e6cf-436e-acdf-9cd579cab7be)(content(Whitespace\" \
+         \"))))(Tile((id \
          0b93ae76-b524-4f38-82b5-227c32c935cd)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         00b5c0d3-65fd-49ba-bf8d-a18dead57aa4)(content(Whitespace\" \
+         \"))))(Tile((id \
          7b0cbaab-4d96-4bc9-a645-036dde319e7a)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          dbfedbf8-08ee-4317-bcb4-bd9126ed7875)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         548fa5f2-a613-4e0b-bb82-c274b4b18ef0)(content(Whitespace\" \
+         70708a8f-2cf6-4ef7-b04f-ed42594117c6)(content(Whitespace\" \
          \"))))(Tile((id \
          2c8ef00d-2fe7-4922-8de5-864887d9e48e)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         769244c5-46d3-4b3a-b9c5-a615e2004f63)(content(Whitespace\" \
+         \"))))(Tile((id \
          13f2f6fd-dc83-48ae-b537-40e2100053f3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e0129d6c-9a9f-4f34-b531-02d8c7ad39f5)(content(Whitespace\" \
+         \"))))(Tile((id \
          f0ac5ed9-33dc-4ad0-bafd-0a9b4ebc7ca2)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          367091df-9c11-46b5-ab3b-99d91fe0da34)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e7044b24-12a3-49a2-a7f5-4f73e04874d2)(content(Whitespace\" \
+         877877c8-f1d4-4b12-b5a1-100fec3364cd)(content(Whitespace\" \
          \"))))(Tile((id \
          8b346d3b-a71a-4a4d-bc4b-ffe346cc4ba4)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dd77fc0a-d374-4ac2-a52c-26a61d4d5997)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a0ccdfe-6954-46f7-8707-e49b247d5943)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ef6fe6a3-11ce-439e-8f39-884b32cffab1)(content(Whitespace\" \
+         \"))))(Tile((id \
          1c9e5b72-729a-4d81-a6a3-14889d6f7e3a)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         007d6113-b66c-4994-97df-63435e7b525b)(content(Whitespace\" \
+         54dd82fd-a59f-4279-ae0f-7bfe50784f15)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         996618a6-3204-4da6-8be8-467fe0c4b645)(content(Whitespace\"\\n\"))))(Tile((id \
+         a943fcff-3282-4ad7-b887-e043887982e3)(content(Whitespace\"\\n\"))))(Tile((id \
          34a59533-48fc-427a-8026-e9cca12e6deb)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         86ddaaba-dca4-4646-b0e7-111321f1af81)(content(Whitespace\" \
+         99758a2c-1d82-4b93-9a06-ebe7844b7ca9)(content(Whitespace\" \
          \"))))(Tile((id \
          75848351-a49c-41b9-931f-4f83ec527068)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7c40b46c-77f7-4b8f-a107-8774a8760f3b)(content(Whitespace\" \
+         d0c49528-e1b7-454c-bbb7-fbd678be15aa)(content(Whitespace\" \
          \"))))(Tile((id \
          fb98724c-2429-4efc-b394-210d421f62d6)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ef5a1ed1-5dd7-4f10-b0f8-5260426710f7)(content(Whitespace\" \
+         e60c8b0a-7b48-47ad-aeee-4ff0030fa7b7)(content(Whitespace\" \
          \"))))(Tile((id f5a56f84-50bf-4a38-a17e-b342c06d3464)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          e87e153b-1241-4cb4-bcb3-a00b7c4a58e8)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         ba847210-ca32-45c0-89f4-c86e7a2091d2)(content(Whitespace\" \
+         c640ee22-716a-416f-8642-098b72cb8b98)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c1c49e69-925b-4ae3-a787-f896fcd5a207)(content(Whitespace\" \
+         bccb02a5-9cf9-44f5-8b87-e2273884102f)(content(Whitespace\" \
          \"))))(Tile((id 39c47f4c-93a9-4876-9646-0cb90ad52923)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         29b7787d-0899-4bbf-b7c0-bddcbd7a7ead)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          7b5e793a-b42f-406f-ab16-36ff52d79a74)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -188,7 +207,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          71c4466e-c440-46fd-9707-c8c3b8f408bd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e6b8c69a-d4aa-4953-b8e4-0ed1605260a3)(content(Whitespace\"\\n\"))))(Tile((id \
+         e5caff34-bc9c-43c9-8eab-6a8fe69a705b)(content(Whitespace\" \
+         \"))))(Tile((id \
          ea9a0dcb-355c-400b-925d-7ade67326348)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -214,7 +234,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          69373f89-3dce-4ecb-b76d-ad27ed024593)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         afaafc85-8255-4a5b-b30c-b4844249dfcb)(content(Whitespace\"\\n\"))))(Tile((id \
+         52a33082-27ca-4b05-97c0-5cc74b80a588)(content(Whitespace\" \
+         \"))))(Tile((id \
          41b67222-1956-4408-a100-70869978465f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -224,7 +245,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aa6f44d6-64a0-4715-8fb3-a8c4100b8004)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         25848c2b-106c-447a-8f28-f62669c325a6)(content(Whitespace\" \
+         e214e0ef-112e-45fb-8414-6edeb750e4b7)(content(Whitespace\" \
          \"))))(Tile((id \
          24c68231-655f-4bcd-a93a-f3bf20e9228f)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -232,98 +253,108 @@ let out : string * Haz3lcore.PersistentSegment.t =
          02b23771-2674-4b4f-bc7a-e4ef77bfba9e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8b672797-0bcd-4825-8536-675db3333d62)(content(Whitespace\" \
+         166e81c2-964b-47cb-aa80-bea009f640ca)(content(Whitespace\" \
          \"))))(Tile((id \
          5c6db7fd-e553-45c7-bc26-ed02d92752bb)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6666fd1e-69d9-4243-aac5-6d56f62edf9b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         58fe7ae5-c266-4c4b-9681-e1b8dab57cb2)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         13d37ac7-029d-4e5e-b424-7c5edd301cb3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9548b912-9037-43df-8f4c-1f3490529572)(content(Whitespace\"\\n\"))))(Secondary((id \
-         97ad6875-c8ea-4980-9186-631c6af82118)(content(Whitespace\"\\n\"))))(Tile((id \
+         044730d5-81fb-4ec6-8f62-c8a1a99de8ab)(content(Whitespace\"\\n\"))))(Secondary((id \
+         87b2516f-2527-4f70-9d47-20ac4a1ce230)(content(Whitespace\"\\n\"))))(Tile((id \
          bedfca29-b0f8-44be-b4a2-79a9b1bbf022)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         fda3f351-a955-4dc1-96aa-b926cddcc3fd)(content(Whitespace\" \
+         0f9cfa30-fad3-4be3-9e4b-4c34211f760e)(content(Whitespace\" \
          \"))))(Tile((id \
          0f0d2428-c47c-40ed-9246-6bde733f3761)(label(StudentMissing))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         56e33e35-9493-4c23-9179-de9cc71b6ccb)(content(Whitespace\" \
+         25c9f716-1444-4359-855d-c1d2956f6fd0)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f149ccea-b0fa-4476-baf1-e6de41c4a852)(content(Whitespace\" \
+         a66dd8bb-0099-464d-9402-59ab44e17d00)(content(Whitespace\" \
          \"))))(Tile((id \
          65f3f4d8-bfa7-490a-9ba4-37841e9d1405)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          ecc629b2-6a5b-4c56-8305-de9d439aed07)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         69cfe89c-4364-47a6-8163-2a471488db39)(content(Whitespace\" \
+         \"))))(Tile((id \
          85f30b03-872a-490c-9c76-9ae350b8cdf8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         37885010-b3ce-4f82-95ff-60962b81d581)(content(Whitespace\" \
+         \"))))(Tile((id \
          def8776a-2304-4c40-83fe-1b4b57fb598b)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a2d20d83-888d-44af-9338-1359933fcf02)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f93dae1b-1440-46ae-a16b-f02c8bd9bc29)(content(Whitespace\" \
+         0fa97c18-8de2-4afe-b073-738c3193b2df)(content(Whitespace\" \
          \"))))(Tile((id \
          f589f4e9-64c2-4e78-a142-99025e6c345c)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5bd6617a-2d98-4b2c-8960-64962d8117af)(content(Whitespace\" \
+         \"))))(Tile((id \
          a1216ee3-48fa-41c6-b6ce-da9af785e6da)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e66af703-5045-4f1e-a93e-94a485110867)(content(Whitespace\" \
+         \"))))(Tile((id \
          aa8d51fc-3d5b-4486-bd48-32c2f0d9267a)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f5265e8c-49bf-47a7-8a24-9d50837860e0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         077a6476-7cb5-4baa-9755-87715a3786ac)(content(Whitespace\" \
+         8bae43bf-a78f-4aae-bd68-8df270680b4c)(content(Whitespace\" \
          \"))))(Tile((id \
          28b698cc-56b2-445f-a9c9-e4f5f6557c41)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bf231845-10d7-429c-8e2e-77950f85db1e)(content(Whitespace\" \
+         \"))))(Tile((id \
          1e05edba-2c01-4da2-bfa0-632a5cba9bdc)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5305464e-8805-43b5-9f85-1e2bdb20b68e)(content(Whitespace\" \
+         \"))))(Tile((id \
          6aeeff04-4687-4e63-acde-211d27105ce0)(label(OptString))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         86668f99-804b-4f7d-9004-bbc3343c9a93)(content(Whitespace\" \
+         b7a83bf6-36fe-429c-afb9-bb22ffa7800e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8be8fa35-37fa-4cf8-8d1d-742a6dcf9d90)(content(Whitespace\"\\n\"))))(Tile((id \
+         7dccf4ed-bd7f-4ba0-b578-e37b6268fbf4)(content(Whitespace\"\\n\"))))(Tile((id \
          7f522e23-4c6e-4779-985a-52b341c5c765)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a67c8756-f735-4368-92ca-815be79306df)(content(Whitespace\" \
+         4a396288-5611-4c14-852c-c008ac0aa3b2)(content(Whitespace\" \
          \"))))(Tile((id \
          5c52c5d5-a24d-4b79-af88-b5b24cb97f50)(label(studentsMissing))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1a43bea2-5c93-4c02-b657-1143879ec708)(content(Whitespace\" \
+         e2c6da02-c27e-4a49-bd29-0b3dfdb9ca2a)(content(Whitespace\" \
          \"))))(Tile((id \
          35379da2-f643-468f-8dd3-c1c88bd0b26e)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         599fdb7b-440c-4440-9971-f206e2d9d796)(content(Whitespace\" \
+         fb66b3d8-56de-461c-9a71-c6eb2852b029)(content(Whitespace\" \
          \"))))(Tile((id 603776a9-7f54-4a12-a2a9-d03e1fda1abd)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          df4e0c6f-c68c-4bcc-a054-383d733b9881)(label(StudentMissing))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         fcf334a0-df89-459d-8e57-300df6c3b76e)(content(Whitespace\" \
+         e2ae5909-5485-4b7f-a9e1-21633884b056)(content(Whitespace\" \
          \")))))((Secondary((id \
-         df71bbb5-92ab-4d0c-a5ed-1c4cc4aeb481)(content(Whitespace\" \
+         483b0283-9d95-42ca-8238-21c57df0b421)(content(Whitespace\" \
          \"))))(Tile((id 29921422-a208-49b6-926c-5d3cc1658f55)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         7c19cfda-88c3-4ee9-89ef-73bf0233a09a)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          67c016b4-51f7-4abb-9064-5baba78e0e3f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -355,7 +386,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          31a43836-269e-432d-abbb-b8398346f565)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8cdda4a1-50e9-42c0-8124-663eac158154)(content(Whitespace\"\\n\"))))(Tile((id \
+         2c34cca3-b39b-4788-a876-9b0992322838)(content(Whitespace\" \
+         \"))))(Tile((id \
          9e597b6f-579b-4a8e-92ab-6662138ae5c9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -393,7 +425,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e0b8de32-572c-4500-8572-4931334ea27b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5a5bf141-8f9a-45b3-a369-629f6b518ccd)(content(Whitespace\"\\n\"))))(Tile((id \
+         a801406b-727b-4696-9b34-e758079a46ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          8577a5c1-efab-4a3a-86e2-74e2b159c919)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -403,7 +436,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4ed19353-8185-4569-a11a-9715da6d7e6d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1483d3e0-15d5-41ae-a1e5-f0e3ae00e24a)(content(Whitespace\" \
+         37f98c3a-149c-4c5a-aa4f-e297cf0cfaee)(content(Whitespace\" \
          \"))))(Tile((id \
          2e00840f-31c6-4f6d-84d9-08c94841a147)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -417,84 +450,91 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c08de2a9-8d05-4f69-9a51-8f0142ec1f6e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         87ffc505-6c24-4a93-b0b8-168c1d16c235)(content(Whitespace\" \
+         883e65b3-3ccb-4b1c-8f35-228749a20cde)(content(Whitespace\" \
          \"))))(Tile((id \
          376d059a-8208-44ba-9560-3502ab975b8a)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e43d003f-3204-4c28-8dc9-27c50c7bbb6f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         4acf220d-05da-413f-a79d-2d2c0002fc71)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         cdb3c5a4-53e1-4a8b-a6b3-b89471430007)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6dbcbd42-61fa-4c47-a1cd-554f6536c206)(content(Whitespace\"\\n\"))))(Secondary((id \
-         11eb9dd7-8f26-4124-b744-8d02af003a54)(content(Whitespace\"\\n\"))))(Tile((id \
+         1227a1ca-14cb-46e5-9207-461811a679ce)(content(Whitespace\"\\n\"))))(Secondary((id \
+         41e0004f-bdd9-441c-9c97-2fbe040b58a8)(content(Whitespace\"\\n\"))))(Tile((id \
          bc8a1369-9d73-4b7f-a3be-c3c0d611e436)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a03ee854-ab46-41cf-82ce-47ff51384496)(content(Whitespace\" \
+         6e4d0428-d966-4095-9d3d-d4a420491887)(content(Whitespace\" \
          \"))))(Tile((id \
          0fbc0029-1871-4828-bc6f-7235d19b67db)(label(Employee))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         8ad85f0e-d628-49d4-bfa3-d52b3a3d29da)(content(Whitespace\" \
+         a80d38cf-520c-44ca-9ea6-ddbedf7382fc)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a4e8af0d-1d4c-46c4-a349-e8d2048bbfb1)(content(Whitespace\" \
+         fc66e75e-fd40-4f76-83c7-b9dd1d5de8d6)(content(Whitespace\" \
          \"))))(Tile((id \
          85d7761d-ce3c-4f49-b1f4-0420dbfff839)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          4e736f71-a835-42bc-b448-8af5cbccff6d)(label(last_name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2e5f4379-464f-4a9f-aeb4-99479c5b9c54)(content(Whitespace\" \
+         \"))))(Tile((id \
          51bc2351-f6d2-4f46-ae78-345b98547006)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ecf98d25-e1f5-4817-bb3c-4b26d97228fd)(content(Whitespace\" \
+         \"))))(Tile((id \
          5670db9e-0555-415d-8dc3-336e4678901b)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ec778a6e-b190-410d-b27b-8cd248506ecc)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b847c2c8-fec8-4550-b203-ae34ca2468bb)(content(Whitespace\" \
+         ae8eb796-3a52-4108-93d3-94a6e8fcb9ae)(content(Whitespace\" \
          \"))))(Tile((id \
          c002f368-a8ec-43a9-837e-173dd06c79a6)(label(department_id))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dfe2a77e-854a-4662-bc63-20dbf862259f)(content(Whitespace\" \
+         \"))))(Tile((id \
          0b620b86-a9bc-411e-aeb3-8120b08d2067)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4554ba86-47e9-4031-b63e-305075215fab)(content(Whitespace\" \
+         \"))))(Tile((id \
          b95fe499-e0da-4458-a26f-aef3f1c66eb8)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         bb34e2e6-2a57-4fff-bcba-dc84b9d2a888)(content(Whitespace\" \
+         bca529e3-e90d-46d9-abc8-a8ef76f06844)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f012e92c-8062-4a8c-b68e-be540b7f5900)(content(Whitespace\"\\n\"))))(Tile((id \
+         eb603062-60c7-4e94-8aa9-6f6667f2d6c6)(content(Whitespace\"\\n\"))))(Tile((id \
          ae9ecd65-4ba4-4b21-9972-836862eb2b13)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         ee79e2d5-32fe-4ac4-b306-07b0ec10b2d9)(content(Whitespace\" \
+         2dff1de1-c5d3-4afe-b8fb-5d9486e9852a)(content(Whitespace\" \
          \"))))(Tile((id \
          2d106f76-8c2e-4ee5-97b2-a282b44266d5)(label(employees))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         43cb4fe8-7dfa-4df4-8a29-198fd2663c5c)(content(Whitespace\" \
+         22964c9a-9fd4-489e-a03d-435cde6d1f8d)(content(Whitespace\" \
          \"))))(Tile((id \
          e3385790-88b8-4546-ae5c-aee1a2fa3c8f)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4d617253-6f37-4511-bf43-1ce0366458bd)(content(Whitespace\" \
+         c1daf38c-8111-41e4-9a34-53d36ec2a78b)(content(Whitespace\" \
          \"))))(Tile((id 89741386-c6df-4303-b753-187984b5d576)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          6336ae0b-8dac-4e81-b0a9-d47d501d466f)(label(Employee))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1f38f929-9198-4df6-bed4-6a0e5270b396)(content(Whitespace\" \
+         123623fd-6e57-47cd-9116-85e66779caf9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         50d550bf-6b1f-493e-b7f6-3e3acb20a793)(content(Whitespace\" \
+         ac797e43-ffcf-4675-943a-d3bc8378f939)(content(Whitespace\" \
          \"))))(Tile((id 2c2d50e0-b016-4bad-8d55-3efc8064643f)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ba59187c-3965-492a-826a-f6aaf089db59)(content(Whitespace\"\\n\"))))(Tile((id \
+         32c4c06a-3724-445d-b03b-f0c4ae6dba8d)(content(Whitespace\"\\n\"))))(Tile((id \
          43c51890-db6e-4eb9-9cd2-5454f5886536)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -518,7 +558,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          959f5064-ee9f-4353-a097-f2485ca286da)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f4d19843-bfe3-40ef-9c9d-3cfa3cb847f3)(content(Whitespace\"\\n\"))))(Tile((id \
+         616ef909-8415-4343-b2a2-114e7eb37b8e)(content(Whitespace\"\\n\"))))(Tile((id \
          058c79a1-b263-46e3-aa17-ebae66db6ba8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -542,7 +582,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          11de8098-6173-463c-b90b-1ff21930d88a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         37cbf4fd-09dd-48b8-8390-86ef4bb4788f)(content(Whitespace\"\\n\"))))(Tile((id \
+         1edb4c72-25ef-4d26-ae0d-729403f2974d)(content(Whitespace\"\\n\"))))(Tile((id \
          8e54f353-e94b-42ed-ae4e-688259521372)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -566,7 +606,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1c518381-f72d-4f27-9205-b9ef3f17cda7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         52458d7c-e45c-41e2-93f0-761ea5424a2f)(content(Whitespace\"\\n\"))))(Tile((id \
+         55ca5821-bac1-4305-94b1-04bdca8aa50c)(content(Whitespace\"\\n\"))))(Tile((id \
          35b4b8e7-d897-42bc-9622-166113c67387)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -590,7 +630,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3d93381b-89ac-4923-9569-f9f4389f8215)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1a23fc96-fabb-4398-9c35-a413cdc95bc1)(content(Whitespace\"\\n\"))))(Tile((id \
+         214d6030-840c-4fbb-b709-7be4ae6caded)(content(Whitespace\"\\n\"))))(Tile((id \
          6940d197-3df0-499c-8cc4-5575483bb995)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -614,7 +654,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b6ee682c-688c-4f64-84c9-0e5575aa0116)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6085106f-e0b9-43ca-996d-5d64189e3576)(content(Whitespace\"\\n\"))))(Tile((id \
+         6ecb8122-5d86-4fd7-8eb0-73f015424d3c)(content(Whitespace\"\\n\"))))(Tile((id \
          246dbbc7-828e-4733-bdc2-f73a7f8c3cb7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -624,84 +664,91 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d72878c4-2fea-4e9a-add6-2af881f98a1c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         74042341-9750-47b2-87f8-591a42bdffb9)(content(Whitespace\" \
+         8151d9bf-1575-49a2-b928-456dac549aff)(content(Whitespace\" \
          \"))))(Tile((id \
          db7295ac-8d19-4ce6-8d0a-78c89866e12f)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         277355f6-a052-471f-b8ad-73dc44b67b37)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ee31188f-2ab2-452f-8512-8e7c3899e09b)(content(Whitespace\" \
+         d2275db3-5082-4b40-8eac-7d4ea50b53d1)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         9edcd160-424b-48c6-85b9-e67779deb3fe)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         530a8e67-46b0-4f48-bd67-3072d3e30ccc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bcfc1f4c-e298-41bc-821b-594802cc640c)(content(Whitespace\"\\n\"))))(Tile((id \
+         2ff7cd78-cc11-4a4f-a193-6ec4a1a36ea3)(content(Whitespace\"\\n\"))))(Secondary((id \
+         af54122b-07df-4370-99f1-35e8d02fb478)(content(Whitespace\"\\n\"))))(Tile((id \
          c884cbad-f44d-4cbe-8f67-9d746c6656e8)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e2c2bacc-c678-4f33-9b8b-6564f192a75d)(content(Whitespace\" \
+         42a0b629-8039-40ac-bbe4-bc5582221658)(content(Whitespace\" \
          \"))))(Tile((id \
          48e18452-92b2-4a73-968b-382abbb1e723)(label(Department))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         e2d2bf62-fb20-4378-adbd-e6e9ecdf833c)(content(Whitespace\" \
+         b131f7a4-750e-4d90-8a56-a5b7f989d3fa)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4cfca89f-677d-4b3a-97e9-72f49ace8f25)(content(Whitespace\" \
+         b8f5786b-2da7-499d-9fd7-1601a1e90e93)(content(Whitespace\" \
          \"))))(Tile((id \
          dea3606e-4494-4e0a-8b37-12255f37705f)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          e9eeef06-1898-4ead-85c3-12e6665c3066)(label(department_id))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ecbd7c9b-9c0b-4f46-91a4-103ba3f0e529)(content(Whitespace\" \
+         \"))))(Tile((id \
          3a9b5263-d353-4f15-ac9e-8f0102b01c10)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2227f3de-7ad4-447c-be15-93107632273e)(content(Whitespace\" \
+         \"))))(Tile((id \
          8d5698f7-f7cf-4121-9408-1ab04674b82b)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d7f6b17b-acdb-4c87-a262-63ea01573f22)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         57c73c1d-a78b-4c75-b5fc-be86c18dc935)(content(Whitespace\" \
+         b18597a6-d790-4d36-8ac1-9674b021489c)(content(Whitespace\" \
          \"))))(Tile((id \
          2fd64603-cb14-44ae-abc4-f6a48488dd8e)(label(department_name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         50cbaf75-0d15-4373-a991-bffa20f39175)(content(Whitespace\" \
+         \"))))(Tile((id \
          2a4ba984-e748-477d-8ff6-6ef2d14d6821)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dc0a182a-a670-4625-9e2a-86923f7b1297)(content(Whitespace\" \
+         \"))))(Tile((id \
          04374779-7376-438a-b19b-954ec58053cd)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         bfe7594b-5039-4f98-bd14-601bf376f93a)(content(Whitespace\" \
+         dfa61620-e780-4279-9050-dbe7461b804d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5345a472-56d0-4498-976a-16db4ba61ad0)(content(Whitespace\"\\n\"))))(Tile((id \
+         7673fc23-2402-49fa-84fc-bbc1721d3e70)(content(Whitespace\"\\n\"))))(Tile((id \
          83e4c4ec-5ca1-42d5-9783-7a32573ca1c3)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         7c0ca418-5cc1-45b0-8eb4-7ac86dbbf553)(content(Whitespace\" \
+         be924619-057b-472e-8c21-b02c52168655)(content(Whitespace\" \
          \"))))(Tile((id \
          9c726609-3574-4f7b-a43d-44b23c9737de)(label(departments))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e8dc438e-4820-4e10-8fe8-b2515e829721)(content(Whitespace\" \
+         17202e0a-2ab7-4e7f-bf16-812edb725c9d)(content(Whitespace\" \
          \"))))(Tile((id \
          60e0428c-4bda-47c0-a2fb-588f9e27925e)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         58bbfbc2-7558-47b7-9b24-dda549793d5b)(content(Whitespace\" \
+         2b0d2ec6-d0f3-4c0e-89d6-e5035c42a6f9)(content(Whitespace\" \
          \"))))(Tile((id efe077fa-1989-4f87-bd55-0f6758f7a132)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          73b0c2c4-bdfb-4417-9daa-e3d7e4ff7d0f)(label(Department))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8068237b-1452-40b7-a6bd-27b3298a11e0)(content(Whitespace\" \
+         dbcc040d-03f4-41ca-9c14-e2d6f85cb06d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         79521ec6-0aca-4228-8036-2e6e0fdb0ca1)(content(Whitespace\" \
+         8b7bd2f6-db0f-435a-9590-9931c4d00473)(content(Whitespace\" \
          \"))))(Tile((id 271c320f-c95c-4b01-8b74-635d06013112)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a53d0a34-f3ab-448e-83d0-4d81680fc06c)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          9c7ebff6-07cd-40dc-a4f9-131c1a3bd235)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -719,7 +766,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7add9d04-b40f-45ef-a002-fe5c8b87f450)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4bb1dc83-f1f2-484e-9880-a014aa21d403)(content(Whitespace\"\\n\"))))(Tile((id \
+         3333ec48-17c6-4fde-a180-04e3e661bc52)(content(Whitespace\" \
+         \"))))(Tile((id \
          3e10ca38-49d9-4e75-9786-b8306b597b1e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -737,7 +785,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aba45263-04fd-4f63-bc12-fa648df0ea8f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2dcbbefd-bc91-4942-bc7b-c52a2e696f30)(content(Whitespace\"\\n\"))))(Tile((id \
+         c5bdc6af-1044-42c3-953c-5726af988205)(content(Whitespace\" \
+         \"))))(Tile((id \
          88a4f220-3a23-451a-a8f4-0c0d38236d6a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -755,7 +804,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cdb3367e-9b34-4d76-ace9-219338bfc213)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6379d1c1-addd-4675-9f6b-e9a3366e9b97)(content(Whitespace\"\\n\"))))(Tile((id \
+         55793d3d-9087-4d43-8f42-1481942e6d79)(content(Whitespace\" \
+         \"))))(Tile((id \
          d6377fc2-3e25-4747-a127-363a8304d240)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -765,196 +815,228 @@ let out : string * Haz3lcore.PersistentSegment.t =
          79dfb239-ee3d-449b-807f-4a63799cf2d2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ffe76b4d-87ac-43ef-aaa7-1964829767c8)(content(Whitespace\" \
+         84811acc-dc18-4b84-8bcc-b699f6b019d6)(content(Whitespace\" \
          \"))))(Tile((id \
          92dba703-09f2-4fd2-be3d-6ef096609f38)(label(\"\\\"Marketing\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         88ef3918-8b0a-4628-bf9e-eab398f5296e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         868fc860-12a0-4d36-a629-c82ddbda005f)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         de266d6a-8a17-498b-9979-6fddfcc367df)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d1a8231e-a5a7-44d0-baaf-3664261e88f5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1309dfa7-6da5-46e0-9585-4b3123b9d7c0)(content(Whitespace\"\\n\"))))(Tile((id \
+         31f7e4f4-5cea-4683-a194-f1f8d6710953)(content(Whitespace\"\\n\"))))(Secondary((id \
+         03b32690-b824-42ca-ac30-fcdbbb8d46e7)(content(Whitespace\"\\n\"))))(Tile((id \
          cf1cb0d9-17a9-4b3f-824f-d45654a25e03)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         9c663d77-15e4-4493-b210-ac4e92d544f6)(content(Whitespace\" \
+         95b764f9-e237-4ad4-bb50-4ca7c140be3a)(content(Whitespace\" \
          \"))))(Tile((id \
          54b6a376-979a-45c2-b798-db46119d0c96)(label(JellyAnon))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         8d773fc2-ede3-4349-837c-8498ac1a23b4)(content(Whitespace\" \
+         deabc19f-cab4-42d8-bbf7-8be7b323a57f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c6842c3d-f606-4d9a-b5a0-18f4578d01ea)(content(Whitespace\" \
+         52de64c0-78af-45a7-8f1a-6299106bede3)(content(Whitespace\" \
          \"))))(Tile((id \
          e9ffe176-cf03-4b25-8769-534386b12523)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         08f5c653-76db-431f-89b7-c657429fbc6c)(content(Whitespace\"\\n\"))))(Tile((id \
          d0762fa1-ce54-46b4-98a0-664571cf004a)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         747f4179-adc8-49b0-9dce-0faabb85d22d)(content(Whitespace\" \
+         \"))))(Tile((id \
          2d144e48-4612-4223-9980-8080e43dc034)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e02d5475-504b-4769-b3f7-c8af0b4a66bd)(content(Whitespace\" \
+         \"))))(Tile((id \
          996f39f9-3c21-4502-aa31-9a6baddf72b9)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bce68860-2963-4094-8300-67e52419ae0d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d3e0b6a3-23b2-4c26-b096-87287b28f2a8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         27f2eac6-5e71-4063-9f26-d860cdc443c9)(content(Whitespace\"\\n\"))))(Tile((id \
          a9f53454-4d17-4c5e-8c71-973bd1133c31)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cc20f5c6-4110-4d27-b3e4-023efe3c1d5f)(content(Whitespace\" \
+         \"))))(Tile((id \
          57e719cc-5fd1-499c-a31f-a953434d4e94)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         60feea0d-1109-4e24-9ae8-73066381f66b)(content(Whitespace\" \
+         \"))))(Tile((id \
          d39ca109-a2de-46a0-bd69-f67268d2a99b)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          1b2c74b4-7c57-44e0-81d5-d0f81d1a4e50)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         591c3d3e-0d7a-4ad9-ba55-9642e2e6edbb)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0dcf4642-85e6-4d29-be5b-17ba749cc463)(content(Whitespace\"\\n\"))))(Tile((id \
          4684b42b-ab34-499f-907c-51309348fc35)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         df68a22d-84c7-44e1-a08c-43b6dfcb41b5)(content(Whitespace\" \
+         \"))))(Tile((id \
          6b3c0329-6832-4b2f-9eb5-be461e4ff92a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         21842dc8-11fc-4e04-9448-2fdf8dc60b97)(content(Whitespace\" \
+         \"))))(Tile((id \
          d364dddc-f82b-4753-923e-a042b9361c71)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          8f1987cf-579d-4f5a-9e3e-fce84915ae67)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a4614347-3918-49ad-b856-ee70615905f0)(content(Whitespace\" \
-         \"))))(Tile((id \
+         fd22b8d2-5775-43eb-aa07-70e6e7574ec5)(content(Whitespace\"\\n\"))))(Tile((id \
          c37863b8-3d47-4009-be16-9fcb6bf0f20a)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e4382382-153a-4c3e-8cce-a64f55ba56b7)(content(Whitespace\" \
+         \"))))(Tile((id \
          d36b2c9f-0ac2-4364-86d9-63d7adb77df5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e5a87a6e-8839-4fd9-839f-5f672e208741)(content(Whitespace\" \
+         \"))))(Tile((id \
          98f1ec91-b61a-470b-b84b-c8e7f28f7a90)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5179144f-0782-4ad1-b895-b5b41e702ebf)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8e7dba0b-8de5-407b-a903-11739c12e7ac)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8210e4f1-6dbe-48b2-89c2-14fd1a0fe0c9)(content(Whitespace\"\\n\"))))(Tile((id \
          a9f2d6c5-0591-4b65-93aa-2c9a15b43f4b)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e6c33fc9-036b-4f83-a7d5-3afb91cb58c7)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce9026f2-b208-42ab-bb86-07604e70c460)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         339e8257-ff4a-4af0-8636-193559c8e440)(content(Whitespace\" \
+         \"))))(Tile((id \
          a56685a9-7dae-42c3-8a58-bdcbe632c188)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          073b8387-06cc-4006-81c4-50b1b4003e1f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6c2344f8-365d-475b-8f42-c1f155f7183d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         a0664c8f-cc22-4194-a9d3-133239cdbef4)(content(Whitespace\"\\n\"))))(Tile((id \
          9131b90f-447b-4f3d-87ba-52b255390ab5)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         873f5496-fdf7-45a0-9975-54bf299820e4)(content(Whitespace\" \
+         \"))))(Tile((id \
          7b6fc876-4aae-47ed-84fe-805880be8f40)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         387870bf-8432-4e60-a8ee-ca0e52299f1a)(content(Whitespace\" \
+         \"))))(Tile((id \
          60cd7f07-5dec-4d8e-85ad-40ce7fd11c9d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ea5de8d6-51c6-4093-aa13-394ca3fd25ff)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d55fcce0-d54f-4454-a708-0fba40a7e713)(content(Whitespace\" \
-         \"))))(Tile((id \
+         200189f3-7401-43fd-83c9-59e1205a9e05)(content(Whitespace\"\\n\"))))(Tile((id \
          694fc51f-9923-49a2-ad93-5a9996b6fbe9)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         fdee7832-44b3-4080-8ea1-6eab71d5278b)(content(Whitespace\" \
+         \"))))(Tile((id \
          a0ef8382-0eed-4f95-92cb-d9fe70133e4f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         10d1c9e5-f3a6-4030-b77f-7ac142f66b00)(content(Whitespace\" \
+         \"))))(Tile((id \
          62c0dfd9-5d90-466b-8db7-eeae20df0044)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5bb076b1-42d8-48cd-bca1-141398338a32)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2d8bc7cc-5e14-40f7-a8a8-d97ec5ae34ab)(content(Whitespace\" \
-         \"))))(Tile((id \
+         272367a6-d8a0-4a20-b52c-88d9901062eb)(content(Whitespace\"\\n\"))))(Tile((id \
          1809b122-32cd-4bdf-8080-1c88a4ba9e05)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f77f7211-37f3-4c6c-97ab-484648f027d9)(content(Whitespace\" \
+         \"))))(Tile((id \
          22e1b8fc-dadf-41a1-8f30-f4a61a580a32)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fd80448d-75f4-4d85-80ec-659515ca033f)(content(Whitespace\" \
+         \"))))(Tile((id \
          2b940c4c-3ca7-4fc2-840d-3752619c6b82)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e44c86e9-0280-4454-ad19-c51ec3f24e45)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         823b0c24-9f87-479c-9275-47713c17fa1f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e6d62940-5f0c-475a-943f-d0487016c9d7)(content(Whitespace\"\\n\"))))(Tile((id \
          d4c135d0-d6e4-456c-ab38-e91f028b885b)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         999f1be5-a74f-4166-8e35-d033b99883cf)(content(Whitespace\" \
+         \"))))(Tile((id \
          074b5811-104a-4f40-8575-f343de4d72f6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1bef92df-8f61-4bba-8742-c1514b535cb4)(content(Whitespace\" \
+         \"))))(Tile((id \
          e6aa3a1f-f90f-4171-965d-03d390c24c21)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f1cb4ab4-e1a8-4dc8-8f5f-ca596d65299f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6516aca8-695b-4de6-bdb2-565c84a7b5c9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         96b5d383-428d-48a6-b29d-1ad1435cc59d)(content(Whitespace\"\\n\"))))(Tile((id \
          32cab0b1-5d24-4288-baf0-6e4ff6a42501)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3e0e7086-993b-402f-a299-cb71c5c30e6c)(content(Whitespace\" \
+         \"))))(Tile((id \
          48bc13d6-1673-41c9-8f4a-de76d945348e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         238448fc-9594-4869-a769-ff03e39ee699)(content(Whitespace\" \
+         \"))))(Tile((id \
          138020b1-f7bc-4b0e-bced-29e9d79cb620)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7a884000-b9d9-4255-8872-b4912970223f)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9f4a13ef-2ea6-4bcf-aa4d-419d6addaec8)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         4117cec5-504a-4525-915e-085f5a14c14d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         956305ee-4e02-4eb4-9416-d9b64964db66)(content(Whitespace\"\\n\"))))(Tile((id \
+         a2c3dd9a-a241-4066-9c87-9ac9dd1b0436)(content(Whitespace\"\\n\"))))(Tile((id \
          0d885cb8-fe57-434a-ba35-7ca4fbee3b1c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         95b90e77-1819-4ade-a235-da015964d5e1)(content(Whitespace\" \
+         9c15f8ac-133e-40e3-84d2-95170c09b3b8)(content(Whitespace\" \
          \"))))(Tile((id \
          2b8d3be6-1878-4ff4-8955-b23e67974465)(label(jellyAnon))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6b5f8bb4-8dcb-4e22-b76f-40e07197aea6)(content(Whitespace\" \
+         b209e028-22ee-4f3d-9e93-b502ed7ad8f0)(content(Whitespace\" \
          \"))))(Tile((id \
          adfd8592-3bc9-4db5-a3df-da6c0efd4b06)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f5404650-8fbb-4a7a-a34a-b606ba992a82)(content(Whitespace\" \
+         9bb96d53-8dfc-47d5-bede-d60603b44425)(content(Whitespace\" \
          \"))))(Tile((id ae99cffc-9e05-490b-9b4d-843f4747830a)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          e629b720-9423-4e85-b4d0-969c1f1125db)(label(JellyAnon))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         83fdb372-4b23-4564-934c-321bfd401a54)(content(Whitespace\" \
+         816b7de7-2463-4dcc-9471-e21294fb9f1e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4d163c51-0ad9-4628-9fa9-f40ef0991a46)(content(Whitespace\" \
+         b755e3bd-c9dd-4807-9242-f14c0f3a1d12)(content(Whitespace\" \
          \"))))(Tile((id d7b0d871-6750-42bd-ae3a-65514088c68c)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         d3318cef-a443-482c-a8fe-e15aa8b3f09c)(content(Whitespace\"\\n\"))))(Tile((id \
+         cad6c49e-bd80-4264-8948-5c2718be528c)(content(Whitespace\"\\n\"))))(Tile((id \
          d0e0d0cb-e44f-40af-97ab-785169e934f5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Projector((id \
@@ -1076,7 +1158,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6943af69-0760-4dcf-99fb-10729fe6a457)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         74674a89-9bdc-46e8-85ce-d36ff9ad878a)(content(Whitespace\"\\n\"))))(Tile((id \
+         fa3a01cf-cba7-427d-b696-78389ea8c0ab)(content(Whitespace\"\\n\"))))(Tile((id \
          01109f2d-bbc6-48f6-b0b2-0b4b126c876f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Projector((id \
@@ -1198,7 +1280,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3150604e-bd37-435b-b45f-86fc6baf4250)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b0223246-cd73-4d54-a114-4dd0fc90f325)(content(Whitespace\"\\n\"))))(Tile((id \
+         9a4fee1d-a72a-44ed-81ac-89220cfeebe7)(content(Whitespace\"\\n\"))))(Tile((id \
          8c6c66d4-fce5-47fa-81f0-d37ba978631a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Projector((id \
@@ -1320,7 +1402,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9bafe98f-dee3-4436-8c6b-614295107154)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         906f3399-3767-433c-bbaa-2898c8392e97)(content(Whitespace\"\\n\"))))(Tile((id \
+         d09e0e80-664f-407f-940d-d0d78a6e559e)(content(Whitespace\"\\n\"))))(Tile((id \
          6a7dc497-434d-4b32-9e50-3fabc5e398e1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Projector((id \
@@ -1442,7 +1524,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0b8047f3-0e50-49ab-81bd-95103c80193a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         52424297-5bd0-4648-98a4-bdf6f1b2b829)(content(Whitespace\"\\n\"))))(Tile((id \
+         e22a378b-efd9-4831-8f01-fb4c8ff3fb85)(content(Whitespace\"\\n\"))))(Tile((id \
          8aa2155a-acd1-453d-912d-fa0545044d58)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Projector((id \
@@ -1564,7 +1646,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3fc9406d-5b3a-41d5-9772-ed5bd5e099dc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e5bb894e-0a4c-49cd-905b-0fd0b3157625)(content(Whitespace\"\\n\"))))(Tile((id \
+         01c6d1bd-6297-4455-9579-7eef407307ca)(content(Whitespace\"\\n\"))))(Tile((id \
          ec0bec7e-2ed0-410d-b449-c3b16e757493)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Projector((id \
@@ -1686,7 +1768,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dd77f09c-a7ab-4330-97d0-73c0e8e55dbd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b558fd80-9e83-4846-ac1c-00a54c6cb4bb)(content(Whitespace\"\\n\"))))(Tile((id \
+         0669b326-a72b-4f1a-8fb1-aed0c8aeb6c4)(content(Whitespace\"\\n\"))))(Tile((id \
          3481f15c-41a1-4973-b60d-eb67a8a60d98)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Projector((id \
@@ -1808,7 +1890,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          28b5fd05-1950-400c-a1aa-44d529b4ffda)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3d1d9ba7-34bd-40e2-be5d-ad3416774fb1)(content(Whitespace\"\\n\"))))(Tile((id \
+         fa53d022-d082-4782-bd2f-3a5a7680dfb3)(content(Whitespace\"\\n\"))))(Tile((id \
          278ac9b5-7e2a-4d9b-bb26-cc7aabe9298c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Projector((id \
@@ -1930,7 +2012,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          eedd2b68-5ed2-4ddf-bb88-a87a6d67d367)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         84abb827-c92f-4769-9a07-00f9ada0bdc0)(content(Whitespace\"\\n\"))))(Tile((id \
+         99d46eac-f536-4054-9617-36bcae49e7e6)(content(Whitespace\"\\n\"))))(Tile((id \
          b65bf971-755c-4ce6-a1a9-2b958342d036)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Projector((id \
@@ -2052,7 +2134,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          899c5d49-81b0-4f7e-8be2-1cd7f12d94a1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c89cecbf-a067-4431-b038-a9be06944ef1)(content(Whitespace\"\\n\"))))(Tile((id \
+         a66e8ec9-6c67-4a67-b94f-2699473d9a71)(content(Whitespace\"\\n\"))))(Tile((id \
          eee14278-6510-426a-be83-a5101f53e25d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Projector((id \
@@ -2066,7 +2148,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          09bcab2a-45f5-4daf-8a47-6b914df058d4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5645a4cd-d9ea-447c-b363-5cb7a7a6765e)(content(Whitespace\" \
+         0da5182c-e23f-4b06-a211-1cae2662402b)(content(Whitespace\" \
          \"))))(Projector((id cdf38fab-3c23-463f-92ff-016524329491)(kind \
          Checkbox)(syntax(Tile((id \
          59d7c101-c5e0-456b-b1af-4d9e380c8a3e)(label(\"(\"\")\"))(mold((out \
@@ -2078,7 +2160,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          461fda16-4e4c-4dde-9ddb-a77973a67f26)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         44c005e4-6a95-4ffe-a0ef-5aac7b675a54)(content(Whitespace\" \
+         06eb2f9a-4866-41f7-8993-2e929448f641)(content(Whitespace\" \
          \"))))(Projector((id 9212bea7-2dd2-4d83-9764-93d267a6418b)(kind \
          Checkbox)(syntax(Tile((id \
          ec4553c8-f5a3-48d8-8567-7f9d48dc44f6)(label(\"(\"\")\"))(mold((out \
@@ -2090,7 +2172,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c751154b-2651-4979-bd5d-797d7f8b8558)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aeb1492a-3861-435e-8042-77f928b38705)(content(Whitespace\" \
+         d8bdd5b5-d3ac-422a-8cb6-94578da54475)(content(Whitespace\" \
          \"))))(Projector((id fab0538b-b1e3-4da6-91ae-c71fd05b3761)(kind \
          Checkbox)(syntax(Tile((id \
          ad6ef900-bbb2-4135-9e6b-c317f756254e)(label(\"(\"\")\"))(mold((out \
@@ -2102,7 +2184,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fd9f9bfb-23f5-45f7-a6da-ae16c1d77788)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8ac6e7cc-54e6-49bf-b330-ee3118a270f9)(content(Whitespace\" \
+         f2100f23-8a42-4c62-bfce-555875958d40)(content(Whitespace\" \
          \"))))(Projector((id d63da67c-ca07-4c95-a8a1-53fdc830cde7)(kind \
          Checkbox)(syntax(Tile((id \
          8f61f5f7-ee4a-453b-be86-a292d288678a)(label(\"(\"\")\"))(mold((out \
@@ -2114,7 +2196,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          689afcf8-e77d-4eaf-8db5-9ee00f19fe1c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1ed093f3-eeae-473a-a9ab-88f2cbcda128)(content(Whitespace\" \
+         3938dc48-3eab-4e0c-9ba6-21978cdaf8b0)(content(Whitespace\" \
          \"))))(Projector((id e95c54ad-78b1-4aa5-9ad2-61c060fc9c57)(kind \
          Checkbox)(syntax(Tile((id \
          39d7e270-bf15-4729-885f-51159f09b06e)(label(\"(\"\")\"))(mold((out \
@@ -2126,7 +2208,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8575980e-ec68-4fe2-adbb-41f70bc75605)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2b7350af-3071-4993-9199-dc9a7441bcf5)(content(Whitespace\" \
+         953c51ef-24c9-42c0-8cea-ff61d18687cf)(content(Whitespace\" \
          \"))))(Projector((id 3257c3c7-7fb6-49f7-8527-674b4cccbd13)(kind \
          Checkbox)(syntax(Tile((id \
          8759e5a7-8ca7-4305-8667-1b25d3d77ce7)(label(\"(\"\")\"))(mold((out \
@@ -2138,7 +2220,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          78a53404-b901-46ac-80a4-58070e05fb6a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c6f80584-6f0f-4a3b-8ea4-fa1327306f88)(content(Whitespace\" \
+         15b5b897-9a9b-4361-8561-bd8d6cf53b16)(content(Whitespace\" \
          \"))))(Projector((id 0d4f5482-986c-4a15-82cf-6a88ed87efc0)(kind \
          Checkbox)(syntax(Tile((id \
          83df15d0-3dbc-4321-8bdc-d2b5d6a2520d)(label(\"(\"\")\"))(mold((out \
@@ -2150,7 +2232,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          29419df6-0647-445a-9756-8744c88a0974)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6038099b-3fef-4465-bfac-03a4de705810)(content(Whitespace\" \
+         a4cff747-305f-4cc4-8d9b-d65105b69aa2)(content(Whitespace\" \
          \"))))(Projector((id 6095e4fa-0c36-40c0-a517-d4bbabe41632)(kind \
          Checkbox)(syntax(Tile((id \
          5b83882c-4967-4ee4-a5ba-33f738cca836)(label(\"(\"\")\"))(mold((out \
@@ -2162,7 +2244,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8bc25158-4864-4716-ab6b-ea34806ac968)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1c330915-96c5-4025-aa04-e1ef75171314)(content(Whitespace\" \
+         ccf6935c-d115-43c0-bab1-f5efe4e690b4)(content(Whitespace\" \
          \"))))(Projector((id ea9def76-9595-459a-a93e-6798a2900bb2)(kind \
          Checkbox)(syntax(Tile((id \
          9a84bca0-df2a-41fe-95e6-f0b6d9e4bd5d)(label(\"(\"\")\"))(mold((out \
@@ -2171,205 +2253,241 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b230b0d7-4021-472e-af0c-b8c1349030ef)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\"))))))))(Secondary((id \
-         90ef78cf-bbc9-459e-830c-a949cb9aecb7)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         0b763049-a65c-4491-979f-5b8e3fde6ccb)(content(Whitespace\" \
+         5b649d45-3f40-4ffa-9555-958a7be8b648)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         0b5aa736-68a8-40f0-bf1b-af5426a0ad66)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2b54e466-7e9b-45fd-bc0e-3d5ec6f31f9f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3629baf7-2bc9-4ae5-87d1-9c83689e656b)(content(Whitespace\"\\n\"))))(Tile((id \
+         48990ec6-85af-45c0-b718-e2372045eeda)(content(Whitespace\"\\n\"))))(Secondary((id \
+         0ef8a2db-3afa-4312-8339-2abbde454e10)(content(Whitespace\"\\n\"))))(Tile((id \
          45dbdcb2-30ba-4151-9e97-79f0ab6787c3)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         d89bd95b-0f53-42a6-bff8-5f3fc97b9696)(content(Whitespace\" \
+         167b372f-1cd9-441e-ac13-56e32bbc56f3)(content(Whitespace\" \
          \"))))(Tile((id \
          015961b7-9126-4e90-9c1a-d2d26320d1e2)(label(JellyNamed))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         62311eab-daa5-46b7-ad1c-5ecc4367c725)(content(Whitespace\" \
+         5173d850-68f2-4a25-bc43-eaf929e91a43)(content(Whitespace\" \
          \")))))((Secondary((id \
-         638e69b1-7e17-434d-af38-75b2e444f31e)(content(Whitespace\" \
+         3ac0c887-58bd-4714-a87f-f0905ae7bc28)(content(Whitespace\" \
          \"))))(Tile((id \
          4c0a3d66-4e61-4fdf-8e46-b9d7e1538031)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         3a3cf6b0-35f5-448c-b470-43415b8f65c4)(content(Whitespace\"\\n\"))))(Tile((id \
          efcb33ad-64d8-4203-a7c6-b82dd76a0327)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         49e6b92a-2b00-4e9d-9beb-0fa5c54f105a)(content(Whitespace\" \
+         \"))))(Tile((id \
          5c7d9155-c7f3-42cb-a58f-5fe1d341eb2c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a5a580f4-035c-42bd-952f-9382183dd749)(content(Whitespace\" \
+         \"))))(Tile((id \
          a77756c4-30a2-4d07-bf67-01df90c057e7)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          dbe70d9b-4187-4cac-8633-3356e1e73c56)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         42da2949-f22a-449f-a780-f2ff6c17233d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0a6efbeb-20c4-4a51-a636-a8df07196ed5)(content(Whitespace\"\\n\"))))(Tile((id \
          b47d375a-325b-43c7-a7f7-469a05711e4e)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2153e36e-88b2-4abf-81fd-a2946738bb4e)(content(Whitespace\" \
+         \"))))(Tile((id \
          a104467f-50cb-4327-864c-fa03f6791832)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a2f6036c-cab0-4f5c-a4d8-88521e6f75e8)(content(Whitespace\" \
+         \"))))(Tile((id \
          b2fdcf80-0f33-441a-9cd8-8d598f56a1bf)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b981f332-fb34-428b-974d-de894a2dce44)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8e157cc2-4635-400e-baf4-54d94d4cb8cf)(content(Whitespace\" \
-         \"))))(Tile((id \
+         308ace5f-38d2-4c7b-b260-b3acd382f631)(content(Whitespace\"\\n\"))))(Tile((id \
          d81f80d5-6626-4cf8-bf5e-f4a2f8c4237c)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d65c9034-674d-47c8-929d-6a0604633688)(content(Whitespace\" \
+         \"))))(Tile((id \
          67e43487-e3b1-49fb-b53d-afe1674523f7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1ff6c402-4c26-44fc-860b-9d861ad9b893)(content(Whitespace\" \
+         \"))))(Tile((id \
          b848351f-72e5-444d-89ed-ed38eaf6c600)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e9cdd6c0-6c69-4192-8cef-a82503144b5b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4a8bb082-091f-4adb-b00c-871e03c61c2f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8f29acca-d5d2-4420-bb43-801163e26601)(content(Whitespace\"\\n\"))))(Tile((id \
          cf651bc5-1554-4de4-b149-a2348af3ec18)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         123cc9f0-5c7d-48f2-9758-00e556a47a9d)(content(Whitespace\" \
+         \"))))(Tile((id \
          54881102-3200-4bbe-a95a-e0c1c2bb6847)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         25e4625a-006c-454d-a57d-3c3b290408f9)(content(Whitespace\" \
+         \"))))(Tile((id \
          4697f568-46c7-4d87-ae98-e3a2f986dd90)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          25e08c50-3365-4422-ae99-f78fa9a2543b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7ac3a742-abb7-4ac3-911e-eacc9f1c17fc)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9fa513ce-e20b-4568-a504-61e94f846acb)(content(Whitespace\"\\n\"))))(Tile((id \
          0974039f-0243-4214-be97-af3f0a797354)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c51902c8-f581-4554-8b42-1cb7c729eabc)(content(Whitespace\" \
+         \"))))(Tile((id \
          44ab95b1-e767-4b5d-a499-2bc4bf9a2e2c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e3bdb7ef-7256-4c6f-a5a5-c49b90b3777e)(content(Whitespace\" \
+         \"))))(Tile((id \
          f3cf30e8-a364-4d8d-8d2a-b8f251bf8a09)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          cdb29db8-23cc-4f47-ab8c-d7790ebc46c8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bc1fdba7-2875-460e-a9aa-0b5c453b3b76)(content(Whitespace\" \
-         \"))))(Tile((id \
+         6f10c3c6-ab4a-46bd-a3d9-f26ad5f1212b)(content(Whitespace\"\\n\"))))(Tile((id \
          ec9f67d7-d513-46a4-9bb5-bf09601fdeec)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         94419876-3458-4d07-8c49-33f95e2f57c5)(content(Whitespace\" \
+         \"))))(Tile((id \
          81043b7b-433a-477e-9367-d3697ecbacc1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b2bd4a55-5301-4cb0-a7c0-06e4b74b3b3c)(content(Whitespace\" \
+         \"))))(Tile((id \
          3b6a8d8e-64bc-40ae-bbc3-3f0a1dbb468d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          2623bf89-84e4-47d2-8fe6-592fb9e879c5)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5dbd5cf3-b07e-4870-b76b-6b92c25488c4)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5845633c-0c24-44ea-adb8-856f8efbfd64)(content(Whitespace\"\\n\"))))(Tile((id \
          6eb57298-4226-4f53-9a0b-56ebc4134800)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e3ab2de6-b2ca-4cc6-9db5-3df1c43dbf57)(content(Whitespace\" \
+         \"))))(Tile((id \
          28da27f1-bcbc-408d-94f7-758d6f46aee2)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4895640a-7c95-403b-b173-83c8ae2ad8d4)(content(Whitespace\" \
+         \"))))(Tile((id \
          410317ab-cfc3-45b3-908a-45838d0878b6)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b33b77f9-5bf3-4683-8974-470e6b299ef0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7b84207e-8632-4b98-b16c-1d60b624c13d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         afc50c4c-c39b-44de-9d5d-0dab76726af6)(content(Whitespace\"\\n\"))))(Tile((id \
          dea8add9-ee45-4f30-832f-3131aed45ae9)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         29d5becd-27dd-45dd-bf95-b36804a2a860)(content(Whitespace\" \
+         \"))))(Tile((id \
          a3634c1c-25d0-403e-9164-af52c233104e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         43fbd5ee-a583-4796-a4db-a892aea727f7)(content(Whitespace\" \
+         \"))))(Tile((id \
          804abfc0-d651-43c4-ad94-353176ae0c83)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          55a2f588-0b35-47d9-8782-e6e3d0a8a1a1)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         29a1b6f5-82cf-4575-8bf3-5a7002cabf82)(content(Whitespace\" \
-         \"))))(Tile((id \
+         45943a65-7078-4e33-bfe7-8b5937d0dcd6)(content(Whitespace\"\\n\"))))(Tile((id \
          e8d46f97-e127-4bb2-9635-a3d361f02114)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4a9ba78c-c2ad-4a08-bb19-b3e2bd3a7986)(content(Whitespace\" \
+         \"))))(Tile((id \
          a6d335a8-bb28-4868-8394-dc994d6ac1b2)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a1e79b5e-f7a0-4b18-a453-4790c7dcbd7b)(content(Whitespace\" \
+         \"))))(Tile((id \
          644d6dae-43c2-4879-8475-0ccb1798bb32)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          504177a9-f7e3-41fc-b37e-6d4721caa077)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         47b7466e-4791-46df-84e8-908024be2f08)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ef9b19fe-f34b-4f17-97a4-ee07da197497)(content(Whitespace\"\\n\"))))(Tile((id \
          cafda246-2c60-423d-aa08-5f8436213bcf)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f2922679-6698-416c-baca-d0322dd1c8c5)(content(Whitespace\" \
+         \"))))(Tile((id \
          34e4dc28-14be-4080-9844-0f110e238e5c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e81c5b23-6052-4969-ab7b-fc6b03ba2e87)(content(Whitespace\" \
+         \"))))(Tile((id \
          55b34d84-0dee-4bae-b981-606ee83a37c6)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          78dde6d4-aea2-4570-a696-a9eb21428b8b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ecb8080b-017c-4820-8c03-d45a24ad906f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         7aba907a-6396-41fc-ae77-d813f8f63635)(content(Whitespace\"\\n\"))))(Tile((id \
          9d64b889-a2d1-4926-9665-f39f0117cf65)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8c02f86d-1e77-4a79-bf66-05b9a6f00bdb)(content(Whitespace\" \
+         \"))))(Tile((id \
          64378075-b022-4973-abea-81321b5e25b8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         789b1819-4a0f-4fba-be59-142c908bf15a)(content(Whitespace\" \
+         \"))))(Tile((id \
          d2c640a7-504f-40b5-9915-d24edb8402ea)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d0f09130-a723-4e7d-8dbb-ecf53a657a05)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1eb6d97a-30f1-41df-92f6-3684cfe05a8f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         d896144d-7974-4b18-96b0-36842222aacb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8e4b874e-33f7-4bf2-9364-424dc19a0dbc)(content(Whitespace\"\\n\"))))(Tile((id \
+         2c1a7789-200c-433b-b38a-05169c9f58a1)(content(Whitespace\"\\n\"))))(Tile((id \
          096b2878-e66a-474f-808e-545ba65040a0)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         67490752-f8af-4b07-ab4e-9f17f5801ac7)(content(Whitespace\" \
+         74f59aca-4c2e-44aa-ae30-a864597e8591)(content(Whitespace\" \
          \"))))(Tile((id \
          f7bd57fa-bd2d-4330-a0d1-bd849cd3066c)(label(jellyNamed))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8c70cb47-0f4b-4288-90ca-7ebf79f87324)(content(Whitespace\" \
+         756538c9-6055-4696-aa76-2fe835db93f9)(content(Whitespace\" \
          \"))))(Tile((id \
          9a77a574-8d8e-40c8-b4e2-5db1dd2212af)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d963062c-339e-43ff-b561-f0a3b4b88fd5)(content(Whitespace\" \
+         dd7e9b42-4293-4285-9937-f801cfbac3ca)(content(Whitespace\" \
          \"))))(Tile((id cac78415-c922-4ef9-aff9-9f7726f5c299)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          bb345b74-0439-4b86-95bc-f4ad29d21158)(label(JellyNamed))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         59b1681f-7234-4123-a4e1-ba2eb537b327)(content(Whitespace\" \
+         1d716eab-9148-4774-9d4f-b810ac448897)(content(Whitespace\" \
          \")))))((Secondary((id \
-         eb207377-25d1-4691-8e49-dd5605c8e091)(content(Whitespace\" \
+         eb7ef9f0-0e37-477f-98e8-e210e4263064)(content(Whitespace\" \
          \"))))(Tile((id 99d57bed-b284-4111-84e3-e50fb046f81c)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         32ac474e-0768-4840-ab95-6dfc38a244c7)(content(Whitespace\"\\n\"))))(Tile((id \
+         1a79f854-0fd0-4ad9-ad8a-bbf4cc96311c)(content(Whitespace\"\\n\"))))(Tile((id \
          ca7263c3-e7a4-4c72-af2a-bd5e41eb92c5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2505,7 +2623,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e65904ae-27f5-4e5c-8d01-8277b99ee64e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3315a386-9023-4e5b-a731-908518f627a9)(content(Whitespace\"\\n\"))))(Tile((id \
+         b59bde71-3651-4483-897d-219cb1b51619)(content(Whitespace\"\\n\"))))(Tile((id \
          7736334f-58ce-4ddb-8675-8a8e9e61c611)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2641,7 +2759,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7979b775-0577-4a4e-8e8b-37a219140f9a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ee0e3a4a-ba3a-4d4d-9da6-83fba0ff628b)(content(Whitespace\"\\n\"))))(Tile((id \
+         556ced10-0994-4b5d-90d2-5bf61e0a300f)(content(Whitespace\"\\n\"))))(Tile((id \
          f042c417-b866-4909-9570-39add3ff4fa3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2779,7 +2897,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2e619a6c-c2d5-4209-afba-94044748c4f5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         206ed87c-d576-4964-b609-5b180e38953c)(content(Whitespace\"\\n\"))))(Tile((id \
+         e51278b4-dba6-4eeb-957c-f6cac5d2c2b8)(content(Whitespace\"\\n\"))))(Tile((id \
          9dce2067-5dcc-45ff-97cc-b373425bd3fe)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2915,7 +3033,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f3530c9f-58d5-4258-903f-b69d8ef883da)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         12b3ea67-d1f8-4051-945f-3f06caf25489)(content(Whitespace\"\\n\"))))(Tile((id \
+         10a492e8-5936-424b-b5ac-77446a176b53)(content(Whitespace\"\\n\"))))(Tile((id \
          4e784330-67d2-48ec-9e58-bba72e2e31db)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3047,7 +3165,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4d118414-ee88-407b-86a2-b8e55fe5f1db)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d1d95d9d-010a-4506-87ad-47b490741e8e)(content(Whitespace\"\\n\"))))(Tile((id \
+         c6ba59cb-10f0-4d90-8d14-8bc297237555)(content(Whitespace\"\\n\"))))(Tile((id \
          28394b1e-a7e9-4c10-a9f5-4bd656265106)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3183,7 +3301,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ba21b39d-b7e9-49f3-80b3-e4c86716cba0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aff577a4-5a98-4263-8833-032517ae3f93)(content(Whitespace\"\\n\"))))(Tile((id \
+         dcc770bb-382b-464e-a353-866505e385d2)(content(Whitespace\"\\n\"))))(Tile((id \
          c6c6a169-cc70-4878-91ca-8ebc7c37d005)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3317,7 +3435,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0d27ee6b-10bb-42eb-8a81-1ad495e733dc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         397ab3ee-c558-419e-8e6a-36236a983adf)(content(Whitespace\"\\n\"))))(Tile((id \
+         77e1583f-51b4-4973-ae30-c410165abaa3)(content(Whitespace\"\\n\"))))(Tile((id \
          a7114f0a-c5da-4e6c-af5d-d6f3e7204148)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3449,7 +3567,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e769888a-ad25-4581-b022-dc935f4f09b0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bf48876d-1201-447b-bb20-bffaba79af16)(content(Whitespace\"\\n\"))))(Tile((id \
+         740dc690-be36-463a-9918-11d8d332a9b0)(content(Whitespace\"\\n\"))))(Tile((id \
          81335a3e-dd07-4747-a1ec-bc617ca7150a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3583,7 +3701,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          50db2ea2-f08f-48a6-817b-6f5738d14fc6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         16bd3099-7b4d-4f09-b238-54825883031e)(content(Whitespace\"\\n\"))))(Tile((id \
+         9682a6e0-07e1-411e-8d39-9416f7b04a39)(content(Whitespace\"\\n\"))))(Tile((id \
          02211d50-de24-4f6c-b777-16841595740d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3593,7 +3711,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          40e3e52c-e755-4bd6-b649-b9f42071d340)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2774fa26-b929-489e-a9d5-e3e3ce86670f)(content(Whitespace\" \
+         342ad2b5-b5ef-48bc-9af8-1bfc5f796884)(content(Whitespace\" \
          \"))))(Projector((id b39f561d-5ef0-4db1-9a4f-f81c77807946)(kind \
          Checkbox)(syntax(Tile((id \
          b6c8ac32-9a91-4d74-9138-38e74d664fb4)(label(\"(\"\")\"))(mold((out \
@@ -3605,7 +3723,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e73cead3-65f0-4667-af65-f7b6450a80ea)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         034008ad-32ab-4a0a-8a23-89296c7f694e)(content(Whitespace\" \
+         32b43fc3-6bb7-4c71-86f4-36800bdcccf8)(content(Whitespace\" \
          \"))))(Projector((id 40111174-4b96-45d2-bffb-8e7c9aa485de)(kind \
          Checkbox)(syntax(Tile((id \
          78447527-6be0-412f-991e-48effcadb60a)(label(\"(\"\")\"))(mold((out \
@@ -3617,7 +3735,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          87db2e74-6ab1-4126-8f9c-8c05cd47ce68)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         22156819-1acf-425d-bd5f-b121b456219b)(content(Whitespace\" \
+         5ea2cce6-11e9-454d-a6fd-5b0180a584aa)(content(Whitespace\" \
          \"))))(Projector((id 48c912b4-4ac8-4aff-98b7-af9eb268cecd)(kind \
          Checkbox)(syntax(Tile((id \
          8c0886ae-4fe5-4b4a-9e0c-e131d7ca6e8f)(label(\"(\"\")\"))(mold((out \
@@ -3629,7 +3747,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0b3b2d61-6875-4f10-a327-745cd191d905)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9ad225ad-01c2-46be-9ac1-26e792417b53)(content(Whitespace\" \
+         53b98868-2525-4b06-ace0-084175bec27f)(content(Whitespace\" \
          \"))))(Projector((id 2068f188-49b0-4034-8edc-7e33191d479d)(kind \
          Checkbox)(syntax(Tile((id \
          8d215328-e294-4041-a713-77661089cb44)(label(\"(\"\")\"))(mold((out \
@@ -3641,7 +3759,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cb23abb4-0fda-473e-b23a-ad1f5126a2ae)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2704f4c8-04a5-45a1-ba56-633f3f3571b5)(content(Whitespace\" \
+         403850bc-ac2e-4dc0-8813-ec3ebf55ebb9)(content(Whitespace\" \
          \"))))(Projector((id 23e52cdd-5f4e-47a4-84b8-033ed159b5c5)(kind \
          Checkbox)(syntax(Tile((id \
          b351c720-0434-4f79-ba36-fd30b5b8082c)(label(\"(\"\")\"))(mold((out \
@@ -3653,7 +3771,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5e82b07a-830b-4d68-a5ec-bfe412eda177)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         92cd4466-22af-434b-b8c4-0d7faaf7d8d8)(content(Whitespace\" \
+         987b85ec-8b11-4b10-8b7d-395031134ad7)(content(Whitespace\" \
          \"))))(Projector((id 2d11d2c6-3262-4986-9de6-0c80afda790c)(kind \
          Checkbox)(syntax(Tile((id \
          0cba2ff8-42a2-4543-948a-9ea66fad7a46)(label(\"(\"\")\"))(mold((out \
@@ -3665,7 +3783,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          17b3fe74-f145-48db-bc58-bbbdeb7318f8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         518a5517-9218-4da2-9ff2-54f227835326)(content(Whitespace\" \
+         540cd3c1-bef2-416e-b6e4-5435fe5ec323)(content(Whitespace\" \
          \"))))(Projector((id 7c3d83df-20ae-42fe-bdc4-815211b269ad)(kind \
          Checkbox)(syntax(Tile((id \
          b4bb8e1a-1155-4808-b081-d250938ea0bd)(label(\"(\"\")\"))(mold((out \
@@ -3677,7 +3795,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e606c676-b3e7-4163-a884-432e568fe6f5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7c4dc03d-4101-48c1-b02e-3a624054392b)(content(Whitespace\" \
+         b7553e59-ebb1-4bf8-b313-588ba777f50f)(content(Whitespace\" \
          \"))))(Projector((id f9676ac1-ccf5-4aab-8001-8008c8cb6577)(kind \
          Checkbox)(syntax(Tile((id \
          d50b1e44-4175-4274-8f57-9855c739ade6)(label(\"(\"\")\"))(mold((out \
@@ -3689,7 +3807,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b93876b7-5608-473a-bc6b-0d2d77c65f04)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b6aec2b1-01c0-45ef-8d60-423c149251a1)(content(Whitespace\" \
+         6c25022e-9f42-49f2-8e10-37ca16c5cfc1)(content(Whitespace\" \
          \"))))(Projector((id 55df22f6-6e1e-4feb-92e6-cf150881bcdc)(kind \
          Checkbox)(syntax(Tile((id \
          d1aee544-dea1-400c-bd38-8d09e63b93b0)(label(\"(\"\")\"))(mold((out \
@@ -3701,7 +3819,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          059570a2-7575-4fb1-9ce3-dbbabad533e5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d6491719-67e4-43b8-87d8-2e6b5a9a7472)(content(Whitespace\" \
+         7c81a178-2f5e-4902-9285-323c00ee5bbe)(content(Whitespace\" \
          \"))))(Projector((id ba329ac8-0666-46a8-9142-6b602ddfe622)(kind \
          Checkbox)(syntax(Tile((id \
          74ad2779-767f-4d89-9887-71435c0048a1)(label(\"(\"\")\"))(mold((out \
@@ -3710,164 +3828,195 @@ let out : string * Haz3lcore.PersistentSegment.t =
          707d6914-ddc6-493e-b6f3-ff8edb548df7)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\"))))))))(Secondary((id \
-         60d9947e-95ec-4d08-bc08-b8f916f9d9f1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3287ebe1-cb6d-43c2-8f53-bca2b91fc1bd)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         d7f7c15b-6759-495d-9038-9269fbf66eae)(content(Whitespace\" \
+         c2173284-ef8f-4ffe-ad2c-a74cab13d4fe)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         40730697-6ebb-42be-ab98-0d7692d19447)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         95227945-aec5-4455-9155-dffd0b7f740a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         49aeaae8-e501-41ef-b4a9-51fbcadbe86f)(content(Whitespace\"\\n\"))))(Tile((id \
+         96d356d9-8da5-4da3-a24e-25f8f6a9c75f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         260e18dc-f608-43f1-b74f-df208132506b)(content(Whitespace\"\\n\"))))(Tile((id \
          a76e1e09-032f-4f0e-b94a-b247e36c3de0)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         5382a252-05e3-4a9b-9b79-aaf9231cabe6)(content(Whitespace\" \
+         f27e48df-f6ff-460e-b70b-b478e7e4ef75)(content(Whitespace\" \
          \"))))(Tile((id \
          dec504bd-5268-485d-a470-af31a4027c71)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         5ae6b2f3-ecd8-4a75-9341-d3d5a2117b35)(content(Whitespace\" \
+         ffe31c7d-8b0c-41e6-8de4-5af5ec046671)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f37e2843-0b8b-4f28-a703-8142f4f6152e)(content(Whitespace\" \
+         a94531ee-2694-478b-aacf-ebf26205b8cb)(content(Whitespace\" \
          \"))))(Tile((id \
          ace6edc8-d52f-4927-80b6-c43724c2e106)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          b73ba530-b6c8-4ada-ac93-ea375192b18a)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         db9df075-782d-4005-871c-1e365809f40e)(content(Whitespace\" \
+         \"))))(Tile((id \
          f8541f66-142c-494f-a6fc-e21fded6fb5e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7d734301-e186-4597-a6d0-8b35fc047aa5)(content(Whitespace\" \
+         \"))))(Tile((id \
          292e7309-48b5-4203-827c-d280945210e8)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          fe222094-d0b2-4713-af99-95e3faf18c3a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         402a101d-7bbc-433e-9801-3bf689d51205)(content(Whitespace\" \
+         e479ece2-3bf0-41a0-9843-b5d81366c090)(content(Whitespace\" \
          \"))))(Tile((id \
          bab84f5a-d13b-4f5e-8553-ef6b95675cc5)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ebdf4fc7-6387-4a00-9512-be883f96c1bd)(content(Whitespace\" \
+         \"))))(Tile((id \
          75461a78-e17d-4353-a127-64ebca770f51)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         09e19b67-f917-4898-a432-2a33baa93046)(content(Whitespace\" \
+         \"))))(Tile((id \
          42c43e79-b24d-49b1-b5f3-dde00b0893b0)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          080f6f31-9a51-413b-8938-ee69410a5b70)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8d7c2422-605d-42ea-85cf-1fb990ad552d)(content(Whitespace\" \
+         c037b2b5-0ee8-4156-8978-a20a55356ec1)(content(Whitespace\" \
          \"))))(Tile((id \
          50918ed1-db6b-4500-a746-a48aff1facb4)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b777763c-6a51-450c-a46e-9be942eb63a9)(content(Whitespace\" \
+         \"))))(Tile((id \
          298ceaa6-6f56-4011-b0e8-a0fc2a97cc8a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7bbc00ae-6129-48e2-a135-7165d0f061d6)(content(Whitespace\" \
+         \"))))(Tile((id \
          6a18d982-dfac-434c-b6da-b4ffadac369a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          290637f2-36ff-4803-acd5-e6aaf834614b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bcd21da6-71e1-4bc5-9fb8-b6049db9e75c)(content(Whitespace\" \
+         25998c02-40e4-4a27-a4b9-5d55b03a3164)(content(Whitespace\" \
          \"))))(Tile((id \
          72bb8f45-1569-4afe-a69c-0bcfd513cf6c)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dfda66f5-2d48-4ea3-a1f9-a21ea77963ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          d1db22d2-519d-46a4-b51e-2921a05a059b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         af4c5827-b93d-4703-8098-a6b7bc8691d3)(content(Whitespace\" \
+         \"))))(Tile((id \
          05fa9099-9545-4329-9ecc-628e01ad1e18)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9af424de-df53-4377-8ef0-e48436673ee0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9831b695-e01d-44f0-a4d8-7b4f9d00b805)(content(Whitespace\" \
+         b24544f0-195b-4504-8eff-bcd7c0c5dbb0)(content(Whitespace\" \
          \"))))(Tile((id \
          103566cb-a95a-4e6a-b791-147202afa655)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ffc625ff-9690-43b6-a1ae-b735454cb89f)(content(Whitespace\" \
+         \"))))(Tile((id \
          6eabde29-c830-4f98-bc13-e2f5db090582)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b760ae2f-4726-407a-89c6-209be9278e82)(content(Whitespace\" \
+         \"))))(Tile((id \
          1437fcd8-307f-43f9-a42f-269ed3a9f0ca)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          2527a86f-ab27-4c61-888e-eded2c952aa4)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3f5be580-7376-4252-a6fe-606610a4c7f1)(content(Whitespace\" \
+         f785dd67-65d1-40d0-8f7d-1bb88fe43d91)(content(Whitespace\" \
          \"))))(Tile((id \
          25f61964-0a10-4915-b5a3-4410e03f4f43)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         965271bc-46db-478e-8e47-936216de3208)(content(Whitespace\" \
+         \"))))(Tile((id \
          473326f0-9cf9-407a-8863-0d554a32fafe)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         164214fa-4108-49f3-aeb4-041a4dedaece)(content(Whitespace\" \
+         \"))))(Tile((id \
          d0a82f57-b0e5-4ba4-a92c-646a1b8be470)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4e646b7c-5062-44a2-b986-eae4a5d0a3d2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0af175e0-8832-40b4-a76b-80dcb9188512)(content(Whitespace\" \
+         d439bbbc-cc89-47b8-9307-ea2758b7ed69)(content(Whitespace\" \
          \"))))(Tile((id \
          ee6d3440-6eda-41c6-8b0e-a840140ade6f)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         60c77e90-3bf5-4fb4-8da4-6343508c98c4)(content(Whitespace\" \
+         \"))))(Tile((id \
          03836214-e9d1-4907-85bd-b0e1815e0768)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e4a7cba0-28ad-4cf7-82e9-315ca35bc2f4)(content(Whitespace\" \
+         \"))))(Tile((id \
          58ad5f40-a8bf-45f7-a81c-1e3b5b75fe75)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          058302e6-6e4f-4529-892d-5c14e756cbf5)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         87a93de3-218c-4f6f-b32d-7ee33b1afc27)(content(Whitespace\" \
+         01359d44-d0c2-43ad-829f-fbdf72880b36)(content(Whitespace\" \
          \"))))(Tile((id \
          0a0be07e-2314-4828-a23a-ca10986cfdd9)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e33ca1ea-840a-4a96-9fb4-1a80330e392b)(content(Whitespace\" \
+         \"))))(Tile((id \
          b390e222-92b6-4dbc-8948-f37e70c964a6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         942e7b45-3a40-4b4f-b09c-650b135da276)(content(Whitespace\" \
+         \"))))(Tile((id \
          96c73bfe-ba9c-4135-af7b-394cf5fbb018)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1a92cedb-8d73-4f45-aa96-b356e92d8c15)(content(Whitespace\" \
+         dd3b4ed3-5a80-4d22-a198-de6c742972c5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         36097be0-aefa-41e0-81dd-63c89e747321)(content(Whitespace\"\\n\"))))(Tile((id \
+         1ff2bfb7-7a37-4459-b2a2-f1b991412106)(content(Whitespace\"\\n\"))))(Tile((id \
          20a6152d-1308-44b0-af21-f1573ca77cda)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         217b3d62-b8a4-47bf-9e9b-985763558156)(content(Whitespace\" \
+         1d6e3d11-6fb2-4ab1-8b3b-0320b1e90737)(content(Whitespace\" \
          \"))))(Tile((id \
          f2f5eb65-10d8-4627-be04-acb381b5995c)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d6570c00-f441-4b1e-a9f3-0bb8493ec97f)(content(Whitespace\" \
+         92c7e27b-e7a1-45b3-857a-2e4bdcbb2ce4)(content(Whitespace\" \
          \"))))(Tile((id \
          c9a99cd6-02c3-438d-b312-caf717d37240)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d75bdd1a-689c-4697-b2f7-b12096d26137)(content(Whitespace\" \
+         0a57f9ed-5545-40a1-a0c6-daacf38c3894)(content(Whitespace\" \
          \"))))(Tile((id 2db7a558-7036-437e-92a2-660d966e73d5)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          f84151e8-9f8a-4301-8b43-df4bde7f409f)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f711c6c4-e761-46e5-9c31-657476213804)(content(Whitespace\" \
+         6868da28-2dc3-4766-9eb4-4785809fe3cd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         43e07618-09a2-4f48-ad3c-46b61f3b0c9b)(content(Whitespace\" \
+         01beb228-2c7a-4f09-b478-124538fd8286)(content(Whitespace\" \
          \"))))(Tile((id 28f307ea-cf84-4261-8af6-efa4256c1040)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         bf96f82a-4c0b-4ab0-9c17-5f17231b3474)(content(Whitespace\"\\n\"))))(Tile((id \
+         8725f9d4-3bac-4803-8e10-ac2345d6203b)(content(Whitespace\"\\n\"))))(Tile((id \
          9bda0513-ab77-48e3-aabb-1b9a107beb76)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3937,7 +4086,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2908eb2e-ee6a-452c-b8ce-95d2c7d8e81f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         15832bd9-512f-4657-89ba-e18854243cb1)(content(Whitespace\"\\n\"))))(Tile((id \
+         586b6f95-5a47-496d-ad19-569e69d46ac7)(content(Whitespace\"\\n\"))))(Tile((id \
          87798e5a-eeb1-4ba1-93f7-49a129afd1c3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4003,7 +4152,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bf650394-2581-4e55-baad-653279c3bcb9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4726f522-b281-43b6-88b1-9357504024b1)(content(Whitespace\"\\n\"))))(Tile((id \
+         b9a7fda8-9d85-48ef-97d2-22cc92317f31)(content(Whitespace\"\\n\"))))(Tile((id \
          08a32b40-927e-4605-8408-19b61a3fa066)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4013,11 +4162,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          95cbf5a3-b942-461b-97df-e11551a83726)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d23a304d-e36f-46b1-ab3a-7ace368a16cf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         359bee60-2d88-456b-af21-f75579b74321)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         77430fef-7c74-4181-b8a2-dafcf9486dcc)(content(Whitespace\" \
+         d07b8b7e-38c0-4821-8768-c555a2037611)(content(Whitespace\" \
          \"))))(Tile((id \
          34bede50-7fcb-4730-96cd-d6f58e661987)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4025,7 +4170,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5bd3b4f1-d991-4f42-8771-3a6a27e9bca0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9521c0b3-9b26-4c15-adf2-76ae562d8a6b)(content(Whitespace\" \
+         20d47a9f-6dd6-424c-b2ab-0518b46a508f)(content(Whitespace\" \
          \"))))(Tile((id \
          f00dfa4c-8be1-4196-aa66-9315856af7ec)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4033,7 +4178,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          18b76710-26a5-4bb3-acbf-bb846da18ff5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e52d9e8c-5dda-4739-9053-75956fa23be4)(content(Whitespace\" \
+         03824322-f62e-4364-8575-e9fb4b88431d)(content(Whitespace\" \
          \"))))(Tile((id \
          f1910ac8-c6bb-4f2f-83c7-1e32edadb30b)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4041,7 +4186,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          47ce096a-7b0d-4ec3-a6f8-5f477cb22b4f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a0075ca9-ed37-40cb-87dd-2382b7dd3348)(content(Whitespace\" \
+         95cfe963-f166-4d91-9112-f74049b380df)(content(Whitespace\" \
          \"))))(Tile((id \
          9fb0cf90-ba93-43a9-9e32-05859df7acdb)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4049,7 +4194,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a3eb67d1-6489-4325-ba03-6ac430051c28)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a77439b5-c9b2-4ba9-9f22-897eda8639dc)(content(Whitespace\" \
+         25fefba7-b327-4565-a32b-1ac3360d5dca)(content(Whitespace\" \
          \"))))(Tile((id \
          c531ddf5-42d1-4bc5-8306-bea84f9c3c62)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4057,7 +4202,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          125fa919-a1a6-49b3-b783-43f6315b5570)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         82718cce-2086-4eec-8c73-034dbb51a894)(content(Whitespace\" \
+         f81d4477-9687-494f-a121-c7eb3f5cb553)(content(Whitespace\" \
          \"))))(Tile((id \
          62dd1882-8f67-4a0b-b1b2-7931a197dea8)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4065,168 +4210,195 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7a8bce6f-586f-4a7f-a554-c68ce289de16)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         772ffe67-9357-4ee6-a17e-01fb25af203d)(content(Whitespace\" \
+         272ba0c3-c87b-4143-9b1b-be32efd9b90b)(content(Whitespace\" \
          \"))))(Tile((id \
          1c71e674-9d26-48e0-97dc-f5afebedfadb)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f23a8b1f-3196-43eb-912f-9b2f119e4b87)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         346faedd-73fa-4d50-a49b-0fcc0c0fb23c)(content(Whitespace\" \
+         26c0251e-fe91-48d7-9fce-82597d53115d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         3df8aa8c-b83a-449c-a520-30c7f6263645)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         abc08365-42ab-431a-bc4d-8a53ce3da398)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4496e22b-82d1-46b1-b5fe-79b85ff2c0f0)(content(Whitespace\"\\n\"))))(Tile((id \
+         89c53709-9360-4452-a6b4-12d294422fd3)(content(Whitespace\"\\n\"))))(Secondary((id \
+         c142d619-641b-4ecd-b012-5b18ffa7e7df)(content(Whitespace\"\\n\"))))(Tile((id \
          b71ce369-1f63-4e5d-a741-42044165b303)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         dcba89a5-bd3d-48f0-a101-198a473a77e2)(content(Whitespace\" \
+         7a14b960-c26c-4d9e-b9bf-287b7d863f39)(content(Whitespace\" \
          \"))))(Tile((id \
          711ad203-d2ba-4389-aa53-3dfbb2cc96cf)(label(GradebookEntryMissing))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         00510869-56ba-4d24-8577-7142279e876c)(content(Whitespace\" \
+         6766c208-09e3-4ad9-bea6-730fe4d754fd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c19a92dd-a358-4dca-9c5b-be6338ff6f01)(content(Whitespace\" \
+         21056feb-cd2d-468b-9fd7-05d95f36aa31)(content(Whitespace\" \
          \"))))(Tile((id \
          7c94dcd3-a699-46c3-9152-f8e7f8a77b4b)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         f1fa699e-f7e0-4b5e-a928-ae29c8298a8f)(content(Whitespace\"\\n\"))))(Tile((id \
          632c8b4f-14ab-4f81-b707-4e67202f5517)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6b7aad59-ecfe-47e8-a159-53fbbfaf7c21)(content(Whitespace\" \
+         \"))))(Tile((id \
          17c484ba-cee8-48a0-b7ba-385d5d56bb1e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1ad76274-845c-4f27-a5e5-0ded067b5071)(content(Whitespace\" \
+         \"))))(Tile((id \
          1a5a79d6-da27-4972-b8be-4a1608eceaf2)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4c5b8a21-df52-499a-832f-cddbec7d3026)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c25e428a-631c-4e0a-8dea-caededf026d4)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e6f8e568-cdf6-4b8d-967d-7208eb7a609f)(content(Whitespace\"\\n\"))))(Tile((id \
          856a84a4-a4da-4b00-ab5a-87e4161305e5)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3feac599-b78e-4d74-9044-f59c883f881f)(content(Whitespace\" \
+         \"))))(Tile((id \
          1c5f645e-60ea-4b40-ba41-46f48249db30)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         11e36764-ba2e-4422-851e-9541ca4de03a)(content(Whitespace\" \
+         \"))))(Tile((id \
          1784ec6d-a345-4da9-b907-1a92f6c790b0)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          549307d6-14f5-4067-b9bc-7dcdbcc14376)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d3a7cb79-93e7-487d-b75b-87ae27f962f8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         17cbcb9b-f938-4862-b4f9-d1d2c920b5c2)(content(Whitespace\"\\n\"))))(Tile((id \
          e5de79a4-71f6-4f7b-ae70-7dee72c632be)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cb87f443-a957-4822-98ed-670bc7d5cc88)(content(Whitespace\" \
+         \"))))(Tile((id \
          3dad1a8a-59c0-4f47-a52f-6cc9e942a8a5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         13fbcbc1-fbb9-4d68-8ebb-15bec5968018)(content(Whitespace\" \
+         \"))))(Tile((id \
          41d5241c-7928-4280-b43e-119ca6eac857)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          8f26304a-0747-441c-94a2-5ab0d1c10419)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         73fd277e-6b48-48eb-87a5-59761a017542)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b6aeeac4-232e-4603-8193-cc7a143a4928)(content(Whitespace\"\\n\"))))(Tile((id \
          b6b9677e-37cd-49f6-bb40-1dd3812fddcc)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b696e728-6ecd-4160-8716-98a4af278d26)(content(Whitespace\" \
+         \"))))(Tile((id \
          7add431e-1e5e-44c9-8af8-6a15c69ba29e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1568f2da-c669-4de3-90e4-3d7c3c62ad60)(content(Whitespace\" \
+         \"))))(Tile((id \
          d2cca6b4-227d-43a1-865a-6c0237e2ac72)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0e5dbd8c-5e64-4b69-acb2-3bcf9e27800f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         acd28e2c-7f5a-4661-a85d-15b3a6b6d504)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0f85cf14-db8e-4561-9c97-d1a5e23ca1ca)(content(Whitespace\"\\n\"))))(Tile((id \
          60796e72-66a6-4b8a-ad41-bcd0efeeaee7)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a84db58b-1157-4396-96d8-811b9f6fa9c1)(content(Whitespace\" \
+         \"))))(Tile((id \
          4243e7e0-3844-476e-a791-598d667043d6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4fa76b9e-1e40-4b6a-ac7b-a2c1f7096397)(content(Whitespace\" \
+         \"))))(Tile((id \
          85eedb42-9729-4f70-8db8-2f7b95a7c883)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          81ddef94-a99b-4cf5-b140-157c5d7d8caf)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ba645689-3820-4e99-b77d-8eb83ea5b46c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         488284f8-c5c4-4336-a79e-55abf530f2e4)(content(Whitespace\"\\n\"))))(Tile((id \
          24ca9513-2234-4994-8d91-6e0c6372c4e6)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         15bd73ae-8d22-4238-9b6f-d6703dca8321)(content(Whitespace\" \
+         \"))))(Tile((id \
          c6f680c6-cd95-41d5-9a5b-eec0cb2c5147)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bbcb975b-0645-4dd4-8d0e-f7442230a80c)(content(Whitespace\" \
+         \"))))(Tile((id \
          83197979-308a-4a2e-90ff-8a87ea102225)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6357d079-9b17-44b7-8ee6-1d09547506b2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         067d1a65-a7af-48aa-8cc5-1d0999b7b0e6)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b1ff7b9d-f10e-4229-8044-3e6d96331551)(content(Whitespace\"\\n\"))))(Tile((id \
          aa23d1ef-ecf3-4aae-ad19-7ac5f3caaa41)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a5bdab5c-c88f-4b7c-b8be-bfc2b6ec12cb)(content(Whitespace\" \
+         \"))))(Tile((id \
          fb4963e4-9efd-4f7c-be77-ea547e749b2f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1794b72e-16cd-4bdc-9c18-f4e40113182d)(content(Whitespace\" \
+         \"))))(Tile((id \
          4ec003a5-e7e0-44f0-af8c-08caa507299f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bb4f65d2-8098-42de-802c-698da17e3051)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5ae0f1a8-b134-43ed-9770-1d9172423a17)(content(Whitespace\" \
-         \"))))(Tile((id \
+         65a69b1f-8d9c-4305-af5e-7e1f8be5ccfb)(content(Whitespace\"\\n\"))))(Tile((id \
          8e368529-4c3c-442b-9332-4c7af18973c7)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         853a43f3-8bac-420b-8f4f-5f8b2d25d9b8)(content(Whitespace\" \
+         \"))))(Tile((id \
          f4f78671-743b-4c60-8e21-1c4d71922e8a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         aa09898d-98db-4fd5-9d09-12251bc07ed4)(content(Whitespace\" \
+         \"))))(Tile((id \
          ca61069e-c082-42e3-866e-501ac078b5d8)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8eb4e558-a608-4f21-8018-0fcbf1dce871)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5244f464-89cb-46ba-8e2c-a6ddc9c4135e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         bd6458f1-b4a5-4d95-bb16-f7bf23ede61e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e0574ad5-78d2-42c5-a104-df36dfe8a477)(content(Whitespace\"\\n\"))))(Tile((id \
+         ce58944f-9305-4ab0-80ef-04ebf96d5635)(content(Whitespace\"\\n\"))))(Tile((id \
          02becb9a-c1dd-4da5-8e97-cd2464b20e00)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         7c9015f2-b413-447f-b80b-8c0c041a8907)(content(Whitespace\" \
+         6e9ec51f-e04d-4ebb-81de-c3c5e98e4f3e)(content(Whitespace\" \
          \"))))(Tile((id \
          112dbc27-b74e-4310-96de-a8448b227df1)(label(gradebookMissing))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0f4b6c87-9497-498a-8a41-cab2794cb2cf)(content(Whitespace\" \
+         ae688f1f-145c-47bc-8a83-d7792a05a32e)(content(Whitespace\" \
          \"))))(Tile((id \
          af2f07dd-6b43-4507-bf03-039a43d6d3d5)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         df865c82-d55b-4804-ab86-1d693bd09e9b)(content(Whitespace\" \
+         cde873b5-bc8f-4c28-9281-5481a73447f9)(content(Whitespace\" \
          \"))))(Tile((id caa2b107-5479-427c-b78d-7e49f8b879f5)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          5541a410-e565-46b2-ae66-1c1dc56cb158)(label(GradebookEntryMissing))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         2a3e9e6a-6cef-4547-a1c0-824e468b774f)(content(Whitespace\" \
+         2512689d-cd1a-47cf-890f-61024f188140)(content(Whitespace\" \
          \")))))((Secondary((id \
-         90a50245-e718-4b32-86dd-24b6d1e321ef)(content(Whitespace\" \
+         965c2ac8-b58c-48a0-b661-c20b546d83d1)(content(Whitespace\" \
          \"))))(Tile((id 8b742cd3-ed2e-46b4-b5c1-60c20cbff250)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         28687b22-88d6-4eb2-9533-b6fd6687b551)(content(Whitespace\"\\n\"))))(Tile((id \
+         62910555-1ef3-4633-9533-1e3a04e1ed7f)(content(Whitespace\"\\n\"))))(Tile((id \
          7d3a2a6b-b338-4f63-8db1-b23d98913a4a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4314,7 +4486,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e5c80609-849b-4993-ba0b-c71d7250e81b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7c8d32f5-796b-4466-9bb2-daa0f027b0e3)(content(Whitespace\"\\n\"))))(Tile((id \
+         0ba0346f-16d4-4d06-98b0-1b9c19d8de8b)(content(Whitespace\"\\n\"))))(Tile((id \
          f977011d-aba5-4122-9831-fecdd1ac2fde)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4392,7 +4564,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3acc86b8-9600-4314-9618-5594520da70a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c0641ac5-a42d-4a86-a5a6-3ff338747d87)(content(Whitespace\"\\n\"))))(Tile((id \
+         30b25e73-7ff0-4b06-ae5d-9505b1b6287b)(content(Whitespace\"\\n\"))))(Tile((id \
          81e043ce-b106-4185-b540-a203528883d4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4402,11 +4574,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2d0dadc3-5c2f-462f-88ef-f1cf38628ef0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8a5e67d6-5cce-41a5-914f-e22a5d5b5c70)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fec27684-1701-4c2d-8208-c55da6187502)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f52920d-9751-4dca-8b69-dc92dcec0367)(content(Whitespace\" \
+         413efdb1-3e5c-4449-9bd5-329cd89b3b80)(content(Whitespace\" \
          \"))))(Tile((id \
          384a51eb-af69-4c51-a499-6f9b59daf43b)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4414,7 +4582,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9f01d62b-a34c-44d0-8adb-524f2bdd4f2e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cc504284-8c79-4561-aa39-1e8e11b03cf6)(content(Whitespace\" \
+         cb218070-411d-4c72-ae4b-c487ae958a7f)(content(Whitespace\" \
          \"))))(Tile((id \
          b3896126-b92a-4816-a50a-ac6eec53948a)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4422,7 +4590,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fc733f9e-be93-4814-b99d-1166e187bf2f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dfa1ffd9-1c66-4b6b-a2d7-70e995211e8c)(content(Whitespace\" \
+         668d4353-ad89-4824-b2ee-6119c38e841a)(content(Whitespace\" \
          \"))))(Tile((id \
          2c383801-793b-4dcf-bb7a-4638700640a4)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4436,7 +4604,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f261016a-a6ba-4cf1-b39f-7fbdcbe3c2fd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b2ccbdaf-073d-413e-a1c4-572b458e893a)(content(Whitespace\" \
+         67b6c1bc-c8f2-4257-bf1c-afe889d72261)(content(Whitespace\" \
          \"))))(Tile((id \
          27c29bc0-3bf5-4ef6-aede-6e358dfacb9a)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4444,7 +4612,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e962a63d-ff13-4850-abeb-f703ee0f6fb6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ba352ba0-82a4-456b-bf93-b663841431fa)(content(Whitespace\" \
+         bad2bd4b-89d5-4492-aed8-f21890547fca)(content(Whitespace\" \
          \"))))(Tile((id \
          d431d4d5-916f-4fa7-9cce-706e6064d8f3)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4458,7 +4626,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7143e0af-5dec-4fc3-a1f9-1f9f192a8a16)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9388b53c-3d40-49c0-a225-3d01ef88794a)(content(Whitespace\" \
+         606c7e8a-6708-4704-a56a-c2cec036efb3)(content(Whitespace\" \
          \"))))(Tile((id \
          1890c641-80ac-4f76-85d2-7b7eaea8ce03)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4466,127 +4634,148 @@ let out : string * Haz3lcore.PersistentSegment.t =
          735f490f-00d7-49ff-867d-8c1bdc8e6245)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         291bbad2-5ced-4790-945b-ef0a621d14e0)(content(Whitespace\" \
+         9912eacb-9785-468d-bed8-3cafb706dab0)(content(Whitespace\" \
          \"))))(Tile((id \
          4b7313df-b9af-44f7-8c3d-8f356892b93c)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f26ea766-d85c-424d-9ac8-a5c9fc1c4203)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         0de14160-9417-44d0-8bce-8566f6cca2c2)(content(Whitespace\" \
+         14d1ec1d-cb8e-479c-bc41-b2c61ccae523)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         92eab2cf-67a2-4aee-935b-fe9b34090efc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4ae7b981-f41b-4964-9b79-34432dd9ee43)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ac8480a2-4708-4998-8987-4d5c11b25698)(content(Whitespace\"\\n\"))))(Tile((id \
+         71e94ef4-4cac-4691-987d-d4141d256d55)(content(Whitespace\"\\n\"))))(Secondary((id \
+         163be1c5-d3da-4507-bab5-eff152b5ef20)(content(Whitespace\"\\n\"))))(Tile((id \
          5b354155-4718-4209-8849-e29feb573c2b)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         f21b2137-5719-4bc4-86d0-473c3d8642e0)(content(Whitespace\" \
+         7ef76225-92b5-44b4-8740-14bac2dfd57a)(content(Whitespace\" \
          \"))))(Tile((id \
          5b8558ad-2184-4602-8931-7f3d3a31b069)(label(GradebookEntrySeq))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         434ce58e-bde6-4cc1-b501-580441d74288)(content(Whitespace\" \
+         d8ffe035-68f8-42c2-ae69-7d79a2e624ca)(content(Whitespace\" \
          \")))))((Secondary((id \
-         88e42ebe-473c-417b-b115-f42914140ae1)(content(Whitespace\" \
+         75db491a-5e19-42a7-a137-e8216bae12cd)(content(Whitespace\" \
          \"))))(Tile((id \
          f1255624-d5ac-4aa3-9b6b-3f19c0d64637)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          2566989c-1fe5-42b0-bee2-ee4c0bbcbf58)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d200b780-1f87-4a1f-a0e7-7e7d75ed0db1)(content(Whitespace\" \
+         \"))))(Tile((id \
          aa192398-6743-49f2-b32c-25e566a32294)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6dd1e5c3-09fb-4e52-8b2b-249597390b2d)(content(Whitespace\" \
+         \"))))(Tile((id \
          4dcb76b9-77ca-4eee-a5ee-ef59eb189712)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          97bebae3-6f4d-4ccb-80f7-6ed695a06e4e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3afc1688-39f2-4749-8dbd-081b0d31f702)(content(Whitespace\" \
+         fbe333d8-d908-4a50-81a2-b4c864be35ed)(content(Whitespace\" \
          \"))))(Tile((id \
          64f417be-478b-41c3-9695-8dba302eeddf)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b15105de-446f-4a14-b88e-d950d44814e9)(content(Whitespace\" \
+         \"))))(Tile((id \
          3d68d3bb-991c-4ede-875d-ad627d797a93)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e11c291a-936c-4181-a863-b8bd1f2d3fb5)(content(Whitespace\" \
+         \"))))(Tile((id \
          d862998a-4d28-445b-bb76-37fc540982e8)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0de7bbc0-bb05-4f71-b124-f5d435cf083f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f873c5ed-69a3-4e9d-8d53-219df11ab186)(content(Whitespace\" \
+         1d72e648-f206-49f3-97f5-60ac725cab1f)(content(Whitespace\" \
          \"))))(Tile((id \
          947dfb86-e669-4014-916a-7215562f70d3)(label(quizzes))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f58a7c48-4d91-4973-8256-dd5f870742dc)(content(Whitespace\" \
+         \"))))(Tile((id \
          db5c2634-8b3c-4fce-8975-ed02f7907b5d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d813979d-e9d4-433b-9849-6da98b4bd151)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3fe2238c-dc3e-43a1-b725-248e22f83945)(content(Whitespace\" \
+         \"))))(Tile((id d813979d-e9d4-433b-9849-6da98b4bd151)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          86d3a13c-41b6-4835-ac90-260245468bd1)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          32fc0f32-2c87-43d6-bb12-5dfe26d8ea10)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e0c28581-9af0-4200-8dd6-d269f3dd7847)(content(Whitespace\" \
+         65f37710-2bb3-421d-a8ab-70154c85943d)(content(Whitespace\" \
          \"))))(Tile((id \
          4b53fa2a-24e5-4a74-98ac-d7028304a157)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         fc57e360-9f85-4067-aa8e-7b3029d3b881)(content(Whitespace\" \
+         \"))))(Tile((id \
          8ebd28f7-7c6e-4bac-ada9-7e779abe9016)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         adba5b94-d909-40b8-ac60-9f571731dc11)(content(Whitespace\" \
+         \"))))(Tile((id \
          ac5f4d98-0d87-4634-9c77-ae64cecddcbb)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          12b28664-30aa-41ac-b81a-151d7c69187e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3ee2c12b-9186-41ce-bb6a-391ada866a8e)(content(Whitespace\" \
+         bbbcee10-1a92-40e5-a2a4-3e5ead4d998f)(content(Whitespace\" \
          \"))))(Tile((id \
          8e6a1dc9-e624-4f59-9c4e-1419af3327e1)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2fd70bf3-c2fc-4adc-a472-87e3b2d4789f)(content(Whitespace\" \
+         \"))))(Tile((id \
          d46d0891-a94d-4841-b7f7-42ef4db9a34c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3e2829c4-c86d-42b9-ae51-2e640b66a6ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          ffa9e55d-3d5f-4615-9136-287f97fd7dfd)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         882a2c46-2f12-42bb-9f90-0e4ece0b614a)(content(Whitespace\"\\n\"))))(Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         a1020f89-b69a-41ef-8562-e1c09b279cb3)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         0bd2ef42-6afe-4df6-adc7-59c767636a8c)(content(Whitespace\"\\n\"))))(Tile((id \
          89827bb1-0f8b-4b35-9472-621ba949d9b0)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8f5e9b7a-5b68-4350-a33d-0afd3f04dd20)(content(Whitespace\" \
+         f924e93e-214d-493b-be05-e7b45d9e6c33)(content(Whitespace\" \
          \"))))(Tile((id \
          f90420d3-eea4-455d-a2c2-f28c51a0d745)(label(gradebookSeq))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         643eb90c-811f-4575-9c31-da37bac85cfb)(content(Whitespace\" \
+         52d1ce11-0c08-448d-9f8a-4602964fbf87)(content(Whitespace\" \
          \"))))(Tile((id \
          78e2ad35-ec94-41de-857b-3ee7c4c24e26)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         63f4c15e-12d9-4f87-b17d-3ec488f2e2ce)(content(Whitespace\" \
+         8dcc127f-57f2-4757-af2f-743f513535c7)(content(Whitespace\" \
          \"))))(Tile((id ffc5cb31-abc9-4a89-af03-ae311ef5ec95)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          33b135a2-8a68-41c7-a967-dfc697acb557)(label(GradebookEntrySeq))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e4013e51-a4ae-4d52-97fe-2a7366883df5)(content(Whitespace\" \
+         ce8e039f-2604-4d9e-85ea-f805b7dffa6f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c8113d5a-f16f-4693-8792-7b826bae0599)(content(Whitespace\" \
+         a0f8d41c-a239-4dea-a742-7555bcd11afb)(content(Whitespace\" \
          \"))))(Tile((id f353f6c9-2da1-4323-8582-4221e3e708e0)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         11014318-2aa8-4b33-aca1-239ad5f0fbeb)(content(Whitespace\"\\n\"))))(Tile((id \
+         b386099f-f06d-4ddf-9b0f-8e8b093dc8d9)(content(Whitespace\"\\n\"))))(Tile((id \
          ff95f46c-65ce-4787-945c-0df31f1c756b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4658,7 +4847,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          00c066b7-a0b5-41c4-b024-21611394114a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fb4a85f5-7afa-44df-989e-b8271a506209)(content(Whitespace\"\\n\"))))(Tile((id \
+         f46a5a51-7004-4c23-82b7-6d6cfc7f43a4)(content(Whitespace\"\\n\"))))(Tile((id \
          339c65a4-5eff-47d0-b0d8-0428a00c3314)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4726,7 +4915,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          022ea45d-58e1-4a4c-9ee3-d572627cc6dd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b239e8d2-0976-4e2f-a966-0b6f28225c3a)(content(Whitespace\"\\n\"))))(Tile((id \
+         cf4b43d1-7acb-48f7-b9a7-15e3603093ce)(content(Whitespace\"\\n\"))))(Tile((id \
          2113ed97-b1ad-42e2-92d3-d28c718d59bd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4736,11 +4925,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6862b768-abd7-4d58-9767-19c503eb42f6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b4e90edc-734a-4d66-81ae-5fbd74280496)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ed61ef02-859e-4031-830f-c4b387fa2e59)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         90f3d266-b920-46cc-b12b-55bf65675249)(content(Whitespace\" \
+         fdd69780-e962-4739-9ac2-2a5c06eb4541)(content(Whitespace\" \
          \"))))(Tile((id \
          955ec603-3727-42dc-b132-7a6d00166950)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4748,7 +4933,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7f1bb893-325c-434b-a864-7289ebf1d462)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3bfe5100-95cb-47d8-a401-ff7ddf01d0d0)(content(Whitespace\" \
+         41a12fb1-62d5-44cd-ad78-00cdbab72968)(content(Whitespace\" \
          \"))))(Tile((id 30416d07-8d8f-4e5e-8109-88fd19fe2804)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4782,7 +4967,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a79a71a8-602d-43bd-9366-0a79194f07ed)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f5cbfc30-5dd1-4a59-8ac0-c3f5b1691c7e)(content(Whitespace\" \
+         eafa34f7-a717-4875-8697-9041ca01fabb)(content(Whitespace\" \
          \"))))(Tile((id \
          cc6efaa5-beb6-4b01-b3ce-038fe4851755)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4790,152 +4975,179 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cdb0e7bb-130a-427a-9731-62bf731b9fd3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5466c52e-9f38-4180-9632-00eb5eccbb66)(content(Whitespace\" \
+         187dbb99-f796-4d13-a7fd-8f9afc025158)(content(Whitespace\" \
          \"))))(Tile((id \
          d0d798f6-13e1-4d14-9b49-a1d300283cce)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         654bf057-49b5-4365-b3a9-d9d069f14964)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         1873e6f5-3100-4b1c-b00b-e2f3dfc0b452)(content(Whitespace\" \
+         cdd13408-0c6c-4f95-9d1d-d0381cae355d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c8fe036d-2e63-4d3e-b5b6-c9c9dfa7ae7a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c17e0e10-85b3-48a4-9171-f23420a00345)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8ee720c3-d83f-4cbf-a198-69ff0b16c200)(content(Whitespace\"\\n\"))))(Tile((id \
+         f6c8b734-0008-4fd1-9752-0e28e565315d)(content(Whitespace\"\\n\"))))(Secondary((id \
+         fdb03fc8-3f39-4c7e-a046-2b09aa58b8d8)(content(Whitespace\"\\n\"))))(Tile((id \
          a6238ac3-023e-4d73-81ad-9ef1123f1100)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         7ed1291f-7f12-4911-9699-7f3a062e0d71)(content(Whitespace\" \
+         68100adb-f4c2-4650-817a-96a91536cd15)(content(Whitespace\" \
          \"))))(Tile((id \
          f2ebccb3-3aed-4a50-90b1-48b96b0345fe)(label(GradebookEntryTable))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         feb5e7e6-bb67-4d12-9b21-62d92b048426)(content(Whitespace\" \
+         dc48f8b3-b505-4cea-97bf-b027cabaac90)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8e1686c0-228b-4595-bc20-07d6b2120747)(content(Whitespace\" \
+         e93c780d-36fa-4682-8ea4-b332ded419a5)(content(Whitespace\" \
          \"))))(Tile((id \
          accaedae-1b0d-4398-8354-99ba79d303d5)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          af3a9c6d-f6a5-4bbc-aeb3-248cf57b557a)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e03fd74f-b2c5-4e5b-b2eb-fea316ccc655)(content(Whitespace\" \
+         \"))))(Tile((id \
          5e1495a4-d55e-486a-b8fa-c0d8d6f55a86)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         005c5cf5-0990-47c7-9d78-b6c8023624d5)(content(Whitespace\" \
+         \"))))(Tile((id \
          d02b4d1c-21ae-4409-9a0c-bec3cac950ef)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c0c20e87-a3cd-4163-a1e4-9c5a57a5b907)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         aa7b32dd-1445-4ba1-9c16-3e25082b4dfb)(content(Whitespace\" \
+         d0a70920-fb8e-4d29-b12a-62f37eaabba9)(content(Whitespace\" \
          \"))))(Tile((id \
          ea5385d2-aac3-4d3c-8bf5-0898d7e78762)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2e17d74e-b5d8-4764-b80a-471aea3538e8)(content(Whitespace\" \
+         \"))))(Tile((id \
          447dd94a-8ae1-408b-ab8a-c2010f9ee429)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c9451684-090a-4218-863e-b487acba5760)(content(Whitespace\" \
+         \"))))(Tile((id \
          df0f36b4-3562-4f9c-9bf6-7dda0fbc20ad)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          8a5ba1a3-d7d9-467e-aed0-c8b26913cd45)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9bdcb535-f0d9-4a66-af73-916259078180)(content(Whitespace\" \
+         dadda8f1-a57a-4185-ae05-58b6f483a534)(content(Whitespace\" \
          \"))))(Tile((id \
          676bfbbb-09f2-422e-b144-4c94cb8c5824)(label(quizzes))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f76e5970-fbf8-4fdd-af64-b2c3540addc6)(content(Whitespace\" \
+         \"))))(Tile((id \
          d49fb013-54fa-447f-a45f-a360c21ef3e8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         1d56c103-9bc7-4be8-a81a-2686b0172077)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         57d517a4-fa50-44c3-8e30-3a315a843e7e)(content(Whitespace\" \
+         \"))))(Tile((id 1d56c103-9bc7-4be8-a81a-2686b0172077)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          94aeb9de-0b3a-4117-a6f0-ad011b9e68a4)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          c8e2197f-13fa-4a9d-8ff6-7fa5987398b9)(label(quizNo))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7d842d86-3e0e-4ae9-a410-cfd098fd8c49)(content(Whitespace\" \
+         \"))))(Tile((id \
          07aafaff-326d-4e9f-8708-1d9f835051ba)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3ed12f82-464c-47a1-ba69-6951a3427404)(content(Whitespace\" \
+         \"))))(Tile((id \
          3f720f2c-dfe2-403f-9a07-6192f7eb4ef3)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          8a68ba25-d105-492d-86ff-69d891440a9a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         63061d6e-178b-4c21-807a-a27aab8116ee)(content(Whitespace\" \
+         3e5a2c93-3d0b-49de-9abe-1bfdcaffccef)(content(Whitespace\" \
          \"))))(Tile((id \
          9fa37e86-0c91-4f4f-9139-3154b9943753)(label(grade))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ed0dc8c0-02f6-4512-a8fc-2c478a723639)(content(Whitespace\" \
+         \"))))(Tile((id \
          84358a66-2b14-45b4-8cf4-ba5a01dacafd)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         76c7a2ac-26c3-4e2a-9d9e-35dcfc7d8d76)(content(Whitespace\" \
+         \"))))(Tile((id \
          a3130df0-05d9-4ccb-a6a4-78c0895a83f1)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
          e5373cae-9732-4755-b7d3-5efdfee8477c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e961c75f-8dc5-4bd0-a696-affbeb9e49ad)(content(Whitespace\" \
+         00226a30-fd47-415a-967b-df596036f578)(content(Whitespace\" \
          \"))))(Tile((id \
          89add536-07b0-45cf-91ef-9b2e209cb0d0)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e5766ee3-f6ee-472f-b9af-904350972ae7)(content(Whitespace\" \
+         \"))))(Tile((id \
          ebb0963e-1a7f-49e2-a3a5-c0543783774b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d61608e1-fcfb-47f5-bce4-df91cc3534d9)(content(Whitespace\" \
+         \"))))(Tile((id \
          61ca82c4-43b6-45a1-80f4-71f864270afe)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4c251854-73fc-424e-8d6f-a65881a62ceb)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         07f2ecdf-6d7b-4ab9-b399-274a968f9652)(content(Whitespace\" \
+         2a20bc4d-f9c5-4aa6-85a4-02e0c2bdf9d2)(content(Whitespace\" \
          \"))))(Tile((id \
          191bb457-3314-4316-9a07-7aebb7e656d5)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         94a5f0d3-c2f4-44d0-9aa6-47daf7f1a8ef)(content(Whitespace\" \
+         \"))))(Tile((id \
          7e94d0bb-46e4-4d21-ab61-122412a6ac23)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c166b4a2-8fc0-47f4-80cd-0147fb8b4943)(content(Whitespace\" \
+         \"))))(Tile((id \
          1a503301-ac62-484d-b032-e8ef92407e78)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c36122bf-79e5-437f-b526-af6cac347657)(content(Whitespace\" \
+         16b3ae23-8d87-4bf7-8141-02005e98e739)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4fb78da7-93d1-4567-97b5-4e5e4749f0c7)(content(Whitespace\"\\n\"))))(Tile((id \
+         15e1ed79-b5d3-414b-a2f7-c6578edfb4e9)(content(Whitespace\"\\n\"))))(Tile((id \
          9d0bd15f-57c6-4553-bc03-a156bda2e6ff)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         5fcdd826-c80e-49be-913b-addfad5f5db3)(content(Whitespace\" \
+         7fe0b78c-3b60-42ec-ba0e-c288cbddc429)(content(Whitespace\" \
          \"))))(Tile((id \
          aa30b67d-347b-4c3a-8d47-ecaa2ad3af14)(label(gradebookTable))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1f82b363-c766-482d-84f4-39b7abf89d75)(content(Whitespace\" \
+         9ef382fb-345f-4a0f-a9a1-b2764c107b5e)(content(Whitespace\" \
          \"))))(Tile((id \
          4bee6e97-8c4f-44bd-b769-1b4cc5909b42)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         44372759-c25e-4d6e-8e23-beac4bfa60ea)(content(Whitespace\" \
+         04105c4b-7619-4d67-9823-e09a2286a162)(content(Whitespace\" \
          \"))))(Tile((id 9749bf26-5ba7-418e-a68a-d75d0e1d3bcb)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          789fa71b-34ef-4bcf-87bc-ff0fd471ea7f)(label(GradebookEntryTable))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7d1c797d-c4c1-43ed-a9a0-de7975da314f)(content(Whitespace\" \
+         cd65ac9f-542d-4c9d-9c05-7709a7e045ee)(content(Whitespace\" \
          \")))))((Secondary((id \
-         baac3c2b-f865-4c07-8fd0-0974676dbfb9)(content(Whitespace\" \
+         7d1a92b8-f7c9-4a0a-9f5f-1afa5a5f4b6c)(content(Whitespace\" \
          \"))))(Tile((id 8e41f1ea-4b12-4085-afcb-a756c65020a5)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         d0fc065a-c270-4aee-9ad3-d0675d2d65c2)(content(Whitespace\"\\n\"))))(Tile((id \
+         2e8af26b-416b-4be7-8109-89dc5b32fde5)(content(Whitespace\"\\n\"))))(Tile((id \
          03d7b203-e1ad-488c-b43a-72f776d4ed21)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -5051,7 +5263,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d074b51a-f112-4bb4-8ce2-8c888327685e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         970f6212-bdd0-42cc-93cd-51d78f676ed0)(content(Whitespace\"\\n\"))))(Tile((id \
+         c712dd7d-2f19-4306-acd9-1d45013606a5)(content(Whitespace\"\\n\"))))(Tile((id \
          086a758c-2484-49b8-afdc-50c5a39ca38a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -5163,7 +5375,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          57ebc9c4-9c5e-47a8-87eb-ce0989fc9509)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10336929-5128-4147-b3af-f0bdd21de258)(content(Whitespace\"\\n\"))))(Tile((id \
+         836aab2b-f845-4859-a0db-045ea93fe49d)(content(Whitespace\"\\n\"))))(Tile((id \
          9851f2b8-6e1b-4548-a80d-3e40eef5b3c7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -5173,11 +5385,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ff66fe3d-f72d-4743-8ed6-9732a44895ff)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         042844f5-0ece-49c9-89b9-c9bb08fa30d3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         937632ce-fa1a-482b-b7c6-cc731445d8f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6ddcc6de-0d5b-4393-8150-4c81f639047a)(content(Whitespace\" \
+         129221db-abee-414c-8edf-6d5224d25a2b)(content(Whitespace\" \
          \"))))(Tile((id \
          5ae742ad-b7ca-4404-9c46-cf3c2f1b532d)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -5185,7 +5393,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          deb2bee7-facb-4880-ac10-57cd982cccf6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b85db05b-0991-4a8c-97a5-0807a4514b15)(content(Whitespace\" \
+         697aa40c-9b46-4bc5-94b8-23bc1a348a54)(content(Whitespace\" \
          \"))))(Tile((id b0b53aea-f07f-47ed-8009-295582ff7b80)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -5263,7 +5471,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9d5a6c7d-3d87-4bea-b215-7a4e8f5ef38b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         91980c1a-4de0-4f65-b629-608f785f7b4f)(content(Whitespace\" \
+         3311335b-0bfe-4c61-b5e1-b530ef0f6eb3)(content(Whitespace\" \
          \"))))(Tile((id \
          27669b89-55fc-4c4f-b660-709e1cfe8450)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -5271,37 +5479,31 @@ let out : string * Haz3lcore.PersistentSegment.t =
          34fab834-1a7b-4435-93d3-825d824b4f5f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a8b09e87-8de3-4bf6-a95d-c5bf08c140e0)(content(Whitespace\" \
+         166fe528-95eb-4106-8405-3a862c3aaacc)(content(Whitespace\" \
          \"))))(Tile((id \
          13b98f4e-d579-4c54-878c-dd9af3901ab9)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         373a014b-8a86-41e0-8268-a6adf25e4e2b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         077dc5ea-9366-438f-bb48-213c767c465d)(content(Whitespace\" \
+         eb18f03f-5ffa-4185-8d15-bdbf52ad775d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         a9cfc8cf-05a6-477e-80b4-c5f81bf09f34)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5ffe3b7b-9013-4a95-a5d8-02bbf296c3ab)(content(Whitespace\" \
-         \"))))(Grout((id e6151c83-7a7e-4494-9887-1bb295fd3473)(shape \
-         Convex))))";
+         c79005fa-8ffa-4050-9b89-a5424649d18e)(content(Whitespace\"\\n\"))))(Grout((id \
+         e6151c83-7a7e-4494-9887-1bb295fd3473)(shape Convex))))";
       backup_text =
         "# Example Tables from B2T2 #\n\
          # Tables copied from \
          https://github.com/brownplt/B2T2/blob/main/ExampleTables.md #\n\
-         type OptInt = +None +Some(Int) in\n\
-         type OptString = +None +Some(String) in\n\
-         type Student = (name=String, age=Int, favorite_color=String) in\n\
-         let students : [Student] = [\n\
-         (\"Bob\", 12, \"blue\"),\n\
-         ^^probe((\"Alice\", 17, \"green\")),\n\
-         (\"Eve\", 13, \"red\")\n\
-         ] in\n\n\
-         type StudentMissing = (name=String, age=OptInt, \
-         favorite_color=OptString) in\n\
-         let studentsMissing : [StudentMissing] = [\n\
-         (\"Bob\", None, Some(\"blue\")),\n\
-         (\"Alice\", Some(17), Some(\"green\")),\n\
-         ^^probe((\"Eve\", Some(13), None))\n\
-         ] in\n\n\
-         type Employee = (last_name=String, department_id=OptInt) in\n\
+         type OptInt = + None + Some(Int) in\n\
+         type OptString = + None + Some(String) in\n\
+         type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = [(\"Bob\", 12, \"blue\"), \
+         ^^probe((\"Alice\", 17, \"green\")), (\"Eve\", 13, \"red\")] in\n\n\
+         type StudentMissing = (name = String, age = OptInt, favorite_color = \
+         OptString) in\n\
+         let studentsMissing : [StudentMissing] = [(\"Bob\", None, \
+         Some(\"blue\")), (\"Alice\", Some(17), Some(\"green\")), \
+         ^^probe((\"Eve\", Some(13), None))] in\n\n\
+         type Employee = (last_name = String, department_id = OptInt) in\n\
          let employees : [Employee] = [\n\
          (\"Rafferty\", Some(31)),\n\
          (\"Jones\", Some(33)),\n\
@@ -5310,16 +5512,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          (\"Smith\", Some(34)),\n\
          (\"Williams\", None)\n\
          ] in\n\n\
-         type Department = (department_id=Int, department_name=String) in\n\
-         let departments : [Department] = [\n\
-         (31, \"Sales\"),\n\
-         (33, \"Engineering\"),\n\
-         (34, \"Clerical\"),\n\
-         (35, \"Marketing\")\n\
-         ] in\n\n\
-         type JellyAnon = (get_acne=Bool, red=Bool, black=Bool, white=Bool, \
-         green=Bool, yellow=Bool, brown=Bool, orange=Bool, pink=Bool, \
-         purple=Bool) in\n\
+         type Department = (department_id = Int, department_name = String) in\n\
+         let departments : [Department] = [(31, \"Sales\"), (33, \
+         \"Engineering\"), (34, \"Clerical\"), (35, \"Marketing\")] in\n\n\
+         type JellyAnon = (\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool\n\
+         ) in\n\
          let jellyAnon : [JellyAnon] = [\n\
          (^^check(true), ^^check(false), ^^check(false), ^^check(false), \
          ^^check(true), ^^check(false), ^^check(false), ^^check(true), \
@@ -5352,9 +5559,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ^^check(false), ^^check(true), ^^check(true), ^^check(false), \
          ^^check(true), ^^check(false))\n\
          ] in\n\n\
-         type JellyNamed = (name=String, get_acne=Bool, red=Bool, black=Bool, \
-         white=Bool, green=Bool, yellow=Bool, brown=Bool, orange=Bool, \
-         pink=Bool, purple=Bool) in\n\
+         type JellyNamed = (\n\
+         name = String,\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool\n\
+         ) in\n\
          let jellyNamed : [JellyNamed] = [\n\
          (\"Emily\",    ^^check(true), ^^check(false), ^^check(false), \
          ^^check(false), ^^check(true), ^^check(false), ^^check(false), \
@@ -5385,36 +5602,44 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ^^check(true), ^^check(false), ^^check(false)),\n\
          (\"Nicholas\", ^^check(false), ^^check(true), ^^check(false), \
          ^^check(false), ^^check(false), ^^check(true), ^^check(true), \
-         ^^check(false), ^^check(true), ^^check(false))\n\n\
+         ^^check(false), ^^check(true), ^^check(false))\n\
          ] in\n\n\
-         type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+         type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = [\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-         (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
+         (\"Eve\", 13, 7, 9, 84, 8, 8, 77)\n\
          ] in\n\n\
-         type GradebookEntryMissing = (name=String, age=Int, quiz1=OptInt, \
-         quiz2=OptInt, midterm=Int, quiz3=OptInt, quiz4=Int, final=Int) in\n\
+         type GradebookEntryMissing = (\n\
+         name = String,\n\
+         age = Int,\n\
+         quiz1 = OptInt,\n\
+         quiz2 = OptInt,\n\
+         midterm = Int,\n\
+         quiz3 = OptInt,\n\
+         quiz4 = Int,\n\
+         final = Int\n\
+         ) in\n\
          let gradebookMissing : [GradebookEntryMissing] = [\n\
          (\"Bob\",   12, Some(8), Some(9), 77, Some(7), 9, 87),\n\
          (\"Alice\", 17, Some(6), Some(8), 88, None, 7, 85),\n\
-         (\"Eve\",   13, None, Some(9), 84, Some(8), 8, 77)\n\
+         (\"Eve\", 13, None, Some(9), 84, Some(8), 8, 77)\n\
          ] in\n\n\
-         type GradebookEntrySeq = (name=String, age=Int, quizzes=[Int], \
-         midterm=Int, final=Int)in\n\
+         type GradebookEntrySeq = (name = String, age = Int, quizzes = [Int], \
+         midterm = Int, final = Int) in\n\
          let gradebookSeq : [GradebookEntrySeq] = [\n\
          (\"Bob\",   12, [8, 9, 7, 9], 77, 87),\n\
          (\"Alice\", 17, [6, 8, 8, 7], 88, 85),\n\
-         (\"Eve\",   13, [7, 9, 8, 8], 84, 77)\n\
+         (\"Eve\", 13, [7, 9, 8, 8], 84, 77)\n\
          ] in\n\n\
-         type GradebookEntryTable = (name=String, age=Int, \
-         quizzes=[(quizNo=Int, grade=Int)], midterm=Int, final=Int) in\n\
+         type GradebookEntryTable = (name = String, age = Int, quizzes = \
+         [(quizNo = Int, grade = Int)], midterm = Int, final = Int) in\n\
          let gradebookTable : [GradebookEntryTable] = [\n\
          (\"Bob\",   12, [(1, 8), (2, 9), (3, 7), (4, 9)], 77, 87),\n\
          (\"Alice\", 17, [(1, 6), (2, 8), (3, 8), (4, 7)], 88, 85),\n\
-         (\"Eve\",   13, [(1, 7), (2, 9), (3, 8), (4, 8)], 84, 77)\n\
-         ] in ";
+         (\"Eve\", 13, [(1, 7), (2, 9), (3, 8), (4, 8)], 84, 77)\n\
+         ] in\n";
       refractors =
         "((8577a5c1-efab-4a3a-86e2-74e2b159c919((kind \
          Probe)(model\"()\")))(ea9a0dcb-355c-400b-925d-7ade67326348((kind \

--- a/src/b2t2/slides/errors/B2T2ErrorsMalformedTables.ml
+++ b/src/b2t2/slides/errors/B2T2ErrorsMalformedTables.ml
@@ -1,28 +1,26 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Errors / Malformed Tables",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Secondary((id \
          851208d9-35aa-44a2-a43c-38bba6973e37)(content(Comment\"# No type \
          correlates to missing schema. There is no error as it's valid data \
          without labels#\"))))(Secondary((id \
-         a61c4f81-cac5-471a-b006-d913677a0b5b)(content(Whitespace\"\\n\"))))(Tile((id \
+         c1b199ff-db92-4322-a0d2-4d468399fcb4)(content(Whitespace\"\\n\"))))(Tile((id \
          ff6246e2-f471-4fd6-b9c6-d7b0332f5f42)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a32aa364-f340-4198-bf3e-76b0dbd0b04f)(content(Whitespace\" \
+         cda3d70f-3560-494f-8e23-3927988935fd)(content(Whitespace\" \
          \"))))(Tile((id \
          3a120a5a-1e84-49f7-8142-b5169721c7bb)(label(missingSchema))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         974472f4-9546-45d9-b021-532faf15b928)(content(Whitespace\" \
+         b3769806-ca8a-4d20-b094-a54ae2f204be)(content(Whitespace\" \
          \")))))((Secondary((id \
-         49e85688-e507-49f1-a2f1-b2f860f37071)(content(Whitespace\" \
+         ebbf58e3-7b5c-4569-b74d-5db69ac204e0)(content(Whitespace\" \
          \"))))(Tile((id cf7a0ebf-0043-4959-ac15-b0359a4fe618)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         b211601a-9e73-4f4c-954e-a46fd8fe86b9)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          ed9dbccd-ef94-4bb8-be3c-97df5d574e44)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -48,7 +46,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          37f22de4-7ba6-4c4e-b7c3-d9fcc8e154ae)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4f665686-6014-4fd2-9b20-7e6adf1b4ce4)(content(Whitespace\"\\n\"))))(Tile((id \
+         c886387a-949c-4e7d-9d30-f73b8273aad8)(content(Whitespace\" \
+         \"))))(Tile((id \
          9f985e16-a42a-4240-ac29-f124a84fdcc5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -74,7 +73,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e6166fa1-385b-4051-8f7e-ea4b31c54d20)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8373da9c-2f99-4ce2-b0ba-ad0f30de6a0f)(content(Whitespace\"\\n\"))))(Tile((id \
+         ce1c887e-4e71-4621-9176-cf35bf5627a2)(content(Whitespace\" \
+         \"))))(Tile((id \
          71d56402-15a2-4aea-8976-a920cb7ab74f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -84,7 +84,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c4d6b35d-b85c-414d-8d2b-588084d04db6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1ab598b2-212b-41b2-9d1a-6437caf1eef5)(content(Whitespace\" \
+         eb4fe51e-84d3-48ea-98e4-dd074d023a07)(content(Whitespace\" \
          \"))))(Tile((id \
          0fa2df1e-03cc-4931-9170-fd67373adc23)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -92,27 +92,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          15f611a6-ae04-4389-8828-10734d7b1f58)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5b04ca2c-38a1-4107-aa78-3040d2329558)(content(Whitespace\" \
+         285369ab-1e9a-4f2d-9caf-d1fc48c147a0)(content(Whitespace\" \
          \"))))(Tile((id \
          77c3c917-3327-46d2-a634-4f01487d1e71)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         cba48f88-085c-485a-b9e6-eeb4f15fc14f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         3afd4605-79e2-4ac3-b768-369f5a4eca99)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         e07b48d6-f4d4-4e9a-b7c2-c4c25ec2a07e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fa62e739-2170-4cd5-8f14-3d1908a33cf7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         894ce8d0-71b7-4174-a5ba-3e78df27375a)(content(Whitespace\"\\n\"))))(Tile((id \
+         abdf3aad-bfe6-4b8c-8ad6-73875096b307)(content(Whitespace\"\\n\"))))(Secondary((id \
+         cc2e1c44-58cc-4718-91d9-08d1957b3087)(content(Whitespace\"\\n\"))))(Tile((id \
          5fe12a9e-b1e3-404f-9e39-f6139dc56446)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         576264e3-8102-48f8-90ef-cb1392c12441)(content(Whitespace\" \
+         4773db78-dda4-4578-b9cf-97f52c40e4eb)(content(Whitespace\" \
          \"))))(Tile((id \
          f18b7082-0819-44c2-a255-8294fbe28b3e)(label(Schema))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         8efc6c9b-c058-4af6-962a-a96a9b03c66d)(content(Whitespace\" \
+         5a6b7664-c700-4c4f-9cc6-91ee3c9bc722)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e2f3749b-d688-4daa-ac9d-388a4b270b62)(content(Whitespace\" \
+         9a9a9917-7bf9-4fb0-bfec-2d44b1f4ad63)(content(Whitespace\" \
          \"))))(Tile((id 28cd2507-d92b-40c8-9621-c68dc99a6fcf)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -121,73 +120,85 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          9faf4f9c-4d83-4329-bf34-2a6cdafbc8cc)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         24f2b840-84e6-4c15-b66e-c52b18809a17)(content(Whitespace\" \
+         \"))))(Tile((id \
          35939107-8593-4e56-a8aa-159a020b19c0)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6198f109-3b3d-4fe5-89b0-dfbc0324685b)(content(Whitespace\" \
+         \"))))(Tile((id \
          9ea6461d-bbf8-4530-80e9-62c3287d4315)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9a02dbaf-432b-4276-a9f5-1b067b318b61)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         74f1d8b9-4e01-4273-870e-d67912faf289)(content(Whitespace\" \
+         023c4a26-bde1-4f3c-a8fe-73d3e4e39246)(content(Whitespace\" \
          \"))))(Tile((id \
          b718d373-50f8-4ffa-a835-c9915a0faf9c)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1ebaa334-2fe1-47a1-8d95-e9eaa2fe8728)(content(Whitespace\" \
+         \"))))(Tile((id \
          5ec8483d-47eb-41c7-ac3e-1ff9396a5037)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1a50cd90-a342-4cbf-ba8c-40611878bcf4)(content(Whitespace\" \
+         \"))))(Tile((id \
          a771a49b-989a-43dc-a961-de0ef9575e90)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          3dfe7330-2d7f-4a1a-bf24-29f1058fcdc2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b8a17889-e52f-4c86-893e-619970f5b07b)(content(Whitespace\" \
+         b4871e99-8b4d-4c73-ac01-2fcbbc322895)(content(Whitespace\" \
          \"))))(Tile((id \
          c934242f-844e-48b1-ac9d-e2a0fc6c2dc0)(label(\"`favorite \
          color`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
-         Typ))((shape Convex)(sort Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         442be989-95d7-4594-b69f-29148f05ec51)(content(Whitespace\" \
+         \"))))(Tile((id \
          30bc5bb3-a680-41dd-a8a4-57892e0e3f57)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a6e11b41-a47d-42a5-97ac-16765ce4386d)(content(Whitespace\" \
+         \"))))(Tile((id \
          2d3dd8bf-b117-477c-9522-c8aacfc603ed)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         1dcf879e-49d3-4853-8f8a-5ea3675440bb)(content(Whitespace\" \
+         9fb0f3c0-9386-4bc4-b958-a961df4b3515)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9a49579c-a5ef-4197-89b2-6d34664b232b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         db894371-feba-422c-ab14-5c1639b94064)(content(Whitespace\"\\n\"))))(Secondary((id \
+         3f6924c4-68d9-441a-9422-b00f1a484604)(content(Whitespace\"\\n\"))))(Secondary((id \
+         0356762a-9ece-4666-8714-6e70d7e796ed)(content(Whitespace\"\\n\"))))(Secondary((id \
          e2ccfc67-a6e8-455d-b43e-47cf4b44361f)(content(Comment\"# The missing \
          row is represented as a hole. #\"))))(Secondary((id \
-         d56393e3-f7f6-4e04-8566-8052df5ff576)(content(Whitespace\"\\n\"))))(Tile((id \
+         3c036745-c39d-4761-ac6f-2b378e949835)(content(Whitespace\"\\n\"))))(Tile((id \
          4528633d-1ab2-4336-8268-b201a4f6ee62)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8f14b10e-cad0-4a01-86cf-d34061a1713e)(content(Whitespace\" \
+         2420fc72-58f7-4d4f-85f8-114ba8cbda91)(content(Whitespace\" \
          \"))))(Tile((id \
          f9791055-0b78-47ab-a99c-0ecc46b188c0)(label(missingRow))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6afc4126-7718-4154-8d3f-b55214f2267b)(content(Whitespace\" \
+         70bb346c-583b-498b-8f6c-2f4782bfa87f)(content(Whitespace\" \
          \"))))(Tile((id \
          a84ab86f-d6da-4bcd-a7f7-384a2afcf3f9)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         04ec9221-7e0a-4817-8287-f21eee7914e9)(content(Whitespace\" \
+         afcaa6f6-5db1-4309-9e94-5634abb45ea5)(content(Whitespace\" \
          \"))))(Tile((id \
          c46f854a-ce07-4a6d-90c4-3f1f697f1bb2)(label(Schema))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))((Secondary((id \
-         96b60342-c6d4-4641-9561-dfe3967c9bb4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b4b14180-b65f-4e1e-98ff-36e89df735fd)(content(Whitespace\"\\n\"))))(Tile((id \
-         544539c9-8fd6-4dbb-a3f7-ec5bb39e0c51)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         35a25150-eb44-4812-b21c-293a3534ae27)(content(Whitespace\"\\n\"))))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8768f837-2a67-48de-93fd-3500379cdc2b)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         b3a656cd-0d5b-4dd4-98f8-35dee9e4f7ef)(content(Whitespace\" \
+         \"))))(Tile((id 544539c9-8fd6-4dbb-a3f7-ec5bb39e0c51)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          5ee653da-4258-4a72-9762-c737dcfd2438)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -213,7 +224,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          31d8937b-9ce2-470e-9b94-5707fe12eb18)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0f93c0db-94a6-42af-8534-90b8f4c95ddf)(content(Whitespace\"\\n\"))))(Tile((id \
+         67a58fb4-e931-481f-a0bf-7ebf7b3c9e22)(content(Whitespace\" \
+         \"))))(Tile((id \
          03b3ed72-b4a3-42cf-a756-809044a4919a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -239,43 +251,42 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6353563b-e182-4ea8-94ad-cfc0517435b3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         46143e40-76ef-4b93-9796-42cd6e84942e)(content(Whitespace\"\\n\"))))(Tile((id \
+         b4c091fb-6149-4589-b433-5d5513949587)(content(Whitespace\" \
+         \"))))(Tile((id \
          aaeb68a7-29e9-491a-8c8d-2c57d09d96b0)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         fb7d7f6c-f30a-4dea-9703-d7e244bf3423)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         48e675f1-b3b1-4b22-8bab-fc9aba1f4e6b)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         7c658aa5-ef63-4869-8073-5192c29042d5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b119722e-6cf8-4c53-88bc-0c0fb25a5c9d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b0afc0bf-d4ee-45f5-bfe8-58f406a6e381)(content(Whitespace\"\\n\"))))(Secondary((id \
+         46ac0eb5-7111-44b3-9dfc-24f7f2054aef)(content(Whitespace\"\\n\"))))(Secondary((id \
+         59b30234-0499-442d-9814-b92fd8ff61fd)(content(Whitespace\"\\n\"))))(Secondary((id \
          b559cac4-dcef-4371-ba34-edc93e2c9842)(content(Comment\"# The missing \
          cell is represented as a hole#\"))))(Secondary((id \
-         6a618487-ab0f-4d58-85a6-d82f8f797210)(content(Whitespace\"\\n\"))))(Tile((id \
+         6a0f8424-c16a-4956-93a8-5e772a515ad9)(content(Whitespace\"\\n\"))))(Tile((id \
          935c6af9-4f87-479e-a4ff-368fd080ce03)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3d19b5d3-b96c-4250-8146-133978c9b5bb)(content(Whitespace\" \
+         34a419c0-9646-43e3-b094-f46fc2d1c977)(content(Whitespace\" \
          \"))))(Tile((id \
          68811f10-02da-4949-a25c-1a140c1d8d66)(label(missingCell))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c7119099-ca78-4c67-a6cc-b91bf7f6b47b)(content(Whitespace\" \
+         335df51a-eb82-4cdf-9be0-d07d199a7b85)(content(Whitespace\" \
          \"))))(Tile((id \
          fa35f121-bc93-4151-9256-81ed2cc4db0c)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f778986e-b8d8-4bf9-914c-7afd14a4f83d)(content(Whitespace\" \
+         d380a8e1-b9ab-4f1c-982e-d07804542f53)(content(Whitespace\" \
          \"))))(Tile((id \
          cbbb580e-10de-4cea-ab11-b6e6eadd5695)(label(Schema))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         523e3dc8-ce0b-430e-b902-92d9f82a467a)(content(Whitespace\" \
+         0db9d14c-d297-458a-affc-23d0cef11c5c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8cdc0795-000e-4b9a-887a-e311ec35f0c8)(content(Whitespace\" \
+         fcec2bc1-d699-42e2-bab2-e98c575bfe33)(content(Whitespace\" \
          \"))))(Tile((id 4d83762a-d56a-4896-b6bd-533b3f1612fc)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         e50a7238-1bdb-44cc-aa58-328b31dc9b51)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          69863e7c-dc11-451a-91ef-e2857a24fa7e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -301,7 +312,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3ffdcbee-a06e-449e-a7ad-1c9031cc943a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         82001407-338d-4eb4-aaef-6e717a909a31)(content(Whitespace\"\\n\"))))(Tile((id \
+         ef02b1ae-ce0b-4e09-866b-539bed1dfb6b)(content(Whitespace\" \
+         \"))))(Tile((id \
          b5dcc381-7cae-48d3-b4ca-c99f6f64b2b5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -327,7 +339,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e5403711-8914-433d-9422-948c85ab0fd6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cf5c98f0-f1d2-47c6-a2f8-77a55642fbb0)(content(Whitespace\"\\n\"))))(Tile((id \
+         7e7c5cbe-11bb-496a-9d74-5f20888b7f48)(content(Whitespace\" \
+         \"))))(Tile((id \
          a03c4fee-622f-4147-830c-99c8affe2637)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -337,7 +350,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a6bb1ca6-7ad3-4894-b8c3-d90f780d0971)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4d054896-d4a3-4ce6-9a2c-73163a1a2369)(content(Whitespace\" \
+         ee7e457b-4b5e-4cf3-a7ee-39f51db9bc50)(content(Whitespace\" \
          \"))))(Tile((id \
          e9618caa-449a-47f3-ac58-df958a924007)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -345,46 +358,44 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3a4ddd88-2329-41ef-9bc1-899726f65e0a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         17ccae29-b3f9-4cb0-a9c8-6bdfd5bb2b3b)(content(Whitespace\" \
+         05889b7c-428e-49f1-a637-ab6813dd6e6f)(content(Whitespace\" \
          \"))))(Tile((id \
          ebdd0dc1-e308-43f5-bf26-bd983c8f8f83)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e1d7efd1-ea6a-4224-a33e-611af89cf4f0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         22c55fe9-328b-46c4-a40b-3949bc71f33b)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         cc4699fe-a416-4f9a-9d9f-b5530d6605f9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         21740d4d-52b5-4d6f-ac46-debfb7db53e4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         13979b96-c403-47ef-9d03-a69b2f21e084)(content(Whitespace\"\\n\"))))(Secondary((id \
+         0c8591df-103a-48f6-aa07-bf2fcd95275f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         73fc0bf2-457c-48ef-948b-b07895cd8e0c)(content(Whitespace\"\\n\"))))(Secondary((id \
          2189c0dd-0ec7-47f9-95d5-e881bdd24fd5)(content(Comment\"# The age/name \
          columns are swapped. The error is added to every relevant cell and \
          says which column it's for as well as the type error \
          #\"))))(Secondary((id \
-         150b87bf-b022-4eb5-a05c-b058e74436fc)(content(Whitespace\"\\n\"))))(Tile((id \
+         21c5d83c-ca28-4460-9b1d-21d431475d56)(content(Whitespace\"\\n\"))))(Tile((id \
          285db55c-fa96-4114-885d-1c54e7e8a9e7)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c4c00e43-83cb-47ee-9b32-f06f197bc97c)(content(Whitespace\" \
+         8479f588-9bd6-4b1f-87c8-8042a1528808)(content(Whitespace\" \
          \"))))(Tile((id \
          cd273f23-d33e-41c9-81f5-2810404068d4)(label(swappedColumns))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6f56d035-48a9-4e26-8b78-6ae28b88876c)(content(Whitespace\" \
+         eb1fdae5-2079-4b8c-86f7-2e5fe2b357b2)(content(Whitespace\" \
          \"))))(Tile((id \
          a65706cf-c4e4-4b44-8aa6-8837b917e2e1)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8ee7e1f3-28c0-44da-8b4b-217c8b1f7bc7)(content(Whitespace\" \
+         51119ef5-a8b6-4d20-87c3-740afedfd9ec)(content(Whitespace\" \
          \"))))(Tile((id \
          2872704c-c23b-4b88-b85f-be92f2973fa5)(label(Schema))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         835cfe79-11c3-4cc5-bbac-197658797a1c)(content(Whitespace\" \
+         70dd8d38-e871-41c8-a411-e575f30c7622)(content(Whitespace\" \
          \")))))((Secondary((id \
-         99ef8a1a-130e-4f2d-a85d-ada9188870b1)(content(Whitespace\" \
+         2882b8ae-893e-4f6d-8668-c3e51ead259a)(content(Whitespace\" \
          \"))))(Tile((id 3162d189-4b40-416a-9645-62785c18686c)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         40ba980f-02c9-4a1a-a6fa-ee0001708f66)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          c0bc7495-b4c4-484f-9670-7d7d92b7dc1d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -410,7 +421,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f37cdaeb-da3a-4c9d-b38c-794ab1b726bf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a598bcd0-adc0-46b0-bba7-bc5cdef153dd)(content(Whitespace\"\\n\"))))(Tile((id \
+         d85c5328-009f-441a-b59b-0cdaa9fd9289)(content(Whitespace\" \
+         \"))))(Tile((id \
          32beaf29-1815-47c7-b932-c35e32415b69)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -434,7 +446,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          829dab4a-5786-4d5a-b3c7-5cc93765f648)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         001e1bd8-9589-4ed3-a41a-12aff89ec9b7)(content(Whitespace\"\\n\"))))(Tile((id \
+         d37b5247-39e0-451b-b7d8-4b744d342e15)(content(Whitespace\" \
+         \"))))(Tile((id \
          73398360-e18c-479a-ac17-bd1ee664135e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -444,7 +457,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a752c3bb-49ea-44bf-aaf9-5800505bfc31)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fcb6b33e-f480-4727-9ada-37d904d883c0)(content(Whitespace\" \
+         ecde834b-ddb7-4e96-89e9-f64d1657774a)(content(Whitespace\" \
          \"))))(Tile((id \
          90c389f1-638f-41ab-a1b9-7bb6fd2b7ca2)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -452,35 +465,34 @@ let out : string * Haz3lcore.PersistentSegment.t =
          904b03bf-e91a-4305-b256-80a0e8050174)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1f9485bd-e9d4-498c-8645-3ffd63f20c04)(content(Whitespace\" \
+         2b5fa60c-5fea-457d-a384-9b993767bd96)(content(Whitespace\" \
          \"))))(Tile((id \
          19b9af6c-0e50-47f3-83c5-b2c04f55f33a)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b1c9e688-b071-4a62-ba61-852ebeebecd7)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         98ec65ad-f727-4a9d-818c-1e9aed27e5e8)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         d0719d74-9647-4b2f-b91c-40f6ce38000e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a4844663-d69e-4c66-8a71-684c7ec86678)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e978ff11-aa4f-4b64-b17b-fa6c07d30463)(content(Whitespace\"\\n\"))))(Secondary((id \
+         6db99c74-a55d-49a7-97c9-d3040962f7ed)(content(Whitespace\"\\n\"))))(Secondary((id \
+         237e7336-d2c6-48c6-9a4b-37ec4fde0109)(content(Whitespace\"\\n\"))))(Secondary((id \
          b282091c-ed03-4c28-aa69-c7c487637e72)(content(Comment\"# Error marks \
          are added onto the tuples.  The last row uses explicit labels which \
          makes the inconsistency easier to identify  by marking the unknown \
          label.#\"))))(Secondary((id \
-         730570b1-499e-4c9b-8f8e-d6796a460e25)(content(Whitespace\"\\n\"))))(Tile((id \
+         8dcc77ee-b048-49c7-a505-3a01c91363de)(content(Whitespace\"\\n\"))))(Tile((id \
          cb594ec0-f9e8-4b0e-9e0d-3d2d257afcf7)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8e358762-1781-4f83-8212-679e5a738351)(content(Whitespace\" \
+         d1f630d5-71de-4884-aa5a-c2f3fb432042)(content(Whitespace\" \
          \"))))(Tile((id \
          e564c893-8d46-4f67-9155-9c9c84a1e82b)(label(schemaTooShort))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         be8736fd-fcfa-4ce2-9254-6df3a9a2bfc6)(content(Whitespace\" \
+         5973007b-4b93-4ede-85a7-869976003a68)(content(Whitespace\" \
          \"))))(Tile((id \
          1a96ba6e-ca71-4169-bb94-ebc4789e7a1c)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b8ec6311-63f1-4c44-b354-d1c34209fddf)(content(Whitespace\" \
+         2e75b0dc-bda2-448c-8583-f33c846715de)(content(Whitespace\" \
          \"))))(Tile((id 80698932-da60-4450-a8ed-1c97a63a6511)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -489,34 +501,42 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          5eaa0f06-2ab4-4481-a9e4-289f3da151d9)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c2b6777d-c3a8-4b3a-a1d4-ab99b6c5d462)(content(Whitespace\" \
+         \"))))(Tile((id \
          3b03e484-f6fd-4e17-9967-90a37925be45)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1ede3cde-54c0-40fb-98b2-adb13c4ac45c)(content(Whitespace\" \
+         \"))))(Tile((id \
          be0acf65-5c43-40f9-a340-ba1271b16fc4)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          8041ade2-9c5e-485a-a952-e4fd17336c39)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         cd4c8291-52d3-4c8e-853c-08cb4309b1e7)(content(Whitespace\" \
+         7b36af92-d9fe-4431-bcdf-ebfc930cfc3c)(content(Whitespace\" \
          \"))))(Tile((id \
          37f8f48c-9d9d-4a15-b70e-66c97725e698)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         136fbdf0-0209-488d-8c9f-9249693b5bd7)(content(Whitespace\" \
+         \"))))(Tile((id \
          bfadb2cb-d56f-4eb4-b5f9-786804902d35)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a5988779-d49c-41c7-b24c-a624b858853d)(content(Whitespace\" \
+         \"))))(Tile((id \
          532f9f08-9691-46c4-9ff4-fdeead23c98e)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b53848b1-2393-445e-b0d3-dbd0edea29cb)(content(Whitespace\" \
+         9fe77209-8109-4180-84e4-46a85f2d0305)(content(Whitespace\" \
          \")))))((Secondary((id \
-         444fd956-c05b-460a-b25f-14b69069c68a)(content(Whitespace\" \
+         c69e81f0-bdd6-4450-b390-fa9facb3ddbe)(content(Whitespace\" \
          \"))))(Tile((id e548f97a-ae34-4018-93ce-1adbebbdfe9c)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         0df4c088-8b84-4c78-9a27-c1a2e7089e45)(content(Whitespace\"\\n\"))))(Tile((id \
+         a6190fc4-5b30-4e7f-82ee-8a41962640d8)(content(Whitespace\"\\n\"))))(Tile((id \
          2d5efba3-5fb2-4364-beca-5e4bf916e638)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -542,7 +562,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4b78947e-3faf-4c73-9d52-6305b77551ff)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         845eec72-15b4-45d8-81bd-1150ae2c9456)(content(Whitespace\"\\n\"))))(Tile((id \
+         f3caa589-ce56-4869-9aa5-e5a79066cfbf)(content(Whitespace\"\\n\"))))(Tile((id \
          4f90abd1-f522-4eef-bce1-1e4e93df268d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -568,71 +588,84 @@ let out : string * Haz3lcore.PersistentSegment.t =
          168b6999-5d7e-401d-aae7-6c582b2dcc02)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6bcf4419-2634-4d50-925f-88675d33ad17)(content(Whitespace\"\\n\"))))(Tile((id \
+         8884309e-cdbd-4d98-ab6a-d1760900acc6)(content(Whitespace\"\\n\"))))(Tile((id \
          617d9f92-45dd-4864-a15a-53bfa50fd1b4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          f6101090-a1bf-45b6-8af8-ae869f82a808)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a4a1f07f-818d-47eb-bcd7-3807a9735dc0)(content(Whitespace\" \
+         \"))))(Tile((id \
          8ab516cb-3591-499f-9a5c-e38e4bd57748)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6c3d2242-3a49-41aa-a60e-e93fa6afaffb)(content(Whitespace\" \
+         \"))))(Tile((id \
          374914eb-7170-47ca-a821-2818b4f6c2d0)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          cb214c84-adf8-4b3c-b46f-8ea99064430d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69b7905c-6466-4ef7-b1b5-09eef3d9b785)(content(Whitespace\" \
+         721a154b-c4f7-4fda-adfb-eed25104fbff)(content(Whitespace\" \
          \"))))(Tile((id \
          958df835-c775-4d6f-bf77-a3d74574ec5c)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2d921c26-a1c1-4456-96ed-6b850a680435)(content(Whitespace\" \
+         \"))))(Tile((id \
          09a5c978-5341-49d2-9923-eee7dacd2f46)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cb778e87-58c4-4a00-8c52-e57568b07e3b)(content(Whitespace\" \
+         \"))))(Tile((id \
          60243bf6-b998-484c-ace9-41b987e2ba1f)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          00b2d51f-b909-4535-90cc-2c892d8fa68e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a116bb45-781f-4d3f-978f-9bddfd4ba864)(content(Whitespace\" \
+         7be655d6-2938-425a-8e9a-9321b7b83299)(content(Whitespace\" \
          \"))))(Tile((id \
          24cd49ea-c3b9-4665-9aa2-a60332cfa3bc)(label(\"`favorite \
          color`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         92a191d6-6d36-4179-98cc-250a34b5e709)(content(Whitespace\" \
+         \"))))(Tile((id \
          6899ecef-a535-483a-a4ab-5873ec082b7c)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         db0b3a75-42d4-453d-878f-d0c1986d6357)(content(Whitespace\" \
+         \"))))(Tile((id \
          9e914866-7312-4c07-9605-c6f336747ae9)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1659a893-ad75-4af9-bd02-368e28b7f43b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         cd4365d5-bfeb-4e64-ae93-24414d7f57bd)(content(Whitespace\" \
+         396509ca-47f5-44f9-b9c3-b42c3980eb22)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         9308aec6-5626-4482-b066-5941fdc6d5a9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cb564f75-e66e-4184-9b9e-c21de9344c68)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8e86f1d2-3e2e-445e-b5bf-6460a3daaaa4)(content(Whitespace\"\\n\"))))(Secondary((id \
+         4e46d636-9447-4e90-8862-833d6817cec8)(content(Whitespace\"\\n\"))))(Secondary((id \
+         2ec567a4-9173-4cc9-84ad-f60243418235)(content(Whitespace\"\\n\"))))(Secondary((id \
          5454d4b2-6780-42ce-8063-67c46eee6331)(content(Comment\"# Error marks \
          are added onto the tuples showing the inconsistency. The last row \
          uses explicit labels which makes the inconsistency easier to identity \
          #\"))))(Secondary((id \
-         34894a20-2d82-4770-8bd2-c68f36b2f3e2)(content(Whitespace\"\\n\"))))(Tile((id \
+         ac04e346-a4cc-48a9-9c9d-7ad5d369024a)(content(Whitespace\"\\n\"))))(Tile((id \
          7e4c479d-ea42-413c-b195-706959bba92d)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         21b0b9cb-0606-4c6d-a1bd-650123f01663)(content(Whitespace\" \
+         c01f38b7-4e1d-45d8-bd44-ec50b944eae9)(content(Whitespace\" \
          \"))))(Tile((id \
          27bbc3f5-d537-441c-be51-a4ee8c2a7e96)(label(schemaTooLong))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         405968df-7171-4d0b-8e98-817dc6d5598d)(content(Whitespace\" \
+         18160af7-a134-41ec-8d90-206173168b29)(content(Whitespace\" \
          \"))))(Tile((id \
          0a05ef74-e6e3-4ce5-9029-3e044ec64849)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         083b219e-333a-45d8-a823-e8d3530c6ce0)(content(Whitespace\" \
+         4fb9ceef-3206-48ad-b8e4-87e99dbfe629)(content(Whitespace\" \
          \"))))(Tile((id 616df163-e4c0-42eb-aeb0-46e5d8fafe0b)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -641,62 +674,80 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          67ee8524-482e-4dc0-a42a-ba0623bd2e5a)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6f500642-228e-43ac-9f68-c7991cf200c1)(content(Whitespace\" \
+         \"))))(Tile((id \
          e7db867d-8477-4e57-9929-97c83a7dea98)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         47623fbb-b110-4d4f-9d90-8da4c432513d)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb992e48-169f-4dd0-b13a-0e8edd4e81fe)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ef17d584-1fcf-491a-b4d4-6cf445f53f06)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c1508721-b7ea-4f6b-859a-bb24b99311aa)(content(Whitespace\" \
+         16c7e211-f1de-4206-aca2-28701c3b342f)(content(Whitespace\" \
          \"))))(Tile((id \
          9faae6b0-0da8-487f-8ccb-13a5f67c4252)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d35d88c0-e721-4f1d-a5b2-bb0c21603c56)(content(Whitespace\" \
+         \"))))(Tile((id \
          d38608fb-519d-4e1e-8697-f8a100f0d71f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         60ab7493-fc1b-481b-9165-a9a6c67cd3fe)(content(Whitespace\" \
+         \"))))(Tile((id \
          e7320fbf-c17b-494b-b9a2-c23ba7be74b9)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          3960c1bb-38a3-4806-ad53-2fdecf808625)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b38d9860-c1b4-4307-8bff-55d183d5248e)(content(Whitespace\" \
+         067f828f-2535-47ae-a971-726647ab5a14)(content(Whitespace\" \
          \"))))(Tile((id \
          6b5afd60-f6b0-4bb9-9f35-5a06469ff434)(label(\"`favorite \
          number`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
-         Typ))((shape Convex)(sort Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         23c0968a-7655-4be9-955a-1666f5cd757c)(content(Whitespace\" \
+         \"))))(Tile((id \
          55a6d54f-605f-4f4e-9930-61eb7d1b306c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b8ad9f18-26b6-4ccb-8a7d-037045f72efc)(content(Whitespace\" \
+         \"))))(Tile((id \
          312a6cad-918d-4b68-a012-183dbde505dc)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          75eec5aa-6c43-4ad3-bcf5-29186d9ad490)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2d66da6f-747b-4501-8d32-3c0318128406)(content(Whitespace\" \
+         067574fe-e7d0-4e0d-b12b-cff5e7f6339f)(content(Whitespace\" \
          \"))))(Tile((id \
          ba5ab7e8-2088-4334-a708-20e157a011e1)(label(\"`favorite \
          color`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
-         Typ))((shape Convex)(sort Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1795511a-192d-4f94-adc9-2f67a02d3073)(content(Whitespace\" \
+         \"))))(Tile((id \
          9a218d20-b0ec-4ef6-ba4a-03a0059b2300)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5191afa2-1c45-45c4-bc8f-bdbbaaa14287)(content(Whitespace\" \
+         \"))))(Tile((id \
          58f1ef5d-fd90-4a2e-8f03-e5ad4eef7dee)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         c6ab548e-6210-44d8-992f-76d1fbb4cd98)(content(Whitespace\" \
+         02762816-81b1-46a0-bbfd-4ec6ccbfe242)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7a4a29e5-0a09-42f3-b521-f51c2347414f)(content(Whitespace\" \
+         c9102e13-5c31-46ec-8d6e-f3e3c1a8413d)(content(Whitespace\" \
          \"))))(Tile((id bf9a839b-ced6-4de9-90a8-aa2598e0d20e)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a126f9e9-e043-4ea9-b320-d74cf49f67b1)(content(Whitespace\"\\n\"))))(Tile((id \
+         8a0c4777-05ec-4018-90d2-ba6e08be8b6f)(content(Whitespace\"\\n\"))))(Tile((id \
          cc81b921-2b75-41d1-966e-990398fb77cf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -722,7 +773,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1dc0b2b2-81e2-4daf-a87d-1b262e8cb1dc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6b0248b0-60df-4828-ab4f-d763e3d6337e)(content(Whitespace\"\\n\"))))(Tile((id \
+         808ed954-e098-4846-addb-b9da31517aae)(content(Whitespace\"\\n\"))))(Tile((id \
          39862b80-5c59-47fa-b144-cbb6078485e9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -748,100 +799,102 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b26a7ff1-d10d-45a5-91db-204c299bb22e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bac5f0f9-125e-4057-8f6f-fc9e59629387)(content(Whitespace\"\\n\"))))(Tile((id \
+         912d1db9-b3a1-4c62-b37d-bfbb5d32a737)(content(Whitespace\"\\n\"))))(Tile((id \
          c20965e3-5e42-4589-be03-866a707b71be)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          91c6e8ae-303a-446d-98a7-60eeb537ce56)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         5527405c-c4e1-43bd-b74f-1a169bd87c0c)(content(Whitespace\" \
+         \"))))(Tile((id \
          6ddedd80-9437-43df-9667-e0c6131cbab3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fb95a29c-df88-4f79-a790-366282ae1837)(content(Whitespace\" \
+         \"))))(Tile((id \
          8175d434-01d0-4053-bf64-bcc2dba83915)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          37b735df-3199-443e-bde0-03636e25c9b3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9a5afef1-ff5c-48e2-aa08-a5991bcded44)(content(Whitespace\" \
+         af4a4b7c-1d8f-45ed-a94a-595df980ea24)(content(Whitespace\" \
          \"))))(Tile((id \
          30dfb4b3-627b-4277-9515-d2c79898140c)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6671ea71-fd22-4be1-bb0a-bcdc6c5fa1d8)(content(Whitespace\" \
+         \"))))(Tile((id \
          539c2b89-319d-42e9-b4d5-a03b4ae5f20d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         19859679-6639-4fd1-9674-d1e8a7bb8aee)(content(Whitespace\" \
+         \"))))(Tile((id \
          fcebd70e-4f68-497c-9526-7040ab431382)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          9907dd89-ee24-4a73-84cf-94fa81f1ce2a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e6b1e8aa-2e8d-455c-8265-293fce086b7c)(content(Whitespace\" \
+         4d00c07d-d085-422d-bbf1-12816fd86c61)(content(Whitespace\" \
          \"))))(Tile((id \
          5b75ee4e-3ead-4e41-9366-787dc9ea8f47)(label(\"`favorite \
          color`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d30f6fa9-e4ed-415d-b6a4-9c70ccb405f0)(content(Whitespace\" \
+         \"))))(Tile((id \
          18765920-cfa7-4437-bf7d-11429c1f565a)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d79e73fe-49e9-4348-84cd-f1815ee758b6)(content(Whitespace\" \
+         \"))))(Tile((id \
          f8f3983b-ab59-4bb6-ab33-eff5b38898d9)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         024bf9e7-5fb4-4f72-b57e-478ccd6636b9)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a21ab3ec-0b79-40bb-a609-b0a0c59f21fa)(content(Whitespace\" \
+         89a17b67-5b97-4e20-90f8-2d42c69a7662)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         6ef0819f-a66e-42a1-afe8-dbe7f5c350a7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         42800e43-c7f8-4706-a60c-c17f4429cb6c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ce51e7a3-2e48-4656-90fd-d616b437c6e6)(content(Whitespace\"\\n\"))))(Tile((id \
          d40e69f5-2ce2-4482-b274-8053817635f9)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))";
       backup_text =
         "# No type correlates to missing schema. There is no error as it's \
          valid data without labels#\n\
-         let missingSchema = [\n\
-         (\"Bob\", 12, \"blue\"),\n\
-         (\"Alice\", 17, \"green\"),\n\
-         (\"Eve\", 13, \"red\")\n\
-         ] in\n\n\
-         type Schema = [(name=String, age=Int, `favorite color`=String)] in\n\n\
+         let missingSchema = [(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")] in\n\n\
+         type Schema = [(name = String, age = Int, `favorite color` = String)] \
+         in\n\n\
          # The missing row is represented as a hole. #\n\
-         let missingRow : Schema= \n\
-         [\n\
-         (\"Bob\", 12, \"blue\"),\n\
-         (\"Alice\", 17, \"green\"),\n\
-         ?\n\
-         ] in\n\n\
+         let missingRow : Schema = [(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), ?] in\n\n\
          # The missing cell is represented as a hole#\n\
-         let missingCell : Schema = [\n\
-         (\"Bob\", 12, ?),\n\
-         (\"Alice\", 17, \"green\"),\n\
-         (\"Eve\", 13, \"red\")\n\
-         ] in\n\n\
+         let missingCell : Schema = [(\"Bob\", 12, ?), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")] in\n\n\
          # The age/name columns are swapped. The error is added to every \
          relevant cell and says which column it's for as well as the type \
          error #\n\
-         let swappedColumns : Schema = [\n\
-         (12, \"Bob\", \"blue\"),\n\
-         (17, \"Alice\",\"green\"),\n\
-         (13, \"Eve\", \"red\")\n\
-         ] in\n\n\
+         let swappedColumns : Schema = [(12, \"Bob\", \"blue\"), (17, \
+         \"Alice\",\"green\"), (13, \"Eve\", \"red\")] in\n\n\
          # Error marks are added onto the tuples.  The last row uses explicit \
          labels which makes the inconsistency easier to identify  by marking \
          the unknown label.#\n\
-         let schemaTooShort : [(name=String, age=Int)] = [\n\
+         let schemaTooShort : [(name = String, age = Int)] = [\n\
          (\"Bob\", 12, \"blue\"),\n\
          (\"Alice\", 17, \"green\"),\n\
-         (name=\"Eve\", age=13, `favorite color`=\"red\")\n\
+         (name = \"Eve\", age = 13, `favorite color` = \"red\")\n\
          ] in\n\n\
          # Error marks are added onto the tuples showing the inconsistency. \
          The last row uses explicit labels which makes the inconsistency \
          easier to identity #\n\
-         let schemaTooLong : [(name=String, age=Int, `favorite number`=Int, \
-         `favorite color`=String)] = [\n\
+         let schemaTooLong : [(name = String, age = Int, `favorite number` = \
+         Int, `favorite color` = String)] = [\n\
          (\"Bob\", 12, \"blue\"),\n\
          (\"Alice\", 17, \"green\"),\n\
-         (name=\"Eve\", age=13, `favorite color`=\"red\")\n\
-         ] in ?";
+         (name = \"Eve\", age = 13, `favorite color` = \"red\")\n\
+         ] in\n\
+         ?";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/errors/B2T2ErrorsUsingTablesPart1.ml
+++ b/src/b2t2/slides/errors/B2T2ErrorsUsingTablesPart1.ml
@@ -1,57 +1,56 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Errors / Using Tables / Part 1",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id 62113b4c-0c40-4a45-b224-1dc986d93454)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         8e57d637-7299-4cec-beb5-950b90bbd48e)(content(Whitespace\" \
+         7bb4da35-228d-44d5-87f9-55c10fd0d119)(content(Whitespace\" \
          \"))))(Tile((id \
          468e58a9-356a-4e8d-aa92-c740a314cbb5)(label(Image))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         96c1dde1-c139-4dd2-8b4b-48cb9a85f3d6)(content(Whitespace\" \
+         135ed46b-ad9c-4f66-b34b-839a9bbd07b2)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3c593e37-f9ee-49af-8f97-3b6369d0e137)(content(Whitespace\" \
+         de7a04bf-67cb-4424-b198-24490a742225)(content(Whitespace\" \
          \"))))(Tile((id \
          63b9b5f9-e044-4bd0-811e-f4c10af444bc)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         ccb3adb9-7819-4477-addf-e29d085772f2)(content(Whitespace\" \
+         31b5c194-bac9-42bb-b452-ccc9c97e5774)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         bccd0e33-d64c-4af4-bcc6-311c850375d3)(content(Whitespace\"\\n\"))))(Secondary((id \
+         7a4d8475-92f1-41d9-b326-1b01fbbe0ce4)(content(Whitespace\"\\n\"))))(Secondary((id \
          32ebc6a0-4a3a-47f0-b894-dfed9bbf6702)(content(Comment\"# Representing \
          column names as projection functions for better error localization \
          since we don't do first-class labels #\"))))(Secondary((id \
-         7a35598d-68fc-4a1e-add3-80cb01f86922)(content(Whitespace\"\\n\"))))(Tile((id \
+         c141f167-8539-4c68-a57b-d6aadae388c3)(content(Whitespace\"\\n\"))))(Tile((id \
          35c30e13-a200-42f8-b8c9-0b7883dfee7c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e361f8be-c461-440e-b5ca-b2de860b7cfa)(content(Whitespace\" \
+         ac6c3777-1d2e-4954-ab13-748e13cf538c)(content(Whitespace\" \
          \"))))(Tile((id \
          0d836609-14db-415f-bb9b-ac31cf845b80)(label(scatter_plot))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7a80e690-ab08-4b4a-b5c5-0cfde2b1166d)(content(Whitespace\" \
+         cf26e9e7-af48-4917-af10-72220eac0dbd)(content(Whitespace\" \
          \"))))(Tile((id \
          3e9af85b-83b3-4fa7-916c-03eddf766274)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         879817d6-a285-4107-abd2-94504bbba38e)(content(Whitespace\" \
+         b2a1a99b-4cc3-46a3-8944-31e82b7820d6)(content(Whitespace\" \
          \"))))(Tile((id 49546b40-32af-493d-a6f5-217c84dcaeaf)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         e74722c8-287f-4438-86d9-26f995fd4216)(content(Whitespace\" \
+         7379cedf-2dce-462f-b575-ed8c6f30efbe)(content(Whitespace\" \
          \"))))(Tile((id \
          a876ae22-acfe-460c-8c80-844cf0c46980)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         d8da3ddc-d112-4640-a4df-15daa5be25a9)(content(Whitespace\" \
+         cacc90e9-d7d9-4266-be1e-73f971114cd8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2ddc4a71-5069-4e1e-acbc-379f866b7f0a)(content(Whitespace\" \
+         e48695b9-9fbe-4373-818e-cfaed45b5f95)(content(Whitespace\" \
          \"))))(Tile((id \
          a59f2f90-4d1f-4ec6-a7ba-b3640a5f7c69)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -65,17 +64,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7637a5d9-f953-4bc0-ad07-f4793146681a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7d3271fe-c58d-488a-9977-3707a9558c34)(content(Whitespace\" \
+         4898a9f5-d287-4d85-97dc-d587cff32ed5)(content(Whitespace\" \
          \"))))(Tile((id \
          0ef1008c-be01-4cf5-aeff-50949767c14a)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         ef78bc66-5301-4e38-924c-39ad1e90492e)(content(Whitespace\" \
+         209bc2e2-c881-4b05-bae1-2288908af941)(content(Whitespace\" \
          \"))))(Tile((id \
          ef9ce60a-6929-4c75-a833-4b7eeb1f98eb)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9aae21b0-4b71-4af1-ba65-c766c6a12948)(content(Whitespace\" \
+         67b47185-283b-40c9-a32b-51e078a8e466)(content(Whitespace\" \
          \"))))(Tile((id \
          6d7e1c7e-d626-4e38-b0ea-c98a8e4bfc70)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -83,70 +82,70 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dc9cd30b-da1b-4d6b-a4cf-f7903707f124)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         94633c92-6161-4cb2-b17c-c0e3c6252ea0)(content(Whitespace\" \
+         55cffdca-e581-4a57-bde6-8e7d5017309f)(content(Whitespace\" \
          \"))))(Tile((id \
          96f8c17a-84c6-4bb9-a23f-192b0c87c58f)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         17fdbac2-0418-40bf-b7f2-84eea4ef9658)(content(Whitespace\" \
+         30aa3bc0-ccaf-4a50-8e5c-8aee7f8ccb87)(content(Whitespace\" \
          \"))))(Tile((id \
          846f302a-8c3e-4a28-90bd-e17f192ff646)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         81f5f171-8410-4d53-9c7f-72dd4109624c)(content(Whitespace\" \
+         a310dc85-4d77-4d19-921b-8841ee639fba)(content(Whitespace\" \
          \"))))(Tile((id \
          a481a245-803f-49d8-bffd-5fd15ff4b848)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         fc015d71-6c78-4506-83ab-93e1ab7c6dc6)(content(Whitespace\" \
+         26a92ba8-a3c7-41a3-8484-6c41718fdb2e)(content(Whitespace\" \
          \"))))(Tile((id \
          2749ddbb-0606-4840-9ef7-75e471d69685)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7973a17a-854d-466c-b51d-6e60e82aca62)(content(Whitespace\" \
+         820cebbd-f18b-4cbe-9a13-9f8bdccddf2f)(content(Whitespace\" \
          \"))))(Tile((id \
          03ea2d63-4124-476f-986e-74cf5f0d0939)(label(Image))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         9836b14d-2395-4691-82c3-1f20e468b15b)(content(Whitespace\" \
+         ec0f2877-5282-432b-b2f8-318103f0049e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         017eee81-290f-40f3-a368-a6e5317e8662)(content(Whitespace\" \
+         b4303a69-76da-4a5c-9acb-bd407536a153)(content(Whitespace\" \
          \"))))(Tile((id \
          5f457878-dc57-4e54-b413-89d2de86ab21)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         a74d21c1-231f-4484-8744-339692d85a5a)(content(Whitespace\" \
+         6162fa51-ab2e-47ba-ad76-640ba59f3514)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cd9d0efe-2752-4236-a746-6d30505aa80f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         98bd3da4-f40b-4dda-a71f-e476c9409700)(content(Whitespace\"\\n\"))))(Secondary((id \
          de738e92-a400-445b-9d5d-7f028814aaec)(content(Comment\"# Using ? for \
          the categorical variables #\"))))(Secondary((id \
-         dad18d10-1b2e-4091-b6c9-3ce4f7642fd8)(content(Whitespace\"\\n\"))))(Tile((id \
+         8d37a592-bd1e-4807-8922-e5ac4157dd7f)(content(Whitespace\"\\n\"))))(Tile((id \
          bd406c09-1ab9-48f5-8d62-ba7254e12fb9)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         6396d02a-6c1e-4cd8-8297-56c9bf4a6f19)(content(Whitespace\" \
+         38422e41-2fbd-41ec-adc8-e18365b9ace6)(content(Whitespace\" \
          \"))))(Tile((id \
          32b8796a-19fd-4c9f-af84-17086fd4887e)(label(pie_chart))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         62eb75a6-4c4b-45a8-aa15-a1da1299617c)(content(Whitespace\" \
+         23fdd627-3e57-4a50-afc4-6b19443b7a43)(content(Whitespace\" \
          \"))))(Tile((id \
          af1b5649-2df2-4727-ac4c-ee225212d638)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0b493024-0cc3-413b-a09e-c481b253e17a)(content(Whitespace\" \
+         f123c990-276f-4b4e-b6c7-bc0cd13fe2a7)(content(Whitespace\" \
          \"))))(Tile((id 76c3602f-8384-4f85-a0c3-0c1197cf9e69)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         f4f47306-5297-416d-896c-2df0ad8db597)(content(Whitespace\" \
+         59c19c18-6057-4537-94d1-8a0eeacf6f84)(content(Whitespace\" \
          \"))))(Tile((id \
          47632f92-f1c4-47e5-bee0-5a9a43d287c9)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         4a32b53f-7f4b-4f81-a178-29f76c4c452f)(content(Whitespace\" \
+         d38f8bb2-287f-482a-8343-c5110b5b7957)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c2cea122-ac0b-4eef-8a9a-ac54ab2640d6)(content(Whitespace\" \
+         c3694d1c-e33b-4643-8405-eb88fbd7dbd4)(content(Whitespace\" \
          \"))))(Tile((id \
          e7327d17-b82a-45ee-bed9-276234843f5c)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -160,17 +159,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5c851849-d79a-48fc-bdd2-bffae94446f6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         47d16217-d469-4a04-b57b-7d20d5c47249)(content(Whitespace\" \
+         5ca2eb82-cff8-4b38-ad48-55a537fdac95)(content(Whitespace\" \
          \"))))(Tile((id \
          cca50cbf-fb8b-4850-bbd9-423af666fd5f)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         78e46ab0-8f58-479a-b08f-84a3e0fe7562)(content(Whitespace\" \
+         0fd3603b-5852-4915-a9d7-8b61a59612ff)(content(Whitespace\" \
          \"))))(Tile((id \
          ecdb55f8-a023-4cf2-a857-7b5675c74a05)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d1befa51-d487-4c37-b0ec-4e837ef3c501)(content(Whitespace\" \
+         b6dab499-7576-47db-87c8-fd5539f65dc0)(content(Whitespace\" \
          \"))))(Tile((id \
          1fe35fd6-04b5-408f-a033-5c9a3058cc50)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -178,201 +177,233 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d6485a41-0b9b-4cfb-a8a4-8962b15caa68)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4382089f-0595-4331-a390-aa546a6255ba)(content(Whitespace\" \
+         c4ee27d4-7ed0-42bc-8302-48c3c5d4b675)(content(Whitespace\" \
          \"))))(Tile((id \
          9289dab4-ca9d-4bf5-a212-35b848a28649)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         32877ebc-2092-468e-a920-4051d3e2fb06)(content(Whitespace\" \
+         b0460740-8f94-4b61-8573-25ff1fe97abf)(content(Whitespace\" \
          \"))))(Tile((id \
          cbbf2562-e9a9-4880-b473-a06bcde6df2e)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2558651f-b4f6-4b47-a092-4be3b4175f93)(content(Whitespace\" \
+         0dca4f85-36db-4ca9-9a53-2b40bae6dfe8)(content(Whitespace\" \
          \"))))(Tile((id \
          9e25f17a-4ae4-46b4-a06f-1a2b4b9b40cc)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f3ff408b-97db-4521-ac49-3fb062cc1d71)(content(Whitespace\" \
+         9960d33d-efca-4112-81a7-377fc81cc251)(content(Whitespace\" \
          \"))))(Tile((id \
          214084e3-7394-4dc7-966c-6819e1c0a6ce)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         40c8e216-0ad1-475a-a6ed-deeb0084f3a9)(content(Whitespace\" \
+         d7496231-249d-4ac9-ad68-b42a13d1ba7e)(content(Whitespace\" \
          \"))))(Tile((id \
          58dd6a10-ff45-4583-b1b1-8911418a2971)(label(Image))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         810c3cd2-ac4f-46be-a378-b47041401b06)(content(Whitespace\" \
+         bdf40acb-ec2f-4335-896d-97a0d9d89a0b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d8865162-d9d3-426a-87c2-016b4b21ac8a)(content(Whitespace\" \
+         9ecf556d-f694-4172-8b6c-c090d8561a5e)(content(Whitespace\" \
          \"))))(Tile((id \
          372810f3-f53a-4f73-bac2-9edd25005c4a)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         17aa2f65-83a1-4668-9350-40da901e3b5a)(content(Whitespace\" \
+         c85f5cf8-c6c0-4ecc-8bfa-5585d734ea92)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6161e006-7bf4-4db5-a76a-445cc716e1c1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7533f4f8-50a4-4fb5-bc2d-46eebf314b84)(content(Whitespace\"\\n\"))))(Tile((id \
+         8800ea2b-c439-47c9-a1a6-2fd0759767f9)(content(Whitespace\"\\n\"))))(Secondary((id \
+         1da3ccdb-cc2e-4ed6-a7be-b3ce4ea7f13d)(content(Whitespace\"\\n\"))))(Tile((id \
          c1fec18c-7f10-4363-9c46-9c0b3531133d)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         506054d2-bcbf-4836-a9c5-8a0f99519f2f)(content(Whitespace\" \
+         21d4aca0-6fb2-42e1-bdc4-53f1686f275f)(content(Whitespace\" \
          \"))))(Tile((id \
          9058d182-58ae-4f0f-ae81-af62965e6820)(label(mid_final))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2cf1430b-bf1f-4f60-aa1a-2263f0748b52)(content(Whitespace\" \
+         fb84595d-e8ad-4fac-b902-5a981c56cf75)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b3d73127-4501-486b-9f2c-cd4c2c53881b)(content(Whitespace\"\\n\"))))(Tile((id \
+         e43b5996-e004-4a50-9964-3d41fb17a273)(content(Whitespace\"\\n\"))))(Tile((id \
          45ac5dda-8b8c-4d3d-ae2c-af3d7e51adf4)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         33e69db6-21a8-4f3b-9c9e-e3c8d89e5fa1)(content(Whitespace\" \
+         911ac77d-de60-496b-9b6c-d9f2bcb77a66)(content(Whitespace\" \
          \"))))(Tile((id \
          d6cbbc1d-5151-4a1b-a6d5-dca0d32e54bd)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         34079128-d648-44fa-8322-c59f1af3e4b7)(content(Whitespace\" \
+         43fbb1e8-bbac-46c2-81b9-e8ae2b732615)(content(Whitespace\" \
          \")))))((Secondary((id \
-         08f18e82-bcfc-4673-9ff2-c1e0dfa422ac)(content(Whitespace\" \
+         64acda7c-64c3-4d41-a05a-b0f0ea552020)(content(Whitespace\" \
          \"))))(Tile((id \
          c55ab0ee-193c-48e3-9e60-a20ceefdf7cc)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          e2a9875a-58c5-4db6-94b2-345543312542)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6354afbf-6836-46f0-ae26-0f864da1ce1b)(content(Whitespace\" \
+         \"))))(Tile((id \
          feda7188-602e-4bab-bf16-1068f6b73bb3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f22ddc36-c15e-4070-9688-340acbc12431)(content(Whitespace\" \
+         \"))))(Tile((id \
          83db7d88-b086-4c75-8a51-6c39d450c9c0)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9b40dfdd-869a-4da2-b404-e89d3d280f33)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b35cb16c-1d85-4b97-8d36-1180446f2806)(content(Whitespace\" \
+         d4341eab-b2ed-497a-a33f-8e58c130289a)(content(Whitespace\" \
          \"))))(Tile((id \
          0031e2c4-3171-40c9-8dc7-3de06cd775e2)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cec2c0f1-3a14-4a5e-95c5-b46d0ffe53c1)(content(Whitespace\" \
+         \"))))(Tile((id \
          92ba9f40-1b9c-4981-91b9-ac035ddd4ec1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4f7ded59-1538-40df-a7df-79e3e02d610f)(content(Whitespace\" \
+         \"))))(Tile((id \
          636ee08d-9601-4afc-87b7-e15917b89a07)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          78fdeff6-2c72-4a2a-a666-6f04939aab98)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b37a9bc4-2b79-40cc-b322-3f5a0a82d7a0)(content(Whitespace\" \
+         dba5a9b9-eff6-4ac9-8f23-b7660438c458)(content(Whitespace\" \
          \"))))(Tile((id \
          7e4a0222-0076-4795-82c6-cfa0c39016e6)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dba04494-689d-46a5-90b7-1e102670e531)(content(Whitespace\" \
+         \"))))(Tile((id \
          dc14bcf7-82e1-4b67-a6b3-94c10dab1201)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5f99d07f-a44a-4119-a2fd-293ed5769900)(content(Whitespace\" \
+         \"))))(Tile((id \
          1a48e1ae-3f9c-4056-ac2d-526cc0e8ef0d)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6f8f6343-6318-407e-8694-ceb27eb6ab25)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         63e45773-7075-4db5-ad60-7060eddc48d9)(content(Whitespace\" \
+         3110c5bb-e63a-482e-a786-0a48c6f3ee23)(content(Whitespace\" \
          \"))))(Tile((id \
          27483dc8-eaee-4fac-8360-5da67e9551c2)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         37338faf-fd93-4bf5-a4b5-a92f743964c4)(content(Whitespace\" \
+         \"))))(Tile((id \
          96e2c14e-a427-4d51-a41c-af269df4435d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ffb7a148-23e6-4ea8-a849-e32a9f9a451c)(content(Whitespace\" \
+         \"))))(Tile((id \
          0038f20e-323a-4781-9377-13369852cf32)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c5565668-0282-4efc-adc5-c2195adc113f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         afea77eb-8b2c-450b-933b-b6f6106179b6)(content(Whitespace\" \
+         64dcb316-fe7f-44cd-bb83-cf958faf4da0)(content(Whitespace\" \
          \"))))(Tile((id \
          3d113b3e-9180-4e8e-b1ae-1223de77dcab)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         743a2c65-efa9-4582-9139-26b146d5b3ed)(content(Whitespace\" \
+         \"))))(Tile((id \
          e6f8d049-7f12-4a02-ae96-8dc716fe215c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a74501aa-93cd-41d3-9267-38a809ebe72e)(content(Whitespace\" \
+         \"))))(Tile((id \
          5218c9bf-51c6-4269-bf91-31fbac413ef9)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          dece5faf-7d12-4397-b07b-4638fbccb87e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8f860424-cd27-4288-bbbb-3ae71dd4832e)(content(Whitespace\" \
+         c6256cba-37f7-425c-b548-00f6dcc40ca5)(content(Whitespace\" \
          \"))))(Tile((id \
          5e96eae3-5a92-430f-b5b4-7669fa56437a)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         57039ab8-bd90-470f-92b5-d8b66a980bc5)(content(Whitespace\" \
+         \"))))(Tile((id \
          adf02c1c-cf3e-4f78-bd2a-7adc37322b67)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9492e925-4e40-4f8c-85ae-ddc31e96379c)(content(Whitespace\" \
+         \"))))(Tile((id \
          e93cd3c6-bb90-4d87-8248-4c7393704bb2)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a68f2a6d-b2e2-40d3-9b39-d01cd9b6075a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d5d716df-9657-4b48-b42f-23525c6a0f7d)(content(Whitespace\" \
+         9436e622-cf0e-4d90-b2a4-4af12e9d96dc)(content(Whitespace\" \
          \"))))(Tile((id \
          31d0745a-093b-46f3-9352-d75c95d43b5b)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         10058793-b023-40bf-9962-1f0d3bc1287d)(content(Whitespace\" \
+         \"))))(Tile((id \
          dc255df8-3927-4c42-bc47-0532fd3c68f4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         52f2dd0f-0ec5-4cc1-9b67-e5099a11080a)(content(Whitespace\" \
+         \"))))(Tile((id \
          17d1e661-4cc5-481c-9197-6d69dd1160ea)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b865a028-8ec9-4354-87d4-79358b2af60e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         60819bdb-85c2-4bcd-ae33-ed2a42367751)(content(Whitespace\" \
+         df7b8c45-3365-4c62-b12e-430424fd5440)(content(Whitespace\" \
          \"))))(Tile((id \
          0d64b188-0717-4e7e-a487-7a486f11cb3c)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d25ab2ec-78de-423b-85a0-6e7fa10e2731)(content(Whitespace\" \
+         \"))))(Tile((id \
          c8d7b8a5-2ebb-4c6f-9bfe-4c94dafdfe71)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2b4df86e-9a64-4e8d-900f-a1e03c02fa6d)(content(Whitespace\" \
+         \"))))(Tile((id \
          d0c407e4-bb5c-4cd2-9282-0ad23da8ef8b)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         215b56cb-88ea-42d0-bbe4-707590b170b6)(content(Whitespace\" \
+         f05ed768-3a9d-4666-90e2-b225f01a33eb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6c8d757f-05bc-4c24-9619-eca2daa95e07)(content(Whitespace\"\\n\"))))(Tile((id \
+         baef3b38-1931-485c-a318-ea506ad4abd4)(content(Whitespace\"\\n\"))))(Tile((id \
          5aa357f1-444e-4d6d-9b32-347b53be86e7)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         7c9cbde6-270c-4aa1-a037-f82f004292d6)(content(Whitespace\" \
+         b79382c9-32d4-4d88-9128-ea93e2848a75)(content(Whitespace\" \
          \"))))(Tile((id \
          1428bcc6-2184-44d7-a98d-9903c572112e)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         53669df0-fc9c-423b-9bc7-94bc3d6f0f46)(content(Whitespace\" \
+         bf0c8edc-eb71-43d6-a44f-13c2c2c1ddc9)(content(Whitespace\" \
          \"))))(Tile((id \
          eb456e75-6c21-48d2-8c00-a4bed655d915)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         134c6582-a45c-403e-b874-f7211dd60a82)(content(Whitespace\" \
+         1664e09e-8420-47f2-913b-db5dc9c6de2f)(content(Whitespace\" \
          \"))))(Tile((id 61e2cbe1-4c83-46a2-b052-8c78adeb00e3)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          ad4e9498-f922-4676-9f4a-ea84a6c4575f)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         46e94ea8-2856-412a-8c1a-43e7cc8e7940)(content(Whitespace\" \
+         1704db5e-ae8c-4d7c-9803-137a9985e084)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e35243fd-39c6-4282-8dde-390233702726)(content(Whitespace\" \
+         e7f6e497-c297-4b1c-aff0-cb8c543543c5)(content(Whitespace\" \
          \"))))(Projector((id f2d1598a-3fd8-401f-b1f9-b806ee16fb57)(kind \
          Fold)(syntax(Tile((id \
          48ed7354-09dd-43b5-97cf-3de3cbb3e103)(label(\"(\"\")\"))(mold((out \
@@ -586,24 +617,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          b50f34c3-c6d9-427f-8183-b948574204c9)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         0df6f473-8ca9-4001-a6f1-0283bd5907f7)(content(Whitespace\" \
+         64d98266-c78f-4055-887d-4e40041aba0f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ae90df30-64e8-466a-a6f1-ca041f9b3584)(content(Whitespace\"\\n\"))))(Secondary((id \
+         f20e43a7-2d88-435c-a654-bc2d26d7b7c4)(content(Whitespace\"\\n\"))))(Secondary((id \
          8e00bb2e-0515-42b8-b47a-f6f9e45ab3c1)(content(Comment\"# Currently \
          requires explicit type application. Error message is localized to \
          error and shows what possible labels are. #\"))))(Secondary((id \
-         0d244412-bf6e-45d1-854c-e2558555695c)(content(Whitespace\"\\n\"))))(Tile((id \
+         1843c1c0-f011-4c52-9c95-96b094b7907c)(content(Whitespace\"\\n\"))))(Tile((id \
          db3cfad5-4d3f-4164-b62e-25b760143c19)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         d3024faa-e26d-4a14-9de7-b699e04b2303)(content(Whitespace\" \
+         e26a2cf3-823b-4bc5-b7e7-a18abbaec895)(content(Whitespace\" \
          \"))))(Tile((id \
          5b3c3446-c20f-474d-948a-f2efadf6781a)(label(incorrect))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5eb62834-65c3-46cd-a35b-4cbd4797c51c)(content(Whitespace\" \
+         78b39e2d-d438-4616-b9d3-74a52b7660f0)(content(Whitespace\" \
          \")))))((Secondary((id \
-         bc0d4973-9c42-411a-9e04-ce2f5113f99e)(content(Whitespace\" \
+         9283a833-b41b-4c2a-ad76-25255a243642)(content(Whitespace\" \
          \"))))(Tile((id \
          b64f0c64-2e3e-442b-84d9-847c5ddcd7fe)(label(scatter_plot))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -623,18 +654,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e176bb06-8b1d-4150-9342-1961c8f6778e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b74abf57-e8ce-45b0-9558-e4bc56d431b6)(content(Whitespace\" \
+         78c0dedd-d6d6-4517-ba65-a69676be88ba)(content(Whitespace\" \
          \"))))(Tile((id d9ec20d3-391b-45c8-a3ac-cce73d136444)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e3422c7e-4578-4f65-bb68-9aa7a66fd7df)(content(Whitespace\" \
+         3fcb42d5-ffba-41b8-ba13-cf82869fecb0)(content(Whitespace\" \
          \"))))(Tile((id \
          d8e917f2-ea6f-4f44-ad35-2349e1dcac0c)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c48678a8-ea49-43f3-94bc-d6af50aaba72)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         a5dacb08-1405-4789-9eb1-f7b64be7c9ab)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e8566495-688a-43d1-95cf-29780d7a3f4f)(content(Whitespace\" \
+         \"))))(Tile((id \
          81f7a72b-f154-40c2-b722-b2e9e9de0a35)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -647,19 +680,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          20f0ff77-198c-4e87-b782-6ffc70f36189)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         929e000d-eca2-4a3e-bd9a-702c44daf897)(content(Whitespace\" \
+         49949996-dd0f-4ffa-9340-c33494a944be)(content(Whitespace\" \
          \"))))(Tile((id 5139f5b7-c13d-46d8-94d4-2512fdd870c3)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         0a030e34-6a5f-4b1b-a112-1ac3a8651d57)(content(Whitespace\" \
+         29c58315-d086-4de3-bf04-a7e91a631172)(content(Whitespace\" \
          \"))))(Tile((id \
          77e8a372-c578-47bf-b74d-a62602bd98a6)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c7eb589e-2fc8-4fc8-a67c-e3a01af7a099)(content(Whitespace\" \
+         da8e12de-d1df-4270-b8ae-49259d5b94eb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         acdacee7-13e0-449c-a4d7-bebe2032974f)(content(Whitespace\" \
+         ca2a2632-3fe9-4270-9de2-b6bfbb68dabd)(content(Whitespace\" \
          \"))))(Tile((id \
          a3c4d19e-7315-4ff6-b729-6f1239814ff8)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -670,20 +703,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          20f9f428-1240-4afc-b37f-d1245ef890f1)(label(final))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         379eeb98-df51-4442-8723-e91a7a535220)(content(Whitespace\" \
+         cbc065fe-9b27-4661-9cae-02dbc2763ccf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b9fe1b42-b47b-43c5-9fcd-ef78a3c02ebd)(content(Whitespace\"\\n\"))))(Tile((id \
+         35e7b5a4-1217-4dec-a798-adf9556050af)(content(Whitespace\"\\n\"))))(Tile((id \
          5dfcbb3e-80d3-4304-8d7a-294c332a08bc)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c3fc0abc-11a8-4eaf-9f66-dde23941fff4)(content(Whitespace\" \
+         f82124d2-a7ea-4533-a178-b9c274d5f15c)(content(Whitespace\" \
          \"))))(Tile((id \
          74eb747b-1ec1-461d-8da1-e562932ad0ec)(label(correct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7b74cca1-1c64-4653-b821-7a76470faf63)(content(Whitespace\" \
+         8078127c-aec7-4049-9f8c-9e261aa580f7)(content(Whitespace\" \
          \")))))((Secondary((id \
-         52eb698a-ff7c-4a0d-b335-d3de3679bf49)(content(Whitespace\" \
+         53dc9f49-9491-4885-8b6c-82fd3112d1a2)(content(Whitespace\" \
          \"))))(Tile((id \
          03a2689d-5438-4ef0-8ffb-86f04a953374)(label(scatter_plot))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -703,18 +736,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3be216fa-8fb0-4e2f-b7ed-29767d216f5c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         376dac53-55f5-4d17-b83f-f15c8e7de10a)(content(Whitespace\" \
+         56aff642-9fd9-4d10-965f-3e196536112d)(content(Whitespace\" \
          \"))))(Tile((id fd49d7a2-5df0-47db-ab37-07226b7e952c)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         16e07479-58ea-4118-a89f-8079fb46c173)(content(Whitespace\" \
+         46c97ee6-4508-47d4-ad33-ed72057923dd)(content(Whitespace\" \
          \"))))(Tile((id \
          7a44ca95-3b3d-413c-80ed-9f0ef4b77b92)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2b4b80d8-8493-4785-bd86-1564cc9726ea)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         dc8f9f3e-1761-49d9-93ba-d9f93ae60505)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         b8bd864b-c29c-4201-9bd3-72dbb50c4d67)(content(Whitespace\" \
+         \"))))(Tile((id \
          9f53999c-2f4b-469e-a2c1-6ceadaefa8ff)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -727,19 +762,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b6d9836a-efa9-4c02-88ab-f8997b581a2c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0a901397-f919-4975-9830-bc233b96183e)(content(Whitespace\" \
+         45a13121-7d78-4f79-9970-a7348eae77ed)(content(Whitespace\" \
          \"))))(Tile((id 98ee829b-5ade-4872-b8a4-d610e9268349)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         1608daf3-2b77-4e2c-83d2-73f9ebb4d781)(content(Whitespace\" \
+         a31f1d36-4d53-40f0-8754-4934d0358159)(content(Whitespace\" \
          \"))))(Tile((id \
          9bff50d3-6682-4695-81e4-730727b84748)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2f44fc39-5974-4ee5-98ca-ff1f3322e068)(content(Whitespace\" \
+         eaaf0271-29b3-43d3-b71c-42edf0674941)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         06beff32-8721-4396-8b10-7ec7d4328ef8)(content(Whitespace\" \
+         4696e8e7-254e-4d38-bfe9-6a29e318ab18)(content(Whitespace\" \
          \"))))(Tile((id \
          2aebeb52-02c7-4a86-be79-8befa97171c9)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -750,207 +785,236 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c0b7851f-304b-47c3-bba8-f18d53759310)(label(final))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         0fc0c2f6-ba68-4239-a0bb-91739811f615)(content(Whitespace\" \
+         7e62639a-aba8-45e1-9722-fc525126fbaf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         22083e20-7d4e-4452-80c5-cecc86f377bf)(content(Whitespace\" \
-         \"))))(Tile((id \
+         736f5096-4c0c-4173-b626-4369ac67a407)(content(Whitespace\"\\n\"))))(Tile((id \
          6bc9be66-f162-4a41-91ce-57a072c74072)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         6540aa7d-50bc-486d-a315-d69b86869b2a)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ba3a63d2-6ba1-4723-a3a1-cbdaa2378d2f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ed777091-0ab6-4f91-bdb3-520dc4556ff5)(content(Whitespace\"\\n\"))))(Tile((id \
+         fe62631e-35fb-43da-b02e-a46cf40ebab6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         606c9355-76f6-4c22-b09b-5ee4e9cef51f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         fbe5d82f-9a7c-43db-8ad4-bebfce51e1e2)(content(Whitespace\"\\n\"))))(Tile((id \
          437cf7f8-c75a-4fc2-9e5f-97e42e6feeef)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         6e4b45e1-a99f-487e-b3ea-eac269fe71b4)(content(Whitespace\" \
+         3e29e0e6-4956-4a0b-8433-9fc27e21aecb)(content(Whitespace\" \
          \"))))(Tile((id \
          e939eef6-ed95-4eca-b161-d165ab98e7a3)(label(black_and_white))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8a46afc0-aa5b-4a15-9ad6-dca4272ede48)(content(Whitespace\" \
+         6f9570f0-3b96-45bc-bb95-086f5aa236fd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         94453f1e-9487-4aaa-b22f-f963b510a892)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33355ad4-bebd-40f7-ab87-a73a91e0db54)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3dde153e-bc83-4240-9b47-eca86c6fe89e)(content(Whitespace\"\\n\"))))(Tile((id \
+         561c6c4e-e427-4588-8f0b-3cc1fa3d99d8)(content(Whitespace\"\\n\"))))(Tile((id \
          e20211af-9af3-48cf-953b-dcba4c584730)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c334a511-b17b-4716-afcc-a22cceb69087)(content(Whitespace\" \
+         7670e85b-02ab-4723-bd33-15a2c37022a5)(content(Whitespace\" \
          \"))))(Tile((id \
          5b13c819-6f18-45c1-908c-72a3751cd35b)(label(JellyAnon))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         5a9eb7c6-c796-47f8-badc-cb0bbf2f7f08)(content(Whitespace\" \
+         376194fb-8272-4d88-8f89-6088c425b705)(content(Whitespace\" \
          \")))))((Secondary((id \
-         81b93591-b802-4a36-9bd4-7c3174648603)(content(Whitespace\" \
+         1dc0fed8-7749-4353-8d0f-bece6b775081)(content(Whitespace\" \
          \"))))(Tile((id \
          1eb88a2c-e0c3-4a13-bb9b-93d22e632273)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         50cd35cc-3923-4512-982d-7955c715e8da)(content(Whitespace\"\\n\"))))(Tile((id \
          fc05b8fc-a05d-4b36-b067-7b4848f3ec6c)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c7d77652-87f9-4494-873b-ecf71972df0c)(content(Whitespace\" \
+         \"))))(Tile((id \
          b7440949-47d8-4b57-9916-7e28ec0325c7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         def9d49f-8210-4fc2-9765-67c2242d7080)(content(Whitespace\" \
+         \"))))(Tile((id \
          0ff3f430-fe6f-4356-a3d1-37317c12c5dc)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          60f98fe3-7d27-4f68-bdce-ff565ea5cf3c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d4d5365b-c5b2-47b4-bbeb-8a436b913717)(content(Whitespace\" \
-         \"))))(Tile((id \
+         80bccf86-4d4a-41b6-9962-4f87f76d0d06)(content(Whitespace\"\\n\"))))(Tile((id \
          63dccdba-63af-4074-b44e-93a06933ccb8)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         35a2a6f0-9d1c-412c-8ead-3c8040deb359)(content(Whitespace\" \
+         \"))))(Tile((id \
          fb7bdba8-6670-412c-a173-c7d44a014e1e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         945827cd-f1a5-4996-9823-a20ae1305e85)(content(Whitespace\" \
+         \"))))(Tile((id \
          62f886b0-1426-44c1-abed-2237a3544976)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          84fe94f1-3ecd-4e87-af60-0a5a027cfa0f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3f92395f-a63b-4acf-9f9f-a7d50fedb201)(content(Whitespace\" \
-         \"))))(Tile((id \
+         229eea7e-9842-4d15-9171-7fca2378c3c4)(content(Whitespace\"\\n\"))))(Tile((id \
          5d2bc6de-0aaf-472d-9812-5647bb2a4d20)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9af27920-ad4c-4b04-aa2d-3597f41311fa)(content(Whitespace\" \
+         \"))))(Tile((id \
          6bae48af-c2d4-4663-a083-c73f9724f61d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9d333fc2-92a0-4dfd-9e7a-ebedb6b6d404)(content(Whitespace\" \
+         \"))))(Tile((id \
          f2c3a957-7eef-40e2-8ccc-7c0f83fd2b6e)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6425b293-aa76-42ab-ba23-d1976d8ce3de)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         41e34ad2-86fd-4a9f-81cb-9498f8d9a9ea)(content(Whitespace\" \
-         \"))))(Tile((id \
+         2963dfd7-5cb9-4cea-9b66-d01b4d13747f)(content(Whitespace\"\\n\"))))(Tile((id \
          0b3b3485-2de0-433d-9405-f6d734c8a07a)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6fd020d8-4a32-4bed-aceb-83e57691c0f6)(content(Whitespace\" \
+         \"))))(Tile((id \
          c1a813bc-6df8-46c9-a4cb-6dabdcd8b7cc)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ed336c36-c966-45f7-9c44-4a8ff79c9545)(content(Whitespace\" \
+         \"))))(Tile((id \
          7aa9e48e-6447-4146-9c3b-26214fe94b84)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0422187c-4422-4bd1-9d79-f72743b1bad1)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dd2c2899-1ab7-45d6-9ec2-009657385128)(content(Whitespace\" \
-         \"))))(Tile((id \
+         2cefec80-9201-4f0c-8340-5420ed064234)(content(Whitespace\"\\n\"))))(Tile((id \
          bfff5791-ad1e-4710-8d70-6ee3b63362a1)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         79381869-6e47-4cfe-b0ff-02bac3a20bf8)(content(Whitespace\" \
+         \"))))(Tile((id \
          74c10798-6f76-40f7-ad4a-fea22edbad98)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8ab9cf0d-506f-441b-9c36-5db5f03e2590)(content(Whitespace\" \
+         \"))))(Tile((id \
          9eab069a-085c-475c-b121-1a2fb2946f08)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d19840ec-062f-4223-857b-abe62372d1af)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e3da4a9e-40cc-43f9-8a12-2ebeb879ce61)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e3dcc243-48c0-4fd5-a02a-da3257636cfc)(content(Whitespace\"\\n\"))))(Tile((id \
          0067ce3b-7f4b-4a7a-9a49-34bf95930d91)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5eb7b614-d453-4526-b946-7cc35b882a2c)(content(Whitespace\" \
+         \"))))(Tile((id \
          253674b8-e5b9-49d0-8ef6-e81886397e24)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         86e94fd7-8158-4c86-b604-5b9281893f04)(content(Whitespace\" \
+         \"))))(Tile((id \
          723c71e6-0f59-426f-9ca0-fa36d78691cf)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          db223b07-53df-43dc-9de6-5b3b8a5fb68c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a07eb35d-ab5b-47cd-b112-0aff5ac1afd8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         dedb4660-1c6f-4fa9-9651-2780d5ea97b2)(content(Whitespace\"\\n\"))))(Tile((id \
          825a835d-736d-4f22-a08e-538522bd9f98)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f78c619e-fc59-4de0-a80a-23f60416de02)(content(Whitespace\" \
+         \"))))(Tile((id \
          36a1fd79-8362-4ed1-ac56-90ae70e181aa)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e958e117-d3bd-41b2-907e-025975235218)(content(Whitespace\" \
+         \"))))(Tile((id \
          20f5a606-404a-4a14-a6e6-d7aa0bc8d2d0)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e033995f-cb91-4514-bbde-3f452bc0750b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0cf72ef1-3c5a-4d61-8379-94d59208d65e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ad7c4606-fdb5-4e9c-be47-82bcbbb63a51)(content(Whitespace\"\\n\"))))(Tile((id \
          0bf03561-b74c-4243-a249-3767dac08c51)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f44aa277-0e02-4229-b3c8-c55368e0f91e)(content(Whitespace\" \
+         \"))))(Tile((id \
          a6c8797d-a679-436f-a4ef-39027e427b30)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         883bb2bc-5d44-4e54-bbb7-0118904da55f)(content(Whitespace\" \
+         \"))))(Tile((id \
          325c5f31-08fc-42da-b822-db895dc74bfb)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7eb62596-70c7-4e59-9e58-dead8a7df167)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0317dbd0-df43-4d2c-91e5-6dc26c6b3a61)(content(Whitespace\" \
-         \"))))(Tile((id \
+         362f55f9-b04b-4eb2-bef5-09f69b750c01)(content(Whitespace\"\\n\"))))(Tile((id \
          ebca270b-358f-45b6-b062-760657cc4385)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5d0940ee-79bf-4f13-a731-70b12bc2d479)(content(Whitespace\" \
+         \"))))(Tile((id \
          36964e53-69ba-497c-b118-6fd6822b22e3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         48fe7695-e4fe-4f18-b6ae-4499145c0408)(content(Whitespace\" \
+         \"))))(Tile((id \
          51053ea6-3146-456e-8583-6f74db02d1e3)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9f57bbe7-f9d8-48e2-8be6-9d507a3ea963)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e534e5c7-19b3-4f3e-8684-951e2b1640a9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         bb44e104-cd80-4486-9084-ac976a1520f7)(content(Whitespace\"\\n\"))))(Tile((id \
          b89a6d9d-476f-4720-9a4b-b97d0b184797)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         064159a5-b9d4-4f40-85b9-5b09f0db1b7c)(content(Whitespace\" \
+         \"))))(Tile((id \
          f32e3399-8773-4b66-b721-252011acf722)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c887e5fd-533a-439f-bd51-cfc77280483b)(content(Whitespace\" \
+         \"))))(Tile((id \
          fe02a6df-9241-4d9c-acb5-787184292130)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         ccb445de-5fba-4fcb-ae3c-be805330add3)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f9dedad7-bbc4-4cff-b6e3-81f3e2362076)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         071417e7-145a-4f39-90b6-da5f50c13a2a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         901a403e-fe5a-4c43-961c-896034421a43)(content(Whitespace\"\\n\"))))(Tile((id \
+         b188f220-0433-429f-af07-405c1ac35c8e)(content(Whitespace\"\\n\"))))(Tile((id \
          d1382cb5-3131-41e8-915c-6c0e5e3eca5c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         2abf397f-faf7-4d8d-b676-c4356884a89e)(content(Whitespace\" \
+         fcd9c1cb-9b1e-4d09-a9b3-9ec5024a179c)(content(Whitespace\" \
          \"))))(Tile((id \
          0a121e10-91a4-4325-82a4-6e9c67f9713c)(label(jellyAnon))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6398cad1-26eb-467b-af43-4462b8865764)(content(Whitespace\" \
+         7bcd2800-54b9-46ea-b978-0726c8863a1c)(content(Whitespace\" \
          \"))))(Tile((id \
          53d4f816-dce0-4ba6-b593-7e27e5f5196f)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6f5ebf0e-df7d-4e26-83e2-4c585ee98c25)(content(Whitespace\" \
+         b1170950-2bd2-46c5-a922-5c4cbbc05cc5)(content(Whitespace\" \
          \"))))(Tile((id fd3603c3-2db0-48cf-80cc-8c3c0bbb86fe)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          aaf8a5b0-830f-4c92-8096-e95b837e28e2)(label(JellyAnon))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0d6a1c92-3235-4906-9c7c-df2725b825a7)(content(Whitespace\" \
+         9326189d-d5fe-483e-9ecf-453d3270d860)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3e2b9914-0f61-49a7-a9b1-c90ee8720a5a)(content(Whitespace\" \
+         835231ed-e301-4131-9f93-bfea8cb81125)(content(Whitespace\" \
          \"))))(Projector((id 1fcbf699-2bf3-431b-9084-27b7387c8080)(kind \
          Fold)(syntax(Tile((id \
          28022d2b-e4d8-4ff7-bc4f-164250a8bad6)(label(\"(\"\")\"))(mold((out \
@@ -2178,66 +2242,67 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))))))))(model\"()\"))))))))(Secondary((id \
          d6c28fe3-d6d7-4389-ae67-51b049681ffe)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         c3e2ef44-4920-48c8-8a8f-cef08a72587b)(content(Whitespace\" \
+         35d2bb83-5c1f-46d7-9894-b5d8519bb6a7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a877f085-3c34-41b5-951c-257f0adc2b48)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bf487a3d-d9ca-4a19-ae70-76821094ccaf)(content(Whitespace\"\\n\"))))(Secondary((id \
+         0087cfcb-c054-4f5b-a939-fa3141e674a2)(content(Whitespace\"\\n\"))))(Secondary((id \
          1edea429-8829-4a6b-b772-303f33b86948)(content(Comment\"# Using \
          alternative buildColumn that takes projection to new tuple \
          #\"))))(Secondary((id \
-         fbe43bb1-6505-4646-a2cd-2be7da0ef5b8)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d0fc6b6f-9ae7-4177-9ea7-0e5dd38fb579)(content(Whitespace\"\\n\"))))(Secondary((id \
          7226a74f-cb14-4a42-a291-f8e02434b82b)(content(Comment\"# The version \
          taking a string can be used but it would give no static errors \
          #\"))))(Secondary((id \
-         6bc58400-d797-4cbc-a873-6392c819135d)(content(Whitespace\"\\n\"))))(Tile((id \
+         4c62cbf8-8003-4b01-9a36-d51e8654c48a)(content(Whitespace\"\\n\"))))(Tile((id \
          c9aa255c-3828-4594-841b-df50c1f67844)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a56e3fe1-84eb-46e2-bda9-71d7f3dcb242)(content(Whitespace\" \
+         40caa69d-5d6a-4a20-8eac-b67d105b3c91)(content(Whitespace\" \
          \"))))(Tile((id \
          5a2bd99d-c874-4f1d-bb5d-d4c3196fefc6)(label(build_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         909540fd-caf9-4ba8-a5bd-069fac1bb112)(content(Whitespace\" \
+         \"))))(Tile((id \
          7e7c6c56-fb4e-4a6d-8e74-29dfd114621b)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         31f65ce4-dd9d-4f45-a69b-f57801d08bd9)(content(Whitespace\" \
+         d74851ea-d247-475e-9c6c-83cbfb882d3c)(content(Whitespace\" \
          \"))))(Tile((id 73f9dc13-7c16-4fce-9e11-3008fed2de6a)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         3e487a2d-7e5e-4f84-bca4-cf1794efa6b5)(content(Whitespace\" \
+         7da53dfa-1e8a-45b5-a8d4-5b885625ad34)(content(Whitespace\" \
          \"))))(Tile((id \
          d16677d7-ddc3-4cfd-bf07-f39fe2ebe88e)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         f2626441-0622-479f-b560-2211c67c0d9e)(content(Whitespace\" \
+         3564e516-6eb5-4ebd-85c9-86477e5f40fb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7d19c259-c49a-4376-8125-d15eeb177aa7)(content(Whitespace\" \
+         8c75d71d-24f8-441e-b453-505d8d02e32c)(content(Whitespace\" \
          \"))))(Tile((id 3f3ebc09-76bf-459e-a3d1-933b5393dd66)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         c547ee2e-4313-4134-98b1-ab07ca2e4156)(content(Whitespace\" \
+         af5003b1-a35b-476d-86cd-720cdc2c993a)(content(Whitespace\" \
          \"))))(Tile((id \
          9708dd9a-438c-40b7-ac77-bf9c7c23b92e)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         d302f590-3fe4-485c-bf3c-06d1b09d057e)(content(Whitespace\" \
+         fd3a2b00-c963-46f2-a2d7-542e58e6c4b0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2e4f52ce-c607-48ad-a870-a9cc481eab57)(content(Whitespace\" \
+         ecba9a32-fd7e-47a5-8f79-624762293fc4)(content(Whitespace\" \
          \"))))(Tile((id 115ac869-8801-4245-a02f-dce83d1f2036)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         17966650-8b93-4b81-b2b1-7cc2d48e46f8)(content(Whitespace\" \
+         f6bebb67-5493-44f8-b990-e82aa4985f71)(content(Whitespace\" \
          \"))))(Tile((id \
          eb3d9c1e-8f90-4856-af8c-8e98d5ea3e1c)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         abb6099f-aa07-4f16-a478-543024d1991e)(content(Whitespace\" \
+         971362a3-ab90-48a9-88f0-3fac79c7949c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c9b2e08d-b765-4494-bfb3-9ea22cd74c7a)(content(Whitespace\" \
+         164b84e8-1d8b-4d8b-aecd-62a8e6a9428a)(content(Whitespace\" \
          \"))))(Tile((id \
          fed483d2-8aa3-4738-8d1b-ccad13b55cbb)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -2251,17 +2316,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          09543d1b-4114-41d1-88fc-769e42daa939)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9d87bff2-2c76-47bc-aa7e-93e5c5db7964)(content(Whitespace\" \
+         a7f0f859-f282-4c13-9ede-26f6a7864963)(content(Whitespace\" \
          \"))))(Tile((id \
          0156a978-a81d-4f6d-941f-a9f40812816f)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         43d48bdf-cabe-407e-be5c-1f02515e7d63)(content(Whitespace\" \
+         76124ad2-e897-481b-a33a-83e650eb09ad)(content(Whitespace\" \
          \"))))(Tile((id \
          c1982e13-ef00-41bd-9dba-8e82b2e89ecc)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f4e4c827-574f-4638-b149-e4fc5dce7ba3)(content(Whitespace\" \
+         ce28019d-e071-43af-a350-802b463fe137)(content(Whitespace\" \
          \"))))(Tile((id \
          b0684147-c315-4d8d-a1cb-dccc4258f004)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -2269,7 +2334,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3379388a-4fee-46ea-ad37-1a6b124dd3d4)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         276e838e-8145-4899-be75-65ad34d19fe0)(content(Whitespace\" \
+         2a6e553a-8173-4a3b-9465-2e82c8593272)(content(Whitespace\" \
          \"))))(Tile((id \
          233a9d66-3cfe-4622-84ad-1b8adf2da217)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -2279,74 +2344,77 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          0c0efd19-9a3d-4f21-a998-d4d26dec3e50)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b2ebf2f5-1959-48eb-b67f-128a4c30900d)(content(Whitespace\" \
+         \"))))(Tile((id \
          946d8074-1752-4567-916f-823b1356607c)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         492e11c2-d757-4678-a81c-4fd8a928d261)(content(Whitespace\" \
+         4f47bc3e-d362-4e53-a4c2-8f3b4494c8c1)(content(Whitespace\" \
          \"))))(Tile((id \
          e821b0c1-5b61-4be8-bb2e-bdc04fdeb01a)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         86499032-e28e-4565-982e-e128f4762276)(content(Whitespace\" \
+         1d3bdf29-b111-4613-8e58-4424978eb908)(content(Whitespace\" \
          \"))))(Tile((id \
          ceacbabe-74d3-4f99-9448-1f92479cd2ec)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         2564a78d-228f-4777-b7fd-5f0a1fbc4dbf)(content(Whitespace\" \
+         63189716-397f-47bd-adfe-30f9aa28ad8a)(content(Whitespace\" \
          \"))))(Tile((id \
          a4c2d5c4-78cc-4da6-b849-f734d27a794e)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         db4979c2-f102-4aea-ac11-486d300774ab)(content(Whitespace\" \
+         eb269fc0-ef4f-4022-9a00-cca0ebef1831)(content(Whitespace\" \
          \"))))(Tile((id 4d7b1fda-3bec-4bfc-a9f6-b13d55364af3)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          40f1a344-7522-4cb3-9998-1a1d26cabe7c)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))((Secondary((id \
-         3c2e6991-899d-4da9-a35c-d18742cdcb4c)(content(Whitespace\"\\n\"))))(Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         e0ffc4f7-fcba-4dad-9496-927c50182878)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         33999a67-6423-4513-8d31-95cdccd86663)(content(Whitespace\"\\n\"))))(Tile((id \
          e8c6fc95-4d28-4742-8903-dffc75f89a1a)(label(typfun ->))(mold((out \
          Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         24a92f03-356b-4fe6-9f74-cb8daf45859f)(content(Whitespace\" \
+         b8aadcd4-0f30-4731-ab6f-194448945b8f)(content(Whitespace\" \
          \"))))(Tile((id \
          1f4cc767-9af6-4207-96cf-976af39c1dd2)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         56f4f767-1792-4ec6-a7f2-a4b2bbdc172a)(content(Whitespace\" \
+         99a4af70-e8f7-4d9f-bcde-9152afc9f408)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         90fa67e8-6e12-441b-b2e4-117e407d0aee)(content(Whitespace\" \
+         2c836184-1878-4c49-a47c-11cac77bc2c9)(content(Whitespace\" \
          \"))))(Tile((id a44a0cf0-dfc1-4d15-9118-87a7d6f3380d)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         b0e1f48c-74de-48ca-8732-52da9573921a)(content(Whitespace\" \
+         3e889c48-1bdf-4675-bd41-13c15308c0f7)(content(Whitespace\" \
          \"))))(Tile((id \
          cb59c1ea-243d-48af-9ba9-a6dedf861c23)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         8c2013f5-739a-437e-bf88-1f97099f9c91)(content(Whitespace\" \
+         ec87bfb6-2ea5-422b-bc5d-2149f0355691)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d88dfb03-9f53-45aa-804d-1cad1e374a7b)(content(Whitespace\" \
+         80add948-bacb-4645-8315-37fb428b2cc2)(content(Whitespace\" \
          \"))))(Tile((id a8bfab81-617e-4f33-9fd9-91d0c33c7f8a)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         23f2ace7-bc45-41d2-862b-81278e05615a)(content(Whitespace\" \
+         009c368f-832e-4ece-aa8b-cad47ae0a1a6)(content(Whitespace\" \
          \"))))(Tile((id \
          1d06ae1e-a365-428a-b132-d5806584564c)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         d05e48fc-20ff-42e4-8c8f-173073b7d052)(content(Whitespace\" \
+         f280edcd-881a-4ef4-8336-19cf2dd18da3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7eb955dc-2666-4053-a9cc-f1768a83cec2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5643f40e-1c14-4b62-b15e-b740c40650aa)(content(Whitespace\"\\n\"))))(Tile((id \
-         5ec88925-ba2a-4783-a4f5-20ca8f20e9a2)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         12f79a42-88f6-4a1f-987d-89d3c585eb1e)(content(Whitespace\" \
+         16c01a8f-bb3e-45c2-9e72-28b264c5f9bc)(content(Whitespace\" \
+         \"))))(Tile((id 5ec88925-ba2a-4783-a4f5-20ca8f20e9a2)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         0cab9353-1c0e-4d23-b3af-ae3ec830975c)(content(Whitespace\" \
          \"))))(Tile((id \
          bc925db8-2eeb-4443-b253-b58218cac7a5)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2357,7 +2425,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          82ccd3b7-dbca-4520-ad2f-cfddc1fc6323)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ba77e0f8-c633-409c-81d3-f05e6cb19c97)(content(Whitespace\" \
+         f992e7d3-0f43-475a-b4cd-611ec4da0029)(content(Whitespace\" \
          \"))))(Tile((id \
          9fc1f074-82e3-4ce6-aa4a-b20d3a3986ad)(label(project))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2365,14 +2433,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e107ba4f-2b8e-4865-8d26-c14b53518ad3)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         d1bb8117-a552-45b1-af41-7d7058053ca8)(content(Whitespace\" \
+         5d693f40-4919-400d-b93d-37e13e476b34)(content(Whitespace\" \
          \"))))(Tile((id \
          6948a76d-b35f-4c04-bcd6-cbf4d0236ff3)(label(build_result))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         0ba7a286-f092-4bf5-a0c0-b9edbbce14e1)(content(Whitespace\" \
+         68c7cc78-339b-4fa6-8c6d-b06381e40c49)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         083dc755-bba7-4452-8155-49faa0444efe)(content(Whitespace\" \
+         ea11ccf3-b841-411c-be7e-706072b34882)(content(Whitespace\" \
          \"))))(Tile((id \
          1eb72f0e-e9b6-4309-a39d-bb78d4a6033a)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2386,27 +2454,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          557c8324-09e4-4289-8846-04599d434046)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c57ffe56-268e-4211-8397-47b6b067f55e)(content(Whitespace\" \
+         be7eef85-3df0-499f-959f-9fef6c77559c)(content(Whitespace\" \
          \"))))(Tile((id 2e9de19e-fcf2-4f32-b8e3-222c3c18906d)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         db5cf4bd-12ef-4e58-a76f-6cfe1c8cb09c)(content(Whitespace\" \
+         c035e3a9-fe05-4f57-8214-64ac242fb730)(content(Whitespace\" \
          \"))))(Tile((id \
          51f69789-fdf4-4c2e-9839-45048d5a6943)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         d39f4407-9375-4cca-b93b-9104bda9010d)(content(Whitespace\" \
+         \"))))(Tile((id \
          44ff300a-c4d2-4cd3-b9b6-5940fd2152ee)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2f3486c2-d38a-4ee4-b69a-5ca2c68ad8f3)(content(Whitespace\" \
+         f7cc2b99-7945-44fd-a16d-6572faa1283d)(content(Whitespace\" \
          \"))))(Tile((id \
          c3ec3c60-22ad-4354-9455-7a210645aeae)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         feb1d618-e90c-41eb-9518-b002b2b62030)(content(Whitespace\" \
+         e5bb37c9-44a8-41d9-9778-d9af9d0176e0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         62fa2eb8-3878-49a6-8c17-247b25312e32)(content(Whitespace\" \
+         e2b983cb-75d9-41cf-88af-fb4b11d4c8c0)(content(Whitespace\" \
          \"))))(Tile((id \
          0e92fa0d-e71f-43f4-826d-45705d1123bf)(label(build_result))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2420,7 +2490,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6790d558-a884-4dc4-b008-6d4502e59513)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4c5d6654-0ce2-4f10-b773-7402a8b3f442)(content(Whitespace\" \
+         70786575-1799-407a-bc44-622177302495)(content(Whitespace\" \
          \"))))(Tile((id \
          452cf0cf-a87f-4c38-a124-5f1e7bed4b0d)(label(project))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2431,54 +2501,53 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fe91cd5b-3ba8-42b8-b7e3-a6e84fe0f826)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         b70e258a-0cc9-4a4b-a6bc-959a49a3beb6)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         5f1a5251-45fc-47fc-acf3-e5490a3132c6)(content(Whitespace\"\\n\"))))(Tile((id \
+         8074399c-4dc0-4870-b548-4c5bd158db99)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         b15fb2bc-a5d7-45a8-a66d-093d7173d663)(content(Whitespace\"\\n\"))))(Tile((id \
          fa52c4ab-8b5c-4597-b356-6d5356146841)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         9fea8987-19a3-4e90-a0ec-fce7bd035bac)(content(Whitespace\" \
+         2b014716-1950-46e5-827e-4a7473bfa711)(content(Whitespace\" \
          \"))))(Tile((id \
          572f7db0-168e-4f3c-a73d-a9539d774ee6)(label(incorrect))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f8fde660-a9ea-4848-a1ac-25dd7368af33)(content(Whitespace\" \
+         414f3b13-f0ea-4c1a-91ac-175df7dafea8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ed42e1b9-5d54-4bb7-bc6b-7f51d6b6478a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2d89e34-7f94-4f28-b221-4a915d95c54a)(content(Whitespace\"\\n\"))))(Tile((id \
+         d05a6b16-13fb-4fc6-96d3-1f24872e344a)(content(Whitespace\"\\n\"))))(Tile((id \
          0504cdbb-91d7-4225-872b-1313becb8394)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         6dfcfe97-4184-40bc-b921-e584b24ee06d)(content(Whitespace\" \
+         2ff16151-0ac5-401e-bed5-baa20b3b89ad)(content(Whitespace\" \
          \"))))(Tile((id \
          f60bb360-961e-4a95-a023-2707ecd59d12)(label(eat_black_and_white))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         34218eb1-c0c7-4dbe-9727-99e777bfc89f)(content(Whitespace\" \
+         8888c2ea-4522-4590-8383-03d67426dcc2)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8f87118f-c19c-4cde-8dcb-d71ed436055f)(content(Whitespace\" \
+         96d06568-a62f-451f-bde1-0bef3e3aeea7)(content(Whitespace\" \
          \"))))(Tile((id ef0eea84-ce96-4676-9cb3-182f2e958469)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         0f3ecf42-b7d7-46bb-8a56-5a61a0ed9b57)(content(Whitespace\" \
+         a8416ca4-94a1-434e-b2cb-681476043185)(content(Whitespace\" \
          \"))))(Tile((id \
          3d3a0e06-9086-459a-8635-115b7ec962a5)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1b93b021-7203-49c8-b1e0-38ab93a43bc9)(content(Whitespace\" \
+         5a6b91fa-79b4-4e3e-aa05-24710aed1fa9)(content(Whitespace\" \
          \"))))(Tile((id \
          a0a5ed39-030a-4b45-8a6a-6b64b3035334)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         86d4d986-b1ec-4008-8b35-019cb3505099)(content(Whitespace\" \
+         51f0321e-981d-41d9-83b5-8320cb5c0928)(content(Whitespace\" \
          \"))))(Tile((id \
          cf6f0950-c815-4364-a353-5f51fa4834fe)(label(JellyAnon))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         41869aef-d14e-43ff-9bc8-09992725550a)(content(Whitespace\" \
+         1495ea93-a01e-45c5-8a8d-de55afc8c764)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5d29522c-c441-4e18-86d2-508a6fda9213)(content(Whitespace\" \
+         c1607efb-829c-4faa-b368-ce36c7d181d1)(content(Whitespace\" \
          \"))))(Tile((id \
          2c9ac03f-40d9-4270-bc42-45c038d0c1b5)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2490,30 +2559,28 @@ let out : string * Haz3lcore.PersistentSegment.t =
          white`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         76c2ce37-9f2d-46fb-b352-b352995a22b5)(content(Whitespace\" \
+         2ddef7d9-f9aa-490c-9a08-aa6904c6b28e)(content(Whitespace\" \
          \"))))(Tile((id \
          b5055680-2a53-4cde-990f-f1374c8fe0d7)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5ee756f5-1e7e-4374-8d23-c0f493a8ff25)(content(Whitespace\" \
+         b3b2a434-f271-4b51-9c56-81a83569a21c)(content(Whitespace\" \
          \"))))(Tile((id \
          e9179400-b4da-4a7a-9bcc-2426ee8afb10)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         df6ae9fa-5d16-4cfd-a9c1-dbd7b4ef8318)(content(Whitespace\" \
+         49bb0dd6-9d27-440a-8125-bbc8f3d6413b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1c222041-88cb-4ec1-9a46-f0925ceae2a2)(content(Whitespace\"\\n\"))))(Tile((id \
+         ee8c0a5b-ee6f-4144-bc5c-7b212c14d8e1)(content(Whitespace\"\\n\"))))(Tile((id \
          75ca9a1d-aabf-4afc-bf50-0a657d5c23a3)(label(build_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         e93f2412-80dd-46a1-870a-b1a051225cf9)(content(Whitespace\"\\n\"))))(Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
          d0b9d01e-fb78-4720-8a11-c15ca892a106)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          d20597ba-2ac7-48ab-b283-f46801d37a40)(label(JellyAnon))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c7a3e9c9-2398-449f-8d07-0f754b71ec96)(content(Whitespace\"\\n\"))))(Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
          ff3e3b3b-d4bc-4b79-a0da-b5ebc3d43717)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2522,169 +2589,210 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          d0ae3225-4e21-4c40-9afb-68241c4e9b59)(label(\"`eat black and \
          white`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
-         Typ))((shape Convex)(sort Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         91da4fa4-810e-4344-8466-5f38fd8599d9)(content(Whitespace\" \
+         \"))))(Tile((id \
          900ddd6d-27c1-4bc5-b333-7be9aeb54e26)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d7b4f6f3-53b9-4f28-a04c-322cf5c9d549)(content(Whitespace\" \
+         \"))))(Tile((id \
          8bab6007-a0ac-40eb-bcfa-301afb721067)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         7ad6a12e-2559-4d43-b19a-946bc7426649)(content(Whitespace\"\\n\"))))(Tile((id \
+         Typ))))))(shards(0))(children())))))))))))))(Tile((id \
          679fd2ba-de47-4323-818d-ea0a5c599f9d)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          526cb9e9-ae9c-4f4c-b9f7-971e92cff899)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         29f90628-5782-4ae1-a4bb-06bfe9adf4fd)(content(Whitespace\"\\n\"))))(Tile((id \
          4db659dc-9d7f-40c7-92c5-721aa63f37e5)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8770049b-1b23-448e-93db-9accb8d8700e)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce3ec405-8db5-4a85-b076-44092eac3c8b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a10ab494-6106-4d97-af26-c7a86d77ecc1)(content(Whitespace\" \
+         \"))))(Tile((id \
          cebcf946-1d46-4a94-9bc6-88ad1c8f007d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7a2042f8-30ce-4849-b3ae-6425c78e1436)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         40bd3e42-6148-4412-a2f2-e339fc71a9d9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         a717f2b1-814a-4351-968f-9f02011276d0)(content(Whitespace\"\\n\"))))(Tile((id \
          8c26925f-4492-4ba3-bd9f-0d12964f0b5f)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         59266b82-b2b5-418b-85d5-35b4cdedeb6f)(content(Whitespace\" \
+         \"))))(Tile((id \
          d961a5d0-12e6-48be-aefe-dda274451ea5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1c3f5c81-30f8-4ab7-8a8c-475e50736424)(content(Whitespace\" \
+         \"))))(Tile((id \
          6d02e2cf-97ca-4353-81e5-e3b86b6724d8)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7b820e23-c9aa-43c7-a270-07c943429b20)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         61c408d7-305e-4635-a923-24aa1d86283a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9879a351-7aef-459a-9a38-8d9738c8d6e8)(content(Whitespace\"\\n\"))))(Tile((id \
          b2c111a7-9722-47f6-9d40-809c5320aebc)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4e655cdc-082c-4cde-bbfd-ffe8b4c59627)(content(Whitespace\" \
+         \"))))(Tile((id \
          ba4063c5-d7e9-4198-b2f8-31ccd289c003)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         07f93523-1f9f-4e5c-ac23-27f3b75f8fd0)(content(Whitespace\" \
+         \"))))(Tile((id \
          60c20bde-c625-423e-9a52-be914a9706e1)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7d0ef495-33d0-490c-9c62-915e20eeb9e0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d7b53108-60ab-48fc-b9a4-d7161f4d8195)(content(Whitespace\" \
-         \"))))(Tile((id \
+         88b0dbf7-1b24-4b50-a539-1af484d80466)(content(Whitespace\"\\n\"))))(Tile((id \
          25eecff6-0ad3-4751-b8ff-b67f5630f2f7)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e228ca73-f90b-428a-a0f9-d324370cac3f)(content(Whitespace\" \
+         \"))))(Tile((id \
          046727fd-6afd-43b3-b16b-d5aed20d1042)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b9dd64fe-43dc-41bc-9369-23cdc7b187a5)(content(Whitespace\" \
+         \"))))(Tile((id \
          6f0471a1-1142-43e6-a77c-0dc3f71daddc)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0b567f26-3211-40be-ad50-26d3da3ea83b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d9e2d8b5-e7e6-4e54-a805-c6128243f185)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8138398e-56e5-4469-990a-194315c6a95e)(content(Whitespace\"\\n\"))))(Tile((id \
          236a4163-50b6-4251-8bab-31fd5ac89e77)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bf9637c4-883b-41c1-8eb1-77d98f469913)(content(Whitespace\" \
+         \"))))(Tile((id \
          d1a8a175-a873-4daa-af06-c296e28375b6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2aa4aed1-57f5-475d-a64d-d49b9aba4593)(content(Whitespace\" \
+         \"))))(Tile((id \
          a1487e5f-8249-4150-a2fc-858add98430e)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          99b0b732-82f6-4024-aafc-9c2d85302634)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         691f1f26-8249-443b-9bc0-a94dca2c3623)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5082e953-6c88-49d7-b233-b02fa0ff1404)(content(Whitespace\"\\n\"))))(Tile((id \
          56807079-e6d2-4c00-8d19-953c9f974c9b)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b65a9926-c234-488d-ad1d-09d37369917c)(content(Whitespace\" \
+         \"))))(Tile((id \
          4e6abcf0-3288-489a-be40-9cbb4a15c9f4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a3852c36-3127-4f74-8be9-d3ffbbc3fac9)(content(Whitespace\" \
+         \"))))(Tile((id \
          5f4c4c95-0578-4e29-827a-115457eecf4d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          baf6f21c-f278-445a-aa75-6a4bc5126cea)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c56630ea-967b-400b-be02-d807ab62b17f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         036cc9c2-39ae-4758-8e68-f2e7e10cb39b)(content(Whitespace\"\\n\"))))(Tile((id \
          4d7ff662-656d-4649-905a-514607ae8101)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bc0f297e-62e9-41e1-992c-afff8b4e95cf)(content(Whitespace\" \
+         \"))))(Tile((id \
          e5cb8bec-f22e-4908-b0ae-48d869f75534)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ed91a392-240a-4fda-855c-40616ff38316)(content(Whitespace\" \
+         \"))))(Tile((id \
          633caad0-2a6d-475f-9dde-de3a00c527df)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          be08bbe8-910d-4e9d-b9cc-0ff32d85d034)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6c389c9d-cb2e-4579-a809-16f2e0107859)(content(Whitespace\" \
-         \"))))(Tile((id \
+         47c39341-c09b-4ecd-94e5-d1b0b3cc370e)(content(Whitespace\"\\n\"))))(Tile((id \
          04c3c487-a888-4558-9fa3-fbe860f2ec75)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1610c1cd-d823-4cef-a995-4870bb3eafe3)(content(Whitespace\" \
+         \"))))(Tile((id \
          a998af03-ef52-427f-a05d-4fe63956ed0e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         88bf608a-3703-472f-9311-89a97d6cc762)(content(Whitespace\" \
+         \"))))(Tile((id \
          dc9a9da5-1571-4d61-9baf-07c22ca542d0)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          072c1af7-da63-48a5-b095-3d603eac90f6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8092c274-bdcf-4417-9edb-8c019f577c47)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e8744694-832e-47b5-a9eb-6b9d672fe478)(content(Whitespace\"\\n\"))))(Tile((id \
          bee01b01-36bd-4595-991c-fc4ae9f96b85)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6eda2d7c-6175-4b2e-be9c-036e57ce3392)(content(Whitespace\" \
+         \"))))(Tile((id \
          c73848b4-9e5b-4072-bff8-bc6c9ea5918e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bec761d4-effb-4bcb-aca2-24da2ce50568)(content(Whitespace\" \
+         \"))))(Tile((id \
          5b6ad794-2a93-4a82-9341-96d40a202a56)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d8926e27-49de-4727-8f85-c712b053c5e9)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c8ca6f62-8a75-4ea8-89e2-f0b1b519da06)(content(Whitespace\" \
-         \"))))(Tile((id \
+         a85419d2-e5f2-4fb5-ba90-57599914ee85)(content(Whitespace\"\\n\"))))(Tile((id \
          b74d7ae6-fde7-4f06-b8b4-2d994eb1cb20)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1c34d769-5def-4fac-bcb2-bb7861860a7f)(content(Whitespace\" \
+         \"))))(Tile((id \
          d6270327-055a-4b40-ab34-524074f993b5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         975ca033-e7cc-4dda-8e63-0db4a241a502)(content(Whitespace\" \
+         \"))))(Tile((id \
          995397e0-ca8c-4035-b08d-703fd4f12137)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0e5b707e-4f8e-4756-80b2-c2256e6781e0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         591bf0fd-66c6-4a83-a854-cb78e45e6b33)(content(Whitespace\" \
-         \"))))(Tile((id d6dbfdac-3052-4ee6-ab6b-2f3d763472be)(label(\"`eat \
-         black and white`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
-         Typ))((shape Convex)(sort Typ))))))(shards(0))(children())))(Tile((id \
+         a07e136e-03a4-4a20-afbe-0c586e3ba111)(content(Whitespace\"\\n\"))))(Tile((id \
+         d6dbfdac-3052-4ee6-ab6b-2f3d763472be)(label(\"`eat black and \
+         white`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
+         Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         734938ea-c486-4f0f-aa14-18fff086c134)(content(Whitespace\" \
+         \"))))(Tile((id \
          6506c34a-a4c5-4e0d-8fa0-49083a942f2d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7b631e72-ffd6-440a-92c8-353744aa6ba0)(content(Whitespace\" \
+         \"))))(Tile((id \
          be55dd92-aa02-4bb2-93c4-9afe09cce3ee)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         bbed9b75-93b7-40fa-8576-5319f4d526ed)(content(Whitespace\"\\n\"))))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         78976ba8-ff6e-4a1a-91a3-1267e1350d04)(content(Whitespace\"\\n\"))))))))))))))(Tile((id \
          f5859071-c2aa-4dff-a81d-35476e73d85d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2694,28 +2802,34 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dae2fabf-11be-46c8-b406-f20cba50e091)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         08d3b1c3-cc73-4815-94dd-f79c97ae7d33)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bf483b48-3280-4992-ba55-952987bceed4)(content(Whitespace\" \
+         db40c3d8-c270-466f-a653-ce62be856943)(content(Whitespace\" \
          \"))))(Tile((id eee20895-8afe-420a-b861-7c78e06d26ff)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         966ea0b0-811d-482b-90f4-68811cc25e5e)(content(Whitespace\" \
+         7ec926af-657c-44ea-8d35-7b852fafdbb5)(content(Whitespace\" \
          \"))))(Tile((id \
          32c0c67b-b300-4283-96bc-d3e88dbb1e27)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e8f478d3-52b7-4f84-be22-5b76f9e6e182)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         e3ac83a3-27bb-44cc-a3c9-66d5ce73ab7d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ee43ea23-1413-4e96-9dbd-ad06acca410b)(content(Whitespace\" \
+         \"))))(Tile((id \
          2b7b77e4-ac36-4559-bcb3-8cc732cbd6d7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          51757d95-325f-4f33-a91f-a0eab9412966)(label(\"`eat black and \
          white`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         eb91d508-53f0-4e0c-9f80-620f92f950d4)(content(Whitespace\" \
+         \"))))(Tile((id \
          2dcb541e-8d00-4a7c-94c7-ecb15b034884)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         904ae7a0-4f6a-427b-a083-d26c7c7be759)(content(Whitespace\" \
+         \"))))(Tile((id \
          8814fb4e-d5c2-4fc8-9d6c-03437d50b373)(label(eat_black_and_white))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2728,13 +2842,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e514678d-15f4-4bc5-8215-e8c027aa1eda)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         697ba6b3-6539-44c5-94b7-6656d9488ebb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2aae8edf-05eb-400b-8755-26242cf7b546)(content(Whitespace\" \
+         8b1e14d6-ff91-40e8-802d-dcf63fb34b8f)(content(Whitespace\" \
          \"))))(Tile((id 0cf21a53-59fb-4ee1-8f00-1bec1a505904)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         aff409b1-f361-46b6-89c9-4669b106d6bb)(content(Whitespace\" \
+         667c5e5b-bf83-45e0-87c1-35d364bb5a6e)(content(Whitespace\" \
          \"))))(Tile((id \
          6fa11c71-3fcb-4acb-9e42-cc695e22ba9d)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2745,85 +2858,92 @@ let out : string * Haz3lcore.PersistentSegment.t =
          90b1c97a-bc46-4699-96f4-8018e19e5432)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         c0e0c32a-5083-46e0-a7c3-47de17bbb572)(content(Whitespace\" \
+         b1addfc9-eea5-4acd-a8b5-36baf5db86d9)(content(Whitespace\" \
          \"))))(Tile((id \
          1ae496b2-d623-443b-b11e-51d076898a1b)(label(b))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         22c00b81-916b-4669-8c5e-3952c1ba5f9f)(content(Whitespace\" \
+         3332e315-4d52-4730-9e09-c21fa0015644)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         04a067af-edea-4f35-82c3-2b0e73f1a6eb)(content(Whitespace\" \
+         dc171bdb-4f8a-4821-b3c4-3d6c0f715cb3)(content(Whitespace\" \
          \"))))(Tile((id \
          98829acb-b9ae-4185-817f-0cd604a4e013)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7d97b5c9-d93e-4328-b25d-708a67d54127)(content(Whitespace\" \
+         \"))))(Tile((id \
          2abe74cf-c148-499a-9f69-30bc1ff99f60)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         743801c9-00d9-4823-86ef-d959148c8fe2)(content(Whitespace\" \
+         \"))))(Tile((id \
          9ae92baa-f3ec-4f93-ae8c-44450974916d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          53190de7-a6da-4865-af7a-95955eb8e88c)(label(\"`eat black and \
          white`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d22500f7-ff94-465d-95ae-5260fb9aec4f)(content(Whitespace\" \
+         \"))))(Tile((id \
          77e193a0-03e5-45ec-814a-d69f0d55c5cd)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         08fb7ed1-3833-43b8-90b7-082b89edfbee)(content(Whitespace\" \
+         \"))))(Tile((id \
          50552a1f-4331-4ac0-80cf-be2253691f1e)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         dbff856d-b57a-4910-9af6-13fe0187595b)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         de861f36-571a-46ea-9a46-88844dd060fe)(content(Whitespace\"\\n\"))))(Secondary((id \
          6a6c9216-7461-4b8f-8b60-e09ab8863ebc)(content(Comment\"# b is being \
          autolabeled here#\"))))(Secondary((id \
-         af3e1002-1bd4-4c4e-a138-9e4d03a16860)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e0dcfad4-55a9-42b8-966d-cf8cb2937349)(content(Whitespace\"\\n\"))))(Tile((id \
+         5b6f973c-a33b-443f-bc65-9b36c0d12dcd)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3d8451fc-08f0-44b1-acd4-8edec75b62a4)(content(Whitespace\"\\n\"))))(Tile((id \
          e2ed137b-998f-4967-a9e6-8fa21335ba02)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         714f1f41-66f4-4f89-9ac5-67a22dae5d57)(content(Whitespace\" \
+         12ef3bcf-59c7-4bc5-82f6-263c7ccd06e7)(content(Whitespace\" \
          \"))))(Tile((id \
          ef115d40-76ab-43c5-abd9-260e26fbd3a3)(label(correct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c09aef4f-aa53-4443-99df-07537a8d0770)(content(Whitespace\" \
+         ce0e3796-7676-49f7-9529-cf8a9eccc0ee)(content(Whitespace\" \
          \")))))((Secondary((id \
-         08c3db1b-3f88-4f41-94f5-1a398e558a07)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         193113b7-1dbb-459b-8c5a-2e21d8392c11)(content(Whitespace\"\\n\"))))(Tile((id \
+         6b87f795-299f-437b-b1cb-41439566c31e)(content(Whitespace\"\\n\"))))(Tile((id \
          a367f352-8229-4df0-8756-4219504e84e6)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         f79fbddc-ae69-4cec-9231-75906fdf6012)(content(Whitespace\" \
+         abdf6c0f-4941-4b48-b7d6-fb97f3a87ad6)(content(Whitespace\" \
          \"))))(Tile((id \
          8522c5a2-17be-4413-a873-86b0584a922c)(label(eat_black_and_white))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7752e07e-eabd-415a-9dd6-672f45fd4bf3)(content(Whitespace\" \
+         76db0064-d0cc-468b-8149-7198f0b9b9a8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         024583a1-d95f-4b79-bb2e-b700070d3eaa)(content(Whitespace\" \
+         b0c9ba7a-16cc-4011-ba8f-0b79d4e66095)(content(Whitespace\" \
          \"))))(Tile((id a5402a4c-415a-40ce-a920-daf9e79b8fe5)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         711bb898-6384-47d4-8ca4-cf0833213b33)(content(Whitespace\" \
+         62ae5d91-ac4e-43ea-85a0-f448009ece82)(content(Whitespace\" \
          \"))))(Tile((id \
          cd0b99f4-b0bd-44ab-9d47-aad2422ecbf1)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7ad531de-7d6b-4ef2-97ae-a668460834e4)(content(Whitespace\" \
+         ee3d2e4e-eb21-4d12-be63-2d8a859ea003)(content(Whitespace\" \
          \"))))(Tile((id \
          e810eaef-5e4d-4356-8d08-99e5cf7b6076)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b4a23214-4100-4cad-87c3-1036bee52d99)(content(Whitespace\" \
+         36c66f59-9f07-4aa2-99b5-620677a70139)(content(Whitespace\" \
          \"))))(Tile((id \
          2ace1016-2596-48c0-a5f5-f69e082771e7)(label(JellyAnon))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         61b15db5-102f-4592-a55b-51a7fa24dfde)(content(Whitespace\" \
+         f3e4f891-3bd3-420f-af77-5ef89916914e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ce77394b-c0d1-4704-a8ba-a1a7c86047d3)(content(Whitespace\" \
+         2a1a79cc-44ff-4193-86de-8e2637767959)(content(Whitespace\" \
          \"))))(Tile((id \
          24c6aa44-68ce-49a7-af81-fd04bfc85ed0)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2834,22 +2954,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9090e469-d8f6-4715-b88c-416e041ddaec)(label(black))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         88cd05f0-a740-4bdb-ab71-2bba44d5a619)(content(Whitespace\" \
+         4f3f44d3-0bb7-48b0-9336-2616d29a4ccb)(content(Whitespace\" \
          \"))))(Tile((id \
          7a06f1c0-1d62-42ea-a5e3-af973d2d85a6)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3960b431-5099-4713-a944-1b018c5bd911)(content(Whitespace\" \
+         d52945a8-0faa-4223-9ddf-7f9bc794d866)(content(Whitespace\" \
          \"))))(Tile((id \
          43968227-e41b-4334-9f9b-546a6e38c147)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         55cf793b-f343-4a10-9ef0-22fd973f91a7)(content(Whitespace\" \
+         aa384936-f6a8-416c-a0ef-d3e47f0f897d)(content(Whitespace\" \
          \"))))(Tile((id \
          f4e3ce65-e22b-402c-b0f2-1d86422bf0cb)(label(&&))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 32))(sort Exp))((shape(Concave \
          32))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ffc5a34f-8f2e-40ba-ab14-7bc21ce98510)(content(Whitespace\" \
+         b2e6e8c5-8634-4ed6-ad42-fbd790631471)(content(Whitespace\" \
          \"))))(Tile((id \
          a879145e-1101-41c8-a6ab-e73e3ad39a4b)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2860,30 +2980,28 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9aaa86a8-9f6d-456e-9de7-aa795786d665)(label(white))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b0d49d94-3e91-45a5-bf37-9a62c3554ad3)(content(Whitespace\" \
+         1633968a-2b29-423c-a67c-745dd69f8005)(content(Whitespace\" \
          \"))))(Tile((id \
          5043cf5a-c4ec-472c-909e-2717e84ae6cd)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         980ede49-61dd-40e9-bbdb-073705998266)(content(Whitespace\" \
+         a912d747-16f7-4860-847f-c94ebef9378b)(content(Whitespace\" \
          \"))))(Tile((id \
          1637bc8d-0053-4064-b8a0-5540a4ec0689)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         9d3895de-e8ad-4828-85ff-957d158edb84)(content(Whitespace\" \
+         497105cf-7b0d-4ebc-bf72-b656330e1ac1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6783fa51-ec95-4854-967d-6868091f3573)(content(Whitespace\"\\n\"))))(Tile((id \
+         373e6b98-e34b-48ac-9985-796a3defb080)(content(Whitespace\"\\n\"))))(Tile((id \
          14fbf4d7-9b68-44a4-8094-57a211e61784)(label(build_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         276b52aa-b61a-42ac-93df-a0a5c93eb209)(content(Whitespace\"\\n\"))))(Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
          83453b22-9d4e-47fd-82d6-a0ad7e4308f2)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          74919487-76bd-43e5-b0d1-51135b575db0)(label(JellyAnon))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         80cf5ec2-46a3-466a-b1d5-cd9be84ca839)(content(Whitespace\"\\n\"))))(Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
          3a6c45b2-09f0-45bd-b007-6f7bfd6f39d6)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2892,169 +3010,210 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          33f9d49c-5bfe-472f-957a-2e1da00bd37f)(label(\"`eat black and \
          white`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
-         Typ))((shape Convex)(sort Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8953aa78-cd57-42eb-a4c1-cb246a3b3a47)(content(Whitespace\" \
+         \"))))(Tile((id \
          4362ea74-0d1c-46ae-a8d9-8a35f706b9a6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ad4d4969-094d-4731-bade-b4c01dfcea50)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb6d890e-304e-4203-b8c2-e90dd76c33cd)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e20e2472-2d79-46ab-b863-5f1ec5032d8d)(content(Whitespace\"\\n\"))))(Tile((id \
+         Typ))))))(shards(0))(children())))))))))))))(Tile((id \
          9d3bf6b0-2bcc-43c2-8ee7-87879707376f)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          52594c25-6785-4230-954f-1c18c67ba5af)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         41569ae9-890f-452c-8268-f5ac955aa486)(content(Whitespace\"\\n\"))))(Tile((id \
          ca9a5ef2-a352-4143-bfec-5e17324c93f0)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a5b0d4dc-1439-4ff2-92c2-6b6d5817d849)(content(Whitespace\" \
+         \"))))(Tile((id \
          218c50b4-a415-4f71-a450-2ba7e33a373a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         812e2648-eb7a-465a-b74b-c3a5c1cb38da)(content(Whitespace\" \
+         \"))))(Tile((id \
          89a71fca-4a67-442b-aec5-b0701387f6e8)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          832444d5-9b57-4047-a289-7b264384586e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8f01b223-e694-43fc-9a09-c78ccd06dd44)(content(Whitespace\" \
-         \"))))(Tile((id \
+         36407d0b-df20-4992-87f7-7e8f76508c67)(content(Whitespace\"\\n\"))))(Tile((id \
          a43611f2-0613-4fca-a549-c61bccb0254f)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ef70bfc8-fa90-42c7-b95d-023927af5092)(content(Whitespace\" \
+         \"))))(Tile((id \
          a857ccf0-49a7-46bd-9ee9-08e7ad10c3bc)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0d7ee6d5-3e95-4bf9-b248-cd1a8c737769)(content(Whitespace\" \
+         \"))))(Tile((id \
          0cb67239-007e-4ebe-9280-cecaca0f47f6)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d2aa7269-180f-4a60-9a80-2d0a65d82551)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3a016188-8757-4766-8d01-09f3ddaff46a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         267b82f4-5796-4723-806b-65aaeff8e202)(content(Whitespace\"\\n\"))))(Tile((id \
          b3617d2c-9618-4a94-a56b-3c0e12562704)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         fb5d18a5-b2cb-46b5-b5ea-47f72fbc671a)(content(Whitespace\" \
+         \"))))(Tile((id \
          cdf26308-e318-4a60-889b-c7b81b66c882)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         32ca95a0-d77d-46b0-b233-3e1a33eacd78)(content(Whitespace\" \
+         \"))))(Tile((id \
          52dc777b-ebb6-496a-a790-f897ed0b5d43)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bcb3f0c4-b944-463c-90ee-eb4dca67c2b9)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a5304f7d-c733-4af7-9ece-14867ff54583)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d0490af9-0f64-46fb-8ae2-78ee529c8fae)(content(Whitespace\"\\n\"))))(Tile((id \
          5a91481a-736e-40a2-9815-208fb896907e)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bb6510b9-9544-4fa5-99e3-95391bd7c4cf)(content(Whitespace\" \
+         \"))))(Tile((id \
          01be5eef-4702-4853-87d3-a77c0d44f0e1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bd3bc09d-fd4c-42a6-ba85-3fb1fd58cd5c)(content(Whitespace\" \
+         \"))))(Tile((id \
          4c2d44f4-023c-4d6a-9d10-77bf72cfefa2)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          77c9cb7f-dd30-48f1-8fbe-861311c47842)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         58d64241-f3db-4bbb-afbd-a19f6e4718a2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         6d24414b-8494-4871-8bdb-1d569d61b7d6)(content(Whitespace\"\\n\"))))(Tile((id \
          b9db3bbf-5e75-43b8-b497-b64b6cda7174)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         71cd45a4-caf4-4203-8abb-5f729aada984)(content(Whitespace\" \
+         \"))))(Tile((id \
          3a0888ab-8943-4a13-b607-d0d00fb13c15)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8eaff3f9-d900-496d-99e4-86e856df56b4)(content(Whitespace\" \
+         \"))))(Tile((id \
          e60ac360-166f-4b51-a127-6e6111e82942)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6f78c315-62f1-4d99-a3c4-12fb7922c501)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a36585e2-db13-4937-9c28-68ea91b9e357)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3b7c3987-f83d-4b00-bd1d-49e9999166ee)(content(Whitespace\"\\n\"))))(Tile((id \
          519cba6c-5698-4c9e-94bd-e3b62f6be3ab)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3fbd71ab-b942-41a7-870b-36425fce704f)(content(Whitespace\" \
+         \"))))(Tile((id \
          9147ebec-f780-4899-a17c-9538a48cce7b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         88f5e50b-e154-4514-89fb-0e2b52a32161)(content(Whitespace\" \
+         \"))))(Tile((id \
          0b19b24b-8d00-4872-b202-d303e466fcb9)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a4bc662b-bc24-41a3-b7f4-1e40f182cd38)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0d73715f-8525-4f53-922a-dd719244f47d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d7d317ce-ee62-42bd-b704-9a0de4b996e7)(content(Whitespace\"\\n\"))))(Tile((id \
          f9cc72cd-8fb1-4599-a798-1fdf4a09c600)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         275d5df8-45b8-4a9a-a204-bef291eeaf30)(content(Whitespace\" \
+         \"))))(Tile((id \
          b1a9edb7-7e87-460b-a658-b0f2c7521cdc)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cc1e1c7e-d821-4fbf-bc82-2bfc00ad1230)(content(Whitespace\" \
+         \"))))(Tile((id \
          ae2fbe98-3358-42b1-9d10-d1e3c02f8289)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          28bf69bb-f20b-4ea6-98c9-9e488d74c1df)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         50f2b65a-67ac-42f1-975f-936a1693b806)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9cdf878c-6da8-4bd8-ad09-66d7010ced40)(content(Whitespace\"\\n\"))))(Tile((id \
          82827141-5a54-4ebb-8459-170071097780)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         21433644-6cbf-4fb7-a8fb-32c2ce8aace9)(content(Whitespace\" \
+         \"))))(Tile((id \
          dff15b82-0ed1-417b-9879-fc50618f9c1b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cf3e8c85-0e64-46ba-ae91-dffc96fdddcf)(content(Whitespace\" \
+         \"))))(Tile((id \
          e92607b2-f2c7-4da2-80a8-d9cc0bdba3cd)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5814effe-9ee2-49c5-95d8-3d225bc013cc)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9a202e9f-9799-4972-b526-f7c1691daf14)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5fd2ecb6-199e-4bc9-b84d-9549ded945c8)(content(Whitespace\"\\n\"))))(Tile((id \
          246b40a3-1ccc-4a2f-8b59-290d748456ff)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7f6ac524-e12e-4c2d-9ec5-41c384b60f8b)(content(Whitespace\" \
+         \"))))(Tile((id \
          d1791c89-a02f-465b-be17-1e145fea92fc)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9e6a579b-9bcf-4a17-86fb-8d150ff1c95e)(content(Whitespace\" \
+         \"))))(Tile((id \
          07780960-04c5-4da3-8267-53a8ec5991d2)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4e921878-3b86-4fb7-8221-11b9fd38f84b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0340e52e-9c23-43ee-8ad3-20809a0ebe65)(content(Whitespace\" \
-         \"))))(Tile((id \
+         81628681-a1f3-4d0a-9ac1-d025f0c185e1)(content(Whitespace\"\\n\"))))(Tile((id \
          290e52fd-3f15-4ea8-8c37-e4716aaa661e)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8572f691-7514-49c7-9871-9ef5e073c5f9)(content(Whitespace\" \
+         \"))))(Tile((id \
          f6475d11-664b-4668-9f38-13cca8321bff)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1e8db216-068c-4f8b-8483-cd9486dd6ae1)(content(Whitespace\" \
+         \"))))(Tile((id \
          dfd2e002-0c64-4f62-b037-88f0bbb4b7e2)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          eb0e7185-f590-454c-af87-00118dc269b3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3904626a-5e80-49e4-a71d-c3052579ffef)(content(Whitespace\" \
-         \"))))(Tile((id 2e1a1842-9803-418d-84cc-69a04e47431d)(label(\"`eat \
-         black and white`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
-         Typ))((shape Convex)(sort Typ))))))(shards(0))(children())))(Tile((id \
+         0d74b8bd-f309-47fc-a6b7-edb20a9534c5)(content(Whitespace\"\\n\"))))(Tile((id \
+         2e1a1842-9803-418d-84cc-69a04e47431d)(label(\"`eat black and \
+         white`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
+         Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d46c3222-0da9-4316-b42d-b2a4a03e6c29)(content(Whitespace\" \
+         \"))))(Tile((id \
          13807329-6298-4aa7-9faf-125c7117dcc7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         477723dc-90ba-4614-ae45-28937a6f3c00)(content(Whitespace\" \
+         \"))))(Tile((id \
          b1d73e7e-3628-483f-a9b3-dc005d15d5f4)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         fa006067-0f01-45ea-9277-1b46fec3d6d5)(content(Whitespace\"\\n\"))))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         38e20098-9370-414c-a895-fc5d0b346013)(content(Whitespace\"\\n\"))))))))))))))(Tile((id \
          e4e8eddd-875c-40c5-a7bb-051f3265f313)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3064,26 +3223,34 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a8d209f1-2343-4e1a-82da-8f8bfcbf72a3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0ee6e96d-007b-40fd-8d8e-221d7c4cbd26)(content(Whitespace\"\\n\"))))(Tile((id \
-         2d254881-184b-4db9-8cf7-65073be47d87)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         74bac979-ad5b-43e4-9f2c-7133651aa5fb)(content(Whitespace\" \
+         5aca4629-4be4-42c5-895b-459afe4235c0)(content(Whitespace\" \
+         \"))))(Tile((id 2d254881-184b-4db9-8cf7-65073be47d87)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         b28362b0-00c8-4171-9441-72c00d6bf1cc)(content(Whitespace\" \
          \"))))(Tile((id \
          38ec7b39-38f7-44c7-bc0f-125ca5bbc475)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b394f977-3165-40a0-ac58-b489143e9ae3)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         1eade7ef-7958-4abc-b87a-ccca11fcbb35)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         36f7b52e-4b57-45eb-85a5-a04964f406bd)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce4dad62-47bd-4356-9ac4-3ab52248623e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          de6396d3-1072-42ac-a917-1e7baf188769)(label(\"`eat black and \
          white`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ab52e0bd-acf1-44ce-9a84-c07ad2a9ad43)(content(Whitespace\" \
+         \"))))(Tile((id \
          9ac9e2ac-8126-4207-af02-d328e880feb3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         be701ec3-b0d7-45a0-939a-2d3b3d1dbb58)(content(Whitespace\" \
+         \"))))(Tile((id \
          acbb4f96-0956-43e1-9ecb-78bb2ef51875)(label(eat_black_and_white))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3096,11 +3263,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d05ebc5b-c294-4f7d-857e-e0ea4d0aec85)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e07ce29c-780a-4f75-b7b0-1b77cadb3d01)(content(Whitespace\"\\n\"))))(Tile((id \
-         1fdb483f-e3a2-43ae-9944-32fa66b2920a)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         12f6a55e-557c-4f5c-a637-20b01da5e754)(content(Whitespace\" \
+         4f77cb3b-77ab-4cd6-a699-49985e300416)(content(Whitespace\" \
+         \"))))(Tile((id 1fdb483f-e3a2-43ae-9944-32fa66b2920a)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         8292f847-2e38-4d5d-9080-93894e454db5)(content(Whitespace\" \
          \"))))(Tile((id \
          c1a36822-7aa3-461e-83e2-3bbe1e712ab4)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -3111,237 +3279,275 @@ let out : string * Haz3lcore.PersistentSegment.t =
          18dd7736-b192-46a7-8a58-60385a8e2653)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         9d02141c-b761-4255-b4fb-1634967ea0f4)(content(Whitespace\" \
+         1b9a3c54-6b82-4f84-8045-7cbcd682324e)(content(Whitespace\" \
          \"))))(Tile((id \
          b899546d-3afd-4154-b28f-d58f38b203ce)(label(b))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         6814470e-d875-4270-889c-b59317fca433)(content(Whitespace\" \
+         66db77d9-a125-43e6-ab1f-938b7e392f14)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e1e548c0-f62a-4f49-9b8e-5c38137a4875)(content(Whitespace\" \
+         c5eeb0bb-a336-49df-a524-dde47959d3fd)(content(Whitespace\" \
          \"))))(Tile((id \
          ddee2573-ca8f-40f6-9cc3-47192fc12a64)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ea4679f5-c6dc-4a46-9f3c-8ea387813790)(content(Whitespace\" \
+         \"))))(Tile((id \
          f2d743a7-4b63-4f67-a9e6-1addd9bdcc81)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c5f341c1-fdb1-4964-bdf8-98aa6612d04e)(content(Whitespace\" \
+         \"))))(Tile((id \
          93da5faa-0b82-4b9f-b188-d1877d40b4b0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          e1cad031-b828-458f-82b5-2225f39bb1b3)(label(\"`eat black and \
          white`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c3b3142c-6c26-4846-af54-dfa96443a01f)(content(Whitespace\" \
+         \"))))(Tile((id \
          e1950973-70f1-4845-b022-e7b5d16c3ec3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         94d37493-e789-43a4-96c0-bc2aeef4a4e3)(content(Whitespace\" \
+         \"))))(Tile((id \
          091c3dcf-5b8c-4d23-a9ce-02922b8424fa)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         bb28ef64-cc05-43ab-81ba-11d1c7cbe99b)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         797e3b2b-77e6-4d27-bacc-65595efd45f4)(content(Whitespace\"\\n\"))))(Secondary((id \
          3eaa4e28-53db-465c-b875-5828a073b5dc)(content(Comment\"# b is being \
          autolabeled here#\"))))(Secondary((id \
-         19fc18f7-ac86-4856-a570-95a84bc4da2a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5f08b5d6-fdf4-4802-b2c6-b041366c69d3)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         4eefa88d-cdcf-4799-86d1-4ab81c44ab73)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c5c3713b-5c1b-454d-8431-a2a418f636b5)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9db41db9-93c4-40b6-948a-de493d3c38bd)(content(Whitespace\"\\n\"))))(Tile((id \
          15784d36-3b8e-4e60-b676-ebf72fe03f45)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         abed1a6a-97fc-48cd-8f29-f9fb9e6c5d1d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         277f39d6-0850-47a0-8e3a-3263dacbf27d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         78a79872-14ec-4859-973f-9d562f3d1134)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2e3249d2-3d8b-406d-84ab-902501ceea6f)(content(Whitespace\"\\n\"))))(Tile((id \
+         13fc7984-1e58-4a42-a788-6bdafeb5de5d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         03070aec-2703-4eb5-9b6d-2e5289f4dfd1)(content(Whitespace\"\\n\"))))(Secondary((id \
+         74729539-0c1d-4f5e-b5d1-97b564f7d2a3)(content(Whitespace\"\\n\"))))(Tile((id \
          8ba894ff-50bd-4c34-8caa-62708c96a4ab)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1b06bd22-73de-4b98-9fdc-2bbe7762141e)(content(Whitespace\" \
+         0b5ec7d3-336c-4e58-8847-5041e23a68a2)(content(Whitespace\" \
          \"))))(Tile((id \
          3cdb444f-4728-45da-84f7-e58d40538e23)(label(pie_count))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         17e7a26d-1ac5-4947-99d0-89e9e36cebbd)(content(Whitespace\" \
+         7ca0dd86-1d19-483a-a099-761cc553ab46)(content(Whitespace\" \
          \")))))((Secondary((id \
-         63942a93-0559-49dd-bd43-8d8d3e5f8335)(content(Whitespace\"\\n\"))))(Tile((id \
+         b8517681-f3d2-4c54-9bdf-930d71ca2c89)(content(Whitespace\"\\n\"))))(Tile((id \
          87c12b06-c297-4088-82c5-6cdf32d62d47)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         79a5aea1-af10-464b-90ae-efe06098b055)(content(Whitespace\" \
+         ad300bc9-d9fb-48ff-81ff-2c0bc3a4513c)(content(Whitespace\" \
          \"))))(Tile((id \
          f5523cb8-9e0a-4264-90d5-b6e69879e620)(label(JellyAnon))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         7acb2371-2198-4c15-b1f7-036bf8647c27)(content(Whitespace\" \
+         9de40fc2-9e4b-41bc-bd42-4971edaf31eb)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ee947e0d-770b-4093-b3e3-57b799ac1b9d)(content(Whitespace\" \
+         719eec2e-0c11-4146-9d0c-34e12c818e7b)(content(Whitespace\" \
          \"))))(Tile((id \
          1b8169b5-bb9d-4711-8782-6fb770482e08)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         d11816d2-1f25-4b81-ae63-ee5fc86f0eea)(content(Whitespace\"\\n\"))))(Tile((id \
          2fe38fc5-8288-4246-9c91-4168333a6367)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e7e42741-0c67-4e62-b2c4-deb6bae32012)(content(Whitespace\" \
+         \"))))(Tile((id \
          c07e0de9-df80-42ba-a048-4d0d67c50e36)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         eb3548f4-fa49-4fe0-ac11-9a35fb334c50)(content(Whitespace\" \
+         \"))))(Tile((id \
          9eca4aee-b458-4b94-a9d3-b6f24361e5dd)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          cee9a912-4d4c-44ce-a137-facbe5f70e84)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1770b780-e62a-4030-9180-c90cf5fa4cae)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9f3c7129-3285-4cf3-960e-3c8832c63d21)(content(Whitespace\"\\n\"))))(Tile((id \
          db13f1c1-7661-4896-96cd-72ad828d50ec)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f77e8203-d5d4-41c6-93c6-af718b42d9cb)(content(Whitespace\" \
+         \"))))(Tile((id \
          1518e4ef-c1f5-405f-81e6-5225adde330d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a20219f5-7185-4ed8-8ef7-cd87d7d5c7e2)(content(Whitespace\" \
+         \"))))(Tile((id \
          7ba79db0-6b16-4d53-ad54-eba287b80bda)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c558b4b5-0ab2-4e64-a8b0-86a37b8d666d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ea5205ab-442e-4fce-bd06-798fcf845a19)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b038ff36-4faf-49e6-8258-7f18c3e99350)(content(Whitespace\"\\n\"))))(Tile((id \
          be0dfc52-ac19-41d1-b93a-c19885445714)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7aa8a44c-25f4-4771-921d-47e83260e856)(content(Whitespace\" \
+         \"))))(Tile((id \
          d232ee58-28d4-4a12-83fe-36a433d4fa3b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         63b2e108-b591-4110-af79-57f425dd10a1)(content(Whitespace\" \
+         \"))))(Tile((id \
          65a98e5c-9185-4561-bad7-bfbc4954cf2a)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d66020de-f4df-4083-8700-dbd91b2f32b6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c7edb7b5-952d-4072-9141-2d674926c34c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3720b41e-452c-42c4-9957-ca9a5cccd05f)(content(Whitespace\"\\n\"))))(Tile((id \
          ca00b355-d648-433f-92ff-269140c33b3c)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         999f476b-78e9-4013-b6ec-1b61ce3f50b9)(content(Whitespace\" \
+         \"))))(Tile((id \
          f84e8e2a-1b7c-4fc3-a704-7f22e7bb4611)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         17d5e41e-bfe5-453a-930e-6c6bbdc5d9d0)(content(Whitespace\" \
+         \"))))(Tile((id \
          8afc686f-f8b3-4d38-8ea6-7ababb500395)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          3f6b95e2-f3a3-4779-af9a-f1d076342099)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         102b3208-aef6-40ff-92f6-76df6d9d6c65)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c7b72c9f-be5a-4ebb-89f1-66321a80a107)(content(Whitespace\"\\n\"))))(Tile((id \
          3ccab8df-0d23-4028-a24e-980ff5b9aa06)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         77e4c3e0-3266-4ee2-969f-282f2b9f362b)(content(Whitespace\" \
+         \"))))(Tile((id \
          4c42938c-88d5-4d93-b44a-9eca63246ffc)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4063a6a7-5774-4740-9dc4-1d297dfde587)(content(Whitespace\" \
+         \"))))(Tile((id \
          46d019a6-c98b-4d63-902b-4d018f079c5b)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d7f0195d-96e3-46c4-9d89-84a621a46e76)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7ed191a0-f732-4fa1-aa99-b3eadc0606d5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         7bd252c8-4831-45df-813c-9e59c9bb8088)(content(Whitespace\"\\n\"))))(Tile((id \
          274753ba-1b25-4a1e-b50b-662ce2c3185e)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3f1ace1f-4fb4-42a7-b6cf-95f3a570bff8)(content(Whitespace\" \
+         \"))))(Tile((id \
          da496e14-9878-4cb4-ab9f-6cc1488056ab)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c17527e8-8df4-499f-9c6d-aadfbef49298)(content(Whitespace\" \
+         \"))))(Tile((id \
          636cd58e-cdfa-463c-98c8-c5ab9dfbf6f9)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a57d6a11-43be-43be-bafa-bd4d037023c8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4d95b2a6-62a5-4b47-8862-450b34339519)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b90452d1-c3f6-4950-970a-55d711c52f38)(content(Whitespace\"\\n\"))))(Tile((id \
          bce496b6-ccc4-43a5-9e3c-fcc67cb03fb5)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a0476936-a298-40be-93d6-7e1edc783e68)(content(Whitespace\" \
+         \"))))(Tile((id \
          c605e7fa-0387-495b-a512-cbcfacae2c06)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         986b4764-4a4f-46d6-bc83-30e538b04823)(content(Whitespace\" \
+         \"))))(Tile((id \
          4be7b04a-da91-403e-ab22-c20ff08ef04f)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4a10bfd8-3f02-4daf-8249-6315c21077b3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8e23d884-3ddb-42e8-8b1d-94c21e4bfa77)(content(Whitespace\" \
-         \"))))(Tile((id \
+         68eaa560-bf5b-4e38-a11d-c6ee5c0e040f)(content(Whitespace\"\\n\"))))(Tile((id \
          0d21a2b8-50f4-496b-b50e-308fd2338c39)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         efa68d29-10bb-49aa-b68a-7394895fc84c)(content(Whitespace\" \
+         \"))))(Tile((id \
          19562270-226f-40ff-931f-31f6440d9120)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1337ddf1-fc10-43d0-9dd4-d97577bdec29)(content(Whitespace\" \
+         \"))))(Tile((id \
          3da88462-e1df-4870-ad64-ea641a85aa71)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b0fce494-89aa-4de4-a919-cbbaae982be0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c9f12051-7724-4051-a496-be97443b76d1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         588664ba-82f0-4151-aeb6-45c56118a86a)(content(Whitespace\"\\n\"))))(Tile((id \
          b60b4e71-f838-483d-89d4-218244566456)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7b1e109c-2f09-468b-a167-624f37e9e9a6)(content(Whitespace\" \
+         \"))))(Tile((id \
          a1ee85af-f296-41d4-af7f-9678c2ef2c45)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e407573b-13f1-4e71-971a-3d35e810eb0f)(content(Whitespace\" \
+         \"))))(Tile((id \
          3d7cebd1-fa20-43e2-aab2-7ed3f74ec2e8)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5a83ceb7-4ced-4179-9cf2-4742c3006596)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         455f06c7-daa1-4a93-bfd4-1e225ff530ea)(content(Whitespace\" \
-         \"))))(Tile((id \
+         2a26b7e0-a26c-4334-a7b0-6695764ce65c)(content(Whitespace\"\\n\"))))(Tile((id \
          957ec646-1594-4464-872a-90e1f2bca74e)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f06f4c4b-a302-4a8e-acb3-5ca49ae9bc96)(content(Whitespace\" \
+         \"))))(Tile((id \
          ab74d293-22a7-4a64-8d50-5fbeace1e6bf)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3824bd65-9400-4c3d-b145-08c475d48a62)(content(Whitespace\" \
+         \"))))(Tile((id \
          85cc12cc-e8fa-4d3c-9ba2-7ae70c91307e)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         436592bb-11ab-4baf-9bb0-b7bd695d7bff)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4a8d8310-55e9-46e3-ab18-d0e40af3d4f4)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         76426d7f-70d6-4f6a-9083-04ce18af13f1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5f9722cc-d858-417d-b232-2287d7e5a612)(content(Whitespace\"\\n\"))))(Tile((id \
+         32a32c61-22b1-48cd-8f1f-f56df0ad811f)(content(Whitespace\"\\n\"))))(Tile((id \
          50f7fc33-89b0-4ca6-a378-41ea5b39ba2b)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         7dad7a23-6785-487f-b2af-6828fef98a03)(content(Whitespace\" \
+         dcc251df-020f-4981-82f0-c3cf58ec4525)(content(Whitespace\" \
          \"))))(Tile((id \
          c1381fb1-bee5-421b-a25e-2afffa89f366)(label(jellyAnon))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         58b26584-429b-4ec6-8d07-68551cd3e527)(content(Whitespace\" \
+         d0145cfa-d5f4-4ee3-ba6a-3a5d4005758a)(content(Whitespace\" \
          \"))))(Tile((id \
          d672388f-f284-4f10-a218-ee7a45bfbabb)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e12fc84d-3507-4858-a8f2-560cfdb1f98b)(content(Whitespace\" \
+         1a8680ad-3ba8-47a9-9319-7c678e586b66)(content(Whitespace\" \
          \"))))(Tile((id 4baadd35-7324-4058-9507-69b1261a5629)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          53f96dc7-5422-4967-855c-eefbb20e9eb2)(label(JellyAnon))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         b74df67c-c547-4b50-99b6-7070cca224f2)(content(Whitespace\" \
+         a503a568-d851-44ab-b778-1e004197be69)(content(Whitespace\" \
          \")))))((Secondary((id \
-         1d7b667f-e8ef-4be4-8413-60932a4ba27f)(content(Whitespace\" \
+         cb730a5e-bb08-4d3d-a6fa-31376155ac62)(content(Whitespace\" \
          \"))))(Projector((id 5ec6f8c0-f7ff-4142-9bc0-ea2151e74fab)(kind \
          Fold)(syntax(Tile((id \
          770e7f76-8ca8-45a9-98b7-74c36369156a)(label(\"(\"\")\"))(mold((out \
@@ -4569,60 +4775,59 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))))))))(model\"()\"))))))))(Secondary((id \
          de7ee636-23bc-4726-ae6a-d94d8fa6cd28)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         4abfcd68-f434-4c3d-93fb-89ed418df64d)(content(Whitespace\" \
+         f88ab0fa-5b1a-4cb4-aa36-8179104ddc34)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         48b0c27c-f779-45b3-ae5a-43b368e94914)(content(Whitespace\"\\n\"))))(Tile((id \
+         69d5af69-27a1-4468-80f1-a9538cfd43a8)(content(Whitespace\"\\n\"))))(Tile((id \
          0ad1ef0b-8fc1-46a5-8591-2107b7b3dc4b)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e6c376e7-05f2-4f3c-b0f1-4c56bfe6a8b9)(content(Whitespace\" \
+         88a33ef7-d104-4058-a75c-d927730341e4)(content(Whitespace\" \
          \"))))(Tile((id \
          d0e65a1e-234c-40cf-867f-0eb62354e9fe)(label(count))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e59758d3-cfd3-40c7-8ccd-4901cdd844cf)(content(Whitespace\" \
+         c75872ae-db89-4a67-91df-10af0034ee28)(content(Whitespace\" \
          \")))))((Secondary((id \
-         98c6890b-4036-4c83-a14e-9f85bc7bb0f1)(content(Whitespace\" \
-         \"))))(Tile((id c72ca369-70ee-44c6-a7fd-0ecf793e7d11)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         f70c2c09-1ebf-4f73-8084-2fe3defa954a)(content(Whitespace\" \
+         8e49561f-2083-464d-9700-ec4208b115e3)(content(Whitespace\"\\n\"))))(Tile((id \
+         c72ca369-70ee-44c6-a7fd-0ecf793e7d11)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         d26c0856-2966-4cd5-947e-dd787f459afa)(content(Whitespace\" \
          \"))))(Tile((id \
          4499416e-43ce-4ed9-be0e-dd44019ca5d6)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         97cc226e-8da6-40f7-9b59-48f85dfc8c8d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dedd0ecf-4f8c-4e75-b5fd-664b63671398)(content(Whitespace\" \
+         c4df8a0a-75ff-4e86-949d-cc1bb62d08d3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         faa1a859-41fc-446b-a0e3-9bdbf4de0de8)(content(Whitespace\" \
-         \"))))(Tile((id d97d65ea-74c8-4c13-b986-7841280ea0db)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         294bc0f6-4ab9-4d94-8dd9-7f96bd9b71ad)(content(Whitespace\" \
+         16d3ffcf-27e3-4a48-a65f-fdec119202b7)(content(Whitespace\"\\n\"))))(Tile((id \
+         d97d65ea-74c8-4c13-b986-7841280ea0db)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         29df68ec-9701-473a-b54e-5d6d9774e05d)(content(Whitespace\" \
          \"))))(Tile((id \
          a40ddf29-16a4-4278-85a2-4270cba042c0)(label(v))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children()))))))))(Secondary((id \
-         76e4089c-31aa-48db-8398-40d26dda09cb)(content(Whitespace\" \
-         \"))))(Tile((id 02b6c66b-8980-42a5-ac4d-eda8b5a932ff)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         4e38a1d8-88f7-48b9-83d0-c4ef352d2153)(content(Whitespace\" \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         f3ca4362-e78e-4e9a-b134-2bc37bb4a54b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3c409dfc-a17c-426c-ad72-3d6a3bd7d68c)(content(Whitespace\"\\n\"))))(Tile((id \
+         02b6c66b-8980-42a5-ac4d-eda8b5a932ff)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         68bc8f3e-65a9-4ad1-9cc5-c8db261d2790)(content(Whitespace\" \
          \"))))(Tile((id \
          f80a1e59-e4a2-4d91-9054-04adebbcaf26)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          f639c379-39ed-4878-acfe-3fde391fb151)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ff595da5-d13e-4362-b117-844b472d528c)(content(Whitespace\" \
+         \"))))(Tile((id \
          6f079ade-4722-40d8-a4b9-e7c871f6a005)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c9aa872b-c492-44cc-8bbf-4f08e331ed18)(content(Whitespace\" \
+         a0eecdb6-dc20-49b2-beec-0a7561101c61)(content(Whitespace\" \
          \"))))(Tile((id 0a0d53d7-389e-4ae5-ac8b-63368862a5fb)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -4632,61 +4837,62 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5cb41b52-200b-4398-851c-4653717aff67)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         a869c6bf-e020-46a7-a24d-552ab74afddb)(content(Whitespace\" \
+         bdee1b7d-ed05-4079-a36a-428cff540a48)(content(Whitespace\" \
          \"))))(Tile((id \
          439aa1f9-4476-46bf-b221-c932d5947a8c)(label(proj))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b8e04076-227b-47c6-a663-ae98deaf86be)(content(Whitespace\" \
+         d771ec1e-aea9-40db-9adc-726069c24a46)(content(Whitespace\" \
          \"))))(Tile((id \
          5e657c82-1162-41ca-82d6-16e9135140af)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f07e2710-9206-4532-8703-b07c2ff689b4)(content(Whitespace\" \
+         8bd916f6-69f2-41d2-91b2-37b76d34f87c)(content(Whitespace\" \
          \"))))(Tile((id \
          25bb3a8c-76fe-45be-9c88-546201c543f2)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         bc30598f-3020-4d0a-822e-3a9e7f885745)(content(Whitespace\" \
+         49506981-89c7-4625-bbeb-8b2cf114b276)(content(Whitespace\" \
          \"))))(Tile((id \
          40a47614-2a55-4062-8ad7-f5e4c11ca013)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         15122420-8c0d-444e-b40e-ee98412ea163)(content(Whitespace\" \
+         bb6194f6-7dca-4a11-a820-fb0811e296f8)(content(Whitespace\" \
          \"))))(Tile((id \
          671f94c5-cb81-43d3-8bf2-f607fe9b860a)(label(v))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         9dafcc35-0e3a-4341-aa9f-f7c8c37db4e7)(content(Whitespace\" \
+         e1fd49cd-a2c7-499f-9fbe-fcbb54bb0d4a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         bed3156d-e5a1-4277-b29f-b37ad508cb72)(content(Whitespace\"\\n\"))))(Tile((id \
+         d7e567c7-2a1d-4d60-ab52-f879cfc3426c)(content(Whitespace\"\\n\"))))(Tile((id \
          6813f7c4-c1e1-4ced-8e28-ff771510d12b)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         4aa43184-c4a9-4130-bf78-ec00474b2ab6)(content(Whitespace\" \
+         d6ab206d-fd34-47e9-9480-2753742c6d9a)(content(Whitespace\" \
          \"))))(Tile((id \
          483440be-0bc5-4757-adeb-a762c901b395)(label(go))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3568a113-4687-4a90-96d3-c95d48eb699a)(content(Whitespace\" \
+         c6edb93d-89b5-4507-bc08-f6bdaf941e0d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         89c0deb6-5dbd-4b53-9f79-0683957c50d0)(content(Whitespace\" \
-         \"))))(Tile((id 1bb075e6-dfa5-45c7-981a-5a8626f22569)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         8f91d25a-055f-420b-aa05-02166e246250)(content(Whitespace\" \
+         6c2f36d2-d379-4e59-9dfc-0a1219ce2f90)(content(Whitespace\"\\n\"))))(Tile((id \
+         1bb075e6-dfa5-45c7-981a-5a8626f22569)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         c8dfb230-722d-42e0-ada9-322097551737)(content(Whitespace\" \
          \"))))(Tile((id \
          ad374ab4-3458-4998-98fb-bd2da225c620)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          92e589fa-dcaa-465f-b11b-95093e0af6c4)(label(groups))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e63cf461-ffdd-4f64-8d91-c48ae87089f1)(content(Whitespace\" \
+         \"))))(Tile((id \
          fc5d9f1a-3375-4603-9230-02b45bace076)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3dee8785-84d8-4244-8a2a-8a9627b086d1)(content(Whitespace\" \
+         d49a957e-9c21-4aa2-a07b-324341dab587)(content(Whitespace\" \
          \"))))(Tile((id c122cf59-1326-4ab3-831c-0a2f8a972c06)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -4695,48 +4901,60 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          5e9fd5e3-66b4-4ca9-ab6e-53aaec32c72c)(label(value))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b13ba26c-dc0a-4be6-861c-4152cbb345e8)(content(Whitespace\" \
+         \"))))(Tile((id \
          6c8664ae-10b5-41b9-8202-c24bdb412186)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         497d1567-0273-45fd-9494-4a14263917eb)(content(Whitespace\" \
+         \"))))(Tile((id \
          8fbd5b5f-446e-4486-9067-df5805984975)(label(v))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4a811b99-6b72-46b4-9c63-cf4685e3f78a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         74bf906f-7298-40d1-a744-5fe56f4cd738)(content(Whitespace\" \
+         d6596422-662f-4874-b2e1-bf557f8eb641)(content(Whitespace\" \
          \"))))(Tile((id \
          e1a22140-1a10-4176-9c33-9b9e07e747d9)(label(count))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e571ce09-a075-457e-b9ef-36d903ea30a8)(content(Whitespace\" \
+         \"))))(Tile((id \
          6f38b5d4-0a95-401a-ab33-6ea9b52e3ce3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ef69892a-d6b5-49e2-b95d-a689d349e264)(content(Whitespace\" \
+         \"))))(Tile((id \
          2d074dc1-a3ff-403c-bc37-69e74765ac31)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
          540d0a10-134f-4c5d-b232-a3750b14f535)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         a1b17c8d-b192-4ed7-bee4-c35f876f2b1c)(content(Whitespace\" \
+         2f6d105d-d357-4057-876c-460847ea2484)(content(Whitespace\" \
          \"))))(Tile((id \
          fdc3fe66-b377-43d1-9de6-b6a588f45833)(label(row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         8f41a7e3-7e39-4eda-b94b-f3adc20162d8)(content(Whitespace\" \
+         \"))))(Tile((id \
          5cd50dd9-046f-49d2-adfd-12fe34fe76e9)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         936f8b8a-656e-4a71-8737-e03782dfca38)(content(Whitespace\" \
+         \"))))(Tile((id \
          ed1f8199-1e4d-4738-a658-cb8069f5c111)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         eb7f4b6e-4317-44a7-8378-81c7e35ead7f)(content(Whitespace\" \
+         a6719f75-8993-48ee-92b3-bce0ef08ddbd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         30d6b16e-f701-4c64-9791-82752fc6a420)(content(Whitespace\"\\n\"))))(Tile((id \
+         47743bdf-4204-4a63-a60d-70d7a87c2176)(content(Whitespace\"\\n\"))))(Tile((id \
          0270cb5d-8925-4b90-a9c7-eb4778085ff5)(label(case end))(mold((out \
          Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         d24c8319-8719-4215-94bd-26ce3393ccb9)(content(Whitespace\" \
+         f046f876-82c5-4831-a981-14c9e1fb7b92)(content(Whitespace\" \
          \"))))(Tile((id \
          a1eeb304-32f6-4f53-a889-efee7c3e54f8)(label(find_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4750,19 +4968,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          01d7854d-9643-4af2-a5c5-c5f9ee096195)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9d9c7b7c-1206-4f41-81ea-e45a5acedd7a)(content(Whitespace\" \
+         39a52eb2-f38b-4188-9b22-2a468286f7ca)(content(Whitespace\" \
          \"))))(Tile((id 232b3bec-1b0d-4fd1-8f39-a1a72d3e0fb3)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         726418c5-f39d-4f18-a3af-4d45a016d52c)(content(Whitespace\" \
+         9101559c-efe2-4a90-9938-b184790c6a96)(content(Whitespace\" \
          \"))))(Tile((id \
          e9472996-add3-49c5-b05f-e3522dc47a33)(label(g))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         bf698248-77a9-4e21-b04a-da46487855ea)(content(Whitespace\" \
+         c2ef991c-3492-4eae-92dd-bc9d0e27b369)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2c437f7c-63c5-420c-909d-e1324adde1c6)(content(Whitespace\" \
+         5bc320c6-9a5d-4d5f-8536-5840dca7b6ab)(content(Whitespace\" \
          \"))))(Tile((id \
          81f9f79a-23ad-49e8-a592-36c7134206a6)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4773,12 +4991,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2cf728e6-a6c3-412e-818e-414bfd729961)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         00b193a2-6812-414c-bd61-0d85918ca2a1)(content(Whitespace\" \
+         da477548-afc8-457f-a54c-174dc28ac86a)(content(Whitespace\" \
          \"))))(Tile((id \
          292658d1-b871-404c-9184-9dd20e40e2d0)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2c28b7fb-5314-4620-b816-2783c109e2e4)(content(Whitespace\" \
+         372f08a8-18f8-407f-9758-d746f597bac1)(content(Whitespace\" \
          \"))))(Tile((id \
          6edba552-06c3-4703-9c80-932ce70e23cf)(label(proj))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4789,7 +5007,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ce965386-c3df-41d3-a1fc-0713df8b047f)(label(row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e6f2ac97-0f7c-44e6-9bbc-0da08af65926)(content(Whitespace\"\\n\"))))(Tile((id \
+         d654e8a1-7040-4468-ad28-bd99408bd2b0)(content(Whitespace\"\\n\"))))(Tile((id \
          ac4fe792-52da-48ec-a98f-108600368bc2)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -4800,17 +5018,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          17a5219e-37dc-4bf6-8628-379680b9d7db)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3b89e659-a8ce-4efc-be6e-f56e1f3fb3ed)(content(Whitespace\" \
+         2ad96bff-7a94-40fa-af0b-cd77a84fdab4)(content(Whitespace\" \
          \"))))(Tile((id \
          03193e34-4d19-434b-a426-2514fb07cc27)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          5c4e7bcd-1e31-4b19-875d-11dd0af52f9f)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6de97302-7fe8-450f-9fc4-cea266a7adf3)(content(Whitespace\" \
+         \"))))(Tile((id \
          a032171b-867a-4705-a995-46e266965e9d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e9d95618-70ba-458c-98c8-f4bf4813a134)(content(Whitespace\" \
+         \"))))(Tile((id \
          1d71be0c-dda4-4d0d-899c-942eadcf90c8)(label(proj))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -4823,28 +5045,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          789bf40e-e6e9-4acb-a1d4-5eb05d66f05e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2f92639e-5858-4696-94f3-1221e065c4ee)(content(Whitespace\" \
+         5cb28614-473f-49fa-a501-c36012433194)(content(Whitespace\" \
          \"))))(Tile((id \
          fdd3b4dd-7a6f-479b-840e-bcdcd7703c97)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         43483b3f-ec0c-4713-826a-1e4b1709d8c3)(content(Whitespace\" \
+         \"))))(Tile((id \
          c969bbe3-02f9-44fe-9f62-c6393e560113)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         88a1c760-1e5c-4f06-9cf3-79370387b6c8)(content(Whitespace\" \
+         \"))))(Tile((id \
          1bc534fb-a7b3-4a8c-b141-94804bece569)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         673a6b03-28eb-48c3-8a63-e2a80a0a0bae)(content(Whitespace\" \
+         29336fae-250c-4166-9245-fa3a15ccf3f3)(content(Whitespace\" \
          \"))))(Tile((id \
          38bb5a30-6f71-4169-b62b-19ea6c1f7645)(label(::))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
          29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8f3588b9-466b-4565-8f67-df223c72f79b)(content(Whitespace\" \
+         cb2855b7-4104-430b-8429-c30911a20fc9)(content(Whitespace\" \
          \"))))(Tile((id \
          f9535243-dd76-4366-86c0-dbcc84f6f7d4)(label(groups))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         24ceb113-867a-4fca-98ed-f44adba6445a)(content(Whitespace\"\\n\"))))(Tile((id \
+         e7969632-8a97-47ba-962d-e72b2304b3a1)(content(Whitespace\"\\n\"))))(Tile((id \
          9dcc22b2-5206-4772-9345-c45a07aa7bd1)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -4862,7 +5088,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8b36c357-aaf2-45f4-9f43-1e1a6ec83d7b)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
          39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         330773fd-2479-42ae-8fb2-d49b059ae98f)(label(v))(mold((out \
+         330773fd-2479-42ae-8fb2-d49b059ae98f)(label(_v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
          0372b083-2391-46f2-ae48-839a31eb06ad)(label(,))(mold((out \
@@ -4879,17 +5105,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          b4474a98-5691-422d-9009-9a1f24695cfa)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         daa51199-133f-48bb-9196-7794e71b75b0)(content(Whitespace\" \
+         b8343f55-a3da-4f5a-9a57-3d7ca36ab808)(content(Whitespace\" \
          \"))))(Tile((id \
          399a69f2-8f3a-4f72-9688-ddb4d7cbbbe8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          90f1339a-8f63-45c0-b1ae-7c79f07c91f2)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3d9fc461-c20a-4202-8e18-3f0ef30ca761)(content(Whitespace\" \
+         \"))))(Tile((id \
          18aaf1c8-84e2-4cf0-9ac8-7b1f5011b67d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2a4b4301-9de4-4c2a-a5fa-c5450384ed96)(content(Whitespace\" \
+         \"))))(Tile((id \
          4363bcb9-8823-421e-b5ec-90882d6df975)(label(proj))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -4902,29 +5132,37 @@ let out : string * Haz3lcore.PersistentSegment.t =
          964bbfa2-060d-43b6-b95f-a2c5ad4ee61c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5f4cc399-c528-4a67-9d9d-3b6bfee40283)(content(Whitespace\" \
+         0b5d0649-e5cd-4f13-abd4-e278229bfa63)(content(Whitespace\" \
          \"))))(Tile((id \
          6220bb71-1f59-415d-a332-7c21d031f2df)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8d94d27d-a8d6-45f3-b50a-cf71be59ecb3)(content(Whitespace\" \
+         \"))))(Tile((id \
          f3a754c9-ea18-4831-b9f0-65ed94392d65)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         446ad453-061b-40d4-add3-d26e560311cc)(content(Whitespace\" \
+         \"))))(Tile((id \
          c0804f86-e411-4888-b52b-cdb7279c2826)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6bb34d90-38ac-41ba-8d8a-44d63b32d092)(content(Whitespace\" \
+         \"))))(Tile((id \
          1c7641f1-e6e3-4d3b-8803-b3e92fb8caa6)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7da5056c-126e-472a-ae98-3abf1a5916ca)(content(Whitespace\" \
+         \"))))(Tile((id \
          be3b1697-97aa-482f-8d67-f3cf6006501e)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fa4c143f-ca7d-4871-a8f0-0bdd676d773a)(content(Whitespace\" \
+         65d238b8-38de-480f-b471-15642760ddc4)(content(Whitespace\" \
          \"))))(Tile((id \
          b761fb0f-5057-4ae8-ac84-7909876755bb)(label(::))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
          29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c88d17f8-4508-4755-b36b-5076581c7db7)(content(Whitespace\" \
+         05d2e39e-c802-4f2d-9e48-468036caaa66)(content(Whitespace\" \
          \"))))(Tile((id \
          5ddf626c-76b3-48a4-8bc8-fe96cd2cc558)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4938,19 +5176,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          029b7a9f-ad4d-4602-8711-5778cd15b0a7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1bf8af29-bc1a-437c-9dd5-26cfdeab7b62)(content(Whitespace\" \
+         96cf7c15-3ae6-4f34-bf2a-c1a480f2999b)(content(Whitespace\" \
          \"))))(Tile((id ac9ba549-55c0-4d77-b85e-1ce9f4854bed)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         827664b8-530d-4ae7-b345-70c0d708be49)(content(Whitespace\" \
+         6d3de96e-0a4a-4356-8da9-28a0f2411552)(content(Whitespace\" \
          \"))))(Tile((id \
          8d11fbbb-4eb0-4ba2-84af-7ed55848ae9e)(label(g))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1a48d41f-fb95-4276-af8b-f0d81a815dea)(content(Whitespace\" \
+         286e773c-d45d-4ecd-80b3-ae9f335c6a9c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         44fec0cc-b4a7-45ba-9d8d-f3cf63e1f314)(content(Whitespace\" \
+         d7189261-4adb-45cd-bbd9-e5abd468c343)(content(Whitespace\" \
          \"))))(Tile((id \
          234d83a5-7afa-45f1-ab69-c949b2621020)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4961,12 +5199,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ada96a26-ba0a-405c-bf37-d94a9fe8e52b)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         e4ff5e1f-6179-4a81-9d27-7fbca6e78575)(content(Whitespace\" \
+         a90d33a3-d29e-4a42-ad9e-f0639c24240c)(content(Whitespace\" \
          \"))))(Tile((id \
          8611ab42-d51c-4b9c-ba7d-f74ddfbad2e1)(label(!=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cc289bd8-37d2-4b3c-8826-a391771feb45)(content(Whitespace\" \
+         1ddfcacc-2b1c-4665-b9ba-e2aff86cee7c)(content(Whitespace\" \
          \"))))(Tile((id \
          417acd17-9fda-4a1b-ab4b-1343e32b697b)(label(proj))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4977,11 +5215,10 @@ let out : string * Haz3lcore.PersistentSegment.t =
          28efa3cd-7973-4ef4-a9fb-cb8b893ac8e8)(label(row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         db73b959-8cb6-4602-acf2-c9379b0c6f25)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         c9f1b40c-4bd9-429b-bf6a-70956b91778d)(content(Whitespace\" \
+         b70a35f3-19c8-425e-939a-5a8e7df0f7d3)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         2289951b-a2a9-4f56-82af-8846136bf054)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e5f5bed4-5335-49a8-8ea8-36b0c641ac2e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c8cad235-a09b-4cd8-af92-9c4f59a51acc)(content(Whitespace\"\\n\"))))(Tile((id \
+         efc2d4ab-6c84-4fd2-a4fa-ed26f00cc878)(content(Whitespace\"\\n\"))))(Tile((id \
          77ce5b97-1d93-455a-8dab-87c8c157abfb)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -4994,7 +5231,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a4e15403-61f2-4abe-87cf-123d98b37535)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f1dff04a-4137-4ebe-be99-ec83ed05d5b1)(content(Whitespace\" \
+         8e083a76-d952-4a1b-9a22-98fd3bc9ccbe)(content(Whitespace\" \
          \"))))(Tile((id \
          c8ab83a0-f823-4406-9966-cf3a11a94c75)(label(go))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -5002,15 +5239,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          412c7d7f-631b-4f18-9f5d-dcf222ff5561)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8de8ead3-3811-45b8-b087-3b71daa514b1)(content(Whitespace\" \
+         f3e50122-9d23-4a5d-8b5c-febf338b9111)(content(Whitespace\" \
          \"))))(Tile((id \
          d34c3c24-47d6-42a2-b1a4-6b7eee79920f)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         99517803-0411-4dfe-ac05-8b9ec2883633)(content(Whitespace\" \
+         \"))))(Tile((id \
          435e9913-a8a6-4d2b-8ddd-b385f418dac1)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         476d152f-4da5-4ee7-bc5d-7a9a24a15ff8)(content(Whitespace\" \
+         afad67ae-0063-4b7e-9ba9-487f87bdf442)(content(Whitespace\" \
          \"))))(Tile((id 4db65384-bb82-44f7-bec9-2f764dd101c2)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -5019,42 +5258,49 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          f7026613-ae17-4e0e-9f75-626c040b867b)(label(value))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1992d345-b29a-47a1-bb1c-8dc39c1d3d17)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a28054f-5a8c-4e7c-b401-ec1d7cbae68b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2a2976f3-eaea-43af-97fb-ece3adc467ed)(content(Whitespace\" \
+         \"))))(Tile((id \
          dc485dc6-0309-4c54-b15e-1357a8246767)(label(v))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          69821884-2ace-4397-9f6e-4aa6e6c439ef)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1b60650a-0851-4c52-ab57-63c4bd99e0c1)(content(Whitespace\" \
+         3b5c4ff7-a9d7-444e-ad17-0c3dc9b569a1)(content(Whitespace\" \
          \"))))(Tile((id \
          3a67df42-26d8-4499-934d-0bcaa609ba64)(label(count))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8481f530-adc5-4ce6-8f23-16df3233a80f)(content(Whitespace\" \
+         \"))))(Tile((id \
          81b93422-e324-478a-9697-e77b7fb9f82c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         73139a1c-916b-472e-a183-50303c3490b1)(content(Whitespace\" \
+         \"))))(Tile((id \
          a9e22b19-4ae7-40b3-96c6-f77aa2cd53be)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e7fd48a0-533b-45d1-b111-95891af64593)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         158f2b06-11df-4df6-8d97-3f5ae587b747)(content(Whitespace\"\\n\"))))(Tile((id \
+         2f15d2aa-e137-402c-92b8-ad4e9f959f27)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         401a17e6-e65a-4d25-98ff-457bc618551e)(content(Whitespace\"\\n\"))))(Tile((id \
          68c18a6c-bf79-47be-873e-6db607f9fefc)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8642acd6-cc88-47ef-ae32-3200e067142f)(content(Whitespace\" \
+         f87c8d46-fe81-48a4-9a06-8c35fc1cb3c1)(content(Whitespace\" \
          \"))))(Tile((id \
          978cb256-17db-439a-a0f5-c89cd5807e8c)(label(incorrect))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         43f2e1b9-396b-4eb2-a480-d5f8c2ad223d)(content(Whitespace\" \
+         2073889a-02e6-4ba1-9676-ef99fe762fac)(content(Whitespace\" \
          \")))))((Secondary((id \
-         1d87ed44-0c59-4457-b3f3-3677de0cb7a4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         72fa7012-715a-4f94-ba54-1456a2d5b24d)(content(Whitespace\"\\n\"))))(Tile((id \
+         856c1ae6-dbb1-40d4-a81a-646a7879834e)(content(Whitespace\"\\n\"))))(Tile((id \
          cf0f614b-bc63-4e17-a8af-8bf415fbdd5a)(label(pie_chart))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -5066,24 +5312,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          48a76a1e-c8b3-4085-8105-df42bb9d6892)(label(value))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         db934279-45da-4691-90a2-a04ea3e02feb)(content(Whitespace\" \
+         \"))))(Tile((id \
          98179b67-5389-4f8f-b797-d27487b18a6b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         82b35dc3-51df-478a-9144-f7bbff707bca)(content(Whitespace\" \
+         \"))))(Tile((id \
          d01f3b70-c58e-4ac9-8a90-8b1b4a633756)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4b5d5d35-5b49-4046-b320-a2a494c8dec7)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         66c95358-6946-4b83-a7fb-d16b3123b502)(content(Whitespace\" \
+         ac371be9-c3d5-481d-b386-4df6fa3c499e)(content(Whitespace\" \
          \"))))(Tile((id \
          2fe83c88-6a18-4437-ab86-00b1f68f6249)(label(count))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d9e6031f-3c75-48f3-9144-1e7faffefe30)(content(Whitespace\" \
+         \"))))(Tile((id \
          b5378a1c-e77a-43ec-8b9c-2757285b53e0)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6042787b-24c8-411f-ad13-2b397176cfb8)(content(Whitespace\" \
+         \"))))(Tile((id \
          8d9971fe-533f-43fb-8d6a-1f8c63850f0c)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
@@ -5140,19 +5394,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          68ba862f-c320-48f1-8a8e-286043fab33f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4fd8e71f-2329-4129-913b-4b427fe99b9e)(content(Whitespace\" \
+         7519a773-afef-48a6-a455-5808a20833ce)(content(Whitespace\" \
          \"))))(Tile((id 29ab121b-2bcc-40f6-93ee-25451dc2ad42)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         3a9859dd-0a6a-413d-afc3-6f2936f67256)(content(Whitespace\" \
+         f9c3a1e8-2a11-46bd-9c0f-1929c84e6b4d)(content(Whitespace\" \
          \"))))(Tile((id \
          8b1f8bf9-6ee8-4385-8899-46b3ff6a4b19)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         11b35cbc-3470-43ca-b697-aa2ae37d9d71)(content(Whitespace\" \
+         e77ced22-9a62-4214-986c-1b5c348bad53)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0d51336b-dce7-494c-891c-eff8be8e88bc)(content(Whitespace\" \
+         b17881b6-aa7d-4bd1-a0c1-c53c6c39149b)(content(Whitespace\" \
          \"))))(Tile((id \
          fec98c56-378e-447f-a622-eb5406bf0a9b)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -5166,19 +5420,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          990dcf7e-028b-40f1-968a-ab17bd1f9949)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         26ce38c0-583d-4f0d-8dba-135206e956a9)(content(Whitespace\" \
+         30380adc-0c78-43f8-be77-4f31d0daa4a6)(content(Whitespace\" \
          \"))))(Tile((id 7416b2a2-9a71-4265-9b20-4649d68b76a7)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a61dd02f-5ce8-48e1-81a4-c39c167e6826)(content(Whitespace\" \
+         82af8272-1e87-45da-8106-d9065c42438b)(content(Whitespace\" \
          \"))))(Tile((id \
          1817d7c9-2b93-4614-b0ab-447173dbd22d)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2ae9c4ff-8e9d-4d41-aaa7-d5bcb7903ee8)(content(Whitespace\" \
+         781e2286-001e-42c6-adbf-17ddd8187354)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9b01c6f1-802e-4113-a200-2889e594fe9a)(content(Whitespace\" \
+         98bf1a3a-f37d-4ed2-994e-1b02e2ada89f)(content(Whitespace\" \
          \"))))(Tile((id \
          91a626ff-b6ef-424b-91f0-47179628367a)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -5189,21 +5443,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4c352c8c-d2b9-42ef-bb27-3ef7f79044f8)(label(get_acne))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         bfcd5b08-26ba-455e-a795-edb71ffc149b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         7b0df115-6045-46a0-ada1-9087b25097f9)(content(Whitespace\"\\n\"))))(Tile((id \
+         c2779e30-2869-4ff6-b6ae-4468718598d0)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d56febf2-ac2e-4cc6-a6f0-c994aa9c9c44)(content(Whitespace\"\\n\"))))(Tile((id \
          6f8f773b-5238-40bd-b44b-81ea19da9649)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         79c4b762-a870-43ea-8f34-c3ad4414c0f8)(content(Whitespace\" \
+         93860380-16b6-4a3e-a05d-37201e1687da)(content(Whitespace\" \
          \"))))(Tile((id \
          5cf4ebc3-ee3c-4350-a134-4bb92fce0462)(label(correct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d2d6cac3-2f26-4a0d-90e0-4be45065312f)(content(Whitespace\" \
+         b883bc3e-188e-4558-85e0-f4039daf909e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         265d63ba-9a75-44ee-86a6-0e8c9a4979f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1bed174-f3ed-49f7-b3fa-d28e7d357c8d)(content(Whitespace\"\\n\"))))(Tile((id \
+         c909099b-d9ed-415b-85a9-5ff821ff5b0b)(content(Whitespace\"\\n\"))))(Tile((id \
          8099c42b-13ce-4d1b-a195-954c1aa1182b)(label(pie_chart))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -5215,24 +5468,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          275f1188-929f-4eed-9b84-55ce89781850)(label(value))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         81b7163c-b367-4068-a3c2-7d20135b32c4)(content(Whitespace\" \
+         \"))))(Tile((id \
          2498472f-7417-44b3-8b02-1a4ce78f0c2d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3bebb70c-9de1-41d5-af2b-66b7498313fa)(content(Whitespace\" \
+         \"))))(Tile((id \
          7eb99927-a4a9-47d3-9a76-273b7c00dc92)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6661ac99-50b9-4edd-afaf-73ba4d10fc0e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ad1888b2-1c7c-4184-a909-c21e5b8e88ac)(content(Whitespace\" \
+         a183f272-e73d-47e7-903e-810b3b6fd29d)(content(Whitespace\" \
          \"))))(Tile((id \
          06494e75-ac5f-4502-823e-c8dfe0a7c8c4)(label(count))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b324f06e-fd28-495e-a841-6ffacf3a966a)(content(Whitespace\" \
+         \"))))(Tile((id \
          951f2534-72c9-42c5-bb02-2f4639e6d321)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6b7c7863-e665-4e00-b827-015ab56e50ba)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce9d9704-2dfe-43ba-a3f7-0a1c1555ff11)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
@@ -5289,19 +5550,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7778a7da-0f81-4cb6-97e8-26f454f4479f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c5b30ade-0a09-4ca3-9e4a-091141effe6a)(content(Whitespace\" \
+         64d11597-ee84-49c5-ae94-e77f25467bfd)(content(Whitespace\" \
          \"))))(Tile((id 9ef0c40a-1540-498b-9d04-a5b0e816df99)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         15fb2209-d733-4ec7-b062-8e610cb8cbcd)(content(Whitespace\" \
+         60b96f97-55ce-44c7-9f13-e92e45e49f7e)(content(Whitespace\" \
          \"))))(Tile((id \
          9e77d2ac-190f-47b5-ad23-59eaae23e955)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         01aa5f2b-1953-4993-b2e6-3fc6857081ca)(content(Whitespace\" \
+         7d6741fa-b019-45d6-89dd-fc649b54ae49)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1149d89a-b6ee-48e8-ae21-261f177a67ed)(content(Whitespace\" \
+         605a28e2-2a56-42a1-b4f6-6a1adf631b26)(content(Whitespace\" \
          \"))))(Tile((id \
          11ff1cab-dd66-4ec3-bc1d-2c9cc7140c69)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -5315,19 +5576,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e04a5f86-dc7e-40c8-ac31-2b6fdee003cf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         601e6ad4-dd1c-414c-98cc-74cc2aeeff80)(content(Whitespace\" \
+         6de9ada2-b14c-47e3-bedc-8ed2bf99b69d)(content(Whitespace\" \
          \"))))(Tile((id 72d12362-8a3f-4434-969e-ed21b45391af)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         2be42836-4547-458b-9ea3-444891466d6d)(content(Whitespace\" \
+         29a796d5-2aed-4453-9721-ac0180d026bd)(content(Whitespace\" \
          \"))))(Tile((id \
          434d15cc-0027-49df-86a3-80699b3a9a9f)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         081410e3-e50b-4a27-a90b-653d220d9236)(content(Whitespace\" \
+         e5a1210f-5194-4928-a319-5aa36ed25f6b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ee81f666-3b77-44a5-b889-ffc7dc9a6d3d)(content(Whitespace\" \
+         4b748cc1-1b60-485c-a9aa-a2578642fb04)(content(Whitespace\" \
          \"))))(Tile((id \
          02a4dce6-f953-4537-9a2a-3a52d9fb74c4)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -5338,15 +5599,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d173dcb5-8127-42ee-a74d-1d7fed48d107)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         a355fc3b-23bc-41b3-921f-d080904b7e1d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         cda280ed-fa00-478f-a808-d90ed5019bf9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9a09c950-0972-4697-a695-1336ecd55795)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7c030b4d-cc53-423d-9e3b-6c38ca42340b)(content(Whitespace\"\\n\"))))(Tile((id \
          76c227e7-a1e4-483e-a09d-40ded5b5f687)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         87b9ddb5-3d27-4bd6-8770-3774932f6850)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         886d5761-4496-4723-ac6e-fa97e3b17b25)(content(Whitespace\" \
-         \"))))(Tile((id \
+         6bd5d9f5-dd5a-4aeb-8dfc-65e9b7d4f8c9)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         4064156f-cf4c-44b2-a59a-d5f70395752f)(content(Whitespace\"\\n\"))))(Tile((id \
          d5eab350-4e08-45dd-9a24-637b1ec8baa7)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))";
@@ -5360,8 +5621,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          let pie_chart : poly row -> ([row], row -> ?, row -> Int) -> Image = \
          ? in\n\n\
          let mid_final =\n\
-         type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+         type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = ^^fold([\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
@@ -5369,89 +5630,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ]) in\n\
          # Currently requires explicit type application. Error message is \
          localized to error and shows what possible labels are. #\n\
-         let incorrect = scatter_plot@<GradebookEntry>(gradebook, fun r \
-         ->r.mid, fun r -> r.final) in\n\
-         let correct = scatter_plot@<GradebookEntry>(gradebook, fun r \
-         ->r.midterm, fun r -> r.final) in ?\n\
-         in\n\n\
-         let black_and_white =  \n\
-         type JellyAnon = (get_acne=Bool, red=Bool, black=Bool, white=Bool, \
-         green=Bool, yellow=Bool, brown=Bool, orange=Bool, pink=Bool, \
-         purple=Bool) in\n\
-         let jellyAnon : [JellyAnon] = ^^fold([\n\
-         (^^check(true), ^^check(false), ^^check(false), ^^check(false), \
-         ^^check(true), ^^check(false), ^^check(false), ^^check(true), \
-         ^^check(false), ^^check(false)),\n\
-         (^^check(true), ^^check(false), ^^check(true), ^^check(false), \
-         ^^check(true), ^^check(true), ^^check(false), ^^check(false), \
-         ^^check(false), ^^check(false)),\n\
-         (^^check(false), ^^check(false), ^^check(false), ^^check(false), \
-         ^^check(true), ^^check(false), ^^check(false), ^^check(false), \
-         ^^check(true), ^^check(false)),\n\
-         (^^check(false), ^^check(false), ^^check(false), ^^check(false), \
-         ^^check(false), ^^check(true), ^^check(false), ^^check(false), \
-         ^^check(false), ^^check(false)),\n\
-         (^^check(false), ^^check(false), ^^check(false), ^^check(false), \
-         ^^check(false), ^^check(true), ^^check(false), ^^check(false), \
-         ^^check(true), ^^check(false)),\n\
-         (^^check(true), ^^check(false), ^^check(true), ^^check(false), \
-         ^^check(false), ^^check(false), ^^check(false), ^^check(true), \
-         ^^check(true), ^^check(false)),\n\
-         (^^check(false), ^^check(false), ^^check(true), ^^check(false), \
-         ^^check(false), ^^check(false), ^^check(false), ^^check(false), \
-         ^^check(true), ^^check(false)),\n\
-         (^^check(true), ^^check(false), ^^check(false), ^^check(false), \
-         ^^check(false), ^^check(false), ^^check(true), ^^check(true), \
-         ^^check(false), ^^check(false)),\n\
-         (^^check(true), ^^check(false), ^^check(false), ^^check(false), \
-         ^^check(false), ^^check(false), ^^check(false), ^^check(true), \
-         ^^check(false), ^^check(false)),\n\
-         (^^check(false), ^^check(true), ^^check(false), ^^check(false), \
-         ^^check(false), ^^check(true), ^^check(true), ^^check(false), \
-         ^^check(true), ^^check(false))\n\
-         ]) in\n\n\
-         # Using alternative buildColumn that takes projection to new tuple #\n\
-         # The version taking a string can be used but it would give no static \
-         errors #\n\
-         let build_column: poly r1 -> poly r2 -> poly r3 -> ([r1], r1 -> r2, \
-         (r1,r2) -> r3) -> [r3]=\n\
-         typfun r1 -> typfun r2 -> typfun r3 -> \n\
-         fun (table, project, build_result) -> map(table, fun r: r1 -> \
-         build_result(r, project(r)))\n\
-         in\n\
-         let incorrect = \n\
-         let eat_black_and_white = fun r : JellyAnon -> r.`black and white` == \
-         true in\n\
-         build_column\n\
-         @<JellyAnon>\n\
-         @<(`eat black and white`=Bool)>\n\
-         @<(get_acne=Bool, red=Bool, black=Bool, white=Bool, green=Bool, \
-         yellow=Bool, brown=Bool, orange=Bool, pink=Bool, purple=Bool, `eat \
-         black and white`=Bool)>\n\
-         (jellyAnon,\n\
-        \ fun r ->(`eat black and white`=eat_black_and_white(r)),\n\
-        \ fun (a, b) -> a...(`eat black and white`=b)) # b is being \
-         autolabeled here#\n\
-         in\n\
-         let correct = \n\
-         let eat_black_and_white = fun r : JellyAnon -> r.black == true && \
-         r.white == true in\n\
-         build_column\n\
-         @<JellyAnon>\n\
-         @<(`eat black and white`=Bool)>\n\
-         @<(get_acne=Bool, red=Bool, black=Bool, white=Bool, green=Bool, \
-         yellow=Bool, brown=Bool, orange=Bool, pink=Bool, purple=Bool, `eat \
-         black and white`=Bool)>\n\
-         (jellyAnon,\n\
-         fun r ->(`eat black and white`=eat_black_and_white(r)),\n\
-         fun (a, b) -> a...(`eat black and white`=b)) # b is being autolabeled \
-         here# \n\
-         in ? \n\
-         in\n\n\
-         let pie_count =\n\
-         type JellyAnon = (get_acne=Bool, red=Bool, black=Bool, white=Bool, \
-         green=Bool, yellow=Bool, brown=Bool, orange=Bool, pink=Bool, \
-         purple=Bool) in\n\
+         let incorrect = scatter_plot@<GradebookEntry>(gradebook, fun r -> \
+         r.mid, fun r -> r.final) in\n\
+         let correct = scatter_plot@<GradebookEntry>(gradebook, fun r -> \
+         r.midterm, fun r -> r.final) in\n\
+         ? in\n\n\
+         let black_and_white =\n\
+         type JellyAnon = (\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool\n\
+         ) in\n\
          let jellyAnon : [JellyAnon] = ^^fold([\n\
          (^^check(true), ^^check(false), ^^check(false), ^^check(false), \
          ^^check(true), ^^check(false), ^^check(false), ^^check(true), \
@@ -5484,25 +5680,119 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ^^check(false), ^^check(true), ^^check(true), ^^check(false), \
          ^^check(true), ^^check(false))\n\
          ]) in\n\
-         let count = typfun row  -> typfun v-> fun (t1: [row], proj : row -> \
-         v) ->\n\
-         let go = fun (groups: [(value=v, count=Int)], row:row) ->\n\
+         # Using alternative buildColumn that takes projection to new tuple #\n\
+         # The version taking a string can be used but it would give no static \
+         errors #\n\
+         let build_column : poly r1 -> poly r2 -> poly r3 -> ([r1], r1 -> r2, \
+         (r1, r2) -> r3) -> [r3] =\n\
+         typfun r1 -> typfun r2 -> typfun r3 -> fun (table, project, \
+         build_result) -> map(table, fun r : r1 -> build_result(r, \
+         project(r))) in\n\
+         let incorrect =\n\
+         let eat_black_and_white = fun r : JellyAnon -> r.`black and white` == \
+         true in\n\
+         build_column@<JellyAnon>@<(`eat black and white` = Bool)>@<(\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool,\n\
+         `eat black and white` = Bool\n\
+         )>(jellyAnon, fun r -> (`eat black and white` = \
+         eat_black_and_white(r)), fun (a, b) -> a ... (`eat black and white` = \
+         b))\n\
+         # b is being autolabeled here# in\n\
+         let correct =\n\
+         let eat_black_and_white = fun r : JellyAnon -> r.black == true && \
+         r.white == true in\n\
+         build_column@<JellyAnon>@<(`eat black and white` = Bool)>@<(\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool,\n\
+         `eat black and white` = Bool\n\
+         )>(jellyAnon, fun r -> (`eat black and white` = \
+         eat_black_and_white(r)), fun (a, b) -> a ... (`eat black and white` = \
+         b))\n\
+         # b is being autolabeled here# in\n\
+         ? in\n\n\
+         let pie_count =\n\
+         type JellyAnon = (\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool\n\
+         ) in\n\
+         let jellyAnon : [JellyAnon] = ^^fold([\n\
+         (^^check(true), ^^check(false), ^^check(false), ^^check(false), \
+         ^^check(true), ^^check(false), ^^check(false), ^^check(true), \
+         ^^check(false), ^^check(false)),\n\
+         (^^check(true), ^^check(false), ^^check(true), ^^check(false), \
+         ^^check(true), ^^check(true), ^^check(false), ^^check(false), \
+         ^^check(false), ^^check(false)),\n\
+         (^^check(false), ^^check(false), ^^check(false), ^^check(false), \
+         ^^check(true), ^^check(false), ^^check(false), ^^check(false), \
+         ^^check(true), ^^check(false)),\n\
+         (^^check(false), ^^check(false), ^^check(false), ^^check(false), \
+         ^^check(false), ^^check(true), ^^check(false), ^^check(false), \
+         ^^check(false), ^^check(false)),\n\
+         (^^check(false), ^^check(false), ^^check(false), ^^check(false), \
+         ^^check(false), ^^check(true), ^^check(false), ^^check(false), \
+         ^^check(true), ^^check(false)),\n\
+         (^^check(true), ^^check(false), ^^check(true), ^^check(false), \
+         ^^check(false), ^^check(false), ^^check(false), ^^check(true), \
+         ^^check(true), ^^check(false)),\n\
+         (^^check(false), ^^check(false), ^^check(true), ^^check(false), \
+         ^^check(false), ^^check(false), ^^check(false), ^^check(false), \
+         ^^check(true), ^^check(false)),\n\
+         (^^check(true), ^^check(false), ^^check(false), ^^check(false), \
+         ^^check(false), ^^check(false), ^^check(true), ^^check(true), \
+         ^^check(false), ^^check(false)),\n\
+         (^^check(true), ^^check(false), ^^check(false), ^^check(false), \
+         ^^check(false), ^^check(false), ^^check(false), ^^check(true), \
+         ^^check(false), ^^check(false)),\n\
+         (^^check(false), ^^check(true), ^^check(false), ^^check(false), \
+         ^^check(false), ^^check(true), ^^check(true), ^^check(false), \
+         ^^check(true), ^^check(false))\n\
+         ]) in\n\
+         let count =\n\
+         typfun row ->\n\
+         typfun v ->\n\
+         fun (t1 : [row], proj : row -> v) ->\n\
+         let go =\n\
+         fun (groups : [(value = v, count = Int)], row : row) ->\n\
          case find_opt(groups, fun g -> g.value == proj(row))\n\
-         | None => (value=proj(row), count=1) :: groups\n\
-         | Some(value=v,count=c) => (value=proj(row), count=c+1) :: \
+         | None => (value = proj(row), count = 1) :: groups\n\
+         | Some(value=_v,count=c) => (value = proj(row), count = c + 1) :: \
          filter(groups, fun g -> g.value != proj(row))\n\
-         end in\n\n\
-         fold_left(t1, go, []): [(value=v, count=Int)]\n\
-         in\n\
-         let incorrect = \n\
-         pie_chart@<(value=Bool, \
-         count=Int)>(count@<JellyAnon>@<Bool>(jellyAnon, fun r -> r.get_acne), \
-         fun r -> r.`true`, fun r -> r.get_acne)\n\
-         in\n\
-         let correct = \n\
-         pie_chart@<(value=Bool, \
-         count=Int)>(count@<JellyAnon>@<Bool>(jellyAnon, fun r -> r.get_acne), \
-         fun r -> r.value, fun r -> r.count)\n\
-         in ?\n\
-         in ?";
+         end in\n\
+         fold_left(t1, go, []) : [(value = v, count = Int)] in\n\
+         let incorrect =\n\
+         pie_chart@<(value = Bool, count = \
+         Int)>(count@<JellyAnon>@<Bool>(jellyAnon, fun r -> r.get_acne), fun r \
+         -> r.`true`, fun r -> r.get_acne) in\n\
+         let correct =\n\
+         pie_chart@<(value = Bool, count = \
+         Int)>(count@<JellyAnon>@<Bool>(jellyAnon, fun r -> r.get_acne), fun r \
+         -> r.value, fun r -> r.count) in\n\
+         ? in\n\
+         ?";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/errors/B2T2ErrorsUsingTablesPart2.ml
+++ b/src/b2t2/slides/errors/B2T2ErrorsUsingTablesPart2.ml
@@ -6,49 +6,51 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         da01d03d-2e84-49df-886f-1648f2382979)(content(Whitespace\" \
+         3a0c6858-6e55-4c40-8c48-306046c0d585)(content(Whitespace\" \
          \"))))(Tile((id \
          cf648aa9-0763-4fda-b638-ef81861f4749)(label(Image))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         0adabb46-7140-438b-9919-13045fba35d0)(content(Whitespace\" \
-         \")))))((Tile((id \
+         220435a3-e065-446e-9749-f684d14b6e3a)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         237e63bb-4b99-4843-b97e-43806c83bcbe)(content(Whitespace\" \
+         \"))))(Tile((id \
          7d7fa2c8-feef-44e8-b1d5-8e11400e0b85)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         1ed4d2c7-92ee-4556-ac43-367559ea3a64)(content(Whitespace\" \
+         8ca5719e-9fbf-4b5c-919e-426bbe4d0620)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ab5c113c-966d-444a-bc00-6b66d65f0d79)(content(Whitespace\"\\n\"))))(Secondary((id \
+         6b72d41c-f137-4a9d-8019-8ea0c2361aa6)(content(Whitespace\"\\n\"))))(Secondary((id \
          27fd112d-e0e3-44d5-a92d-b9c6e7b81403)(content(Comment\"# Representing \
          column names as projection functions for better error localization \
          since we don't do first-class labels #\"))))(Secondary((id \
-         15ebdf56-6552-4e93-af96-1417c94951f9)(content(Whitespace\"\\n\"))))(Tile((id \
+         06ad87ca-4be3-42c3-9438-3b6e3b6b9f50)(content(Whitespace\"\\n\"))))(Tile((id \
          ca2f25b7-aeb9-4028-b9e1-0206e18a7e5a)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         772dea0e-67f5-426c-a6e3-29d32b47feb5)(content(Whitespace\" \
+         8e2ca3d3-2224-41e7-90da-74490daf0b5e)(content(Whitespace\" \
          \"))))(Tile((id \
          be645883-3807-485f-b4c2-9255a3f643ed)(label(scatter_plot))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         fb98b50f-b90f-41a7-93ec-69e03684958a)(content(Whitespace\" \
+         3685fbf4-7c2b-4c01-b8c5-4f2ddea928c7)(content(Whitespace\" \
          \"))))(Tile((id \
          563bf53d-1738-4ad0-b9df-2d9310fd3c41)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a5c16b16-62d2-40e1-aa10-958bb055a553)(content(Whitespace\" \
+         ccb2a90a-ac98-4dfa-adb5-3f4f22936b6c)(content(Whitespace\" \
          \"))))(Tile((id 5ea5799d-a71f-42da-bb60-132b390a8cfb)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         241b072b-b810-4647-a6b7-007d1672c1a9)(content(Whitespace\" \
+         6fb14585-f585-4f47-b967-c1f0f42e7cad)(content(Whitespace\" \
          \"))))(Tile((id \
          64ddd5a6-2fe0-4b7d-b746-187acd4e72a3)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         5b5b43e8-7d40-4ed4-86c0-7e15f833f103)(content(Whitespace\" \
+         6487073f-6ed1-465b-a295-8d54a3b2b3df)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7a7dfd7b-2735-45f0-a8ad-a931c872ab5f)(content(Whitespace\" \
+         36043fe8-887e-4842-a0bf-1335525c24a9)(content(Whitespace\" \
          \"))))(Tile((id \
          f9ccf8e3-87ed-414d-8327-1bf11e951be9)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -62,17 +64,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e079e529-7ddc-4f76-ba30-86274755ca4a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fe353424-823b-45b7-90b5-dda1d56c9f69)(content(Whitespace\" \
+         ae63c556-d31e-4df2-a0f5-6aebe4631653)(content(Whitespace\" \
          \"))))(Tile((id \
          cf13bdab-7f52-4286-b11a-86b64b2f3191)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         b2b18581-f669-49c7-815b-3616725ad536)(content(Whitespace\" \
+         787054fc-68e5-45f4-a456-5d9df62a7f9f)(content(Whitespace\" \
          \"))))(Tile((id \
          6d18d358-2e84-4174-baf7-d6109e8ec5b3)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fa7bcc34-8a68-4319-8862-4e12661b386c)(content(Whitespace\" \
+         6958363f-8f56-448c-be44-e518b6b5868c)(content(Whitespace\" \
          \"))))(Tile((id \
          540f3f24-df93-4338-86f2-61a6a53bfb76)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -80,72 +82,70 @@ let out : string * Haz3lcore.PersistentSegment.t =
          85844fe6-9377-4b16-972d-5eae47cde23b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2e79abd2-a5ce-4e95-845d-c69be6879259)(content(Whitespace\" \
+         aba11e53-6a92-4dbd-82eb-be073a9a1891)(content(Whitespace\" \
          \"))))(Tile((id \
          a13e9cab-4173-4b3d-a028-7480a1d6775f)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         a6144429-84c8-45cf-8606-9f749e27652a)(content(Whitespace\" \
+         a6abc0c1-e158-49bd-8e43-12de1ed78f86)(content(Whitespace\" \
          \"))))(Tile((id \
          fcfcccf4-e566-4de8-8eac-8c28f115ab0a)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ac08a0bf-451c-4bc8-8188-3b0be34eb48b)(content(Whitespace\" \
+         b060ea8b-b22e-4fc9-b360-273b13db4927)(content(Whitespace\" \
          \"))))(Tile((id \
          2d7b4e64-3d99-4ee3-ba8b-20c813ad031e)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         4e540fab-28a8-4965-b6ea-e008affa9a85)(content(Whitespace\" \
+         0129bff5-ecb0-42b8-984e-4cbe3f606ddf)(content(Whitespace\" \
          \"))))(Tile((id \
          2b58d8dc-39a2-4f5b-9630-42972f99711d)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f53ff7e5-a121-48d5-b40b-e5de9f7b8c81)(content(Whitespace\" \
+         f082e069-e5c7-4345-bc84-433c5cc24c46)(content(Whitespace\" \
          \"))))(Tile((id \
          c032e76d-a2fd-4840-a159-a4e02782221c)(label(Image))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         6f66f081-6e9e-4c11-a4f3-6de3f9b35424)(content(Whitespace\" \
-         \")))))((Tile((id \
+         3ccb1ec6-a8bd-40a9-9ff2-e71107627a27)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         e0d1d325-92de-4b97-8b95-0e950d75cc27)(content(Whitespace\" \
+         \"))))(Tile((id \
          eb4ae237-4966-458f-b7c0-540795afda10)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         e49d04bf-8888-468d-8303-078edff23961)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0911c49e-55b6-44ac-9b25-41780cc66962)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ccf8dc0-e7ed-4786-bc8d-704fa2280d46)(content(Whitespace\" \
+         d9ee19fc-5d4c-4531-9914-c25e2ecac6b8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8e4014de-152f-40e5-9b90-ee73b16a5d7a)(content(Whitespace\"\\n\"))))(Secondary((id \
+         767cbf06-a796-4321-87f7-9ebff3450f99)(content(Whitespace\"\\n\"))))(Secondary((id \
          0874f823-e2a7-4646-ab24-782b045683d8)(content(Comment\"# Using ? for \
          the categorical variables #\"))))(Secondary((id \
-         cd2e5852-bf3c-4443-8a14-11c896b3a102)(content(Whitespace\"\\n\"))))(Tile((id \
+         1932b06c-f1a4-4b10-a7c1-64e3913e9043)(content(Whitespace\"\\n\"))))(Tile((id \
          9545484d-f1b2-4257-b1e6-fa05da940851)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3a265d89-28df-4316-bc67-75eb3cb852be)(content(Whitespace\" \
+         61a175eb-f847-476b-854c-20af6927f510)(content(Whitespace\" \
          \"))))(Tile((id \
          eae3e6ee-d8c5-4808-a303-b525eb39a455)(label(pie_chart))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         dd949f69-aa8d-4909-a0ed-6e36b678bee9)(content(Whitespace\" \
+         54db1c09-8ede-483a-ad1e-3b3f230ed0cc)(content(Whitespace\" \
          \"))))(Tile((id \
          87fbbe7b-382c-4bc7-b5c2-e4d9a44e0ff2)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         cc52003c-0f72-443a-88e3-790df45be620)(content(Whitespace\" \
+         1d2ae488-08d0-4a43-8555-7189e16afb4b)(content(Whitespace\" \
          \"))))(Tile((id 99585c5e-4fca-4002-890d-3ce5e3a6820b)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         7a37aff7-eb72-4296-9a9f-c88a8adc9f26)(content(Whitespace\" \
+         066aa07f-bc8a-4a98-bd4e-9fd993a169b4)(content(Whitespace\" \
          \"))))(Tile((id \
          0115ab7a-6fb6-44ae-8e94-ed88b41cf6d7)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         b9480e1f-e1b0-48e2-9f85-124f34f2ef97)(content(Whitespace\" \
+         1768418c-30e0-43d5-a78d-92ce88d50f7a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5396160a-9110-4f4d-a22f-3c313475a3e3)(content(Whitespace\" \
+         eeb3a29b-8710-40d1-9a62-e51e3ba4bc30)(content(Whitespace\" \
          \"))))(Tile((id \
          e8d0350d-6f9d-49e0-80b2-825585e747f4)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -159,17 +159,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b50cbd05-ac7f-4105-8526-52a2612b1485)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c81469ec-6aff-43c6-bb55-fed2b0b5b376)(content(Whitespace\" \
+         6848b888-3721-4e57-97e7-48d3c3fc23b6)(content(Whitespace\" \
          \"))))(Tile((id \
          1cec4df8-5f2e-4266-9be0-e03fd1180b69)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         4f22ce6a-034b-4c6c-85a1-23c1124a6d64)(content(Whitespace\" \
+         508a8eee-34d4-4a0b-97e0-6e2abfcd9737)(content(Whitespace\" \
          \"))))(Tile((id \
          19dc1f07-05dc-4e3a-8955-a61221e69932)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a94af02b-fa79-4f36-9ba9-38897db5da96)(content(Whitespace\" \
+         e1faa42d-c69a-4575-89d9-269cd1b9538c)(content(Whitespace\" \
          \"))))(Tile((id \
          aa08c2ff-2c61-43d5-92de-ec741aecbd75)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -177,273 +177,288 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b30b2b8b-b5e4-44f6-9798-c79f46b51d09)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         481010ea-76a3-488e-9ef8-9a69e8a94568)(content(Whitespace\" \
+         f072f9d2-39e0-493d-b52d-7126fc283b39)(content(Whitespace\" \
          \"))))(Tile((id \
          439fc545-61c5-4965-be21-4bd2cd8cad6d)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         c9fcda91-6594-47c4-84ad-942fa1a03d11)(content(Whitespace\" \
+         81220f04-5770-4010-bc2b-2fb5b4e596f2)(content(Whitespace\" \
          \"))))(Tile((id \
          817a1964-114e-45a0-8600-0a9fe2675ece)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         383cda63-b589-4393-abfd-bd9550eeb3ed)(content(Whitespace\" \
+         f059243b-d455-43dd-9e27-953bf5d9c883)(content(Whitespace\" \
          \"))))(Tile((id \
          78e2e816-a591-4bfe-9a3f-169476e1227a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7f1a8a81-85aa-43ed-95d3-220694b52a5d)(content(Whitespace\" \
+         9ccdd791-7eed-48cb-8075-5391bbccba58)(content(Whitespace\" \
          \"))))(Tile((id \
          f8748574-86d1-4ab8-8bb5-283d7b6d9204)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7e28b43a-22c0-4f7d-80e5-d9edff80909b)(content(Whitespace\" \
+         432f31f7-0bf2-4292-8192-a06144bbd830)(content(Whitespace\" \
          \"))))(Tile((id \
          e23d6188-d2fd-4ff8-af95-edbb9bdb71c5)(label(Image))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         63c4597b-bfe6-4f28-a8f2-6f08ca4f825d)(content(Whitespace\" \
-         \")))))((Tile((id \
+         63355a93-7887-401e-8841-7244b0fc2d0c)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         9a064061-830d-4fb7-9a96-4bafc374b56f)(content(Whitespace\" \
+         \"))))(Tile((id \
          532052a1-2a18-45ed-8aae-9332cdc41700)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f73778ff-c077-4044-b325-4424f373935b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         35652c16-c784-4c28-86da-92a52afc6f02)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bfe1c656-0092-4658-94e1-dc74c856e9d2)(content(Whitespace\" \
+         8ee42f47-432a-458c-a7c4-9ca9f9ea786c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8320f9fd-74ec-4027-be55-bde512dcf635)(content(Whitespace\"\\n\"))))(Secondary((id \
-         014f16ad-595f-4797-8909-edd37637d9ca)(content(Whitespace\"\\n\"))))(Tile((id \
+         b3ac7fff-7479-4ce2-bc84-0ab9a6b74362)(content(Whitespace\"\\n\"))))(Secondary((id \
+         250772f1-170f-473f-80f6-0167d270c069)(content(Whitespace\"\\n\"))))(Tile((id \
          dd1b4083-8f56-4552-bf08-83609861c073)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         87137d60-40fb-4d9a-ad8a-fe40ea2ab71d)(content(Whitespace\" \
+         3bdc7baa-2e67-40e0-99e5-a82ee43833b8)(content(Whitespace\" \
          \"))))(Tile((id \
          274015b6-adbb-4db5-8a4c-3d830a53d9d1)(label(brown_get_acne))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f231ea19-93e2-4155-9f25-5e2aa690a6cf)(content(Whitespace\" \
+         b72bc3f5-1576-4f1a-be48-a2f80315f506)(content(Whitespace\" \
          \")))))((Secondary((id \
-         03fca034-1e59-4235-8844-bb8c8ca658b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         be91ca45-4f32-4231-a8cc-cdd8b8cbd563)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ee64f06-a66f-4127-a3f3-d065f3d1a94f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         181dfe03-bfa7-4673-af22-81c98b2b7443)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57a05e49-844b-4593-845f-7610cc799f11)(content(Whitespace\" \
-         \"))))(Tile((id 5821632e-0d90-4fb2-9102-308f1b366e4d)(label(type = \
-         in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         84089a59-5366-4a2b-bc9b-13ddb178995b)(content(Whitespace\" \
+         5a569c5e-37cb-463b-90a8-2d460f03645a)(content(Whitespace\"\\n\"))))(Tile((id \
+         5821632e-0d90-4fb2-9102-308f1b366e4d)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         76c0b34f-1962-4e9e-a76d-e2f0fa3a7777)(content(Whitespace\" \
          \"))))(Tile((id \
          f449e44f-61a7-4485-8e32-8b992b5642ea)(label(JellyNamed))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         eb5107b8-8485-44de-b610-9011d8858d51)(content(Whitespace\" \
+         11da24a4-0bf0-4229-b95b-393dd80d67f5)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0ed1b1f5-c7ce-4600-8545-0fa7807a6bf6)(content(Whitespace\" \
+         54d40ec9-f8cf-40ab-bd38-f2fa1e6dcf4f)(content(Whitespace\" \
          \"))))(Tile((id \
          ab95f1e8-81cb-4d45-8dd3-e89446ee3d07)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         4d49adca-a762-429f-9822-4a5cac95ad1d)(content(Whitespace\"\\n\"))))(Tile((id \
          88062ac0-241b-4d00-b76f-414232ac04d4)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d1e6766c-20df-40ce-ba0a-27c15577a287)(content(Whitespace\" \
+         \"))))(Tile((id \
          0b39c852-99e1-4a61-ab51-4df2f76d1d7a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         13a3706e-d418-42c6-8c4f-de8ecf8f231f)(content(Whitespace\" \
+         \"))))(Tile((id \
          3f7ab065-4a8f-4172-aa71-441e057036cf)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6412e854-0d6b-42e6-87f2-2c08c04babf2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9f6d51a8-6fa0-454e-ad91-15ec906dc98f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b0a8d8eb-5e17-433d-8199-9372f19e8f06)(content(Whitespace\"\\n\"))))(Tile((id \
          12e99def-9ac3-4a11-868c-780c4d5d7795)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c868de2f-5cfb-4f5e-a0f3-7c08bf65a38d)(content(Whitespace\" \
+         \"))))(Tile((id \
          623dad40-0c99-4baa-97f9-d173f9d54856)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6abe4795-5f4b-49d5-ac59-4088357fbee6)(content(Whitespace\" \
+         \"))))(Tile((id \
          4c877323-28c9-4dcd-a2ee-bda74faa4125)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          078562c7-bcc8-43b2-a452-a9407ff12a0b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ab891848-3460-4933-b38e-e05108c81817)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e76723cf-2070-4977-a3ca-f5f79ceb3607)(content(Whitespace\"\\n\"))))(Tile((id \
          1efcf588-0fe9-443e-a8a7-e8da6acd017e)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         aa9dd3df-5df2-4093-8849-253f40303376)(content(Whitespace\" \
+         \"))))(Tile((id \
          9b11d207-d42c-4edc-897a-58f6381af8d3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         271d7e65-0c7f-4ea7-978a-d425e48a4d73)(content(Whitespace\" \
+         \"))))(Tile((id \
          bde3f8d2-82fc-442d-af1b-ba2324567fd3)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          18258c01-d91e-4215-85c2-1b15704a4414)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         120f966c-4d5d-4232-9d6c-84d3077cc9de)(content(Whitespace\" \
-         \"))))(Tile((id \
+         894ee329-59dc-41fc-bcfc-54d5b68adc44)(content(Whitespace\"\\n\"))))(Tile((id \
          d55ee268-a744-4548-b0e2-b6272fe622ad)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6fe4018a-540e-4291-9bcd-f71b6ddb85d2)(content(Whitespace\" \
+         \"))))(Tile((id \
          1441b4bd-c2b2-4598-9fb3-f790440b294b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         32e24bf7-e703-4f60-ab6f-5049409fa138)(content(Whitespace\" \
+         \"))))(Tile((id \
          67aa2ae6-c04d-45ac-9b92-4bb93d85482b)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          da09064a-2fb7-4d04-8ce4-885cff49258d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4aada96c-0592-4d0d-b6df-9f9c2ca1deeb)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ac7c09bc-50d9-4a6d-86ba-6f9297d79283)(content(Whitespace\"\\n\"))))(Tile((id \
          87bcf85f-80b9-4ea3-bfd0-fa0be7e48f66)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b31df3f3-1947-4c0e-9cac-7c7354f29e52)(content(Whitespace\" \
+         \"))))(Tile((id \
          dbfc8812-b313-4bba-9cdc-0c6fa522306f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         09825c74-c9d4-41c5-8038-4ae38c2d7c49)(content(Whitespace\" \
+         \"))))(Tile((id \
          d64894d0-f192-4bb0-9695-adf842c5cb68)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ad750188-a5d4-4496-a30f-af1a95f302da)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1397c784-7f47-4d46-a1e8-11d3ab1e34f9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f13f368b-0869-4423-ac95-efb4326b71e3)(content(Whitespace\"\\n\"))))(Tile((id \
          cfe36b01-612a-4ce6-bb48-fbf09da18ed7)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9f69c88f-5eba-401f-9791-d04f7e20cc44)(content(Whitespace\" \
+         \"))))(Tile((id \
          2e0f6af8-0b96-4a70-a8b8-d0637bc45f96)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b6f51961-d82e-4c63-b4e3-f82f8fcf8269)(content(Whitespace\" \
+         \"))))(Tile((id \
          d8799995-5319-4221-9b02-bb1fbb57193e)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          1304e9fc-77de-48b7-959d-183e362cc9b7)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e310e8a5-c0a2-4fcc-919a-0cc997329d7a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0ef482d4-c1b8-4ea6-9c5f-dd223553e827)(content(Whitespace\"\\n\"))))(Tile((id \
          6c3868eb-e9e4-40ab-8c1e-314974e34ca9)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         eef7b404-ba5f-4489-bec9-7686cf75935a)(content(Whitespace\" \
+         \"))))(Tile((id \
          9b120948-42d3-4db7-abcd-0cc11ac48fd2)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6b50203c-5987-4884-a9b6-9089e81efdd5)(content(Whitespace\" \
+         \"))))(Tile((id \
          94095801-6916-45fb-94c5-2535fcc5497d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ee2916ff-bffd-4e4f-9e86-61c8f043f5eb)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e62975cc-dab2-44ae-a0f1-0abaedbff09d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         758cf1b1-9cde-4fb1-bec0-9ac83a2d91ee)(content(Whitespace\"\\n\"))))(Tile((id \
          8339c596-0d77-46af-aa91-d35ab9206035)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         512cae7a-7581-4819-8bf2-03e2d3545ddb)(content(Whitespace\" \
+         \"))))(Tile((id \
          5462a93c-bbdc-4f96-8ab4-1160945bcb18)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         83c3a669-d00d-4d73-8bc7-a5cd4020fca0)(content(Whitespace\" \
+         \"))))(Tile((id \
          cc9c10a2-1cab-4c57-b86e-c36fabf17796)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c84b103e-fed4-4cce-b2cf-d2aa835cac88)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d880cb08-41a4-4d56-ac12-5e308cd66b1a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         963964d9-6878-4c5a-bbda-7ac54b388873)(content(Whitespace\"\\n\"))))(Tile((id \
          252ca5a4-2753-4053-a487-48b2b9b90b32)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         13356b30-ba70-4d0c-b115-8104a10857dc)(content(Whitespace\" \
+         \"))))(Tile((id \
          c0cd1467-f376-4315-96e8-dbba13934b74)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ee702261-aa44-49d0-b660-654b6b45c4cd)(content(Whitespace\" \
+         \"))))(Tile((id \
          ea19ff46-4740-429c-8d8a-4d0264cdf547)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ab47671f-f3d3-4b5a-8880-5c85030cf87f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         427521ea-9321-4861-bd8a-f70aadbc68ce)(content(Whitespace\" \
-         \"))))(Tile((id \
+         480ff1e5-e3e0-403e-9460-d8709633d2cf)(content(Whitespace\"\\n\"))))(Tile((id \
          ada457a8-c469-48fa-92d9-3ea2792eed1f)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bdd0435d-7253-4c14-bb72-8f431751e8e2)(content(Whitespace\" \
+         \"))))(Tile((id \
          52de8a21-d378-4487-892e-e19570226fc5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a770bf86-c938-4855-8439-e167907cbdaf)(content(Whitespace\" \
+         \"))))(Tile((id \
          68b2e35b-c060-40c1-aeae-cc9d86a68319)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b118c428-8af3-42b7-8663-384b4655c2d8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f9ef03ec-003f-4f8a-a5ee-81451c62ca2a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3aacf4db-a7fa-41e7-a9eb-4e590deae880)(content(Whitespace\"\\n\"))))(Tile((id \
          dd794ceb-95b6-47ea-9779-58f54321a94d)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c2472921-0876-462f-aa2f-03ad2d92d7c4)(content(Whitespace\" \
+         \"))))(Tile((id \
          dad3c04f-afe6-45fb-a411-9999ac886b6e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         70ecc669-18ae-4399-a042-e97b6d7becfa)(content(Whitespace\" \
+         \"))))(Tile((id \
          33a78195-431d-404e-b543-01cf2189dbd8)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8edf9b08-d24b-4881-9c11-50fac6214201)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e34a9d2e-45d2-43cc-9c1b-f6df15d3466f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         09353686-1c12-40c4-a853-4231a1753b06)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         74a29c26-e0a0-4e77-b250-ea5dee26e81b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         aabba1ba-487f-42e2-8582-341e4347436e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a3f9191d-9389-4845-822b-0595d7724227)(content(Whitespace\" \
-         \"))))(Tile((id 463d75c9-e0eb-4ace-a41f-a85e18e8d025)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         62fed09d-59ff-41f3-a4d7-c65253ffb2d5)(content(Whitespace\" \
+         96e00408-9d12-4fab-9f92-8877e89c7f5a)(content(Whitespace\"\\n\"))))(Tile((id \
+         463d75c9-e0eb-4ace-a41f-a85e18e8d025)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         28e61c81-2c9f-4ed2-b9fa-d76d1adba478)(content(Whitespace\" \
          \"))))(Tile((id \
          33c9e5e4-42be-4c19-a176-8d34688b6669)(label(jellyNamed))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9e786309-04cb-4b38-bb94-ffd821099836)(content(Whitespace\" \
+         2ac27665-7814-44ce-8401-33d9dee4c65b)(content(Whitespace\" \
          \"))))(Tile((id \
          a6b4111c-77c9-48ca-b833-bfb4d0e741d7)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d9021d16-1e70-4ee2-81dc-a2c450c8ace9)(content(Whitespace\" \
+         64dbdc51-97f2-4500-91a8-793434700263)(content(Whitespace\" \
          \"))))(Tile((id d56af3e2-63b3-42f9-bd1d-d1671d95cbc8)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          d5112f6d-8003-4124-aaec-b3916510b379)(label(JellyNamed))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         36093415-2595-4b07-bc94-b103ffca0af1)(content(Whitespace\" \
+         070e4c6b-045e-406d-8b47-1b0c92fa29e8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         96da7265-6a3c-4f7d-b715-fcf1f8881bd5)(content(Whitespace\" \
+         0b2793dd-46b8-47e7-afc8-e8a974fddccd)(content(Whitespace\" \
          \"))))(Tile((id \
          d62be268-0a61-46bd-bc0a-780d38861aa2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         87c87234-9bcd-421b-ae9f-b9d223f4413e)(content(Whitespace\"\\n\"))))(Tile((id \
          1c2d7cc0-f494-402b-842d-e212fcb84d4d)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         1fe5521e-7076-4b94-b2fe-78fc4ffec0c4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ec4e5839-b26e-4060-9302-bcc00c63e81f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ba94ad4-e45c-4b50-9337-217fcdf386eb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         29c1fe57-2f37-480f-b329-eeed86e1b7e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         038c83a8-8ad2-4e49-9996-d4f569e95429)(content(Whitespace\" \
-         \"))))(Tile((id \
+         54d65e14-60ce-4e62-9598-e164863ca119)(content(Whitespace\"\\n\"))))(Tile((id \
          02b9ed73-c5dd-42c8-bd31-d6f8998ad452)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -569,15 +584,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3c71d62b-84c2-44c4-9f04-2aba39043f64)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         98c369f2-32c8-4c76-9377-1e52a5e12429)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c251a6c0-49f7-4c76-a23f-29a734e08fb0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6ae59f5c-9dfb-4852-9ca2-daf585692b42)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3ffd8f17-f86d-4b7b-bedd-e42427c61ef6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         986fa62d-abe7-4891-82d1-3422711041fc)(content(Whitespace\" \
-         \"))))(Tile((id \
+         289d599a-9e14-4bca-be58-fe87e27679f7)(content(Whitespace\"\\n\"))))(Tile((id \
          5403dd1b-1446-4610-9657-1a85ae0e0ff9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -703,15 +710,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f521d71e-473b-4b81-b834-362812ea1d3e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         03915760-fb03-4395-8865-eacd4d5701fc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         305a5b95-f903-4e05-b496-38331707a651)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a77a91db-2c81-4e12-841d-6acb9e4cadf3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ffb9ea73-d6e0-4809-8cae-8e518efe7b0b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         11ec04a7-b6d8-4022-b24b-464390657867)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0b5039fc-2147-45ce-a445-891ba2dc1f58)(content(Whitespace\"\\n\"))))(Tile((id \
          88fd6b90-f8d3-412b-b76f-0920e7cac46c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -839,15 +838,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e273257c-8a10-4d1b-b65e-0aa09f180b08)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5c22631e-fddd-4c02-975b-ec1083a42ff2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8b0a7c16-6581-45ee-a429-230854ffa4b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         daee3804-1e99-41aa-8c98-2796ac2bde1a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e0714e1e-76f3-4068-aaa7-894176436481)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb045a3c-0775-43c3-8a81-cb9982b61827)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ca060ddb-9055-4dab-8103-a874b90c74f1)(content(Whitespace\"\\n\"))))(Tile((id \
          b57df125-e835-464c-8a5a-faf0f5a1b6e9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -973,15 +964,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          37c2279a-befd-42c2-946e-8771fee7e25f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         93fe4732-bd9a-43fb-8ef5-55379e369432)(content(Whitespace\"\\n\"))))(Secondary((id \
-         667c43b3-cfa0-40e5-af02-397d352ca470)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a5f650ce-0f30-4ab2-8510-450721d34663)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         98d2ff59-7c85-4e98-ad88-247039f33aa5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         313312ed-b9a6-4554-ae3b-8140fb8f9e55)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b2d4e4e6-fb36-4edf-a555-8069f6d6a529)(content(Whitespace\"\\n\"))))(Tile((id \
          c967e558-f272-4a63-99ec-5bd7869026a2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1103,15 +1086,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e02e1cb2-d348-418a-abe2-8eceb61d8bf2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dbe0d26a-e19e-4a3c-8e30-2002c51c60ea)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ed7b5e06-8cec-48a3-9081-29803c942bb7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a70d9ac7-1907-4291-ba1f-5ab3f781cbd4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6888de9c-d642-449b-810e-c566cd3fcf33)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5d7245b-992f-4514-a573-69332d8075c2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         fa6842bf-c217-4cdd-b401-669701188e8a)(content(Whitespace\"\\n\"))))(Tile((id \
          e574b079-2523-4b43-8321-8c3dc50c05fd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1237,15 +1212,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dc44af27-ac4f-4c84-843e-15b6548810b9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cebca6c6-14ae-4235-b3b5-d5d471941404)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d3a64d29-6bc1-41c0-9f9b-c3b37344a233)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04f92c49-498c-4364-bb54-b28ba9913a43)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         195d4eeb-8e38-4c45-af45-6c366051ab1c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6a7d78ed-7ca1-41ec-a4fa-022c4d9df038)(content(Whitespace\" \
-         \"))))(Tile((id \
+         42ed4665-8968-4930-98a4-7ae8714d554f)(content(Whitespace\"\\n\"))))(Tile((id \
          0e6d7714-d0b2-4e43-8d60-255f2bb0d283)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1369,15 +1336,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dfb8d28c-cfca-4296-b2e9-890da1c46f0a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         273f33a9-9e78-429e-8261-9c82f285dbc6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f43d890e-75d6-437b-83ba-2c1e349eecfc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bfe03ade-ce8f-4013-b684-72e36989fa5c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         96c100f8-3775-4616-adba-1d4a42ac6cd2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c3f1d9ed-f47f-44f1-90f6-ff116703a58d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         831cb785-af7d-4d39-9715-7089e7dbf032)(content(Whitespace\"\\n\"))))(Tile((id \
          028dccc4-8714-4f0a-a2a4-4ffd16a2af9c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1499,15 +1458,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c56d7eef-32f0-43c6-89fc-a78bb11c3600)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3881d7bf-6acc-4513-9c89-c22c31d3fc05)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f75aca43-137e-481d-b729-1fa69ab19637)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e79c6c24-2be2-4a33-af78-727ecf8e388b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         62095a78-1219-4b66-95c0-50173fc3c833)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         22a223d5-3bd9-4ad2-8982-3ce1003701c1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ef2365d9-d721-4717-b953-1a452ab9770e)(content(Whitespace\"\\n\"))))(Tile((id \
          6bd22e6f-1ad9-452c-9465-81c24ecf3b8f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1631,15 +1582,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c9c48d29-fab0-4ed8-bd80-52042f8c2ede)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dd255bd5-6b64-4857-b8e7-8b4e8cd94ad9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         391a1e90-0765-449c-869d-b2258a055656)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         548f3235-0e21-4b74-97ac-ab81cfe7fa56)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9f0d50ef-7986-4f91-888f-684f31d127ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         17adae6d-4028-497b-9144-0da30ec1ecf7)(content(Whitespace\" \
-         \"))))(Tile((id \
+         bdd1a012-13c9-46d7-8493-807ab96ca65d)(content(Whitespace\"\\n\"))))(Tile((id \
          86362537-6519-4104-b618-f1117b73933a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1649,7 +1592,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6989673d-0723-45e9-a330-bdfd230debb3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e50c8d6e-0913-4589-8e00-d71de054d314)(content(Whitespace\" \
+         1b6133e2-aef8-4a60-b8d8-5b8732576d3d)(content(Whitespace\" \
          \"))))(Tile((id \
          61e72456-438a-4282-b4bd-b6457b6a5643)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1660,7 +1603,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          60fe5055-06bc-4756-aeaa-72f1864a1b1f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2352f17e-9686-4bf2-bf3e-7c929810533c)(content(Whitespace\" \
+         95dab465-7f4c-4b42-a887-21b4a664cce0)(content(Whitespace\" \
          \"))))(Tile((id \
          4f6645d2-4c93-4cda-970c-668b1bf68ff2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1671,7 +1614,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          02931e67-44f6-4ff4-bfbd-85c602afd35a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         987d5cf4-997b-4f5f-9733-d7e736c0eb9f)(content(Whitespace\" \
+         afcf7879-6ae0-41b6-acf8-5388d6e971b2)(content(Whitespace\" \
          \"))))(Tile((id \
          8c762c73-4281-47b2-b627-2709630b7632)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1682,7 +1625,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ff56ba20-9deb-4be9-9988-254561f43d28)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a34cd6e4-a81b-4225-a23e-cec4740a3b40)(content(Whitespace\" \
+         c3395340-267b-4db0-b7ed-7bf5f3860530)(content(Whitespace\" \
          \"))))(Tile((id \
          5868e0bf-5c78-43ea-adcf-14f1dada9e6d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1693,7 +1636,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0108685f-da33-4e5b-bbb8-10504477b9b6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ca5ca742-321a-41ca-a22e-0699fe09b6b9)(content(Whitespace\" \
+         2da4343e-8ad0-4524-9007-48e9dd2123ec)(content(Whitespace\" \
          \"))))(Tile((id \
          4ad40986-f960-4e1f-86cf-6bf5ab16cd3c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1704,7 +1647,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9855c038-f2d3-4217-b9bf-0ece982235f8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9e52f79f-27e0-4607-8aef-5512cf329800)(content(Whitespace\" \
+         0b9713eb-ce6a-424d-88b6-cb6e916e18ec)(content(Whitespace\" \
          \"))))(Tile((id \
          e450d1c8-c46e-4314-8e37-20cf868757fe)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1715,7 +1658,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f2863868-ab5c-43f9-8830-8427fecadcdb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69dc59c6-3ca3-4735-9f7d-ebcdc5695775)(content(Whitespace\" \
+         89bc8724-4b70-4a90-b5a4-06eb980f7d0e)(content(Whitespace\" \
          \"))))(Tile((id \
          fe352314-d69e-408f-b7c1-9d7cfe33cf15)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1726,7 +1669,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          80af015d-c335-4a2b-9da4-31e116881f8e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1277fc9c-c870-47dc-ad60-204ea5369c6d)(content(Whitespace\" \
+         e82fdec5-c647-4fc8-9acd-b4dda6d642e6)(content(Whitespace\" \
          \"))))(Tile((id \
          2f8824f1-20c5-4d45-998a-3a431e3072b5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1737,7 +1680,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7e2278d1-2e59-48a4-9251-8fbbf6c93861)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a1b75358-e9ad-4633-b7f8-ee87935fc9d9)(content(Whitespace\" \
+         986369e5-7c9c-4b5a-ad02-9e9f48832a21)(content(Whitespace\" \
          \"))))(Tile((id \
          ff6bdf72-c223-483b-9f42-e95dda4bdbfa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1748,7 +1691,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          521abcfa-6448-404a-8b4f-81e79b971dfe)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cd50175b-12e8-439e-909d-120ab62cebfa)(content(Whitespace\" \
+         7daaad89-ac2c-41a6-b625-8eebfa1d3294)(content(Whitespace\" \
          \"))))(Tile((id \
          66924777-21d9-46c3-be2a-529642e12e57)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1756,51 +1699,44 @@ let out : string * Haz3lcore.PersistentSegment.t =
          78f298b4-b294-46d9-99f8-59f99f4bcf39)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         202ddde8-be4b-48f6-be48-03e52d8c5ff1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         29feb4f2-4faf-4c32-a697-cc2e73d6ba97)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eb7c4669-87a4-4aa1-bde6-9be16cf77c82)(content(Whitespace\" \
-         \"))))))))))))))(Secondary((id \
-         9b604b56-b290-42ce-b231-da6c6a5ef023)(content(Whitespace\" \
+         c46859ac-bb4e-4c18-9248-8871bd40f2a5)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         2472624c-0f1b-416c-8979-0c5c176f0a02)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         4b32c769-2771-469a-8dbd-3dbf79a74b27)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6fa0bcb7-5545-4736-9803-11959166d814)(content(Whitespace\"\\n\"))))(Secondary((id \
-         da3c56c7-af21-45d5-9ff2-44f409e0621f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d0deb212-e3e6-4fe9-a5f5-0f674d919675)(content(Whitespace\" \
-         \"))))(Tile((id 17002e3e-519b-4ac8-b700-690121ca565d)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ecd71632-a2d8-4a48-b5bf-b78da1d86f73)(content(Whitespace\" \
+         45a46700-3fa1-44b7-8738-2354c7cdb28c)(content(Whitespace\"\\n\"))))(Tile((id \
+         17002e3e-519b-4ac8-b700-690121ca565d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9e1f4360-3c9f-4156-972b-0e7bdccde8f1)(content(Whitespace\" \
          \"))))(Tile((id \
          e3719158-bf0b-423b-8b73-f6a7e004be4f)(label(brown_and_get_acne))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         228f4903-7d11-4400-ae6a-eda0cf4f4c0a)(content(Whitespace\" \
+         1aeaf6e7-0b49-4408-8eb2-76320769b390)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0743c9c1-fc52-4e4a-bba7-4eaed746aeb0)(content(Whitespace\" \
+         ee5eee50-cbde-4d56-a3ff-36c12777c6c4)(content(Whitespace\" \
          \"))))(Tile((id b0b00cec-a02e-4540-b8c8-03a4f1fe8f5c)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         4be2cd43-6a81-49bd-a086-ce11d3585b0a)(content(Whitespace\" \
+         245fc245-e27d-4e2e-9f20-aa3028ab63df)(content(Whitespace\" \
          \"))))(Tile((id \
          ec49f9ce-31a8-4959-9281-eb7561e5dc43)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c074c944-1e0c-41e6-a58f-c3006ae675ff)(content(Whitespace\" \
+         87cc4416-53d2-4b1e-96d8-2ceb2febf469)(content(Whitespace\" \
          \"))))(Tile((id \
          f9abba70-cd31-4289-bf48-c77c1cd8111d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c943124f-1434-49b2-a2f5-24ec070f9fe6)(content(Whitespace\" \
+         a6faf837-27f9-4ad5-bd7e-5424fcde38df)(content(Whitespace\" \
          \"))))(Tile((id \
          410cb948-e49e-4abc-97ff-81e2c27f3341)(label(JellyNamed))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         e271522a-1a4d-497c-9d31-e1d0366158dd)(content(Whitespace\" \
+         1b3a2459-3668-4132-b7e9-e3317c5dac1c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6086beb3-84da-4e51-b06a-3e4e67f9ae2c)(content(Whitespace\" \
+         92b9fbb0-b8a1-4230-9640-c4e46fe6aae7)(content(Whitespace\" \
          \"))))(Tile((id \
          5ec3294f-b362-4191-9ed0-a6d989e5c146)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1811,12 +1747,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          94fcc281-14e0-43ed-b26a-a8f9f6664062)(label(brown))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         6cc2eafe-33ab-496d-9188-612a657ae380)(content(Whitespace\" \
+         546fe223-f892-4e75-84b5-99b7e8fd1807)(content(Whitespace\" \
          \"))))(Tile((id \
          9f46dad7-37c4-4356-846f-cb758b5ceea6)(label(&&))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 32))(sort Exp))((shape(Concave \
          32))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ca0e0d4a-30f0-475f-9f87-dcd4e9c01dd3)(content(Whitespace\" \
+         bec504d4-1521-43e3-ae4b-f8b7e69475e2)(content(Whitespace\" \
          \"))))(Tile((id \
          7ad0125c-f339-4f5b-854a-7ee9286a7f85)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1827,67 +1763,64 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7b440940-3e58-4124-9a1e-2b95b379e5e3)(label(get_acne))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         38f8aa87-633f-42f2-8b4e-1df4272e5791)(content(Whitespace\" \
+         0c7f99e1-2361-4114-8e87-5886f6ef2633)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a1280af6-7db9-4c17-8a03-b6faf22255b2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d608e1a4-7f2a-4651-bb6f-c115354a1645)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         24d426a6-3dda-45c2-b7c4-e13169628b2d)(content(Whitespace\" \
-         \"))))(Tile((id 0decc9da-c077-4c7e-90ba-cb09680d583d)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b7711349-93cd-4403-aed6-e0f70718f1ed)(content(Whitespace\" \
+         81013dcb-f1ec-477f-96e5-47d11dc35405)(content(Whitespace\"\\n\"))))(Tile((id \
+         0decc9da-c077-4c7e-90ba-cb09680d583d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9d708f2f-7cea-42c6-b08c-dc5b4424d3d8)(content(Whitespace\" \
          \"))))(Tile((id \
          754c448f-db85-439a-9591-457d7a4df034)(label(count))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         fff0d364-40eb-4f8b-baf0-c60c5c04a962)(content(Whitespace\" \
+         945542c7-1873-449d-ab2b-c2da72d49831)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f486de66-c7fc-416b-a88e-b56905da6c60)(content(Whitespace\" \
+         2d366a41-fdf4-4dcb-85e0-cb34d6674650)(content(Whitespace\" \
          \"))))(Tile((id \
          badc95dc-4fc8-4586-b2f8-69958e823c37)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         c4ce2a65-0030-4aba-ac66-d7e56b396b22)(content(Whitespace\"\\n\"))))(Tile((id \
          8af45840-288e-467b-8b35-d2748f17acaa)(label(typfun ->))(mold((out \
          Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         cb5fd20e-da07-4764-aac3-48b1fc96db69)(content(Whitespace\" \
+         20f3652e-f93d-4eb6-8015-8f83e5db5a71)(content(Whitespace\" \
          \"))))(Tile((id \
          cf7a24f1-1adc-405a-8875-c29e3d9f8cdb)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         02041cff-b4fd-446f-bd1e-12c5ed4c5be6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c10af653-42d0-4caf-be5c-0c8789898299)(content(Whitespace\" \
+         8ea4d199-3486-4ea0-b399-f7d8e5cbaa05)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         71efab45-3409-40a4-96c3-f648546f98ea)(content(Whitespace\" \
-         \"))))(Tile((id 4484ee86-a679-4a97-a9ce-7416c8351748)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         2b30853f-3a65-496e-b61b-c4d73c08f220)(content(Whitespace\" \
+         b5a9c097-2521-4de7-902c-296937383a34)(content(Whitespace\"\\n\"))))(Tile((id \
+         4484ee86-a679-4a97-a9ce-7416c8351748)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         3f1879ae-a1ec-42d4-9935-97589d133dda)(content(Whitespace\" \
          \"))))(Tile((id \
          376ca200-2c44-4d77-b2d9-502aba4f9363)(label(v))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children()))))))))(Secondary((id \
-         5d9a670c-9bd0-4e11-9944-2a42d77517b4)(content(Whitespace\" \
-         \"))))(Tile((id 2f425553-73bf-4c85-8bf5-a35fc4bb152e)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         05ea8655-c011-4b4c-b603-dddb7b8658bd)(content(Whitespace\" \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         ffec12cc-5274-43a1-8fa1-60c9c3f0a5c8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         bc6a6676-fbc9-42e9-9cf0-997a1020defc)(content(Whitespace\"\\n\"))))(Tile((id \
+         2f425553-73bf-4c85-8bf5-a35fc4bb152e)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         be7f361c-5444-4130-814b-b3c47ebc8c46)(content(Whitespace\" \
          \"))))(Tile((id \
          05c5a570-3d72-4710-b4e8-5539fddf5439)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          7aa4951b-ea16-4562-9b9f-292ec835f6c6)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         642acde9-f37c-4f5c-9964-225f5ec62508)(content(Whitespace\" \
+         \"))))(Tile((id \
          a0fd9aca-0224-4304-9fd3-912458272006)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ec65881b-802e-44a6-9bd8-a9acbb290cdd)(content(Whitespace\" \
+         885e77a0-665d-4bdb-9809-996cd445eec5)(content(Whitespace\" \
          \"))))(Tile((id ca99a121-bdba-4d69-aabe-3efee51a4a90)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1897,69 +1830,62 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9d5231be-04bc-4b9e-8c77-1c400ad0b610)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         97ce2054-effa-4f77-9945-a269e5e9e061)(content(Whitespace\" \
+         3cc5e06d-7d35-4235-9894-514bc0a9d5eb)(content(Whitespace\" \
          \"))))(Tile((id \
          ce92a2b5-edb8-41d8-8ba8-dc9d0e8ddfa4)(label(proj))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         993445c4-ae5d-4891-b3d6-55f703370d6f)(content(Whitespace\" \
+         29686ba3-5239-48e2-9ff5-919de3181c32)(content(Whitespace\" \
          \"))))(Tile((id \
          0560d9ff-deec-484f-9324-591047b9391d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7c0ff72d-6935-48ca-81a4-24098a1921ae)(content(Whitespace\" \
+         19d4ffad-5e4c-4b43-bf1d-753230558d96)(content(Whitespace\" \
          \"))))(Tile((id \
          e4d46e25-e16c-44af-b112-ac8f98dc0750)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         ee509890-5413-489d-ba24-81d6304e2108)(content(Whitespace\" \
+         40616d7b-ced3-408d-b7b1-60b4abcc873d)(content(Whitespace\" \
          \"))))(Tile((id \
          9792625f-f5df-4cfd-baee-8580ab316bc9)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1f10c870-9556-4467-8a77-81ac9832b149)(content(Whitespace\" \
+         8fee2631-8c96-464a-b392-2776c3376f0c)(content(Whitespace\" \
          \"))))(Tile((id \
          bcee5a78-4a4f-4f27-bfe5-15518e0cf111)(label(v))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         b5e6ef64-2187-4034-9853-30ebd017a35e)(content(Whitespace\" \
+         7d4f16ab-881f-4ac7-9727-a1e19f66314b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         04a594a4-b258-4ae5-a51e-97f65dcdcecd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         22d0bd76-1854-484d-819f-bf3297d232fb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         488bbd2e-20f0-43cc-818f-06853df99961)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e21f3fe-efa4-494a-8f66-7a1e94ed72b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58ba8b9d-b5b3-42a6-901e-2e596a92f9fc)(content(Whitespace\" \
-         \"))))(Tile((id 97c8c5a3-38a8-46ee-946a-65115cb874c5)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         4e6ab3f6-424d-4873-89f2-269b3dcf665e)(content(Whitespace\" \
+         f4a1b1d4-3229-4fe1-867f-d4747c49db69)(content(Whitespace\"\\n\"))))(Tile((id \
+         97c8c5a3-38a8-46ee-946a-65115cb874c5)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0ca0bf13-5067-4d42-be28-c6379ad32fe6)(content(Whitespace\" \
          \"))))(Tile((id \
          f2641331-8d3f-4804-a0dd-4be7223795c4)(label(go))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d3dd99a8-ad3f-450f-bbfe-7e0936fe08d1)(content(Whitespace\" \
+         db1b2a02-c8a2-4ed5-b3d2-0c41e674a8d6)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2d70229f-1154-469d-8148-3ba4c744ecef)(content(Whitespace\" \
-         \"))))(Tile((id 19f34c8a-da8b-489b-adc6-89b58b05d251)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         8c666025-3f9c-4258-b215-470fa86193d9)(content(Whitespace\" \
+         eb798271-d87d-4913-8e34-f0e3dedbcd5d)(content(Whitespace\"\\n\"))))(Tile((id \
+         19f34c8a-da8b-489b-adc6-89b58b05d251)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         0b343457-db9d-43ab-a542-16ffbd206c9a)(content(Whitespace\" \
          \"))))(Tile((id \
          3c527fb5-191a-41f1-9787-c39fe91d027d)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          02242368-6dc9-47c8-a425-05a27efc4e57)(label(groups))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cf84f131-bb3f-4bc7-b2ff-719a95a5fe8b)(content(Whitespace\" \
+         \"))))(Tile((id \
          2547b7e4-4497-4594-ab3e-41ae56ceb57a)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         88756cfe-fc28-4ba6-be88-c962aa77a173)(content(Whitespace\" \
+         718699de-5a86-488f-a89a-0d8d17bd9102)(content(Whitespace\" \
          \"))))(Tile((id 709bf41f-57e5-4159-a39d-fdc4ac35ba60)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1968,59 +1894,60 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          4c2eaf06-c743-44f1-86ef-2354fd95d367)(label(value))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e59068c1-006c-4073-943e-d06ada0d16dc)(content(Whitespace\" \
+         \"))))(Tile((id \
          d15666b3-375d-47cb-b640-aa44527121e8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b9ea2d65-7243-41ff-8227-21488fde1731)(content(Whitespace\" \
+         \"))))(Tile((id \
          1dfe26dd-47c0-4390-bd82-2b211a63b316)(label(v))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9b2b5e77-300b-4617-bcfb-5f7310bf9a5c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         98144bbb-4aaf-49fb-bb21-3bbcacdf00dc)(content(Whitespace\" \
+         97fa2727-fd55-4c97-9d56-5c4abdd0dd3a)(content(Whitespace\" \
          \"))))(Tile((id \
          dfd768be-e8cb-46f7-ba77-2e29ff8869c9)(label(count))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0a70e6f1-67ec-478d-a073-7f5beced0c20)(content(Whitespace\" \
+         \"))))(Tile((id \
          528692f1-d3a1-469a-8dce-da37c9d18436)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3db47ce4-59c8-4ae0-a7c0-63ab17aeb87c)(content(Whitespace\" \
+         \"))))(Tile((id \
          1411c801-3276-488b-938c-d1c5adbad025)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
          3c50d5f6-e297-4879-aea0-b485fd9d09b9)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f294078f-7cf9-48d0-b569-bdfbb3c881a6)(content(Whitespace\" \
+         2d15ed44-67c4-4a05-9b04-ac586e4cb0de)(content(Whitespace\" \
          \"))))(Tile((id \
          9f94d798-1436-4f8b-aab9-3cf6e3c503a4)(label(row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f12d657f-abc8-4adb-b9f9-179da99a14cf)(content(Whitespace\" \
+         \"))))(Tile((id \
          703edfaf-3c10-470f-8048-0a83e2d0a487)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5ee615ee-673f-484b-a771-a356916bd8d0)(content(Whitespace\" \
+         \"))))(Tile((id \
          4579ee45-f704-4bc6-82b6-63a4ef369ea3)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         6ccb1806-606f-4e19-aa52-8142cf337d67)(content(Whitespace\" \
+         635e84fa-de82-4d5d-a78e-7bc538f131fd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cc71180d-ef83-42ce-8496-acdba0a09b99)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3eff7208-9bbc-4947-8f18-28695a59ac69)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27182abd-24cb-4136-89b5-21ddacd7650a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         373aafb6-c8af-4258-999d-28c46cf86f2d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46695ad6-7ba6-460b-8dc1-089366baf4ec)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bf5dbad3-70d0-41bc-b680-76dbce891692)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0530c972-c86a-4d27-83f4-0229832e3168)(content(Whitespace\" \
-         \"))))(Tile((id 73098b07-4c69-46c1-93fc-897efa42f88c)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         d0965bef-649e-4210-9781-10dbc113a816)(content(Whitespace\" \
+         026fffff-e2c0-4b72-bbd2-cc06016b0904)(content(Whitespace\"\\n\"))))(Tile((id \
+         73098b07-4c69-46c1-93fc-897efa42f88c)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         cb1a93ff-1338-4780-b4d6-dafd26664354)(content(Whitespace\" \
          \"))))(Tile((id \
          c6783a1b-975e-4f7c-b908-f6b71e6cd800)(label(find_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2034,19 +1961,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b3aa505f-bfd8-497a-ad0f-47ba5564cba8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0a1343cf-e50c-4d0a-bba4-be753f08b611)(content(Whitespace\" \
+         72236287-1e26-4460-a0b7-8f9c953776d9)(content(Whitespace\" \
          \"))))(Tile((id 07ab32ba-efde-45f7-87a2-647d0216a4a2)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         dcce28e8-61a9-43b5-875b-b56c11fd0e32)(content(Whitespace\" \
+         bee8f839-1166-40db-b0bf-28605dc64e0b)(content(Whitespace\" \
          \"))))(Tile((id \
          06491969-2d4e-4acd-8eb5-2247f0be662b)(label(g))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2a298ee8-73a5-486e-95a5-963658f6057b)(content(Whitespace\" \
+         2d44dc7c-3aaf-4568-af7b-7deb7fb006cd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         34174c11-6994-4d08-aee4-c91e92d6c69a)(content(Whitespace\" \
+         fe53998f-ad63-4d42-8a13-dc2d44db1c25)(content(Whitespace\" \
          \"))))(Tile((id \
          cf40e6b8-d1d0-4210-ba7c-3f731c3522b3)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2057,12 +1984,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3a2e5dae-47d7-4471-843b-53517fb1d77c)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         73956a86-cf14-4d71-bdbb-1542d6377d25)(content(Whitespace\" \
+         04a1f8e5-d701-41d0-9b98-a787f358803e)(content(Whitespace\" \
          \"))))(Tile((id \
          af0bafce-789b-4170-abdf-5fce73816951)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         309c72dd-a86a-4657-b57a-94c33443bcce)(content(Whitespace\" \
+         0213380d-0b3c-4bd9-8628-c0882ad670d2)(content(Whitespace\" \
          \"))))(Tile((id \
          1e5e7f12-726f-451d-8889-ec20c77f4891)(label(proj))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2073,22 +2000,10 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c57e0472-7218-4ac2-84d9-a770a9760d12)(label(row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         95664e42-dfdd-41f9-ada7-6b4d7720c090)(content(Whitespace\"\\n\"))))(Secondary((id \
-         07cf6712-d389-4dc8-82a2-a40a4530cee9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4162f758-4921-46fc-ad2d-e5af872e69e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d1c9f315-cea3-4eae-bf13-86f750291ad5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         851c3e75-9f9d-4f44-9e1a-be519c911226)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7d4f1738-37c6-4463-97e3-e02365f4966e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3973ef7d-2bad-4df7-950b-244ecb7ad26d)(content(Whitespace\" \
-         \"))))(Tile((id fa128b9e-8cf7-422d-b04f-4767a48b712d)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         37738267-fb12-4ecc-9538-08d9b2989e69)(content(Whitespace\"\\n\"))))(Tile((id \
+         fa128b9e-8cf7-422d-b04f-4767a48b712d)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          4c2ab802-ed45-4fc2-a8aa-d747d841be66)(content(Whitespace\" \
          \"))))(Tile((id \
          4a3c086f-fdd8-4a53-8259-ec8c27725967)(label(None))(mold((out \
@@ -2096,17 +2011,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          dcde0af9-4451-4050-bb78-3709e41f1b15)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0a21e028-03bf-45dc-8ee2-f6f90ae7bb0c)(content(Whitespace\" \
+         af3aca26-4b7c-4b5c-bc3c-9f8639ef03a4)(content(Whitespace\" \
          \"))))(Tile((id \
          51e0f566-6d7d-468d-a49c-7fec5d11998d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          a38bf9d8-0eb0-42e3-9e93-86eb8b25ad46)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d074bfd0-4441-4752-bc42-e2af6b41789c)(content(Whitespace\" \
+         \"))))(Tile((id \
          7b705f73-cfa5-405f-8318-86e0b22d9f7a)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         645b7ed5-ef8c-4f85-a59c-07bb4707bdf3)(content(Whitespace\" \
+         \"))))(Tile((id \
          f8364417-c9f0-4b5b-923b-037e79c0ca33)(label(proj))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2119,43 +2038,35 @@ let out : string * Haz3lcore.PersistentSegment.t =
          19677f70-d558-4049-8c16-1469e7b4c442)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f987ed0b-252e-4148-ae93-a9aca0c7e8ee)(content(Whitespace\" \
+         24d8baf5-4ee3-4c26-a450-f0210f3e445a)(content(Whitespace\" \
          \"))))(Tile((id \
          d646dd2d-8025-41bc-9197-3f2d59f83382)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1fea710a-f2cb-4e31-892e-f9e555814126)(content(Whitespace\" \
+         \"))))(Tile((id \
          51920a14-4daa-4aa1-9f20-6c4aa5d6dbd6)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2a17e6ab-a7d7-4a2c-a2a0-dd08161e6f40)(content(Whitespace\" \
+         \"))))(Tile((id \
          7b915550-8882-470c-b2bd-deb8fcc548fa)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b41e0369-86bf-492d-bda9-38a619014127)(content(Whitespace\" \
+         72cd5bc7-2cfa-4b8f-9275-4f1425b24609)(content(Whitespace\" \
          \"))))(Tile((id \
          2abb9cd9-4832-4cb3-9cf7-cadbb0293132)(label(::))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
          29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         56ecbae3-5981-48b7-abfe-0aa0372f3d3f)(content(Whitespace\" \
+         faa78d33-996f-4958-b00a-ee59767f7801)(content(Whitespace\" \
          \"))))(Tile((id \
          d2c41f70-970c-496e-baf7-922f06b68b20)(label(groups))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         372214c0-9c01-49af-8e27-51dfacf7f064)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6820b23c-3f4b-4b14-b9c9-75a8d139e4cc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         edb59e59-0bd5-4308-bdd1-3afd27b0f4bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc0346ea-4c3e-40b3-8332-5edb50d00c29)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc1f78ad-5db1-4cb4-8155-89b412ad5652)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b970bee8-2d78-43b1-9b6f-5bd8a0c9ee50)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4cf0f40c-679d-4c29-bf34-f7d177884865)(content(Whitespace\" \
-         \"))))(Tile((id dca54d73-9f5b-4f6d-beef-0701304d0c59)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         80b24524-6b7c-435e-ace6-954b8bbeea1e)(content(Whitespace\"\\n\"))))(Tile((id \
+         dca54d73-9f5b-4f6d-beef-0701304d0c59)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          23047a0f-393e-41bc-9546-671ae0a55d58)(content(Whitespace\" \
          \"))))(Tile((id \
          47fe3120-be72-4ec6-8ec6-5554e8e0a8f9)(label(Some))(mold((out \
@@ -2170,7 +2081,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          83d8c4a7-d323-4179-8abb-7b63c915c0cb)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
          39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         e4c27c00-e3db-48ae-a1de-483c23d247bf)(label(v))(mold((out \
+         e4c27c00-e3db-48ae-a1de-483c23d247bf)(label(_v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
          d54be4dd-efaa-42cb-a803-f4e6ffb5d539)(label(,))(mold((out \
@@ -2187,17 +2098,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          4fee8fe8-facd-4aa7-99ab-c1e5a4978043)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8ce05f47-dff6-4c54-80a9-a3b8fdcefaae)(content(Whitespace\" \
+         cb3ec559-8fd8-4a2e-aeac-1b7db67c547a)(content(Whitespace\" \
          \"))))(Tile((id \
          1c8e6a2e-3e9d-4f85-b1c1-060f7eea6b66)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          525dac81-3fad-4ccb-a1c2-385f36787a92)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         0689ddf5-de7d-4636-9354-9478b8a1647b)(content(Whitespace\" \
+         \"))))(Tile((id \
          14ec2083-bac7-451d-9641-c38736d742ca)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e7067962-c28f-4c71-b943-f3819c6b4e8b)(content(Whitespace\" \
+         \"))))(Tile((id \
          733821f3-d340-47f9-8e6c-6839025a4ecb)(label(proj))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2210,29 +2125,37 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a965d1ea-e4bf-4def-85e7-3d271e3f8513)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7b1f4595-c107-402b-bb94-cca1a7ef5882)(content(Whitespace\" \
+         c267610b-ba39-43ec-a413-879658947f82)(content(Whitespace\" \
          \"))))(Tile((id \
          fde3e53c-80ec-4de1-bb9f-39a286d4e9a2)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         bb7180dc-1273-416b-9c2d-7257e1c17e11)(content(Whitespace\" \
+         \"))))(Tile((id \
          33e6a710-7814-4508-bfe4-57648937949e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d30532e7-6c18-48f8-bba2-67c2af6a3fa7)(content(Whitespace\" \
+         \"))))(Tile((id \
          53b74799-a56d-439d-b741-b88bacfc05f4)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         beaed60a-e164-4dc0-a17a-046863d367e9)(content(Whitespace\" \
+         \"))))(Tile((id \
          a821f3b5-e7aa-4733-a913-34d744a024bd)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bd7174bc-4cba-41f7-9b5e-e09bf55db606)(content(Whitespace\" \
+         \"))))(Tile((id \
          e7d04d0f-cbca-4723-8dc6-9a48da9782a6)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         18a7cce9-9423-4cc5-a153-ca6ef76e2d0f)(content(Whitespace\" \
+         16a865f6-f292-486f-ae41-b10f45cdffc1)(content(Whitespace\" \
          \"))))(Tile((id \
          a139bee0-fb6a-45eb-82dc-a087a7a94735)(label(::))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
          29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3056e92a-c15a-46ff-8f9e-9c3a5d6a3b80)(content(Whitespace\" \
+         5264fbb8-b49e-4c4a-bd37-218078e62db9)(content(Whitespace\" \
          \"))))(Tile((id \
          361ef171-d06f-4431-b5fe-2924f2b201dc)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2246,19 +2169,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          508acf29-7890-41a8-ab05-08100ea40948)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b7a2e7cc-9c5e-4771-b65f-99ba30907645)(content(Whitespace\" \
+         708dc498-31f1-49ae-a5d0-42e092925033)(content(Whitespace\" \
          \"))))(Tile((id a1d2cbb7-0905-4152-b0a0-1466599ace64)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         1d9c63ba-2c20-457b-9ed6-51b1d1ac9fd9)(content(Whitespace\" \
+         452eaf3f-d282-49e8-89c0-3fa598f358f3)(content(Whitespace\" \
          \"))))(Tile((id \
          f789cb24-0c43-4eb3-afa4-48a0284669ff)(label(g))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         574f0d3e-c815-4ae6-b75f-8dc9369d6e84)(content(Whitespace\" \
+         174784ae-ed34-4e4f-b30e-23eb0902abb8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         15058167-341a-4f82-81b0-9674de346980)(content(Whitespace\" \
+         cfa76280-2e73-40d2-90b7-ff4fd0d246c2)(content(Whitespace\" \
          \"))))(Tile((id \
          8618d208-4499-421b-b4a9-c195802564a9)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2269,12 +2192,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c4cce713-7d79-44e0-abe5-0af246f1cb7d)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         7e3ffa11-347b-4617-a8e8-3e980b50c781)(content(Whitespace\" \
+         daed39c1-6d83-4d87-b3dc-cc17991e5d5e)(content(Whitespace\" \
          \"))))(Tile((id \
          797293ec-e09a-469b-a2aa-262057bc8bf2)(label(!=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c04711b0-a64d-4df1-8ac2-3286c696e6be)(content(Whitespace\" \
+         1f4db7ab-4a1f-4be0-ade8-a6ed8f7a3cbd)(content(Whitespace\" \
          \"))))(Tile((id \
          b3c54841-9f7e-4180-bcb8-0420661f3061)(label(proj))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2285,39 +2208,10 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d6dcbcff-6da6-4955-a2ac-f01e0f85a7d4)(label(row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d9705e20-6d20-4c97-a64b-536e50022c45)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a146792d-14cb-4834-91e0-459827196b7d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         67b12520-fd44-457d-91c9-c5341977f2bb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f936515-7f04-4b89-8330-43784abf1d12)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         218d7ae4-1cb1-4dc0-b459-594618d925f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4ea12138-5e6d-4d9b-826d-8668b442b014)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2ac920d1-25eb-4ad4-a17b-3f351c450b1f)(content(Whitespace\" \
+         270e5dcc-45b6-4400-b6c3-e808bffb64fd)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         e8ac4b38-4c80-4602-9b8a-8c6c01510ceb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3f3b1660-ca91-4219-8ee7-3ede5545478e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         032073cc-df6b-40df-9b24-d17ce040c106)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9629d3db-428c-44c3-a467-d5fd9c9cd4ca)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         adae2b7f-e016-43fb-a7a1-458ec6903da1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         64daedb1-7094-42d3-9eae-b4e6f88aac41)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         03bcc08d-c0ac-45b5-be7e-087f53c1b58c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c0f5bd9c-e0af-4e7b-a460-afc5bb544eda)(content(Whitespace\"\\n\"))))(Secondary((id \
-         372cac90-3f2b-4983-a8d4-daaa2d4f08ad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1bb85b01-9707-4da1-80b2-7491b22b38bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c3563e69-123c-4a9a-bbe4-e9671e1a05e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8f97479d-aa47-4b95-8791-673d37e4fdb1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         95e46bd4-a7d6-47af-9767-117d4bd5930d)(content(Whitespace\"\\n\"))))(Tile((id \
          96b6c975-9bee-4d17-8cfe-341993713d3b)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2330,7 +2224,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          55c8dd46-a4be-4eac-a7bd-422ba223ce69)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         089903a7-3ce8-41cb-bee9-01a6348301d5)(content(Whitespace\" \
+         a34fe573-5e3c-49e6-85f2-0cb0c98b3a8c)(content(Whitespace\" \
          \"))))(Tile((id \
          50b50e0f-e3d4-4aa5-bfdb-0ede3259aa1a)(label(go))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2338,15 +2232,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4ce9a469-9ddc-481a-b255-70486d33175a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         067a9bb9-76a1-4daf-b026-db54454d624e)(content(Whitespace\" \
+         1e9cf27c-07d2-4e6d-a23e-1eb7a83ef576)(content(Whitespace\" \
          \"))))(Tile((id \
          2418f21c-2c74-4d14-94da-c2073488ab58)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         70c6d072-5405-4995-b90b-7da478b30216)(content(Whitespace\" \
+         \"))))(Tile((id \
          8beed99f-1753-4760-98ec-48e6c16fb19e)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         46fea389-1564-43c9-b322-5dd1db518d5f)(content(Whitespace\" \
+         e303e747-010f-4934-92e4-52888057752d)(content(Whitespace\" \
          \"))))(Tile((id 40d9a7e4-eed7-4dfc-a7de-67698516370b)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -2355,82 +2251,89 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          fbb24ac0-a2fc-40a5-a4c1-5fb473a0aa87)(label(value))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a480dedb-d8f0-4e75-9c84-08dfbfc2edd2)(content(Whitespace\" \
+         \"))))(Tile((id \
          83b1bb24-a9c7-46aa-b3cd-92d5cf556deb)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         137dc48c-22a2-4ac9-b636-dbe8c9a6f2bd)(content(Whitespace\" \
+         \"))))(Tile((id \
          27bd409b-96b4-4a21-bf09-f4fd635aa175)(label(v))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a5988c91-a63c-4a4c-bb7d-cf925b42a10f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b677a0d0-3023-49ca-9f73-c56ec510ce64)(content(Whitespace\" \
+         d753ed50-1571-4d2f-8963-24eb3fa7c125)(content(Whitespace\" \
          \"))))(Tile((id \
          dd19de73-36a4-44a5-9ab0-459455a10ff5)(label(count))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         426f9c40-a813-4f80-ba60-203281ddd498)(content(Whitespace\" \
+         \"))))(Tile((id \
          f747f012-a841-4805-99a6-2319ef552d85)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         af630b69-e9ce-470c-8154-89ac357ccc44)(content(Whitespace\" \
+         \"))))(Tile((id \
          a3c88d4b-c87e-4890-97fa-d534008a0c01)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         070ee576-af66-4902-b3e5-a0565b2e6199)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         b8f8e6b2-fb77-48a0-863f-ba78b2397de0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         2c1a9845-3287-4883-8941-595476d4cff1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2fd96f8e-2908-49f8-8d89-1a15913d81bf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b7a75a58-4ca9-48c0-89bd-3821c5935588)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9c608d26-b962-4288-9d55-b918721b46bc)(content(Whitespace\" \
-         \"))))(Tile((id f46589d1-b73d-43fe-84b3-e1b94ea6f25a)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         bbb85087-80e5-4e8f-a9ce-bd2e9ae0a049)(content(Whitespace\" \
+         a3564400-d372-4960-8c10-71efdb808718)(content(Whitespace\"\\n\"))))(Tile((id \
+         f46589d1-b73d-43fe-84b3-e1b94ea6f25a)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         4d0a61a6-56ea-4c71-b912-35f53cd04dc3)(content(Whitespace\" \
          \"))))(Tile((id \
          ba74d9f7-b977-43c2-b655-40a52eae72c2)(label(build_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0d18f514-0dd2-48a0-b806-76abebec68ee)(content(Whitespace\" \
+         \"))))(Tile((id \
          a269832a-5c52-4608-b601-5fd2bc05adbe)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b7d12ab0-cf70-48d2-84eb-e83cf0436878)(content(Whitespace\" \
+         7983e350-7419-41e5-9182-029d08edbd72)(content(Whitespace\" \
          \"))))(Tile((id c7410e21-6103-4235-8731-67ea0d3c7c20)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         62a2348c-cf3e-492e-8697-e6fd19e5b1e0)(content(Whitespace\" \
+         6ed3d8e8-82e7-4be6-bfe3-ec9b071ba1ac)(content(Whitespace\" \
          \"))))(Tile((id \
          714c580c-4985-49dd-b3d2-5840a1e489a0)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         b84dbc6f-0866-4ddc-98f6-163d30b3fc0b)(content(Whitespace\" \
+         bdb5f207-7883-45a9-8144-2c8328d34582)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         93c5d8ec-b02a-4afe-8b48-8bf3019ea49e)(content(Whitespace\" \
+         406ddce2-8d49-41ed-96f8-ed504ccb95b6)(content(Whitespace\" \
          \"))))(Tile((id 28cf9ba3-4af8-4357-ade2-2307d47b5e99)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         66f1db4f-4d73-41eb-90c8-a520ba1cc1e2)(content(Whitespace\" \
+         92ade4e0-a469-4cc5-8156-d0423d659d5c)(content(Whitespace\" \
          \"))))(Tile((id \
          34cf9b9a-55a7-47a8-a274-f213473df802)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         b01d86cd-f47e-4536-96f0-236082e5bc7b)(content(Whitespace\" \
+         7f7573e8-a215-4b07-9b02-58e25e0399c5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9f06df43-4862-4b2f-9b17-253bb7fa8fba)(content(Whitespace\" \
+         d85ee556-fedb-4478-8819-156433f13ff4)(content(Whitespace\" \
          \"))))(Tile((id 8167c511-6897-4623-813f-8427e3f7d6f4)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         3b80917f-4839-4c57-ba21-68bf57333ada)(content(Whitespace\" \
+         ad5f7937-2ffb-4092-8ca7-7655619dec2d)(content(Whitespace\" \
          \"))))(Tile((id \
          de029984-5891-4558-84e0-a119a8b296a2)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         d9747181-f528-4cfe-bafe-634cf3e4be17)(content(Whitespace\" \
+         a238373c-1a67-47ad-aab5-9cea83f5d164)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8b326ffe-0cfa-46dd-b1eb-a369958f6a6d)(content(Whitespace\" \
+         6187a7c1-a7cb-4a0a-9ada-3f7e5b02b8ce)(content(Whitespace\" \
          \"))))(Tile((id \
          83b30b2f-1b60-4d81-9b74-1102ac88757f)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -2444,17 +2347,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          157a4104-8a35-44c2-a6b7-0f20df8e8c9a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1b5f2041-9e19-4e2e-a074-54476f988357)(content(Whitespace\" \
+         3ed39a5e-7302-49ed-be3f-b50b62a45f5b)(content(Whitespace\" \
          \"))))(Tile((id \
          2baa9b52-ac0f-41d6-b3f0-c6c6302399b0)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         74bb58f7-8522-4d86-b9fe-a7ccd1898ea4)(content(Whitespace\" \
+         48f7ff71-6484-4e68-889e-e1f43768a748)(content(Whitespace\" \
          \"))))(Tile((id \
          ee5f519d-e149-42ab-bfc5-f894e85b640a)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e7b7f035-2473-40cf-9198-80fe51d4ef53)(content(Whitespace\" \
+         b3b8e9fd-f3d4-4195-b871-2e2a8c9f1991)(content(Whitespace\" \
          \"))))(Tile((id \
          d50fcc47-3f01-42ee-8216-4a73bb1ef793)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -2462,7 +2365,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          890941ff-b97c-40e3-9d56-90e7d7d8b8f7)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         70c11b6a-17ac-4e8a-a3c8-9b820cf1b6ad)(content(Whitespace\" \
+         c44e2730-2e1d-4067-962d-58af888e0d46)(content(Whitespace\" \
          \"))))(Tile((id \
          fae25060-1eed-4c8c-9c65-9227a82c81d6)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -2472,86 +2375,82 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          82c666ee-f2af-4068-bcf6-8e76ece2aa80)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9638ca3d-bb86-466d-9f8c-33cca825a9fa)(content(Whitespace\" \
+         \"))))(Tile((id \
          a85b1f11-6211-4c05-8f72-d099cfe1c725)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0a7f06cb-3e09-476a-9418-5f7d0835e9cd)(content(Whitespace\" \
+         4255cca2-e23f-422d-b4ff-41a4419e042c)(content(Whitespace\" \
          \"))))(Tile((id \
          e21b8ded-b5a2-4aa2-9cc4-402f1d32a76c)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ea3e1573-8ea1-4f32-a7c8-246e3619a7f3)(content(Whitespace\" \
+         b4363524-9478-4391-bd8d-de3045ebb185)(content(Whitespace\" \
          \"))))(Tile((id \
          deedd570-22ae-4e24-b9c8-43e2915fba5a)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         6b2d880a-c8ac-4067-ac36-c572b3446a82)(content(Whitespace\" \
+         8c7287e2-3031-40dd-a50c-70a07fb4e39a)(content(Whitespace\" \
          \"))))(Tile((id \
          9f2a38b5-03ac-43f8-90e5-ca8b25b40220)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c3b72d1b-e0e0-41f7-b1ca-29bd636abaff)(content(Whitespace\" \
+         6928d6bb-fc5e-4610-9004-dc3ba859960f)(content(Whitespace\" \
          \"))))(Tile((id e3238192-424a-4e92-ac1e-aac3c4bdd4d0)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          39aaec45-4076-4db3-a882-3ad562bf239d)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))((Secondary((id \
-         035fa229-abb2-443e-92a9-d4e6ef69de8a)(content(Whitespace\" \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         26f82e79-2a8f-4802-ad70-23b13e85c7a8)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         3415b5ce-f988-4dcb-abfe-e70f0756a7ef)(content(Whitespace\" \
          \"))))(Tile((id \
          0979f82d-1243-46b0-9e9f-63b473ba7562)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         10cf1722-65be-4f18-9030-2ea9b9f9b171)(content(Whitespace\"\\n\"))))(Tile((id \
          5aed1646-8eea-4cbd-bc8d-b4b160e5a905)(label(typfun ->))(mold((out \
          Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f4779fd9-ea53-44de-babc-3e3dab80c977)(content(Whitespace\" \
+         e057c5ff-d58b-4647-96f2-3848476a1da3)(content(Whitespace\" \
          \"))))(Tile((id \
          56fac73c-143e-4b72-b2d5-d6f04139d22e)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         91308082-8ffa-465e-9e7e-6480397a7bbe)(content(Whitespace\" \
+         5be02895-f2dd-484c-83f0-c11fa566c10d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e78e57ba-9061-49c7-98c7-39a1473cbc61)(content(Whitespace\" \
+         a90d56dc-6150-43e5-90f6-c51225272295)(content(Whitespace\" \
          \"))))(Tile((id 256bf20a-851b-4914-b248-274ece446fb5)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         6a351a7f-cedc-4e0f-ad5c-b54977e6689d)(content(Whitespace\" \
+         834c69bf-934b-4015-8d36-bb146733f5d8)(content(Whitespace\" \
          \"))))(Tile((id \
          da9fefb6-ed27-4b64-b1ea-1dccff397031)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         2ed11e85-94e4-445c-8ac8-3cb69ef65bc7)(content(Whitespace\" \
+         fcfd89bf-d9d1-4bcb-bba4-d0adef757b03)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3de82593-2d24-4b65-9ae1-efcd0af24750)(content(Whitespace\" \
+         34748bfd-c837-42d7-bf13-045039b9672e)(content(Whitespace\" \
          \"))))(Tile((id a6d6b57e-273d-4961-906e-69f7c3a6ad26)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         bf8cd83b-f3c3-46dc-a387-6ad0e030c8c4)(content(Whitespace\" \
+         7ed11c73-e01a-4832-acb3-847d07e12b46)(content(Whitespace\" \
          \"))))(Tile((id \
          c9cd0073-f98a-4068-8e18-8de4a07961f2)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         6d9dd230-2c18-4f39-a9bd-f4cfd9826a20)(content(Whitespace\" \
+         2aa29c8c-6dcc-4a08-be0c-a84ad4efe299)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4b9a1420-5ba9-4939-81e5-6b5509b8c098)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5b6441e5-8d0d-4ad3-94fe-9aa807cc905b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ce748205-c5d0-4317-9e2b-5258b7667c98)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f7fa6e9-ad6d-40da-a7ca-5ff0ef89b612)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         631c10f4-09af-429f-adc6-e8da7b000368)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2e63a7e-a96d-4ee6-ab52-2a3c19e83a2a)(content(Whitespace\" \
+         5cb59a43-0ed7-4d03-b3d8-f60424c02f0b)(content(Whitespace\" \
          \"))))(Tile((id c60833cd-b420-4b09-bc50-330125d50892)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         31961991-9ed3-44dc-8d22-15084e4502d1)(content(Whitespace\" \
+         e55cb59b-fbb0-4698-9045-cc966f9959e5)(content(Whitespace\" \
          \"))))(Tile((id \
          b3145321-03ad-4176-846a-36940eff123f)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2562,7 +2461,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6173d761-b229-4210-8d41-b948ce1ed2e9)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         07c9a011-3a16-430c-a1eb-9fd0a4db7067)(content(Whitespace\" \
+         d0ba7af8-e826-4b4f-9eb7-ca9996ce961c)(content(Whitespace\" \
          \"))))(Tile((id \
          93d1d9af-8655-4461-aa68-1b64ab96b3fe)(label(project))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2570,14 +2469,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cdbb8887-66a9-4ae2-ad8a-4fc2f744b5b9)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         349b2289-02a5-4b5f-acfc-e6ba209b1a9f)(content(Whitespace\" \
+         6eeea24a-787d-409e-83b7-9c3b60cad121)(content(Whitespace\" \
          \"))))(Tile((id \
          d8466461-a6ca-4c51-9305-0b11b6f7742e)(label(build_result))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         9f7be87f-26fd-4edb-9783-4e1df30e3061)(content(Whitespace\" \
+         b610e285-f6a1-4284-9e71-61ecd9369c09)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4e375767-0c93-4256-a2bb-f26f79b2433b)(content(Whitespace\" \
+         6004c2c9-0d7f-4dcf-b48a-6a01cf7c5aa2)(content(Whitespace\" \
          \"))))(Tile((id \
          4476ab65-fdb0-41f8-9d4b-2362a2b7b2c2)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2591,27 +2490,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b99beb28-484b-4e19-89d9-c0062836f14a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8aaf37d8-52a6-4238-8c70-43a2dc72c06d)(content(Whitespace\" \
+         a9f0a688-01b1-4d09-acc2-62f0595a3315)(content(Whitespace\" \
          \"))))(Tile((id 95e2c8bf-e588-4584-8dfd-c489fb072fa5)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         b27f0d03-696c-44b6-8ab8-72fa74916dcf)(content(Whitespace\" \
+         86d2570c-e8fc-437a-a7b2-d3bb481406e2)(content(Whitespace\" \
          \"))))(Tile((id \
          7694fbd0-e058-488c-a3d4-3c247eaef364)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6b4e8b13-762a-433a-8a8d-b2df5f836db5)(content(Whitespace\" \
+         \"))))(Tile((id \
          30ccff35-9326-44e5-85c6-0177f4d649ea)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ef2b8072-9469-48c1-b100-b8b564a2ccbe)(content(Whitespace\" \
+         9e0f5960-9d06-404d-aec5-3e0804f54d29)(content(Whitespace\" \
          \"))))(Tile((id \
          feec48a5-e21e-4f2f-bad2-1ae47859a3f5)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         9c2ee3b1-8bda-4add-a642-b805b5604c91)(content(Whitespace\" \
+         62cc1f95-f955-40b4-8084-4a7b4adabb23)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         add0945f-9135-404a-bea4-1e7ab1eff20d)(content(Whitespace\" \
+         a9dbae36-621e-493d-a8c2-837f3b92801d)(content(Whitespace\" \
          \"))))(Tile((id \
          14814480-7b4d-4162-94e4-89d18aa9d88e)(label(build_result))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2625,7 +2526,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          becd4983-12f6-4537-852a-c7bc21c41efb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         19218880-c872-4a50-99ae-8c6d6d31564e)(content(Whitespace\" \
+         0a03c16a-dced-459e-91dd-f304cf2944ec)(content(Whitespace\" \
          \"))))(Tile((id \
          d5b31ce1-5f81-422b-b0e4-c738991c98c8)(label(project))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2635,289 +2536,256 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          2850b882-f861-49b9-8a9b-bc057466b6d9)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         2a2a3e07-a147-4650-8372-7d01f5c15cc1)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         d35e134d-5d4b-48c9-bb79-af0d6f9471e0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         214989e7-31f9-42e3-98b1-b9b5490baddc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         65b80843-529c-4ea1-980f-8c96a4c595c7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         31c115de-eb21-48fb-8f15-a55f479f6748)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3c4f400d-7ad3-426d-aa64-6a4c670095de)(content(Whitespace\" \
-         \"))))(Tile((id 40044cb8-fbaa-4195-903c-d4fe1f5f08bc)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d1d8ecc3-f6a2-4566-9272-d43ef5adb6b9)(content(Whitespace\" \
+         d04c6c5b-34b3-4b80-a1dc-7e290460d816)(content(Whitespace\"\\n\"))))(Tile((id \
+         40044cb8-fbaa-4195-903c-d4fe1f5f08bc)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5cb6fdce-b72c-481a-b808-41aac0913338)(content(Whitespace\" \
          \"))))(Tile((id \
-         5f166aec-2f9f-4fec-bc0e-d195102f238d)(label(incorrect))(mold((out \
+         5f166aec-2f9f-4fec-bc0e-d195102f238d)(label(_incorrect))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         fcc1a85f-cafd-461e-aaf2-0c39bac5e96b)(content(Whitespace\" \
+         42a77cc4-3060-4759-9f7f-c0ee10e3725b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ee0973c0-0d71-475b-b140-fc0889805b4a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c87b4cd0-54db-42b7-a588-922a1eab8dc0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9026d70a-f7be-432a-abbc-359acd34e988)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9a3800b-f001-40ce-b5ac-ff3c8010467f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d2c04a70-38a3-4166-858a-af500d7ac296)(content(Whitespace\" \
-         \"))))(Tile((id 55718a63-623b-4ceb-87ae-a037b7ee5268)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ffa19510-979d-4157-8251-3cbfaf60e429)(content(Whitespace\" \
+         ccf2ea25-0c08-4327-abae-58b461ea49d0)(content(Whitespace\"\\n\"))))(Tile((id \
+         55718a63-623b-4ceb-87ae-a037b7ee5268)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         fe256276-4afd-458c-9177-2073b0072a64)(content(Whitespace\" \
          \"))))(Tile((id \
          44cbbc7d-522e-469e-b63d-1ea0e0aebad4)(label(brown_and_get_acne_table))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         08b6d513-2f48-4216-9384-ce284437ef79)(content(Whitespace\" \
+         c3b2414c-256c-4ca3-a1b6-920e3a5099e1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8217a3ff-e20f-4334-a224-06abdd62293e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4cf93e12-b105-4d69-a1d3-0f0335a3704a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2720ff82-55f0-40ae-9b9d-da7015a17ec7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3bf8ac28-b60d-42b1-ba63-322ecca32cfe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3883361f-ca45-4cd6-8a35-cd731d5c9216)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ee9f5456-acb9-47d3-aca4-b8e075b454e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f47854be-417d-4e06-b5e0-4c679eb33fde)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b31818f9-98d1-47ca-841a-23f862b6c4bd)(content(Whitespace\"\\n\"))))(Tile((id \
          9b239f68-6163-4466-85f4-600c98d9d3c3)(label(build_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         1023b5a7-f204-4ce6-a7a7-a39fafac45bc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0b1de1d9-e460-4de1-9f1b-86adc39e0089)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a362cb6d-1cb8-4586-b353-159432bc3256)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82d15fd0-2dd2-4d13-9576-659f3ff949b9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4be8239f-0fae-4ef5-9bf5-dfc4a048816f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ce625ef-77ad-4b97-aa8c-2dabf4332453)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d1d471c5-0197-4dc9-95b5-72c734ed72ec)(content(Whitespace\" \
-         \"))))(Tile((id 367d874d-53b8-43e1-a8f2-92402adba97a)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         367d874d-53b8-43e1-a8f2-92402adba97a)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          b51b5f2c-b203-4179-98a4-96a1a3563862)(label(JellyNamed))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         ba650d4f-777a-46e1-987a-65503feb4d6b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         162b2f2a-3838-4219-b711-7b4ddd65da59)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         752ac8e6-0c3c-4ac0-8c0e-f7d0a6fd32b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         71738fe9-632d-4afb-b8b7-49c9f5450b38)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f2805a65-05e9-4d10-8bad-76ecdcf3fd28)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e99ce6ac-8ea6-4227-84f4-75b6d65e5081)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         297bdb08-de2a-43f0-a17d-37113550ab3a)(content(Whitespace\" \
-         \"))))(Tile((id fce84d91-3f0e-4a6d-9ed7-1cc6fba078f0)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         fce84d91-3f0e-4a6d-9ed7-1cc6fba078f0)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          66b728dd-7fa3-4edc-855f-e280d566256f)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d5c37f33-4fa8-470d-a4a7-8ffbc9017a40)(content(Whitespace\"\\n\"))))(Secondary((id \
-         20ea205f-62e8-4664-8046-29963eae14b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b1beb234-1d2c-46a6-8bc4-9e5d093a46c3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de0d3426-ce24-4120-b9c4-7ec5be8e789e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8427290c-88f5-40eb-b5a7-012d4c2e74bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d91ba80a-32f0-4aea-a771-c90b05e01590)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         18acd15d-55a3-4ee5-8bd7-2359dba0d774)(content(Whitespace\" \
-         \"))))(Tile((id 4a47c7f2-eb27-406d-8d9a-c168aa91d1a7)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         4a47c7f2-eb27-406d-8d9a-c168aa91d1a7)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          976a0a7e-584f-4a17-86d7-4d2b3100e553)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         31329227-bb92-4d20-bcba-e205686f90ba)(content(Whitespace\"\\n\"))))(Tile((id \
          b50079e1-8988-481b-b9c1-3256d411d2fa)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9742875d-981a-4168-9d62-adbc63cc75b1)(content(Whitespace\" \
+         \"))))(Tile((id \
          d973f845-5e81-4c57-94aa-0857c39a6628)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         aa9be891-cff0-4d53-b615-c56d1d1b0da8)(content(Whitespace\" \
+         \"))))(Tile((id \
          d98b6441-ad49-4c94-8a5a-7529d058a54b)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9218e933-8b1e-44d8-a51c-09956f7b763f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5f025242-443c-446d-8a2d-56557f333a5b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         aa7e4ec4-4008-4415-ac28-3ce10c69d989)(content(Whitespace\"\\n\"))))(Tile((id \
          2bdba3f1-6df0-4cfa-b3db-89e8183157a2)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1e8cd5a9-69dc-450d-b5a0-7532b6b0b262)(content(Whitespace\" \
+         \"))))(Tile((id \
          63ae35de-a48b-48bf-b2ce-fd59179fd0c8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2f41eb64-a906-4508-a8e6-ffc37fe29130)(content(Whitespace\" \
+         \"))))(Tile((id \
          df641e59-f0b1-4fce-8a75-04766d9cd92e)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a9be200d-e87c-44d5-bba6-a6850f71b92d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         28a90174-c699-4ef7-bcbe-7742b5242c8f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         4204897c-bac8-4366-aaf2-db330e484231)(content(Whitespace\"\\n\"))))(Tile((id \
          fbe279a7-d04d-455c-8221-49959658c277)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         53054072-040f-4411-bace-a89ad56c2689)(content(Whitespace\" \
+         \"))))(Tile((id \
          de109dec-5cdd-4998-8bbf-99aaeb575a22)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         956d926f-cda8-4555-a414-43ec7ccb289e)(content(Whitespace\" \
+         \"))))(Tile((id \
          fed91e24-f4a8-4b0f-80ac-d74354a2a74c)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4d7dd5f1-c1b2-45d2-810e-83d1ba31b0ee)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         584a0989-fd29-4771-a0d7-e2ea3f1c86ea)(content(Whitespace\" \
-         \"))))(Tile((id \
+         aaaec958-8420-470c-9696-3035b6d17674)(content(Whitespace\"\\n\"))))(Tile((id \
          875d6d94-49a8-472c-885e-b7e6862e56a7)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9f5d25b3-fbe5-4c2e-9e4e-4f95b8b838cc)(content(Whitespace\" \
+         \"))))(Tile((id \
          ba264290-d053-4fbc-963a-6137b27d8c70)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         187c80d1-d60c-46de-80b3-e931433ba4ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          bf7a6950-4cc2-42d4-bd0e-37c692cf4814)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ba5cd8bd-691c-4108-892e-0a8f978c0000)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1e8806d3-2db4-4805-9d31-77447a360d0e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         bb12de84-e316-4e67-9a63-8736e5845511)(content(Whitespace\"\\n\"))))(Tile((id \
          e7e9b134-5ec8-4e74-b1e5-4829302e3c95)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         07a5b92e-485d-4fab-ba1c-c5cee01c3770)(content(Whitespace\" \
+         \"))))(Tile((id \
          4d85bac8-4b8d-46cb-b488-d4e6a2d6b790)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         106cde3f-66f6-4336-8989-fd7ac5be6c5e)(content(Whitespace\" \
+         \"))))(Tile((id \
          a613bf90-506f-4a24-8eed-be504933e975)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b37de840-c1e8-4515-87b4-4ce751576624)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ecebf2ad-29f5-44b2-bbb8-8caab19f77ec)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e924d4b3-aae3-4afb-8dd1-4fb5ed37d034)(content(Whitespace\"\\n\"))))(Tile((id \
          99905d23-b0a1-4b63-b4c8-bbb793940b07)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         943fea46-33ed-4f54-8a6e-312d54c14acd)(content(Whitespace\" \
+         \"))))(Tile((id \
          dbd80d88-6ad4-4899-b34a-f43e2898d515)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ec94e93b-6d27-422c-acbc-f72cc4d4bd69)(content(Whitespace\" \
+         \"))))(Tile((id \
          c872032b-3f00-4f82-815f-91726560537e)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          97c16dc0-b784-4e3d-94cf-dfba46c8affd)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         75c1d0aa-77d6-40d4-8824-f3dbb154df28)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c782b563-5395-4d8e-a9a2-0e5b3798dd17)(content(Whitespace\"\\n\"))))(Tile((id \
          b723da81-f864-40fe-8ad0-8e366c1b01b8)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b071f8b6-b08a-4a94-997e-3b3024210871)(content(Whitespace\" \
+         \"))))(Tile((id \
          a33b40b4-2943-4b69-a9e9-e125a052b0f1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b678f3d3-02ef-4477-9b6f-e7cca4ec5bcb)(content(Whitespace\" \
+         \"))))(Tile((id \
          70f85092-d0f2-4ddc-afab-9c0bf1411573)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          32266cb8-c316-4ebe-865e-3194694cf485)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ff45f881-b8a4-4842-876d-3af67448e5a8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         33f87dae-30d7-46a3-a2ab-a21017b70607)(content(Whitespace\"\\n\"))))(Tile((id \
          a9bea7c1-c9ec-43d5-a315-9e84b3ec132a)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6d6890b9-7988-48e7-94fb-b3e2dc766315)(content(Whitespace\" \
+         \"))))(Tile((id \
          d67d2d3a-c801-4e03-8701-ba2f0327ae34)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f2ecc5bf-a5db-4c74-b3a8-e1805c75dd6f)(content(Whitespace\" \
+         \"))))(Tile((id \
          6e1a3073-350f-4bea-8ec3-8e7e1b3b64cf)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5a955f24-70f3-43b2-a43d-925203525233)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         88f0bec3-555e-48c8-8772-00b04d13969b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         145a0ee5-8aa8-4d5d-a5e3-eb84deebfed5)(content(Whitespace\"\\n\"))))(Tile((id \
          bcdcb6ef-ab30-44b9-99ac-4614e1c5c497)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6f1d86a5-905b-44e5-80bf-80b8f6a63ca0)(content(Whitespace\" \
+         \"))))(Tile((id \
          0dc90059-a5ba-4ac2-872a-03e7b539389f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a2c2e9a9-a8c1-45ba-9fd2-e71c02220781)(content(Whitespace\" \
+         \"))))(Tile((id \
          4cf7bf17-890d-492b-aaec-77c63fc32fae)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c50d93fd-52a6-45f2-a665-245cdecfb68e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c25c456d-d689-4c0b-8920-422050986f88)(content(Whitespace\" \
-         \"))))(Tile((id \
+         223a11aa-6ce3-4530-a55e-a88927293e7a)(content(Whitespace\"\\n\"))))(Tile((id \
          e1671a9f-fe4a-4d7d-9e46-6bda294d9f11)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         06d799b7-9dfd-41c6-8a45-2def3880111c)(content(Whitespace\" \
+         \"))))(Tile((id \
          30501e60-b60a-4dc1-8985-82dc55ba62ae)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fda23c8e-0a04-4c43-8321-13214a6694b0)(content(Whitespace\" \
+         \"))))(Tile((id \
          2cac8798-59d9-4f3c-be65-a99b19ff5148)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f3b1a562-90ec-43c1-a895-0c2741d6e93d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         067de9c3-0303-4e2b-9d54-8aa51a358864)(content(Whitespace\" \
-         \"))))(Tile((id \
+         36acd924-b32d-4478-b7d4-7cdf3592834f)(content(Whitespace\"\\n\"))))(Tile((id \
          02a8fa4b-227d-42c3-b19e-c6c6ec32a963)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c808c37f-3837-4caf-9f58-cb3a4514aa21)(content(Whitespace\" \
+         \"))))(Tile((id \
          ae2a4bc7-af5e-4137-bfcb-e0b44abe6b7f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3070b546-6094-4d23-853a-7f4973c6e769)(content(Whitespace\" \
+         \"))))(Tile((id \
          2fbc6cd8-fcc6-46c0-a36d-5c76e5e1b91d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c6c37e86-152d-4f31-8c28-b8538f228c71)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         095a5bb1-145a-458e-9576-0257beb72ad3)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3f6a2a1a-4307-46bb-add9-02f31b4feec4)(content(Whitespace\"\\n\"))))(Tile((id \
          37265718-56e6-4ffd-8a9e-6d972ccb8a52)(label(part2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5e45a9e9-8fe2-45bd-af66-8907f28fda11)(content(Whitespace\" \
+         \"))))(Tile((id \
          32a02fdf-dd8b-4243-8e88-95f7bde8f706)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         71bae9c0-8f34-48ff-a111-7ed0e4166a49)(content(Whitespace\" \
+         \"))))(Tile((id \
          dd9bf401-6680-47f8-a9c0-8ca3ad0ed074)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         c6cf6bf2-bb97-427a-b137-795b8a9d2dc7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d74406d1-82ae-48bc-bf25-cdef0a8641f1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         88ec4657-f569-45ad-8d30-1a5080d6a2be)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7be4b1f3-6c3c-4ee3-addc-1a34fda451aa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dd2ef328-707f-4f9f-82e3-af6ba1788034)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8fb25597-2c60-4889-a2d1-73300dd80e82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1dceacb0-5e03-4ab2-b47c-cb0cd1b2f333)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d84926d8-ae83-45e4-b034-f0dd263d9d93)(content(Whitespace\"\\n\"))))))))))))))(Tile((id \
          d57314eb-0bde-4de3-a912-d870e09082c5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2926,17 +2794,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          7ae2674f-5a99-42dd-af13-41b7e8e30352)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ae95991c-88b7-45cc-9e73-ca70ccc7b3c2)(content(Whitespace\" \
+         \"))))(Tile((id \
          a756d67b-32b1-41ae-9934-c6e3a10175d9)(label(brown_and_get_acne))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          0001c713-c00a-47ac-82bd-438e08c14263)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         91d898a8-edca-4f69-9f59-6c386b68a2ce)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         974cd9c9-de3e-4bc8-a9ec-ea29ea52e2f5)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         39a203c7-c6dd-48db-b04f-1cf11f606237)(content(Whitespace\" \
+         \"))))(Tile((id 91d898a8-edca-4f69-9f59-6c386b68a2ce)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         c7dc9af7-c3ea-4528-8e5e-fa0392bf7da7)(content(Whitespace\" \
          \"))))(Tile((id \
          39312412-c43d-4683-957a-fe0ddbbc51cb)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2947,235 +2819,258 @@ let out : string * Haz3lcore.PersistentSegment.t =
          831a2bf4-faaa-412e-ac0f-df4fee73ef55)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         396dfaae-9fa7-4aa5-807d-511ab8437dcb)(content(Whitespace\" \
+         1a780e7e-7bee-43e3-81e0-b3dab9c47c5a)(content(Whitespace\" \
          \"))))(Tile((id \
          ce6c8c95-7fc2-4163-ae61-bdff8ed8468e)(label(v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         712c9d2f-b0f3-4a00-a681-85eba7faee5a)(content(Whitespace\" \
+         af712e00-986a-43ae-8227-3bc7d44a9c5b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d92c6751-e04b-46ea-9dd1-4b16682e6e59)(content(Whitespace\" \
+         ffeb83f7-27a3-41cb-a68b-c4d99a2745a1)(content(Whitespace\" \
          \"))))(Tile((id \
          93822593-8724-467e-8eab-c7fd793dd581)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2c3a56f4-de8f-4e43-bdd1-fb273086952f)(content(Whitespace\" \
+         \"))))(Tile((id \
          9341d354-29ce-47c9-9991-b17bd7315d26)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         83bb5a12-8bef-460a-b48b-2cf6dde529ba)(content(Whitespace\" \
+         \"))))(Tile((id \
          328abdb5-9855-418b-b6db-b7217b6f12fa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          5b6e90a9-6047-498d-83db-56eeed9f86d8)(label(part2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         489c4252-74f8-4043-8f81-a3803cc85e11)(content(Whitespace\" \
+         \"))))(Tile((id \
          94f9371a-15c3-4f38-a033-4806ade92cc9)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3185307b-eb64-4524-a81b-9241bab23f28)(content(Whitespace\" \
+         \"))))(Tile((id \
          41920068-4cb6-45f8-bbee-a077a034e77e)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         78fa51bf-6e99-4d03-a3e7-3a4a111d40b5)(content(Whitespace\" \
+         9681c474-66d6-45a3-a036-06eaaa77b01a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ef8e06b2-5d59-4340-95bc-31e6d8809f26)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b57f48ff-fd52-4cdd-b4f8-484f11fecad4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         42b5add0-63b4-43fa-88af-5098e713905b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         56f4f489-d64e-4491-8499-9d33c5689b0b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0362bf41-25b8-4cfb-9be7-69374038473d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f8c2eada-0dd1-462e-9057-0b655ef59eed)(content(Whitespace\"\\n\"))))(Tile((id \
          11bfb9d3-a3bb-4f18-a935-ee8dc7c7021f)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         5946b0cd-5af5-4f8c-a85c-7f5ea6b646f3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4edbdbc0-d095-4b52-94c2-90d339d0cda9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ee24679-324e-40c6-bc1c-9ced7be01020)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3444c749-c551-4561-8ad8-265538e589b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6a024a79-5cbe-4c77-9e19-9ad137412cd2)(content(Whitespace\" \
-         \"))))(Tile((id f7bb3a51-fae1-4235-89cb-444c6cc96fe6)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f7bb3a51-fae1-4235-89cb-444c6cc96fe6)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          d24793f5-97f4-4aed-b6d5-c0379d18e7f4)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         38de0f3c-f438-4686-bada-6a6e1fd257b3)(content(Whitespace\"\\n\"))))(Tile((id \
          8ea0335b-14ef-4fa3-a91c-e19f745bea58)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c1d6dc3a-e760-4c7a-900d-55b17222df71)(content(Whitespace\" \
+         \"))))(Tile((id \
          a2c70541-c680-4470-8b9d-ca8bff1b24f1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3f537a45-4447-414c-8ea5-e79fea79f779)(content(Whitespace\" \
+         \"))))(Tile((id \
          900acee0-922c-4fac-ad44-6df2c70426b3)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          df845dda-ad57-43c9-9626-bacbb9a1ad85)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6167ec5d-cb26-46e8-92d6-3ff74034365a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d2f5016e-abb8-49b8-9422-c8815fd0fca7)(content(Whitespace\"\\n\"))))(Tile((id \
          2cc3a9f0-d301-40e1-acf9-7764533a08e0)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         45f970ee-6918-4244-89b1-a7eba02f4e7d)(content(Whitespace\" \
+         \"))))(Tile((id \
          1fadfee3-048d-48c1-a3eb-4e20b38a211d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         553bb576-139a-4c17-a3d9-89a08289cd52)(content(Whitespace\" \
+         \"))))(Tile((id \
          72815fd5-8568-4494-860a-307c63a36033)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b5a4dce2-3bcc-473f-8875-713ad1251464)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b402fa4f-7ba5-4dec-a114-7821e263402c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         2e339585-1eab-4d2b-90c3-b1da1525408c)(content(Whitespace\"\\n\"))))(Tile((id \
          6929bc0e-2974-411d-9a75-d5cde9c7d317)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3519692d-ad05-4697-b081-a392aa864395)(content(Whitespace\" \
+         \"))))(Tile((id \
          58fb462f-ee3c-4523-9607-b6f2967689f6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8390830a-c579-45ee-86ab-29e4791efb67)(content(Whitespace\" \
+         \"))))(Tile((id \
          db286607-741c-4d63-8543-e9ec41df5d4b)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4c913563-b409-47f8-aebb-e2e8bcc7d35b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0c975fec-52a2-474f-8ed0-1ad9d7d8404e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b43b5cd8-f068-4bd4-91e2-9eb24a82c770)(content(Whitespace\"\\n\"))))(Tile((id \
          09bab39f-80d9-47b2-b060-0a62a0e18ff6)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a1caa8d1-bf30-4472-a827-deef42c75b13)(content(Whitespace\" \
+         \"))))(Tile((id \
          c5d65d60-d456-4c18-8127-faa519086ad3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         db3aa3c1-76a1-47c1-9cc7-de20088cc8bd)(content(Whitespace\" \
+         \"))))(Tile((id \
          c17d909b-b589-4b9f-a072-fba599ba585c)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          def76886-4925-4c86-b30d-5b1ded950e1d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8c62e4cb-53e8-4d5d-9e9f-85d445abd694)(content(Whitespace\" \
-         \"))))(Tile((id \
+         789fc392-17e3-4343-86e4-887317731c3c)(content(Whitespace\"\\n\"))))(Tile((id \
          53dfdf54-7f4a-4318-9650-eec426626ae3)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         15778228-aa2d-43e7-a4fd-0a61bbd9f4f5)(content(Whitespace\" \
+         \"))))(Tile((id \
          06bfcfb2-4ca2-4f2f-b117-a2dd273bd98f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         049d23cb-8d59-4af0-8fbb-f8a5f4443f12)(content(Whitespace\" \
+         \"))))(Tile((id \
          484da310-9686-46a7-b644-16ab946b3408)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          153608aa-0435-43ed-84b7-2de97dffe7db)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f6303da9-21e6-44eb-b3bd-355a476e062e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         617d2bba-f197-4d46-88a9-016a7da24732)(content(Whitespace\"\\n\"))))(Tile((id \
          2f774f34-caef-449b-b2af-2b8d5c6b9072)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5d0bee4c-196b-41a3-b741-ad766dcb517b)(content(Whitespace\" \
+         \"))))(Tile((id \
          ddda9a68-adce-43e6-b585-142fddcae16b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a4f33977-a42b-4209-8e61-2ca1c23c681b)(content(Whitespace\" \
+         \"))))(Tile((id \
          f5dcb489-efae-45ae-80a7-adbf86995d76)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b175ed17-d2cb-4084-b948-e44a93041d64)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         cf976b86-ce82-4c23-90c1-6a4a27e8472c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         30c7579b-0537-43eb-aec2-dc0b311a951c)(content(Whitespace\"\\n\"))))(Tile((id \
          549ed863-ae2a-42a2-b223-ea3485d13845)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e4d2a62f-d8c9-47a1-b374-fdf86b4ec63a)(content(Whitespace\" \
+         \"))))(Tile((id \
          4fc255dc-c75a-4c99-9884-4682d66747e5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         34564818-5a2e-46ca-a008-8c7a90827060)(content(Whitespace\" \
+         \"))))(Tile((id \
          d2de5633-e91c-4151-8d27-c6327329f965)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4be1b4b5-e6b2-4252-9a86-d32959717638)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b9103882-cf2a-490c-ae87-e1307abe30ef)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8b04066d-91f7-4304-a3e3-c71ed860a50a)(content(Whitespace\"\\n\"))))(Tile((id \
          26211003-da73-43ab-95c7-228fd6195a8b)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9aa636a8-a57b-4844-a8ce-908ef6bd4f66)(content(Whitespace\" \
+         \"))))(Tile((id \
          03abbb83-20b0-4868-9665-e2cf8634b823)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5bad1735-4685-4c40-b964-b6c5eb148ecf)(content(Whitespace\" \
+         \"))))(Tile((id \
          8675bef8-302d-4408-b8ee-c719306f736b)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          77244d8b-e78e-4cc4-a6e5-f7fa26425649)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         676bfa6c-eed1-4bb7-a716-e0b5ca821109)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e09dc12f-8efc-44a2-a95e-7120e033965d)(content(Whitespace\"\\n\"))))(Tile((id \
          5bbb4999-8589-4f92-b531-c128dfe752b4)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dff9776d-4171-4105-827f-584db71af0b5)(content(Whitespace\" \
+         \"))))(Tile((id \
          3f544833-80d2-4997-b997-4c454de2475f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         59d8cc35-f15a-40e3-b2d7-6324cb3a0200)(content(Whitespace\" \
+         \"))))(Tile((id \
          80556118-2283-4461-a2a6-29a4a479b6e4)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9d260564-abe0-417c-a86b-2e0ab7daf3b6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b555ba5d-5820-489b-95d8-33366be0c22a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         13463df7-b522-452e-834f-38c5c0b149e9)(content(Whitespace\"\\n\"))))(Tile((id \
          b92c29be-e419-480d-b7b6-3655131a7836)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ecb8625e-2dfe-42d5-920b-8ed77ef4c5e6)(content(Whitespace\" \
+         \"))))(Tile((id \
          8f64d77d-4ced-4760-8bc1-d6858799b759)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         68c5160f-5953-4729-acf5-7005a9222e41)(content(Whitespace\" \
+         \"))))(Tile((id \
          e01e3853-d1db-4372-8982-30c8e5a408b3)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          94c4b262-353e-4d82-80a1-a67c35cdbdb5)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9f5c4b81-66cb-4622-9329-26f52f49ba74)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9b76c55f-f005-474c-beef-24babf5fd39a)(content(Whitespace\"\\n\"))))(Tile((id \
          8b92044d-13b1-4b3b-a324-8b5b8669aadd)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         143be6f2-9476-4d8f-9473-4c7bf40a7713)(content(Whitespace\" \
+         \"))))(Tile((id \
          1d07f899-9f6e-4966-8f65-953c9f49c086)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9f71a884-7e2e-4a4e-8741-e27df4413294)(content(Whitespace\" \
+         \"))))(Tile((id \
          29d45f5a-78a3-479c-a337-115b0e6a64f4)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bf93a769-478c-428c-91fa-1d197a1a13bb)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3d19f823-8860-4744-be0b-5acde5288d61)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8f1b01b4-3f92-4806-a676-61e07767f242)(content(Whitespace\"\\n\"))))(Tile((id \
          2f6b433a-5d64-4415-956e-326ddb948ae3)(label(part2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         545089a9-0592-4fda-8a12-993f14062f49)(content(Whitespace\" \
+         \"))))(Tile((id \
          f7726d51-9c98-463c-a767-43f6f6dcfb4f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e7accef9-01fd-4135-832e-8cb2a000a81e)(content(Whitespace\" \
+         \"))))(Tile((id \
          66f5af87-2c07-450c-87c9-e534ce5f21bb)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         cc764319-8248-4d32-b9c0-bc51890b94f2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c278395b-5f89-47f8-a511-72c308d2d398)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3b91157a-b821-4e48-9fed-9210f2b36219)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         698a9c37-c764-4bd1-bb52-428c9e6a74a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fb2bde0a-4916-4d33-81bf-c9ab8b904074)(content(Whitespace\" \
-         \"))))(Tile((id b0a8d016-c923-449f-968c-d2120d5e3549)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7ebdb9c0-eb0f-40fb-9c7d-938dc38d5234)(content(Whitespace\"\\n\"))))))))))))))(Tile((id \
+         b0a8d016-c923-449f-968c-d2120d5e3549)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          c174e614-0f15-4cf4-83eb-61be9cd54c43)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
@@ -3188,19 +3083,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b3432c3f-ecbb-4498-915f-3a6b817cfebf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cde74088-2b5a-4bdb-b838-5669b0ea77d4)(content(Whitespace\" \
+         5a28d16c-b1ff-4fd3-948b-3cbf47daf33e)(content(Whitespace\" \
          \"))))(Tile((id e367ae3e-a066-419d-9849-99787a0d3104)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         856561fc-8879-401d-a79d-977452170029)(content(Whitespace\" \
+         013514fd-ed93-47d3-a853-2016c10b6ccd)(content(Whitespace\" \
          \"))))(Tile((id \
          9fd3bd47-6142-4842-b5f2-c15d985e218f)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         728721df-bfd6-4ab4-80af-7b3c074cfbe0)(content(Whitespace\" \
+         e92aaa42-db7e-4615-83c8-922027d5141f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         926ef30c-911c-4e55-be71-1df70a73df45)(content(Whitespace\" \
+         db9e8352-efe4-46df-ab63-d1dd9531dd4d)(content(Whitespace\" \
          \"))))(Tile((id \
          02768f41-f8c0-449b-a253-a5c72cea2861)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3212,290 +3107,255 @@ let out : string * Haz3lcore.PersistentSegment.t =
          acne`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         cec7361d-cf0b-42a9-997d-845e6e9efe80)(content(Whitespace\"\\n\"))))(Secondary((id \
-         da87389f-5c0a-4817-a0db-3ecf17856868)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         86284ab1-3372-4506-9a1b-6270af336454)(content(Whitespace\" \
+         afb22c3b-874a-415b-9b2b-5888c1d48209)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b423516d-b0c9-45b6-b7e5-7931c850585c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fd0eb809-b4c1-4217-b523-cf45dfbe6ad6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a5084924-3e55-416c-9e28-777a68954c4e)(content(Whitespace\" \
-         \"))))(Tile((id 90ff6a10-e3f5-4843-b749-35779bc1310d)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e07263ab-554f-403e-95e3-089df03d5d5f)(content(Whitespace\" \
+         88835376-5343-464c-b902-99c65d7bbf66)(content(Whitespace\"\\n\"))))(Tile((id \
+         90ff6a10-e3f5-4843-b749-35779bc1310d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         c1671768-0dac-446c-a9f1-6229d20074b2)(content(Whitespace\" \
          \"))))(Tile((id \
          52888c11-006c-4a35-b0ce-4f2334e459bd)(label(correct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f4bf5e01-f380-42f0-9137-aa02354224aa)(content(Whitespace\" \
+         45fa6f3c-641c-4075-a974-5665be2c7109)(content(Whitespace\" \
          \")))))((Secondary((id \
-         015f001b-9d5a-42a7-a20d-8985bda1de9c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d40c67c9-76a6-457b-8b74-8913c3561d3f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         34d513f6-a26b-4b6f-a7c8-e5e99ec01951)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2a48bf1a-9e12-4596-847a-8a86c6024b53)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d5fe057-75e1-4f60-9726-1cd55f2e1bc9)(content(Whitespace\" \
-         \"))))(Tile((id c7dd7262-43aa-409a-adca-39b621509bf3)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e12cbd06-113e-44c8-ba31-d3c465f4ef28)(content(Whitespace\" \
+         52002e52-b991-4a78-9788-1558e749fcbd)(content(Whitespace\"\\n\"))))(Tile((id \
+         c7dd7262-43aa-409a-adca-39b621509bf3)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         df8cc002-b307-4254-bba4-ffaa23d93a7d)(content(Whitespace\" \
          \"))))(Tile((id \
          1291beca-dadc-4912-bd64-ac8a5798baab)(label(brown_and_get_acne_table))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3a0bbf8c-e94e-4e86-a75b-7c1149d62f09)(content(Whitespace\" \
+         745f078b-fa9b-42f0-b115-0177004554c3)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7b09edf1-e1f7-416e-b28d-342365813a2e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         67faebf5-c9b1-452f-bf17-d78d56b23ca7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         22e91854-829f-4180-ae45-341f38418514)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3f747374-e686-40d3-ad02-f1db23bfc96b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c244e15-5d92-461c-aa00-ee2ca0a5f62e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         08b1325c-8cee-46a5-a7ef-baad166e397c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4830dd1a-e5e1-4a48-8c91-59136523626b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         523276b2-3ec8-4e63-a7f8-ebb3960b895f)(content(Whitespace\"\\n\"))))(Tile((id \
          6a741618-47b0-4a8f-aa61-3cc32994e2c2)(label(build_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         8b74c11c-6fa3-4c34-855c-b4a311e62a73)(content(Whitespace\"\\n\"))))(Secondary((id \
-         59a93e3b-89e2-41c8-8613-37111c8f3dbb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8a180e16-a144-4cb2-991f-2c9f5116ed85)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         84050fef-a11e-49e3-87e6-28d0ad3d51be)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f4426a2-b498-4525-bed2-d5d3b1dad65e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         55bf21cf-d2cc-47e2-a9cc-0d20643a24f9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4027ff03-601d-49df-8ceb-bfe94ddc834b)(content(Whitespace\" \
-         \"))))(Tile((id fec51e89-949c-427b-af57-cb786c0a8f66)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fec51e89-949c-427b-af57-cb786c0a8f66)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          3464d228-5d1f-44e6-becb-60133c3ceaa4)(label(JellyNamed))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         57d4cdaf-045d-4b60-9b94-b6e9e3010c2e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3eea853e-16a8-432f-83d9-2e6f62e04c16)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         63e36441-65e8-4ff7-b7de-f9aff495f5d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9733863-e131-4245-a560-652f9a0f424d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58d99c42-52b5-4a9a-98d4-498ed2be8906)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04e44280-1237-4831-9792-a1712b7c306a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8eecd315-294c-40a8-acdc-5191dcb75cb5)(content(Whitespace\" \
-         \"))))(Tile((id f6577759-5783-4d86-b4f8-d2bd08c2f8a9)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         f6577759-5783-4d86-b4f8-d2bd08c2f8a9)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          865425b1-60e4-47fc-96d9-751517028ad0)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         35137366-2e90-487e-b987-9554212ca39b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2b787fd7-8d0f-48fa-80bc-3876e1fdb4c2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         967a57ab-4b1e-4971-b89f-62bc0c7950fe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         08b91d64-438c-4146-80e1-96be8cdc0399)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4dd9203d-21ed-4725-b618-1716df5d0160)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e77c1a8-1645-4c8d-bc43-a1fcbca95577)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         16136d22-b6b8-4cd7-831d-45e3d5ac3de9)(content(Whitespace\" \
-         \"))))(Tile((id 28da76a5-d2d7-4d4c-824d-5a646f43139e)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         28da76a5-d2d7-4d4c-824d-5a646f43139e)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          1dcd21ce-9dff-409e-93f4-40b469fb0400)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         9d57c43b-1c8e-49b3-9f73-7384488a6289)(content(Whitespace\"\\n\"))))(Tile((id \
          6bc26984-6445-4053-b314-8497a35a20b1)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f7b747b4-72ad-4599-98f0-3b954f8b46d4)(content(Whitespace\" \
+         \"))))(Tile((id \
          4a78dc1c-d393-413a-81a2-a6adf49cf125)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         aa445b5e-2aa3-4032-b731-e75525c827c7)(content(Whitespace\" \
+         \"))))(Tile((id \
          182063e7-fe2a-4697-bf9a-365ae1d79b4c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9548f19d-e68c-43b0-8a2e-ab0a3f900c39)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9691eb46-fc6f-47fe-844a-c0a90aaf9833)(content(Whitespace\" \
-         \"))))(Tile((id \
+         309826f3-e4d4-492a-b4be-566c17fd58f0)(content(Whitespace\"\\n\"))))(Tile((id \
          8a60290b-8ee8-43d3-9f83-a552b9ef5bf2)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         703b2f39-c221-43af-9115-4d9aff24949e)(content(Whitespace\" \
+         \"))))(Tile((id \
          565fa282-86fd-47b9-a6e4-0f33b446deb5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ab396b4d-0f58-43be-8557-edf46db04317)(content(Whitespace\" \
+         \"))))(Tile((id \
          74ef8b8d-a9fc-4540-baff-536a21368ac8)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          42fe7ef0-4c59-4fb8-87d6-f89c738125ef)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d856ba1a-5ac2-464f-b467-596d55f99ea5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ff65998a-c9a0-4373-9ffa-7c1757460ee8)(content(Whitespace\"\\n\"))))(Tile((id \
          7a45c58d-e7c9-4b63-a5a5-eece9cd759f2)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c59c2d4f-d813-468a-b055-b70f0b7b42e6)(content(Whitespace\" \
+         \"))))(Tile((id \
          a9f8aa5f-7c05-46e3-a1bb-f03f5c710b37)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7a492915-d09f-44d5-9c2b-b7e43af43d25)(content(Whitespace\" \
+         \"))))(Tile((id \
          00f5569c-bd7b-41ed-8ca7-5996b003bbb4)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          fb373df4-2496-44ee-9f83-18ecc3bae29c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0fe85d97-e6af-45f1-86c2-10fee00290df)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3490019d-77d0-424e-a3f9-6658de97903b)(content(Whitespace\"\\n\"))))(Tile((id \
          6c86fe9c-fcc5-414c-a3e8-553664083d1b)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c4bc85c6-9f91-4b5d-bca6-87311866541e)(content(Whitespace\" \
+         \"))))(Tile((id \
          687e2bca-efc5-4456-991a-9c78718929b4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         664ad0cc-75e5-4b76-9eff-ba8dc6784af2)(content(Whitespace\" \
+         \"))))(Tile((id \
          3796ba2c-9359-462c-bcb1-2bdf81aeac4c)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f2523139-5af3-4db0-abdf-31dac1a6d395)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c2f14400-58ba-45c2-960f-a8349383bc1e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         68aaa663-0a9d-4deb-b80a-427cff19df90)(content(Whitespace\"\\n\"))))(Tile((id \
          f5250016-b98f-4588-80b2-1126b87c8eca)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         25182a36-e669-486e-b71c-2fcc242e5597)(content(Whitespace\" \
+         \"))))(Tile((id \
          5cf45999-849f-49f5-97e0-cab7ee7afbff)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b8e45f69-e93c-4fc4-a42e-f0a18738795f)(content(Whitespace\" \
+         \"))))(Tile((id \
          771eceae-2427-44cd-a1e5-f17351148b89)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b66b62a5-69c8-4962-9f10-1504e6653bb2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         81451d32-cea4-4aec-8f5a-7db11cb12278)(content(Whitespace\" \
-         \"))))(Tile((id \
+         def50f53-83f2-4fe3-bbe1-f50efff11df2)(content(Whitespace\"\\n\"))))(Tile((id \
          4576bf80-bf0a-4b32-919d-bc944c31a588)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4c9823d3-bd9d-42cd-8c38-3fe3a61fb98d)(content(Whitespace\" \
+         \"))))(Tile((id \
          c6e89753-1464-46ea-b0d1-a90c844a2aad)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         db98351d-3cd7-4069-a91a-dd948e4db92f)(content(Whitespace\" \
+         \"))))(Tile((id \
          26872b59-61f2-43cc-994f-c2a7590ac1ce)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          02c48884-4a9f-4781-9e01-2fdc28ffd46f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d77e6cf4-f901-49ef-abc7-89f419edb787)(content(Whitespace\" \
-         \"))))(Tile((id \
+         000bad47-1387-42ac-a542-33ead00f1fa9)(content(Whitespace\"\\n\"))))(Tile((id \
          1b3c3eea-1b9f-40b5-8554-4d49ec056e7f)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         da699bd4-41b9-4490-ac69-e44c86216bd2)(content(Whitespace\" \
+         \"))))(Tile((id \
          4bc8534e-fef5-4190-9eda-014536198e69)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c56af719-1a35-458a-8fc2-eeebe97929b4)(content(Whitespace\" \
+         \"))))(Tile((id \
          54cf6a52-b166-44ce-bc69-a7247b43b992)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ec50ca80-820d-42c2-b7f0-ed2d2d4d407a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         83cbe6fe-85ec-4ac3-b273-5632647462db)(content(Whitespace\" \
-         \"))))(Tile((id \
+         25de0492-a1a7-4bba-822a-d14a7683aae6)(content(Whitespace\"\\n\"))))(Tile((id \
          679be3a7-8af9-4259-bde7-a7acea073447)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8c8be53f-3646-4f65-9357-d76533399e87)(content(Whitespace\" \
+         \"))))(Tile((id \
          e720d367-a364-413d-bdad-6e9d39a454b5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fe8a16fa-8376-4ab4-a2e0-5f9662cd797a)(content(Whitespace\" \
+         \"))))(Tile((id \
          da15bafe-dc3e-4998-a813-369d39c2261d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b9cc111a-956e-42c4-bc8e-15fcc563252c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e5155e37-ac48-4da4-94ca-fa744a7d5eaf)(content(Whitespace\" \
-         \"))))(Tile((id \
+         152c3c89-433c-4aa5-8949-565f2c637b4a)(content(Whitespace\"\\n\"))))(Tile((id \
          cbf0b195-5f5c-4f46-a82c-7aec78396e92)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ac9534dd-2fde-4d06-a51f-3c7048273d8d)(content(Whitespace\" \
+         \"))))(Tile((id \
          2f916383-9710-4119-94c2-6b631c2b6083)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2469083f-6d5d-44ac-9e18-3ce93e8cda6c)(content(Whitespace\" \
+         \"))))(Tile((id \
          988c72a3-21f1-4a2a-a187-55cea02b118f)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bd16b935-d1a8-4920-b3a1-712e72546033)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3dcfc533-f792-4219-8758-c539457e4459)(content(Whitespace\" \
-         \"))))(Tile((id \
+         2541de46-1a5e-467a-a408-07416234b40e)(content(Whitespace\"\\n\"))))(Tile((id \
          6117495f-cd93-4588-891f-82737677e1b0)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         61394088-6bae-4e45-9f22-bf3ebaa853a0)(content(Whitespace\" \
+         \"))))(Tile((id \
          52af8233-7fae-48bd-9cc6-0b3bc39b3d71)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ceef3166-ba14-4f4b-81ad-60a96a7c9706)(content(Whitespace\" \
+         \"))))(Tile((id \
          0026858d-3456-4b99-99c0-5937aba1b885)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c67ea88f-2f06-47da-a3c5-837643976bef)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         558629f7-33db-4726-be3c-7dcbd9385e30)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b1f5d166-1d3f-4c90-8743-260692ca9ea2)(content(Whitespace\"\\n\"))))(Tile((id \
          23372757-de96-43ff-b463-71796087fc0a)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         acc6f0cf-8adb-46ad-8bd9-58db76d71319)(content(Whitespace\" \
+         \"))))(Tile((id \
          11180acf-7726-4f69-b484-3a7a2df93b03)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b83a3a9c-99f2-4c3d-85b9-e550b4006969)(content(Whitespace\" \
+         \"))))(Tile((id \
          8ec3bc78-adaa-4ed9-9fe1-32f1d296e8d9)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          64193aa4-b9b5-4ef2-afbc-8b7f226d1aac)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d55923ac-3b06-4a35-a444-aa0a898e3f04)(content(Whitespace\" \
-         \"))))(Tile((id b4e7d3d3-e93e-4d7e-83d4-d0ad44609247)(label(\"`brown \
-         and get acne`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
-         Typ))((shape Convex)(sort Typ))))))(shards(0))(children())))(Tile((id \
+         6c9b69dc-1101-43de-9236-bfab2a083fb2)(content(Whitespace\"\\n\"))))(Tile((id \
+         b4e7d3d3-e93e-4d7e-83d4-d0ad44609247)(label(\"`brown and get \
+         acne`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
+         Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         425bc523-845c-4283-8c25-dceaf9c11c60)(content(Whitespace\" \
+         \"))))(Tile((id \
          d84d1e30-adac-4465-81ff-e3bff9379f14)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         80594597-6537-48a0-9312-68bf41b25462)(content(Whitespace\" \
+         \"))))(Tile((id \
          83f4a20a-8d79-42ad-8de2-9a0d72faff54)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         9aacf8e3-8f73-4aa6-9097-ec9767b1a2dd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d0e44e3c-d5ca-417c-b9e6-083400ae00f5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         06e2b0e3-78a8-419a-83f8-c633d72193a1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         20225232-e909-40f9-9c99-f6ae56a38736)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7707ddf8-90c6-4cc4-89d4-7f53dbff34c6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         617f5187-a916-4972-ad29-e5ff8c1fa7c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3085e300-d380-41cc-9e7d-6bb7f612057f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         97d4c7f2-d04b-48b7-a88d-ff4d3228ed93)(content(Whitespace\"\\n\"))))))))))))))(Tile((id \
          29af53aa-2421-498e-8397-94b5c8e5e7ed)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3504,17 +3364,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          8f9dab43-f58c-4e52-949c-68d9040d92b2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fb3afe05-4cd7-4baa-885c-8d047bcba807)(content(Whitespace\" \
+         \"))))(Tile((id \
          281b3742-f252-43fb-98fb-e22d44b4195d)(label(brown_and_get_acne))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          18c28963-920b-4308-8655-2ad8356b6c5b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0273b965-b296-49b6-9fdb-99b2613282d7)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         bb551c26-5499-4f4b-bba7-076bdec19bf7)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0ef199b2-7d80-4f16-a4f1-4df0ddf53fb7)(content(Whitespace\" \
+         \"))))(Tile((id 0273b965-b296-49b6-9fdb-99b2613282d7)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         7f54f006-1706-4bb1-b403-52a8d16ed3f1)(content(Whitespace\" \
          \"))))(Tile((id \
          6afd8845-5e8a-439b-a160-ef3a587e32f6)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -3525,234 +3389,260 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1031e02d-6a99-481f-9a85-5e658a495b1d)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         67283b9b-8cfd-4440-88a0-f8ac97be5e38)(content(Whitespace\" \
+         cb493c5e-21e0-431d-86cc-e5fb496b6bd1)(content(Whitespace\" \
          \"))))(Tile((id \
          d070b942-cf38-4db4-9497-eae25a3a95cd)(label(v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         5f391251-79c2-490d-be96-03c5f948a20b)(content(Whitespace\" \
+         d0b4531a-81a0-4628-bca0-eefc5fe32e45)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f8ee6baf-89ee-4b22-a2c4-c5e5fd81fa06)(content(Whitespace\" \
+         d5b247f4-88d5-4741-b60d-c9468837da89)(content(Whitespace\" \
          \"))))(Tile((id \
          2f3424be-8d16-46b4-abb7-8b1588e21cd2)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         362fa42c-7bd5-4cd4-a43b-5adb76a7a60d)(content(Whitespace\" \
+         \"))))(Tile((id \
          76f5a93c-6b4f-42c1-b5be-df7c9598d1a4)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4aed5924-0f8f-4d62-85eb-66fbc91c659a)(content(Whitespace\" \
+         \"))))(Tile((id \
          60c7ed56-3cfe-4dd8-9384-224b88d0a960)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          0e7e6558-62a1-4a14-a641-f111cf186347)(label(\"`brown and get \
          acne`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         033cfff4-5bb5-4327-ac76-7e4529d2ab5a)(content(Whitespace\" \
+         \"))))(Tile((id \
          db6f9585-eb6d-49f9-8dda-2a4a355bfbd7)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8b9b89c6-2dd0-47df-b97e-bfcf2fd2404a)(content(Whitespace\" \
+         \"))))(Tile((id \
          c8329c2b-b4f1-416c-a927-f86d83160757)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         0bd0ad46-83e5-4ec4-bf06-a944a5b61313)(content(Whitespace\" \
+         4353d85e-072d-4905-afb9-28446a9dd8df)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ea885163-67a1-4caf-a683-1f2072e10db3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3fd72f08-0701-4c34-85ee-9bb92f4729f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd60156d-2fb5-426f-94a9-d4e079dd4862)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         356abb94-a7b2-4d84-ac06-3c7b5d3ff522)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         80219249-9365-430f-a9e7-189994e7a1ac)(content(Whitespace\" \
-         \"))))(Tile((id \
+         257d3463-17cf-4e97-ade1-145ec9d107cd)(content(Whitespace\"\\n\"))))(Tile((id \
          64898647-33a9-4542-8c5b-fde2efcb4b4d)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         7dafc427-6ffb-4dc5-821d-11375061a8ee)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bbe5761a-0192-49a6-af99-829748ca8a4c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         35c26e55-4e45-42cc-93b9-c002c4af33f1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c26817f9-19fe-4a45-8915-0a9294e80f00)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e9a6f05c-1c2c-478f-837f-1c9f25efbea2)(content(Whitespace\" \
-         \"))))(Tile((id 80015a64-41c7-418c-bdb5-2d03f6370b48)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         80015a64-41c7-418c-bdb5-2d03f6370b48)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          2e62afb1-cff4-4bc6-908e-194c6d1ce67a)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         7cb06a03-7684-49d5-b1d0-9adf2b933531)(content(Whitespace\"\\n\"))))(Tile((id \
          e97a7556-05ee-4fd9-badd-dee52323b3db)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8d599bc1-6aa5-4add-9aa5-02378af0e229)(content(Whitespace\" \
+         \"))))(Tile((id \
          4f208a63-1ad6-4428-9623-6864317e69a9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         228e9bea-9bac-478e-b886-548e59df8a96)(content(Whitespace\" \
+         \"))))(Tile((id \
          dd3009df-af6f-40f4-b055-2f6a15c8d8db)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5b1894c7-2d7e-4194-8653-a0dc8bb29121)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0e40f7ca-7176-48e2-b3c6-53d90e27416b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         952d3626-5d48-4656-8556-ca028225c0f3)(content(Whitespace\"\\n\"))))(Tile((id \
          50536afb-6ef1-417d-8c1f-2224ef58101d)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         34510b72-fdc3-46d4-9c9b-7d46eea58f42)(content(Whitespace\" \
+         \"))))(Tile((id \
          1ddcabd6-49af-4cb1-a981-3a4a1c76010c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ff78fc96-f74e-4569-9174-eb9226d65d9f)(content(Whitespace\" \
+         \"))))(Tile((id \
          7ab349bb-22ed-4888-bf03-a2e4f6373c96)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          254ddc65-8c24-454b-aa92-f27e66e7d821)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         da1318f9-9094-4466-a26a-aaeb2052cb62)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c9aa656b-0cce-495a-8470-d8dcedaffd8e)(content(Whitespace\"\\n\"))))(Tile((id \
          9df3629b-43a7-4c7a-a738-709de78e2563)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2980135f-6a05-4dcd-86b1-ef82eee17af5)(content(Whitespace\" \
+         \"))))(Tile((id \
          44df10d2-3eb0-4179-85b6-65c978089575)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f430b6cc-68d8-4802-86b5-a7345eacd59f)(content(Whitespace\" \
+         \"))))(Tile((id \
          3c696c35-90e1-470c-87e7-5dd1392891b6)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          558f560a-44c0-4d47-b213-f15441df9a4f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         06e2c4ee-801e-4d8b-ace1-98fad485bfc2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8fb13c39-354a-4929-9442-3bf303331d3b)(content(Whitespace\"\\n\"))))(Tile((id \
          fc30a5e8-3f13-4535-8a94-9eba700e9095)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3c9ba788-146b-495b-b258-766305d9d05b)(content(Whitespace\" \
+         \"))))(Tile((id \
          db6eb123-d764-421c-b4d7-46f20264a511)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a51877cb-fdfa-4036-a46d-47823f720d91)(content(Whitespace\" \
+         \"))))(Tile((id \
          8b41c862-6bab-4956-92b8-4db04f2ccfa6)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ae8c0b5a-26ad-43c4-bd61-962c3ec92610)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         785bbe25-5944-4480-81fa-e5735416feb9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d5e96a6c-56d3-4846-99f8-d7f7a30b0f65)(content(Whitespace\"\\n\"))))(Tile((id \
          7954a879-c720-4c42-beb3-6f879e431ba9)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dbb1a8d1-b994-47c0-a93a-6e50cab38f22)(content(Whitespace\" \
+         \"))))(Tile((id \
          5d921a74-fdfb-4b28-8d57-06a37d9a977a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a6453f62-b920-4cc4-8c09-eb81cc22616c)(content(Whitespace\" \
+         \"))))(Tile((id \
          3eb719ce-604d-435a-a9aa-14c862de1885)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          474acf2c-1e16-4ccb-a519-b05ee6a6265e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c99a68a5-faad-4a80-88f3-e1bb2f02b823)(content(Whitespace\" \
-         \"))))(Tile((id \
+         bb56c4d7-fd0b-4e51-8182-eda9abffe4ba)(content(Whitespace\"\\n\"))))(Tile((id \
          254b7df9-2604-4772-b6c0-3fd99e852975)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         96e3ad6b-0bbb-4083-a2fd-948006908f4d)(content(Whitespace\" \
+         \"))))(Tile((id \
          0241a296-6c64-4dc1-9120-9be936155cda)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8b276ee7-af5e-4721-bc4e-8b0052878583)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb8c1ca0-1e4b-4fc1-b980-fc677e73df0e)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          fc2159d4-3e93-4ff6-94f8-750a3a194fbe)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         934599a5-8710-4e2e-90b2-b51553f44244)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9c782811-e8c3-4fc6-ae34-042d0145b4af)(content(Whitespace\"\\n\"))))(Tile((id \
          2b9bf4b3-52a4-4181-9c99-d68da2533976)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e8d505bf-9ec9-4052-9f16-20796a7a55de)(content(Whitespace\" \
+         \"))))(Tile((id \
          c7191305-74fe-4f16-8b7e-077edbdbe26a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fac6a9ad-d95f-4a6b-afc7-e8954fc47eb8)(content(Whitespace\" \
+         \"))))(Tile((id \
          e25c58c9-4393-40d9-b940-3a81406aac0a)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          041a1537-13d1-47fc-8f99-329a0c20b554)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e98a8daf-2a9d-4900-870e-c094d89e7c69)(content(Whitespace\" \
-         \"))))(Tile((id \
+         fd17135e-cf9f-48c1-b095-d03dfcc28734)(content(Whitespace\"\\n\"))))(Tile((id \
          7741d4e2-567e-42ad-8e1a-2d0e0092c261)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6e52c466-cc39-4e5e-9eee-e2b02b529183)(content(Whitespace\" \
+         \"))))(Tile((id \
          2f3c405d-83b9-4816-9989-3ab75f52190c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cdec1017-48ff-4e77-ab26-40e86110a9c0)(content(Whitespace\" \
+         \"))))(Tile((id \
          7762f9d5-3533-4dd1-bffe-2a69078fa793)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          8be732e2-022e-4b15-b6c0-d44c6c74ee15)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         590a5556-3dcc-495d-aa2b-984906a60be9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         781e58ae-e66b-4940-82b3-385fa0539c59)(content(Whitespace\"\\n\"))))(Tile((id \
          d27f687d-be3b-4c5c-9b47-a0f611145a1b)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b9270e3f-361f-4826-b2db-aeb184b1f36a)(content(Whitespace\" \
+         \"))))(Tile((id \
          b6e8f8c0-c6e6-4f61-a25c-df170422d6ad)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5ea7bd41-6f44-4d9f-8811-2ee7aedd4b21)(content(Whitespace\" \
+         \"))))(Tile((id \
          287efa7d-f094-4e4f-b61e-deb0ca447488)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          dab9cbf9-185d-4683-848e-4c16767280ce)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ab169b75-07f0-4145-863d-8fefe58e15c0)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5c63ea63-9b63-4ce9-8382-54f7d2e4951a)(content(Whitespace\"\\n\"))))(Tile((id \
          30175c24-7197-4207-b036-6d5578aa5f8a)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a1ae85b7-1397-4853-85e5-162cad84a6ca)(content(Whitespace\" \
+         \"))))(Tile((id \
          c50a0dab-acbf-4661-8dc3-24a499012fdd)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0b76a78c-65d5-4f20-9ddc-e0cfde490e05)(content(Whitespace\" \
+         \"))))(Tile((id \
          15598e3a-086c-4c7c-8436-79f2c2208a89)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          45ccfd5e-f8d4-4e00-b6b3-aa536926b254)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         284c60b3-3e31-47be-b859-ae293d57cbe9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         6c68269d-c465-41aa-a84e-f6cac9d78dd8)(content(Whitespace\"\\n\"))))(Tile((id \
          d977ccba-6c42-4f23-9ff6-a608c808c6ec)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4d599ee6-6e8d-4f0d-901d-c4133d0e8bbe)(content(Whitespace\" \
+         \"))))(Tile((id \
          aa397e4d-c7cc-4430-925e-029af5cd6990)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d766887b-78f6-49f3-a2b7-415a6d6795b3)(content(Whitespace\" \
+         \"))))(Tile((id \
          58efb117-b103-4191-959a-2ef74c938432)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a0e7e20b-e9d3-4aac-bcb1-5fb4d8aca3d5)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b56fb4b2-cb92-4ff9-b451-ac2bc4bb91e0)(content(Whitespace\" \
-         \"))))(Tile((id 09dd508b-fd59-4b75-9a76-9878f43e3e6e)(label(\"`brown \
-         and get acne`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
-         Typ))((shape Convex)(sort Typ))))))(shards(0))(children())))(Tile((id \
+         a66c1d14-4c39-4b90-83ae-c86f6245b6bd)(content(Whitespace\"\\n\"))))(Tile((id \
+         09dd508b-fd59-4b75-9a76-9878f43e3e6e)(label(\"`brown and get \
+         acne`\"))(mold((out Typ)(in_())(nibs(((shape Convex)(sort \
+         Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d435f2c8-4db6-411d-b474-86c3b7f6214d)(content(Whitespace\" \
+         \"))))(Tile((id \
          7e496151-c92a-4de4-9289-ba4bc962a3a9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         00b7908e-c657-4f83-b82e-a96fa70b4a5f)(content(Whitespace\" \
+         \"))))(Tile((id \
          292bfa44-0cd7-48ff-a9b9-5cf9b9b864dc)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         965f7079-31da-4551-9842-bde677f307a3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ac707742-b0bf-4042-9210-c442f3df5d1a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb8ff914-6db0-4fb5-ba40-b41e841f9cea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5b4c41fe-680d-439b-aeb0-ac1345dad8ce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         25e84239-483b-4959-9ad4-523542fd0593)(content(Whitespace\" \
-         \"))))(Tile((id 9bf34d8f-dd75-4025-ba5d-fbbfcec8012a)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a235ee14-f601-4e7d-a1d5-540f396c4e2b)(content(Whitespace\"\\n\"))))))))))))))(Tile((id \
+         9bf34d8f-dd75-4025-ba5d-fbbfcec8012a)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          f678c0ce-b40c-43e2-b6cb-1cc9c05a4e18)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
@@ -3765,19 +3655,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7e30713d-3f2c-427b-b95d-83b57f790193)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         eb7679cb-9234-4934-a61e-a9d918e69255)(content(Whitespace\" \
+         92c7b150-b967-4577-b755-d4c5f8b6b7da)(content(Whitespace\" \
          \"))))(Tile((id 1efda640-18a8-4396-8502-a2f7f5cc6b83)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         072b6258-73b2-4551-9407-5332c20de399)(content(Whitespace\" \
+         b4dad6e9-d7e5-4e99-a7a0-0d09ea10b367)(content(Whitespace\" \
          \"))))(Tile((id \
          7e129e44-a7a8-4281-aacf-6e4659ee8a1b)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9b9b783b-59a3-4e3a-b73c-7648b5997742)(content(Whitespace\" \
+         5a15a9c5-60ca-403e-9e57-6831dd6f3478)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         efa49ece-6930-4acd-9901-13718c940cda)(content(Whitespace\" \
+         eba6d05d-6c0d-4349-945f-309e8eda9a52)(content(Whitespace\" \
          \"))))(Tile((id \
          b15614d4-881d-41d8-b1a4-61c54fd7daa2)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3789,34 +3679,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          acne`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         0661733b-bd95-407a-b824-4bf849a1478d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         655dc02b-f128-4c3d-b947-014e1c0fa834)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         86e58da0-08d7-4d29-801c-3b8d1b22cdd8)(content(Whitespace\" \
+         ea970884-a18c-42b8-b50a-76b84c8083cd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         585401a3-6c83-4c33-a91e-293b20da6a61)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cc149159-1951-4aa8-9f83-a22b1887f214)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c67286d4-990f-47ce-80df-581b1d6316a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         136293e3-127d-4766-ab58-afa97c242618)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ca8c915c-3efc-4825-bbf8-76293ea8b0de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a206eecf-e28d-4fe6-9f78-bfcb9397c6c3)(content(Whitespace\" \
-         \"))))(Tile((id 3e14926c-de49-466c-830f-304e75caa64d)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         d9a75c33-4d29-4d38-940d-4d5742187658)(content(Whitespace\" \
-         \"))))(Tile((id \
+         66afe3e7-1d78-4682-95a0-dbe564eafb5a)(content(Whitespace\"\\n\"))))(Tile((id \
+         3e14926c-de49-466c-830f-304e75caa64d)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         59ce4b8b-7bca-4400-8c6a-0f322ec1645d)(content(Whitespace\"\\n\"))))(Tile((id \
          d6e47eed-ef63-4522-b372-a751fcefee88)(label(correct))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         92587536-a3e4-4057-9536-435fd236e1a9)(content(Whitespace\" \
+         65ec48ca-999b-4d38-b930-bc76cd204b38)(content(Whitespace\" \
          \"))))(Tile((id \
          a3de5f7a-4029-4cca-8234-e05d00fa16b9)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         59f7f5dc-2172-4a08-b6f3-6569c592b2d1)(content(Whitespace\" \
+         3f0fa34e-1502-4dbe-b9ae-a2d6ea660ac8)(content(Whitespace\" \
          \"))))(Tile((id ee1ae4fb-007e-4d49-9c8d-7743f44d647e)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3849,65 +3727,70 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6a32083c-68e1-4b1a-8410-d11ad62e0219)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         56befd19-ee6e-46c9-8cf0-faa72ccf3782)(content(Whitespace\" \
+         2097ff2a-0d17-4484-aa79-163f99295ba7)(content(Whitespace\" \
          \"))))(Tile((id \
          02d7c487-5ec3-40c6-a09c-399d5017f742)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          87a84f69-514b-4d94-8d68-c3333167cee2)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6f50f293-45fd-4e41-a724-981063780a08)(content(Whitespace\" \
+         \"))))(Tile((id \
          51733ea8-b94a-4cea-8ca2-39b7acc02b15)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         397c32b6-bfad-4432-b6be-522c36d19437)(content(Whitespace\" \
+         \"))))(Tile((id \
          92243c59-aa95-4424-ada4-b5aa69b235fe)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          95712139-87e4-461b-b74c-e92d0f551571)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         45d41cc5-f337-47ce-94e7-e081fec1cba4)(content(Whitespace\" \
+         c6aaa1e3-706b-4a77-a2f2-5384a5907cdc)(content(Whitespace\" \
          \"))))(Tile((id \
          10431ab6-5886-4568-bb1e-ff3b8ebe7432)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a886614f-cea0-4373-b2f2-0a4a6c572f2f)(content(Whitespace\" \
+         \"))))(Tile((id \
          56568003-80f5-4470-88c4-a33c496ad934)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e406a80a-afcd-4149-aa3d-f7c6a56d6a4f)(content(Whitespace\" \
+         \"))))(Tile((id \
          6cd90026-0fb9-4e2a-bfb8-43efc2587c6b)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d9d32929-2f95-4b50-b305-8c09799211c8)(content(Whitespace\" \
+         19ced3f8-0113-4158-bf00-6689e5be6e21)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         148089fd-2cdc-4394-bf87-3908f9759f28)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         d3cf4d0f-bfbf-427e-88f2-c8011c886af5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         15cdaf69-06a0-440f-98f1-74013cead563)(content(Whitespace\"\\n\"))))(Tile((id \
+         488d738e-85c2-41f7-b968-bb5057f8634e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         45aa6cf6-c728-4ee5-bf1f-59f6b5ce70b9)(content(Whitespace\"\\n\"))))(Secondary((id \
+         ee79955f-b86f-4d7a-a398-7aca718e561f)(content(Whitespace\"\\n\"))))(Tile((id \
          0213d854-4d9d-4a23-b1c2-d3c218f27dbf)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         9a814726-c861-46f7-b1e9-4d8668bf46bb)(content(Whitespace\" \
+         0dba6db2-bb96-481a-b018-e3d53af2725a)(content(Whitespace\" \
          \"))))(Tile((id \
          7162788f-2090-4962-9bcc-0ac679e132e1)(label(get_only_row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         56e0e2c1-3621-41eb-bbca-03f0eeedf211)(content(Whitespace\" \
+         8acbb64c-c569-4bbb-b3e6-6a4f818563a9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3cb9b04f-659e-4bbe-81b7-37c05cb1284f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fe2a8fb9-dd4c-4f5a-8f9b-865cc53fa94b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a96c5936-07a6-48c0-b4f8-2ab8718540b9)(content(Whitespace\" \
-         \"))))(Tile((id 6d02a138-21e5-426c-9c44-25c98801c7de)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         051278ae-da82-47e4-bd7d-d7892483a44a)(content(Whitespace\" \
+         8a2315c1-2753-447c-b716-87861566976f)(content(Whitespace\"\\n\"))))(Tile((id \
+         6d02a138-21e5-426c-9c44-25c98801c7de)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         85fcb295-701d-4475-9ffd-40b4c54f034f)(content(Whitespace\" \
          \"))))(Tile((id \
          f7a20148-7b8e-4404-8706-fc0eb9742b05)(label(tfilter))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e0bc9ed6-7726-49bc-a051-381f32cd5414)(content(Whitespace\" \
+         598c847a-3621-4c54-819e-fc3d6db92be1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0a0d3620-4bce-46ac-a3b1-251d1f223bd3)(content(Whitespace\" \
+         7b0f7407-eff1-492f-afc3-17093ca83417)(content(Whitespace\" \
          \"))))(Tile((id \
          12092a71-2885-43c5-b961-e66ddb3e8cfa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3915,30 +3798,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          15f9baff-8727-4679-ac89-2f92b083b722)(label(typfun ->))(mold((out \
          Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f715bc50-aa5a-4dd1-8b38-4d16aa198631)(content(Whitespace\" \
+         f9e71c5b-ed48-4ef1-9a4f-7aa8499fa97b)(content(Whitespace\" \
          \"))))(Tile((id \
          2819e852-17a3-4ef5-8ba9-db5e586b2b71)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         f3d5d64c-52a8-4939-a31f-eae61cf3f49b)(content(Whitespace\" \
+         b85fddfd-ccbb-40e1-9bc4-afcc96c0daa1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c2918dec-de7a-4483-979c-1dc2c212f2e2)(content(Whitespace\" \
+         c3620c0d-a5e8-4b97-8503-8eda402f820f)(content(Whitespace\" \
          \"))))(Tile((id 2ab6fcdf-9b87-4038-9593-a7589008bac6)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a2d1ebee-fb0b-476a-9029-235d20c65cdf)(content(Whitespace\" \
+         c42f9cb0-77a3-494f-98c6-839ee3c12fec)(content(Whitespace\" \
          \"))))(Tile((id \
          0f2368ac-9961-4fdd-bc32-3d1640522159)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          b5d9b7f6-a281-409f-bb24-021da65752d4)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         72d8d0a2-3bb0-4b64-bcef-2c66466b1ce1)(content(Whitespace\" \
+         \"))))(Tile((id \
          6be4035d-44a5-445b-9444-78cb0fc99498)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ed33c5a3-3094-4017-a59a-3fab5efa13ff)(content(Whitespace\" \
+         921f9cbf-2a8b-4e6e-94e1-bd66d7b76b80)(content(Whitespace\" \
          \"))))(Tile((id 07dd20a9-a0d1-4805-9275-fbb0c28da8d8)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -3948,32 +3833,34 @@ let out : string * Haz3lcore.PersistentSegment.t =
          999cb04c-a764-456e-a05e-819fb6bc9c53)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         c1c475c4-3884-415e-8db6-ab412da928c6)(content(Whitespace\" \
+         806df500-0b16-4481-85c8-ffd46e5397aa)(content(Whitespace\" \
          \"))))(Tile((id \
          2c5da1ec-c434-4134-bff2-69a2e427a5fd)(label(pred))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0abc7ff9-ebc4-40f9-8f92-82530eab51a5)(content(Whitespace\" \
+         e9e4a369-ee96-4827-be7d-3c8558fa4342)(content(Whitespace\" \
          \"))))(Tile((id \
          f5109b46-c470-4515-8359-61a2be16cf9f)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b191de1b-169a-416d-8852-0037f530e164)(content(Whitespace\" \
+         8c665e75-5cbb-450b-a21a-c863c8d483ef)(content(Whitespace\" \
          \"))))(Tile((id \
          26e0685c-1107-4af1-8099-66411abb765e)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         0f32ca62-ef4d-47da-a8ca-15bd7d974208)(content(Whitespace\" \
+         61cbbad2-2e05-4491-90af-3227e73e3d1b)(content(Whitespace\" \
          \"))))(Tile((id \
          7d2364a1-e110-4b7f-84f4-1db9b5921945)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         904aaea4-4238-4361-b6ef-f6e6252f1a0e)(content(Whitespace\" \
+         b2ed701f-3cd4-42e7-887f-986d9f62531d)(content(Whitespace\" \
          \"))))(Tile((id \
          551f5c5e-d824-408a-8710-0a1e0c7c6cdb)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b9adb333-32de-4837-aa69-da5bf0ca4a3a)(content(Whitespace\" \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         3beadf1f-1468-4e92-b3d5-776b7cf66ef4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c7fc5092-1676-4857-bcd8-852c6e621ec1)(content(Whitespace\" \
          \"))))(Tile((id \
          8d4ff691-5294-42c7-8f9e-b57c71cb5163)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3987,116 +3874,111 @@ let out : string * Haz3lcore.PersistentSegment.t =
          75127d5a-4746-43f4-96e3-1bf3a83bffaf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7e201a49-81ef-43f0-94ae-fc2d7ed2b1cb)(content(Whitespace\" \
+         02cd1b48-edca-4054-be67-9135f4ed3333)(content(Whitespace\" \
          \"))))(Tile((id \
          0febe568-8d57-4567-894b-e6318cd75386)(label(pred))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b26d7be5-76a2-4b0e-9b35-29ccea76dbbf)(content(Whitespace\" \
+         be674eb9-b970-4678-8f69-97a7686cd95e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b9b810eb-e5db-4de6-9b6c-5584f7518525)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8c14f78d-415c-4279-95a1-9eedba97e5f3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ccb39bf-92fc-4283-9148-4b657c9b6c50)(content(Whitespace\" \
-         \"))))(Tile((id d1a6924b-5b95-494c-9ac4-7f10a4651aee)(label(type = \
-         in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d6dc2b52-1de4-4ae4-93f7-e69e2dc22b28)(content(Whitespace\" \
+         3b00162c-f2e5-466b-a842-8acdf56faa67)(content(Whitespace\"\\n\"))))(Tile((id \
+         d1a6924b-5b95-494c-9ac4-7f10a4651aee)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         b422a126-bb1d-460d-9f56-c5b41e69f644)(content(Whitespace\" \
          \"))))(Tile((id \
          c26445e4-4232-476b-ae21-36c00fead663)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         089751c2-c923-4cc8-8eee-17dd752ad17d)(content(Whitespace\" \
+         f31017a6-e122-40eb-b9a1-9e10f4039a25)(content(Whitespace\" \
          \")))))((Secondary((id \
-         bf1c1e94-bd59-44e3-b5ec-fa6e0fec0116)(content(Whitespace\" \
+         522a1dc8-2a09-4920-a775-2516707a8f9b)(content(Whitespace\" \
          \"))))(Tile((id \
          748bd9d1-dae2-4403-b1d6-e8a856682a40)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          03f6e9e8-4858-4933-afe0-00e32ac40d64)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         803b9302-b4e5-4cd8-bf40-f3f99cc5a30b)(content(Whitespace\" \
+         \"))))(Tile((id \
          857c7574-a6a8-4919-b508-90568fbc9413)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6ac36b5b-d02f-486c-bbf5-7e3d19fed65b)(content(Whitespace\" \
+         \"))))(Tile((id \
          35cc395d-fa1b-465b-b5ee-9cce0f21f961)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4cfe4144-9612-42f3-9d00-dd47d8e9de67)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         45d3bcd6-ce51-498f-af4f-8acad514ee8e)(content(Whitespace\" \
+         0b1ddd39-32f8-4359-ac90-04f9b296b70b)(content(Whitespace\" \
          \"))))(Tile((id \
          ed76d026-86f7-4fc9-96ed-d904b4cabd18)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         693d927c-30de-48fd-ab61-202b78355b81)(content(Whitespace\" \
+         \"))))(Tile((id \
          2ac31b11-6a09-4984-886c-52bf2489245b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         25f4c52c-4467-4bcf-9363-b38e03ade8fb)(content(Whitespace\" \
+         \"))))(Tile((id \
          98446c62-2d5f-4b96-abc1-1fcec908c926)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          95c93659-8730-4148-9236-9e4bb8694d73)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         832ad010-d928-4eb6-a936-b2f87c009246)(content(Whitespace\" \
+         73126c92-a43f-4528-8a2d-feaab0ade378)(content(Whitespace\" \
          \"))))(Tile((id \
          81d4bcef-7b90-4b36-8add-c93327f2fb64)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c3c5607b-7701-4443-af17-c94145d41c84)(content(Whitespace\" \
+         \"))))(Tile((id \
          3b0f690a-fb49-4846-82ff-bf5fe775de0e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9c56315d-c578-463c-b818-7a40a5e75cfc)(content(Whitespace\" \
+         \"))))(Tile((id \
          988f1b74-c887-4ad4-b408-b1c7f233f778)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         371c6d6e-4ee5-407b-89e9-97bdba24e871)(content(Whitespace\" \
+         8e445255-5ffe-496a-9f30-5a16d8ded353)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8d7034d0-f024-4406-9c88-690aaeb4fa8e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         abe2f6ab-9163-45fc-a52d-b590e46ae0f3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f766b58-eb4e-4da4-b017-f39af9cbb1f2)(content(Whitespace\" \
-         \"))))(Tile((id fa479cf5-fe50-4d25-a3f6-572114e84a9d)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         82a11ad3-1694-48c1-9b87-c85537ac8957)(content(Whitespace\" \
+         189c170a-079e-43ad-a48a-04caf97301e5)(content(Whitespace\"\\n\"))))(Tile((id \
+         fa479cf5-fe50-4d25-a3f6-572114e84a9d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e69bdea5-076c-419f-a5e0-59ec6907e4f4)(content(Whitespace\" \
          \"))))(Tile((id \
          522c9972-3723-4658-9978-eacf078228e4)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3ae9184e-9a0c-4fea-9d1f-9cc14d9b67e2)(content(Whitespace\" \
+         9fbd150b-d009-4bee-a94f-45be27a11162)(content(Whitespace\" \
          \"))))(Tile((id \
          6bdd1f19-9488-4022-afb8-ccc96d5e33f7)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f78caa8a-edb7-458f-be14-6518d744ec84)(content(Whitespace\" \
+         faed053a-877b-43d4-8557-84808c1d735d)(content(Whitespace\" \
          \"))))(Tile((id f1142e81-7f70-446b-9f4b-fc6ffb3e7f50)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          fefcab08-a55a-4a53-aa1f-2b6521c6d095)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f2f1cb09-3701-497c-a61d-1c978998785a)(content(Whitespace\" \
+         c25e1e52-45ff-43e1-9df8-18595829383c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         90c347b1-4dbe-4dbe-8e38-f1a9bfd5d891)(content(Whitespace\" \
+         eeb0480d-0a8b-4495-8139-8d716d95496d)(content(Whitespace\" \
          \"))))(Tile((id \
          d405acff-5811-405e-80fc-05fd72c4c64d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          8827de1d-fc9e-4edd-b176-5da5e3ae942e)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         8353f884-583f-4db5-87b1-a2e67313facc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8cde48d4-ab08-42dc-9f84-ff8f99eaa39c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c1ef3b3-4420-4af3-b1ed-8a4d140cd698)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2b34f73-dcea-4939-9704-a11428228674)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e1c3023f-87e7-4eb6-becf-e809d2a2d9ba)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          690fc360-4e38-45ea-b624-dbdd99c2f690)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4122,14 +4004,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b12e2abd-3264-47dc-b4c8-ab4b0720e757)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         07ff0dd7-1a0e-4edf-876c-9dc5e6894887)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d2c9e446-88ab-4a78-b63e-9f9bd402b0d8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4b33ac86-812f-4391-81ec-f64bc9caed8d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c218f90f-ad6f-4978-9908-e337d7423f82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cce5bd09-a743-4531-928b-6baaa424d59c)(content(Whitespace\" \
+         9e751ea1-5375-46fa-bfc3-eed25f9ee9d0)(content(Whitespace\" \
          \"))))(Tile((id \
          09d089ec-02bc-4a95-83c1-b558d255f424)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4156,14 +4031,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          79216238-6a47-466d-af67-daabffacc5d4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fa54d686-9665-4712-b8ca-309ffc00ceaa)(content(Whitespace\"\\n\"))))(Secondary((id \
-         46b92ef2-044e-4377-b202-ed0a461d178d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e59f8e9-c985-4389-b943-85792e0e8844)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb54770a-1192-4f38-8c1e-127a496a9d0b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e75938a9-ca63-4800-ae7e-09004252a31a)(content(Whitespace\" \
+         20400164-a852-4371-affe-10d28c8fdff6)(content(Whitespace\" \
          \"))))(Tile((id \
          8b5b96a9-f4ef-4ac1-88ee-0e5bedca982a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4174,7 +4042,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fc115a7c-91c4-4053-b7cb-cdcd92dca678)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3b266686-42cc-4ec0-9798-ba58ad2bdcd5)(content(Whitespace\" \
+         bfba8e73-d1a9-4a0a-90b3-af0574b7e809)(content(Whitespace\" \
          \"))))(Tile((id \
          cba3b988-cb24-4fd0-a25a-13c98f497035)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4182,55 +4050,28 @@ let out : string * Haz3lcore.PersistentSegment.t =
          46c8a745-cbef-44d0-b615-5b723898a08e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         13b55750-1f0e-4cbb-9956-8d749f38cc3d)(content(Whitespace\" \
+         2afff19a-2850-4d1e-84b5-72bf7ddeb28f)(content(Whitespace\" \
          \"))))(Tile((id \
          3d5aae59-2849-433f-b60f-94603c6a4b78)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         bab4f55f-2022-4145-ba8c-7204473e3aca)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d3420608-a01f-4e6e-ad86-46231292ec17)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1454590c-55b4-41ec-b796-870707f4cc86)(content(Whitespace\" \
-         \"))))))))))))))(Secondary((id \
-         35c79217-85da-40c6-82df-83ade645c011)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         bea67747-ea2c-44b5-bce4-fa8d62ba7604)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3a7b1a5c-72a8-4b30-b834-4dd59b8b4d57)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f90c9613-5ade-468b-abe2-fd3a2e2ee374)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8abbc917-c657-44d3-bb88-f28b587c648b)(content(Whitespace\" \
-         \"))))(Tile((id e9821e03-85bf-43ac-98e4-e40e3bb99bc9)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         fa33d63d-6221-4fc6-a16b-002b1217929b)(content(Whitespace\" \
+         b4c05ec0-e22a-436c-b79c-4ba1d6928648)(content(Whitespace\"\\n\"))))(Tile((id \
+         e9821e03-85bf-43ac-98e4-e40e3bb99bc9)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         7c7678eb-44a7-4682-ac6b-cc78c4119442)(content(Whitespace\" \
          \"))))(Tile((id \
-         dc552ebc-55b7-42e3-8a9d-b806eefe15ca)(label(incorrect))(mold((out \
+         dc552ebc-55b7-42e3-8a9d-b806eefe15ca)(label(_incorrect))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         12b9a9fe-d5e5-402c-a26c-ec9fff060156)(content(Whitespace\" \
+         d4125f67-b72a-4f0d-bf1f-c976aefb31d9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8eb9d0be-a1f7-46c7-a6d6-307ab7a9e4d9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4c4929ce-2c6d-42d0-8d47-bf2681dc65ca)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f0d22b7e-291c-41a8-955c-ee5746dd7ca6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e34c100b-3d7a-453c-b109-57f61fdb9f23)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ddf35f49-71bf-4328-841c-c44aaea6fa36)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         54d3cd63-84a1-4f1c-9549-363b2c4a02d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         abc9bb65-b37c-4114-8d87-14fee4321f27)(content(Whitespace\"\\n\"))))(Secondary((id \
          b6747b32-f7a0-424b-8303-5f6cb745f501)(content(Comment\"# No static \
          error. Dynamic error `undefined.favorite_color`#\"))))(Secondary((id \
-         0f19dc10-88d2-47f9-893b-e24a0fe3da2a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8e901013-d682-4832-8852-27855c7ab9b2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         008882a0-d0bf-4655-8db5-154953df9498)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d3bc1e14-7f55-4a3d-aeac-9ba583b6cf47)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a7d827b-b848-4669-b0d7-c7cbf44adcd5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         fa5105cc-ede7-4894-9c06-9f680f8b3a7d)(content(Whitespace\"\\n\"))))(Tile((id \
          2dc29f11-cf9c-4cc3-9a3b-a1f0bdea9329)(label(nth))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -4302,33 +4143,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          587a5dc1-e968-41d7-91ff-eafeb0dd31db)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         719a1e81-abeb-4f7d-9a54-66e31d5a14f5)(content(Whitespace\" \
+         07c58210-2932-4998-bd98-7a72f17e04ee)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e8f47a5c-d81c-4a65-9aa4-02f1eb60236b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c53385a6-0fb1-48bc-ac92-08a773b88947)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fa3e9254-6ed7-43df-9afd-21304b59ffde)(content(Whitespace\" \
-         \"))))(Tile((id 34ca8d6e-2c10-485e-af85-fcb6438441c2)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         6c8e198a-db07-4235-a1c0-119d6ca5a840)(content(Whitespace\" \
+         c0948e48-f97b-44db-bac3-c7bf68a5b099)(content(Whitespace\"\\n\"))))(Tile((id \
+         34ca8d6e-2c10-485e-af85-fcb6438441c2)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         3f23c8cc-1cfb-460a-bc93-2704e3c1d70a)(content(Whitespace\" \
          \"))))(Tile((id \
          ac0a7d79-16b2-4e2f-98e2-51ab8825804a)(label(correct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d7cec1cf-cd48-42d9-9eb2-44c2aed1f700)(content(Whitespace\" \
+         a215e547-1c7b-47d3-b091-14b07a855694)(content(Whitespace\" \
          \")))))((Secondary((id \
-         73135a73-6295-468b-986a-975e10e7ea6b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a90bd169-12e3-4208-ad54-1350add77553)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3df27bf5-db4a-477e-8d72-46506d8bbbaf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c40b37d0-e599-4a83-b68e-e479df35cb5b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         77927b66-ec2a-44d0-a59d-38af37b2ec10)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9dc385a-db46-4ca5-b5e8-ad5240eb0eb1)(content(Whitespace\" \
+         07a68eb6-9f8a-439d-970e-d132c9e17591)(content(Whitespace\" \
          \"))))(Tile((id \
          24f722dc-d7da-4d6b-b99f-f76ab7c969b8)(label(nth))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4401,68 +4229,54 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e956cdb8-d5df-43b2-9a95-c5709e5ff03f)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d8cef8ba-dff5-4df7-884f-cb5a536d1624)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9b22d39f-766f-4d1f-8791-2de0cf36774e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bcd02440-dcfa-442a-9733-9ad83226a163)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f01dd668-40d2-4e71-a52c-e17ab9be303a)(content(Whitespace\" \
+         d3309059-ad3f-4e50-bbee-42699a72ff8a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8d2c28af-dc9a-4321-877a-3365b092bf8a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4b4f3748-31b5-4aaa-8bd3-0317203396d0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eed493e3-74a7-476d-9248-c96bde2c7059)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d98ced9-9851-4b6c-8409-876fe58278c5)(content(Whitespace\" \
-         \"))))(Tile((id 73071a63-5634-4215-9295-6c15d71cf421)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         638b2e6c-7639-4872-b688-f9b0fc0b2ca8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c3798f74-4f52-4cca-8903-dc8b0681742c)(content(Whitespace\"\\n\"))))(Tile((id \
+         73071a63-5634-4215-9295-6c15d71cf421)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         6199afb1-0e05-44c1-8992-88f7f3d064f2)(content(Whitespace\"\\n\"))))(Tile((id \
          463f9dd4-e928-439d-97e8-088425b2711c)(label(correct))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         5fd66c94-2adb-436a-a5e0-06b62cdf266a)(content(Whitespace\" \
+         3dac0d5f-41bd-48ae-99db-027a5efdb45c)(content(Whitespace\" \
          \"))))(Tile((id \
          648c8388-3a33-4c2a-9211-f13ee86cba9a)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9a4788c6-c79a-4056-92f2-5ae97b9a2d3f)(content(Whitespace\" \
+         389a80ff-75d6-4f5a-b797-64177972982d)(content(Whitespace\" \
          \"))))(Tile((id \
          a3e9eddf-1a57-4fd9-ad83-a6c0300fd428)(label(\"\\\"green\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         22188842-c84b-4275-a228-7c8bcb4cb895)(content(Whitespace\" \
+         c829d5f6-2404-417c-a610-c24ee29e93f7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b921f0cb-5c10-49e6-8454-ac752a6dcbbf)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         23d10647-50a5-48b8-8c36-0ff0b89ba785)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c2c829a5-f8ad-452d-86bd-df1535a65f2d)(content(Whitespace\"\\n\"))))(Tile((id \
+         f6e99dc2-79f3-48e3-8a82-8e343c35d663)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         13c42e7c-9806-48b5-bce3-75a2ee580bd8)(content(Whitespace\"\\n\"))))(Secondary((id \
+         40737763-026e-49bb-b0d8-c9660f790aee)(content(Whitespace\"\\n\"))))(Tile((id \
          fed0ae77-42a0-40eb-946e-1db8a1b9d8c7)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e0fee2ee-bbfa-443a-8ea9-84c10fa73c40)(content(Whitespace\" \
+         4ee9d429-e25e-4333-9f26-4c80128c080e)(content(Whitespace\" \
          \"))))(Tile((id \
          91d07e10-1422-4d02-ac90-3c26d6ca3a23)(label(favorite_color))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9e88793a-295d-401c-b05d-20129014a36b)(content(Whitespace\" \
+         35389789-8f78-4d27-a5f5-3664347ae437)(content(Whitespace\" \
          \")))))((Secondary((id \
-         76f25d07-640b-4df2-8e9d-6d5bc536af60)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eb8f9df2-5651-4812-9e3d-c7813cd66972)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac423b9f-8113-40d2-b7d3-abdf98bbc576)(content(Whitespace\" \
-         \"))))(Tile((id 9580407e-7938-4231-833c-843a94b87068)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         85b21296-135a-4f61-81f0-918fc78dc781)(content(Whitespace\" \
+         dc16e44e-91ea-48a4-bd4f-e56b8fa5e5d7)(content(Whitespace\"\\n\"))))(Tile((id \
+         9580407e-7938-4231-833c-843a94b87068)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         4a03a086-8591-4f5c-85b1-e975ed974456)(content(Whitespace\" \
          \"))))(Tile((id \
          c163d0ee-89b1-4b36-b960-0769ab38481d)(label(tfilter))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         70e0812c-6f1a-408b-b473-18be0e9ce6e8)(content(Whitespace\" \
+         f8cd82bf-a4cf-404d-a4fb-5afd7803bba3)(content(Whitespace\" \
          \")))))((Secondary((id \
-         cdebb962-4719-458a-b3ec-e5a6f77f1860)(content(Whitespace\" \
+         6daf47e5-cf02-450d-ad49-185db51013ff)(content(Whitespace\" \
          \"))))(Tile((id \
          32abdf28-9e02-4ac5-9b3f-de04ec58a5ac)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4470,30 +4284,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          49ea0379-02e1-4945-8de5-e8407ffbd116)(label(typfun ->))(mold((out \
          Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         cb961d96-3025-4905-a1df-c25bb9daf3b9)(content(Whitespace\" \
+         e07fa275-c012-4370-9d87-1376ade00140)(content(Whitespace\" \
          \"))))(Tile((id \
          380c0530-5c69-4385-bd38-ea36aaa62e66)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         8655880f-4ff4-42dd-be0d-62d9a5332c76)(content(Whitespace\" \
+         83fd5218-6e57-4a9e-b67b-fd74ed8995e5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9ed14bd2-2c29-4cd7-ac93-a059b91f3cbc)(content(Whitespace\" \
+         9e17390b-92b9-4b0b-8422-9f81b8625227)(content(Whitespace\" \
          \"))))(Tile((id 3df4c305-4946-4040-a7cd-5e90bb8692c8)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f9187d23-c35e-4146-8ba2-59a6ce047813)(content(Whitespace\" \
+         c14622fe-51eb-4fdd-89ad-42a2e24b1f8f)(content(Whitespace\" \
          \"))))(Tile((id \
          d60c9918-49ea-441b-80b9-3b78bd92c781)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          46b715b0-09af-4115-9f2b-5b731fedd49b)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         68554e06-94af-44b0-87e6-f6393636a5c9)(content(Whitespace\" \
+         \"))))(Tile((id \
          e548e0d4-1ec8-4057-9cde-a789aa258133)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3bc03856-d9d4-45be-b371-c24030337b0b)(content(Whitespace\" \
+         7ac413f0-6ff4-426c-bb19-66909b98fbb6)(content(Whitespace\" \
          \"))))(Tile((id 6fae4ea6-ff3b-4f93-9dcf-50de1fa045c1)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -4503,32 +4319,34 @@ let out : string * Haz3lcore.PersistentSegment.t =
          381bd81d-320f-488b-86d4-84a85988c6ea)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         9c91a1b2-04e4-411a-9bbe-80b58438e0f7)(content(Whitespace\" \
+         71f32315-9ac4-4dc0-a664-379a4af7a389)(content(Whitespace\" \
          \"))))(Tile((id \
          d853c675-295c-43b6-875f-e518700904cb)(label(pred))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d8a993e0-f73f-460d-845b-1242f4ce7514)(content(Whitespace\" \
+         2814a77e-f11e-4f9e-9271-e38d01601ada)(content(Whitespace\" \
          \"))))(Tile((id \
          c49dbad9-c669-4c43-a92b-f204c2dbc9f8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         baad7890-ceb8-4f7f-af2d-0da2bf911070)(content(Whitespace\" \
+         734e92a0-523c-49e5-8c7c-1c305f5bd213)(content(Whitespace\" \
          \"))))(Tile((id \
          02bc6038-b88f-45ed-89fe-93670829d780)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         80dbc026-fc61-4669-8aed-76fce0798a21)(content(Whitespace\" \
+         742510c2-0189-466e-8449-de598fb482bb)(content(Whitespace\" \
          \"))))(Tile((id \
          91087f61-b219-41cc-9481-bea2860d736c)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         20c6db46-a769-4c20-aa51-845759bf0a18)(content(Whitespace\" \
+         91abad37-b749-4717-ac1f-c0de763b15be)(content(Whitespace\" \
          \"))))(Tile((id \
          66aa1730-a89a-4db9-8827-1ed3291b7926)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         de725821-ff3c-407e-b6f0-d33e34cd9215)(content(Whitespace\" \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         9fe45853-776a-4d51-a5b5-e132cba3dbc9)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         88f3d4ff-d4ce-4411-8a48-890a59e29f86)(content(Whitespace\" \
          \"))))(Tile((id \
          719f2231-0404-4a8b-afbb-18e655413b10)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4542,116 +4360,111 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ea624b66-8efd-4e28-a03c-61258600ffbb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cef218f8-4ad3-4f8d-ba29-ec589aad25b3)(content(Whitespace\" \
+         7d823577-36af-4211-ba78-0da75274c9f8)(content(Whitespace\" \
          \"))))(Tile((id \
          64a10edc-c179-4301-b94d-d61ab1b86e2c)(label(pred))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         bcf6d160-7d31-4c6e-b4cd-a1a0b733ca6c)(content(Whitespace\" \
+         b7d3ed20-0d08-4f7f-8e8b-949be9556748)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f96f817b-8269-4ed7-ab51-84ceec59e078)(content(Whitespace\"\\n\"))))(Secondary((id \
-         93cce2ea-d451-42d0-9466-55947f7d8277)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5fe40abb-d190-403e-b0d8-ccc705b9a607)(content(Whitespace\" \
-         \"))))(Tile((id 34fbf86a-75d1-4bde-9598-8f0b082c020c)(label(type = \
-         in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         1e83bd98-5307-4e6b-b87c-32e42ef68fcb)(content(Whitespace\" \
+         af615d6b-de4d-457c-80e8-fc8704f80374)(content(Whitespace\"\\n\"))))(Tile((id \
+         34fbf86a-75d1-4bde-9598-8f0b082c020c)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         220083d7-1519-4ee2-927e-8e73a865672f)(content(Whitespace\" \
          \"))))(Tile((id \
          18e062af-c718-4835-b5bf-51dd982b1115)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         2bb2cffd-b570-4ff5-9785-f2398767fa35)(content(Whitespace\" \
+         2bb29420-3360-40b2-a50e-c5f8f01f855c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4b512085-021d-45d6-86eb-ded047407741)(content(Whitespace\" \
+         3a126a35-196a-4e31-a835-e8ac0c4c3ed2)(content(Whitespace\" \
          \"))))(Tile((id \
          f2a241a8-721c-480a-a7a9-0a51b6db183a)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          2c20863d-1723-4843-8d3a-3bf03e998e2a)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         fbfc0f3f-40f1-4d50-82a3-62251096d90a)(content(Whitespace\" \
+         \"))))(Tile((id \
          64f71a9a-bd27-4799-a401-5695a4dd3ecd)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bab6c3b8-d2d7-4d6c-96f9-4cf3689fb259)(content(Whitespace\" \
+         \"))))(Tile((id \
          e1218ece-0762-4f79-9677-83f8406da831)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ae56b24c-c91d-4b54-b96d-e7c577ccb3b9)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         051f7e31-7b5c-4482-8822-153ce583e2c7)(content(Whitespace\" \
+         08cbdac9-15a3-4da4-85c6-597da87480ba)(content(Whitespace\" \
          \"))))(Tile((id \
          8aabd6e9-ab11-48c5-8226-2f569e2b298c)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bde4c34c-d677-433a-924f-b30507c83257)(content(Whitespace\" \
+         \"))))(Tile((id \
          34c631b1-4e88-42c0-b1ce-f0021fa2a313)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f42333ea-c7f8-4cd7-9f1f-9067c1ce2d38)(content(Whitespace\" \
+         \"))))(Tile((id \
          c3073c7b-0b57-4c8c-87e5-8af9439d8940)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          823ebc95-200a-442d-a182-db3f02be437b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2b917615-56a5-441e-a21b-0c52bf527978)(content(Whitespace\" \
+         3d263cb5-81af-4c53-bf18-5e95a22c9bff)(content(Whitespace\" \
          \"))))(Tile((id \
          2fbdbe6b-0a59-44c7-8337-f6239ede195a)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c020d313-5659-499a-97e9-815f7e63c260)(content(Whitespace\" \
+         \"))))(Tile((id \
          e1f194a9-9c51-4614-b031-002980a1744d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e7ff1a09-b252-47f0-8720-09549c7b8529)(content(Whitespace\" \
+         \"))))(Tile((id \
          03feb874-334d-448b-9a10-a5d3ed4af33e)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         6da0e8e1-693d-45eb-b1dd-e00cde55333c)(content(Whitespace\" \
+         a758273c-889e-4140-9731-5dc24bb4ed4a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6a098638-ee4e-4176-8303-1a4a0c2d2e0d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c6e91b67-e6e9-4d1e-abe2-cb21fdff3810)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a403268e-e7e3-48f1-885e-092bf97ba4ed)(content(Whitespace\" \
-         \"))))(Tile((id 3328bffc-aa92-4d07-8372-1326b8a78bce)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         501917c7-62d8-4f52-858a-9cf2593852b6)(content(Whitespace\" \
+         c28c7b3f-8559-46e8-8530-316861f8ac9f)(content(Whitespace\"\\n\"))))(Tile((id \
+         3328bffc-aa92-4d07-8372-1326b8a78bce)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         70b0629a-04de-42e5-a4d9-83083ea52ba1)(content(Whitespace\" \
          \"))))(Tile((id \
          b1dbfee8-d7a8-41cc-8d11-da31891c9f30)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         caeacc22-2ae6-4f16-a2d5-d8026ca9ba5b)(content(Whitespace\" \
+         1a87af8b-612d-4ea9-bab5-34a747d8e7d5)(content(Whitespace\" \
          \"))))(Tile((id \
          c2b10cfb-ed4e-40ee-9f82-f6e7872729f7)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a0db2f6a-88bf-4f66-b79b-485783241dd5)(content(Whitespace\" \
+         630c892d-3ccd-4fbc-a00d-cd3ef6dd6bda)(content(Whitespace\" \
          \"))))(Tile((id 51d50a21-1272-46e6-8188-58f8c9e49fbd)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          10e67f49-839d-41c8-a253-7b6e6adf6f61)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0dbb2886-289d-4867-9b77-951d0d590635)(content(Whitespace\" \
+         1d669695-41dc-47f8-827d-0e841c08ea8a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         1209e79d-501b-4aeb-ac58-b0689f419c60)(content(Whitespace\" \
+         caf29ec3-df48-4390-8480-f801da6f35cd)(content(Whitespace\" \
          \"))))(Tile((id \
          f9db11bd-a7d7-4a0f-97c4-199c56f63aac)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          aecf1298-87c9-4a31-8762-d420e4ea8db9)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         032175e9-aceb-45e4-bf5b-c9039a86a3a6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bcef4c78-2deb-44a0-a212-45d9f380218d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1585bfd1-826d-4995-bc3d-38c6e94c044f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b6594e6f-d7ef-40b8-b40c-32e4061df125)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bfa12df1-f40d-41e7-ba09-79035b02855f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          6a9d9b80-7df5-4384-8cdb-d08a24cafe87)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4677,14 +4490,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          81cf62a8-806b-434a-8771-a7959250bf03)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         838c9c2e-894c-4dc0-93d8-c2aaf383880b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2f76132a-0155-48d8-8d4c-fc53b9923f0e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2b08583c-6ac6-4db5-95a5-667e635c4c76)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         084f5ccd-488e-4fd3-b432-aeaddef8db5b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9afa6831-17c7-4d01-a42c-63189d93229c)(content(Whitespace\" \
+         52eb145d-29ab-46d8-aed7-e5cd0548721c)(content(Whitespace\" \
          \"))))(Tile((id \
          2d216796-d6bb-4373-af6e-3283cdeac037)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4711,14 +4517,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8111ef6d-e9cd-4d69-82e5-bfaa653d865a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cca5bedf-be25-4222-9a70-a24fa2dfb422)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ae66c4ce-8b75-495c-afd7-a3b8d660889a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae9cc0f6-31bc-480d-b93d-5a1ec9f02897)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         889de1b5-e53c-4cc9-8f90-39f7ad06cf05)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5cca6ab3-483c-4672-8612-a287cc2545c1)(content(Whitespace\" \
+         1d2da3fb-79d2-47f7-a1ac-45d436b72ae6)(content(Whitespace\" \
          \"))))(Tile((id \
          7ef312ba-7ba8-4d98-948e-82179340abc7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4729,7 +4528,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1c1cc8d6-e34c-4996-b9f0-0eca282ad05f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         eb588044-c6fb-481a-a892-799268054fda)(content(Whitespace\" \
+         e7517fc1-302b-4f7d-b000-f50c85f0579e)(content(Whitespace\" \
          \"))))(Tile((id \
          06a492d3-7ec6-4635-aa73-67c16bada975)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4737,43 +4536,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e3883fb4-19d9-4093-9b67-2fee4cca75e3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         08b9b19f-9f5d-4a16-90b1-225a7a5493b6)(content(Whitespace\" \
+         b04cbe8e-c598-4878-b00b-6d4c2cfca765)(content(Whitespace\" \
          \"))))(Tile((id \
          5921047f-8547-409e-b44b-80d9b54b49d6)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1cfb7edc-a7e9-4d79-8988-7f23c4a49569)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f4366431-ad0f-41af-a491-a96799e44c38)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8892e22-e1a2-433c-8efe-0884f1d242d0)(content(Whitespace\" \
-         \"))))))))))))))(Secondary((id \
-         a37e9524-fb99-4e2f-857f-e66d301f5982)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         38c126c8-059c-4c07-90a6-e7484979d00f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8f09e915-eb4e-455c-b0cb-ee9f0ed93bcd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         46f12c20-15b8-4af5-9189-979e3d2fae7b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         959a6fb8-ccec-42ae-965d-1b3a552d5408)(content(Whitespace\" \
-         \"))))(Tile((id c6b00640-8678-4bf3-a7cf-84a0a3c4398c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ba34c435-2e05-44d5-a972-42c035117541)(content(Whitespace\" \
+         8b5da268-3523-4425-b10c-679ef86710e7)(content(Whitespace\"\\n\"))))(Tile((id \
+         c6b00640-8678-4bf3-a7cf-84a0a3c4398c)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         cc4a5527-f127-4a30-97e2-fae1b4182ea6)(content(Whitespace\" \
          \"))))(Tile((id \
-         640b5971-eeb3-4b81-83b1-3dff58b6d86b)(label(incorrect))(mold((out \
+         640b5971-eeb3-4b81-83b1-3dff58b6d86b)(label(_incorrect))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         150eaaa1-f722-4d47-a26f-e80bdda6afd8)(content(Whitespace\" \
+         d7caf269-68a4-4403-8c23-a77da534a72c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         138cd6e7-8dc8-490b-b5dd-9787c4bc229b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0721a58a-8974-4cb7-a2a2-98ac259d3629)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6cca536b-c2cf-4fea-89e5-6c0913f5217b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         377b4bf5-6a34-4a03-8190-94e66ea0ac50)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f3981ed-d23e-43ed-99d7-89c52b5bc169)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e951df6-cde9-4f47-9143-71eed655d010)(content(Whitespace\" \
+         35b89b7b-3e0a-4605-83c0-4f69358c20dc)(content(Whitespace\" \
          \"))))(Tile((id \
          45a7dae9-00e3-4e16-9ca7-77ff8789e833)(label(tfilter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4793,19 +4574,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          680a6f44-ffab-4288-99d7-265126a57962)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d8399308-df55-4348-90aa-c4c02385f17f)(content(Whitespace\" \
+         4a50be09-ac1c-4852-8cdd-42a90ca602a5)(content(Whitespace\" \
          \"))))(Tile((id b98ddcb2-577b-439f-ace4-8f5478cbf395)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         bbd9c8f2-9d8e-4eab-b44c-1ccda023c087)(content(Whitespace\" \
+         ec260bb4-b4a4-44ab-a05b-ffcb66656dcb)(content(Whitespace\" \
          \"))))(Tile((id \
          581d6fd0-23f9-4097-ab86-7731d7a799d5)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1cd83f22-838a-4370-bc05-f007bb595167)(content(Whitespace\" \
+         b6aba92c-039e-4d40-9868-69ee1f33bc6f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         37cf12b8-1bf9-480f-a6b1-8984a1cfac58)(content(Whitespace\" \
+         356066a2-2765-4c15-9c33-d1d8920beffc)(content(Whitespace\" \
          \"))))(Tile((id \
          9b85bf4c-d9bf-4a9c-9d6c-a3e2234b2f89)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4816,33 +4597,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bfeb65bd-9e67-470c-a592-4939d0f41c26)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1cabfdb2-7ba4-493e-a19f-9f8381fa3ca7)(content(Whitespace\" \
+         72781289-3551-4f47-a7bd-59af42adf9f0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d8f7abb2-943a-4d43-92c4-59148e3e6ce6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         570d749e-99b4-4547-9899-e8af2dc6d040)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0020def5-c3eb-48f1-8dbd-0e6bfd0c170c)(content(Whitespace\" \
-         \"))))(Tile((id 26d01f74-aeaa-4539-ac59-f7fe049c484f)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d63db687-620a-479b-a960-83f2178d30f1)(content(Whitespace\" \
+         ba5a36ab-e9b1-4788-b60b-b63e6c45c20e)(content(Whitespace\"\\n\"))))(Tile((id \
+         26d01f74-aeaa-4539-ac59-f7fe049c484f)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         8ca1054b-f57c-4ee5-8cd0-723e06e378ef)(content(Whitespace\" \
          \"))))(Tile((id \
          94863898-00cd-4fe8-9fcd-1d07f720c675)(label(correct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         41e3f97a-a2a2-425a-b1f3-242cf71cb08a)(content(Whitespace\" \
+         db055e37-50fe-4ee6-92c9-d40517978636)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0ac5f226-0be5-4e4b-bc2f-5f9f1a3e5cda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5970fed6-db70-42fb-b56e-98361de202fe)(content(Whitespace\"\\n\"))))(Secondary((id \
-         98798198-2140-44f9-ab02-b0276350bf3e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c9c4caa-5332-4169-9213-420ef3bd6e77)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c7a0999-42f4-43bd-8982-07404d86e09f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db42bf01-e0d1-4eed-84aa-627030a233ac)(content(Whitespace\" \
+         7094d9a1-1176-4863-b351-bc3cce44ebd1)(content(Whitespace\" \
          \"))))(Tile((id \
          602c4a7f-862a-4c27-9f2b-7c04e07e2479)(label(tfilter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4862,19 +4630,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7ff2e280-8351-479d-92be-92e337f657ad)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dca37bd4-5d7e-46be-b3f4-86905f37aec6)(content(Whitespace\" \
+         94f681d8-6e17-478a-b0fc-d0253ff8ee87)(content(Whitespace\" \
          \"))))(Tile((id 8545785f-987f-4199-aaa1-f538096f3378)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         dcebe41d-5e66-4096-baf6-950fecd7f360)(content(Whitespace\" \
+         6a7acd14-c3ce-435f-8004-f32f5bc3de4c)(content(Whitespace\" \
          \"))))(Tile((id \
          ecd73a72-9588-4293-826c-1d1b36af7176)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d42f1569-968d-435e-b513-d68dca92b1e4)(content(Whitespace\" \
+         a7e6b431-3424-4d8a-b484-4f60490a4966)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f6e71461-b400-4d59-94d6-43f91a771a97)(content(Whitespace\" \
+         fd0caf53-9193-4aad-a1f9-4b4d820bcf86)(content(Whitespace\" \
          \"))))(Tile((id \
          e713a2d9-b816-45e9-a645-d5bef15d5301)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4885,46 +4653,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9a9fd448-6293-4c6c-91e3-8b4e6ea334a3)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c9f541ce-24e3-4dea-af72-eb397599d425)(content(Whitespace\" \
+         960909be-3530-4d9b-9437-c033c39bd759)(content(Whitespace\" \
          \"))))(Tile((id \
          bd014e92-1668-46b7-b07f-69c63a40391a)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         832b60de-2fe4-4b64-8402-8009b9f690a2)(content(Whitespace\" \
+         1d4b3828-20f4-4d2a-adc4-23b29654d73e)(content(Whitespace\" \
          \"))))(Tile((id \
          f62e9d1b-2ac3-426c-8119-e410de0b93d9)(label(\"\\\"green\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         053ee4a5-dfd4-4ae5-a4d4-076dbf258bf2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         583bed3c-2248-4249-8061-87129d554345)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f3a3b56-9b0c-406b-89a1-35186691c1bd)(content(Whitespace\" \
+         4c83c6e1-e2a0-4c3e-baa1-2cf89d9a5bb0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ba21e3e4-7e5a-48fd-bae4-a938025d8044)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2d573981-08b2-493a-8acd-498ef18b9106)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e3df0794-219f-4805-8acf-e9002bf7fec5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f6a96e7-e675-455f-b31d-1cb242a65a2c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         826c3110-c4d1-42da-a9d9-6cabac56f853)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6edb4843-5b75-4ce2-a616-967de6ef30f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8457cb34-b1f4-41db-b30c-3c1668dcb0a3)(content(Whitespace\" \
-         \"))))(Tile((id d59be432-d6d6-4f89-8b10-ec50e4fb9e3e)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         408aabf3-29a6-4749-82b6-0b2f284d009f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         1c8551b9-9c3d-476a-95bb-d9e64633eea3)(content(Whitespace\"\\n\"))))(Tile((id \
+         d59be432-d6d6-4f89-8b10-ec50e4fb9e3e)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         6ec8e548-e25c-4a07-9469-03adca1b6b07)(content(Whitespace\"\\n\"))))(Tile((id \
          2438eacb-e934-4fdd-970c-14fac8a735fd)(label(correct))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d1beb15d-bf61-4fa5-b681-910de68c725a)(content(Whitespace\" \
+         c8ff6a7a-36b7-491c-98bb-5364a51a0df2)(content(Whitespace\" \
          \"))))(Tile((id \
          bd114778-e095-4f72-ba37-f2f2df0c02ea)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f760cda1-9169-440d-84b0-bbd18803de4c)(content(Whitespace\" \
+         7196a7c4-0a54-4a76-bd8f-45c0e2e21f9d)(content(Whitespace\" \
          \"))))(Tile((id 86a96dd2-8f65-4ee1-b8b1-260445b739bd)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4937,7 +4691,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          043274eb-b223-4325-9870-d827fc571d5b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c459f414-34d9-4a82-9c21-da857c41c9d6)(content(Whitespace\" \
+         77f5ff0b-8cbd-4e4b-ae7d-302b794443ee)(content(Whitespace\" \
          \"))))(Tile((id \
          400ae54c-3c15-40ef-bea8-ca573cab6fc0)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4945,150 +4699,184 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a095312d-67c7-4abf-8065-c4d39fea1cb0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4e551a20-02bc-4d9a-892f-b7856b56bb07)(content(Whitespace\" \
+         3d6f5d0e-cbb0-44bd-9949-56196bf2d16f)(content(Whitespace\" \
          \"))))(Tile((id \
          a11d7c79-f3d2-4e32-a323-5e9b2f24a3a2)(label(\"\\\"green\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d1ce14c1-5bf5-40e7-adc3-f1f351f97322)(content(Whitespace\" \
+         d9fc38b9-1766-4129-9773-213d0ae4d19b)(content(Whitespace\" \
          \"))))(Tile((id \
          d78dc953-9c24-4aff-8a3a-6b37cf9323ba)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b198eecd-52e8-49a5-ad5f-76bee1e4d067)(content(Whitespace\" \
+         f0ce2fd7-8c23-410d-806c-2a779b314ec7)(content(Whitespace\" \
          \"))))(Tile((id \
          699185a2-16ca-46b7-bd57-01d7c4c87d5a)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e4375ee8-820b-4827-a033-2d9393565ebe)(content(Whitespace\" \
+         08633736-2ca6-4899-a493-840a68c291bf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         aa78c202-5603-4653-8582-1c32e0bcdd3f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         543ac7b5-9903-4fdd-b75f-6dce8897c933)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0d4bad4c-f981-4f2f-b64a-615683acda20)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f02ab026-df28-4f1b-9dbb-3b4b49421e04)(content(Whitespace\"\\n\"))))(Tile((id \
          c7ddc1b2-582b-4652-a63e-401d96170cdd)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         8fe8e6b2-0f89-4c94-9c8f-14e18a6e47ca)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type Image =? in\n\
+        "type Image = ? in\n\
          # Representing column names as projection functions for better error \
          localization since we don't do first-class labels #\n\
          let scatter_plot : poly row -> ([row], row -> Int, row -> Int) -> \
-         Image =?   in\n\
+         Image = ? in\n\
          # Using ? for the categorical variables #\n\
-         let pie_chart : poly row -> ([row], row -> ?, row -> Int) -> Image \
-         =?   in\n\n\
-         let brown_get_acne =  \n\
-        \  type JellyNamed = (name=String, get_acne=Bool, red=Bool, \
-         black=Bool, white=Bool, green=Bool, yellow=Bool, brown=Bool, \
-         orange=Bool, pink=Bool, purple=Bool) in\n\
-        \  let jellyNamed : [JellyNamed] = ([\n\
-        \    (\"Emily\",    (true), (false), (false), (false), (true), \
-         (false), (false), (true), (false), (false)),\n\
-        \    (\"Jacob\",    (true), (false), (true), (false), (true), (true), \
+         let pie_chart : poly row -> ([row], row -> ?, row -> Int) -> Image = \
+         ? in\n\n\
+         let brown_get_acne =\n\
+         type JellyNamed = (\n\
+         name = String,\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool\n\
+         ) in\n\
+         let jellyNamed : [JellyNamed] = (\n\
+         [\n\
+         (\"Emily\",    (true), (false), (false), (false), (true), (false), \
+         (false), (true), (false), (false)),\n\
+         (\"Jacob\",    (true), (false), (true), (false), (true), (true), \
          (false), (false), (false), (false)),\n\
-        \    (\"Emma\",     (false), (false), (false), (false), (true), \
-         (false), (false), (false), (true), (false)),\n\
-        \    (\"Aidan\",    (false), (false), (false), (false), (false), \
-         (true), (false), (false), (false), (false)),\n\
-        \    (\"Madison\",  (false), (false), (false), (false), (false), \
-         (true), (false), (false), (true), (false)),\n\
-        \    (\"Ethan\",    (true), (false), (true), (false), (false), \
-         (false), (false), (true), (true), (false)),\n\
-        \    (\"Hannah\",   (false), (false), (true), (false), (false), \
-         (false), (false), (false), (true), (false)),\n\
-        \    (\"Matthew\",  (true), (false), (false), (false), (false), \
-         (false), (true), (true), (false), (false)),\n\
-        \    (\"Hailey\",   (true), (false), (false), (false), (false), \
-         (false), (false), (true), (false), (false)),\n\
-        \    (\"Nicholas\", (false), (true), (false), (false), (false), \
-         (true), (true), (false), (true), (false))\n\
-        \  ]) in\n\
-        \  let brown_and_get_acne = fun r : JellyNamed -> r.brown && \
-         r.get_acne in\n\
-        \  let count = (typfun row  -> typfun v-> fun (t1: [row], proj : row \
-         -> v) ->\n\
-        \    let go = fun (groups: [(value=v, count=Int)], row:row) ->\n\
-        \      case find_opt(groups, fun g -> g.value == proj(row))\n\
-        \      | None => (value=proj(row), count=1) :: groups\n\
-        \      | Some(value=v,count=c) => (value=proj(row), count=c+1) :: \
+         (\"Emma\",     (false), (false), (false), (false), (true), (false), \
+         (false), (false), (true), (false)),\n\
+         (\"Aidan\",    (false), (false), (false), (false), (false), (true), \
+         (false), (false), (false), (false)),\n\
+         (\"Madison\",  (false), (false), (false), (false), (false), (true), \
+         (false), (false), (true), (false)),\n\
+         (\"Ethan\",    (true), (false), (true), (false), (false), (false), \
+         (false), (true), (true), (false)),\n\
+         (\"Hannah\",   (false), (false), (true), (false), (false), (false), \
+         (false), (false), (true), (false)),\n\
+         (\"Matthew\",  (true), (false), (false), (false), (false), (false), \
+         (true), (true), (false), (false)),\n\
+         (\"Hailey\",   (true), (false), (false), (false), (false), (false), \
+         (false), (true), (false), (false)),\n\
+         (\"Nicholas\", (false), (true), (false), (false), (false), (true), \
+         (true), (false), (true), (false))\n\
+         ]\n\
+         ) in\n\
+         let brown_and_get_acne = fun r : JellyNamed -> r.brown && r.get_acne in\n\
+         let count = (\n\
+         typfun row ->\n\
+         typfun v ->\n\
+         fun (t1 : [row], proj : row -> v) ->\n\
+         let go =\n\
+         fun (groups : [(value = v, count = Int)], row : row) ->\n\
+         case find_opt(groups, fun g -> g.value == proj(row))\n\
+         | None => (value = proj(row), count = 1) :: groups\n\
+         | Some(value=_v,count=c) => (value = proj(row), count = c + 1) :: \
          filter(groups, fun g -> g.value != proj(row))\n\
-        \      end in\n\
-        \    \n\
-        \    fold_left(t1, go, []): [(value=v, count=Int)]) in\n\
-        \  let build_column: poly r1 -> poly r2 -> poly r3 -> ([r1], r1 -> r2, \
-         (r1,r2) -> r3) -> [r3]= (typfun r1 -> typfun r2 -> typfun r3 -> \n\
-        \    fun (table, project, build_result) -> map(table, fun r: r1 -> \
-         build_result(r, project(r)))) in\n\
-        \  let incorrect =\n\
-        \    let brown_and_get_acne_table =\n\
-        \      build_column\n\
-        \      @<JellyNamed>\n\
-        \      @<Bool>\n\
-        \      @<(name=String, get_acne=Bool, red=Bool, black=Bool, \
-         white=Bool, green=Bool, yellow=Bool, brown=Bool, orange=Bool, \
-         pink=Bool, purple=Bool, part2=Bool)>\n\
-        \      (jellyNamed,brown_and_get_acne,fun (t, v) -> t...(part2=v)) in\n\
-        \    count\n\
-        \    @<(name=String, get_acne=Bool, red=Bool, black=Bool, white=Bool, \
-         green=Bool, yellow=Bool, brown=Bool, orange=Bool, pink=Bool, \
-         purple=Bool, part2=Bool)>\n\
-        \    @<Bool>(brown_and_get_acne_table, fun r -> r.`brown and get acne`)\n\
-        \  in\n\
-        \  let correct =\n\
-        \    let brown_and_get_acne_table =\n\
-        \      build_column\n\
-        \      @<JellyNamed>\n\
-        \      @<Bool>\n\
-        \      @<(name=String, get_acne=Bool, red=Bool, black=Bool, \
-         white=Bool, green=Bool, yellow=Bool, brown=Bool, orange=Bool, \
-         pink=Bool, purple=Bool, `brown and get acne`=Bool)>\n\
-        \      (jellyNamed,brown_and_get_acne,fun (t, v) -> t...(`brown and \
-         get acne`=v)) in\n\
-        \    count\n\
-        \    @<(name=String, get_acne=Bool, red=Bool, black=Bool, white=Bool, \
-         green=Bool, yellow=Bool, brown=Bool, orange=Bool, pink=Bool, \
-         purple=Bool, `brown and get acne`=Bool)>\n\
-        \    @<Bool>(brown_and_get_acne_table, fun r -> r.`brown and get acne`)\n\
-        \  in\n\
-        \  \n\
-        \  test correct == [(value=false, count=9), (value=true, count=1)] end\n\
-         in\n\n\
+         end in\n\
+         fold_left(t1, go, []) : [(value = v, count = Int)]\n\
+         ) in\n\
+         let build_column : poly r1 -> poly r2 -> poly r3 -> ([r1], r1 -> r2, \
+         (r1, r2) -> r3) -> [r3] = (\n\
+         typfun r1 -> typfun r2 -> typfun r3 -> fun (table, project, \
+         build_result) -> map(table, fun r : r1 -> build_result(r, project(r)))\n\
+         ) in\n\
+         let _incorrect =\n\
+         let brown_and_get_acne_table =\n\
+         build_column@<JellyNamed>@<Bool>@<(\n\
+         name = String,\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool,\n\
+         part2 = Bool\n\
+         )>(jellyNamed, brown_and_get_acne, fun (t, v) -> t ... (part2 = v)) in\n\
+         count@<(\n\
+         name = String,\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool,\n\
+         part2 = Bool\n\
+         )>@<Bool>(brown_and_get_acne_table, fun r -> r.`brown and get acne`) in\n\
+         let correct =\n\
+         let brown_and_get_acne_table =\n\
+         build_column@<JellyNamed>@<Bool>@<(\n\
+         name = String,\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool,\n\
+         `brown and get acne` = Bool\n\
+         )>(jellyNamed, brown_and_get_acne, fun (t, v) -> t ... (`brown and \
+         get acne` = v)) in\n\
+         count@<(\n\
+         name = String,\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool,\n\
+         `brown and get acne` = Bool\n\
+         )>@<Bool>(brown_and_get_acne_table, fun r -> r.`brown and get acne`) in\n\
+         test\n\
+         correct == [(value=false, count=9), (value = true, count = 1)] end in\n\n\
          let get_only_row =\n\
-        \  let tfilter = (typfun row -> fun (t1: [row], pred : row -> Bool)-> \
+         let tfilter = (typfun row -> fun (t1 : [row], pred : row -> Bool) -> \
          filter(t1, pred)) in\n\
-        \  type Student = (name=String, age=Int, favorite_color=String) in\n\
-        \  let students : [Student] = ([\n\
-        \    (\"Bob\", 12, \"blue\"),\n\
-        \    (\"Alice\", 17, \"green\"),\n\
-        \    (\"Eve\", 13, \"red\")\n\
-        \  ]) in\n\
-        \  let incorrect = \n\
-        \    # No static error. Dynamic error `undefined.favorite_color`#\n\
-        \    nth(tfilter@<Student>(students, fun r -> r.name == \"Alice\"), \
+         type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = ([(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")]) in\n\
+         let _incorrect =\n\
+         # No static error. Dynamic error `undefined.favorite_color`#\n\
+         nth(tfilter@<Student>(students, fun r -> r.name == \"Alice\"), \
          1).favorite_color in\n\
-        \  let correct = \n\
-        \    nth(tfilter@<Student>(students, fun r -> r.name == \"Alice\"), \
-         0).favorite_color \n\
-        \  in \n\
-        \  test correct == \"green\" end\n\
-         in\n\n\
+         let correct = nth(tfilter@<Student>(students, fun r -> r.name == \
+         \"Alice\"), 0).favorite_color in\n\
+         test\n\
+         correct == \"green\" end in\n\n\
          let favorite_color =\n\
-        \  let tfilter = (typfun row -> fun (t1: [row], pred : row -> Bool)-> \
+         let tfilter = (typfun row -> fun (t1 : [row], pred : row -> Bool) -> \
          filter(t1, pred)) in\n\
-        \  type Student = (name=String, age=Int, favorite_color=String) in\n\
-        \  let students : [Student] = ([\n\
-        \    (\"Bob\", 12, \"blue\"),\n\
-        \    (\"Alice\", 17, \"green\"),\n\
-        \    (\"Eve\", 13, \"red\")\n\
-        \  ]) in\n\
-        \  let incorrect = \n\
-        \    tfilter@<Student>(students, fun r -> r.favorite_color) in\n\
-        \  let correct = \n\
-        \    tfilter@<Student>(students, fun r -> r.favorite_color == \"green\")\n\
-        \  in \n\
-        \  \n\
-        \  test correct == [(\"Alice\", 17, \"green\") : Student] end\n\
-         in ?\n";
+         type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = ([(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")]) in\n\
+         let _incorrect = tfilter@<Student>(students, fun r -> \
+         r.favorite_color) in\n\
+         let correct = tfilter@<Student>(students, fun r -> r.favorite_color \
+         == \"green\") in\n\
+         test\n\
+         correct == [(\"Alice\", 17, \"green\") : Student] end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/errors/B2T2ErrorsUsingTablesPart3.ml
+++ b/src/b2t2/slides/errors/B2T2ErrorsUsingTablesPart3.ml
@@ -6,214 +6,232 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         7824cfb4-8721-4f84-93b1-c25d24be68f5)(content(Whitespace\" \
+         84860912-0b58-4e95-8e40-00a5d3904aed)(content(Whitespace\" \
          \"))))(Tile((id \
          86da670e-7d8d-4ae3-b799-315dda201c03)(label(brown_jellybeans))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6995ec9d-0540-48cc-93a8-56aa3e8f5fc4)(content(Whitespace\" \
+         cd6ca8db-58cc-40b6-bc8f-0a7757a90b67)(content(Whitespace\" \
          \")))))((Secondary((id \
-         09f8aa7a-6c93-4b6a-ad8e-bb30038c9610)(content(Whitespace\"\\n\"))))(Secondary((id \
-         27f485d4-4690-4849-b459-638a20a57a5b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fe193890-52af-43c3-b3d3-ae5de2ca5ed2)(content(Whitespace\" \
-         \"))))(Tile((id c8f5ea94-3832-4e8a-abee-76d6d6d52c9f)(label(type = \
-         in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         2f0acc08-d2d7-42be-b589-0ffa452c9757)(content(Whitespace\" \
+         2094cec8-523c-43d6-8e80-a9888e2e16ad)(content(Whitespace\"\\n\"))))(Tile((id \
+         c8f5ea94-3832-4e8a-abee-76d6d6d52c9f)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         75b428fa-fbeb-4e3c-8811-e2c20de7723c)(content(Whitespace\" \
          \"))))(Tile((id \
          4bfc8635-b80c-489e-8299-40ec397b2cd6)(label(JellyAnon))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         c8526784-1e74-4ff9-a737-3c42bcd3c989)(content(Whitespace\" \
+         ae54c4ea-6361-41c8-ad32-6a63050ee4b6)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9125d85c-74a4-4c73-a3d9-b981985adf4b)(content(Whitespace\" \
+         1966f99d-45f7-4b1b-81ed-e9dcda42cb6d)(content(Whitespace\" \
          \"))))(Tile((id \
          bcd7ae54-0929-482f-8c02-31d9d36f3468)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         1deab38a-2a1f-4cf1-94cf-d8ea0dff861a)(content(Whitespace\"\\n\"))))(Tile((id \
          99af5313-d489-402b-b84c-1ab92ac746d5)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         09c5e9b7-5f86-41b1-bb0b-8f9a78ec9738)(content(Whitespace\" \
+         \"))))(Tile((id \
          742bbc81-4c60-4e22-8f70-60e025d3c33a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         21e3cb01-0cc3-470c-8172-e343985f61c7)(content(Whitespace\" \
+         \"))))(Tile((id \
          9923c868-d80b-49de-b248-320c2cbc4122)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e89ea286-3e5c-493c-8ab6-f6587d80d255)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a67c9318-c0e2-4923-bde2-557aaa137441)(content(Whitespace\" \
-         \"))))(Tile((id \
+         eb023629-f7f2-4115-b547-21cfb2a59143)(content(Whitespace\"\\n\"))))(Tile((id \
          3fd795fc-b7d7-4e43-8c7d-f01a3163b060)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         aa800ddb-eeb1-4240-99ce-d14ccaafc879)(content(Whitespace\" \
+         \"))))(Tile((id \
          f90dca72-17b1-4b7e-9ba4-91b8e722c29d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cef3d0e3-68d0-4d88-95bd-ec884bbe0198)(content(Whitespace\" \
+         \"))))(Tile((id \
          be26c25e-6245-4b11-85d7-8ca4e97058b1)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9871d9bb-df3e-4506-9def-1d9bf654548e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b3b38b6d-d039-4bb3-a61e-31592af55882)(content(Whitespace\" \
-         \"))))(Tile((id \
+         78a456a1-41e7-43db-bece-422860bb815f)(content(Whitespace\"\\n\"))))(Tile((id \
          6f892983-7448-45f3-986d-8bfc31d51703)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d06cec1a-9b7d-4e8a-93c9-0598ea003574)(content(Whitespace\" \
+         \"))))(Tile((id \
          8b9f9fe4-c651-4081-8dd8-7464ba613619)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         59a5ed26-0a05-4ad7-b382-2da273819667)(content(Whitespace\" \
+         \"))))(Tile((id \
          a35eedb3-da6a-4bda-a086-9daff3e75125)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          fd3ae907-d9b8-409e-80d9-b113d3ec362c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a3034ea7-f3df-4faf-b50e-5d661fe95d5c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         02264361-874a-4b9b-8bfa-75221409348e)(content(Whitespace\"\\n\"))))(Tile((id \
          62704cad-8691-4830-ae0e-c9ca3ac6170e)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6ab9bd8d-9b79-4d96-83b9-43280123b5a8)(content(Whitespace\" \
+         \"))))(Tile((id \
          ae1b1bcf-c1a4-4110-8c50-a2f0a2e680ab)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7ee2f12b-0e1c-46da-9255-f5a56e520de7)(content(Whitespace\" \
+         \"))))(Tile((id \
          f1632811-5c2a-42fd-8651-26673ad8611d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d6a08d18-4bd1-48aa-ac9b-5ba5f3d6696a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ddd45734-aa99-46d8-9f72-60e4e3a54533)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3dc73227-05e1-4391-982c-c8889422d516)(content(Whitespace\"\\n\"))))(Tile((id \
          eb57bdf2-7e6b-4bc9-97fd-16cc36f9c16a)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a6e39dd1-f38e-4730-9e67-fd95e7893598)(content(Whitespace\" \
+         \"))))(Tile((id \
          5ac31796-96bf-4dcb-ab45-2835d24e15b5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         420e8f66-f239-45fe-a1b3-d3f7c425ce05)(content(Whitespace\" \
+         \"))))(Tile((id \
          063fb663-83e5-480e-b20f-b3544acb08c8)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e198f40a-8132-4b8f-b5ea-b5726bc08b54)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         55715404-6dc4-4aa1-bd26-7df52a1c4c30)(content(Whitespace\" \
-         \"))))(Tile((id \
+         7296acfb-2d03-45b8-8a17-4a19ba5bbd46)(content(Whitespace\"\\n\"))))(Tile((id \
          1c3d0f83-fbf3-40d9-8285-496105367a18)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         40aa922f-4868-40fd-bd6e-6c6a9e43ff13)(content(Whitespace\" \
+         \"))))(Tile((id \
          6e90cd59-bb10-465d-b053-b3b3ab29bcc7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cd4ebe98-d3b6-4739-b12a-5a4acf6161aa)(content(Whitespace\" \
+         \"))))(Tile((id \
          091e7083-5276-4853-ae76-fee563a0f41c)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          41c39a62-4d15-43bd-baa0-adf9261431b1)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dc90f014-9643-4a48-8ed7-095e255b08aa)(content(Whitespace\" \
-         \"))))(Tile((id \
+         a1351e06-89e2-47e7-9647-44cf0f0b61f5)(content(Whitespace\"\\n\"))))(Tile((id \
          c2b8f1d5-f57d-4b1f-9a61-2d6391a25168)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         23b30e2c-2e45-4efd-9477-2913a1684a3d)(content(Whitespace\" \
+         \"))))(Tile((id \
          d44d07a9-8edf-450e-9302-50f841dd235a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6bb37865-9d82-42c2-ac83-5cdc6a948471)(content(Whitespace\" \
+         \"))))(Tile((id \
          7958b0aa-99e9-44ed-9fc2-590c58a53bb9)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          247308d3-69f1-405d-9df7-b3e7475d852b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a3a86a41-cfd2-4253-bae9-8ffdb97529f9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         890da33b-1e67-4c67-94a1-d5f77afaf783)(content(Whitespace\"\\n\"))))(Tile((id \
          8305670a-b85a-4004-afe1-1afaa04af0c1)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9d82d93b-55a5-4618-b5fd-295a2c018fc7)(content(Whitespace\" \
+         \"))))(Tile((id \
          8fd4cc95-c2bc-48c7-b223-522c64eac578)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         05553338-1420-4587-ae3d-4b14518ed86d)(content(Whitespace\" \
+         \"))))(Tile((id \
          052f5be4-c3ae-4b88-803b-d9f5910fa26c)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5260560e-eb44-46ef-841d-cdab663cb8f9)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         daa9e6aa-a371-45a8-b430-ef110aef60b6)(content(Whitespace\" \
-         \"))))(Tile((id \
+         15cb618e-b0eb-4c9a-868c-51d2a4408ffe)(content(Whitespace\"\\n\"))))(Tile((id \
          f4788c16-404e-4482-bb33-6da7c1ba4f33)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b8e0b857-c317-41b9-af6f-50245242b926)(content(Whitespace\" \
+         \"))))(Tile((id \
          ea1cffbf-0a1e-4a31-9372-6cd4318180f8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b7789fe2-47e2-43e6-a325-86d01a557903)(content(Whitespace\" \
+         \"))))(Tile((id \
          d32becbb-1ea3-4a53-80b2-fdfc76e2d95d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e6e03a0c-4aa8-4924-b2d9-99c0163474e8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         eba75c98-6c5c-4222-9bc3-ade813f63aec)(content(Whitespace\" \
-         \"))))(Tile((id \
+         16986597-a590-4e8c-a877-8d82a440460f)(content(Whitespace\"\\n\"))))(Tile((id \
          f3e80db4-7c30-411d-ad4d-7d8e5f578f12)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0838e22c-9a43-4946-a92d-07e73bdc08b4)(content(Whitespace\" \
+         \"))))(Tile((id \
          fb587cc4-8633-46e6-be7b-53b28de01a5b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6baea21d-234d-4399-9e43-389a96b3bbec)(content(Whitespace\" \
+         \"))))(Tile((id \
          57863a2d-0784-45a4-81a4-18b554c5dd27)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7e355335-2891-4e6d-ad73-620f77101068)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         91d1d47a-3bf9-43a1-98c2-e7514a7697cb)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         871113d0-4466-4e0c-85aa-7b1b64b7f3cc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         201705b7-f088-4c58-8e6c-70eb7a3a29ed)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b5360d51-05e8-40de-8ea6-b30d7749b3cf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8656738-1ab5-4672-b843-dd17cd2a2a0b)(content(Whitespace\" \
-         \"))))(Tile((id 9aa44ac2-2dbb-44b4-a9c9-7ec8ea576480)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         0ad9cbdf-7625-43e9-bc03-8f35535beae0)(content(Whitespace\" \
+         58988ac8-2cce-424c-a246-e0c34d6fe3eb)(content(Whitespace\"\\n\"))))(Tile((id \
+         9aa44ac2-2dbb-44b4-a9c9-7ec8ea576480)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         8ef2429b-8555-494d-8b1c-5aee2c75c9f5)(content(Whitespace\" \
          \"))))(Tile((id \
          e7ebd571-b486-4daf-ad8b-3bef88476b11)(label(jellyAnon))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3a34191a-aa2d-44c6-ab49-6fc3cdfee1d1)(content(Whitespace\" \
+         b267eab6-7412-43a2-b97f-f642eeabb28f)(content(Whitespace\" \
          \"))))(Tile((id \
          a1dbabc5-d97b-40e5-90d4-4ec968509099)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c4888b7f-3b11-49a1-a46f-2df8051ae825)(content(Whitespace\" \
+         d4ad7c36-389d-4cf7-85d6-398a098771c0)(content(Whitespace\" \
          \"))))(Tile((id 015138c4-8861-4f0f-a7cc-e5631d6c7552)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          c709aa1e-9df5-43a0-9228-5e0ac259fc9e)(label(JellyAnon))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7442d466-4eec-47b1-8143-352e4ef5c478)(content(Whitespace\" \
+         2a83284b-42f0-448f-b939-14587742912d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0731e3e2-fec6-4e6a-a4a4-9295e152f2c1)(content(Whitespace\" \
+         8a230b9e-aede-47c5-b0c4-c54cae8f5329)(content(Whitespace\" \
          \"))))(Tile((id \
          d6faf01b-c3c9-4fd8-be10-dc10e921f428)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         d4e3a671-de70-460a-abd5-a0a809685e4c)(content(Whitespace\"\\n\"))))(Tile((id \
          f57573b1-9c96-4140-84ae-d1c8a1dbc26b)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         2ff9d5ca-c3c7-4d9d-b752-70a80c915fc0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         476d2dae-cf13-4173-9919-29af1fec8d09)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2cbdf98d-db54-4cd6-a31e-5202d9c96916)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac2f4d4d-04b5-412e-afdd-4f656689e2e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f513136-06d0-4720-9fa2-e3070309a7b5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         cb89e867-12f6-45aa-aa98-950a1c9bc82c)(content(Whitespace\"\\n\"))))(Tile((id \
          9272abe6-da11-4272-a3b5-074e404b6925)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -325,15 +343,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          da1154b9-ee05-4a10-937d-b0c32708646f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4dc035bd-bf4f-4960-9563-46708ffbd047)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b779f344-67d2-4922-a136-c10f07dd76c6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5075b085-14d1-426e-9ae0-cdac3467877f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de21ca49-b5ed-4a13-b0b2-aad72e60d844)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d787cb7-301f-40e3-aab2-6db0a20bba09)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0230a996-a646-425a-bba8-469ce62f72fb)(content(Whitespace\"\\n\"))))(Tile((id \
          ecd666a6-d5f3-4261-a586-51086b7f5c04)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -445,15 +455,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          63edc423-c13a-40b0-8e74-72b90dec2e95)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f40a7bf8-a944-4a10-8f30-29d250cb895a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c24eecbe-c6f8-4861-b86d-fcdb236bf9bd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ca78cf48-0dad-4124-8d70-5b9493832d5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0794cbc1-b08f-4d36-af72-eb04dcedff05)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0c1b2de5-fc08-46ff-9dd0-941635fd44ed)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0e92c123-2611-4722-8bbb-f0d0fd0240e1)(content(Whitespace\"\\n\"))))(Tile((id \
          72adbd16-b6f1-4450-84d1-9fe9b384f8cd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -565,15 +567,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          38f398c7-01b8-4407-8e29-3aab2d890f8f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cbbf210e-6d47-436d-852d-b4cec77e9115)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c232bd10-8cb7-43f9-992c-f1b9cdf42650)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e6adf126-6931-4cc0-a69b-3980b0a28fa7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc89be94-6151-4cb7-8272-60e316599e92)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1242f2f8-05d6-416f-9791-92f4978fa1a2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         a50a514b-076c-43ef-a884-e7459ed227c7)(content(Whitespace\"\\n\"))))(Tile((id \
          f5405475-18e1-4750-98d7-3f8ee7e8b813)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -685,15 +679,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6321bec8-24be-40a6-a4b7-87838908c0af)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         767ab625-4a92-4915-94d7-9307c828dd07)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0cee4af1-3469-4fc5-9449-b93087930091)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1bc0ad9a-abf6-4329-82e8-f27651f48136)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fdc80afd-ab71-4b87-a443-73e292867171)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8be79660-ce51-410e-9aaf-b6ded481897a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9beed718-e5db-4aa9-9ba4-18584350d692)(content(Whitespace\"\\n\"))))(Tile((id \
          1fd4d93e-af59-40a3-9a5a-ec6fe7bc0dd9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -805,15 +791,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          70dd7294-f83d-49d6-a899-cda40ea523ae)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         071e0e09-73fa-4425-a990-c04e59954d41)(content(Whitespace\"\\n\"))))(Secondary((id \
-         14b0c641-3fff-4f9a-8420-b747c842dcda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb4305ba-3dfa-41b7-9df8-efe87acb3b13)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1925ad33-150b-40a7-b4bd-43553f69d09c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4ab73600-6a54-4a62-ae8d-64ac4b1f9ad3)(content(Whitespace\" \
-         \"))))(Tile((id \
+         bce34571-5c12-454c-8afe-6c5e34a7d92c)(content(Whitespace\"\\n\"))))(Tile((id \
          70d2390a-5805-4e60-b221-52ffcb19c69f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -925,15 +903,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          24438145-356e-4a4e-a92a-af0e355dcc21)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8c226fde-f599-4676-836a-038830b82798)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c11e9271-0ef4-41ee-b715-d886b7301d52)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e8d65e9b-f5cc-4e15-adab-f7fbbb2fbf91)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         66cb56d5-6575-4793-a3eb-061bff74ad2b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9234455-ebc4-4297-b394-b755deabb8d8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ad219ca2-e130-4cd8-acf8-7f7efe44ec83)(content(Whitespace\"\\n\"))))(Tile((id \
          692f9f8b-8881-4b8f-9f48-0a58870a6ee8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1045,15 +1015,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4e3751bb-365d-4724-9495-c1e98ec6f000)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7a2c451c-0468-4af9-9911-cd1366ed4c8c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         39515125-fbc6-4602-b8db-33d64fc3aac2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         98330c66-0940-4bc7-adad-24e21f4c5c83)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         920cdab1-fa7b-4407-a4c1-c7000478ae05)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9623d15a-e444-4c25-928f-ccd5d93c23e2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b47561ee-6610-4ea9-8cf2-473b017a3996)(content(Whitespace\"\\n\"))))(Tile((id \
          61b358c5-09ad-478b-b721-353d32874f8c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1165,15 +1127,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5c30b3d1-2b9e-4752-a4d8-71c92a084dae)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4bd10536-c71c-44fb-8c56-81c9dc2ac857)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b1704c22-edba-4353-9bee-ad24bfff6366)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea10dafc-a192-4d20-b98c-93579805ebeb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8db6a020-7d52-4550-8825-c3f574e26e30)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a754e3e-4a00-4bb5-b8b1-831edb54b1c8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f15c8507-b9e6-4c59-a225-7a4a3965d1cc)(content(Whitespace\"\\n\"))))(Tile((id \
          429058f2-cb1f-441a-857b-69c777ca59c7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1285,15 +1239,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3e34ecdb-7453-4a02-9edb-f9bc71079377)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b6ff9b67-53d1-4e72-bc01-c68e70cb805d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         29842151-2446-430b-b298-1c557f369b3e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bfc4044f-fd57-46d3-a891-0d3d91c43752)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8f70169c-e1f0-43df-a480-2a7d11bb4abc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9202247e-6b28-4c1e-944b-3e03e4aff736)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3d2626e8-00d1-4981-b304-fe27419b2d4a)(content(Whitespace\"\\n\"))))(Tile((id \
          9021e652-163a-4292-a0b4-eab795534a82)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1306,7 +1252,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7e36e77b-a073-4260-b61b-ed9a6679c682)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f73da0f9-bf88-4dce-9359-0f02c1d0c260)(content(Whitespace\" \
+         c623ad68-f27d-40d1-82b2-3a359e5f6aae)(content(Whitespace\" \
          \"))))(Tile((id \
          f5e38dd0-9aa7-4920-8dec-750091577b3e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1317,7 +1263,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5d9f59c7-4b3d-46cd-aa95-83d552be0842)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         72ecee9c-99a7-4f1c-a3dd-a0ccd785a101)(content(Whitespace\" \
+         657590be-2966-49a2-bc6d-0103e980ec52)(content(Whitespace\" \
          \"))))(Tile((id \
          b0035649-162a-4d0f-9ed1-0a8b8f0b1912)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1328,7 +1274,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c533bc11-1524-4a32-aa75-97abaa1d031b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         477337bd-4d0f-4afe-a960-2e31e39d7619)(content(Whitespace\" \
+         0019acb2-f8cb-467e-9676-62aca6ba9a25)(content(Whitespace\" \
          \"))))(Tile((id \
          303cf7f4-460a-4822-bf97-20c19795973f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1339,7 +1285,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d567e75c-d5cd-460f-a45a-90ef405160c0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6db6bbfa-5f64-4b2b-a694-b1b0ffe34250)(content(Whitespace\" \
+         a0500841-a6ad-4e09-8e3b-8ea1f6a60fc9)(content(Whitespace\" \
          \"))))(Tile((id \
          608ffb99-2238-445b-8f74-f318d68d7e72)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1350,7 +1296,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1352d7e0-27b0-499a-a55c-92fe9a20124a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aef7443b-0a6b-40a5-8428-98a566d72793)(content(Whitespace\" \
+         59e64a8b-78fc-456a-822f-4fe576653a00)(content(Whitespace\" \
          \"))))(Tile((id \
          e9609bcb-e683-4a75-944d-eb1a4af7738a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1361,7 +1307,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fcca7ef6-e687-4f6d-bcc1-632f75731fb2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c00f5ff6-201c-4695-9dea-39f79214d750)(content(Whitespace\" \
+         d36cb6ee-08a1-456b-be4d-e46c13e6816a)(content(Whitespace\" \
          \"))))(Tile((id \
          19308068-bbaa-4b7f-aa8d-fce70690160c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1372,7 +1318,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          22b1f1f5-bf9e-45f1-96da-2ddcba7cba3d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0c407e8d-ac5b-4571-a1fe-3ba2ee2b3891)(content(Whitespace\" \
+         4447ad02-d662-40a3-bf56-9ca0f0c7d049)(content(Whitespace\" \
          \"))))(Tile((id \
          5911edd3-2abf-49fd-9e17-74a8742bf228)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1383,7 +1329,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          010a3c82-90e9-4c19-8404-d21ca39de6ec)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ceeda763-c834-44e0-ae8e-dab2330ba6bb)(content(Whitespace\" \
+         60a53f16-3525-4332-b157-c0ee481958ef)(content(Whitespace\" \
          \"))))(Tile((id \
          de34af20-c188-4309-beaf-60c47bcc344f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1394,7 +1340,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a8077132-5f74-4531-8aab-fb4b7a841d7c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         015ac059-e587-438c-b2e2-2b496800b7be)(content(Whitespace\" \
+         ce0acc3b-3401-4aa4-b633-2d0e4f48d55a)(content(Whitespace\" \
          \"))))(Tile((id \
          7c1ea196-2e05-4718-8bb3-41c8dad1f6af)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1402,66 +1348,42 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d846fc8e-1ac1-4b2d-a481-0d84dfebf499)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         ebb22c91-c5e7-4680-9a47-47ba6bf613f4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ef6971e1-04fd-46bd-852d-f9d9df7477d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7276251e-8f8b-4f68-9ec1-b26dfc0cd431)(content(Whitespace\" \
-         \"))))))))))))))(Secondary((id \
-         6e38dc06-1bc4-448a-9735-733a6d9237e4)(content(Whitespace\" \
+         e9ba4135-9fec-4ee3-b0e9-e7e44ddac102)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c39020ee-9330-4753-8f75-1ad850e05ba4)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         680b79a9-73eb-4169-aff4-f508a31584a3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e5494cf9-3dcc-4f3f-b93c-bd59c273847d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b304ecc7-e4ca-4841-9459-00b74d4336a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0a74760f-bb08-4be1-af49-9f38be58567e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e24bdd11-186a-4b2c-9e8a-985b1333bc75)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a2ec1026-f3cb-40f2-a03e-71275a0f3cd5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c9419296-e7a4-44cf-b44b-a1da148ac67c)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         c4e79961-f2f7-4df2-a54b-f61f4ca58d7e)(content(Whitespace\"\\n\"))))(Secondary((id \
          0e79489b-e35b-410f-9979-e55280453189)(content(Comment\"# Version that \
          uses string params for the column names gives no static errors \
          #\"))))(Secondary((id \
-         2a357105-cab7-4d7e-8d50-883fb82ad2a0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         915fecc7-08dd-4c9e-810b-cf1d38e61ab6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         487892d9-b438-4c45-b641-e13a13a6278c)(content(Whitespace\" \
-         \"))))(Tile((id a898c785-f357-4472-b988-2414f1d524da)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         1868ab58-3927-4376-954f-89e92842dcf7)(content(Whitespace\" \
+         b28492c4-6e82-4f12-a548-78ef5a7ed158)(content(Whitespace\"\\n\"))))(Tile((id \
+         a898c785-f357-4472-b988-2414f1d524da)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         eb175882-45f3-4a62-a1aa-caabf64a6036)(content(Whitespace\" \
          \"))))(Tile((id \
          397fef04-9aac-4a55-8dc4-6af4df1777ae)(label(v1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a4448a81-f037-46ac-ae29-f4fd015e1379)(content(Whitespace\" \
+         ed048515-bf98-44cf-9911-eeeb1a921600)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f2461d97-9b44-4333-b153-4e96fbc22fe0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c0265e7f-9e4a-4c09-a01e-04472072b9aa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e7d79d2f-d1a4-4f2f-9d0f-807303c3a0c1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9be6975a-cce7-4986-9d8e-20f9fa039353)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dea94f9e-8371-4498-b9e7-50a7243fdcec)(content(Whitespace\" \
-         \"))))(Tile((id 85c3a187-b026-492b-a3b4-0ec7140ee9a5)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         40cc7ce6-63ca-4a8a-9dbc-f802780830df)(content(Whitespace\" \
+         f6e35058-0420-4868-8a98-205cdd9db5ca)(content(Whitespace\"\\n\"))))(Tile((id \
+         85c3a187-b026-492b-a3b4-0ec7140ee9a5)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         8cf978b4-9d85-4abf-94a6-e1241240f038)(content(Whitespace\" \
          \"))))(Tile((id \
          3970fb20-b648-4cb8-905d-330a4fbbf6a8)(label(get_value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0abaf25c-020d-4a1e-ba80-72b153571319)(content(Whitespace\" \
+         975b7762-5511-4e93-b6cb-0206e46f10b4)(content(Whitespace\" \
          \")))))((Secondary((id \
-         26a04e20-1d0a-40af-a472-a4943ed8ead0)(content(Whitespace\" \
+         0abcc355-8fef-4472-aa54-6cd46e9a7755)(content(Whitespace\" \
          \"))))(Tile((id 4987b28d-0b10-416b-a308-c7d2619817e6)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         181e1395-dfbe-4510-93a4-d1755dc4d336)(content(Whitespace\" \
+         365a5d0d-23dc-4a40-8ccf-29a430cbb101)(content(Whitespace\" \
          \"))))(Tile((id \
          e1fa2e94-39db-45c3-ba0c-fd85f7bd2c71)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1471,20 +1393,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          3884d727-4ce9-4f71-bbdd-29ae8456a569)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         3e22f2f4-7b3e-4868-b3ec-1cb0b27e8c64)(content(Whitespace\" \
+         \"))))(Tile((id \
          443c732c-86c5-4517-b47a-a67445c2313d)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         bee23079-62e6-4fa1-9b85-fd14836f0651)(content(Whitespace\" \
+         1bf6720f-4a0b-45ba-96e3-04d676ed4aef)(content(Whitespace\" \
          \"))))(Tile((id \
          8768d15b-0f5f-4c9a-a27e-53e6561b576b)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2af5837f-e97b-4985-90fb-d0518aeccd83)(content(Whitespace\" \
+         \"))))(Tile((id \
          bcf4a71a-f633-4ce3-b6de-099ad795b41f)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a3d29dad-cdc3-4b42-a25e-3aa2a957e4b0)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         5536b30f-2a80-45cc-bd23-279a520fae31)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         0c086586-ff18-4962-b837-ceefba800f05)(content(Whitespace\" \
+         \"))))(Tile((id \
          b8d00f01-3828-4bef-b9cf-59e560899a0a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1497,11 +1425,13 @@ let out : string * Haz3lcore.PersistentSegment.t =
          087ba126-553c-41f0-984f-38ecc382c943)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         2c2f4672-4e33-4605-aba5-79634288eef0)(content(Whitespace\" \
+         375f0a84-9bcf-4547-8e0e-7e8fe652feba)(content(Whitespace\" \
          \"))))(Tile((id \
          189aac7e-6870-4f07-baf1-8d597a0c0ab7)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a84fa0d2-48ef-47d2-bed7-22ec2ef8b2a1)(content(Whitespace\" \
+         \"))))(Tile((id \
          a387a06f-2f67-4de6-a367-69b71f051faf)(label(find_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1513,56 +1443,68 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          069611fd-8f68-476a-8f46-8318c2b655e3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         177f3596-a2c5-410a-9456-af5882986ddf)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         892bf3a5-d9fc-4f86-9e10-35fd8a1ced4c)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9279ca49-173b-42be-8bb6-127d0a1cdc52)(content(Whitespace\" \
+         \"))))(Tile((id 177f3596-a2c5-410a-9456-af5882986ddf)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         8d91cf47-a3f3-40c0-a61c-0aa215bceb69)(content(Whitespace\" \
          \"))))(Tile((id \
          d2a10604-5278-4356-ae79-d95703bffd41)(label(label))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         544530f3-e1d8-41f8-ac44-eb22e2da668f)(content(Whitespace\" \
+         \"))))(Tile((id \
          7b16378f-8e05-4530-975f-876c4ffa5799)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         62d07d1f-f3a1-4fad-8a5e-813da7c00564)(content(Whitespace\" \
+         \"))))(Tile((id \
          4d195e5f-4073-402d-87ea-30e3bb97a7eb)(label(l))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
          be380bbf-3f03-4a0a-9e0b-5344f3de1cb9)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         0382323a-c4d8-47f7-bbce-eb360d80d34e)(content(Whitespace\" \
+         b15b4f93-3315-43f0-8580-789d908e2a67)(content(Whitespace\" \
          \"))))(Tile((id \
          dba13046-7b14-4f3e-8250-be28d26b1c8e)(label(value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6c17a3f6-790b-4dd9-8166-b564678d2493)(content(Whitespace\" \
+         \"))))(Tile((id \
          9cffd788-d9d1-4eb1-ac3e-b66d5f92e34e)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         8e2f9dbb-507d-4ae4-ba96-fc0a7bdc70ca)(label(v))(mold((out \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         e4f27497-1bbd-4f62-a73d-c0a5a14fc891)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8e2f9dbb-507d-4ae4-ba96-fc0a7bdc70ca)(label(_v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ffe1f128-ef74-4244-83ab-5ca30e3f817f)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         51b93b67-90de-4a35-9bc5-f63ddcba4a2e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         bc0cad84-62cb-4ad7-ae58-b5d56c9371d3)(content(Whitespace\" \
+         \"))))(Tile((id \
          2984ccd3-296a-48c7-91bb-c1929f23214c)(label(l))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         42a28135-1b9a-4da2-ba77-822a5b4d6635)(content(Whitespace\" \
+         df54b516-41ce-4a8a-b39f-f283e9fe3000)(content(Whitespace\" \
          \"))))(Tile((id \
          11158787-65f3-4f34-9fbb-09dfefecfe1c)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         62efe16d-db0c-46f8-9e70-9b63005d19d4)(content(Whitespace\" \
+         c2a6fdfc-7844-4274-a39d-5b593a09b1be)(content(Whitespace\" \
          \"))))(Tile((id \
          598dbab9-fe6d-458c-9318-fada57de6edb)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         cc4eab9f-2960-4e67-9e21-b6b6509cf280)(content(Whitespace\" \
+         649d58d2-777c-4ae7-b77c-2aed9fe1a150)(content(Whitespace\" \
          \"))))(Tile((id \
          ecfe520e-c7da-4171-a85f-93e908ef95ca)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d15896f5-337e-4ee0-a6f7-5d481c9e2194)(content(Whitespace\" \
+         bd480bb2-30df-414d-afe0-3d4ba5d0a0f2)(content(Whitespace\" \
          \"))))(Tile((id \
          059ad488-2a23-4abc-98c3-6d535e3c67e2)(label(option_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1576,18 +1518,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4bba25a5-94bd-430a-9a60-6ec58ac2563e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         818cc689-634d-46ec-aac2-4e15d58c01c4)(content(Whitespace\" \
+         10abe728-ec8f-4035-988f-29c157f6ade9)(content(Whitespace\" \
          \"))))(Tile((id a2100e47-9656-47b3-8a9b-9a0bc48fdc58)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         05cb3632-b3c6-4aed-9bbd-82cf210eb44b)(content(Whitespace\" \
+         a0c676d3-2588-43a8-98f6-ef7102909e7e)(content(Whitespace\" \
          \"))))(Tile((id \
          e2101beb-030c-43cd-9255-f3cf3e99eacf)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         37e35d60-4263-4a2b-8e2d-8e8e782ad8e0)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         c908fb67-9a21-476a-a900-53595101509f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f82db5c2-653a-4274-a2cc-9e8605790542)(content(Whitespace\" \
+         \"))))(Tile((id \
          be689e7e-a163-47bd-a290-dbc638240127)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1597,103 +1541,79 @@ let out : string * Haz3lcore.PersistentSegment.t =
          537409b5-62a8-4089-a617-149d1026564a)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9d862a9f-08b2-46b4-a476-d62ec7aff616)(content(Whitespace\" \
+         3bf468e5-e3a3-49e8-89ae-3575d7d59b39)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4220c89c-7c65-4c9d-a238-052670515f2d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         96e2b4c3-3c40-4cb3-af66-94f7983df69b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         52993d8e-6431-4459-8173-e25e49d77cf4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c1b3132-264a-42ba-a65d-c642dee9b7ea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         387fc8d9-d840-459b-b97f-0a7429ac4d67)(content(Whitespace\" \
-         \"))))(Tile((id 40576cb6-7884-45ba-a39a-3060c93af15e)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         76bc56a2-38cc-4780-93a6-3e64c67f6d8b)(content(Whitespace\" \
+         ae70978c-f68f-4125-b60d-c599b1a71bd4)(content(Whitespace\"\\n\"))))(Tile((id \
+         40576cb6-7884-45ba-a39a-3060c93af15e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         76437967-0b1c-4fc6-beb7-af62cef79db7)(content(Whitespace\" \
          \"))))(Tile((id \
          95d6df9c-1399-44f0-bb54-4bc11c41a0d5)(label(nrows))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f5c3224d-32de-4063-903f-5e3903f755ba)(content(Whitespace\" \
+         0dc0e1cf-d4f9-4ce0-9c0b-9c7ecbb11ec2)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d15616ce-8c2b-40e0-bb66-7b018a44f07b)(content(Whitespace\" \
+         ef775a66-af00-4228-a2dc-114ef70e15b1)(content(Whitespace\" \
          \"))))(Tile((id \
          48c0c722-a23a-49bc-837d-19be4d6cb5b2)(label(length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         bcce1baa-da7d-409a-ba69-6bfb8a60ea6f)(content(Whitespace\" \
+         668979c1-758a-432c-851c-32cf283aa13d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fe0aaff0-aaf4-47da-982c-246147506eec)(content(Whitespace\" \
-         \"))))(Tile((id 5aa1d816-c94d-4042-aede-ff75b016f0d0)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         bc941d31-851d-47f5-a3c8-96b5d03e3fe6)(content(Whitespace\" \
+         a448361e-451f-4ee9-b1e3-d19b09606d77)(content(Whitespace\"\\n\"))))(Tile((id \
+         5aa1d816-c94d-4042-aede-ff75b016f0d0)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         256e1a5c-b986-4eed-b611-a19340b8ab3b)(content(Whitespace\" \
          \"))))(Tile((id \
          931a0fa0-7238-489a-8cc0-971b009628f0)(label(tfilter))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         76b8a68c-b710-43de-aa0a-61aa03854e4e)(content(Whitespace\" \
+         44582d31-bc5b-4ee4-9426-69cb274543bd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c5a306d0-7ad1-40c0-9c3b-f442b7bb587d)(content(Whitespace\" \
+         3922a6c1-c705-478b-b42c-a28ea81fb418)(content(Whitespace\" \
          \"))))(Tile((id \
          30eb55e2-2da3-48d2-853c-88c62e0224d5)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         13f31f36-df89-4233-a7b2-57806a06172f)(content(Whitespace\" \
+         92453d80-691a-4aa5-a094-4acd87497072)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9c724e7b-4e91-4af8-a8e7-f04316d2ff60)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d0bbe84-0294-4620-9107-a57340993351)(content(Whitespace\"\\n\"))))(Secondary((id \
-         51efdac1-fc80-4c3f-9410-95294e9ef06f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c6740077-cd80-4a04-b36b-e94976f487b0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         979afc3f-e2c0-4b96-b5a2-e84676cf34b2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         16335820-1441-43a6-aaa3-17b4e48da19f)(content(Whitespace\" \
-         \"))))(Tile((id b450f4ee-7145-4631-bdcf-31db0268bd0b)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b8fa9ddc-b55b-4cf1-a15e-1175ccd3029f)(content(Whitespace\" \
+         9ebde291-4578-40e5-83e0-5dbb749d72a7)(content(Whitespace\"\\n\"))))(Tile((id \
+         b450f4ee-7145-4631-bdcf-31db0268bd0b)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         2515f6ed-b2de-498a-9b0c-38b78607027b)(content(Whitespace\" \
          \"))))(Tile((id \
          75c1fbc7-4c4c-463c-bdc5-df4cc43b409e)(label(option_get))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         61a85475-f5eb-4198-ac2d-ad5ebef48a61)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         20879f18-fc06-42f8-863c-683c9557ba2c)(content(Whitespace\"\\n\"))))(Tile((id \
          fff84bc9-831c-4026-8c46-1c2122c6aa5e)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a364c7fb-dbc7-4a8c-a31c-1944ab0c2764)(content(Whitespace\" \
+         0e42e7db-a12f-4120-89b8-5a6f7902d139)(content(Whitespace\" \
          \"))))(Tile((id \
          a086be74-4fbb-4521-8ceb-191b819344bb)(label(o))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c54755a8-3054-4e71-b409-78dded73b753)(content(Whitespace\" \
+         4a9f7179-2d21-4045-8fab-9ff8f3f03cf0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cb665fd6-bbd0-45c7-a60e-64c7a3001e64)(content(Whitespace\" \
-         \"))))(Tile((id eb8d6164-6e78-4226-9c51-8fa004389711)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         1954dad7-f6c8-4447-ae45-a85476a30feb)(content(Whitespace\" \
+         563a9fb4-e468-4a04-98bd-c9aac33fe3c0)(content(Whitespace\"\\n\"))))(Tile((id \
+         eb8d6164-6e78-4226-9c51-8fa004389711)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         31799eaa-1302-475a-b1af-4024eeb0461f)(content(Whitespace\" \
          \"))))(Tile((id \
          238b2047-3900-4ab9-95d0-53f8fd01a522)(label(o))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         db83a912-6bc9-4ff5-aa55-4c39a542fb05)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6a80faa0-f04f-4e5c-a91a-80f2d81bb959)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ed3eaab9-7139-4fca-8b8a-780beb01f732)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         39e73737-9038-4642-a2b6-11ebeb407a52)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f13d87c4-5556-4ffb-8f13-68132b90677e)(content(Whitespace\" \
-         \"))))(Tile((id 80e18905-ee4f-4529-893b-f9d00d3c7602)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         eb39260c-a493-4ee4-9e89-7c601f033326)(content(Whitespace\"\\n\"))))(Tile((id \
+         80e18905-ee4f-4529-893b-f9d00d3c7602)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          e5f4bf53-0e13-489b-aed1-2d6afab3ef46)(content(Whitespace\" \
          \"))))(Tile((id \
          d1586529-fb04-4716-a37b-9ee2228c2c8b)(label(Some))(mold((out \
@@ -1707,84 +1627,49 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          d8a38ddb-59d2-4d75-8579-478d33937f91)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b078a342-93a0-4772-a82c-c4c471e44981)(content(Whitespace\" \
+         9a75a979-fcdf-438c-86f5-6b1e1571d963)(content(Whitespace\" \
          \"))))(Tile((id \
          e56a0b0f-1068-44a1-8c5d-6a61557f5c64)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         96b47f0d-6f5c-45fd-bcc1-1dcbe62248ff)(content(Whitespace\"\\n\"))))(Secondary((id \
-         24a225b4-1a76-4d1b-aa75-f5b4f66070be)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8eacd11f-520a-4b69-94ab-818d704eb6f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b864471b-5bcd-4ce6-8a45-1d73ca365888)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7049453-1dde-411a-a232-e6591f13e292)(content(Whitespace\" \
+         5e469776-07e5-4130-a00e-6cae3ec7f24b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c31ab7e4-cb08-497a-973d-25a56b16c9e7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f0bac898-b9b8-4d6f-b81c-e9cc9354c685)(content(Whitespace\"\\n\"))))(Secondary((id \
-         93bf8f9f-81fe-437c-96eb-ddc7372bdd64)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5d87d3bc-c443-45c5-b772-b757313bd48d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         51adf25a-f352-4cf9-81ab-41daa2677095)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         60c9095a-cdb0-482c-887d-f3cb8fec57aa)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e58063f0-c750-4174-97d1-d190b4b37f0b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9568637d-28e6-49bd-96af-5be4bc534015)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         85b44c00-c906-4939-8c7d-123436ff9010)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1f482f8f-36c7-4741-9a10-aeccc80b5c49)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a440bce9-c2e5-4129-80fd-099eeeddcac7)(content(Whitespace\" \
-         \"))))(Tile((id 58fedc5a-49fc-4950-9e2b-e29b9e28b664)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         cbdc8a1c-89f2-4268-a49f-6d559c786711)(content(Whitespace\" \
+         87729f4f-4436-43f0-bfe0-7a99938f3605)(content(Whitespace\"\\n\"))))(Tile((id \
+         58fedc5a-49fc-4950-9e2b-e29b9e28b664)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5d4a0c22-9633-42e8-b659-0d7b8946bb07)(content(Whitespace\" \
          \"))))(Tile((id \
          c36de456-96cd-4d70-b165-e353d4f17471)(label(incorrect))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5ee0f720-7e11-4f9a-bf71-4221223a977e)(content(Whitespace\" \
+         3c5cc71e-84fe-4e22-bb5f-dc8951561533)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e5d33b87-66c1-4fc1-a9b2-cfc6011e8ace)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b6d2c285-4c2c-45ad-90a7-db33583c4b14)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ad843c0c-11ee-4419-96a8-ce4846fef7c4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b1cd146-0d32-4960-804d-65433204806f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         15c94e9f-92b4-4d09-bac6-b705f78b6c47)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d2badedc-38b1-4e5f-81c3-caab9da59a8b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4a12bded-5d64-463f-9c10-48738651d542)(content(Whitespace\" \
-         \"))))(Tile((id 17543078-7dc3-4f9f-91e4-dabc579900e3)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e6c4fba7-153e-4f81-b3b3-c35087130865)(content(Whitespace\" \
+         3eb1f275-a7d1-41ac-bc12-48b8145616c8)(content(Whitespace\"\\n\"))))(Tile((id \
+         17543078-7dc3-4f9f-91e4-dabc579900e3)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         2e44b778-d576-4094-b658-cc31805221a9)(content(Whitespace\" \
          \"))))(Tile((id \
          1a802151-203e-4ade-b697-880b0fa9fcb4)(label(keep))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d8ff66b7-0945-482e-957b-6663e80abda9)(content(Whitespace\" \
+         b95a39c8-2a7c-45e0-8c82-2b83a344f62a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f6ced393-fab6-431c-af46-c800c861152f)(content(Whitespace\" \
+         24f922ac-bdf2-4afb-9554-e0162badc0a6)(content(Whitespace\" \
          \"))))(Tile((id 3086d772-bfe3-4e39-b8ce-a21cb2164c59)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         54641d6e-410d-456e-9e35-42edbf48add6)(content(Whitespace\" \
+         31ccbb33-9a18-4878-9bc5-76b509960a58)(content(Whitespace\" \
          \"))))(Tile((id \
          a3e068b9-1e8b-4725-94b7-970a1cb631bf)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         343dde62-b832-42c8-8044-a968d4d0d513)(content(Whitespace\" \
+         3c9b031b-9fe9-4c95-b7ba-718a2fc6d3ca)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         393e8677-2a34-4b22-bb8f-9771e46c4218)(content(Whitespace\" \
+         ce95bcff-c522-4e8c-b2fd-e35284a0ebe5)(content(Whitespace\" \
          \"))))(Tile((id \
          f6d931cf-4c2f-4856-ba49-b6a7399d7e9b)(label(get_value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1798,52 +1683,40 @@ let out : string * Haz3lcore.PersistentSegment.t =
          399da917-2276-4a6f-8a11-3c719754e8df)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6d94b7e7-800f-47b6-9c98-d9a87f8e4d73)(content(Whitespace\" \
+         67c57011-0f68-4095-abda-9d0a0fa4d2fd)(content(Whitespace\" \
          \"))))(Tile((id \
          b6715d9d-9bd1-4099-8387-c3f925d34827)(label(\"\\\"color\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c53d1496-ff4e-4c7b-89bf-02fd34d92e93)(content(Whitespace\" \
+         d3b67d2d-b1a1-4fc3-9b4c-e3821b290f8e)(content(Whitespace\" \
          \"))))(Tile((id \
          10d82935-5da2-49f9-99f8-132c0543e123)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e2b72d03-3213-42c9-b175-2b8632a931e6)(content(Whitespace\" \
+         1d5dbf8b-50ec-41d9-bb4e-191c2ad61436)(content(Whitespace\" \
          \"))))(Tile((id \
          fcbeaba7-697a-4647-98ff-7107343688d9)(label(option_get))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         53945bc4-e13d-4556-96cb-c75b505a96c1)(content(Whitespace\" \
+         cdbc5171-68fe-4daf-8b9f-5a4964bf471f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b699165c-8139-4802-ba8e-bcdcdcdd98a9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3b901172-2313-41eb-a9cb-7b34f8745ced)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e49fbc77-5d1e-4f5d-9769-16557c3814d3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4b39cc97-2267-43b9-aad5-5fec96a9f72a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ef49edaf-de5a-49a3-8e82-37ad112e8890)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ca376bc2-c76d-4330-94ff-3214001f70f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36922e0b-c8ad-4b3a-9a48-bdbc511cfd2a)(content(Whitespace\" \
-         \"))))(Tile((id 350d6d42-3237-43c2-899e-b6e3a4471143)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         1fe3bf3d-39ec-489c-a011-4fb8f4e8adef)(content(Whitespace\" \
+         c8df3e56-e69c-403f-913a-30f649dd3add)(content(Whitespace\"\\n\"))))(Tile((id \
+         350d6d42-3237-43c2-899e-b6e3a4471143)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         8f1f5a27-8dee-4d55-9e87-a5a248fd7c61)(content(Whitespace\" \
          \"))))(Tile((id \
          0828bbf1-5ded-476f-81ce-db95343213ac)(label(count_participants))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b4b44543-c854-4872-ba4c-5c478785bf8e)(content(Whitespace\" \
+         4090dd35-3831-4e9e-8c06-0253999a4ed9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         1523c99d-f0d5-49b0-90db-868cf47cb12b)(content(Whitespace\" \
+         3f538fd7-2994-4e15-b2b6-dd6f8805793d)(content(Whitespace\" \
          \"))))(Tile((id f15eb035-037c-4ef7-80dc-2a240e975366)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         46eb6e36-7f8c-4800-8903-1c41d884f122)(content(Whitespace\" \
+         f161f2ff-934e-409e-8a8c-bf5e9cfb78b3)(content(Whitespace\" \
          \"))))(Tile((id \
          583f84a4-65a8-45d9-9e63-bb1d3fa38c2f)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1854,14 +1727,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a65c133a-db27-4d1f-9f1d-191f0271e360)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         35f4f6ef-2a90-4b0d-942a-0e2920f3dcbd)(content(Whitespace\" \
+         ff9a1c2d-bb6b-4c68-89ba-5ca71fb512c5)(content(Whitespace\" \
          \"))))(Tile((id \
-         b341c488-4c3f-4e27-a0dd-86d2c3e1f776)(label(color))(mold((out \
+         b341c488-4c3f-4e27-a0dd-86d2c3e1f776)(label(_color))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         a92f7a25-0fbd-4154-b13a-7b0efd7c6f95)(content(Whitespace\" \
+         dab68ff3-efd4-4a8b-97e0-540c8708b59b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         92544ccd-a707-4b62-882d-112f3ecd1a3a)(content(Whitespace\" \
+         d124b0db-0343-489e-b5ec-d7efaf34c23a)(content(Whitespace\" \
          \"))))(Tile((id \
          3e01688f-0fcc-4a74-bf59-78dc44c2bff0)(label(nrows))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1881,24 +1754,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d4eca4c3-45a2-41d6-83ee-0fb3879d84f1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         97d87379-3dff-4b44-8657-45d550f78482)(content(Whitespace\" \
+         b00064ca-1f3c-4588-9d29-a9f65dec925d)(content(Whitespace\" \
          \"))))(Tile((id \
          488388d5-0394-4413-a4bb-c0d444f73d6f)(label(keep))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         ee069d4f-1341-4c9e-8ebd-a7e964b8a082)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a20a3c3d-c0f9-4c24-aa19-c3be63f303bd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         24bc3e98-e290-4ce8-9f17-573ced8957a2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         89ea374d-3a81-4969-80e4-1c4e002807c4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         51ef0aec-fcf5-467b-a883-8dba4f2afc55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a93e5271-548f-42a4-8419-b70be46f7a85)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a7122037-b174-4dcc-a4af-f45af631e386)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         37d327fc-8f0a-4813-a737-278d797fc1ee)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f04548b8-3797-41e0-b041-d395373aaa54)(content(Whitespace\"\\n\"))))(Tile((id \
          93d4210a-c089-4585-a5f9-502b6bf94e61)(label(count_participants))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1911,70 +1774,40 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d6c24a51-dd65-4ffc-8dc6-6349de5a47de)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1bd208a6-4e2a-4a05-b58c-4ef38fedef69)(content(Whitespace\" \
+         ecce84d1-1a25-4b79-8f7d-9cd599ca00eb)(content(Whitespace\" \
          \"))))(Tile((id \
          19730ea4-c59d-454f-909b-8375f6daf63d)(label(\"\\\"brown\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         506e3f07-01ee-4511-924f-32886995f80f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         93d04b38-78bf-4c90-88af-a86e524eb979)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c5ba7e15-1c24-4fa9-9745-3592a3feeb00)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ef1e26c7-a3a1-4e89-8472-f80625922244)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         01afab77-56ef-4389-b0f9-0af791b6ae38)(content(Whitespace\" \
+         6f520b7b-1e68-47da-86e0-db5c45a42261)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f6d7108b-9acc-425b-82c1-61417330a042)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a285e013-7d1c-41ab-9907-1f3bae2a255f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         64aa3e41-fc24-46d4-b12c-ca48658d0083)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         919b3e34-9e54-4e40-90f5-20cdef515000)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b1a8d90d-290d-4cf5-8bb7-0b2b9bb2a806)(content(Whitespace\" \
-         \"))))(Tile((id 214acc7a-f607-45e2-bbe5-01f1e2889ac1)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         475d9adc-bd30-44f9-a030-17f4770d5799)(content(Whitespace\" \
+         3e89d7e3-48f7-4842-94ad-d99263f8b14d)(content(Whitespace\"\\n\"))))(Tile((id \
+         214acc7a-f607-45e2-bbe5-01f1e2889ac1)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0d70623d-67c8-4a3c-9e38-c5b814d9cfa3)(content(Whitespace\" \
          \"))))(Tile((id \
          379a56cf-232e-48cb-b808-d9334c8c3273)(label(correct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cc4c4880-ad6d-431b-821f-63c5ea8a38e0)(content(Whitespace\" \
+         75a026b9-17f0-47db-8641-14c6796d4696)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8b45d9f9-9916-4897-b858-004e413216c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f2bde9c-bfc6-43e7-9bd7-eebfdcffe1ef)(content(Whitespace\"\\n\"))))(Secondary((id \
-         559bf9ef-8282-404c-a867-383c41b3cf18)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         217c1def-40a4-4976-9b69-741a53742d19)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8ce38c19-15d6-43d5-b8b2-bce7c7e8b012)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2dd9b309-2acf-4b00-aceb-c6dd68e96dc3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dea92de8-5858-49ff-85ad-923b51365d62)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         11383cc7-3056-4845-bd2f-3b0da391404b)(content(Whitespace\" \
-         \"))))(Tile((id 4260dae3-d22d-455c-bf29-ad64bf62941d)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c22c0ce0-8e39-4fd4-8cb1-afa3afbc6852)(content(Whitespace\" \
+         539c242f-110a-4345-be07-321fc4739d95)(content(Whitespace\"\\n\"))))(Tile((id \
+         4260dae3-d22d-455c-bf29-ad64bf62941d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         17b80ac0-2675-445e-b251-971659b9bbd5)(content(Whitespace\" \
          \"))))(Tile((id \
          4c4e238e-238f-4ffc-83bb-33d6ff9bcaf9)(label(count_participants))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3c339f45-f941-4f66-a296-ba28c818a409)(content(Whitespace\" \
+         5a94c6ff-ee14-4ae8-b700-41240fc809b7)(content(Whitespace\" \
          \")))))((Secondary((id \
-         24b28a0a-605a-4323-a9da-16d0db36efef)(content(Whitespace\" \
-         \"))))(Tile((id b341ffab-137a-43a7-8122-24b04f08d189)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         d56f3d5f-5314-439f-85ad-65d3c23411f6)(content(Whitespace\" \
+         ab5e4e21-8e64-4f68-9279-eda6b54e0479)(content(Whitespace\"\\n\"))))(Tile((id \
+         b341ffab-137a-43a7-8122-24b04f08d189)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         8267f427-430d-43bd-88b1-d1ce9a6a15e7)(content(Whitespace\" \
          \"))))(Tile((id \
          d811fde0-97b9-45ab-9816-f7a6757dba6c)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1985,34 +1818,37 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e55c8f86-0284-4c6a-9b0c-8aaddd726349)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         afb41aef-1e9f-4759-93c3-0b7b5c4f9f7f)(content(Whitespace\" \
+         cdfcb724-53f3-4eea-8cf8-3d9451c7d8f9)(content(Whitespace\" \
          \"))))(Tile((id \
          62f764d0-4138-4440-9777-1416430ca058)(label(color))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         465f269b-76b1-4b97-b92b-84ad374d9ed2)(content(Whitespace\" \
+         9175da91-458a-48fd-8c74-069044d859d6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         733c2251-e948-40c6-bc6d-bd79572d356d)(content(Whitespace\" \
-         \"))))(Tile((id 95f460be-d4f6-49b3-8362-e5dcfb5aeda3)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         fbf576fd-d111-4026-a54b-c77726b4f753)(content(Whitespace\" \
+         7d1557be-b683-4523-af9a-f721ecc27f02)(content(Whitespace\"\\n\"))))(Tile((id \
+         95f460be-d4f6-49b3-8362-e5dcfb5aeda3)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         b909abc4-2ed6-4851-9e2a-82c45b3523c5)(content(Whitespace\" \
          \"))))(Tile((id \
          5eafc703-ce82-4b2f-b097-3a32493c4b77)(label(keep))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Secondary((id \
-         bd245ecd-33bf-45ee-b502-aef464dfd809)(content(Whitespace\" \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c1482811-59a9-4ed1-9d46-af2836d26ff9)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         5c11661f-09be-4b0b-a669-219a2935455e)(content(Whitespace\" \
          \"))))(Tile((id 0b384f88-e117-4d8c-ab83-656a0631cd34)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         4c774504-6a3d-41e5-a04e-5d3d8d4fc019)(content(Whitespace\" \
+         de3df10c-9c4b-4297-9854-b7dcada3700a)(content(Whitespace\" \
          \"))))(Tile((id \
          19c8d396-a238-4bd2-ba6c-bac7b4bb1de1)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         c37260d5-8b9a-4bef-bb0a-6bebfb1c5bb9)(content(Whitespace\" \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c4edd794-2c6b-4305-b400-d22b5d2d97d7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e8b58051-9685-4c38-900b-36b603d14546)(content(Whitespace\" \
          \"))))(Tile((id \
          8d5b68c4-26d1-42ab-a9ac-22538061447f)(label(get_value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2026,25 +1862,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8840bd17-121a-4d4f-8453-0b6042b0feb3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7650b6f5-55bf-4d21-a840-173e02163f6e)(content(Whitespace\" \
+         b6788ba1-fb10-4ed8-bc1d-13ce9481e4a8)(content(Whitespace\" \
          \"))))(Tile((id \
          73854627-8027-46a9-ad4e-ef826f65b0d0)(label(color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d4f2c8f5-68bf-4b01-921f-b34ea1592207)(content(Whitespace\" \
+         ddc993e0-a2ba-4daf-93d1-7a506ee83eb7)(content(Whitespace\" \
          \"))))(Tile((id \
          053fc1d8-3c95-4d6a-93b5-f552e830b8c2)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         91e0347e-6445-4f3a-902c-b6abe044b622)(content(Whitespace\" \
+         161b72b2-b9f3-4876-a23b-7ef108d4ef31)(content(Whitespace\" \
          \"))))(Tile((id \
          1c9913bd-ea12-411e-879e-b3dd6f771fa9)(label(option_get))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c2097f75-dbae-47c9-a714-8c0733090377)(content(Whitespace\" \
+         f54a6915-14cb-4773-99f6-d6e5d1e3f749)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2a27e8da-255f-408d-aec3-1abc767063d3)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c197cbc3-24f3-4f7a-bc1b-7deb664b4e19)(content(Whitespace\"\\n\"))))(Tile((id \
          99ea72c7-291c-441c-8af9-1894fb95810e)(label(nrows))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2063,24 +1898,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          eb3792dd-59b5-46f8-a661-816b68930088)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1603fc8a-8e23-4387-a516-b9f2330b6219)(content(Whitespace\" \
+         b0313d3c-2b9d-4673-9cce-1d8f412e85c0)(content(Whitespace\" \
          \"))))(Tile((id \
          97017eec-1861-4035-b579-d37ec14a0551)(label(keep))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         7d909cd1-9d1b-4c13-8121-12c76abbf55a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cc1eb84b-efd5-4487-b28e-b2c12e201620)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8c1fe9c9-8cf2-4f70-912c-d8ecc8933136)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a9b35a0f-4dd5-4708-a926-d710776877f5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e8d37d13-4eb3-464f-9b89-c3eee40a2931)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         585ca46a-9158-40df-80ee-3d66afbeb852)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e1d66c4a-e41d-4d63-b965-c07b93ee8b2e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         3ba53e64-b1fa-422d-8336-4efb066d091d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         024e38a0-f64f-4011-b295-6ae8b56aa280)(content(Whitespace\"\\n\"))))(Tile((id \
          cb836009-f3ce-4f36-a391-1bd8f58b1330)(label(count_participants))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2093,164 +1918,98 @@ let out : string * Haz3lcore.PersistentSegment.t =
          602cf6cc-c598-4ddf-9017-a557a7fa3534)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         eab9fc97-5d7e-4436-bd87-2103ba360d8e)(content(Whitespace\" \
+         5c360ac8-7c6e-40eb-a9d3-bcb2c41c86cf)(content(Whitespace\" \
          \"))))(Tile((id \
          4261baed-76d4-43db-a91a-43c0575e938d)(label(\"\\\"brown\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         916a4406-2eab-4819-940a-79d0b0b9e031)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1d679015-7121-4802-8ca1-466f4d4563e9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d848ef9f-4b41-4843-8247-7766864681ee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         845ad0b8-cb04-4491-a1b3-58ccd94b89f9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f557020d-8955-4fb1-93be-61ac5a3a5dc9)(content(Whitespace\" \
+         98d5272c-3187-4b14-9ff4-75971cd8f8ac)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         40436f00-1c43-4a7b-806a-6184a68d3d6e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         18a39ee9-33cf-47f3-b8e0-1e2a8d3ef09c)(content(Whitespace\"\\n\"))))(Tile((id \
          10803478-287e-4519-988b-7de727d683a8)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         301d1575-57e3-40b8-bfbc-31c54a2003e0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6b4df812-2646-4426-b78c-44966258af06)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cc959438-054e-43f7-8b31-516fa844f0d8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         95ae539a-7d91-4f48-bd41-5e75017c65fb)(content(Whitespace\" \
+         58de8ac3-6b50-46f8-b79c-55e96e819ba5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c4930015-187f-46e9-9407-fbce9cf10651)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1ed3f0d4-06f6-4ebb-90ef-1e8dbe93ca55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b7638442-07f4-453e-8705-c78512633b32)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d1bd36b2-69bb-48c6-a52c-67c26594f1f7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         23c9f7af-289d-4d0f-b231-1eabd666cc0a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         70115f1a-4857-4601-85d8-b7de7156f92c)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         6c978cd5-8009-4001-8926-b3e6e637e423)(content(Whitespace\"\\n\"))))(Secondary((id \
          c35c8642-b005-42fe-b2a9-4555f7d165df)(content(Comment\"# Version that \
          uses higher order functions to get static errors \
          #\"))))(Secondary((id \
-         8fbde34e-c66d-43a3-8c1f-c6efdaccddbc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b5c03049-cc50-4779-8f4a-709d0a9094a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b09f474-a379-4cc3-82b1-c28ed11d793a)(content(Whitespace\" \
-         \"))))(Tile((id 13ac3957-56f5-4837-9c99-dc2c44e7986f)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b40a090d-bc66-400b-b846-e6b9b5936399)(content(Whitespace\" \
+         66c1be89-4826-42a6-acf0-db983ce99905)(content(Whitespace\"\\n\"))))(Tile((id \
+         13ac3957-56f5-4837-9c99-dc2c44e7986f)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         35653f3c-9829-4f22-9b55-116539ffc0c1)(content(Whitespace\" \
          \"))))(Tile((id \
          b18930cd-fe6d-4cea-8017-bdb0e436344b)(label(v2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cf5042c0-e163-4226-9601-4eb7f1f6b73a)(content(Whitespace\" \
+         96ecd0c2-894b-4c88-b068-83c1a7686947)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7292769e-0bb6-4515-a254-23070d42a25e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a5fe8827-ca01-4e70-91f4-3412b860c337)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1cd4d0d-69cf-400c-8f17-1a2c93bc1c58)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         64126442-f7fe-4017-8b9f-73ba47a9539a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a78b96d2-9212-47e3-b529-d1742ced1039)(content(Whitespace\" \
-         \"))))(Tile((id fc46b5a9-8266-46f6-8834-1c4d5e2fe842)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         9d789ab8-04ba-4b11-95d4-c100e1d92246)(content(Whitespace\" \
+         7fef37ac-9a93-41d3-8245-7189c9ef138e)(content(Whitespace\"\\n\"))))(Tile((id \
+         fc46b5a9-8266-46f6-8834-1c4d5e2fe842)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         99539cd6-3e68-4d03-88ff-130276323257)(content(Whitespace\" \
          \"))))(Tile((id \
          e0067104-ad07-4813-80f8-4697901c6416)(label(nrows))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cc2e02a7-9ea0-4fdb-958b-6bb21e9efb98)(content(Whitespace\" \
+         e7c8d6c2-6c13-4bdd-881a-7240921ae6ae)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a8846d68-96dc-4691-bd96-526bc4b72b4c)(content(Whitespace\" \
+         5d37ca8e-ffcd-412f-ac15-39d9fdb40fab)(content(Whitespace\" \
          \"))))(Tile((id \
          2e5458c1-9c31-4e91-8795-2b670396986f)(label(length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         903b9296-d8ac-42a6-8a8a-c7a5248b2e0c)(content(Whitespace\" \
+         59ed84e3-5ec2-4aaa-bdfc-a5fb0f19836d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1d748d12-b624-41b0-a002-08cd414b4802)(content(Whitespace\" \
-         \"))))(Tile((id f57a168d-aace-44f3-82af-744eeba76240)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         26cfa071-82f7-4ffb-9960-1a3db32ea776)(content(Whitespace\" \
+         81a63ca4-16b0-4f08-8ec9-3415c4369c4b)(content(Whitespace\"\\n\"))))(Tile((id \
+         f57a168d-aace-44f3-82af-744eeba76240)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         7d39199d-e845-4b35-9811-2c38ed83da9d)(content(Whitespace\" \
          \"))))(Tile((id \
          bdd3b2a2-e725-4548-98f4-6b0f94ae57a7)(label(tfilter))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9cd5704f-d016-460a-bd04-9da3807e7742)(content(Whitespace\" \
+         8b7194f3-6904-4486-b03e-afa506a1d4e8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7a971122-9bdc-413e-87d0-d4eed358420b)(content(Whitespace\" \
+         b7d53c62-1110-47cf-9677-4ce679ed7fac)(content(Whitespace\" \
          \"))))(Tile((id \
          273b2ee4-7be7-465d-9ba4-c8377f756eab)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d0431536-9a83-4bae-9d3e-b50f9cd41be6)(content(Whitespace\" \
+         038df28b-19ea-4f15-9f18-128eded394d0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fb884f20-efe7-42ec-83fe-6433d4b40fd0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58d8f8d1-57ae-41c6-83cc-06fb2ad5e682)(content(Whitespace\"\\n\"))))(Secondary((id \
-         926c2db1-121e-4a77-80c6-db2c83ae5225)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f2e82f4f-6356-41a0-819b-b09dbee74b85)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         85d1dc32-c11f-4de1-8250-b20d46afd623)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7b70abfe-6d27-40f7-8bf2-1d539e2c1b69)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c103d046-f72f-44df-8bd6-6986e1e531f3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         68a4ac39-27a5-4826-af84-bc08ce57f2e7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cbe75123-b252-4a4a-abe4-bdf24af3f885)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2e3f24d7-25c1-49c4-8518-24a9b19593e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5d158f9b-de1f-4da8-96e1-ae56615f442e)(content(Whitespace\" \
-         \"))))(Tile((id 435436ef-74a1-4b4e-9b51-b561509ef59d)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ef14f5ec-3f28-414a-add8-b0cfcbeff8f5)(content(Whitespace\" \
+         85c96651-be7f-4704-be9a-d251e7372026)(content(Whitespace\"\\n\"))))(Tile((id \
+         435436ef-74a1-4b4e-9b51-b561509ef59d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9dae36cd-9427-498f-b60f-5e99f780f68a)(content(Whitespace\" \
          \"))))(Tile((id \
          c1f8a766-f177-43ea-814b-97daf580f196)(label(incorrect))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         029b8c4b-2aae-49a5-a61f-db0c14bdc0fa)(content(Whitespace\" \
+         a96f36a2-8fa8-4544-aef7-d508817a1475)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ced275b1-aff3-48cb-957d-d020c0da8cb6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7ea9f5aa-3d0c-41f8-9d2f-07196f8f7ac5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dec6fcbb-6036-43df-b23d-53950e2a821d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dfa595ec-7384-4976-b25a-9752b2820ad6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         826e6d7d-f021-4f8a-a830-942a40920064)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         adcb74a4-4ad8-4e63-b25e-b65abdc6c911)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e5cc44b1-1882-4340-87fe-fbd5b39dd0e3)(content(Whitespace\" \
-         \"))))(Tile((id b33c0e94-7b9e-4000-864e-cf2692ecf74f)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         7400d4fd-310e-405b-ac46-392bc4beff34)(content(Whitespace\" \
+         ef5bd97a-fb43-4836-9774-fceec3d5fb05)(content(Whitespace\"\\n\"))))(Tile((id \
+         b33c0e94-7b9e-4000-864e-cf2692ecf74f)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         2fdf3a28-dd56-47f6-95d5-440189f99afb)(content(Whitespace\" \
          \"))))(Tile((id \
          5bb7a203-abdd-419b-8413-21babc795264)(label(keep))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         62d69e48-504c-4401-93bd-b6a3510ae1d8)(content(Whitespace\" \
+         6eaa9162-289b-42c7-8448-665d20a68e6f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b473ab91-b780-4d96-b685-a6f6b151482b)(content(Whitespace\" \
+         63265de7-c7a5-40f0-a1ed-c6bf3a9ce85f)(content(Whitespace\" \
          \"))))(Tile((id 6b9eadb0-ae3a-43bf-9f18-6f71556a1b83)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         151e3f0e-97f4-4220-ae51-8315105c3c4b)(content(Whitespace\" \
+         52dd6560-f3e5-4487-8fd5-6c04880ed549)(content(Whitespace\" \
          \"))))(Tile((id \
          4d6239fb-6b2e-476c-a5b0-33f65dd696e9)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2258,19 +2017,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          15eb0de5-a4f4-4a00-831c-ee5893889b23)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ae3a7f8c-0c94-4e67-b9f4-12b9d1933b65)(content(Whitespace\" \
+         63d19ba4-8052-44d2-a885-48429f8e805a)(content(Whitespace\" \
          \"))))(Tile((id \
          082cbb62-b32e-4f60-b6c6-ad129ead1058)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         056ddd92-9be7-4993-a3ae-fa2e6ac7265b)(content(Whitespace\" \
+         12c2054f-15d0-4879-8bb1-6a01c4aa9584)(content(Whitespace\" \
          \"))))(Tile((id \
          d8a058be-9453-4a08-9060-b1d1aadcd8d2)(label(JellyAnon))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         770a9558-b11b-452f-a3d2-1c21fca2e9d9)(content(Whitespace\" \
+         5dce2065-9934-4ca7-9ad4-3b1628556d8f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         df28e7f0-4ac3-4c7b-bfe9-c924043aae76)(content(Whitespace\" \
+         c0537662-020b-4c74-9b19-e84136630c35)(content(Whitespace\" \
          \"))))(Tile((id \
          0fd5c671-0097-4019-bae2-eaf6c7550ff9)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2281,113 +2040,87 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1e30707a-917a-4987-94bb-1eff339d179b)(label(color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         8272b28b-2255-4066-b7e2-c43238afceea)(content(Whitespace\" \
+         338e6ba0-be95-443a-a847-f3006bdf9a26)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ae07020f-1a0f-4a99-800b-3be6f4467139)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         45f5627d-1806-493d-af7d-41875bb108af)(content(Whitespace\"\\n\"))))(Secondary((id \
-         502c1b67-596a-4821-b88d-cbba17f8acfc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8dd64b3-db0d-41c3-9547-f0d29dfe3a1c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27fff3b2-38fb-450f-b1c8-38ae25cb69c5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8904ca48-4d7b-407c-8329-575a7cec98a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5078b89-4e50-44a6-b36c-ba01d28cfbaf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c53284d0-c78c-4dbb-8111-57e2fbd1d592)(content(Whitespace\" \
-         \"))))(Tile((id 6f08c55a-5ec8-47b3-a58a-a8977e6632a7)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         9d6a1277-b230-487e-9ddf-0bf3a9f9cebc)(content(Whitespace\" \
+         a221a746-9674-491e-855b-3f47e53009ed)(content(Whitespace\"\\n\"))))(Tile((id \
+         6f08c55a-5ec8-47b3-a58a-a8977e6632a7)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         cc8b621b-d9a0-46cb-a8f6-7732ef252afe)(content(Whitespace\" \
          \"))))(Tile((id \
          d2e83b58-401d-49ec-8f98-51098e3d3917)(label(count_participants))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         594d027c-25d1-4b23-91f3-644935155410)(content(Whitespace\" \
+         7bec2449-8384-4339-9cd6-856d6a3c2d63)(content(Whitespace\" \
          \")))))((Secondary((id \
-         880dcb93-a57a-4c37-8906-b652561c03f1)(content(Whitespace\" \
+         f48c0a5d-a3ae-4f19-b8d7-e841e916a52a)(content(Whitespace\" \
          \"))))(Tile((id 23a9a944-3dd0-422a-88ca-01d52c1cf867)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         adf6efd1-0a62-4193-9280-c0bec7880202)(content(Whitespace\" \
+         1592a71d-4c3e-47d5-a5b3-88c55f43dfcf)(content(Whitespace\" \
          \"))))(Tile((id \
          ccb37405-062f-4610-93a6-50df0852bb56)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         a060351b-5e20-4773-a1d2-a7f1cca668dd)(content(Whitespace\" \
+         8a33208a-68dd-493a-bffc-db413664c881)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2698ec5f-fffa-422d-a905-aadd2ea0225e)(content(Whitespace\" \
+         30b81a34-23d9-47e0-8d51-2138b023647a)(content(Whitespace\" \
          \"))))(Tile((id b35bd5f8-e55a-4d26-aa27-f9b9eb132fd7)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         b1989f7f-153a-49a0-833d-a9adc5aa2711)(content(Whitespace\" \
+         22044686-df41-4355-9928-cf6680c3a045)(content(Whitespace\" \
          \"))))(Tile((id \
          d8eb1826-5261-4a2d-9714-ac39d7734dd7)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          7bd74f1b-2fa1-41bc-8177-08fc04cdd07c)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         edfea679-92b2-4675-a0da-2046c817e60b)(content(Whitespace\" \
+         \"))))(Tile((id \
          d15743f8-deac-469d-896a-79bf2e735c7b)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         f3f63db0-1d2c-422a-9143-51363d9e6f05)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ef197801-8ec6-4947-9570-7864346783e3)(content(Whitespace\" \
+         \"))))(Tile((id f3f63db0-1d2c-422a-9143-51363d9e6f05)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          70653ff0-95a1-4797-af25-c5b18541988a)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          1cbe415d-8c5d-48e6-b302-0bf20896c6f4)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         b5f1a75c-c129-4dab-bcea-70ccb7be5897)(content(Whitespace\" \
+         5f7d4d5f-0c6b-4e34-b8fa-8845b25e47cf)(content(Whitespace\" \
          \"))))(Tile((id \
-         db579d64-1783-4dec-bbcd-2d8c376673e9)(label(color))(mold((out \
+         db579d64-1783-4dec-bbcd-2d8c376673e9)(label(_color))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4954487c-36f7-4ad1-9b01-92e9b6fa083c)(content(Whitespace\" \
+         \"))))(Tile((id \
          4835d0c9-ab01-44cb-88e5-d178e5848947)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8b1783d3-ddad-4108-b9bc-542cdbee2c46)(content(Whitespace\" \
+         fc29b25f-efbd-46c1-8087-0dce2da2c54f)(content(Whitespace\" \
          \"))))(Tile((id \
          60195071-d0fb-4b2b-b25e-46c3a15eee60)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         ee6e88a3-6ec6-43b2-ab7c-54a01e5ee6ea)(content(Whitespace\" \
+         4859b58b-ccc4-4859-b5f2-4b35fedd0bd3)(content(Whitespace\" \
          \"))))(Tile((id \
          42b3a1db-f259-4d32-96f6-e7e63466c38a)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4f87e28d-ef39-4a39-b132-b1b0371e5293)(content(Whitespace\" \
+         6cec6a29-93f6-4c70-b9f3-697b5cfc8051)(content(Whitespace\" \
          \"))))(Tile((id \
          51a5648f-6b90-41f9-94bb-35501f805410)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8dfec030-3ee5-44f0-84af-3efacd3077e1)(content(Whitespace\" \
+         9cec298e-2846-4bb2-9a31-3f1bcc1c7667)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cebd95b6-af5b-47f9-b659-dbfa3c436708)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d50dc38-cc85-4ff0-88ce-c8437f5df231)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cb8e0531-65cd-4799-bc83-99ffd7a91469)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f699d957-a4f1-49e2-8bb9-2b1e10fad0f3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f83f78b4-ed7e-4bd0-b5c3-9164883a15f1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         21e30bfe-1564-4b05-896a-4f0f9481654c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d3f6d2f-7ce4-4960-9d0b-d09fdcc16e62)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f4b92fb3-d01c-4afc-9ba3-4f4afe8e6031)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a9fe3752-5695-439d-a7df-9eb6d1f0169f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d7f8d976-ee86-40db-87fa-0471a7f026b8)(content(Whitespace\" \
+         b899eb11-1c2b-468f-979f-37f0c8de15c6)(content(Whitespace\" \
          \"))))(Tile((id \
          dd59fbaa-933b-4f38-af1f-4b99a2435ddb)(label(length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2407,26 +2140,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fa6427b2-9411-47a9-b4e7-4689ab9a981b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a8202d25-778e-41d6-9d38-476856c3c7f9)(content(Whitespace\" \
+         a86ad95e-52f7-48da-b15c-a1f1de601790)(content(Whitespace\" \
          \"))))(Tile((id \
          2146a68f-415e-4474-9ee5-d8933f6b2727)(label(keep))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         486632be-09e8-4f0e-99c6-851d372f38bc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d0e78090-140f-46ea-810f-4eb19299abce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dec0a280-1f0c-4ba6-91fd-ab802ce6a302)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f16257e4-249a-4c02-989c-430e47cf55d3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         076d9b06-d6f9-47a0-883e-724af5ed7656)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         38be4bb6-c75b-46c8-b46b-aa70f6541302)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         df4d340b-3049-4c7f-91ae-8fd45081be6e)(content(Whitespace\" \
+         12c62813-78b2-43be-a45b-576154afd13c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c4867f5f-2975-41e5-8bb3-74edc3199cd8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3900bdf4-42f7-478d-a47d-d42a40505cc9)(content(Whitespace\"\\n\"))))(Tile((id \
          9a2d2816-05f4-4540-b40c-fa533b180518)(label(count_participants))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2445,19 +2166,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          68eb3278-6113-4616-83cb-87bad01450b5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8db68a1b-8862-452d-99b1-bb5f4c8300e9)(content(Whitespace\" \
+         8f4855db-c4ad-4b3c-ba7b-f766240c55d5)(content(Whitespace\" \
          \"))))(Tile((id 692b006c-e9bb-47fe-9b07-420671451ba9)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         873f3265-2ac9-41b2-9fb4-0454b7193524)(content(Whitespace\" \
+         d6954fd8-a61c-4465-bb0c-271fd598f08c)(content(Whitespace\" \
          \"))))(Tile((id \
          20a6a1f8-697b-439e-830d-df2f16b56c08)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         418607fb-8026-4690-a36f-d3617268b4a5)(content(Whitespace\" \
+         7b6dda6e-aa46-457d-b9d9-2e54a7dba4a8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         80b6bcf0-e499-41cf-87d4-60f3cb11791a)(content(Whitespace\" \
+         d30c4ed4-c4df-4af1-8dd0-4afc43d2442e)(content(Whitespace\" \
          \"))))(Tile((id \
          0933e06d-b28f-49a9-b17d-ccb6f471fb01)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2468,156 +2189,112 @@ let out : string * Haz3lcore.PersistentSegment.t =
          013c75f0-2049-4b4a-b966-dc41d8d52cb2)(label(brown))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d18f7f8a-16bb-4c29-ba78-1cb1e0bca7a5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3ad52985-eee8-4f96-b1d7-bcc4b966aeef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36266c2b-626f-4d4b-924d-d9827f0e8f61)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f63807c5-3ee3-4404-a965-17debb0bf8c3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f05fd005-2a00-41ee-97e4-19b98e0fdbec)(content(Whitespace\" \
+         d193a055-af99-462d-a031-fbfa5187a710)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         925eb098-96f0-41da-b444-320283873e20)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ba967fde-1487-4297-8122-3bc3ea075570)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4949783c-ea0a-467f-9faa-4c311f1345fd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5a4eb477-a378-45a4-9660-51a392a7c2f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         31a11896-e37d-4113-9e3b-4c350a7d1dcc)(content(Whitespace\" \
-         \"))))(Tile((id 3cb0eb58-3919-4618-a9f2-41f32378fe1e)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         8a4186b3-1b8d-4e67-8c76-319ea949639b)(content(Whitespace\" \
+         7cc6dd8a-8ec2-40ad-86e5-fe920ca436d3)(content(Whitespace\"\\n\"))))(Tile((id \
+         3cb0eb58-3919-4618-a9f2-41f32378fe1e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         d81d0a72-7cba-441f-8aee-7ab0110a3bd9)(content(Whitespace\" \
          \"))))(Tile((id \
          502a20c1-cda3-4794-a02b-bdbcc8dbd176)(label(correct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0cdca73d-a1ee-4211-960c-f05655e11b20)(content(Whitespace\" \
+         ee557b16-3cd7-42f7-81cf-2e555e7dad8a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5d85b92d-8cbe-466c-9f9e-4a70574ac878)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         952987d9-f459-4ed6-88b6-7d13576ece1a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bd48299c-c818-4656-95c7-a1bc0ab10ad6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e88b953-8f44-442d-a0b6-2bd5ef91d87a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         051bdd17-9543-4154-aa5b-9fd42e941bb7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7a9c7edc-a633-44cc-aaaf-030456647eab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         593095df-939c-412b-b766-5a6a20eda47b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         78dda0ce-23c1-4e96-bfc6-0c0fa1c6d14e)(content(Whitespace\" \
-         \"))))(Tile((id 30fffc72-16ee-4ca3-82ba-a00abddc9399)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         fdf917f3-dec4-409e-9ba0-2702126d38bc)(content(Whitespace\" \
+         8386f58f-7358-4198-a83d-fbff59879c92)(content(Whitespace\"\\n\"))))(Tile((id \
+         30fffc72-16ee-4ca3-82ba-a00abddc9399)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         bc3615b2-0ae3-4c41-8c3a-7884546c3dfd)(content(Whitespace\" \
          \"))))(Tile((id \
          08e478e0-8719-4b90-9fb2-f3734e512017)(label(count_participants))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         81693893-3387-40ea-b809-dcbd39e44354)(content(Whitespace\" \
+         cf4fd51b-b4d3-4b47-9338-82bea23f483a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         1c2fe9f6-f9f4-40e5-a03f-b1febe83abbe)(content(Whitespace\" \
-         \"))))(Tile((id 1a90aefc-3809-4722-a115-5673fde8cb91)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         c54486c8-8927-4d34-a420-0e5a092a5ee1)(content(Whitespace\" \
+         0d769ae3-ebdd-48d4-b408-15ed1e64892b)(content(Whitespace\"\\n\"))))(Tile((id \
+         1a90aefc-3809-4722-a115-5673fde8cb91)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ae78e163-41be-41d6-8cbe-12f5642ede8d)(content(Whitespace\" \
          \"))))(Tile((id \
          60a32aaa-ee9c-4eb3-9754-edfe2e2e65fb)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         1490260e-f4de-49ba-88cb-808af6cbef90)(content(Whitespace\" \
+         fb988af8-e83f-44a3-9afb-c4ee9807be53)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9d709dc4-6ca5-45dd-b95c-be80b0fa377b)(content(Whitespace\" \
-         \"))))(Tile((id 87794375-24dc-4186-8756-23022d11ca30)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         76b15b68-b7ae-43b4-a507-22a857c231c1)(content(Whitespace\" \
+         d26fc53e-6bfc-4634-95c5-cd387e077217)(content(Whitespace\"\\n\"))))(Tile((id \
+         87794375-24dc-4186-8756-23022d11ca30)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         c9f85a77-7286-49f4-9031-d7b89fbaaf30)(content(Whitespace\" \
          \"))))(Tile((id \
          0701e31f-2898-4aca-8e87-291addeb2c2e)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          31753d49-6911-486a-8c3b-da5ea0f4795c)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ece9fba5-2a3f-424b-bc0a-a857d81bef8b)(content(Whitespace\" \
+         \"))))(Tile((id \
          92778ec9-5ab1-4bfc-ac98-d932c6a9ad24)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         65458e69-f990-4e1c-86f7-d25faa7f5e1f)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5bb12ac8-c9dc-4ccd-a319-7b703220e715)(content(Whitespace\" \
+         \"))))(Tile((id 65458e69-f990-4e1c-86f7-d25faa7f5e1f)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          ee7ab87e-43eb-4c90-8f17-0141cae7017b)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          cb58080d-078f-4ce3-a53d-416120cacd37)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         25604b98-60f6-46fb-a196-eefc04920683)(content(Whitespace\" \
+         5f3edff4-f63c-458b-8f4b-9e462f1c9c24)(content(Whitespace\" \
          \"))))(Tile((id \
          f3174e77-0f0b-44e4-acea-d8459be2f646)(label(color))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e427311d-63a3-4f93-becd-2d3e8f3699a1)(content(Whitespace\" \
+         \"))))(Tile((id \
          2c2b7e96-8364-4e5b-b117-3394bacc6a60)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         548ac92d-f99d-49af-840e-6bbe00a446a0)(content(Whitespace\" \
+         92cb8ca4-c001-42d4-b5f8-aab89d8c5136)(content(Whitespace\" \
          \"))))(Tile((id \
          1542e588-a154-4883-8f8e-5a65ce752d67)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         6422e555-0108-48a0-91c3-a9e0aa330d46)(content(Whitespace\" \
+         d4a72b4a-f6c4-44af-94c1-04ff9c68588d)(content(Whitespace\" \
          \"))))(Tile((id \
          69dcf224-ae36-4cf3-88c1-6666a94e84d9)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1a05fa87-dba9-4a30-a3f8-057a9caff880)(content(Whitespace\" \
+         5539228b-e35c-44e2-abf3-162df5c9065b)(content(Whitespace\" \
          \"))))(Tile((id \
          1b6ea704-f1ed-4c5e-a7b5-b6f78e42ca3b)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         85d3d914-6c5a-4056-99f8-2fbec500d773)(content(Whitespace\" \
+         7c126702-4da5-484c-8199-371eaaa81ccc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         72281045-80f0-428d-9d28-c69253666292)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0ab9c0da-1e18-45d6-b3ce-007ae2ddc9a3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b51d4b4a-3d21-44ae-a839-f71b9f9368e3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         613a5dff-10b5-44f1-bf57-3bd1c376d21f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         628e3355-34eb-475d-8c91-a81c19cf39a8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f5a7afa5-6c1a-4e7f-9365-77ca0223eaed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2423827d-73a3-4e7b-8737-b5c188db230b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b193c46-3021-4fe1-8112-f41f15b91b1f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         131dd5a3-1942-47da-aba2-f48958980f20)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fb926494-a2f6-4e4c-bbec-0adef6a6e259)(content(Whitespace\" \
-         \"))))(Tile((id 08b01b6a-c221-419f-9698-9a77330d79e6)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         2aaf647e-3b62-4dc8-82f2-f83a9bc16e4f)(content(Whitespace\" \
+         2fa6f08b-46cc-4f20-9114-1b107248f9f1)(content(Whitespace\"\\n\"))))(Tile((id \
+         08b01b6a-c221-419f-9698-9a77330d79e6)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5ac21c9e-5578-4387-b8a1-4c49bdb8d38f)(content(Whitespace\" \
          \"))))(Tile((id \
          61cd021e-02d6-4a7d-838a-f773566e0068)(label(keep))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         eeb4a4a6-1378-4b80-9dfc-398ad2bb6968)(content(Whitespace\" \
+         1945bdf4-8701-428f-957a-d45a8ec1f623)(content(Whitespace\" \
          \")))))((Secondary((id \
-         45873e5a-859b-408a-b810-97332040f3bb)(content(Whitespace\" \
+         e4382eca-0bd6-4620-974f-aed764fb7b19)(content(Whitespace\" \
          \"))))(Tile((id e220881f-d50f-4355-97a2-076a853390c2)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e6fe4607-2ee1-44d1-91d6-d50a63cbeaaa)(content(Whitespace\" \
+         3b70b847-a0c1-45f7-9356-99102921d964)(content(Whitespace\" \
          \"))))(Tile((id \
          d37d461b-f76c-4920-862b-c32f56e3c12a)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2625,19 +2302,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          39306ca5-e286-434b-a090-29bc63e24164)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d7497e38-619e-41bb-acad-c5112678a88e)(content(Whitespace\" \
+         ec1c27a1-7f8f-4712-a664-22acec46b274)(content(Whitespace\" \
          \"))))(Tile((id \
          52f8126f-7fa0-450e-be01-8ff73e60cf29)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1fd96130-9f9f-496d-a374-b38dc4a39a37)(content(Whitespace\" \
+         54b8eab5-b591-45c8-83a5-2be9a3a09543)(content(Whitespace\" \
          \"))))(Tile((id \
          64c867bd-0155-4ca4-aae7-969f93f2bfd9)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e299ff67-ce7d-4b1d-864f-cfc6f896cfe4)(content(Whitespace\" \
+         b76c9af9-5df7-482d-823e-aa3f9ab36d07)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8eba5226-05c1-40c7-a77c-6785ecf72a5a)(content(Whitespace\" \
+         aa11be0e-d485-4480-a90b-c8311ed3ad50)(content(Whitespace\" \
          \"))))(Tile((id \
          9c26d112-3968-4968-bb7b-2a1d8ed4a9e6)(label(color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2648,27 +2325,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1569fe0d-2070-4be3-b1ea-009aa872ce8f)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         28f44735-4beb-4adf-9ec0-2619129f3fae)(content(Whitespace\" \
+         656266fa-7598-4b88-a5d7-58f6542b84ef)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9daaf253-f88e-4284-a790-3d3a2c64bdde)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb3daca4-3d1b-4160-8a18-41ae7471c85c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1ff48825-5490-4e9f-8722-1c0a16bf758c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8d8cb2ff-7167-46e5-ac0d-f57e47774ec4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3426ce07-4aed-40b3-b2a6-41720db1503e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ea8f5c6-caae-4406-b1bf-caf4fdf64e6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46d6ebd2-3351-49af-a658-064c69cc7143)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9b0ca2fe-2628-4f69-a836-ab979f1ae84b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d022179a-6ff8-4b0e-8dd9-d5e3cccd986b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c30270e8-ad90-48a7-9d37-3ced2c6668ee)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8bf1726e-0dd1-498b-96ca-37e2bdfd021a)(content(Whitespace\"\\n\"))))(Tile((id \
          4f13b089-68e5-4598-9b01-6b46cba5a44f)(label(length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2687,26 +2346,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3926246b-d206-4b9c-96a5-35be383653c7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fbff4540-3f30-4bd9-a735-459deb851d22)(content(Whitespace\" \
+         9728aa83-7fd6-4820-9843-ba40c7498d65)(content(Whitespace\" \
          \"))))(Tile((id \
          d02dd1ce-2bad-4fbe-9231-dfe4c9e42312)(label(keep))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b9da36c6-9fb0-413b-80c4-137ff4153b0e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d5b5f6a5-cb91-4690-a760-8ef787459ef2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         45b5172c-5b45-4848-a215-67cd5ad9d354)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba977adb-5f21-47f7-ad1f-27fcbf12d36c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9eab746c-49a9-47bf-a717-51a98db2b56b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         48762073-ae30-4be4-aa3f-a5847f1dc939)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1330e677-b669-476f-b493-bd43cf6646c0)(content(Whitespace\" \
+         2a74a981-bcd3-42ae-9c82-5222b0467c21)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         532be168-ee97-42d8-8c41-112abf1151a6)(content(Whitespace\" \
-         \"))))(Tile((id \
+         42b460e1-6448-459a-a443-9faefe8f981b)(content(Whitespace\"\\n\"))))(Tile((id \
          891b49f5-1a38-4eb1-b837-3dfe7f0902f8)(label(count_participants))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2725,19 +2372,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f264fd69-5cd2-41a1-b4d5-56c41342f836)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f24fb639-a3ad-45e5-ab1b-f0def71961c2)(content(Whitespace\" \
+         8978e5e2-973b-4205-a1b6-4aaf0388827d)(content(Whitespace\" \
          \"))))(Tile((id 13baaa16-4a7d-43a6-b287-1568800f1c91)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         7e3e72ac-2ec8-4ed3-8c92-b2b023a59f2b)(content(Whitespace\" \
+         32a3f8be-bd07-4452-a5ed-4d1589d7ce59)(content(Whitespace\" \
          \"))))(Tile((id \
          7318f22a-af22-44dc-bdab-4b793a3a1562)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         35b97596-f134-4c47-93e7-b31b1d201088)(content(Whitespace\" \
+         5659ac24-202e-48bf-b6fd-4cea8904ca02)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9949ce16-2c7e-41e6-b6de-f60fa489f425)(content(Whitespace\" \
+         aea9c364-385a-4c1c-8d60-feaf7b2d09dc)(content(Whitespace\" \
          \"))))(Tile((id \
          40685ace-c867-4a64-ae1d-9011eb454248)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2748,77 +2395,60 @@ let out : string * Haz3lcore.PersistentSegment.t =
          722e9f58-a3cf-46c7-a72c-79fc25dfbdf2)(label(brown))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d00d2b18-c7a2-42ec-a731-d052c9ea06da)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8fcc5bb0-8587-41bd-a569-a5ce0074110f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5705edf2-bd21-4158-9008-1ac979ec6059)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5d6b2139-decc-49e9-b344-246fca9da099)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         030fdaf9-5dcd-42a2-86d7-0ed40b199e34)(content(Whitespace\" \
+         3bcc25bd-ba93-429f-9c98-1f37dcf3a537)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ff40ba89-08bc-432a-b600-5207ceab4c85)(content(Whitespace\" \
-         \"))))(Tile((id \
+         dd2ad3bb-1520-45f2-8391-c6cbd7b5b68a)(content(Whitespace\"\\n\"))))(Tile((id \
          69311bd3-b007-4119-9da3-8a206307198e)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         9f69e871-365d-436c-b4d6-950a1ba14df0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b6b4b73-39dc-4edc-81f4-a20b1c546e18)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         29311535-f3ad-4182-a15a-d53200729767)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1962d745-f4a2-40da-ab80-1705c5e6ecb6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a66871e6-38ae-4470-befe-8da2d5692315)(content(Whitespace\" \
+         f44e7645-780e-43be-8586-2c69ed4b7531)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ec24caff-85b0-459f-b73a-3821b82460bd)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f4f758eb-73a8-4197-8a82-87cb21e750c1)(content(Whitespace\"\\n\"))))(Tile((id \
          f4b24784-6eb6-405f-858c-ed789e5a3781)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c075383c-17f7-40f8-9f0b-afa0c6a68bc4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ecfef3d-9150-46b2-abcb-3556151f5bdb)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         528c38bf-8e94-4572-8a1e-3aa43616db6b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ce9bedc3-6d63-4f30-bd28-89f690430718)(content(Whitespace\"\\n\"))))(Tile((id \
+         3bcd0394-8b1f-412c-9564-6543e06702b4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         946f70dd-50b1-4877-8038-a8065f529712)(content(Whitespace\"\\n\"))))(Secondary((id \
+         61b61e2f-3ca3-4970-9ae7-fe911d5a1858)(content(Whitespace\"\\n\"))))(Tile((id \
          c96367d6-9c91-41a8-ae83-4e305bff7706)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         39207bcb-1a61-43d5-b6c1-fb70cb05202b)(content(Whitespace\" \
+         5cede2ce-aeef-47f1-b31f-87902e256f58)(content(Whitespace\" \
          \"))))(Tile((id \
          46325586-6da1-4a46-ac50-1927b452699c)(label(employee_to_department))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a03f00cd-825e-404a-9723-22c34e8e73ab)(content(Whitespace\" \
+         0d18b686-a981-47c2-b6b1-ffc4c7fa2300)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8d5c8401-debc-479c-b1d4-46391ab6b148)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5bfb6615-d933-47a4-8969-b46825251c4e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f865b60f-3391-4f61-a586-b5a75537a076)(content(Whitespace\" \
-         \"))))(Tile((id cae767d5-507d-415e-bed4-b0d7172c028a)(label(type = \
-         in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         07682fed-7ca2-4aeb-9719-558e136203bb)(content(Whitespace\" \
+         b82bd1e0-b1d3-4d52-b038-15ff4755bf45)(content(Whitespace\"\\n\"))))(Tile((id \
+         cae767d5-507d-415e-bed4-b0d7172c028a)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         12d2cef1-f138-45e5-bc7e-581608fd95ca)(content(Whitespace\" \
          \"))))(Tile((id \
          22de6871-1983-4a41-828b-7669920d298c)(label(OptInt))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         6f65fe95-3c02-4a65-b183-e536eb2b5268)(content(Whitespace\" \
+         b7dd7fe8-c5fa-40b8-8a6c-6bf29a2325a4)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ecd07cd8-9750-4b62-81da-e7070afdaa7d)(content(Whitespace\" \
+         5ec136df-09c3-4f52-8354-c018b253728f)(content(Whitespace\" \
          \"))))(Tile((id \
          e1a3e44a-db6b-4e5e-9d3d-8d247526ff78)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e259e6e2-e494-4ab3-8b73-04630ccd7950)(content(Whitespace\" \
+         \"))))(Tile((id \
          ab8ed243-f9cb-4d37-9af4-a815a0fa0619)(label(None))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         02ee14a0-fa87-44ff-9e6a-740321511948)(content(Whitespace\" \
+         5f01743b-552e-4965-b80c-e64778810e04)(content(Whitespace\" \
          \"))))(Tile((id \
          68f0ec85-b7b3-40fd-b800-687065c2f5ea)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
-         12))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         12))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         45236068-68e9-46a8-8a12-a8225d889b94)(content(Whitespace\" \
+         \"))))(Tile((id \
          9835af46-fe0f-452e-8c45-f06354aa6ab2)(label(Some))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
@@ -2828,97 +2458,89 @@ let out : string * Haz3lcore.PersistentSegment.t =
          16e162d5-c14e-4e50-8cd9-efc2732f7557)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8afafd62-b68a-461f-b654-13a1e70519f5)(content(Whitespace\" \
+         559c4b58-72df-4eb7-868e-08db9a441372)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2484de6a-41f4-4ae4-a9ff-f2ba05f6636e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         33cb041c-aa61-434d-ae42-2ad2c411530a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3c8824de-7d17-45d6-bf5f-5c62f8cd5088)(content(Whitespace\" \
-         \"))))(Tile((id 6334cf9a-08fd-48aa-86a5-4b87c51d4ad1)(label(type = \
-         in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         13c49f1a-0f81-4686-a49c-41871ad151b0)(content(Whitespace\" \
+         e2d9fd28-9939-4ffe-97be-04eb288e6678)(content(Whitespace\"\\n\"))))(Tile((id \
+         6334cf9a-08fd-48aa-86a5-4b87c51d4ad1)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         dbd371c3-dddd-4be8-947c-05a48f0dc9ef)(content(Whitespace\" \
          \"))))(Tile((id \
          83d08190-5b18-4b19-80e8-3bf430c9c798)(label(Employee))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         4534e19e-7ab8-4aa7-850c-fffdc2552f96)(content(Whitespace\" \
+         47764db7-a5db-407e-a964-e48f6ad1fbda)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2309e94c-a319-4d77-97b7-dcde404bcdb8)(content(Whitespace\" \
+         05894dc8-4add-4922-85a2-8a2ba321f89a)(content(Whitespace\" \
          \"))))(Tile((id \
          8027dff5-84f1-40c7-90c5-40c8e98d8af9)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          49c3a2a5-9b84-48fe-9140-015724a69bc0)(label(last_name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d7c77d2c-2d55-4737-a4f4-b4837dd4f6b6)(content(Whitespace\" \
+         \"))))(Tile((id \
          3d2d35ad-9fb2-496f-bc4a-b289ff42b904)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         82c959ba-5d5a-4d1b-a95f-15f5700a72c9)(content(Whitespace\" \
+         \"))))(Tile((id \
          4e6d8013-1802-4b56-ad0f-cb4f46add537)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          228b9a14-bc4c-42dd-a620-e8ebc87df1ec)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e8dcd4f7-b531-4a9e-ab14-5fd51978b442)(content(Whitespace\" \
+         4db1defb-4137-47b7-9926-fb73f31703c8)(content(Whitespace\" \
          \"))))(Tile((id \
          8e48b2fe-3c92-4436-afff-84402d002818)(label(department_id))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         11265a03-f682-45ef-a907-2d24c51dad59)(content(Whitespace\" \
+         \"))))(Tile((id \
          4fe3b511-03c5-404c-a4cb-f956d29f1e83)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d3787555-66df-4ef6-ae8d-b99ea58a62a0)(content(Whitespace\" \
+         \"))))(Tile((id \
          1b7a2ab0-ff96-45e8-b34b-3959c0e9dcab)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1586ee52-e7d9-46fc-a3ad-bc2d87ca051f)(content(Whitespace\" \
+         142d8aad-631f-4022-8d43-5db108d9e747)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e134cd0f-8230-4bab-aa9b-f2fea8ff1793)(content(Whitespace\"\\n\"))))(Secondary((id \
-         690a694e-07c7-435f-baf9-40324748740f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a1716e19-1fdc-4bcc-981d-25f878f3c5eb)(content(Whitespace\" \
-         \"))))(Tile((id 165c6128-aff3-49d1-aa30-da1069c132be)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c9a253c0-f302-4e6a-8f18-c91545fb3e03)(content(Whitespace\" \
+         5a9a5017-0a5b-497c-a2c4-6811f1ee3481)(content(Whitespace\"\\n\"))))(Tile((id \
+         165c6128-aff3-49d1-aa30-da1069c132be)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         1e2ce25d-e132-4aee-86dd-de206a686c11)(content(Whitespace\" \
          \"))))(Tile((id \
          c9c7ee04-12e0-4296-8454-217736ec1708)(label(employees))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         02af7387-e3ce-4ca2-8803-d4724dd791e4)(content(Whitespace\" \
+         5876d61b-f555-4308-be71-e3eaf8c3534e)(content(Whitespace\" \
          \"))))(Tile((id \
          2aee585a-eaf3-4a0c-8e52-67a22aac7afc)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         be937bec-acc5-4d00-97eb-86cea232f6f9)(content(Whitespace\" \
+         a19b6652-7573-4438-8a38-012adc344639)(content(Whitespace\" \
          \"))))(Tile((id 3fd93180-5a0c-439d-bc39-d382f0b568f8)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          ed2bf262-2b06-4770-ad43-6b8af3ddc984)(label(Employee))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         4d1c5a0f-91a9-41be-ae2f-2d2ba764fa7e)(content(Whitespace\" \
+         0130ae6c-e304-4d32-b724-bf9ffb06a06f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         35b49761-49a5-4bff-8879-2c51353d2fc1)(content(Whitespace\" \
+         2653f659-15ff-43d9-8d7f-85daf589ba38)(content(Whitespace\" \
          \"))))(Tile((id \
          51d4ba5c-d43f-4248-9f06-aa07f04df014)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         5797de6c-8a76-422a-9275-3e7555213cfb)(content(Whitespace\"\\n\"))))(Tile((id \
          e8933a3f-36a0-4ab6-a3ac-5fde62aaf96f)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         88fa336d-a866-4959-9735-04beea06dbbf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eebe6d93-5c7b-4bac-8155-5165b4aebcc8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6485b0df-fd59-47b4-a690-ad242fcb42ae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f3f04fd-8367-4ee0-9a66-5f672775944d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         51c4426d-d6c2-444d-bb87-d677de3b38c1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          4a0099a7-6722-49e6-ab6a-422bd6997c71)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2942,14 +2564,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3d4b9fa6-83d1-4bcd-a89c-d94e1a82a800)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7454f825-8408-40d5-8a15-c0b3f770e31a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7a72a51b-222b-4a10-b450-f4f5be528e10)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         05e726a9-489e-4826-b219-5675142840e7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8cf9571e-e0d8-4b28-ad37-927fd383bf98)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f3df2b4-b62b-4551-9733-ad1c50592006)(content(Whitespace\" \
+         4d15f0f4-b26e-4dcd-a287-aafaafa219fe)(content(Whitespace\" \
          \"))))(Tile((id \
          7edc5151-8c14-4895-9373-4f5710acd3e9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2974,14 +2589,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ed489bdc-d26f-4c33-af6b-a23041272a11)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bb55a182-1cd5-4568-8890-2fd1cfc653a7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a2a99a74-9148-4dad-8040-32a91bdd5d6b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         393061d9-3cbf-42c4-9980-f348105d29e1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6146c82a-d4a2-4cba-8a23-399c01735629)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f818459c-80c2-46be-8f38-b9b5f8dca148)(content(Whitespace\" \
+         7ad0ae81-e484-466d-9642-3e922052ca04)(content(Whitespace\" \
          \"))))(Tile((id \
          da1e9de3-4962-47d7-90e1-b0f026f4b976)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3006,14 +2614,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a493a956-8f3a-4192-a613-f49dbbf8477e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6397df65-63e8-4d06-a8c2-38100e944b43)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3dbfb200-bc91-45d1-86ca-b0f870066bb9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         363dc1c4-8d85-45d5-857e-5a7d5b53b824)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04ffdfb1-7f5a-42de-886a-f4076c1650e4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4aed347e-2c89-440f-9774-b9841da8ff59)(content(Whitespace\" \
+         4dc6c80e-ac76-4914-a8b9-a9a3b38da38f)(content(Whitespace\" \
          \"))))(Tile((id \
          9a53c702-b09d-49da-8738-ea8c2ddc185e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3038,14 +2639,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2e1ae701-ca14-41f9-9dd7-1df77a7ba73e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2670ba84-1ffc-423c-bddd-f23b4335f850)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cb7d4d78-1f75-40e7-9557-37e6c3d00311)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a1bf2ec-e3e6-4abb-83a4-3e09469a6f0c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ea4e6be-1c43-442a-80f6-bac35740e0d3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5746e34-5a72-49a5-869f-e86514c55caa)(content(Whitespace\" \
+         e2ba86fc-39e4-4fa7-8e87-594c5f129bd7)(content(Whitespace\" \
          \"))))(Tile((id \
          2290233f-b231-4194-a621-90c3e5e73e54)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3070,14 +2664,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          36f8000c-b754-4518-94e5-2217a692004e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e650f227-d7b3-4cc7-8dba-1f2c88bc2342)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a470112f-2dfa-4620-84d9-42359be0e499)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         53860c5d-2d2e-4880-9b13-8db5bafec0e6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1956afc9-ab51-48c7-b49e-9c6d56e0a525)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         998bbcfd-55f3-415d-b3b3-14e9f03f5449)(content(Whitespace\" \
+         02c7bb16-2c66-48b0-8f5f-78e917eb8b5a)(content(Whitespace\" \
          \"))))(Tile((id \
          e22842f4-ff11-472c-bd2c-0ec5b36d9e45)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3088,112 +2675,94 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9dde7f8f-83c0-4a01-9961-ad128b0c7db0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e5070069-8710-4cc1-98e6-079b77934bb5)(content(Whitespace\" \
+         f67d1cdd-2311-4b50-8482-8710c8eb861b)(content(Whitespace\" \
          \"))))(Tile((id \
          97d4dc6a-1948-42c9-ac95-dd41f920a4ed)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         69c8eb6a-3c9d-44f5-9eca-93a7262cd287)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9a9dae2e-00b6-42fa-a9ad-afc0b3ae7008)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a4aedb07-36d2-4e3c-a496-453eafffe59c)(content(Whitespace\" \
-         \"))))))))))))))(Secondary((id \
-         2bf3b559-6c82-4afa-807b-08ba84ac7f5a)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         41d97aba-1756-4f9b-8796-5b037a99137b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c8fb8708-9771-4d66-b05c-f6e07ffbf9c0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d0c04928-40c0-449f-a86f-52cb4ffb8253)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e7ad91dd-7cb8-46f5-8f86-0b80bf60987e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4ddb9085-28ef-41a9-b686-47b2877a201b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a39ab47-bf1c-475d-954b-f5985ca49427)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bdcc5d13-80e9-4315-85bc-51642f3c3e18)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c2b2c3ac-93b4-4b70-9a1b-31fb247032a6)(content(Whitespace\" \
-         \"))))(Tile((id 54a819e0-1430-4379-a4af-bad50864efa7)(label(type = \
-         in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         de46cd18-94dc-40c6-9ae4-bb01c7522ebd)(content(Whitespace\" \
+         2f263dc4-ad46-47b4-97bc-0f78f6722f12)(content(Whitespace\"\\n\"))))(Tile((id \
+         54a819e0-1430-4379-a4af-bad50864efa7)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         327ddc30-5673-4ed8-9d30-bc3bc577aca6)(content(Whitespace\" \
          \"))))(Tile((id \
          7cdec300-c9c2-432d-a819-5bf2d95084f1)(label(Department))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         5cc51bba-6e9b-415d-b23e-e8aefec14561)(content(Whitespace\" \
+         79ee66de-ea3b-41a4-9d4e-2fc357d30ea1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5b48bc96-8f96-4529-b5a3-b83838043913)(content(Whitespace\" \
+         acf5129b-e24e-47ff-aa03-fe9a800a9290)(content(Whitespace\" \
          \"))))(Tile((id \
          4b33cd79-0f0f-46fe-820e-816904dac86e)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          60b71643-7994-4c53-a9da-7fab941cb5fa)(label(department_id))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4c7f711d-531f-4c53-a01e-a4f900013278)(content(Whitespace\" \
+         \"))))(Tile((id \
          bd0e698f-871b-4b95-ad2d-06b8442d7091)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fb205c91-dfb6-4a84-b4ad-33223e2a61d5)(content(Whitespace\" \
+         \"))))(Tile((id \
          573d0930-26ff-4985-b431-2cb4e4865e72)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          eac829f8-a592-4250-b971-5a0d09acaf5d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3f1e9ea2-56e6-4f35-be32-b658b7676a26)(content(Whitespace\" \
+         511be0c9-a647-4945-a0c5-e2e75afc52b6)(content(Whitespace\" \
          \"))))(Tile((id \
          3536bb09-7153-4884-82b6-7e4c4abe9af7)(label(department_name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         938a17f8-7f76-4e52-9670-47b676554562)(content(Whitespace\" \
+         \"))))(Tile((id \
          a0ae9158-514f-495f-84f7-4f85e3c1b0eb)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         296744bc-f43a-4dc8-9fb1-2c98e3212eaa)(content(Whitespace\" \
+         \"))))(Tile((id \
          6fae4f47-0788-4bc2-adac-a84faf7e6688)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e0389148-825d-482f-a530-cc5af6043259)(content(Whitespace\" \
+         c9717863-6333-4101-ad76-e1e6d4173cdf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6061e9f7-081c-4647-a284-d1483ed4885f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ccad1c10-f51b-42ee-8881-10d38bbd2b26)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         519b33a9-8dcd-4800-a186-876a275799fb)(content(Whitespace\" \
-         \"))))(Tile((id 279c03f4-de34-4df3-b599-203aef5b6fc7)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         746c71fb-3359-425c-8007-7eae8d4d3642)(content(Whitespace\" \
+         a0144459-16ec-454e-a7ba-4f66008fbcfe)(content(Whitespace\"\\n\"))))(Tile((id \
+         279c03f4-de34-4df3-b599-203aef5b6fc7)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         bc1b7448-0448-4a59-8503-323408236b7f)(content(Whitespace\" \
          \"))))(Tile((id \
          6561a64f-af46-466a-8ed9-f6101852fc90)(label(departments))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3cf49eae-4bb3-415e-933b-abe52e7df729)(content(Whitespace\" \
+         830a336a-4af9-47f9-95d0-0791aea576dc)(content(Whitespace\" \
          \"))))(Tile((id \
          7179cfd9-44bd-4544-904d-0acc6aa61bed)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         79ca16bb-f26e-4e55-a63c-8f35a9680a88)(content(Whitespace\" \
+         d53e85cd-8e30-479f-9856-464241a09e7c)(content(Whitespace\" \
          \"))))(Tile((id ba11ab0f-54a6-4e62-95d4-b798f3c008bb)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          2e833f3f-ce2e-4708-b95a-605f35ffcb7f)(label(Department))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         ccf81cfd-1fe5-4420-aaae-8f46e297c215)(content(Whitespace\" \
+         8274fc6c-ffb5-4bdb-b01a-66152a5d956a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5f9201a1-536b-4424-8cad-6002f3dc992e)(content(Whitespace\" \
+         f32cf240-d907-40f8-8e4b-3adee7259abb)(content(Whitespace\" \
          \"))))(Tile((id \
          e3bf2f1c-8252-4d68-b279-af9e8da4274b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          73bcd792-1f61-4eca-85e6-5c4c33c8ac10)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         2f9ea4b9-516b-4b0c-92cd-97b33fd86cd8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         928a80ef-0a53-41c0-8ecb-110003d8952a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1016ad50-a6a8-44e4-b809-78a69eb856ee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e9034c00-1f34-472d-a8c2-7a69060839dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fedf38fb-8b63-43fd-ac57-75f05970d68e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          92d047c7-2bac-4fc8-b8de-e2d6974e61fb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3211,14 +2780,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          638a3321-5f8f-4adb-ba7f-dd854d864993)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         64c73885-afdb-4e66-bb5c-90b30bfd9280)(content(Whitespace\"\\n\"))))(Secondary((id \
-         058fc327-8a08-4651-b629-e59fc7569343)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db9c600d-e92a-4e38-b55e-33bf1f0679e4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         23a6ac11-7b05-453f-8879-7a0c3cf89bed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fc832e07-c0b4-4fb3-8b8d-7b45234a1127)(content(Whitespace\" \
+         555876ce-0611-44cf-9fc5-2f22bee53b71)(content(Whitespace\" \
          \"))))(Tile((id \
          9c1db54b-2011-492f-9d2d-234e456ec30d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3237,14 +2799,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3698e050-b745-45bb-9047-22004b3a1b68)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6566ce55-f13c-4357-93f9-aef5077041a2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8b8c01ab-f9ed-4c4f-8bea-20e751f9c506)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cac20f4b-da1b-4ef9-aa42-7a106cb55fb7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         43d30c3e-e90a-46c0-b2f6-1b9a52b1ed96)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8662e815-fdc3-4bbc-8692-255e855e18bf)(content(Whitespace\" \
+         ac577740-a28a-4380-b040-03606943fff7)(content(Whitespace\" \
          \"))))(Tile((id \
          cab99371-16f5-461d-97fa-13e0794550a2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3263,14 +2818,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          31f6364c-bb2c-43d2-8c5d-bfa42c13ef1b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e2afa3b7-a889-4ce8-8078-0546e8ff298e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         00aa00bb-6d92-419a-9eaf-e6385a0c2f59)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8f165953-0b5c-417e-aa1c-cab77d863ab0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04048d0c-9415-4e73-8927-8ac09240ab39)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eb102ea6-26cc-490b-89b0-bc9fd1d5be68)(content(Whitespace\" \
+         804a9780-2790-448d-90a0-e1286e4cbc38)(content(Whitespace\" \
          \"))))(Tile((id \
          74def81c-4b69-48c5-bf75-7e4150a0a689)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3281,67 +2829,55 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6934ede2-5af9-4d77-a6ff-4850a12b7788)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3c3846d4-c1f5-4eb7-b7dc-014ae383e794)(content(Whitespace\" \
+         df024645-5e3a-4862-9cf6-aca05cc1e897)(content(Whitespace\" \
          \"))))(Tile((id \
          614b7b79-d3ab-4bc2-a039-232b75d93936)(label(\"\\\"Marketing\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7bc02fe7-4c2e-481a-8ae7-251709e86330)(content(Whitespace\"\\n\"))))(Secondary((id \
-         71ff16d7-4b46-42a6-9338-4d5754037d57)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57b69832-bb2d-4fd0-8726-b2a95b91fc08)(content(Whitespace\" \
-         \"))))))))))))))(Secondary((id \
-         aa1b1ce2-5232-4d71-932d-f6b606166423)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         8555326a-befe-4c6b-9d62-b92d06665247)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2609ccd2-608b-482e-80ab-60e9cf887d6e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         be5e515a-ef40-488f-bb37-ded7ecac53b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a616e387-985c-47df-b8a0-3b06e989f57c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         77580618-dc72-4d8e-b109-654156f6a448)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c3c0c036-d5d7-45a6-92c2-36edfeb341e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d58ffcc-13cb-41ca-81ac-b7bc35e10b4e)(content(Whitespace\" \
-         \"))))(Tile((id 1b1a0d32-2a5f-43d1-bf08-5ed0537471e6)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         9998ecda-edbc-432f-95e0-eddb4ab501d6)(content(Whitespace\" \
+         062d3b94-12b5-4e0f-a48e-63eefeedf10e)(content(Whitespace\"\\n\"))))(Tile((id \
+         1b1a0d32-2a5f-43d1-bf08-5ed0537471e6)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         fecc55d8-34a3-4cd7-959f-055311bdf699)(content(Whitespace\" \
          \"))))(Tile((id \
          bf8d4a43-ae60-4bef-b151-acaddd142e24)(label(tfilter))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         14d924fb-fa88-44c5-a5c6-2dde6bcadcba)(content(Whitespace\" \
+         86be8d1a-8ff5-4f48-a2f8-55c29ae35507)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8c9d2ec4-3d91-4cda-987e-e2afcda0d323)(content(Whitespace\" \
+         8c94776d-2638-436c-9874-a6a4ad67e73e)(content(Whitespace\" \
          \"))))(Tile((id b2efc51b-cca9-46d1-b70b-597adddffcf2)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         56f72dc2-e7aa-4d9a-aa01-65dfa57c47fb)(content(Whitespace\" \
+         c6973841-d530-4f1a-b054-7cdc899be471)(content(Whitespace\" \
          \"))))(Tile((id \
          19df232e-6164-4076-9129-b2d8cd098da7)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         2fa7715a-ed3c-4976-ab2a-43c3f6737520)(content(Whitespace\" \
+         f9771ad8-c4d2-4196-a36e-3d4b5b1c05d8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         216c9eb4-76f6-47e0-8149-1bcadd59606b)(content(Whitespace\" \
+         bd0c2aaa-77aa-40cc-99a6-4d0ad097d629)(content(Whitespace\" \
          \"))))(Tile((id 122b21de-8ad6-4faf-974d-eedbcb78c0ab)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         2fa20d8f-ecf8-46d8-96b6-684ea025cf4e)(content(Whitespace\" \
+         76e64dd1-c68c-4c8b-aa22-6abbe4db775d)(content(Whitespace\" \
          \"))))(Tile((id \
          84f3374e-ac37-4b9f-acf3-32ff39225a78)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          be5f7169-6b41-4317-b2c0-81c5ca10d12c)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         db6544a3-709e-432c-ac3f-5660f7016a90)(content(Whitespace\" \
+         \"))))(Tile((id \
          b35c4c84-8751-40ef-beae-5153dc517d20)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c516a9a7-1401-4c75-a820-7f99b2e6fced)(content(Whitespace\" \
+         9339ec08-1fd4-41b4-b30e-d635fb19cb6c)(content(Whitespace\" \
          \"))))(Tile((id 70698d7e-6fd4-4036-8c59-1a617b94b289)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -3351,15 +2887,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          18987571-4ff9-474c-bf54-a8fb766e9305)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         d7942cad-8b08-4a24-86aa-a85a26565c31)(content(Whitespace\" \
+         2fa3fdda-5d23-4437-b189-ca1c29a5ae7f)(content(Whitespace\" \
          \"))))(Tile((id \
          32aff099-0f79-4cf4-9b2a-e0ac748e30be)(label(pred))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         778a28aa-3bd5-426e-85ad-5264df89bade)(content(Whitespace\" \
+         \"))))(Tile((id \
          db0c784e-a6ed-404c-b98f-6da14a12e9cd)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9bc9a1f2-509e-4f6d-a565-0ea72a422b7c)(content(Whitespace\" \
+         3565c362-0040-4d67-b787-94d964250154)(content(Whitespace\" \
          \"))))(Tile((id \
          469a2140-5070-4bed-b7ef-e8f0e7047a7b)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -3367,19 +2905,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ba3614f2-23ad-49e3-a280-f64307455863)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         5bcda75c-91c4-4a0f-a7d8-6037a8c39a47)(content(Whitespace\" \
+         74b0112b-b97f-4f60-981a-32b2a591e9df)(content(Whitespace\" \
          \"))))(Tile((id \
          8bf26080-06d3-406b-8292-dff87dedbbb7)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a1a39a42-68bd-47f8-8318-089fc1eb4f14)(content(Whitespace\" \
+         1b4460a9-3ea1-4309-9d79-8a3ae4ae8b7c)(content(Whitespace\" \
          \"))))(Tile((id \
          73eed312-3306-4706-9187-a98a574be2a8)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         2bd75bbc-ea92-4d64-88dc-da519a7c0efd)(content(Whitespace\" \
+         ccbd3b80-365b-40c6-9ad0-2a9f0fa32a6e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c5e463a7-e0ca-4b4e-92a7-8159a7a9adc0)(content(Whitespace\" \
+         719aa14c-4f0b-4e21-bc18-f46351cb49be)(content(Whitespace\" \
          \"))))(Tile((id \
          9dc90a21-c276-4d3b-a995-0a9c89862329)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3392,93 +2930,95 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          be8bc061-d8e3-4bf4-a692-251bcde62da8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b75e20ec-e44f-4219-abc8-af550d77a9ef)(content(Whitespace\" \
+         \"))))(Tile((id \
          a4de1a9a-29a1-42f4-864a-96dfcd030dbb)(label(pred))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e9ec92ef-5b52-4222-9b19-901a634aa7c2)(content(Whitespace\" \
+         eb51dfd1-afdc-47d7-838a-db27c219fef4)(content(Whitespace\" \
          \"))))(Tile((id \
          5a860ff3-e6db-477b-8598-c447071f1c9c)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         348b209c-2e77-4494-ae97-f98607631e77)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         213d9ffd-f50f-44d0-9005-ad2aa9166311)(content(Whitespace\" \
+         \"))))(Tile((id 348b209c-2e77-4494-ae97-f98607631e77)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          a2f2aee3-bbc1-4526-aa68-53ba9d934eb4)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         3e5908d2-a91c-454e-9950-54bce48b5dc4)(content(Whitespace\" \
+         c3eb6d5b-d737-4580-9db2-c42787bef3bc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         dea257c4-864d-4b54-b0e3-af4f300d8e95)(content(Whitespace\"\\n\"))))(Secondary((id \
-         30df9e56-61e6-42f7-8e40-869ad41dcb4d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7694a564-036f-4925-bbdf-fb7d536975aa)(content(Whitespace\" \
-         \"))))(Tile((id 4c945996-aa38-45d4-a0b7-531180688dff)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         0372949c-e9d5-420d-94fc-494f7306d769)(content(Whitespace\" \
+         35d66f66-a7d9-44d7-97cb-c33a4cda8c9b)(content(Whitespace\"\\n\"))))(Tile((id \
+         4c945996-aa38-45d4-a0b7-531180688dff)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ba99d74a-449b-40a5-bdcc-f9e435b814d5)(content(Whitespace\" \
          \"))))(Tile((id \
          2f338bfc-c54d-44c7-8e5d-566a6da148e5)(label(get_row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f9a68446-f44c-4351-bded-e743f6126c05)(content(Whitespace\" \
+         e192be29-aa08-46fd-94eb-08b4cdc8453c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         40ea3f3d-9082-4295-bb6a-d9959e804127)(content(Whitespace\" \
+         67c1029a-70c3-4dd4-9001-e643f47271ed)(content(Whitespace\" \
          \"))))(Tile((id 2d68f96b-76d6-401e-92ac-d87e68d65414)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e7619a48-3577-4ce7-8c80-b95fd59a1683)(content(Whitespace\" \
+         4d017e20-c846-43c8-ab1d-c18c48a5da85)(content(Whitespace\" \
          \"))))(Tile((id \
          2955ba54-2122-449d-96f0-5e1d6efa5f0a)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         3f11a00d-892d-4a55-ad2c-3ffd51bc8cd7)(content(Whitespace\" \
+         8442357a-6393-4e55-91f1-ee06dbb4fb90)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0cc7d919-acfe-4145-8e94-39a9242f8059)(content(Whitespace\" \
+         0715c8ec-c167-46c4-a8c7-0d9a408fd146)(content(Whitespace\" \
          \"))))(Tile((id 01cfa8d2-5e31-4b03-b7a9-16beca143e55)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         40c725f4-b74b-47e9-8462-2472fb878d40)(content(Whitespace\" \
+         57386232-3451-42a3-a6d2-145001e2efb9)(content(Whitespace\" \
          \"))))(Tile((id \
          5be6ebfc-e2b2-41dc-8333-551f5e53ee25)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          4a19d5bc-aa5e-4fa1-be44-6909a6b8ddd0)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         78df2620-6a27-4d8a-a783-f20fed97406f)(content(Whitespace\" \
+         \"))))(Tile((id \
          107556d6-512f-490a-9ccf-8c34308d3420)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         af1e577f-3ed2-401d-a1a9-822d62239e4f)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         74017507-e03b-4714-8aec-668fcb39882b)(content(Whitespace\" \
+         \"))))(Tile((id af1e577f-3ed2-401d-a1a9-822d62239e4f)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          a3805650-4152-4576-8d14-09ab2ed70d66)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          905b6578-b6e2-473e-89cd-b8a5b93f8600)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f48dc460-86bf-4045-8052-95f144b0eec3)(content(Whitespace\" \
+         b02d7878-4ee0-4e33-b71a-83ce4c984606)(content(Whitespace\" \
          \"))))(Tile((id \
          5110afdc-9aa5-4388-a141-a2d6a2918544)(label(n))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         4ef5f66b-3031-4dae-9fd7-01c6eed46ee7)(content(Whitespace\" \
+         d732a3bf-dab4-4e6f-9287-bcf6ca20775b)(content(Whitespace\" \
          \"))))(Tile((id \
          8720101e-2b42-4fbb-92a0-7e12166d93f5)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         165a68bb-7036-4d31-b9cd-0307aa4d7704)(content(Whitespace\" \
+         847cce45-e73e-48ba-b192-11ab957eebec)(content(Whitespace\" \
          \"))))(Tile((id \
          59988fae-3b8c-474f-b613-5b4d34ac3f7a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         27f52c7a-d5dd-4031-90f1-2a91141cc198)(content(Whitespace\" \
+         11dc85ea-93c4-4660-b1de-6c7cb72e61e4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4fa6dc10-303f-46fc-9428-614e1874479b)(content(Whitespace\" \
+         5b3180e9-69b3-4db7-8728-d0669eb1eaa5)(content(Whitespace\" \
          \"))))(Tile((id \
          946f8601-0d01-4135-a55d-b7b566c557ad)(label(nth))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3491,93 +3031,98 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          02288aa4-a61a-4099-843f-93f90f5f944f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         576aa87f-c7cc-4150-aa6b-92c40d240ef7)(content(Whitespace\" \
+         \"))))(Tile((id \
          84c98bcf-78fd-4e79-945f-6fb6ce7a7ef0)(label(n))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         acbdfc6a-11f2-40ca-b062-53d567c8e49b)(content(Whitespace\" \
+         bb39770c-3921-4072-a236-985e4c44849f)(content(Whitespace\" \
          \"))))(Tile((id \
          d4b70d13-a32b-4f79-bbd5-7baa27c8c2e9)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fd2c434d-b8df-4d4a-9c3a-629867eabcfd)(content(Whitespace\" \
+         dc48512a-ac57-4520-bb69-9350d9c901cf)(content(Whitespace\" \
          \"))))(Tile((id \
          6e754701-09c4-4b29-bc83-64114ed0d1ed)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         0a102055-3cc3-4f64-bfdc-cac25feed920)(content(Whitespace\" \
+         cb71b713-97bf-4677-a45e-76b0d521eb94)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e8d44592-0d34-446e-b42b-82d6589c8878)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c161cee2-29d3-4e81-a64f-7e5afda29f41)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         396aaba1-941f-4d45-ac77-71db3f7cc9f3)(content(Whitespace\" \
-         \"))))(Tile((id 7c340b37-b25f-45f5-9f40-8ce28de4774a)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         093c2505-8a6f-446c-9246-9c57ce7b3f7d)(content(Whitespace\" \
+         dbe01fa9-d7e8-4aec-9730-1abe77967973)(content(Whitespace\"\\n\"))))(Tile((id \
+         7c340b37-b25f-45f5-9f40-8ce28de4774a)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         2ed73df9-d3ab-428f-aeaf-43dad264f176)(content(Whitespace\" \
          \"))))(Tile((id \
          c3c2e144-bd19-4a44-aebd-c3c4a6b275ca)(label(build_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6bfb3082-18e3-4056-aeca-bf465fac1eba)(content(Whitespace\" \
-         \")))))((Tile((id 35e3f162-868c-42c0-9122-538711e23df4)(label(typfun \
+         bf3d0fa3-3928-48ae-8c27-969b39fc8656)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         1c2592a7-a6de-4170-ab77-71c2cccfdfcf)(content(Whitespace\" \
+         \"))))(Tile((id 35e3f162-868c-42c0-9122-538711e23df4)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         21b28bf7-e51d-4ec3-9798-c699d3e40f10)(content(Whitespace\" \
+         f69eebfb-04b5-4e8d-b9c9-e95bb40e30ff)(content(Whitespace\" \
          \"))))(Tile((id \
          2d0b11a5-64b1-4ee9-be68-586d2061f4bc)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         bdf628da-56ca-4a71-8587-d7231ce71f02)(content(Whitespace\" \
+         d794761f-8c82-4bea-850a-357649ca694c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         641c706e-3b12-4769-aa00-edb4ca77ea4f)(content(Whitespace\" \
+         06e007e8-8077-4caa-a1b2-17861fea6691)(content(Whitespace\" \
          \"))))(Tile((id 0e29bdab-3f0b-4bc6-aacf-cb9ba4a98c05)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         0682407b-4a48-4f1c-8434-f639923bfc7d)(content(Whitespace\" \
+         0e3c5833-513c-4443-b41e-e5d9dd589927)(content(Whitespace\" \
          \"))))(Tile((id \
          f82d65a8-fdc9-4889-b4ef-ba5b72805600)(label(row'))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         50f83b8f-0d57-4d31-8270-a43c0f1b12de)(content(Whitespace\" \
+         3c6dfe5d-ab6f-4a3d-8462-627b1b516241)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d8eef6dd-010d-4fc2-8b75-323a57a7f165)(content(Whitespace\" \
+         b79ec315-237e-4c14-8a3c-99cb6d5df3e0)(content(Whitespace\" \
          \"))))(Tile((id 8e68c8e4-639b-4652-bfdc-51e58399a8ac)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         be92e1c5-fefe-4ae9-bca1-6868284e3c28)(content(Whitespace\" \
+         d2ad7934-4db7-4922-aaa0-a20c5954813e)(content(Whitespace\" \
          \"))))(Tile((id \
          f573e7a2-18f3-4d90-8731-f6efa8b3df5f)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          428527a7-2af0-4619-affa-bf45c73743b7)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6dcec299-8ce0-443b-a63b-c61cfc1c3977)(content(Whitespace\" \
+         \"))))(Tile((id \
          df2b996e-8d40-40ba-8e2b-a3c87641ce26)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         503f04c1-4df5-4eca-953b-17aafd4636d6)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ada95065-b07a-45d3-8237-b214629fe78c)(content(Whitespace\" \
+         \"))))(Tile((id 503f04c1-4df5-4eca-953b-17aafd4636d6)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          923e5416-c572-47ef-ae8b-950789a08e18)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          5e45d19a-736c-4540-8686-44780621dbf5)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         d84a0128-b4c7-42f0-83bd-c1afba6f87f9)(content(Whitespace\" \
+         ced90d53-7d95-49a4-80d3-6d76285d3caf)(content(Whitespace\" \
          \"))))(Tile((id \
          97828280-5f5c-4475-8f39-d293adc670bc)(label(fn))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         8b35c475-c222-4f9c-85b7-60110759526f)(content(Whitespace\" \
+         \"))))(Tile((id \
          d881ffbf-1fb7-4595-9703-1db28553f9f3)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dd7a6e2e-a9af-42b8-8b22-8e8649558d28)(content(Whitespace\" \
+         4d81603a-8ce9-4475-b3d9-f16e642f3bf3)(content(Whitespace\" \
          \"))))(Tile((id \
          bf9a338c-93bb-40b2-8af6-4922d9d70c2e)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -3585,19 +3130,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9500ccb0-e253-45d6-9e7a-fede0f87d4b8)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         94a6b877-df68-4293-b256-399b59fd6b7e)(content(Whitespace\" \
+         d68d0428-b6ec-4b3a-be30-c960930bbd2c)(content(Whitespace\" \
          \"))))(Tile((id \
          dd850c56-94a3-42d1-9a48-3303cbafb411)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         36593474-5938-4f68-ad72-7db44f0d6cf9)(content(Whitespace\" \
+         e517619f-fe5f-4683-b38a-bd824a4ad62e)(content(Whitespace\" \
          \"))))(Tile((id \
          856b0e5c-f281-496b-8934-8ab2edec4b3e)(label(row'))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         0fce6137-a1d8-4a12-8efd-82e7eecf7e3a)(content(Whitespace\" \
+         3704be0c-5d44-4663-9d81-33b057f30fc5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7021aca0-7656-4f24-ab39-f8e6dd41dbdf)(content(Whitespace\" \
+         842e2272-4ce2-4baa-9163-494f7fee6d2b)(content(Whitespace\" \
          \"))))(Tile((id \
          ced9087a-ec32-4cc4-957b-c35db9fb33be)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3611,63 +3156,52 @@ let out : string * Haz3lcore.PersistentSegment.t =
          af2407af-f65f-4e2a-b0cb-b144d63d4789)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         146b72c8-63e7-4edb-9c6e-23494405b478)(content(Whitespace\" \
+         f45371fd-fb4e-4b46-ac0f-03771ca49fdf)(content(Whitespace\" \
          \"))))(Tile((id \
          91c7d70f-e20d-4a95-b27e-b443d511ea87)(label(fn))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         207a01cf-aace-4d4d-ba92-b744aa4c902d)(content(Whitespace\" \
+         f4cc3bea-537d-4b6c-af45-a3f659cd79d5)(content(Whitespace\" \
          \"))))(Tile((id \
          de01c9e0-260a-4fd9-8daa-a1050a05dc45)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e1ccb0b9-19bc-43c2-bb9a-f146153a45e4)(content(Whitespace\" \
+         a22ae210-752b-4805-909c-f670ecb92d6e)(content(Whitespace\" \
          \"))))(Tile((id 6464caa7-5ecb-47f7-8dda-8e9dd4c1271f)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          fe0f3fbe-cea5-4e07-b22a-6a2c6c17157e)(label(row'))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d59f11c2-8c23-467f-948c-83234fe32089)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1963d070-4bb7-4a15-aa85-8f4071f700f1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36089be3-1f3c-49c3-ae0e-f58c095ef9b1)(content(Whitespace\" \
-         \"))))(Tile((id a4d004a8-1c65-4867-bcf0-f3ac89ae01ab)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         a0d8d277-d519-4b31-8e67-65ff6be29aed)(content(Whitespace\" \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         04fc123d-ab1d-4e1a-94f5-9f4b27781f07)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         772000d3-5fc1-4781-ac69-1f233e9c9777)(content(Whitespace\"\\n\"))))(Tile((id \
+         a4d004a8-1c65-4867-bcf0-f3ac89ae01ab)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a961b843-e405-4a5e-a4de-1515c91ada1b)(content(Whitespace\" \
          \"))))(Tile((id \
          32e1de9e-396e-4cc1-a207-a3a01537f340)(label(incorrect))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3223dba3-6e18-421e-98ad-b717bdf2a8b2)(content(Whitespace\" \
+         ac2f907b-d229-40ca-acc7-20b309536d05)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2266e56d-dddd-4b74-87e1-4b5b62db409e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         25744493-91f7-495d-8225-5cecf2106176)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         98d0c6fd-4f47-4ed5-844c-b69a415f4579)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1425a1c8-a2aa-40f6-84af-bbf12a8a5de4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         14bde9f7-f0da-4873-828a-f883a931b6d7)(content(Whitespace\" \
-         \"))))(Tile((id eb48d46a-99d5-4b66-875c-ebcc78468444)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         61a3667a-ad4b-4784-8158-5f2b1f1d9e3f)(content(Whitespace\" \
+         b5097a3f-269b-4f84-976d-de6b463b1931)(content(Whitespace\"\\n\"))))(Tile((id \
+         eb48d46a-99d5-4b66-875c-ebcc78468444)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         4d7d8ec6-6fa0-4977-94b0-fc10be63bf60)(content(Whitespace\" \
          \"))))(Tile((id \
          a76cef0d-bbf9-44c0-b407-7cef260d91ee)(label(last_name_to_dept_id))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f3688963-0fa9-4ead-81eb-c67772e849bc)(content(Whitespace\" \
+         3a1abe19-ed77-4585-98d5-43045f9be7c7)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2647d0f0-9605-44a6-a2fb-1c83366b4491)(content(Whitespace\" \
-         \"))))(Tile((id b0ea3f31-2118-4876-a5a4-a714b0951ba3)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         76b83f5a-ef06-4d2b-98ea-c230118ab4fe)(content(Whitespace\" \
+         3e91c355-592d-47b2-af25-c5a4475cfd80)(content(Whitespace\"\\n\"))))(Tile((id \
+         b0ea3f31-2118-4876-a5a4-a714b0951ba3)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e759eeb3-744b-4dbd-ae16-0f3c69c05fde)(content(Whitespace\" \
          \"))))(Tile((id \
          dd69f7a2-b29d-45f3-ab2c-58dcdbdd747a)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -3675,12 +3209,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a798d7cb-e8d1-4659-be74-65d01013b266)(label(dept_tab))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b3c1ea1a-b47c-45f3-aa88-b607f424729b)(content(Whitespace\" \
+         8debc34b-45e1-4f9a-8aff-22b4babfe030)(content(Whitespace\" \
          \"))))(Tile((id \
          5e003d55-beb6-49a4-880d-367abe95ee7f)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6d3ac647-93c5-40d4-9f04-9773a78cb8e1)(content(Whitespace\" \
+         c1f56353-a475-4fbe-b349-b0da589f2546)(content(Whitespace\" \
          \"))))(Tile((id 87be4389-0578-46fe-b82b-81def51b0eab)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -3690,50 +3224,40 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9d89c52d-5874-4eda-b1e2-a3153a1bca61)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         055dee46-6ca5-4a49-8458-3c135595edf2)(content(Whitespace\" \
+         a1570f7a-c469-4a70-bd55-5922d1166906)(content(Whitespace\" \
          \"))))(Tile((id \
          7370610f-6005-4e5d-acb7-c7f48cf4d415)(label(name))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4c829e6d-b4cb-4afc-a3b0-a8578f38a872)(content(Whitespace\" \
+         \"))))(Tile((id \
          e281d878-c865-47aa-b53a-2fee8208e263)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7944df0b-1b04-433a-b669-f11a9ac7a504)(content(Whitespace\" \
+         a6d65e58-1c67-4e8a-a4b5-bf0645e96183)(content(Whitespace\" \
          \"))))(Tile((id \
          e4a62077-4d56-4157-a094-d43340c92fe5)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         5009dc0f-8769-4bd4-948a-74ef1284e542)(content(Whitespace\" \
+         57c4ca4c-06bc-462e-b3f1-6421926d69af)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a7a4f2af-8ecc-4e84-a31b-b43ba57b348a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e42dcc69-4def-4121-b6fd-b93156ed1ee1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eb9d67fa-3c92-439c-b306-c7b83be545ce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cae36a04-5610-4486-886e-e78d6e37e5af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e949959-69be-497e-9c5f-ddd8b49f8c07)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         18737378-8ca6-43a5-bc7f-da4a37f0a266)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         89ef4dc8-cc6d-4914-b948-92524d0deb58)(content(Whitespace\" \
-         \"))))(Tile((id e6f25500-3b52-4073-971d-3da5dfe9ff32)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         7b8bb194-fa53-4ee2-84bc-2dd2cee85cb2)(content(Whitespace\" \
+         2dcd3986-038c-4b43-96e4-ebe5e9ebdf12)(content(Whitespace\"\\n\"))))(Tile((id \
+         e6f25500-3b52-4073-971d-3da5dfe9ff32)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         674f69ea-94fd-4971-8bde-0e8f1a6f2268)(content(Whitespace\" \
          \"))))(Tile((id \
          dfa99157-674b-4136-9c7a-9999813e63db)(label(match_name))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e4199037-8042-48d3-8715-7dfa6886ce48)(content(Whitespace\" \
+         e1fb2489-5dc1-4cad-aaf9-a6af11e44a9d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         09a85779-d753-47b4-b495-30ef32ba41a6)(content(Whitespace\" \
+         c3c00b17-9081-4b50-a70e-ed0a0d8593a0)(content(Whitespace\" \
          \"))))(Tile((id aeac0824-8a4a-4d2d-ac98-5e759330bbfa)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         ae4a5b23-6ab3-473c-9618-114776e858a3)(content(Whitespace\" \
+         882dfbad-214d-4ebc-bd0d-7bfd7b54a44a)(content(Whitespace\" \
          \"))))(Tile((id \
          0c0e542e-f711-4ddb-b110-178037b9b3a1)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -3741,21 +3265,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          20b84797-1de7-457b-af6c-33e59797ed90)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a103f730-dffa-498b-8eee-7afee5b8ffe0)(content(Whitespace\" \
+         f08a105f-aad0-4fc1-bb0c-4654e47bf537)(content(Whitespace\" \
          \"))))(Tile((id \
          80ac3ddc-e329-42e4-af44-9744bfe60e5b)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         91ed26dd-f796-41ff-9c92-e61bf0573887)(content(Whitespace\" \
+         5eef4382-090c-4f22-b01c-a3a0a540c601)(content(Whitespace\" \
          \"))))(Tile((id \
          e895a8f1-83f3-4f60-b61b-8ee2a4d63485)(label(Department))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         50cc6448-fa86-4fed-9689-ebc21fceb548)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c1b0105-3e97-45d0-a7f1-3d08e50ca38c)(content(Whitespace\" \
+         bade2de2-5705-45bb-a2be-0a5e2ec40d03)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3f7f8a02-fde5-4401-9a69-d0a6afe1c865)(content(Whitespace\" \
+         d806f613-e8af-4564-ad4a-826332a98e20)(content(Whitespace\" \
          \"))))(Tile((id \
          58e1e043-82db-4b7a-8ba7-539de4b315e2)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3766,42 +3288,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6379ff27-0490-41c7-ada7-68cfceaad64e)(label(last_name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         cda0deb1-937c-4ddd-8f42-117a94497475)(content(Whitespace\" \
+         e92794f5-f8b4-43eb-bf74-a779ca86799f)(content(Whitespace\" \
          \"))))(Tile((id \
          0846ed52-0cef-406c-bcef-26c19d03b38a)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         09e3dce0-4cf2-4b51-8e05-a7a66245c99e)(content(Whitespace\" \
+         43407508-286d-4bfd-a8be-b4c9ef3b7968)(content(Whitespace\" \
          \"))))(Tile((id \
          bf2d7867-e691-4e9a-8366-d855eb5d7dde)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         4e8a8537-d226-419c-97a1-04934bc0ba9a)(content(Whitespace\" \
+         94e7ec87-616d-4e6d-ba86-b48e82534c22)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6e673c72-b845-4c62-bdf4-9f2ef7402185)(content(Whitespace\"\\n\"))))(Secondary((id \
-         45eb6881-92ab-4263-95e8-51b7a6c9e810)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e6d6a40-d108-435f-8529-0a30cf0dc86d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2ebc7ebe-d0fe-47ab-806d-d01550fa8bc0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         884e2f7d-4688-46a0-a9b3-9f1d63ac9ef7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9b343937-cd1d-40ed-901d-aa7b4b0a751c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27bd14f1-b62c-415d-b54b-473b7ed47e5f)(content(Whitespace\" \
-         \"))))(Tile((id 21274db1-44f5-4c7a-9ad6-a6b5d7362bdf)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         9d48ef9d-df9d-400f-b73b-9bf2e3ee46b2)(content(Whitespace\" \
+         31edd1d2-dd4b-4649-b0a0-1ce0ef65e466)(content(Whitespace\"\\n\"))))(Tile((id \
+         21274db1-44f5-4c7a-9ad6-a6b5d7362bdf)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e652cfa6-94ed-489f-955f-b149513c3e56)(content(Whitespace\" \
          \"))))(Tile((id \
          1ff7fb13-bad1-4c11-a1e2-f770384d326e)(label(matched_tab))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         27eb0450-125c-4987-a0ea-9806320f1633)(content(Whitespace\" \
+         f35f36f5-e419-42e1-b9c9-942658d90f4d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         aba782c2-12ca-4bd5-a674-125ff7c0187a)(content(Whitespace\" \
+         5ad4300e-6208-477e-960d-d5f66adb267d)(content(Whitespace\" \
          \"))))(Tile((id \
          a0a21bf3-1d5c-483d-bde1-0af0c37bee7f)(label(tfilter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3821,37 +3331,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          086cf4bc-0d64-4b32-b3c5-f94db00288ea)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a4dfbaaf-e41a-4ec6-99c0-dcb183e6b9e4)(content(Whitespace\" \
+         3fb8b75c-63e3-4319-8d30-38e67bb0d54f)(content(Whitespace\" \
          \"))))(Tile((id \
          4920ed5b-2eb9-4def-a636-bf20266575dc)(label(match_name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d84f27f5-e96e-4e55-9b0a-ef1dab520413)(content(Whitespace\" \
+         a5de24e9-0af1-40b8-8783-65539e50762b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         08cd5207-aca3-4107-a77d-a587c5ff5837)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d9142e19-02c7-4c99-a095-5cebf7af7791)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cdab9e48-e345-4ebb-bdd4-5b04c9aada60)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d492de43-4d2f-4ad6-8766-fbc44ef90141)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8114ab92-8aa2-43ed-82d3-068c431e9dda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1e7b8bdd-df51-40c2-8398-18f4812e0119)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         191b9035-2ac8-48d7-8c8f-982777276a6b)(content(Whitespace\" \
-         \"))))(Tile((id 1ba289cd-12cd-444a-b114-3a65068d96b5)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         00f6bad0-6b2e-4b00-b265-7a005a404789)(content(Whitespace\" \
+         c636135a-d8ab-4ca1-b3b9-6b9ae049486c)(content(Whitespace\"\\n\"))))(Tile((id \
+         1ba289cd-12cd-444a-b114-3a65068d96b5)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         d0278cc0-b772-424d-9145-12019d448552)(content(Whitespace\" \
          \"))))(Tile((id \
          44ecf7b8-90a2-4f84-aa29-5b2af90c7144)(label(matched_row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1f494016-17b9-4318-b9bf-6129b222c836)(content(Whitespace\" \
+         aa340cbc-509f-40fd-9c87-5d097f56a0f0)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f321f7b8-227c-4d6d-aeca-619dcbe7070a)(content(Whitespace\" \
+         046ff8ce-e48b-4334-bd4c-712915236125)(content(Whitespace\" \
          \"))))(Tile((id \
          6f765534-5eb4-414c-a0d1-0170eb1e7ac1)(label(get_row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3871,26 +3369,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3600107f-7b2a-40cb-be5a-6046faf8bc13)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cc235414-8391-4e3c-84ea-6083e0511dbd)(content(Whitespace\" \
+         15befaae-bbde-4ec1-bb5b-c749972b219a)(content(Whitespace\" \
          \"))))(Tile((id \
          e4b99439-9c44-4476-9c7a-4b87e212b68d)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4ad97829-1d2f-4f7a-a5dd-12cb1b1a9d41)(content(Whitespace\" \
+         c9c0818a-9d2b-4dac-b611-6bcec8ee34d6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d8a79330-e510-4f79-ad77-ebe3d6c6a86c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         635dc3a8-8601-4f02-9a68-830b3e49bdb0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0039058d-850d-419e-b85d-ca5d4b6dd341)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a62069d5-36b1-4089-b013-9316e4286ad2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2fc59da2-819d-47c3-939c-28950be00c97)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1128e339-3a30-471d-834b-b1846af806b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f047be0a-62dc-4f53-b75d-d3cad442e9f7)(content(Whitespace\" \
-         \"))))(Tile((id \
+         009f4573-be66-462b-a484-dac2c85334d2)(content(Whitespace\"\\n\"))))(Tile((id \
          b389c096-d0e3-437a-a2bf-c87f335a664c)(label(matched_row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3900,129 +3386,84 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1f4feb45-9543-4d2e-9ea4-b05924068180)(label(`department_id`))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         0a0f5e74-0e20-44d3-aaff-ee6a7546e438)(content(Whitespace\"\\n\"))))(Secondary((id \
-         75f92e24-9feb-4d13-98a1-c2049eee41d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         157c6d9e-ff42-4902-8ad4-fc1873ca0be6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e5488d1f-42cb-4734-ae51-aeb2853c7862)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b300223-5e71-4cc0-b93b-02e9dd50ada1)(content(Whitespace\" \
+         2fa8f97d-18f9-413c-a62a-8cea0a43d337)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         067d0cd8-9fed-4a2f-8650-8dac1b603cef)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cebd3fe0-3e09-4a7c-bb45-9ff7d87616de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         80357a01-b622-4f42-85e8-12f61043f9fb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3662151f-d33f-400d-80ae-76379149bf82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         06a59a5b-14b5-49ef-afa1-0e29fe23e688)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         99b52269-a040-4610-b0b8-d4ca0db2e5f3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3b59b832-6d94-4bab-9faf-a28a4260f75c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d134627-61f1-4fa2-96bb-084be1722a94)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         559b518e-03c4-485c-b59f-6aadf9419026)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3af078e6-e2eb-4086-ad35-b07047f29b07)(content(Whitespace\" \
-         \"))))(Tile((id 617c3e71-9a59-4de2-aacc-d8d0e54e15f4)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         bd0dd5fc-9ff3-47b6-bf51-5fdbf4eac516)(content(Whitespace\" \
+         e931ad61-a1fe-4c18-8fa2-440338450cb1)(content(Whitespace\"\\n\"))))(Tile((id \
+         617c3e71-9a59-4de2-aacc-d8d0e54e15f4)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         58612191-d97a-4b4b-8ccc-ea25dc324624)(content(Whitespace\" \
          \"))))(Tile((id \
          5a035cff-baf8-4e49-9f03-a3c882d85276)(label(employee_to_department))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         fe401821-8c90-49a4-a720-b0e064f77ac3)(content(Whitespace\" \
+         605aaa85-785e-4118-b6c3-bb7bdae64f9a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8031f19e-caea-45b0-b9c3-6f68672be9a3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f5ee725a-0e05-4fb7-b949-d1155edc3938)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7b86f273-ab30-4f52-b4e9-4895922f3126)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f33c461d-36b9-46b0-bead-d75dd5317eef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         668d98a7-f01d-45f3-9710-f2874a244e03)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e92c5db-4bcb-4402-95e1-44d30a2df27b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6937fc71-3e80-4073-a21d-cfa71a120bdb)(content(Whitespace\" \
-         \"))))(Tile((id cad20e2a-5dba-4fda-a391-ec0472092df0)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         46a2642b-453a-4006-b982-50d91a790efd)(content(Whitespace\" \
+         ec377ad5-3dd6-4455-ada8-884ca706f2f5)(content(Whitespace\"\\n\"))))(Tile((id \
+         cad20e2a-5dba-4fda-a391-ec0472092df0)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         72503266-1c42-4f47-8653-c967c517b787)(content(Whitespace\" \
          \"))))(Tile((id \
          dab48750-cc4a-44c4-b5df-5444315ea945)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         5bead383-62b0-40bc-974f-66f5927ea878)(label(name))(mold((out \
+         5bead383-62b0-40bc-974f-66f5927ea878)(label(_name))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3b15abd3-8291-45c2-9029-e7b4a6500275)(content(Whitespace\" \
+         d0202d6e-e398-40d3-bd29-7963e4c48bac)(content(Whitespace\" \
          \"))))(Tile((id \
          ea39d406-7670-49d5-9c3b-25969659a7ad)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         749f74be-98fa-418d-bb1e-97c441c6095b)(content(Whitespace\" \
+         \"))))(Tile((id \
          2493f89c-9589-4e44-96bd-32e0e17d2869)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          637d3542-4231-4e23-a83c-c19156c03d74)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         bb067d8e-ccef-4a30-8eb9-4987daccfb7d)(content(Whitespace\" \
+         d9627478-9dea-4735-93fb-d784694143a3)(content(Whitespace\" \
          \"))))(Tile((id \
          7dc02a4f-43ae-4ebc-9b29-c673fa93f637)(label(empl_tab))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f6e8457d-9107-4322-af56-6972874e3386)(content(Whitespace\" \
+         \"))))(Tile((id \
          55bee3b3-e1c7-4a65-9113-308270223c60)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c96f5beb-c98e-4851-93fa-6a3f984498b6)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f3e28c82-4583-42d3-9785-78181cbff9f2)(content(Whitespace\" \
+         \"))))(Tile((id c96f5beb-c98e-4851-93fa-6a3f984498b6)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          5ac86075-a832-496e-ae09-fbe7b827c1ad)(label(Employee))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          6cbba857-7961-4a36-89ff-0603f67583ae)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         914144ee-5fac-45ed-a7c4-028bb3bccda1)(content(Whitespace\" \
+         a1c0cba4-09f3-496f-a8c9-6a05354781cf)(content(Whitespace\" \
          \"))))(Tile((id \
          9a9ffa48-4af7-4ae1-be43-e32a2b5a5529)(label(dept_tab))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         348cdcce-f81c-4c5f-b004-e9268823eed8)(content(Whitespace\" \
+         \"))))(Tile((id \
          8377b6a9-46b2-4d9c-b185-150f9a9f1dd9)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f11dbacc-e5ab-452e-8294-76933b4f7783)(content(Whitespace\" \
+         9cf88c78-565d-40ea-91ae-d588fcc47e63)(content(Whitespace\" \
          \"))))(Tile((id b493dab0-dc40-4629-a09b-02f7b401f69f)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          0b15b4b5-88af-469d-92eb-38124f021461)(label(Department))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         9c7e398b-77ec-44cc-b910-1b853f457dcf)(content(Whitespace\" \
+         35326678-7380-4b52-a2e3-ee4c52e82951)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3a4e2f2e-81c6-4e12-a49a-6e1446e728c1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         aa7835ee-b432-4cc0-8de0-a3d15f5bb159)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         540077c4-575b-4a53-8b95-b85922b63544)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         97034235-1c95-427a-a95f-ac16eb9843b2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3ac91f5a-5ffc-4670-806d-815c7bc1799d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d7fe0dba-7ffd-4de6-911c-2b7630e19467)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         52237325-4135-452e-9584-0498381e013e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1e358dd1-819a-42b6-b3b3-a793c9432470)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fc53be26-a8b9-4395-ba7b-26bbbd12c9aa)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9eef8436-7d98-436c-955b-55d2f8be50f0)(content(Whitespace\"\\n\"))))(Tile((id \
          4ee01615-7350-4610-a942-de22fb8c5bff)(label(build_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -4040,38 +3481,50 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          d5b603dd-d189-4264-8470-eed9e7a8f101)(label(last_name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5ab35b7d-9b0d-40bd-b9cb-e88db7bd109c)(content(Whitespace\" \
+         \"))))(Tile((id \
          c567c334-93c3-4ee4-b215-b6fe7f076147)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3091c6f6-0a0a-437e-ae5e-71c5e514d642)(content(Whitespace\" \
+         \"))))(Tile((id \
          d04487c7-cdb2-4ea7-9813-5d05133c7b70)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          2c577899-8d80-4a3e-ba96-095fdfb3fd83)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a998c3b1-fa38-4f17-b3af-cf5198e7863e)(content(Whitespace\" \
+         a81fa642-52ac-4926-8a10-6c109e3d0e28)(content(Whitespace\" \
          \"))))(Tile((id \
          c6f06276-b4b8-4bb5-83eb-ce31f4484ae3)(label(department_id))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1d90a7f5-5e7a-4d4a-9fed-e69815485a2b)(content(Whitespace\" \
+         \"))))(Tile((id \
          5b2e81ef-41d7-4a2a-8ca2-0bf3102aa3fc)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ad9c9202-4405-461a-a71e-8178c2e60219)(content(Whitespace\" \
+         \"))))(Tile((id \
          bc10e67b-2f51-4461-b128-cd5418e30f3f)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d4837706-3741-4054-834a-19657e27cea2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0f097d79-bb00-4066-8a87-3a0539b28530)(content(Whitespace\" \
+         62a8ce79-1ca1-408f-9f03-976f652b9c35)(content(Whitespace\" \
          \"))))(Tile((id \
          67a62f2e-c801-4786-83b9-7c1f3d935d59)(label(department_name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f7078028-dafe-4229-92fe-6ecce972827f)(content(Whitespace\" \
+         \"))))(Tile((id \
          1b6a6d28-272d-4bfa-afc3-48cd394cc354)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         67df1eea-d341-4188-9d79-eb0fdd2666fd)(content(Whitespace\" \
+         \"))))(Tile((id \
          2e4d8eb0-d708-40a2-a875-982a7c10d9f5)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
@@ -4084,58 +3537,43 @@ let out : string * Haz3lcore.PersistentSegment.t =
          56e3d31b-d4c8-4f92-82db-f7a4aa6a88ab)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         63fc1548-3198-4f7f-ab5c-099d6fb5b880)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b49e5acc-95c9-4149-9fc9-4564efc61656)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2dcb6765-c357-44bf-9a35-48ca3d79dcd2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eb5999f8-af89-4702-989d-20bf6d917056)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5424ee01-8f65-4277-b02a-375bb2da2aa9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f98b88f5-af22-497b-873b-0ece463cd4dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c04142ec-b9b0-4762-a8b6-1258ff312a2b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f78e02e-13c7-43a0-89a9-75945dc30e2c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         12302950-de3b-4529-a305-5cb5fcac3073)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         78814bda-0c6e-4526-8b2b-ce66b09a2ff5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         12ef866e-584f-49e0-8a3d-980f4a501c0d)(content(Whitespace\" \
+         ea503913-a4f3-4012-8ced-7126592f014f)(content(Whitespace\" \
          \"))))(Tile((id e0ab71c7-6cc2-4aea-a7dd-aa0c8522bde8)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         b65faf23-78e4-4a5c-b48e-c94bf77e21d7)(content(Whitespace\" \
+         5ca7412b-7fe3-498e-82de-cf48fd2c5622)(content(Whitespace\" \
          \"))))(Tile((id \
          3f887749-0954-4f8c-8167-7a10e76a45bd)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b6c61cad-7f30-43c1-89c7-4c014174e47a)(content(Whitespace\" \
+         7da73f88-7dac-4cdb-b791-7ae1844d2044)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         15008183-0ef1-4740-a57b-8ad08c72b600)(content(Whitespace\" \
+         9fc53fb0-31e2-413c-be47-141eea20a17e)(content(Whitespace\" \
          \"))))(Tile((id \
          30ae1018-c907-4ce6-8eb6-0dde1f3e5734)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c66c612d-60db-46ed-924b-7baa183f8109)(content(Whitespace\" \
+         583d8c9c-ee82-491d-b863-88df2246b3d0)(content(Whitespace\" \
          \"))))(Tile((id \
          f140e146-b317-461b-9735-45877d9d03cd)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bbef8f35-a29e-4272-9ad6-dad56200ade6)(content(Whitespace\" \
+         1d8c794e-c03c-4279-a3c7-abc16667c86b)(content(Whitespace\" \
          \"))))(Tile((id \
          3986e38e-658c-4954-876c-d630d8dbb5f9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          5fa052ae-9c76-430b-88f2-f4a2e74d3212)(label(department_name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         623dfd9a-1542-46fa-84bb-f199e14c4ffe)(content(Whitespace\" \
+         \"))))(Tile((id \
          36e37d8c-6683-4ec0-8ce3-d05b3b5c7b36)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         683a32af-cc66-4cf3-b185-2c2fc6e823c7)(content(Whitespace\" \
+         \"))))(Tile((id \
          6b22ad36-3435-41c9-827e-2a2a4a3a45e6)(label(last_name_to_dept_id))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -4148,7 +3586,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          15b648f6-0a24-4e9e-bce7-468cff7669d8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d1f5cbb1-570b-4db6-924e-59fa43a01d93)(content(Whitespace\" \
+         d8dbeae1-d1d2-4806-bac1-c4788b842b96)(content(Whitespace\" \
          \"))))(Tile((id \
          d1fc072c-f690-45f9-9b06-4e00acf1ac8a)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4159,72 +3597,41 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5d995038-62a5-494c-9e34-1200ed52e95e)(label(`last_name`))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         5f0095e0-e8bb-4337-9cb6-321818ca662a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2d3bfcb0-17c8-4141-a145-bb510b73ceb3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d719ab94-1437-40f0-9fde-5d0916f31ba9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         11684968-1b1c-4cb4-8a6b-21f7dce8c855)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         51f60ef9-1eab-4793-a540-9ce90c4d2153)(content(Whitespace\" \
+         e4ad096c-81ee-4047-887a-dbc620da9e65)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         078b42cc-6c3c-438f-a517-2fa8d1762874)(content(Whitespace\" \
-         \"))))(Tile((id \
+         cb267661-3a08-46e7-8c77-f4e455138074)(content(Whitespace\"\\n\"))))(Tile((id \
          185f614c-8353-4666-9b0d-f1c325cc35b5)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b5bb6641-f14f-48f5-995f-33e43af939de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4816ef8e-bb0c-4940-9c34-ad98ca7562e3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3250e71c-3020-4d7a-b067-b72f00263d5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b87ef911-ddf0-4bae-af6a-3571f5525837)(content(Whitespace\" \
+         dd0ff87b-cc52-44ed-838b-c59d901e8573)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5561360e-045d-49c3-9347-b7aa6b07bc71)(content(Whitespace\"\\n\"))))(Secondary((id \
-         aaba6b98-00de-4f77-9908-08a625692a5b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae111011-6e59-4907-8f62-d7da1d849656)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4bd2e546-89f7-4eed-9561-5cca5caaf801)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d52617aa-7c13-495c-8216-c4beab437cc3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6c46af7b-16bc-4ef3-90a9-2d6180f1edf1)(content(Whitespace\" \
-         \"))))(Tile((id 4ef4e35d-3461-44c3-b0a1-57e2b85cf706)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c7bf3b08-1502-447d-9a20-28d70938707f)(content(Whitespace\" \
+         d5f380a6-20d3-40dd-9c7b-bcf410bdcbf9)(content(Whitespace\"\\n\"))))(Tile((id \
+         4ef4e35d-3461-44c3-b0a1-57e2b85cf706)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         10df4711-66ed-4a91-9a20-8fe97820370b)(content(Whitespace\" \
          \"))))(Tile((id \
          2a0e909c-037d-4859-8185-c6c19448da74)(label(correct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c9d90923-456b-4908-9226-6034261d5a11)(content(Whitespace\" \
+         b422ee16-2015-4794-84ef-3956e2b24e01)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f36b0f16-869c-479b-89d4-df0222e8ed99)(content(Whitespace\"\\n\"))))(Secondary((id \
-         23f7a7c7-4de8-4711-8436-04420d99022e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3336d422-2f04-49f2-b49a-1fe7e314232a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b79fc05a-c043-42d3-a9b2-f14d40b03c57)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04c75b2d-8698-4554-bad0-bd4bee22e473)(content(Whitespace\" \
-         \"))))(Tile((id 0e3bc1b9-13ca-42f8-9f43-24376b01bef1)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         485bb955-0f1b-48d0-ac7a-ce87de6dccf5)(content(Whitespace\" \
+         758d290f-8e39-4675-ba13-76764cbceb2a)(content(Whitespace\"\\n\"))))(Tile((id \
+         0e3bc1b9-13ca-42f8-9f43-24376b01bef1)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         030ec750-555a-4cbf-b516-74ddd9e87cc4)(content(Whitespace\" \
          \"))))(Tile((id \
          9178cc74-6f3c-463b-9917-d888d9a710f4)(label(dept_id_to_dept_name))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         007e29e8-0203-41e5-9255-35b883aa2b5f)(content(Whitespace\" \
+         39f46f71-0217-4463-84de-4c02e070b772)(content(Whitespace\" \
          \")))))((Secondary((id \
-         cccc5fb7-7959-443a-91ef-dc1af1f243d0)(content(Whitespace\" \
-         \"))))(Tile((id b9408ba2-05e1-4ff0-b238-8a4563a6021d)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         36746285-ea1e-4506-b3ce-bc10b87ab776)(content(Whitespace\" \
+         77094d99-5084-4d02-913b-15e4686a5f1c)(content(Whitespace\"\\n\"))))(Tile((id \
+         b9408ba2-05e1-4ff0-b238-8a4563a6021d)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         06e667e1-4f6f-4ebd-940e-21b517e292dd)(content(Whitespace\" \
          \"))))(Tile((id \
          c4143c63-2140-4dc2-97db-19a0a8a6dbb6)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -4232,12 +3639,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3e019c2b-867a-4648-814e-4060efa45d4e)(label(dept_tab))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         83c826fc-a954-45bd-9870-2057b7572c90)(content(Whitespace\" \
+         db85e2b5-7d7f-47c9-8e80-0817eb63ac2b)(content(Whitespace\" \
          \"))))(Tile((id \
          422d465a-c0e1-4a2b-96c3-9abfe2971991)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8a5c4340-0142-4c8f-9ade-5a93cb401b58)(content(Whitespace\" \
+         cffb7d03-3684-4cef-bb6c-d4134d0c6ca7)(content(Whitespace\" \
          \"))))(Tile((id d6e5ba80-5878-4e07-af23-61cebced4a8c)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -4247,50 +3654,40 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aa4920bd-0e15-41ee-83a2-ad0a86686d69)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         8208d3ff-f8c1-490d-8bbc-f329a4682cb9)(content(Whitespace\" \
+         9b11696c-df7e-45cc-8734-356e9a6ed374)(content(Whitespace\" \
          \"))))(Tile((id \
          f8affbcd-773a-4b70-aed1-c4ce1d31891e)(label(dept_id))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f3051458-1e2e-40cd-9039-e5b2e28eb554)(content(Whitespace\" \
+         \"))))(Tile((id \
          c31dfc3b-b3c6-4537-b4ea-93d8929b1f6a)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9cb2fea6-e7b8-4fd3-a7d3-1ae720e54f27)(content(Whitespace\" \
+         3be30b10-ec3e-4ad4-9033-597cca612159)(content(Whitespace\" \
          \"))))(Tile((id \
          26c0f229-3447-4c11-b2d0-681525a19542)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         9b2d8df7-e3a9-4bb0-a852-4dac1c6b14c4)(content(Whitespace\" \
+         fb17d0e3-8a79-49ae-bae5-30f952ae3bd0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         09e6be1d-df1d-447f-a74d-6381bff146b3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3bf070fe-313c-43d9-a73e-0059475aad40)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a5274cc4-33a6-427b-a287-3fe71e555144)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         79f3b99c-b4fb-450f-9a56-5a1e5fd0d49c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c03adff-e2d5-48ef-a1ce-5b48511888ff)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8934295b-e5de-420e-a6b0-d28d5b9677d5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8ee5d986-a7e1-43ac-a3d7-977d96166583)(content(Whitespace\" \
-         \"))))(Tile((id be1ee62a-2cd9-4d5d-af37-25ad4de6078a)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         a38ab483-0812-4d3f-bcf6-a9394ae93378)(content(Whitespace\" \
+         445e9715-978a-4648-82f5-9d60c1cfe19f)(content(Whitespace\"\\n\"))))(Tile((id \
+         be1ee62a-2cd9-4d5d-af37-25ad4de6078a)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e84cc81f-2f23-4dd3-b5c7-b7875268aa63)(content(Whitespace\" \
          \"))))(Tile((id \
          ba5db760-45ae-42c1-936b-cf960e0c03e2)(label(match_name))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         fee904fe-47f5-4c34-a55f-aedcd1e6b2bc)(content(Whitespace\" \
+         b7f2dfbe-7057-4a21-9fe3-95106b8a5f07)(content(Whitespace\" \
          \")))))((Secondary((id \
-         47596093-a22f-4845-a058-6478bd847905)(content(Whitespace\" \
+         2ddda232-5d62-46f9-9483-4358994b98e4)(content(Whitespace\" \
          \"))))(Tile((id fa75f939-c8bf-4cf8-991a-20f800b908d4)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f5ee64c3-1ddc-4712-a88e-52ed405df967)(content(Whitespace\" \
+         94a83bb0-7831-49b7-9054-7d8c062956df)(content(Whitespace\" \
          \"))))(Tile((id \
          41496eff-d8da-4aac-8fc7-1f72cded17ab)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -4298,21 +3695,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c3a38244-b1e1-4313-986e-ba07922cc4ec)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         bd4f66ec-f35a-4c96-b7c7-498740c202d3)(content(Whitespace\" \
+         f134a64c-154c-45e8-b642-18f748b8a9e2)(content(Whitespace\" \
          \"))))(Tile((id \
          d034f275-63f2-4bf2-9aaa-c7773e436d1b)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b3d46d24-c74c-430c-bda1-8705faf6e4c5)(content(Whitespace\" \
+         080fa206-fc9d-4be0-9fb3-403e40af7b69)(content(Whitespace\" \
          \"))))(Tile((id \
          c56ef106-c5e4-4d25-85cf-259e9afc0b8d)(label(Department))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         9d8dd8df-0d84-435e-82b1-37f5805ed02e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c40de8a-1c69-4862-8801-4e1b207ff479)(content(Whitespace\" \
+         5cbb9220-9e18-4969-b69a-4a5d317d7c8b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         351398d3-4451-4f41-a2dc-b5d6efd43959)(content(Whitespace\" \
+         40cceae9-2eb1-42ba-a792-1ffd0f7570c1)(content(Whitespace\" \
          \"))))(Tile((id \
          66c5db97-fa6f-434c-a2a8-54b9c821bba4)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4323,42 +3718,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          04d89543-a63d-4d50-b38a-3c9333259a6c)(label(department_id))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b57f599a-3847-477d-a6b4-dce15fefdeaa)(content(Whitespace\" \
+         cf22d92c-11ac-48cd-b00b-1e2d3f5873d0)(content(Whitespace\" \
          \"))))(Tile((id \
          f466ba57-e50e-4dd5-8cc8-8d6032d3b726)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a890b582-de60-413a-8087-e939e28dcdfd)(content(Whitespace\" \
+         42f2c971-6026-44f3-9fd7-a9b34b775b48)(content(Whitespace\" \
          \"))))(Tile((id \
          ac65bfd5-5f6b-4bdb-8dcf-33dff59d22f6)(label(dept_id))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         96d3906d-f99c-413c-886f-3c607832358b)(content(Whitespace\" \
+         55b75cdd-cac0-4c78-b8ff-fc70d7fc3475)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         49a8e532-304e-4143-8842-b756feb85acc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         99adbb90-90e7-4258-b145-a8944d182878)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e0870718-0249-4216-bb92-4b9e902f7e59)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7307a305-6d46-4449-8666-0e6aeee0fb47)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fcf5b192-02ee-418c-878e-1903f80a1c48)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aa6866ba-c7a0-4245-8579-a87f90575f70)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e461fafd-8d41-4bef-bfe6-3589512e6486)(content(Whitespace\" \
-         \"))))(Tile((id 91a73b8d-5784-4cc1-8c47-b65b06bc0283)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         59a563fb-68ae-4f6a-b603-b6870de4e848)(content(Whitespace\" \
+         69a438d2-86d5-4ceb-ba0a-fd0fa96c25d6)(content(Whitespace\"\\n\"))))(Tile((id \
+         91a73b8d-5784-4cc1-8c47-b65b06bc0283)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         c9681a57-7110-4ffc-ad67-ea356c592134)(content(Whitespace\" \
          \"))))(Tile((id \
          a233b5fb-5f7c-41ad-a729-cf249560fdb8)(label(matched_tab))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f733c65c-9d9f-487f-bd49-a252327fa5f1)(content(Whitespace\" \
+         df6b4d02-0d35-4699-afec-ac88da5164ca)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9373420c-a45b-47c2-9a8c-774bc08e015c)(content(Whitespace\" \
+         d74b26de-3a9a-4635-8380-ab75dfd18b49)(content(Whitespace\" \
          \"))))(Tile((id \
          a6da7650-3927-493f-a89b-366a794a408f)(label(tfilter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4378,37 +3761,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          66daf63d-85e2-401a-9fc2-d6599412491e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b5de6ac1-96f3-4701-8192-d8d046db75c2)(content(Whitespace\" \
+         34ce96d6-a6b0-4391-961b-e6ece8280633)(content(Whitespace\" \
          \"))))(Tile((id \
          36283e7c-42c0-46af-8c45-21ce2ba5a5ca)(label(match_name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b999487c-faf3-4bce-821f-2b29490d52c5)(content(Whitespace\" \
+         658d9bea-229f-49d1-9618-469bd8d84f37)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         25608d62-9093-42f5-9e71-a5d055343622)(content(Whitespace\"\\n\"))))(Secondary((id \
-         12bac74d-58da-432e-9a04-2dd1bb64efc3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8f7e9d02-9800-40b8-ab7f-b270488653fc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         038d6b42-1cdd-4f8c-9cde-842a085bbe76)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         178c3fa7-5d97-4894-93cf-948851bcc2da)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d82a8303-e394-48ea-baaa-7db93df06c06)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fff7da13-a9ab-4da8-a6cd-bd66da09e94a)(content(Whitespace\" \
-         \"))))(Tile((id 04c4b802-d1e2-402a-9c93-c41e542b78fd)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e89c063e-8749-45a2-bede-6651243b641e)(content(Whitespace\" \
+         a05955cd-5efe-46dc-82eb-37325a4cf42b)(content(Whitespace\"\\n\"))))(Tile((id \
+         04c4b802-d1e2-402a-9c93-c41e542b78fd)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         8beddd3b-1790-4513-9af9-d692dba1b784)(content(Whitespace\" \
          \"))))(Tile((id \
          8a88b9ae-bae4-48f6-a939-30c8b9f10bd0)(label(matched_row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b7d735f3-ed12-4ba1-a337-3ac33bcf1e3b)(content(Whitespace\" \
+         5de213af-52df-4448-99da-d0f2e03a3aa6)(content(Whitespace\" \
          \")))))((Secondary((id \
-         017cd18f-bcd5-4689-8d39-15acd9763ac6)(content(Whitespace\" \
+         c6cb554a-50d2-4178-a985-859cb7d7de8e)(content(Whitespace\" \
          \"))))(Tile((id \
          0a47f491-c6b5-4837-896e-9083fb9b7675)(label(get_row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4428,26 +3799,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f264ac80-2ac2-401a-89c0-80e5d2c24f8c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         eb36d173-24ef-4a9a-9ca1-2002afe2cee6)(content(Whitespace\" \
+         58730e13-6bee-4757-b92c-26145cfe884d)(content(Whitespace\" \
          \"))))(Tile((id \
          0084960e-b550-4c2e-a211-e272680d89a0)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         0b22e1a0-d9b2-4edc-bd8c-9cdd8e60b3fb)(content(Whitespace\" \
+         8d19a0e5-d939-4780-80f0-b92343ed2743)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         98c51653-4765-4fd1-a254-b6c5617f3437)(content(Whitespace\"\\n\"))))(Secondary((id \
-         18c0e08a-b0c1-4e41-8516-0fe7a5bed5fd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cd8a673e-7e24-48c8-929c-041f79c81eb6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bcd3a922-e4ee-4563-9c8a-3c5957f37747)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8a33bcbc-7299-48bc-b63b-c69de4a2969b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ade57a8f-886d-488d-992b-22e12e944e35)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8c7b18a1-bb4b-4adf-a61f-40a9726b5a70)(content(Whitespace\" \
-         \"))))(Tile((id \
+         99116647-2cf7-414a-97d7-a1a9ebfc0438)(content(Whitespace\"\\n\"))))(Tile((id \
          da360254-6753-49df-96d1-dfefe38cca7e)(label(matched_row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -4457,60 +3816,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c213a1f3-606d-4a9a-8bb0-5dca5362abca)(label(department_name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         874c1da6-47be-4fe7-8b75-5d1186af78cd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c18756a6-6600-4cdc-951b-885913e1ae78)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5f082dcd-f0f2-4def-8b5b-1b5180658920)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         743a88f8-04d6-4bb4-9c3d-78a224076409)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f1328a84-4ce6-4939-96a4-99d8bbe9144a)(content(Whitespace\" \
+         244d414a-3566-44b8-bf1e-5f34bdd529ce)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4b99ed2f-f08e-4d88-b164-6a7c7ad6a437)(content(Whitespace\"\\n\"))))(Secondary((id \
-         36d35d99-b861-4402-92f1-39ab2e793a36)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         039fbe3b-e336-4fc4-960a-aaf64ea2b6eb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2a6eae1-f0de-4d1b-a0ef-7ad32a6bd630)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ba39c5f-71bb-4050-98ff-97dd77326e2d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         50d410d1-7096-455d-87d8-05b0041cdc5b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0c9ec094-0737-4dec-8045-d7c0e8afee7c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         edd2fb86-b1d9-4422-b964-bde56bf671d4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6515ab5d-d973-4f93-aefb-5cfa06ad5b14)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         75397c96-6013-4187-9d9d-9b613ef707c8)(content(Whitespace\" \
-         \"))))(Tile((id 18858cc0-957e-43e5-a294-c0fa54ad3100)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         fa26d722-8fcb-4f18-ad2a-33a1d08147e2)(content(Whitespace\" \
+         c66dcb51-a08f-47af-9d5c-6f0b06e75ca0)(content(Whitespace\"\\n\"))))(Tile((id \
+         18858cc0-957e-43e5-a294-c0fa54ad3100)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         4aa5eb41-b22c-4fb8-8eb3-c1cc0cde1514)(content(Whitespace\" \
          \"))))(Tile((id \
          1bf673ec-bf5a-4b1e-bcbe-c59e4ce6d4f9)(label(employee_to_department))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3b8288f7-22b5-481f-b2fa-7385c085761b)(content(Whitespace\" \
+         801c8a7a-cf87-4b9c-9063-afd57aa91806)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d1517330-fc12-4cfa-9f54-24cbecb6b799)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2b97c5b3-673c-4c0e-8493-f9431d4d8c8f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         79c74077-7cb7-4edb-9e79-4676bcd2546f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         468f1d48-f82e-4c35-84a3-35c82d0d0c99)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         19f77cc6-9a19-4d58-8267-829a3d9d694d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e16490b6-e463-43f2-a62f-211e73c70282)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         409fe416-415c-4830-bc97-eb45167b5843)(content(Whitespace\" \
-         \"))))(Tile((id ed3d44c8-bfcc-4f6b-86df-a47f91558d7a)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         f8d40d1b-650a-407b-bb1d-ae6870cbcc21)(content(Whitespace\" \
+         c41e8214-141e-4e6b-b721-5c3922833723)(content(Whitespace\"\\n\"))))(Tile((id \
+         ed3d44c8-bfcc-4f6b-86df-a47f91558d7a)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ca395977-82cf-470a-af49-b5777fd10424)(content(Whitespace\" \
          \"))))(Tile((id \
          490a7e11-2aa8-450b-bcaa-5740ba27ce8b)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -4518,91 +3841,82 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ba021e37-5cf9-4a5b-bd9c-67e1cb7001c3)(label(name))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ff696142-c1c7-458a-8647-9dfac197df54)(content(Whitespace\" \
+         60139fdc-a7e2-4a91-a4ab-b226c41e52a4)(content(Whitespace\" \
          \"))))(Tile((id \
          e1bd5853-23e2-422f-a908-d58157f2f831)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8df4889a-0e8e-4676-a64f-78aa814121f9)(content(Whitespace\" \
+         \"))))(Tile((id \
          b9cf8efa-9279-48b1-8b53-89a2378bcaaa)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          954c2dc2-a27d-4fd3-b819-3e7b2a90f41c)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         b7d287e4-978c-4729-989e-ab5fbe047738)(content(Whitespace\" \
+         5238fb4b-d3ce-41ca-a23f-7f67430dca73)(content(Whitespace\" \
          \"))))(Tile((id \
          9d865524-07d8-4f1a-be1c-a2c065457329)(label(empl_tab))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         9c3b363c-3f4b-4d36-b04b-5f266f5fd9a2)(content(Whitespace\" \
+         \"))))(Tile((id \
          2d4e61cb-b0c5-43c2-9de0-b25ff4649430)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         29fc2be3-7b47-4a89-80a5-71f5cde749f5)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         eae3a273-e300-4ddd-b957-83602a28b1a1)(content(Whitespace\" \
+         \"))))(Tile((id 29fc2be3-7b47-4a89-80a5-71f5cde749f5)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          646badb6-13cb-49f4-9933-047abb5a7700)(label(Employee))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          17027b05-5301-4cc5-ab85-8fe9374fc847)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         8d0ee528-cefc-4f12-953c-33128e863465)(content(Whitespace\" \
+         3d77772d-5182-4316-b525-3c3e1558c8a3)(content(Whitespace\" \
          \"))))(Tile((id \
          d9b1493f-eccf-4790-a7ce-acb1b61fd31e)(label(dept_tab))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ba2362ab-b078-4c63-b09c-5116ed762653)(content(Whitespace\" \
+         \"))))(Tile((id \
          98f76cf1-6f6d-4861-b0ba-a02de5945a70)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e6dc401d-194a-45b6-b298-e9b5aaa17633)(content(Whitespace\" \
+         b1e0dbe8-d7bf-47a1-b2fb-c9e55309f618)(content(Whitespace\" \
          \"))))(Tile((id fc00f10a-d712-4ab3-81f7-101166790a5c)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          499feabe-edea-4154-ae82-f2e71e48711e)(label(Department))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         20c727e7-7e43-4d69-a329-93fde3e3884b)(content(Whitespace\" \
+         0024a189-c46a-4e67-99a4-c2dc8370522f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         81c723d5-4d62-411d-9075-bf83d1c27fc2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f82cf9a4-e414-49e4-a6a7-b2ee0a2f76b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e3e12e7-abe9-4de2-86fa-7e35deba4c4b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         67000ac1-edce-482b-8488-b5b6cdeed182)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0c9547d9-4ced-4201-8cc8-79bd5470c9dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1c84ff9-2544-4dcb-b565-61657a4736df)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c4199583-289e-45e7-a705-96967719268b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2646e379-9838-4c12-8b14-f1923a11e9e4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2efcf51-2af9-4809-ab84-e6716788dcb9)(content(Whitespace\" \
-         \"))))(Tile((id 17466ed9-4e55-4258-a905-7c608803a6e1)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         5ef1653e-b952-445c-a074-62c15f9cc085)(content(Whitespace\" \
+         45dea6d2-31bd-45e9-85e4-ab5114767c30)(content(Whitespace\"\\n\"))))(Tile((id \
+         17466ed9-4e55-4258-a905-7c608803a6e1)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         35d7ce18-047a-464a-b8ee-80ec965d46b4)(content(Whitespace\" \
          \"))))(Tile((id \
          667c66c1-34d5-4f6c-872a-80b71c44e10f)(label(match_name))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e29d38d5-5a32-41a2-9e09-4275153935ac)(content(Whitespace\" \
+         ebd6a3b1-9507-46a7-b857-0884d5d2a3b5)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a7494c88-61b1-42d8-862c-43d88552d516)(content(Whitespace\" \
+         e3644ab3-628c-40b9-b322-8bed09a3bae9)(content(Whitespace\" \
          \"))))(Tile((id d6f2e748-b836-45f2-b9df-e9091f3a63eb)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         98b8ad63-c0bd-4f96-abe5-99411fb28b68)(content(Whitespace\" \
+         7dc8e6e5-2b79-4dab-8b7a-6e94c7aedd12)(content(Whitespace\" \
          \"))))(Tile((id \
          3cf4e5a6-fde2-4ea8-aa8d-c539a7538f91)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         33deedac-a1cf-4f05-984a-68cf2b016a6c)(content(Whitespace\" \
+         5431c7b8-25b3-4d53-a34a-6def7b315634)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f6aafd77-2bc9-4ad8-806c-04e3d5d4daf5)(content(Whitespace\" \
+         782beedc-12f9-4f5e-94b9-8422dbd78985)(content(Whitespace\" \
          \"))))(Tile((id \
          bc67bc7a-ca87-46e8-9116-004c50137cb2)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4613,45 +3927,31 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fdd210da-dd5b-48e1-af4e-458bc2c3c0e6)(label(last_name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         0d553c81-7ec6-4682-92ae-722d9f64df7a)(content(Whitespace\" \
+         4728e694-ad57-4d19-8f16-9a43dd3419d3)(content(Whitespace\" \
          \"))))(Tile((id \
          a674f641-4dff-46f7-a53a-5d69ed5986c9)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         efeff4da-674f-4aaf-a65b-0bfcaaa4abb6)(content(Whitespace\" \
+         d6c28bb3-6750-49d7-8a42-d8475a708738)(content(Whitespace\" \
          \"))))(Tile((id \
          ddb1dd26-37ff-4592-be20-cd4d4252025e)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         03c46dcd-f18a-4d3b-98db-501819f29055)(content(Whitespace\" \
+         ca2e77a6-6658-4846-ab7d-eed2da7cfdf0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a9904e5b-946f-4309-a3dd-84705a49c6ed)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9ec5939e-f78d-4f02-a861-53d17f0a9c7e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         08162d00-1efc-4993-a58f-08bd4084af7b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1e512751-90e5-4cc6-bd5c-959768190aea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         16ef88e0-decd-4afe-9cac-81f59c1c52fe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         43673e61-5e06-4aa5-aec1-3aa167704088)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9f9fafc1-7c4a-48bb-abb8-ee7c83e28390)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36863c4e-0465-4e88-940a-06ba5c920a7f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8ecd84c-f142-4be0-85f5-dd8e12f4563d)(content(Whitespace\" \
-         \"))))(Tile((id 329ec519-b9db-4377-9ba8-4be70b24b5ad)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         cc9abe7e-0088-44f7-92e3-e60f7b090f16)(content(Whitespace\" \
+         478d578b-c39d-49f3-859f-20199b3d7a0f)(content(Whitespace\"\\n\"))))(Tile((id \
+         329ec519-b9db-4377-9ba8-4be70b24b5ad)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9e405090-9bf4-49c2-801c-c8f3d9bd9ac1)(content(Whitespace\" \
          \"))))(Tile((id \
          a77c9852-8468-4e34-a92d-fc0e4407fc5e)(label(matched_tab))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         bb0e28cf-b4d1-4e91-90f1-20e94ac71820)(content(Whitespace\" \
-         \")))))((Tile((id \
+         76e9f615-5647-42ec-9270-08bcb75782ea)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         a86bdf1b-6da7-4120-b27c-0d170a4fade3)(content(Whitespace\" \
+         \"))))(Tile((id \
          a3494c3d-eff8-43fc-a54d-61930d3d5b2c)(label(tfilter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -4670,41 +3970,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bdba954a-83dc-4cbb-aed3-e3abaa702798)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bf4aec52-0c1f-487c-8c18-5a06f57070c3)(content(Whitespace\" \
+         e565d601-f26e-4d44-a050-ca6eaa1336a3)(content(Whitespace\" \
          \"))))(Tile((id \
          012af5fb-cb03-4af9-aaa2-c3df43c4d440)(label(match_name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5b99243a-4721-4e22-bfc1-459a3bb1b61e)(content(Whitespace\" \
+         f5f7f442-3a69-434e-bf79-ba33ec473191)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7fe231e3-fa50-47b6-84c8-eda10408d9e8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b899ee77-cd13-4454-b676-778c76b01f51)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fac66301-b00c-4a1a-b234-9f10c4a4a2f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf6bd04d-871b-46ba-9f86-95a01dcdfdac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c2905f4d-4742-48af-8820-7c04a2ad8b13)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         196619fc-926d-4501-b660-8d3f6627e9e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2eb57ffd-c653-4d5b-8f82-152201b4af3a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5cdc9dbb-5df0-40d9-96ef-51d3a191ab28)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33687cbf-260f-4dd5-9d51-e786bcd6e1f4)(content(Whitespace\" \
-         \"))))(Tile((id 174f0d89-f3d1-46a2-a9c2-e60aa83fc0ff)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         654b7714-c4e6-49d9-9605-fd579099b13a)(content(Whitespace\" \
+         81194997-1311-4036-94a0-74d27b768d3b)(content(Whitespace\"\\n\"))))(Tile((id \
+         174f0d89-f3d1-46a2-a9c2-e60aa83fc0ff)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         584c454e-4939-476d-9793-9489d2c497af)(content(Whitespace\" \
          \"))))(Tile((id \
          049cf326-533f-45bd-861d-c1d29c7ab1eb)(label(matched_row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         736514d0-632a-4eef-87c6-58ff5c6e8647)(content(Whitespace\" \
+         fc672e5a-439e-4a51-9be4-ed418f737569)(content(Whitespace\" \
          \")))))((Secondary((id \
-         366be995-2ef9-4b94-9e4e-f83d8f1f08b2)(content(Whitespace\" \
+         f1931958-defc-481e-8e94-709f6d14bf5c)(content(Whitespace\" \
          \"))))(Tile((id \
          a7625927-5853-46d6-bd57-e1f4dd75c68a)(label(get_row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4724,41 +4008,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0c9bf93a-c7e3-4c58-ac45-73cfa19b4b0d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         84d0e15b-9578-46bb-b757-6604cd4a768d)(content(Whitespace\" \
+         8a533cd3-b147-4534-8b1c-ac34c12db9a6)(content(Whitespace\" \
          \"))))(Tile((id \
          e8318cf6-6d1a-4bf5-8d5f-c71c13cdff01)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c3280510-aeaa-4b50-95ce-9c9ab5ca00c5)(content(Whitespace\" \
+         066dd97d-0e0a-4840-be9a-50e1432b1014)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f6a4faa7-2c12-4460-956a-cfaa90d0fffa)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ea135249-c258-4603-8cf7-f7e537d7fede)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         40cb60ae-7bf5-402a-9230-9bde9b21d4ad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         025abd35-756e-49b3-afcd-34f3f6428766)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b3a27876-f90b-4a08-b1d5-9efe5ca2cbb9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e4df4c00-b19a-497f-83c8-95202798c1d8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a1d6c41-5369-4f00-b2af-f725bb981241)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0253cc79-d107-4297-936c-6dec44cf33bb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5489cfdb-d3cb-4df0-9a75-db3a5efd6a17)(content(Whitespace\" \
-         \"))))(Tile((id 9e55c787-2776-41bf-98a0-4fd3fc31e4b0)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c9214a7d-b999-49f8-aae1-7037186832da)(content(Whitespace\" \
+         654ff076-ae88-4e2a-9b74-f4bf5e7c96f3)(content(Whitespace\"\\n\"))))(Tile((id \
+         9e55c787-2776-41bf-98a0-4fd3fc31e4b0)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5416d826-74e5-4b51-a2fd-cac13d5c5bbd)(content(Whitespace\" \
          \"))))(Tile((id \
          46ed4044-e424-44ba-aa0a-d3f7b266da8e)(label(dept_id))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7095d584-6f57-433e-bad9-2ca57ad6a5d9)(content(Whitespace\" \
+         4273d1cd-06f2-4912-b343-1f29701de994)(content(Whitespace\" \
          \")))))((Secondary((id \
-         72ef5ae2-b98d-45bb-a73e-a4c9ab18220d)(content(Whitespace\" \
+         76265e9c-c7f9-4edd-aeb1-088460f2754b)(content(Whitespace\" \
          \"))))(Tile((id \
          cef82348-cca1-4fb6-a843-d480983a9e42)(label(matched_row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4769,89 +4037,35 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a462df31-2f34-446e-8da8-7073e855c01e)(label(department_id))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         6e7ad85b-de5c-438d-9d6d-16f20e1ca217)(content(Whitespace\" \
+         e4684a63-9575-4280-9447-9be501759940)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b3ec19f5-6f5c-4a1d-8be5-a8e7104d8447)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c648a48c-f18a-4e74-9b02-130bb8696bc3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc74e95b-c4d2-4f38-9e0a-bc7d02c8585f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         78502889-c134-4e67-91a6-4e04c87ab0b7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7acea528-e3d9-4f6e-ac36-e3af005d503e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9a74b2ee-578e-4361-951e-fb31c8c180a8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6075959f-d72a-4079-bf27-55492dd562d4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         afed36b6-57c8-4e67-97db-52051b8674a1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ee36c54-7fd2-4d69-a7ed-9f6d115218ad)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9456aa4d-ea24-490a-95d2-7ed579d6ea9f)(content(Whitespace\"\\n\"))))(Tile((id \
          8d540e29-0687-4eb2-af99-c95498d853c8)(label(dept_id_to_dept_name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          b8a90856-9a3e-4b7c-980f-112c580ba2e8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         68c54aa3-b457-40a5-b12d-fc3f5009bdec)(content(Whitespace\"\\n\"))))(Tile((id \
          43fab498-e381-4fc2-9889-0ffd6b80025e)(label(dept_tab))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          7a83a3ff-b2f2-47e1-9b49-28ae17eb70b4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         eae9ee07-9e9a-4c8b-bb26-e750e90dbdf1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         83fcf19a-4b33-4e35-bbf3-c1c3b36ce96f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d188b41e-1070-4437-948d-ae8cc59b0a64)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         55f343f3-cfff-4ec7-83c9-45faafb6fc10)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f53a4573-2dff-4ad2-8067-b5357b282c9f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1be02219-1efe-4c01-83bc-e148825c0092)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c6ea51f1-31c9-43ff-b059-bd1cc1c7709d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8e37630b-a935-400b-87c3-2594cbefaecd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8d0d429-b9a6-4032-abb1-bb4ee2188f11)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ee924814-c28f-4499-a567-63afa2440a21)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04975fe8-a4ee-42e3-aa42-f14834839073)(content(Whitespace\" \
-         \"))))(Tile((id 6fd056d3-87d3-4773-bb2c-81fad946510b)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         501ef343-0571-480d-a26e-b02ec928f475)(content(Whitespace\" \
+         f81adb78-9e26-458f-8240-443244b5bad6)(content(Whitespace\"\\n\"))))(Tile((id \
+         6fd056d3-87d3-4773-bb2c-81fad946510b)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         f00dfa75-6cea-48f4-9e2b-4c328127b42c)(content(Whitespace\" \
          \"))))(Tile((id \
          f1115e44-10e3-4207-8071-5892af000611)(label(dept_id))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f33be587-bf9c-400e-b385-231989c109a3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bb54574d-939d-41d2-b4bc-44f68c7071f3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b508bb71-c391-492c-b6d2-7b956d33accb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea82958e-f500-49a2-910b-24353d979b25)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d7663e81-4e0b-4b21-b969-e7d8d10202fe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         380c4d77-0f8b-4c07-818b-57d9ca89ad86)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3f1c6ec1-dd5b-412e-b305-88fbee9df715)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c8dd4b4-c583-4af3-a1a8-53343d67655a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         332caa76-1e2d-4b54-86fd-64679cee5870)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         030bb165-3022-4ba6-bd93-20a70a4d8b9a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a1e8a671-af88-40f4-883f-74c07b7f8a83)(content(Whitespace\" \
-         \"))))(Tile((id 9289162a-23c8-49fc-a751-929ed8ed3719)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         7f66ad64-d9b0-4f1c-bd9d-1621a3e57659)(content(Whitespace\"\\n\"))))(Tile((id \
+         9289162a-23c8-49fc-a751-929ed8ed3719)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          6e3da60b-95a9-4e1c-a610-6687e8545ac4)(content(Whitespace\" \
          \"))))(Tile((id \
          8d3ed96c-47bc-41b9-883d-1cad8edd05eb)(label(Some))(mold((out \
@@ -4865,35 +4079,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          02bf59e4-8737-4d01-9b53-5e3a6db7996f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e2c98545-8906-4a58-8e08-798877761226)(content(Whitespace\" \
+         df999cd5-8fc3-4cc2-a9c3-f4442a397050)(content(Whitespace\" \
          \"))))(Tile((id \
          94b06eb9-efe4-4766-b59b-dc4570bb5682)(label(dept_id))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b9783e3b-beed-4ed6-814b-fa9f5fe3ba1c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         87333bb8-0d15-4caf-834e-2b5850800eac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae3fd754-bf22-4ed2-9354-a35cefe31003)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         afd21ee7-3dee-48b4-8138-76e08b3a80d9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2c22e73-dc6e-4f4d-ae08-c9a3a742b00f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b8819447-3f73-45db-8968-945170d4f5bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2ace2edc-ba09-4039-a078-4744a1f1d626)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e786d8dd-1b34-461e-8521-c8c4096a2206)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ebc8401-4b54-4e24-9c3a-a5797a2943e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         faa108e8-6885-470a-a40c-c3066fa99cd3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         25e0ad10-0b01-4ede-ab15-69aff71711d9)(content(Whitespace\" \
-         \"))))(Tile((id d7330411-3c86-48d3-9c01-89ebf457dd7c)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         a5c2f29e-3368-40d2-982c-672c3f7ff164)(content(Whitespace\"\\n\"))))(Tile((id \
+         d7330411-3c86-48d3-9c01-89ebf457dd7c)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          9d5a9d61-72ad-4d32-ba5f-ef59ce83e778)(content(Whitespace\" \
          \"))))(Tile((id \
          0c5c71aa-16aa-4516-ad78-50057ebf0284)(label(_))(mold((out \
@@ -4901,69 +4095,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          918ec34f-8559-469e-bfce-24278ff8d739)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f5f30a8b-63d7-487d-866c-6738b18a47a2)(content(Whitespace\" \
+         0f0fe8c6-10e2-447e-b46b-8a4dc7ba4ecd)(content(Whitespace\" \
          \"))))(Tile((id \
          66ef2839-7dd0-40d8-a8e2-e88c0237bdb2)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         87bd5299-7dfe-4223-a31d-3f088ef04428)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         50222612-a533-417b-8f7b-4149144ede2f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5d35b1bc-3668-4869-a451-314dfc416188)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d1af6077-a68e-402a-9d31-ca97b979d4b2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         483f32e4-558b-4891-b850-128565755458)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5dd97af9-282d-495a-99a4-33e7bf85248d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ffca3373-b293-4c09-8cc6-0530c6723bed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fec07a23-9c7d-463a-b8d6-d81df6ae27a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         828798e1-db91-461f-92d3-ff59761bbe83)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9179d02f-a385-49c2-aa0c-fa6ec06ad9b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cda46aaa-984b-4a78-933c-d2ccd0357c9b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ec88339c-4e4e-46e5-8c69-75bae24105a4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         af199188-8ab2-41da-bf64-47e56654a346)(content(Whitespace\" \
-         \"))))))))))))))(Secondary((id \
-         51715651-c03f-464a-b8f9-03e01d97f829)(content(Whitespace\"\\n\"))))(Secondary((id \
-         96836a28-53cf-4830-8523-6a5f221e2baf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         287a1388-83b9-4742-bd92-06e3ac2c20b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         522292ed-be6e-4fa0-a8c8-e8473309bce3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ad01a28a-75ae-473a-851c-f242ea144edb)(content(Whitespace\" \
+         6d0b0386-2fc1-41a7-a7d0-d890613bce85)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         b7ab9872-ada5-45bc-b0c0-06ba34cd4513)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         a795c77f-4a85-45d6-bfac-673ac3d865dd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         774bee9f-60f8-42fb-afd5-26f185aec36d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e47dd807-ac91-4cdb-a500-9c5986bc5c13)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dbd35b98-e3c1-426b-a404-e2093b8949cf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         71f029da-ae62-4752-bdf4-0e596a033fa6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a96e77da-7dd7-48ec-834d-593b7bdacee0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dd9074d6-18b7-45f7-a7bd-43bc9637e42c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f0faf927-005c-4ae9-816b-e51df4a9ff38)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         69abab5f-6f79-4051-8d42-d82f2a2a59ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46443790-8e94-4844-b96a-d975bffb01df)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         09fe6cd2-cdd0-4d80-98a3-9318b064d67f)(content(Whitespace\" \
-         \"))))(Tile((id fa87dfde-8b00-48a3-a27a-1f50aca71bd5)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         7aeeca84-d827-4980-9296-235eb89c1e68)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         25057b74-dec1-4654-80ea-16749429dfb3)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3813f9cc-1b9e-4b6a-ba64-c28de2e5ce57)(content(Whitespace\"\\n\"))))(Tile((id \
+         fa87dfde-8b00-48a3-a27a-1f50aca71bd5)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         1f639458-683d-4583-85ba-ad2c4e3e5d48)(content(Whitespace\"\\n\"))))(Tile((id \
          eb64f300-b8b9-404f-b3ac-bfcc6a3ae006)(label(employee_to_department))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -4976,7 +4121,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e419e3b4-05fd-45de-9431-dbe85c25e492)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7ace3b54-e2ad-4409-9e49-2c543c8a105b)(content(Whitespace\" \
+         82805a56-1ab7-4bd5-b953-ecf1d45024c1)(content(Whitespace\" \
          \"))))(Tile((id \
          0cbf12e1-5a48-437a-a1d0-117d0a7fd944)(label(employees))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4984,185 +4129,169 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e490caa7-ff19-4a5c-9d83-442a3de389fd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e939c8ec-e0a3-470d-9ee8-10fd69fefbc5)(content(Whitespace\" \
+         81dd49aa-a1e6-4577-8fca-3fcbdea866b8)(content(Whitespace\" \
          \"))))(Tile((id \
          ccab6116-5890-4e73-b253-708cee9be8eb)(label(departments))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4091d265-03ae-457b-8cd9-134e7fde2a15)(content(Whitespace\" \
+         32470539-875e-4d62-be3f-6d69f0e887cd)(content(Whitespace\" \
          \"))))(Tile((id \
          b79cc955-a369-47f6-bbdd-bab0fdf4ccac)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         32ae05b5-7a98-4640-b3b4-3257edf67abc)(content(Whitespace\" \
+         68e6ba54-77dd-477e-82c2-c1704f242555)(content(Whitespace\" \
          \"))))(Tile((id \
          f24b672f-c7c8-4f95-9581-2197f497438f)(label(\"\\\"Engineering\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         a13a471d-94b9-4753-92f6-a1fde761bcde)(content(Whitespace\" \
+         4f1ede1d-5c30-4b98-bfd9-d43bb48ed08c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5bc8ecf4-1c46-409b-b0ba-d506ee034349)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5e0aebc2-71d0-4e0f-a971-ada06fffa274)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e6dc5308-4429-41d8-bceb-01e320d1f5a2)(content(Whitespace\" \
+         157f7d64-e15b-464c-a4fc-a324ab4d1e12)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         43a8fc43-bb92-4ff9-a96b-b077b19dc2b8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9fe6fe5f-147e-4b06-8e13-08642676893e)(content(Whitespace\"\\n\"))))(Tile((id \
          6ace5596-5f26-4276-b1df-56503d6492c5)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         31a012f2-2f52-4126-ace1-c29bbfbb31fd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e447fde-1305-4ce5-b16b-cbf9703b4073)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         f743d193-7272-4b87-b8d1-07e43fa0de5f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         42fccb3a-eabc-44f8-bea2-677d7596057d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         cf17d166-4f99-4232-99a9-8b6defd67f30)(content(Whitespace\"\\n\"))))(Tile((id \
          ba125b37-bd34-4f0c-9a0c-7576c85a983e)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         bb6030fb-8970-4c48-ac87-6c9f972d7400)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children()))))";
       backup_text =
         "let brown_jellybeans =\n\
-        \  type JellyAnon = (get_acne=Bool, red=Bool, black=Bool, white=Bool, \
-         green=Bool, yellow=Bool, brown=Bool, orange=Bool, pink=Bool, \
-         purple=Bool) in\n\
-        \  let jellyAnon : [JellyAnon] = ([\n\
-        \    ((true), (false), (false), (false), (true), (false), (false), \
-         (true), (false), (false)),\n\
-        \    ((true), (false), (true), (false), (true), (true), (false), \
+         type JellyAnon = (\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool\n\
+         ) in\n\
+         let jellyAnon : [JellyAnon] = (\n\
+         [\n\
+         ((true), (false), (false), (false), (true), (false), (false), (true), \
+         (false), (false)),\n\
+         ((true), (false), (true), (false), (true), (true), (false), (false), \
+         (false), (false)),\n\
+         ((false), (false), (false), (false), (true), (false), (false), \
+         (false), (true), (false)),\n\
+         ((false), (false), (false), (false), (false), (true), (false), \
          (false), (false), (false)),\n\
-        \    ((false), (false), (false), (false), (true), (false), (false), \
+         ((false), (false), (false), (false), (false), (true), (false), \
          (false), (true), (false)),\n\
-        \    ((false), (false), (false), (false), (false), (true), (false), \
-         (false), (false), (false)),\n\
-        \    ((false), (false), (false), (false), (false), (true), (false), \
+         ((true), (false), (true), (false), (false), (false), (false), (true), \
+         (true), (false)),\n\
+         ((false), (false), (true), (false), (false), (false), (false), \
          (false), (true), (false)),\n\
-        \    ((true), (false), (true), (false), (false), (false), (false), \
-         (true), (true), (false)),\n\
-        \    ((false), (false), (true), (false), (false), (false), (false), \
-         (false), (true), (false)),\n\
-        \    ((true), (false), (false), (false), (false), (false), (true), \
+         ((true), (false), (false), (false), (false), (false), (true), (true), \
+         (false), (false)),\n\
+         ((true), (false), (false), (false), (false), (false), (false), \
          (true), (false), (false)),\n\
-        \    ((true), (false), (false), (false), (false), (false), (false), \
-         (true), (false), (false)),\n\
-        \    ((false), (true), (false), (false), (false), (true), (true), \
-         (false), (true), (false))\n\
-        \  ]) in\n\
-        \  \n\
-        \  # Version that uses string params for the column names gives no \
+         ((false), (true), (false), (false), (false), (true), (true), (false), \
+         (true), (false))\n\
+         ]\n\
+         ) in\n\
+         # Version that uses string params for the column names gives no \
          static errors #\n\
-        \  let v1 =\n\
-        \    let get_value = fun (r,c :String) ->(to_lvs(r) |>find_opt(_,fun \
-         label=l, value=v ->l == c)) |> option_map(_, fun e ->e.value) in\n\
-        \    let nrows = length in let tfilter = filter in \n\
-        \    let option_get=fun o -> case o\n\
-        \    | Some(v) => v\n\
-        \    end\n\
-        \    in\n\
-        \    let incorrect =\n\
-        \      let keep = fun r -> get_value(r, \"color\") |> option_get in\n\
-        \      let count_participants = fun (t, color) -> nrows(tfilter(t, \
-         keep))in\n\
-        \      count_participants(jellyAnon, \"brown\")\n\
-        \    in\n\
-        \    let correct = \n\
-        \      let count_participants = fun (t, color) -> let keep= fun r-> \
-         get_value(r, color) |> option_get in nrows(tfilter(t, keep))in\n\
-        \      count_participants(jellyAnon, \"brown\")\n\
-        \    in ? \n\
-        \  in\n\
-        \  \n\
-        \  # Version that uses higher order functions to get static errors #\n\
-        \  let v2 =\n\
-        \    let nrows = length in let tfilter = filter in \n\
-        \    \n\
-        \    let incorrect =\n\
-        \      let keep = fun (r : JellyAnon) -> r.color in \n\
-        \      let count_participants = typfun row -> fun (t:[row], color: row \
-         -> Bool) -> \n\
-        \        length(filter(t, keep))\n\
-        \      in count_participants@<JellyAnon>(jellyAnon, fun r -> r.brown)\n\
-        \    in\n\
-        \    let correct = \n\
-        \      let count_participants = typfun row -> fun (t:[row], color: row \
-         -> Bool) -> \n\
-        \        let keep = fun (r : row) -> color(r) in \n\
-        \        length(filter(t, keep))\n\
-        \      in count_participants@<JellyAnon>(jellyAnon, fun r -> r.brown)\n\
-        \    in ?  \n\
-        \  in ? \n\
-         in\n\n\
+         let v1 =\n\
+         let get_value = fun (r, c : String) -> (to_lvs(r) |> find_opt(_, fun \
+         label = l, value = _v -> l == c)) |> option_map(_, fun e -> e.value) \
+         in\n\
+         let nrows = length in\n\
+         let tfilter = filter in\n\
+         let option_get =\n\
+         fun o ->\n\
+         case o\n\
+         | Some(v) => v\n\
+         end in\n\
+         let incorrect =\n\
+         let keep = fun r -> get_value(r, \"color\") |> option_get in\n\
+         let count_participants = fun (t, _color) -> nrows(tfilter(t, keep)) in\n\
+         count_participants(jellyAnon, \"brown\") in\n\
+         let correct =\n\
+         let count_participants =\n\
+         fun (t, color) ->\n\
+         let keep = fun r -> get_value(r, color) |> option_get in\n\
+         nrows(tfilter(t, keep)) in\n\
+         count_participants(jellyAnon, \"brown\") in\n\
+         ? in\n\
+         # Version that uses higher order functions to get static errors #\n\
+         let v2 =\n\
+         let nrows = length in\n\
+         let tfilter = filter in\n\
+         let incorrect =\n\
+         let keep = fun (r : JellyAnon) -> r.color in\n\
+         let count_participants = typfun row -> fun (t : [row], _color : row \
+         -> Bool) -> length(filter(t, keep)) in\n\
+         count_participants@<JellyAnon>(jellyAnon, fun r -> r.brown) in\n\
+         let correct =\n\
+         let count_participants =\n\
+         typfun row ->\n\
+         fun (t : [row], color : row -> Bool) ->\n\
+         let keep = fun (r : row) -> color(r) in\n\
+         length(filter(t, keep)) in\n\
+         count_participants@<JellyAnon>(jellyAnon, fun r -> r.brown) in\n\
+         ? in\n\
+         ? in\n\n\
          let employee_to_department =\n\
-        \  type OptInt = +None +Some(Int) in\n\
-        \  type Employee = (last_name=String, department_id=OptInt) in\n\
-        \  let employees : [Employee] = ([\n\
-        \    (\"Rafferty\", Some(31)),\n\
-        \    (\"Jones\", Some(33)),\n\
-        \    (\"Heisenberg\", Some(33)),\n\
-        \    (\"Robinson\", Some(34)),\n\
-        \    (\"Smith\", Some(34)),\n\
-        \    (\"Williams\", None)\n\
-        \  ]) in\n\
-        \  \n\
-        \  type Department = (department_id=Int, department_name=String) in\n\
-        \  let departments : [Department] = ([\n\
-        \    (31, \"Sales\"),\n\
-        \    (33, \"Engineering\"),\n\
-        \    (34, \"Clerical\"),\n\
-        \    (35, \"Marketing\")\n\
-        \  ]) in\n\
-        \  \n\
-        \  let tfilter = typfun row -> fun (t: [row], pred: (row -> Bool)) -> \
-         filter(t,pred) :[row] in\n\
-        \  let get_row = typfun row -> fun (t:[row], n : Int) -> nth(t,n) : \
+         type OptInt = + None + Some(Int) in\n\
+         type Employee = (last_name = String, department_id = OptInt) in\n\
+         let employees : [Employee] = (\n\
+         [(\"Rafferty\", Some(31)), (\"Jones\", Some(33)), (\"Heisenberg\", \
+         Some(33)), (\"Robinson\", Some(34)), (\"Smith\", Some(34)), \
+         (\"Williams\", None)]\n\
+         ) in\n\
+         type Department = (department_id = Int, department_name = String) in\n\
+         let departments : [Department] = ([(31, \"Sales\"), (33, \
+         \"Engineering\"), (34, \"Clerical\"), (35, \"Marketing\")]) in\n\
+         let tfilter = typfun row -> fun (t : [row], pred : (row -> Bool)) -> \
+         filter(t, pred) : [row] in\n\
+         let get_row = typfun row -> fun (t : [row], n : Int) -> nth(t, n) : \
          row in\n\
-        \  let build_column =typfun row -> typfun row' -> fun (t:[row], fn: \
-         (row -> row')) -> map(t, fn) : [row']in\n\
-        \  let incorrect =\n\
-        \    let last_name_to_dept_id = fun (dept_tab : [Department], name: \
-         String) ->\n\
-        \      let match_name = fun (r : Department)  -> r.last_name == name in\n\
-        \      let matched_tab = tfilter@<Department>(dept_tab, match_name) in\n\
-        \      let matched_row = get_row@<Department>(matched_tab, 0) in\n\
-        \      matched_row.`department_id`\n\
-        \    in\n\
-        \    \n\
-        \    let employee_to_department =\n\
-        \      fun (name :String, empl_tab:[Employee], dept_tab: [Department]) \
-         ->\n\
-        \        build_column@<Employee>@<(last_name=String, \
-         department_id=OptInt, department_name=String)>(empl_tab,\n\
-        \          fun r -> r ... \
-         (department_name=last_name_to_dept_id(dept_tab, r.`last_name`)))\n\
-        \    in ? \n\
-        \  in\n\
-        \  \n\
-        \  let correct =\n\
-        \    let dept_id_to_dept_name = fun (dept_tab : [Department], dept_id: \
-         Int) ->\n\
-        \      let match_name = fun (r : Department)  -> r.department_id == \
-         dept_id in\n\
-        \      let matched_tab = tfilter@<Department>(dept_tab, match_name) in\n\
-        \      let matched_row = get_row@<Department>(matched_tab, 0) in\n\
-        \      matched_row.department_name\n\
-        \    in\n\
-        \    \n\
-        \    let employee_to_department =\n\
-        \      fun (name :String, empl_tab:[Employee], dept_tab: [Department]) \
-         ->\n\
-        \        let match_name = fun r -> r.last_name == name in\n\
-        \        let matched_tab =tfilter@<Employee>(empl_tab, match_name) in\n\
-        \        let matched_row = get_row@<Employee>(matched_tab, 0) in\n\
-        \        let dept_id = matched_row.department_id in\n\
-        \        dept_id_to_dept_name(dept_tab,\n\
-        \          case dept_id\n\
-        \          | Some(dept_id) => dept_id\n\
-        \          | _ => ?  \n\
-        \          end)\n\
-        \    in\n\
-        \    \n\
-        \    test  employee_to_department(\"Jones\", employees, departments) \
-         == \"Engineering\" end\n\
-        \  in ? \n\
-         in ?\n";
+         let build_column = typfun row -> typfun row' -> fun (t : [row], fn : \
+         (row -> row')) -> map(t, fn) : [row'] in\n\
+         let incorrect =\n\
+         let last_name_to_dept_id =\n\
+         fun (dept_tab : [Department], name : String) ->\n\
+         let match_name = fun (r : Department) -> r.last_name == name in\n\
+         let matched_tab = tfilter@<Department>(dept_tab, match_name) in\n\
+         let matched_row = get_row@<Department>(matched_tab, 0) in\n\
+         matched_row.`department_id` in\n\
+         let employee_to_department =\n\
+         fun (_name : String, empl_tab : [Employee], dept_tab : [Department]) ->\n\
+         build_column@<Employee>@<(last_name = String, department_id = OptInt, \
+         department_name = String)>(empl_tab, fun r -> r ... (department_name \
+         = last_name_to_dept_id(dept_tab, r.`last_name`))) in\n\
+         ? in\n\
+         let correct =\n\
+         let dept_id_to_dept_name =\n\
+         fun (dept_tab : [Department], dept_id : Int) ->\n\
+         let match_name = fun (r : Department) -> r.department_id == dept_id in\n\
+         let matched_tab = tfilter@<Department>(dept_tab, match_name) in\n\
+         let matched_row = get_row@<Department>(matched_tab, 0) in\n\
+         matched_row.department_name in\n\
+         let employee_to_department =\n\
+         fun (name : String, empl_tab : [Employee], dept_tab : [Department]) ->\n\
+         let match_name = fun r -> r.last_name == name in\n\
+         let matched_tab = tfilter@<Employee>(empl_tab, match_name) in\n\
+         let matched_row = get_row@<Employee>(matched_tab, 0) in\n\
+         let dept_id = matched_row.department_id in\n\
+         dept_id_to_dept_name(\n\
+         dept_tab,\n\
+         case dept_id\n\
+         | Some(dept_id) => dept_id\n\
+         | _ => ?\n\
+         end\n\
+         ) in\n\
+         test\n\
+         employee_to_department(\"Jones\", employees, departments) == \
+         \"Engineering\" end in\n\
+         ? in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/example_programs/B2T2ExampleProgramsDotProduct.ml
+++ b/src/b2t2/slides/example_programs/B2T2ExampleProgramsDotProduct.ml
@@ -6,151 +6,183 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         60d44fc9-f28e-472d-84a6-9d3e6c50134d)(content(Whitespace\" \
+         05ff9673-dc66-4b1d-a582-6e580cf5f837)(content(Whitespace\" \
          \"))))(Tile((id \
          222f1cc7-5dfa-4e65-aef2-f411e3d7ee03)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         3154aac3-d1ff-4e62-a8dc-fe8e0efd85bb)(content(Whitespace\" \
+         e01dfafc-0422-4d3d-8e38-1756d90cea1e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7f1d9cde-8a63-4bc5-a237-1bfcba37223a)(content(Whitespace\" \
+         eb26dc37-c5f1-4439-a90b-d2e242d94aa4)(content(Whitespace\" \
          \"))))(Tile((id \
          df69a4e6-fa66-4f73-a907-34eb94aa103f)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          7c030b6f-e827-4f56-a14e-0a3285227331)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         29a2eda6-fd82-4fc5-abdc-bb7185b3dec6)(content(Whitespace\" \
+         \"))))(Tile((id \
          260bd774-15b8-4a6c-95a9-54d45c3957a1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         452ab18f-1040-496b-98d3-323d6987b62d)(content(Whitespace\" \
+         \"))))(Tile((id \
          d0fe4525-ae04-4eda-a9d4-88a1063b65ce)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          335261c9-f4fc-4add-9571-636f7e312a23)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         27aad64a-5146-4bd2-bc56-652d6bf34ee4)(content(Whitespace\" \
+         94dac87c-de30-4c48-be67-af86ff5ba325)(content(Whitespace\" \
          \"))))(Tile((id \
          3a8b8699-cd7c-486c-9d41-92d409c98501)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         15938f50-c653-4f0c-8773-379a4805dc83)(content(Whitespace\" \
+         \"))))(Tile((id \
          f3b3cb1b-acec-41b5-8e4a-d5e957aea4ce)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3a617a3f-485d-46a4-af66-62c056b4a708)(content(Whitespace\" \
+         \"))))(Tile((id \
          a0d9f1a9-f6b1-42fd-848f-6736bc823686)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          14de8d1f-064e-44fa-a600-6262c4676f25)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         927f03d2-f88d-4bc1-b139-25d9b2e541f7)(content(Whitespace\" \
+         36c9cc36-1ef2-4f59-87ad-421695aadaeb)(content(Whitespace\" \
          \"))))(Tile((id \
          876fc06c-ceb8-455c-bfad-8b94dc2b66d0)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1cdcc891-68fc-426d-a12e-1e5d1151cb0a)(content(Whitespace\" \
+         \"))))(Tile((id \
          45c4c403-d872-47da-b92e-9e4b96888d85)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8d649701-885c-4d49-b3f4-6a448ea3b674)(content(Whitespace\" \
+         \"))))(Tile((id \
          13f516b4-1dff-4cd7-9852-97a06895c5ef)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          1c15dcce-fcb1-4bc0-a5c2-b0fd195c0519)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         67ede6e1-a21f-4218-afbf-1c375cc067b9)(content(Whitespace\" \
+         7973c9b4-05ac-4a36-8240-ce1692afa2bd)(content(Whitespace\" \
          \"))))(Tile((id \
          ae295201-7089-465d-8355-90ac0630ec12)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         10745829-2b6e-410e-9b72-a17c2f2af0c1)(content(Whitespace\" \
+         \"))))(Tile((id \
          243d2c11-81ca-4f70-acff-18669d0aadc5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         94331bf4-0626-45a0-816f-a6adab7b3cc5)(content(Whitespace\" \
+         \"))))(Tile((id \
          b51535bf-755b-46f8-b5fc-451167de2d31)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9616e828-f3ab-4843-8717-bd018961a8b4)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         18f145ef-2f77-4e55-8500-1c5f7c5d91e2)(content(Whitespace\" \
+         4484cc1d-f35a-4633-ba05-3d70881b1bd5)(content(Whitespace\" \
          \"))))(Tile((id \
          5edae0ef-fc61-4cc4-a7fc-7fe3abc07861)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1c7823a8-e639-4c46-baad-cfbfc4e24c98)(content(Whitespace\" \
+         \"))))(Tile((id \
          1da69eeb-5b01-4eed-b931-20b61ec91b46)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d424860e-b6ce-4be6-b9a5-269be207ec43)(content(Whitespace\" \
+         \"))))(Tile((id \
          310b05f7-612b-4193-9d2b-88f6a92a3444)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5ff71f98-bfff-4588-b86a-417738cde184)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         791983b6-61b3-4c4b-873e-00d14291ba71)(content(Whitespace\" \
+         ec4a493e-57ad-4550-a863-ad6fd3ca2c3a)(content(Whitespace\" \
          \"))))(Tile((id \
          ee2ecc0d-0389-4944-8db2-79d76d7e012f)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f82184a3-fbf3-4ea0-a236-bd130aa64cc1)(content(Whitespace\" \
+         \"))))(Tile((id \
          47e30196-ef4b-409f-bc0f-17697ac38eb8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e28ce8eb-2145-4921-a40b-cd627bc344f7)(content(Whitespace\" \
+         \"))))(Tile((id \
          95012a53-cc5b-4d7a-99f2-9e6d20f8f624)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          2ddb4dbd-a05b-42ba-94be-72c70fcb490b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         34540803-4775-4054-b073-d384053742fc)(content(Whitespace\" \
+         76569e49-c9c4-4418-af6f-bafd30c6e190)(content(Whitespace\" \
          \"))))(Tile((id \
          e4c5d283-6615-45d6-b791-fe3ecd508223)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e27e76f2-a67b-45f2-bee5-c1e6ca4fd505)(content(Whitespace\" \
+         \"))))(Tile((id \
          38a21ce7-7660-44fa-9578-edcc0df9cd6e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         85d39a74-66b3-4770-bb50-f0d750ba5e00)(content(Whitespace\" \
+         \"))))(Tile((id \
          0eb9844c-6cab-45e6-bf99-fb898293592c)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7a8a76a8-00b4-42ca-8907-7a4b81743ac7)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         24fb0d4f-49b3-4a51-a440-6221904ce272)(content(Whitespace\" \
+         22f87387-5833-4512-9f28-6aecc00ab1cb)(content(Whitespace\" \
          \"))))(Tile((id \
          1ecff948-43fc-40fd-a794-a3485566e0a9)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b604114d-c188-4f78-8e36-b903da922355)(content(Whitespace\" \
+         \"))))(Tile((id \
          226ad28a-b41d-43e7-888d-3fe38778f26a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         195fdf7d-bd9c-4e11-badc-8d505d8c0873)(content(Whitespace\" \
+         \"))))(Tile((id \
          bf5ff572-a80e-4489-b76b-540c007726f3)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         4f2e881d-8efe-4e69-83d7-e181ee4f7cfe)(content(Whitespace\" \
+         0cae2354-63fc-41b9-b1b3-c2afb34794ad)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a5e8d27e-2e49-428f-8244-2763936fde47)(content(Whitespace\"\\n\"))))(Tile((id \
+         3ddba725-6f65-4c86-959f-0151fefc8074)(content(Whitespace\"\\n\"))))(Tile((id \
          ebb02393-bdd3-4715-845f-89a764cc0605)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         006bf7e1-992b-4417-8360-cec83b746f97)(content(Whitespace\" \
+         363bc04d-d129-41e8-a4c1-d784c4140c8f)(content(Whitespace\" \
          \"))))(Tile((id \
          120f53cc-85a4-4f32-a48d-340f214c06e5)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7afaed04-0416-4d2f-970a-5fe57c96e965)(content(Whitespace\" \
+         e8158d42-be15-44f5-90fc-f98306bf5da7)(content(Whitespace\" \
          \"))))(Tile((id \
          22698feb-95be-4799-b21d-350d3560c218)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a8177ff1-b003-471e-ba10-48ccc12cfaf5)(content(Whitespace\" \
+         9951a709-1df3-4a82-a26b-7817bac26045)(content(Whitespace\" \
          \"))))(Tile((id ef51cf6c-8f9b-4cb6-91b6-39bc11be8eae)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          ecdd1854-e7fa-458a-bebb-bf4e74ca084d)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         cbb3d0f6-fdc6-4e5b-936d-7069432af572)(content(Whitespace\" \
+         e7bbc08e-c514-4735-91c8-045561c425e6)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e85a3af3-de8d-49c9-9408-fd94af8f43b6)(content(Whitespace\" \
+         99225920-fb1e-4a5c-acdd-8a12ea4ee53b)(content(Whitespace\" \
          \"))))(Projector((id aed98db2-aff7-4408-93c7-abb1d7225d3f)(kind \
          Fold)(syntax(Tile((id \
          e8c41f86-338e-462b-b05f-8a6f1af01510)(label(\"(\"\")\"))(mold((out \
@@ -364,99 +396,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          cb660fd3-49dd-4af7-82c1-e4ff3d5ec2cb)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         b4da4174-3686-493e-b204-ffb2cd042a3a)(content(Whitespace\" \
+         ea62d1ea-0cca-4086-a545-a7f20fc53dd6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7cdb12b1-6797-428b-8d04-56e9de135eb2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         313575a8-9408-4fa3-9c35-67f41e9705e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2e99b1c6-c140-4b25-8d2d-eee3695f10aa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e910d55e-2b16-4f86-95af-b2a2c096fa1e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f52cb5ab-c6ee-4ac8-a1f1-de0382bc8ba1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         93f5a086-0139-495e-930d-fa078098d436)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0a6f57d2-914e-496a-85d7-9735adc6da92)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b6e7344-4d02-4cd2-9d6c-887ed7de205f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2e20f267-a635-46b9-953f-6759268d95f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d4d2c32-869b-46ad-b47e-dddfc21d498f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d9be51c2-af96-4c21-b07c-d619bfdae00c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b8f331f-28bb-4245-8fe4-1531b4f4668f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6c24627a-1dc6-4bc9-a6e6-969c65011b5b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6872011e-7e95-4488-b2ec-e508a2efcc9e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f5a6eb1c-4110-4463-98b7-37b960edf869)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c39d1329-bce0-4de7-b591-0f5f0e1b6413)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cde5de5f-5981-4c88-8649-50ba62778f64)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c4e8cee8-2b42-487f-87f7-cbfe6d43ff26)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae02f51f-d4ac-4618-a2ab-e29411457266)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a2e27687-c9fd-414b-a298-8727c8285ea1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7fbb6637-5eb9-4cde-9c88-ef4d8da4e392)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4586b45a-ab74-4dc2-9d72-f09c8d7a0c67)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5239d2d-feb3-4572-bc64-2ea9c41cfd97)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3328b335-90a4-4d0d-94c0-bcb099091ab7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         780e5e75-54ae-4f33-a05c-c565e206d13d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d99bf29e-3663-4ad6-9d17-7da77d023996)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fba503fb-ff74-487e-9b04-825a98c87b8d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a0f237a3-0f8b-4946-a446-b5dbf04db3bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         71cb5739-7d07-4955-9fb7-7d461fe59a6e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         be0a8a05-d2b9-4f20-88a0-a355f70d14c8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         112a41e3-b03b-4124-ab9b-91121aaff492)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0e27d825-7ea1-438f-b62a-d0cd1b5baacf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb87838b-d78e-4502-913f-ec35398fd691)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         59052059-b109-491b-8c10-e70983a9d1cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         68602191-af2f-4257-bcf3-40a689af9e74)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         88fd7d61-09b1-4e7a-9cb0-3bea8f5c246c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         45feedf9-cc79-46a8-834e-eed5cfec3ff9)(content(Whitespace\"\\n\"))))(Secondary((id \
+         244a1a83-59d6-47f9-bd1e-1915bc0e55c8)(content(Whitespace\"\\n\"))))(Secondary((id \
+         0e621998-d25a-4a17-8c91-c71f154bd51f)(content(Whitespace\"\\n\"))))(Secondary((id \
          56ad9bc8-deb9-4557-a8ae-99c087a4b720)(content(Comment\"# Version with \
          String Columns matching API #\"))))(Secondary((id \
-         5bb7cfa1-1f06-465d-b2c3-3cd4c711cc4d)(content(Whitespace\"\\n\"))))(Tile((id \
+         8e4d7040-7a21-46d0-937d-a73398359c91)(content(Whitespace\"\\n\"))))(Tile((id \
          ab281caf-e8f9-40e6-8eca-a682faa1e75d)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         566b0dff-13ca-43d5-b870-0722472ffc67)(content(Whitespace\" \
+         4730ebe5-2dbe-4545-a261-f4b66246f1c9)(content(Whitespace\" \
          \"))))(Tile((id \
          2a027b48-606f-4337-90ff-d84f7130bf5e)(label(get_value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         434bde5a-9de4-47be-9c7d-483ef3d6e5d8)(content(Whitespace\" \
+         fa615206-1f90-4f6a-9d36-a11d8ef1e6d4)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8c6cf7ea-df59-4c93-be08-6c6209726d3d)(content(Whitespace\" \
+         034cab3b-ee2c-4b74-a800-5e39519c674f)(content(Whitespace\" \
          \"))))(Tile((id 5a219740-b227-4db6-b02b-f5482a75de7f)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         24855c05-b08e-4dc4-9a29-549953dfcf50)(content(Whitespace\" \
+         23cd3060-9b53-4acd-91a7-cb92ea21064b)(content(Whitespace\" \
          \"))))(Tile((id \
          9d2845b2-044b-43bf-88b1-095f376da9b5)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -467,14 +429,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cae604be-8604-4beb-af3f-083cbfcf03c3)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         17f8bdfc-6c90-47f3-b491-b7c4f9e92202)(content(Whitespace\" \
+         2581cd96-edfa-4e40-914c-087781c5ca94)(content(Whitespace\" \
          \"))))(Tile((id \
          a7b3ff60-feef-431e-8a81-6bbac8105005)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         1b8f6e40-061e-4ba0-a04a-afb0846901c1)(content(Whitespace\" \
+         f26cfdfe-f405-4cd9-91db-0c22f8379a7f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c83f937b-77d1-47a3-b604-9ca06a823b97)(content(Whitespace\" \
+         e3f85c91-41d9-4d73-a234-f6b27723fcbf)(content(Whitespace\" \
          \"))))(Tile((id \
          7ac67215-1687-4cbb-81f7-a63ee74492df)(label(find))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -533,28 +495,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e534fc31-1da4-4db6-8ee6-3459dad6547c)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         ce8f8877-724f-4157-97f0-8c0c3c415d18)(content(Whitespace\" \
+         1dacb114-f585-433c-9a8c-15102d11068f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         51071b4f-00c9-4216-90a8-6d9d8f2174cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27f435e9-2822-406b-89f5-95b57e5ac471)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0df7a50e-92d6-498d-8146-22e85912c6d3)(content(Whitespace\"\\n\"))))(Tile((id \
+         4329f20b-612c-458b-a1ca-944a94233512)(content(Whitespace\"\\n\"))))(Tile((id \
          c60c3811-7390-4f2c-808e-a812800bdab8)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         20b4d77a-9607-4090-b339-bfe939466b28)(content(Whitespace\" \
+         642a6cc7-42c5-43d3-a727-947bdadff386)(content(Whitespace\" \
          \"))))(Tile((id \
          a51549d7-a070-44ca-9e20-fb64f09ef445)(label(dot_product))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2671fbd7-a115-403f-8766-c5314801dbb1)(content(Whitespace\" \
+         e1f56a72-7655-4c29-afd0-de440a6f7b09)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e6961403-f549-4e6a-9cf1-4571b605829e)(content(Whitespace\"\\n\"))))(Tile((id \
-         d957d9e4-4c6e-4fb0-b45f-c77d28b93c51)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         69ad3da1-5d9f-4a38-9f7f-0d0a5e195fcd)(content(Whitespace\" \
+         c3079317-d66a-4874-b958-b8f8317dbdf3)(content(Whitespace\" \
+         \"))))(Tile((id d957d9e4-4c6e-4fb0-b45f-c77d28b93c51)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         cb3aa5f2-757f-42b0-9b4b-45b6e68fb577)(content(Whitespace\" \
          \"))))(Tile((id \
          82d4248e-de59-4701-95be-2063575d4afb)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -565,17 +524,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b2bcb10e-492f-45db-9901-e28f10dad54a)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         59956ece-5094-4eb9-a1a2-273415f0ddae)(content(Whitespace\" \
+         f4af1398-edc9-4871-821a-2d0ce0f3d834)(content(Whitespace\" \
          \"))))(Tile((id \
          d5c168ca-b30e-4abc-b0c8-92cb8ff5048a)(label(c1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cd6890f4-e944-4c5b-b1d5-debe7d8919c7)(content(Whitespace\" \
+         bfca6e18-d359-42ca-8fcc-f79de61e8ef9)(content(Whitespace\" \
          \"))))(Tile((id \
          c5f6f2fa-d77b-4645-aa58-c2d1cfa358e5)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         317c86c5-93b1-42db-a985-b16fe3499d12)(content(Whitespace\" \
+         aee8d321-0a54-473e-8ac0-8e6de985456c)(content(Whitespace\" \
          \"))))(Tile((id \
          cb25c8d9-511e-4ec6-b1b0-57b7c44e183a)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -583,28 +542,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1742017e-f818-440f-a05f-ad1827064276)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         8361e4b5-0aa0-4c57-8e81-deaeaae4d3b0)(content(Whitespace\" \
+         c106dbc7-3dec-4ae4-8f43-1c0fdbffa097)(content(Whitespace\" \
          \"))))(Tile((id \
          f6ce3ad5-c774-4970-ab9e-725347048118)(label(c2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1326cf9e-f57f-4d8f-98c3-985b6abc7cac)(content(Whitespace\" \
+         e05a5306-244c-42b5-8fc7-352c3a97a84c)(content(Whitespace\" \
          \"))))(Tile((id \
          621111cb-f757-45bb-9140-2455a64d8065)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6e49d04e-534e-4ed1-9647-38ab637ea4b0)(content(Whitespace\" \
+         a54cdf0f-4cc1-4b7a-9050-b4e07af15135)(content(Whitespace\" \
          \"))))(Tile((id \
          dfa30138-7da3-4441-9d0c-91e53ba110d1)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         b679f02f-a62c-44e7-92fa-638f15fecbda)(content(Whitespace\" \
+         1ee14d8e-2075-45e5-9dc2-12c4d3df2124)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3713ec1a-e355-49c0-8903-0d6757348179)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6c27ab50-4445-41dd-8e75-8e0ea4704a19)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ceb85efd-7c76-41fe-acb3-6f9626da5b28)(content(Whitespace\"\\n\"))))(Tile((id \
+         4392c7be-f0eb-42c4-a385-67e762541dba)(content(Whitespace\" \
+         \"))))(Tile((id \
          fb8e89b6-7d17-42d4-b165-c01d6db18164)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -681,20 +637,23 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))))))))))))(Tile((id \
          34bc3b0a-a131-4e02-b48f-e28159aefb85)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         404cc8e7-6883-457b-ac2a-264f7a17ff46)(content(Whitespace\" \
+         \"))))(Tile((id \
          167a24f7-2722-4b72-8ed4-9ac1ba218f6d)(label(int_plus))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          9f1ca10a-fd9d-48c6-bd5f-88eb3cdc3f0e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bb576638-b843-47dd-98aa-e6d12ce92f67)(content(Whitespace\" \
+         8379d3a1-558b-43e4-b603-ed4cd63607cd)(content(Whitespace\" \
          \"))))(Tile((id \
          f90554da-89d1-4ec1-9760-4b4475340726)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6e90a16c-b16f-440f-b328-998e42aefea1)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         6a92a536-1d0e-4c6b-a59e-1b674fc6c5ac)(content(Whitespace\"\\n\"))))(Tile((id \
+         bda44897-d607-44c9-ab57-b76da01f5d11)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c944e653-62c3-4257-aacb-372aef39e922)(content(Whitespace\"\\n\"))))(Tile((id \
          882a41eb-9434-48ac-bde2-0fe624343f5d)(label(dot_product))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -707,7 +666,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fd0f188b-330d-40ab-bb35-0fbd5af89fa8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2f021d75-f203-4ff1-852b-dbfadd7af2b3)(content(Whitespace\" \
+         554a99ce-2d44-4bab-8d55-64af274b379e)(content(Whitespace\" \
          \"))))(Tile((id \
          5b830508-a246-4a30-af0c-9cb0bfa0e378)(label(\"\\\"quiz1\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -715,93 +674,90 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bf93a958-8c9e-4039-bd87-c5e90a6cd37b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         524e2da0-4791-4249-8b9e-399e058477ef)(content(Whitespace\" \
+         6b9b555b-ebbf-4e2e-a92c-d366bb7b27ab)(content(Whitespace\" \
          \"))))(Tile((id \
          63888a87-deb9-4bee-a178-74362b5be7c4)(label(\"\\\"quiz2\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         74cdb50d-6c66-4c50-a587-aa8e545449da)(content(Whitespace\"\\n\"))))(Tile((id \
          f3cde656-8203-4dab-beef-82824279f630)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d0f5cdc9-9d1e-47e9-bd10-6751eef1af70)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f8ec25c3-cf61-45b7-bd6b-335b9f92ffec)(content(Whitespace\"\\n\"))))(Secondary((id \
+         5980e7c0-4344-4573-b156-b7ba477be48c)(content(Whitespace\"\\n\"))))(Secondary((id \
+         cfe034f2-d47e-4e75-913d-dd1072f1f8ae)(content(Whitespace\"\\n\"))))(Secondary((id \
          4b456fbf-b55a-40d0-81cd-a21f5d335b54)(content(Comment\"# Version \
          using function for column access #\"))))(Secondary((id \
-         bf7bccf7-fa8a-4665-9359-3fc192027cb9)(content(Whitespace\"\\n\"))))(Tile((id \
+         a774b7d3-9eea-4fd0-b3d3-3c289cd97791)(content(Whitespace\"\\n\"))))(Tile((id \
          d62ef2f2-d648-4372-a436-319898a4f1d7)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         48d5949e-8121-4769-90ca-716dfca0785c)(content(Whitespace\" \
+         eceeedc6-7941-4b76-b4f4-b5ad7b9eb724)(content(Whitespace\" \
          \"))))(Tile((id \
          41c741dd-1056-43b7-ba30-abb15dbd67ea)(label(dot_product))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         407394fe-a213-433c-9899-e1b7a3373cba)(content(Whitespace\" \
+         eae0bbe9-419f-4d79-a6c0-916e010a893d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a7a4f20b-9468-4245-92ce-1116613e337c)(content(Whitespace\"\\n\"))))(Tile((id \
+         e08440d0-2ce7-44f9-93a5-654fe8cb7959)(content(Whitespace\"\\n\"))))(Tile((id \
          76ae1ffd-da3d-41d6-b9bd-6e0a8ce50a7b)(label(typfun ->))(mold((out \
          Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         c9f447eb-2427-4150-8cc2-5e5187f65b28)(content(Whitespace\" \
+         36116651-40ab-4310-90ce-fece5467af7b)(content(Whitespace\" \
          \"))))(Tile((id \
          2bc4a644-9a7d-4e38-ba3f-e356609262ed)(label(R))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         de0ae0b4-998f-48bb-98f5-c9a052aba206)(content(Whitespace\" \
+         13a2aa08-cbc3-4dc3-b181-887dc970d58e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         47e3bd97-1d9f-4676-b8f9-89ef7646adcb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1f86805c-a7be-4573-a359-875e878d30b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f3072cf-1107-4b78-860d-bc17f1a5951e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         99d1719a-622c-4b1a-b1fa-4f3b2185bff2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         075ba5ab-cf1a-4db1-8314-0ff38a5ae995)(content(Whitespace\"\\n\"))))(Tile((id \
-         ae75de57-f6c5-4974-9f57-7aec1c5be356)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         054baeab-2ce5-4040-853f-cb02caabd239)(content(Whitespace\" \
+         dc10601c-6eb1-48bf-9b0d-cad3733a57ee)(content(Whitespace\" \
+         \"))))(Tile((id ae75de57-f6c5-4974-9f57-7aec1c5be356)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         43d71f56-4d75-42e5-b0ea-6123b129e177)(content(Whitespace\" \
          \"))))(Tile((id \
          3804af13-9d07-4c6e-8a69-4c10bf085e7b)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          a593c4c1-3fe3-4c34-9646-64334d623268)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         213c5bdc-0461-47e9-a807-a373fe724c5c)(content(Whitespace\" \
+         \"))))(Tile((id \
          e0b3e758-f195-4550-abaf-88d9cbf88f3a)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         58091efa-3389-4e62-bd4a-17b6fea57a20)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9124d9c8-4f59-459c-8a14-7703b531b609)(content(Whitespace\" \
+         \"))))(Tile((id 58091efa-3389-4e62-bd4a-17b6fea57a20)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          e5d4b5ad-2d3d-4eb7-b836-e06c1028c431)(label(R))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          e9aecea9-4455-40fe-ac8d-03f4f43a970c)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         17678290-b1b8-435e-b169-6d5b16346078)(content(Whitespace\" \
+         4c023700-13d1-47ff-b9a5-384fc99fffbd)(content(Whitespace\" \
          \"))))(Tile((id \
          a90c10f0-86c9-40ff-b3b6-af6718a159e7)(label(c1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d0afb454-d1be-4681-b8e1-8f6b39adaa39)(content(Whitespace\" \
+         deef680c-bdd9-4c35-94f0-7cc08eb320ae)(content(Whitespace\" \
          \"))))(Tile((id \
          4f31ef87-f409-4b10-afa5-a2e3f8eb59e1)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f3b5831c-8958-41b9-b4d2-2d1ea73cd2ed)(content(Whitespace\" \
+         637e5c10-8f45-418c-892b-d1329d6a3c48)(content(Whitespace\" \
          \"))))(Tile((id \
          b2630e6d-a1cf-444a-a6c4-28c6728766d2)(label(R))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         778a12a0-a5f6-47ee-b3f7-6b8ac82c9acc)(content(Whitespace\" \
+         c1869055-bcda-4139-8d9a-e2293d2ae499)(content(Whitespace\" \
          \"))))(Tile((id \
          d8af2c40-711f-4a50-aeeb-ed8507ef5c8b)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         669c6545-e28a-4c5c-9906-4683242c4e36)(content(Whitespace\" \
+         8cbf91b8-3998-413e-90b7-219bb88f7cdb)(content(Whitespace\" \
          \"))))(Tile((id \
          e7707706-9a8c-4dba-bac0-a322e2c3b17b)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -809,38 +765,35 @@ let out : string * Haz3lcore.PersistentSegment.t =
          71988626-e078-476d-ad8f-57be5c1d42f8)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         274105f3-ccbc-4cdf-9ebc-0faefdc6445c)(content(Whitespace\" \
+         75f740fb-bb23-4359-b76d-d86d9f6defe0)(content(Whitespace\" \
          \"))))(Tile((id \
          d3e297d4-edf9-4c03-ab9f-068a1c8ebd71)(label(c2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a11babaf-9ff8-4286-b75f-6e78f9908bc4)(content(Whitespace\" \
+         6346f329-decd-4f96-9cee-9c7b0abd1f46)(content(Whitespace\" \
          \"))))(Tile((id \
          ce47e08f-eb52-4b7a-b761-c529136e5fef)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         90b2d29c-7bc8-4485-8ecd-c5d2873a821f)(content(Whitespace\" \
+         ce22c1a3-7c7a-4cfe-888b-33f4522a3986)(content(Whitespace\" \
          \"))))(Tile((id \
          24f14566-2751-4dd6-99e1-4744f03e9196)(label(R))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         43d7f8c4-23e7-4274-b43f-1257ccf79add)(content(Whitespace\" \
+         05973a52-f735-4e83-a6bf-be82770cdf4e)(content(Whitespace\" \
          \"))))(Tile((id \
          faa7ee59-cb86-4708-80a5-cc6041a0164e)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9a644f5d-6b36-43da-8263-b3792eb02b59)(content(Whitespace\" \
+         25d9d86f-6522-40a8-8298-2ba75a2d8ad6)(content(Whitespace\" \
          \"))))(Tile((id \
          7d1acbbb-3c7a-45ab-9dcb-32f7072318ef)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         b386dc84-af87-4662-901f-0c3850c97504)(content(Whitespace\" \
+         5f38d6cf-2058-4a87-aefb-30bb435bcc5c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         82398589-ec15-4bb5-8fb5-777c3bb1ba0b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb484985-ddde-406e-a3ca-b7b0d763868f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f6cc51aa-6713-465e-8940-52c39a1d1612)(content(Whitespace\"\\n\"))))(Tile((id \
+         263b318f-cad4-4319-b8e5-c4de128772cf)(content(Whitespace\" \
+         \"))))(Tile((id \
          4033928b-f58a-48cc-8339-acf3d60aa0c4)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -904,7 +857,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3ac259ea-f5c7-474d-ae34-03f69fe967f0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         34d079db-8d6b-495f-ac2b-3446035a9603)(content(Whitespace\" \
+         cffeb63d-d8d9-49ba-b59c-e2c9b045cdc9)(content(Whitespace\" \
          \"))))(Tile((id \
          7c3db0e7-0f25-4fb9-afbc-8f80ccd910b5)(label(int_plus))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -912,36 +865,35 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fc1b1154-8559-4466-98f8-63e0a071b5aa)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e727f84f-cc7f-4263-a5c9-a3fddbdf94fc)(content(Whitespace\" \
+         4d3c740e-a9fe-4d17-9dd2-0c182efdb5e1)(content(Whitespace\" \
          \"))))(Tile((id \
          35fbf285-4371-4dc5-a746-4b327d649063)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8266d51a-57d5-4971-adb0-cc1d1a81fdad)(content(Whitespace\" \
+         a9970d9d-cb7c-4261-ac46-320f5eee275b)(content(Whitespace\" \
          \"))))(Tile((id \
          930e6da2-dc47-4879-9d26-301b88fe1b0b)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f1a4d058-21aa-4f2a-b078-a790cf8209ef)(content(Whitespace\" \
+         fa572fe0-cc68-41fb-9c74-eb406287e471)(content(Whitespace\" \
          \"))))(Tile((id \
          3acc5c6a-e48f-45fd-a958-a1d6aecd13e5)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         6fa053d4-64e7-4fdf-8d74-ae6b8738e87b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         9d11d2d5-589a-4026-897b-99a995eba043)(content(Whitespace\"\\n\"))))(Tile((id \
+         b6ef32c9-b45f-458a-b6ba-afc75305edff)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         8b35fcab-7182-4323-9f18-fa4a7f87620b)(content(Whitespace\"\\n\"))))(Tile((id \
          489dca27-1e4d-4062-9df2-35e2092cb16c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3b8376d2-9518-4bd8-8c4a-62efe99b79e3)(content(Whitespace\" \
+         ccf54538-c758-4f01-8736-6bd019de057f)(content(Whitespace\" \
          \"))))(Tile((id \
          c38758ca-6d7d-4572-83ae-d18c726f936a)(label(result))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6d038144-63d4-4e39-b48c-954087dc1488)(content(Whitespace\" \
+         1cb765c9-2a61-4e12-b63c-d8238ec050d3)(content(Whitespace\" \
          \")))))((Secondary((id \
-         73793c73-49cb-4946-92f0-858c13e309ad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fcf538cd-90f7-4a5b-a994-a926ec32d78c)(content(Whitespace\"\\n\"))))(Tile((id \
+         f14231d2-9a01-4474-b3a9-58f5cbf7fee0)(content(Whitespace\"\\n\"))))(Tile((id \
          e45d6bb8-1d2a-4609-86ea-430af6760581)(label(dot_product))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -953,132 +905,166 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          193e5720-0359-4ebc-a0a7-9e4560cb7f90)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a029d4d5-c3e8-4e20-a253-9f054d718f82)(content(Whitespace\" \
+         \"))))(Tile((id \
          ab2e2116-859d-40e2-a901-49f0221573af)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         867448df-7ccf-4cf6-b1d7-181b925372a4)(content(Whitespace\" \
+         \"))))(Tile((id \
          4096dfe3-15ba-4a99-a80c-cac1455c17a0)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          87829f73-7006-48d0-9d13-f447ef0809e2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         90ecd55f-c8a6-4440-b181-191bcfcda0d0)(content(Whitespace\" \
+         74047cce-156a-47e4-88e2-92c23cba930d)(content(Whitespace\" \
          \"))))(Tile((id \
          a8bdaee9-a168-4417-b10e-c38998cd1658)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1e16f6f0-960e-4097-b988-d164c833efc6)(content(Whitespace\" \
+         \"))))(Tile((id \
          cbcb4581-1ae5-45f5-bc2a-02efdb18dd77)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         db2efbc0-c92d-40ff-980d-3a1b335b45d6)(content(Whitespace\" \
+         \"))))(Tile((id \
          a9856f1e-a2c2-4e27-83cc-757eec931c36)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          1df08e42-82ba-44d5-88d1-acb40d03a4eb)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         faa6e6df-cf53-4b57-9ac2-51ef0d5c5e0d)(content(Whitespace\" \
+         1fd9c737-6cb8-4f7e-9336-e02669cd8067)(content(Whitespace\" \
          \"))))(Tile((id \
          79b4044e-28d9-4d02-ac53-1e997df8daf5)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2a6e7b39-3aea-4afa-9656-d9d1cf215e5d)(content(Whitespace\" \
+         \"))))(Tile((id \
          5e8a3cb7-0af3-4d91-9a80-a6a4209e66aa)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         13190a6e-114d-4eb3-8b39-c92250930f1f)(content(Whitespace\" \
+         \"))))(Tile((id \
          9ecc4e5e-90f6-49fc-9bdd-61619e833540)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e32b4bd0-df66-49db-b0f4-52a46d1c623d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3672022d-f767-4fc1-a9b9-f5b52a232e02)(content(Whitespace\" \
+         0f7188c5-05fc-4c8d-8613-ff6bb603c1fe)(content(Whitespace\" \
          \"))))(Tile((id \
          624ca801-22c8-497f-8f48-654211602c5d)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7de359b9-e4ee-4d46-975a-a3d6cf5bdd11)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce96fd62-ae07-4493-99d8-59b5533d7de6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         af345fb9-1a08-4f82-b6e4-13e1503feda1)(content(Whitespace\" \
+         \"))))(Tile((id \
          4c05a611-8e7f-4cce-9b79-c82d778e004a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0d5710fa-fd39-45f4-a940-05d8bd5d9fd0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6d85727e-2aea-4e20-b7ce-eb8db95e78b1)(content(Whitespace\" \
+         73f9fbce-4b1b-46bb-ae4e-704c7a6a54d0)(content(Whitespace\" \
          \"))))(Tile((id \
          379d4677-2778-473f-889c-0dff9fe52e14)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a2d2aaed-9c71-46d7-9f90-dcd3b24cc835)(content(Whitespace\" \
+         \"))))(Tile((id \
          1356e3bc-fb41-461e-bcaa-93a96c1dc29e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         38a29e88-becd-4f85-a6c9-61b1d004c330)(content(Whitespace\" \
+         \"))))(Tile((id \
          cf184921-8dba-4d03-950e-949a46fe8552)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6eec56a2-ccdf-431b-b375-3038d89cf254)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2df72847-67a7-4269-84c0-040acb2224e7)(content(Whitespace\" \
+         2482d126-b692-4dc2-8228-cb1a37106f5e)(content(Whitespace\" \
          \"))))(Tile((id \
          754a4abf-4c2b-44e4-90c8-312c4e87feea)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5fb39b86-0c63-459b-9d05-66189dfd6209)(content(Whitespace\" \
+         \"))))(Tile((id \
          f0edc0a6-5bd7-4714-a7dd-470403fd3242)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ef9f1a5f-1955-4baa-8ddf-1fc1847a3b2b)(content(Whitespace\" \
+         \"))))(Tile((id \
          47095e18-0493-43ec-96d0-e4a4b807b4ff)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a8f4b20b-79bd-4427-adaa-54bf5e85362a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d17db62c-cb7f-49bc-b21b-65fb3b645ba2)(content(Whitespace\" \
+         0c38b68a-e627-4775-a5b4-acc61eff1eb4)(content(Whitespace\" \
          \"))))(Tile((id \
          2a831977-451c-439a-ac43-fd85b7876025)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6ec34a5c-9680-4630-8479-9b8b20b0075b)(content(Whitespace\" \
+         \"))))(Tile((id \
          8af58500-43b5-4ce2-b4a2-847a95d2e4af)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         60115df1-06bb-4c42-b0a4-64f59d711038)(content(Whitespace\" \
+         \"))))(Tile((id \
          5b51f0a4-d27c-450b-9837-e91afac7b32a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d6e1cd0b-698d-4ab5-8447-8d5a57f670f0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         502b4bdd-2627-4214-8d95-a92689bff3b0)(content(Whitespace\" \
+         bc153156-e850-4494-a0dc-7ba924d54839)(content(Whitespace\" \
          \"))))(Tile((id \
          ebaea96d-dd54-4d76-b605-c859b021b560)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         19d36d19-48ec-439c-9e1c-04dc2570d723)(content(Whitespace\" \
+         \"))))(Tile((id \
          9702d381-c189-402b-a2e3-5e7972601e24)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d9c1d82e-57e0-4a65-9332-952ade003f12)(content(Whitespace\" \
+         \"))))(Tile((id \
          5cb80146-2ae9-47f9-bdba-80ca6b09b799)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
          059f6315-531b-4f05-a428-bde6e5e9c6fc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         81d9f603-d2c2-40af-8bde-97f97e921cca)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          af5301d2-a036-4840-b95b-514c88e40f13)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          143363d3-9b8c-48f7-a1bb-9c3ec09ffecc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4b00540c-986e-4ba0-85d4-859703f6a841)(content(Whitespace\"\\n\"))))(Tile((id \
-         6fc8522a-9e82-4b48-8d80-bf09d26d0463)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         0f6b94c4-6dce-46e0-a3e6-58c68e5a1a6c)(content(Whitespace\" \
+         327eec90-533a-4bcc-8257-41ec70a93ea2)(content(Whitespace\" \
+         \"))))(Tile((id 6fc8522a-9e82-4b48-8d80-bf09d26d0463)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         2e02df0d-cf7c-4a81-9b71-e2b2bd81dc53)(content(Whitespace\" \
          \"))))(Tile((id \
          f7799d46-28da-45ff-bf6b-b0c81a875b30)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2880293c-4bdb-47a6-ba96-ff04162678a2)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         4347ddcc-cc36-4376-abfb-a4901be2d935)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d2dca25b-6e02-45ce-9b46-659127e5d445)(content(Whitespace\" \
+         \"))))(Tile((id \
          9bca7f69-b845-4dcc-8b10-076a75299b30)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1091,17 +1077,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          563d35b7-1f9d-4173-b3d1-94db5b929a2d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         970b5d3e-2e11-43d2-8ca5-24a7983372fd)(content(Whitespace\"\\n\"))))(Tile((id \
-         f915973c-c36b-4ef6-9a21-c3b84e8325be)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         aa70aa18-bdc8-46cf-a808-cfe9c527efd4)(content(Whitespace\" \
+         af05d102-41f6-4723-bb83-a2a9ad7bdc5a)(content(Whitespace\" \
+         \"))))(Tile((id f915973c-c36b-4ef6-9a21-c3b84e8325be)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         bf73ce91-96d2-4a0d-a638-d1f4c0c186a9)(content(Whitespace\" \
          \"))))(Tile((id \
          62846f87-b65c-49f5-9459-0653cdebc37b)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1412f06a-8d4b-4b41-ae2b-8e2a01290b80)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         ca63f9e4-98e4-4e3c-a5fa-c1d606effb31)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         28896910-c62e-4221-83eb-979a42218785)(content(Whitespace\" \
+         \"))))(Tile((id \
          4d74297f-5fa3-4fbd-80da-ee12063fe5b8)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1111,42 +1100,37 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b3c56299-f18f-478c-884e-896cd746ab1a)(label(quiz2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         2d54a7b1-24ba-4dbb-85d4-4f0ba605e8b8)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         6db778d1-6a16-4552-ab0c-fd864852381a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         da89f8e2-8ae4-43b6-8fd9-461a4ac609d0)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c8cab8c8-9fae-4178-ab19-71f40a78266f)(content(Whitespace\"\\n\"))))(Tile((id \
          f3eb529a-1bd2-4268-b958-b5e0fba67c26)(label(result))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+        "type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = ^^fold([\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
          (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
-         ]) in                                   \n\n\
+         ]) in\n\n\
          # Version with String Columns matching API #\n\
          let get_value = fun (r, c) -> find(to_lvs(r), fun e -> e.label == \
-         c).value in  \n\
-         let dot_product =\n\
-         fun (t1, c1 : String, c2 : String) ->  \n\
-         fold_left(map(t1, fun r -> (get_value(r,c1) * get_value(r, \
-         c2))),int_plus, 0)\n\
-         in\n\
-         ^^probe(dot_product(gradebook, \"quiz1\", \"quiz2\"));\n\n\
+         c).value in\n\
+         let dot_product = fun (t1, c1 : String, c2 : String) -> \
+         fold_left(map(t1, fun r -> (get_value(r,c1) * get_value(r, c2))), \
+         int_plus, 0) in\n\
+         ^^probe(dot_product(gradebook, \"quiz1\", \"quiz2\"))\n\
+         ;\n\n\
          # Version using function for column access #\n\
          let dot_product =\n\
-         typfun R ->    \n\
-         fun (t1:[R], c1 : R -> Int, c2 : R -> Int) ->  \n\
-         fold_left(map(t1, fun r -> (c1(r) * c2(r))), int_plus, 0) : Int\n\
-         in\n\
-         let result = \n\
-         dot_product@<(name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int)>(\n\
-         gradebook,\n\
-         fun e ->e.quiz1,\n\
-         fun e ->e.quiz2)\n\
-         in ^^probe(result)";
+         typfun R -> fun (t1 : [R], c1 : R -> Int, c2 : R -> Int) -> \
+         fold_left(map(t1, fun r -> (c1(r) * c2(r))), int_plus, 0) : Int in\n\
+         let result =\n\
+         dot_product@<(name = String, age = Int, quiz1 = Int, quiz2 = Int, \
+         midterm = Int, quiz3 = Int, quiz4 = Int, final = Int)>(gradebook, fun \
+         e -> e.quiz1, fun e -> e.quiz2) in\n\
+         ^^probe(result)";
       refractors =
         "((88773fa9-8d95-4b3b-a38a-0ce37638c239((kind \
          Probe)(model\"()\")))(f3eb529a-1bd2-4268-b958-b5e0fba67c26((kind \

--- a/src/b2t2/slides/example_programs/B2T2ExampleProgramsgroupByRetentive.ml
+++ b/src/b2t2/slides/example_programs/B2T2ExampleProgramsgroupByRetentive.ml
@@ -1,1587 +1,1651 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Example Programs / groupByRetentive",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
-        "((Tile((id a3b69c29-f4ae-4ebd-8752-7fb574b22c76)(label(let = \
+        "((Tile((id 0cef5e85-6cf1-4a5c-b94c-4bc5041d00c4)(label(let = \
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         cfb0df14-198f-4fc0-bba2-82562dd520b4)(content(Whitespace\" \
+         2f5c5530-96a1-46da-b120-bdbae6e45988)(content(Whitespace\" \
          \"))))(Tile((id \
-         34cbc59a-4a96-4f16-b376-887637e2c618)(label(get_value))(mold((out \
+         5e8764fb-381e-4503-91ea-d10f7a114d72)(label(get_value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e0564a64-1881-4634-acbf-5de3694cc1f8)(content(Whitespace\" \
+         15743b8a-1e7e-46de-af72-a5679557de33)(content(Whitespace\" \
          \")))))((Secondary((id \
-         183aa1d5-50e2-416b-a509-000d98eea91a)(content(Whitespace\"\\n\"))))(Tile((id \
-         1137ffd2-fcc6-480e-bffd-38c15433e478)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2a7347a7-d938-4f84-9c7d-caa3f8be617e)(content(Whitespace\" \
+         de476acd-b614-43bb-aec9-c0792fea0484)(content(Whitespace\" \
+         \"))))(Tile((id 113abd53-148f-47de-a652-512b6be97189)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         224409ad-118b-48fc-88fd-9d42e2696ec4)(content(Whitespace\" \
          \"))))(Tile((id \
-         8fdb012f-4807-46ce-9c62-2fc12288cf3d)(label(\"(\"\")\"))(mold((out \
+         844a5b56-5102-41f3-995a-15374e58f03b)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         357926cd-7c99-4540-8685-b7abcf081c44)(label(r))(mold((out \
+         80692049-3d3a-445a-9b0d-608fa59f74b3)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         f0cd4e30-035b-4753-86f9-05570e350090)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         175430b5-5675-4bfb-9729-3deafe22b315)(content(Whitespace\" \
+         \"))))(Tile((id \
+         960b5abd-0a65-442a-bc89-6cc9f3b7841c)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         eecd0640-7706-42df-bac9-bd02fdca2545)(label(?))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1d91c49c-f3a4-4a2f-b0e4-466cebfbf73e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d63314d3-d91e-4365-939b-a45a1fa15063)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         ff78a552-4f27-49eb-8fb0-35a923bed5cc)(label(,))(mold((out \
+         e9563852-7f53-4026-9a8f-fa7bd8fb186b)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         2629b584-75b1-46a2-afbc-001f6709b0d6)(label(label))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         e0c2daca-b746-4403-9d22-cd4e82f2d266)(content(Whitespace\" \
+         \"))))(Tile((id \
+         01c7d1ae-848b-403e-8f2e-d7875333b4cb)(label(label))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         c8c77dcb-addf-47d7-8895-a2d1a0e1b944)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3d083673-7886-49e9-98b9-f6cd406db8bd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         adfd81e1-86e2-46be-9609-42b5f5df7dd3)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         fce06018-4855-4b95-8aa6-9ea27cc60c65)(label(String))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2b507905-e188-4bc0-a653-02b8c26930e1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b31dad3e-5a83-4423-a347-824545196702)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0747b9e1-d49b-4b7c-a905-edc84e92bc42)(content(Whitespace\" \
+         11e6071f-88d9-4849-97e1-b14006d83401)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ec6cb4fb-6f0b-480b-8c3d-ee85b5b471bc)(content(Whitespace\"\\n\"))))(Tile((id \
-         0cabb807-a741-4b53-9ec1-9a6090f6e9b2)(label(find))(mold((out \
+         02f64887-ef83-4e73-963b-4a0582533408)(content(Whitespace\" \
+         \"))))(Tile((id \
+         260b4394-e81f-4a48-88ff-a1977cde99a5)(label(find))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c9894bf6-fcd0-47d7-8e3c-79b6e0cf0512)(label(\"(\"\")\"))(mold((out \
+         467a8a6c-eeb0-4605-b5e6-a27c30cd95c8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e8223658-2864-469a-839c-634887978e30)(label(to_lvs))(mold((out \
+         65e240de-ca16-48df-94cf-0c22c11b279e)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6d8fd25e-e642-46ac-99bf-85e615664b7a)(label(\"(\"\")\"))(mold((out \
+         5dba75e1-f726-4e21-bd81-ae6f077f3dd6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         5f40e936-2f0c-42c4-83e4-9081bbf403d5)(label(r))(mold((out \
+         c77247ae-d84b-456a-8360-24ff3f1dba3f)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8f6cc85e-f2a1-4c6a-ba1f-c7042009e8d2)(label(,))(mold((out \
+         49e35160-f7e1-4758-9761-1207b7195ee0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         fca5781d-3fc9-4017-8da4-a4fb3e6e6b71)(label(fun ->))(mold((out \
+         3ae69a55-2ab5-44c1-86e0-1df8ba40a2a4)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f40a3328-faf9-45cd-96ff-a07730d9a39f)(content(Whitespace\" \
+         a0df98c3-82e3-4206-8c1c-2086f98e91ce)(content(Whitespace\" \
          \"))))(Tile((id \
-         9426f2a7-b57e-4d62-b9df-61b6886dd094)(label(e))(mold((out \
+         33591d96-6896-4892-ac1c-871f7bbcb672)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cf19eb8c-a469-476d-857d-a232b372ef3c)(content(Whitespace\" \
+         3055b79c-df8a-44ae-aa7a-d10f766a895a)(content(Whitespace\" \
          \")))))))))(Tile((id \
-         6605f602-2546-480b-aaf5-67c441e69f22)(label(e))(mold((out \
+         8912727a-56a3-48ab-b8dd-fa74e35fedf6)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a257fb42-20b8-4339-b21f-98d0ee3a1674)(label(.))(mold((out \
+         67694195-7d18-4f01-ba64-e91765896637)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         1a6ada59-0a8c-4bbe-aa86-aecb2c206774)(label(label))(mold((out \
+         acc7ec46-055f-48a5-9e99-f494240d0844)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         32fb06cf-2cc4-4b30-9ea1-ae87c70fbfdd)(content(Whitespace\" \
+         8b9001ac-f058-4468-ac68-958c940090ce)(content(Whitespace\" \
          \"))))(Tile((id \
-         b05d34df-4d04-4142-a7e6-a888b2487aad)(label(==))(mold((out \
+         bae1c243-23e0-41e9-950a-263cbc7fa685)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         67bfcde3-da20-4ac5-8380-e6200cf37929)(label(label))(mold((out \
+         57ef03fb-6fe9-4893-875f-d48f3fd53514)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         4b17ff1e-c8f1-4565-87a0-c65dae18cf46)(label(.))(mold((out \
+         afedeca3-17b9-4f0b-b53d-4d8853ee3504)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         20f217ee-7fde-4a5f-978e-a6dd165f9add)(label(value))(mold((out \
+         1f47adba-56d6-453e-8935-5880d033a39b)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         0e7a4766-bb7d-4b10-9a06-62052417df40)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ff9f4154-905b-46fc-a893-21fafdcd142a)(content(Whitespace\"\\n\"))))(Tile((id \
-         115b9440-6d54-4068-8e1d-e913f7ed2d18)(label(let = in))(mold((out \
+         9c05f502-e12a-42d0-8d6d-928b63bc531a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d297763c-66e7-4c6b-9280-366ecc5601f9)(content(Whitespace\"\\n\"))))(Tile((id \
+         6e77911d-c550-41b3-9afe-9fa7144478f0)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c9ea4fcb-d9c9-41c3-8a82-b1bb435d5d0f)(content(Whitespace\" \
+         e71c98b9-ec43-4aa9-b18b-01b0336bf36f)(content(Whitespace\" \
          \"))))(Tile((id \
-         d0a07a52-a82c-49c7-9808-524fe810bd75)(label(add_rows))(mold((out \
+         6d1c5aec-b0f7-42d9-8dab-547c81275bd4)(label(add_rows))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2cba6407-c94a-4eb9-b283-2bfe930db3e9)(content(Whitespace\" \
+         0917493c-d51f-4b7a-b561-b47e33062afa)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ba0c52a8-95d6-4ce2-98a0-27379bc3bc0c)(content(Whitespace\" \
-         \"))))(Tile((id faaae568-0668-455c-a2cc-545d8d740e65)(label(typfun \
+         04563530-c426-4422-8a0d-75f213d783f1)(content(Whitespace\" \
+         \"))))(Tile((id 769cac0d-39cd-40d0-9534-9ceef3a5aed4)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         71a62282-5b6f-48d4-8fc9-e563dcd0a0d4)(content(Whitespace\" \
+         fd3f0195-9507-4721-b9ee-2c60636945b1)(content(Whitespace\" \
          \"))))(Tile((id \
-         d9c5d98e-7dba-4111-8fe0-d08f229f46ec)(label(row))(mold((out \
+         ea366655-8ea9-498c-90b3-2c3f7345e6b7)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         594b7c5e-6102-478d-85b4-e598c8a278c4)(content(Whitespace\" \
+         195e472a-57ac-4959-ae96-340c988a560c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f8bacf11-a563-4545-9e85-eeaa646d2a16)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         156fba99-827a-426f-ba7d-47b788e1608a)(content(Whitespace\" \
-         \"))))(Tile((id 5b8c7919-0a62-4d7d-83b2-cd922c240281)(label(fun \
+         1e81de88-ce74-438c-8566-6d409c5721cb)(content(Whitespace\" \
+         \"))))(Tile((id 1828256c-d3ff-41a7-abf9-bd1cf960a2db)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         17e8f6a9-0164-4c4b-99c3-204fa6d2941c)(content(Whitespace\" \
+         4562dc0b-2ceb-4a81-8586-d3d4fa7a62fa)(content(Whitespace\" \
          \"))))(Tile((id \
-         7888ae5a-da1d-4378-a884-aceae2597b65)(label(\"(\"\")\"))(mold((out \
+         1abb28a4-47c9-4393-8ce6-d6673c7906d4)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         b32bdd4b-f029-4af8-a5e0-74057d64796d)(label(r))(mold((out \
+         37ef3467-b681-400a-a0be-edc8979f05fe)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         821e9935-4302-40c0-9549-c737921b90dd)(content(Whitespace\" \
+         f948e41d-9ae0-455f-b75a-3caec942fde2)(content(Whitespace\" \
          \"))))(Tile((id \
-         e1265053-7711-41e9-bf19-252ea6069220)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         ad6c9970-4a24-40c0-88b0-cab249ca384e)(label(row))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         cae6652a-5097-4257-a9af-5f211426fd3c)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         8865776f-fde1-4792-983f-a6ca675c67f5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fcaf5c71-6c24-4422-b8ef-f34c2afa48a5)(label(rs))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         af8f7186-5884-4eb7-8d61-281103c2cd0e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         624a6c8d-0d7e-4d44-b0cc-973aa5355bd1)(label(:))(mold((out \
+         aa82e420-2a93-400a-8cd0-65f4d4700f58)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1fb043e4-fa14-4bd9-9948-a9828b153e61)(content(Whitespace\" \
-         \"))))(Tile((id 5e9839b9-20f9-46c5-88e3-8e241c3715db)(label([ \
+         b65ecaf4-f0d9-43a5-8ca4-d5a6f6e69515)(content(Whitespace\" \
+         \"))))(Tile((id \
+         52b24e81-2d24-4556-8541-b682113822b3)(label(row))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         8d1683e7-8600-4274-bd0a-149ddce38f0e)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         78b7d336-0b6b-4ada-b7dd-2911ee1316c1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7e5fc0d9-ec1d-40e2-800e-de7c1dd79087)(label(rs))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         2ac63cca-a023-4f22-8eb5-0c101cbafb2b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         06138eaa-7ef2-4b84-b63c-890353287c43)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1c4d2e40-610d-4394-b630-73ba287a5582)(content(Whitespace\" \
+         \"))))(Tile((id e3061b58-e435-4198-83b6-3e6dfd4bd70f)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         0ace7074-6b74-4ff2-8abc-3bbb028773ca)(label(row))(mold((out \
+         b278748c-a807-42e3-a7d1-438f26bf8790)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         cdde1259-710b-48c4-9978-2c8dc8d7e744)(content(Whitespace\" \
+         9033679b-f508-4f90-a685-41663549c15c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1b6848ab-e76c-45dd-842d-d77441c156a2)(content(Whitespace\" \
+         8aaea9b3-c650-467f-af1c-b007a56e2b8d)(content(Whitespace\" \
          \"))))(Tile((id \
-         85df43b5-785b-4040-89fe-b1347e326307)(label(rs))(mold((out \
+         37433b9b-d9dd-4614-a6e6-5884432d6ce8)(label(rs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         6cfd2d25-aaf3-45b0-96da-89e01247b879)(content(Whitespace\" \
+         b1e3bbb1-a3ab-4bbe-a92f-9e62975ae5f2)(content(Whitespace\" \
          \"))))(Tile((id \
-         d3dbd9e2-e5f9-43f0-b74b-98b428020e2a)(label(@))(mold((out \
+         c593835a-04e8-48f8-9b3b-1ca32027a37b)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a1629171-c837-4fda-8bcb-e2e4928d41be)(content(Whitespace\" \
-         \"))))(Tile((id 11d59312-e564-4453-b237-e87a339960df)(label([ \
+         d6139853-8ea6-4672-b91c-2d0fc9aec266)(content(Whitespace\" \
+         \"))))(Tile((id d57c9373-224a-41af-b877-18e3a3ab74f5)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d368489d-7e05-4bb8-a93a-068aac3e1566)(label(r))(mold((out \
+         609ca6e9-5306-45a3-864e-850ea61033fe)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         53b0a33b-9d1e-4ff6-95ac-a44ff0fab9fd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d50033eb-b3b1-4afc-b3e1-b4ff67b7876f)(content(Whitespace\" \
+         8050c065-fc7a-4568-a0c1-a64276e18438)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         eb7f91eb-391d-4bbb-b643-0b9f5c0c1a11)(content(Whitespace\"\\n\"))))(Tile((id \
-         ca86a8bc-a7d4-482e-a02b-f9c4b3e23239)(label(let = in))(mold((out \
+         ba6dd46d-e17d-40a8-a75b-4a34d06a0647)(content(Whitespace\"\\n\"))))(Tile((id \
+         08abfdd5-c4af-4411-bd87-04c8994a15aa)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         171bf4ee-a32d-4cf8-a334-5d7e4548b3a6)(content(Whitespace\" \
+         127baa33-4781-44ae-9fcf-9f25652066a1)(content(Whitespace\" \
          \"))))(Tile((id \
-         67a2ec8e-f31c-415e-aa70-3b493d68fdea)(label(add_col))(mold((out \
+         9f7dccf9-25bb-4bdb-99ed-8e4d76940807)(label(add_col))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         95d295f6-5f01-4e74-b9c9-dbfb0cfeedfb)(content(Whitespace\" \
+         a9d34486-04dc-48fd-8fda-006434d5edf1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7a0e5fa8-ca03-4ad4-a055-bd4f258da89c)(content(Whitespace\" \
-         \"))))(Tile((id 6e924db2-75b2-433d-98bf-3bc525ab402d)(label(fun \
+         d2bd9d21-74df-4f18-856b-05fe9dfe5606)(content(Whitespace\" \
+         \"))))(Tile((id 045fca62-e7cc-481b-855f-ac5ccb5c2600)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         475f3920-3a0a-4c9e-b4a7-9c9bddedf212)(content(Whitespace\" \
+         9ad9872f-90b1-404e-81d4-a26bd140c3ba)(content(Whitespace\" \
          \"))))(Tile((id \
-         9925c989-c563-4f1e-9bb7-06eee3fd11e0)(label(\"(\"\")\"))(mold((out \
+         51ea1a85-b91b-46f5-9a07-e5cd5580dbee)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         e8535315-8d5d-40bd-a3d4-cdb94899a460)(label(t))(mold((out \
+         98438881-5e07-45dc-b23a-3f89cbd64771)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a1c97478-7ea4-44da-a98c-b1ec164adc03)(content(Whitespace\" \
+         d5a96336-9dd4-4d60-bf6b-4e94887180ac)(content(Whitespace\" \
          \"))))(Tile((id \
-         b6804382-a6da-46c0-9074-cd5283fb0ab6)(label(:))(mold((out \
+         ed687d96-0f57-46a0-9bf4-e5d4ff4860f8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0f1b82cb-d76e-4448-bd9e-825ddefa0d48)(content(Whitespace\" \
-         \"))))(Tile((id 08e649b7-4875-4f6a-ad5e-c0758f94960f)(label([ \
+         aa824ada-7ab5-4729-936a-ebb3e29d2aef)(content(Whitespace\" \
+         \"))))(Tile((id 18f268d1-309a-45f5-9893-85d563e58a90)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         5c174de8-d02d-477b-976e-bf9b1b6f8be8)(label(?))(mold((out \
+         c54370a4-eb64-4f36-a32e-3672ec817d66)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         ccfe8116-0ec8-41f6-a0fb-ab3755a44c9a)(label(,))(mold((out \
+         c24d3da8-ee8d-4233-81dd-eaca49ec0848)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         7ff5d646-3727-49cf-9260-4f0684e76b21)(content(Whitespace\" \
+         41f9ea5e-3a48-4d43-af14-cc196a34b0e1)(content(Whitespace\" \
          \"))))(Tile((id \
-         0b56ca49-04cf-46b1-aa2d-22ba183e0c7f)(label(c))(mold((out \
+         fa990978-facc-4c06-926a-3b29b52dad1f)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         42183af3-11df-4351-8307-37df5626bf8b)(content(Whitespace\" \
+         dafa1a5c-b090-4809-b56c-27025ff80227)(content(Whitespace\" \
          \"))))(Tile((id \
-         a59a41c7-117b-425f-8463-d0deb206b9db)(label(:))(mold((out \
+         8775af6c-c9d8-448f-9ef5-91359dc0d31d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         06be6ad8-3b17-4ac4-a63c-cd763957b625)(content(Whitespace\" \
+         f047f142-bed5-421e-8b86-9b7685cc6e43)(content(Whitespace\" \
          \"))))(Tile((id \
-         52318c6b-fba6-45b3-a7af-326f49d1a583)(label(String))(mold((out \
+         13092090-0a66-407f-93dd-fffedf5f7edb)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         144c004a-a312-438f-b14e-3e98fdf95699)(label(,))(mold((out \
+         ca743505-d2ce-4ac3-80a1-9f3261504a58)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ca370fc5-2335-492f-b31c-f55a1e056ac4)(content(Whitespace\" \
+         8bbc970d-a65a-43e9-bfb2-c365bddcaa82)(content(Whitespace\" \
          \"))))(Tile((id \
-         1386dff0-aca0-4617-a5b5-f4875be66463)(label(vs))(mold((out \
+         ed2348a9-2b4b-4ff2-bc04-2f19b092e111)(label(vs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         9dfc3377-e8f8-4722-99e8-baf3f5b8e33e)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1b85a39c-7e85-4c1b-a692-3eb42818706e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9f13bc65-686b-4628-bb0c-c05a6a4b0f5a)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bc897ed7-e238-4411-96cd-b9ce4848f8e1)(content(Whitespace\" \
-         \"))))(Tile((id d4bb33e8-12e5-4305-bd4a-b41c12f4bba7)(label([ \
+         1ef9f090-f46c-4ac2-a7f0-36b9adec1970)(content(Whitespace\" \
+         \"))))(Tile((id 158cc79b-2c78-41a3-9a26-4780c7d579cc)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         7f35626c-687b-441b-af97-f8fc8c20eec4)(label(?))(mold((out \
+         d0de266b-a490-423d-bb61-8e79087f4c71)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         27b9a19e-fa3d-4662-bf15-611759b21783)(content(Whitespace\" \
+         cd52f5f2-3374-4373-afca-81ab832ced86)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         805d90c3-3eae-40ca-b6b5-5d7e559e1515)(content(Whitespace\"\\n\"))))(Tile((id \
-         dcc10750-65d1-4e87-89f9-86b31f9b19b0)(label(zip))(mold((out \
+         fec0c7d7-7b98-4b0a-b89c-a6b47e02f9ea)(content(Whitespace\" \
+         \"))))(Tile((id \
+         247b1cc2-99df-4741-81cb-4520b261686a)(label(zip))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6c70857c-c1cd-4a96-87de-1c7632bd00c2)(label(\"(\"\")\"))(mold((out \
+         6448cb79-1449-4f1a-9f11-da4bab47e421)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         73a91e73-4192-4cb9-b613-4b2077d34a33)(label(t))(mold((out \
+         a548b2ec-f37e-4b82-a8e9-00d968a47bc7)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e9261ec1-2022-4ca3-9eb9-f035d1a190f3)(label(,))(mold((out \
+         96f73da1-2915-42f6-a4ce-f70fc140046f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5af55c36-bd91-4ef8-87a0-5f239b2c53f6)(content(Whitespace\" \
+         72159be3-254b-4260-97e0-cecf6318ed16)(content(Whitespace\" \
          \"))))(Tile((id \
-         9c5067d1-d4ca-4741-8b26-0de56a5431b1)(label(vs))(mold((out \
+         7fa2779d-e91a-42dd-9773-a7770d14a902)(label(vs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8efaa0c8-888b-4cad-a328-76eb8097ff45)(content(Whitespace\"\\n\"))))(Tile((id \
-         0ceaedc7-6839-41c8-8e7b-06475b43a3c2)(label(|>))(mold((out \
+         3b9665ee-4cfb-4f47-8921-39abaff75d27)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a7269a80-7425-43bd-8aba-1e088c0108a2)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69918beb-51cd-4aaf-bde2-25bea3489295)(content(Whitespace\" \
+         c1b6b4e6-17ba-487a-9d2d-e4364ba98532)(content(Whitespace\" \
          \"))))(Tile((id \
-         05228b41-9cc4-4290-bb81-820ce575e0b2)(label(map))(mold((out \
+         2d286bf6-cfdc-4a5a-80ee-38c1e96c715e)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ede38faa-eaf4-4524-8b17-fe2e89dafc87)(label(\"(\"\")\"))(mold((out \
+         39f56799-4e9f-4ea2-bd89-727b3762185a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9b835fe6-a43e-4825-b74c-c9f2119b2572)(label(_))(mold((out \
+         a532f940-c503-4452-9b38-b5b2662d00c9)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f8b95054-d926-42a5-a230-8cf3e169602d)(label(,))(mold((out \
+         671b4a6c-7976-4f0b-9975-1153d69bfbaa)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b9c3d5b0-0426-4c52-811e-ca1286543af5)(content(Whitespace\" \
-         \"))))(Tile((id d88a8b99-a7da-4051-a759-c5ef86fc8c0e)(label(fun \
+         5275e7a2-c5cc-42e2-8dfc-3eeced5c70a2)(content(Whitespace\" \
+         \"))))(Tile((id 79ef3f6a-1da0-4377-a983-415a3552e4c3)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e30a8506-edc6-4c8d-95e5-7c606c8c9d62)(content(Whitespace\" \
+         5cf0d3fb-9464-4751-8572-f1e3b8ed914d)(content(Whitespace\" \
          \"))))(Tile((id \
-         d9e99daf-3167-41fa-bcff-4ace82748905)(label(\"(\"\")\"))(mold((out \
+         6d501d14-5f73-46c9-92e9-cdaef64f6b27)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         93538b97-27a9-4f5f-8031-71d16d910726)(label(r))(mold((out \
+         fbc3247e-b75b-42e5-96d2-0110b7901bec)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         19e959ea-f38a-4b49-a290-a515822020af)(label(,))(mold((out \
+         516e1dad-8026-470f-af6c-aeab5e4861d6)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         4cec6ef6-dc24-465b-8398-bed222799f19)(content(Whitespace\" \
+         0ccebd43-0860-42b8-b495-fa7e56e1782a)(content(Whitespace\" \
          \"))))(Tile((id \
-         82b797bc-449e-4781-8b97-6e49e6a52fe2)(label(v))(mold((out \
+         a0541742-6de4-4105-9320-f302c4e6a8ba)(label(v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         bb787521-abfe-42ed-b89c-6f17de18ff87)(content(Whitespace\" \
+         5f84b026-0108-4a4e-9477-49db7f191392)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b8d5a89d-e002-4ab0-abcd-33fc9da91efa)(content(Whitespace\" \
+         b3f35a30-b88f-427f-909c-92f1f5691fd7)(content(Whitespace\" \
          \"))))(Tile((id \
-         f685c840-a6c4-495e-acfb-d736106b6336)(label(from_lvs))(mold((out \
+         c2e0c3c9-5e33-4353-8e80-bda2f42b9ab9)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c198120b-435e-4dd8-b00f-c0815f1a6ef8)(label(\"(\"\")\"))(mold((out \
+         1e54f865-fc60-4c23-bec8-41beab94faa1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1cf4c3b0-17d3-440d-a943-ca57f0abdd59)(label(to_lvs))(mold((out \
+         181247d2-cdd4-44e3-bc61-3f539b5384a3)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         682f5337-e775-4f6c-9f7c-917f4735c05b)(label(\"(\"\")\"))(mold((out \
+         2f90ec67-36c1-4b77-a60a-dd2d2ba679b8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4a208dfd-68d1-4174-92ae-4c6701f1c160)(label(r))(mold((out \
+         62682a7c-3ea1-4442-935c-0870ff0acbab)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         20b80bfb-537a-448f-a3d7-c4d1e5d4d78c)(content(Whitespace\" \
+         e09da3c5-af80-47f3-8aef-54d2c6010c82)(content(Whitespace\" \
          \"))))(Tile((id \
-         4b8a0f1d-9115-4930-886e-21997bee39f2)(label(@))(mold((out \
+         2f61ef75-942c-4e9b-bde0-18eff21b2138)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cfb961aa-f37d-4bbc-abcd-d11a81ce9b0e)(content(Whitespace\" \
-         \"))))(Tile((id fe6d1428-11e8-4b41-880d-60e2bdb669e7)(label([ \
+         159e7966-195a-461f-9a1b-bd4e9aa8b6af)(content(Whitespace\" \
+         \"))))(Tile((id a974d12f-3d0b-4f64-bb09-da3abb2370b7)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         11d3621f-d542-4fb2-a3c3-52debbdfdf57)(label(\"(\"\")\"))(mold((out \
+         93a1e3e7-4180-411e-8859-5ad2c3786f3d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         c655f853-9a40-4590-93c0-fc7dbab2d746)(label(c))(mold((out \
+         fd094db7-c6c1-4f5a-a858-7b1c2ea50dcd)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d7ba0df4-b040-4786-8897-8295fb88f7e4)(label(,))(mold((out \
+         0d6f61c2-0fbd-46d2-b8e0-3408c376fe91)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6fb4e623-c9b2-4ee7-88a7-ffd12e192eaa)(content(Whitespace\" \
+         5a4b0bf6-4233-46a9-bba9-e0616ce0127a)(content(Whitespace\" \
          \"))))(Tile((id \
-         18f5ea36-2ad5-452c-8b11-634fdf4d4e34)(label(v))(mold((out \
+         add1e7f8-7d72-4385-a588-d0b4f7ba9b24)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         10c74887-2757-4410-916f-0934d628a163)(content(Whitespace\" \
+         62ce84ba-249d-4546-be6e-1db0c5b33c12)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         217500b8-f301-40f4-b2a5-d9df39039ccf)(content(Whitespace\"\\n\"))))(Tile((id \
-         3f676606-7ed1-4086-8b08-f61f083043de)(label(let = in))(mold((out \
+         0907e18a-b8a4-4932-856e-a4350612e47b)(content(Whitespace\"\\n\"))))(Tile((id \
+         10f5c429-2045-46fc-8ab0-61e15ea5d0a7)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         89f9de8b-e853-4910-9827-59c96b436878)(content(Whitespace\" \
+         562dcadf-fa73-4459-8094-c3d0ec3e871e)(content(Whitespace\" \
          \"))))(Tile((id \
-         ca0d4ca6-357c-40c7-9208-408d81c1597c)(label(remove_duplicates))(mold((out \
+         6e53a762-2c14-492b-9a0f-a484faf68661)(label(remove_duplicates))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         35da9add-bf3e-4dce-92a5-04669fe8a336)(content(Whitespace\" \
+         f0723c37-1e3e-4c37-b6ed-2f84db12a4a5)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f5dfdd68-6a15-4c49-95d7-bc1d074f4fde)(content(Whitespace\"\\n\"))))(Tile((id \
-         033aae22-f6da-460c-a24e-df2170197298)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         83885f40-066e-4bfa-b8f5-25f074206794)(content(Whitespace\" \
+         2264376e-82a1-48f4-bfa7-f314467e9b61)(content(Whitespace\" \
+         \"))))(Tile((id 068e3717-33be-468f-9cb8-c2593aec808d)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         60924b6f-4564-4520-9a1a-4a8c687d33e4)(content(Whitespace\" \
          \"))))(Tile((id \
-         0bb927d2-a185-447c-b7f5-cd1ef0a3baf0)(label(\"(\"\")\"))(mold((out \
+         db787a9e-db3d-4999-ad01-76da32e0f95d)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         f5cc8f96-207c-466a-b053-09bf5d6e2dce)(label(xs))(mold((out \
+         5e4d47c2-6736-46a0-8a1e-6f827bdb26b5)(label(xs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         de0601ad-3358-4b1f-a69a-f0f6ca771e89)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         97fde093-9da7-4bee-8938-690dec1b998d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7fbccb72-0091-4667-b456-32c68a0d4cae)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         91ebed20-c534-40ba-9a72-c53673def5c8)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         ba542beb-cdbb-4d67-8e2d-ef553434724c)(label(?))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         afb81b0c-ffed-476b-afed-56ac10bb9b3b)(content(Whitespace\" \
+         \"))))(Tile((id f81ac3c1-818c-462e-b61e-8537d44b4779)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         bf08f94e-764c-4b2f-b881-2234d85f1ef5)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         0ec7e63c-b49a-4737-983f-a9397d9d58ee)(content(Whitespace\" \
+         65fa2825-fafe-4ca8-b433-f9abc49603f4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         040b89d9-8c4f-40ae-a98d-fef6cfee0197)(content(Whitespace\"\\n\"))))(Tile((id \
-         37f55818-f548-43c7-9784-94488bd4c0a6)(label(fold_left))(mold((out \
+         5fefa13d-6d89-4f16-99e3-7c3871c760b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bd3d4d6c-7372-4860-9dd7-c5bb65222054)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         656fb26a-fbcf-4de8-b260-02f4b2afda29)(label(\"(\"\")\"))(mold((out \
+         3520c221-4447-44a9-afee-cfdd249e8a2a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9b269941-f6d4-476f-9761-e3c056cec92b)(label(xs))(mold((out \
+         c747e020-faba-4265-a6aa-7be21c620ea1)(label(xs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         eb557a02-2ed7-4001-9f56-252535b75756)(label(,))(mold((out \
+         bbac905d-c3f3-48f0-9418-deb72d1c9c75)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d029e4bd-cfda-4870-a795-3392cbd0e2da)(content(Whitespace\"\\n\"))))(Tile((id \
-         4ccb1f9d-cec1-4619-862d-4d11661fb9b7)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2d2950d5-204c-4785-ae60-cb5fdc3e945f)(content(Whitespace\" \
+         a06cde46-9f2f-407f-8d87-73700ae144a5)(content(Whitespace\" \
+         \"))))(Tile((id 6a79538b-f601-4444-a6cc-1af3f84f7037)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         c7b7af08-8f18-4daa-9816-8b9edf561b89)(content(Whitespace\" \
          \"))))(Tile((id \
-         fbd24af9-8eb4-4b5c-9a9f-d5958ef99206)(label(\"(\"\")\"))(mold((out \
+         4c38a1bc-98ee-467f-88c7-fe228fc202fc)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         d6606c1e-6e8e-4814-81f0-238b785bfbca)(label(seen))(mold((out \
+         f8aaf80f-aa52-48a4-93c6-8a6a1eb1ea8d)(label(seen))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         b43b54db-58d1-48db-b644-fcc31a89dccb)(label(,))(mold((out \
+         e8631f26-3b50-42e9-a09b-013c598df113)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         48eb5afa-2ce7-4c14-8f70-b9bde4545909)(label(x))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         e3e19bb8-b2ab-4b3c-b5e9-4ba172f6f2b4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0a71177c-3616-4785-9ae2-cbaeb4a00174)(label(x))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         be8b4231-c72d-48a2-8410-70276cbd9e4c)(content(Whitespace\" \
+         f4760b2c-b88c-42d7-b988-0533819416d7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         832f3503-4093-4c39-a7ce-2f391d80b914)(content(Whitespace\"\\n\"))))(Tile((id \
-         f3fc7d10-d8a5-41ba-b723-d9c58c4ace8f)(label(if then else))(mold((out \
-         Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         36))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         55ee44f5-d944-4d46-a151-54de8dcdda81)(content(Whitespace\" \
+         bd2aacce-634e-4bf0-b5e5-8d392c8eeb9a)(content(Whitespace\" \
+         \"))))(Tile((id 1c0ae2d3-1f61-40d9-961b-c30b31d2c5db)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         26d1b9e7-045a-46ae-8f83-6b723b80d12c)(content(Whitespace\" \
          \"))))(Tile((id \
-         b2a538d3-4f2e-4b47-8708-d12e705bb698)(label(mem))(mold((out \
+         6ce4dd1a-0e02-45e5-b76a-0f9a65f52bbb)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         abb99414-c9e5-4e9b-8564-03386ad064b0)(label(\"(\"\")\"))(mold((out \
+         d727519d-cfa0-47e0-a291-124696a3b1cc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         129afb00-c555-435a-a3f1-6a70d9b83cf0)(label(seen))(mold((out \
+         49dea50e-1e09-4718-8c37-b16695577807)(label(seen))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         15593ebd-8908-42d8-9550-29b74b416c87)(label(,))(mold((out \
+         90e62b9a-aed8-4fc3-aafd-778940865776)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         62053b31-72c8-40f9-9ebd-c7773f81c223)(label(x))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         384c5bee-d652-4682-a61e-b509edb22799)(content(Whitespace\" \
+         \"))))(Tile((id \
+         54cc07b5-01ba-4e45-b5cb-b7fc2cee593f)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c96c906e-188f-4dbd-bbd9-68da4565bc7b)(content(Whitespace\" \
+         e3cb620f-a511-4b73-8676-d8c7ab507c23)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d454f203-178e-4074-a116-d2db83d1d197)(content(Whitespace\" \
+         e63e736f-9021-4796-b7b6-9735b748133f)(content(Whitespace\" \
          \"))))(Tile((id \
-         5221bbc2-7d0e-45a4-a20f-c6c535fea7d8)(label(seen))(mold((out \
+         20357be6-29de-449a-8691-aa31023ad9aa)(label(seen))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         1a633e4c-41a8-44fb-917c-fb3c0628fd46)(content(Whitespace\" \
+         d085f477-8f87-442a-b84f-b9efc49daf58)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         78114476-2b05-4627-bc8f-c2bc252e9158)(content(Whitespace\" \
+         0f3ecd66-ff3d-465e-ac22-e6e592e8759a)(content(Whitespace\" \
          \"))))(Tile((id \
-         71d9191f-c89b-481e-bf4f-d429c1f45293)(label(seen))(mold((out \
+         ece513f0-5fc7-4418-a8c0-94956b85e939)(label(seen))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         06c07728-6342-451b-a315-0b7f2b88060b)(content(Whitespace\" \
+         e922a1b9-f956-4800-84a0-60be10a9d4f9)(content(Whitespace\" \
          \"))))(Tile((id \
-         bc1f7314-77e4-43d4-9c69-13295fb73c40)(label(@))(mold((out \
+         a84024fa-e2dd-440c-b704-e8d7a47be0f1)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b89515c3-6a10-4859-8fd9-694e2bddf04e)(content(Whitespace\" \
-         \"))))(Tile((id ab5a882d-389f-43b7-8544-c383755f2e3c)(label([ \
+         a45837ef-a677-4b74-b7a7-5ebcbd247918)(content(Whitespace\" \
+         \"))))(Tile((id f93176e2-45f6-4f11-b45b-de40219d4fbe)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         09009083-a01f-4963-82b9-f9a43b96f704)(label(x))(mold((out \
+         e2db5ecc-1b79-4840-8923-77db0da3f26f)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         931d115e-7e55-4594-a7d0-46188848d3e2)(label(,))(mold((out \
+         3aa20a63-fe29-426e-a21e-8e48b3a9b031)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3ee3aff3-c844-4026-988c-885c26cfcbef)(content(Whitespace\"\\n\"))))(Tile((id \
-         b720b922-2d10-4374-9f37-f3e1160e4e93)(label([]))(mold((out \
+         a64c4ed2-d664-479d-b39d-bb1776c60515)(content(Whitespace\" \
+         \"))))(Tile((id \
+         28c3e4f3-33ca-428d-8356-56398aec36a1)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         af5e197d-cc39-4a96-ba32-4f9716a0c152)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         76eaef26-c0e8-4291-a89b-2710346ff715)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e1361a93-132e-4bd6-b4e9-a24d4f38763f)(content(Whitespace\"\\n\"))))(Tile((id \
-         1e0acb9c-2095-4bb0-a99f-f1004d21b429)(label(let = in))(mold((out \
+         cf22c5ee-c50b-4c14-aa71-c985066dcdfe)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d1045508-7c5d-4753-9615-8b8805339bd5)(content(Whitespace\"\\n\"))))(Tile((id \
+         cbeabd91-caab-4b46-be2f-7d337220cf83)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         b296998b-1bad-4962-9762-0ca4de703802)(content(Whitespace\" \
+         e253ea9b-f783-4315-8f5c-cc49dbb0a397)(content(Whitespace\" \
          \"))))(Tile((id \
-         8a22882f-3f11-4609-b1dc-cd86ce48239b)(label(build_col))(mold((out \
+         9987965a-37a9-4ea0-87fc-e96d68c154df)(label(build_col))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9fd3d0e7-d8c7-47ff-9ff8-9d69cff4c851)(content(Whitespace\" \
+         7ee27b33-bb5a-4555-98e1-c16db590bce3)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0bd56f2a-843e-4be0-85bc-c564c1b70363)(content(Whitespace\" \
-         \"))))(Tile((id 5ff1de70-1d7a-4273-9337-77910ee86c7d)(label(fun \
+         96894920-a4a4-4248-8224-a6045ac47458)(content(Whitespace\" \
+         \"))))(Tile((id e993e47e-f673-4567-b4e4-8dd57aab4ebf)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         1bdb1f64-fa7c-4e88-ae98-98a8531bef4c)(content(Whitespace\" \
+         50517b6a-a03a-416a-b936-9fde7efe5a79)(content(Whitespace\" \
          \"))))(Tile((id \
-         9bd41bbc-af31-4af0-b70d-93b3a4191a6e)(label(\"(\"\")\"))(mold((out \
+         974f765c-abc6-4358-9538-12a15dec64a6)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         973b542d-d0ec-4094-8d7a-c3bef79e7a95)(label(t))(mold((out \
+         70277c99-088f-4657-a07a-39d8a6b1f2fa)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ea7ff0d9-4f07-4165-bad4-f705562a7682)(content(Whitespace\" \
+         19aa18fd-a8ef-4d7c-a94f-232f3bd7025c)(content(Whitespace\" \
          \"))))(Tile((id \
-         c8dcde2d-74aa-469a-9e1b-f64b1d9ad1b3)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6b7b1bea-d3bd-47d4-a48d-c585fb537079)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         cae47b6f-29f7-463b-918f-17d3a19bafc1)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         87ae9bd8-4bef-42fe-a2a1-2a4e4c4aea10)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         897ae592-7802-415d-93b8-de62777af9ce)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ae0d6f50-2c04-49d7-a63e-f228def55820)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         fcb055dd-9001-4bb4-aba9-7d87939734d4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a906df42-4a90-4b9e-abb5-38d290434727)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         70204340-bec0-4aad-960b-ebc4b186fda9)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         658ee18b-2798-4cd4-9c11-56b30ae2bef9)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f10da243-dfe5-41b6-a0e5-345ad7935125)(content(Whitespace\" \
-         \"))))(Tile((id \
-         40d8dbf9-b9e1-494d-a944-4ad3c257c164)(label(f))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         afb61907-0190-4131-9aa5-b2ce03dd8a9b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ba6244eb-e2d1-485c-875e-d8ab190265b7)(label(:))(mold((out \
+         634bbef5-c4f7-4955-a47f-f4b65da4c4ed)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e4ae29f6-2140-422e-8954-7c4c9d66c338)(content(Whitespace\" \
+         f2d024df-ec3e-4184-8734-db730adce9fa)(content(Whitespace\" \
+         \"))))(Tile((id 1deb1865-ba30-4a42-9438-23c3992af717)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         e4120f97-a85f-46af-b109-3697739c7de3)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         16b37305-2826-44cf-88fe-a16357d81ddd)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         55c1e8a4-bac2-47ec-ad7c-764ec9ca994a)(content(Whitespace\" \
          \"))))(Tile((id \
-         51e477ed-bb9d-4c8f-b672-a854a56d0a8c)(label(?))(mold((out \
+         cf018912-e5b8-4006-bb4e-374b67b0ed74)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         7a0d7ec3-6196-472e-a63e-eea8a5581721)(content(Whitespace\" \
+         \"))))(Tile((id \
+         94267c50-0c8b-44be-98c9-f33176ab638b)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         eb87b1e2-608a-4bfb-8436-db65529db582)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b14a86e4-5974-4ebd-ae68-4c77c05422e5)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         c847eee9-dcaa-4f93-98d1-f90f4cafe488)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         7dc95798-d0be-4dcd-819f-26b7a2cf0222)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7383f71a-e8bf-401f-b7a9-ba502c3efa85)(label(f))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         704f519b-a029-4964-8184-98b91ae05c77)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fd9d548d-986c-4d79-b86b-c17fd9a7c56d)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         180be5e7-fa7b-4a4f-99c0-255dacb7f5b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6f10efda-2dd5-4ed9-b234-444947c6e91f)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         d8ac5329-04ce-491e-82bf-955ceaee4a8d)(content(Whitespace\" \
+         9797589b-2a1c-466e-8492-65a29278b399)(content(Whitespace\" \
          \"))))(Tile((id \
-         1ed940c6-6671-40be-ab8c-3d4dc74d259d)(label(->))(mold((out \
+         6a01652a-605c-4863-8b03-4601e1b5f738)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         68af01ae-4643-4e17-9232-ce84e7cfd50d)(content(Whitespace\" \
+         37b47111-d059-4899-a69e-0f345b87a0af)(content(Whitespace\" \
          \"))))(Tile((id \
-         e8df5e0c-4b9b-4739-9e2d-615006d63ef7)(label(?))(mold((out \
+         ca626e11-8ce0-4a73-99ca-395c14335324)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         220c60e1-0bc7-4f2a-9531-b8e05fea704a)(content(Whitespace\" \
+         69ab6010-d3c3-4df3-9ecb-3d6e1898199c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b76e638a-6129-4a02-9aa8-df77c1cf2218)(content(Whitespace\"\\n\"))))(Tile((id \
-         43d18480-0051-468b-be46-6d0ccc23c73a)(label(map))(mold((out \
+         720c6826-a2f2-4405-83bb-adc4bc08d3bd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         29206772-98d7-4c2d-91a9-c199c5e97483)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         369f267d-1bb5-454b-9c23-257e1eb291fd)(label(\"(\"\")\"))(mold((out \
+         94658742-4124-412e-9cd2-f9d9d595f662)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4141a559-76a5-4112-9ce9-49e1e0aafa8d)(label(t))(mold((out \
+         3d50e724-35d8-4368-b646-bc1bb30de3a6)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         56776353-b3d5-43b8-b631-462040a73068)(label(,))(mold((out \
+         6db09038-cafc-4ad3-8cc1-7e8d9656c934)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         d6d602f2-aa9a-40c6-ace9-5fc8fda79e99)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         7b64c4fc-9aa7-4fef-8317-dda696857a31)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ae915492-7a49-44c6-9ff4-a71afcc8fa86)(content(Whitespace\" \
+         \"))))(Tile((id 53c75784-0210-4ac5-b237-aa3c29d9b8a1)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         67d4249e-c426-47f5-9414-4353d67a00fc)(content(Whitespace\" \
          \"))))(Tile((id \
-         e943b32a-dfd7-4e36-a487-5fb8fd2af57a)(label(\"(\"\")\"))(mold((out \
+         cafb0a61-1fb7-4109-a4fc-2058d9feb0cc)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         b6938021-ceb4-4527-b556-bf0d38d116fd)(label(r))(mold((out \
+         73759b44-2d4b-4eec-bae2-127454062273)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         fbf81e98-f860-4d28-819d-889b92d3af8a)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         ba06e408-b418-43f8-86fd-f882ed77c4b0)(label(from_lvs))(mold((out \
+         e743d2c1-1e2b-4e79-a089-d74b20f5a218)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3ddc7884-0184-4ab6-a5a1-1f04017d29ce)(content(Whitespace\" \
+         \"))))(Tile((id \
+         33996145-6231-4e21-9f66-499a0464a2a9)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d7ebeb11-1958-42f3-bb60-65ec266460d9)(label(\"(\"\")\"))(mold((out \
+         2163c84e-80d6-4422-ac55-a9ec04adbcb9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         547e839f-cd4e-4f55-a94f-c04a78f82709)(label(to_lvs))(mold((out \
+         3eab0115-e213-401c-be1e-4e1592e872e9)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         96289351-4df6-4083-9ab3-e6a2f36fcf95)(label(\"(\"\")\"))(mold((out \
+         6a8eba06-e2ce-4427-bc15-9425bcce6887)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         51af2710-a50f-44c1-a530-26299b214617)(label(r))(mold((out \
+         48593f31-9484-4059-ab3c-666d94541300)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9d5f864c-8a1c-4cbf-9826-fc40757b49a1)(content(Whitespace\" \
+         5e799a6f-a3f2-494d-b45e-e4741bac479a)(content(Whitespace\" \
          \"))))(Tile((id \
-         02338960-67a4-4964-a3a7-34feaf1966d7)(label(@))(mold((out \
+         b84b21c2-92bf-4260-897b-fa96f4a81899)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f8765206-7b6b-46e6-84eb-750b781082ae)(label([ ]))(mold((out \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6416f56c-8d17-44d3-81e0-40ca0a2c93b3)(content(Whitespace\" \
+         \"))))(Tile((id 2ec7a22e-45c6-4444-9298-588ba3da19b3)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         8e07b451-d896-4dc2-8d2b-f315d8e6a814)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e9a78f57-464e-4e6c-9e6e-b6857b35db11)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         06833591-25e9-451d-a773-a77df0f4b0b6)(label(c))(mold((out \
+         f15e483f-ac71-41ce-aea2-16c53f264d1a)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3d75b099-b62c-43c3-b163-3fa7193f37bf)(label(,))(mold((out \
+         78ca2c46-327d-420e-9c73-25ef03a0ac92)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         612e0ac7-bbf9-4be3-861f-57a71798e917)(label(f))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1b6736a8-4ca0-497b-a947-e0543b9b5fe3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f01bf6ea-f5b3-4718-9cc5-6c2aaebec8ee)(label(f))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         43b455c5-3b64-41c5-b569-9848392a01ae)(label(\"(\"\")\"))(mold((out \
+         aa615a0f-797e-483c-8d3a-06ca23c3a7bc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9b4b6376-5564-4000-912a-caa17cf577eb)(label(r))(mold((out \
+         51485625-96d3-4b4d-8e95-d647afe0670f)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))))))))))))(Secondary((id \
-         203f3e5c-4099-4d7f-bcaf-855bf619e35a)(content(Whitespace\" \
+         8b59f82b-1b7f-4282-b6f6-efc1b7954cd9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e2a5f801-4f88-4e18-8989-550ac38e1e67)(content(Whitespace\"\\n\"))))(Tile((id \
-         8a5a12bb-c3dc-4ef7-a003-5547b90b178b)(label(let = in))(mold((out \
+         73c1cd02-973e-4c54-93b3-e249573a7829)(content(Whitespace\"\\n\"))))(Tile((id \
+         c48e892c-3ee6-402e-8c34-7f8f75fad8fb)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         230622f8-bbca-4202-b15c-0919aa031e37)(content(Whitespace\" \
+         4d1a8143-262a-4272-8971-33fe7f568469)(content(Whitespace\" \
          \"))))(Tile((id \
-         7dfa7195-ebd5-4561-a01a-0dbeda9dca5b)(label(empty_table))(mold((out \
+         7ae3b411-1952-4cc8-8004-9ede97b11ba5)(label(empty_table))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e54207e4-ae63-4378-b014-c4d3057e1b63)(content(Whitespace\" \
+         4b283e06-eb42-4f73-b962-10be2b62106e)(content(Whitespace\" \
          \"))))(Tile((id \
-         b0ca93ec-0f2c-4ad2-9b06-d85d3e3f2249)(label(:))(mold((out \
+         79363ebd-19cc-4bb8-8708-0abc5c8857ee)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f0b7271e-5480-40f9-9e60-9c1b5d832a59)(content(Whitespace\" \
-         \"))))(Tile((id 31a6c658-263a-40c1-b6c1-9628256846cb)(label([ \
+         24c561ca-79ea-4a3a-ac82-70cba2d20a63)(content(Whitespace\" \
+         \"))))(Tile((id 27147985-bc8a-4699-8f81-7cfa7b314af4)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         16abbf24-011f-4fc2-9101-4fb63724c391)(label(\"()\"))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))((Secondary((id \
-         b8b6da8e-c1f3-4faf-92d1-7a7f15c993f9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e7b4a04f-dd11-4036-b493-93b9e861ab43)(label([]))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         6a9f7074-edfb-4d45-8831-04b6ae41035c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         57026c81-341f-4466-bf32-00b47549faf4)(content(Whitespace\"\\n\"))))(Tile((id \
-         030cb30c-d525-4d89-a8b1-e742d2eea596)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         16621384-f623-41f8-9e6d-943c3118aee7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         60796210-2dfc-4aee-8920-27a5889c8fc6)(label(table_of_column))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         8f859978-f393-4d91-a180-1095cd132f1d)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         faa4ba27-f9f4-4240-b385-380fd8f6d219)(content(Whitespace\" \
-         \"))))(Tile((id 6f674322-6165-45aa-90b4-346723eb440f)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         1b1f4810-7c3f-4cae-a2f0-13ef4e8902f1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c0f5d572-b9b6-46a4-b34e-e778c93a10f9)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         502efe81-e86d-4262-8801-9c40afc6633d)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         b8f2ecf7-492c-4921-8fbe-ca50b0898f0e)(label(vs))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         9892fd9f-70ac-4402-88c2-5d10f8686b70)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         2ec18b9b-ab72-47f9-86f1-c5f9bb9e3619)(content(Whitespace\"\\n\"))))(Tile((id \
-         4b7975e6-7b99-49c4-b0cb-948316845d01)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         37263445-49cb-4a05-a868-33adb2890410)(content(Whitespace\" \
-         \"))))(Tile((id \
-         609148b7-c1b8-4279-b32c-389403f70a26)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         f015f21c-54e2-4f74-ad4b-f411f4aa0095)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         5df71020-c4e5-43d8-96e2-11b7ddbf2f25)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6e9fefb8-c344-495b-88f8-33e9713f8693)(label(add_rows))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cc3f94dc-8733-4342-a897-906ae1f1cbcb)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         7d418472-6e28-42ee-8052-339e23131c0b)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         45e3a946-2f19-4756-84bd-7192a0df0993)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c7d50b59-4e70-4b16-b2a1-217b3b46020e)(label(empty_table))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f75b4835-0cff-437e-a210-4bd3d9358261)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a234c871-0264-456d-98ca-4d4624e0e02b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c93674f9-92c0-4152-a039-19a1c5c5b69e)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6353e162-1771-46c1-a339-6c164e269d5b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2d4c291e-b744-40c0-b73e-12b38b3245cf)(label(vs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ede7bfa4-225c-4d6f-aa48-f5bc5fb9f5e0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         314b62af-e5aa-4f2c-b1ea-6845c3a99154)(content(Whitespace\" \
-         \"))))(Tile((id 22265540-48f7-4bc9-97b4-9beb52c0d6d5)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         5823068d-3be8-4b65-8ebf-d58e614f7fc3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         541929c0-0401-4861-a0ae-ef181c1fccdb)(label(_))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         5098991c-4dd8-494e-a821-88a861d91328)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         88195087-0561-43a9-bc3b-a3ab7345ad99)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e1045769-26d4-4a39-b885-503c9de6d8d1)(label(\"()\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         dc6918c8-070b-4b9f-8f1a-bccbe6670077)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         53ff2038-4fd3-42e6-8569-05305a97674c)(content(Whitespace\"\\n\"))))(Tile((id \
-         8f0a12d8-d79e-4624-8353-398afc832d0a)(label(add_col))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         63af235f-4531-48d8-aa7d-f325dca21081)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2bf8abd6-4024-46da-9ea3-ea6d12b75332)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         eb240264-7b04-4695-8802-b155dfb1ba65)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7faa387c-1d3b-49e4-a154-0f479d80985f)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ada78cff-9f84-45b2-8712-d2dfd2b6baa7)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         673ddf58-9390-4426-9d7d-5e692bef051c)(label(vs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9b24d321-6bf2-4916-9da3-cbaf02c5bff7)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         896865d7-0beb-4963-a6ae-aa5b8d622f01)(content(Whitespace\"\\n\"))))(Tile((id \
-         e7089731-fba8-44b9-88fc-a19ee2bfbb9c)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         699357d8-da7f-44e6-800e-6fb07e695c0d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         54e69d51-c01c-4adc-ae93-afa9bcf2e3b1)(label(get_col))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         72132b25-fdd0-4019-8ff1-694a0d958cf0)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         c44710c0-ac5d-4110-9a93-115bc22c84a4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e6c8bf2-5b6b-4f13-bb36-d4362ceaa99f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8209ce9f-aefd-4dd0-8727-685af7c97e04)(content(Whitespace\" \
-         \"))))(Tile((id 17e01b94-fbba-4ecc-95c2-46c6ec4d7074)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         48b29603-f5be-4b26-9f71-efc0ccc15722)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c80ecb24-8911-4705-8ecd-5368a4d5cd69)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         f33015ca-e6a6-4a8b-9fb7-9ae755175c28)(label(t))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         704aee89-e062-44dc-8e35-e59f0a2eb69f)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ffef7743-3c0a-40c8-8220-4022003f19ff)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dd86bb2a-ec63-446d-93e0-1654e0ce605b)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d4237cd4-9e41-49e1-a281-97b3b84c5ee6)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d11eccd6-ea41-4e2b-a737-8ed23e12863c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e4d57905-5964-444f-a349-5a5c8262d12b)(label(String))(mold((out \
+         c64a26bb-b106-4e31-977a-c977c84638a5)(label(\"()\"))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         4edbc10a-f49e-46f1-8cf2-f756e2eeea7b)(content(Whitespace\" \
+         97706df9-4d68-46af-b8d1-712cf6ba6709)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         458c723c-88f5-4107-89d7-f6f7afbdf5a6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         23fdbbed-7129-4f52-9567-2de1b8c47c3f)(label([]))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         56da7c59-4753-469d-8d77-9fd53d91c461)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         239fcb48-0256-4a22-b5c6-41cb325e0dd0)(content(Whitespace\" \
+         ca76e3c9-1508-4e67-bf46-68844fa1d484)(content(Whitespace\"\\n\"))))(Tile((id \
+         ee8d0f83-a6d9-4c6e-9226-f070d4a9048b)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f68cb815-de12-4378-9919-c8a51e5b4f2b)(content(Whitespace\" \
          \"))))(Tile((id \
-         458fb842-32e3-44da-9f6b-bfdbf25b5387)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cd9dd684-8b85-4d06-a25d-771342a96103)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         902b6b28-3633-44dc-bd36-df53d20800fb)(label(t))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         627fa4c2-e2c0-4444-a796-1ee201f15a77)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         55c05e39-bc37-4237-9a8a-01a1e69231b7)(content(Whitespace\" \
-         \"))))(Tile((id 09ce2794-051d-4ad7-a34e-464fd7a892c7)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         687cc884-a74c-466d-8b6e-7e3424d93c65)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cf951caf-7669-4f38-a1ba-723fc8f60067)(label(r))(mold((out \
+         a6c54915-21e9-436a-a1ec-e907bf2d76fa)(label(table_of_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d93b9dce-6277-4902-86f1-dcc87c669c48)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d7dcf520-016b-4fc4-a6c3-3dde0c3c06ea)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ad51bf1a-0d04-440b-a9a3-aa7c3ec4be0f)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         563457ad-7d45-4ed6-8cd8-d497dfdcf99e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6d33b148-f1c2-44ac-b77e-1738ef08cbbc)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         80490aa1-281e-4dec-9bfa-603814f84cf3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bdbdb9fb-950c-4930-8c27-1b992817d702)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c10a5d20-30cc-4473-938d-d12db05ad6b9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         48ae5444-36b5-4969-be0b-8a71ba0b3062)(label(find))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cf5239de-9b2a-43f9-8f7e-31225c278391)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         cef86e3e-3ac8-4d5d-b91c-75aad1e9a34b)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d3f59e3f-bae1-495c-8d30-c507b0d3e984)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         df7ec661-b8d0-4a42-9b1b-3c92bcd57d7e)(label(fun ->))(mold((out \
+         76fdb7aa-5db9-41f1-973a-79ccddefb293)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         e63bb927-fd32-4c13-8f4f-21b80e297de6)(content(Whitespace\"\\n\"))))(Tile((id \
+         e635b628-9653-4d13-a17b-fec08bcd3a00)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         002a1cbf-5d94-46f8-920c-3f68c404c55b)(content(Whitespace\" \
+         2c0a8287-01a1-455e-80a8-4e4a44399672)(content(Whitespace\" \
          \"))))(Tile((id \
-         b79ae05b-30e1-49cd-a2c4-a37bfc165977)(label(label))(mold((out \
+         d0c4a98d-fbb2-424d-9b99-97346100e7b2)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         dcb729ab-d3aa-4f66-9224-dee069cd973e)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         ec1e84d1-0186-4c58-95b5-35bdb5a2170f)(label(l))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         80d2734d-1455-48a7-806d-d882731f1944)(label(,))(mold((out \
+         92c59b5f-a07d-4703-b5d2-19b6b295639d)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         5f76737b-1fd0-4f0b-a7fa-7e38c3b0045c)(content(Whitespace\" \
+         499cde64-9cb5-433b-b92b-24b0730d084b)(content(Whitespace\" \
          \"))))(Tile((id \
-         11ddd9a7-1cdc-4154-a097-fb6eb0c3298a)(label(value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         363ee1f2-6480-42d0-a233-ec6817274835)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         80e4858f-cb04-4333-87ce-070bdc507419)(label(v))(mold((out \
+         12090205-2fa0-4e87-802a-2e5733ae2501)(label(vs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b2063d4e-353e-45b7-8e46-75a926e431ed)(content(Whitespace\" \
+         efa49d99-ec7b-4781-9e4c-90a707989707)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         09806f81-418e-4bc2-b9f1-7256615bda02)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0b40cc07-c45e-4872-a53f-7a0ca7ae6b9e)(label(string_eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ea90eddc-fad7-4cef-a1e9-77fae122bdb7)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2328d6b7-abcf-41de-9fce-22c36aabb25e)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ea69db50-e623-4abf-9108-f1f02df89fab)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         2c52e663-2186-473d-90b5-c9aff426732b)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Tile((id \
-         c4c81471-b433-4cc4-a9b0-e1cbd7836011)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         efbbf5f7-8fd3-4004-ba92-9620138d1982)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         1af69798-406e-491e-8c7a-19e8a0313932)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4a504b15-6fc8-4545-b293-d6fb2804690d)(content(Whitespace\"\\n\"))))(Tile((id \
-         a977555f-401c-43ec-96f7-ea39aa95f6b6)(label(let = in))(mold((out \
+         671f715e-c613-4935-a8b7-a8bb383c2f4c)(content(Whitespace\"\\n\"))))(Tile((id \
+         f39e17dc-7462-4ba8-9526-4b31d2d1d9db)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1b58b513-0db6-433a-9b24-9fe72b296ec9)(content(Whitespace\" \
+         28c4a146-abad-4fed-89e9-94363824779f)(content(Whitespace\" \
          \"))))(Tile((id \
-         7c637259-09f8-43b5-8d7c-3801ea87a7ec)(label(group_by_retentive))(mold((out \
+         64d50071-034e-43dd-a901-8fdbd1edc1b3)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b4930ffe-d966-480c-abdf-819c306d4f59)(content(Whitespace\" \
+         8690707f-53bb-46bb-81ac-11d52588b2f7)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0a70bf29-dcdb-4dd7-8f09-07db4b7cca0e)(content(Whitespace\" \
-         \"))))(Tile((id 201f6bc1-0048-4ddd-b41a-6967fe2e05e6)(label(fun \
+         1da1c0f8-a315-44c2-ac8d-e5f6764f94cb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         26ca166d-a5b5-49b1-b217-6d493bd82932)(label(add_rows))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         35005ab2-55ee-4de3-a08a-4dfc4533d706)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         536b1356-4199-4c70-ba81-9a5d16d86d6b)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         6dec3d6b-4a2a-4eb1-acb2-5d68b2cedfec)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         3aa71d46-ff2c-4907-aae2-f443acf3b36c)(label(empty_table))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1dd1b005-ae1f-48af-88eb-2e69401b82ec)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fece1f24-6c98-433b-8e67-e92c0eb1c748)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ace342ee-cc57-4036-964a-d091948e4d3c)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1fcbc4a4-3341-42e7-9157-08df982d65be)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         20efb937-0b68-489f-a7a1-04c1635584e3)(label(vs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8f71cab1-a913-4dc9-a937-45c2ea129c0d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b87d3d42-a4d5-41ae-8fbb-a58c617c9af4)(content(Whitespace\" \
+         \"))))(Tile((id 2a05ecfd-0c43-4ec2-be73-f439018e25d0)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         3944a6d7-d0f2-4a3d-8e72-38b00c0063ff)(content(Whitespace\" \
+         30e99d97-f124-4a10-af16-9acc3ce6868b)(content(Whitespace\" \
          \"))))(Tile((id \
-         374e30a2-f87f-4ce1-b9d3-3ac3c6bcd25e)(label(t))(mold((out \
+         c7ed43de-5144-440f-af9a-5b21f550bfdb)(label(_))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         456a183b-bfc9-49f9-86ed-452982e0b630)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         95d2f835-0308-44de-838b-6993e0eca237)(content(Whitespace\" \
+         \"))))(Tile((id \
+         72811d9c-700c-4038-b935-6f775b00aba9)(label(\"()\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         00a642c2-3f0f-4f0a-a61e-e4f0cafa7247)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         64efe905-901c-4b62-962e-f37baf60dcc5)(content(Whitespace\"\\n\"))))(Tile((id \
+         c6447056-2099-4f30-99f6-84e0ddc2699a)(label(add_col))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d3a9feb3-56d9-4089-a09d-b693d1d843e6)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         5f8e10db-b429-4c31-affc-ea579b292ed7)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f78b8c61-45d3-4eb9-b1e3-a78248ccae55)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         eedef38d-54e8-4fee-a5a3-95e36794ee25)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1e96d28c-e2b8-488e-a04c-882f3843a5ca)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         549d13ff-ca31-4a52-a76f-4257e98e19b0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cabac317-1ee1-4351-bd52-a413bde44c89)(content(Whitespace\" \
+         \"))))(Tile((id \
+         57bf23f4-3d96-413e-9a1e-7436e927ec11)(label(vs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         7a2b18f5-6377-4631-839c-29ae7da3f49f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         15a721e1-46d5-46b6-9e7c-fa4fbb2df80e)(content(Whitespace\"\\n\"))))(Tile((id \
+         dada116a-4fc7-40e6-851c-4341f351ee13)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         bf92451a-fc0f-49a9-80f9-8baa10248e4a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a9f4fbfa-6997-45c6-8f44-e55f9be7e2c4)(label(get_col))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         84db0308-f3ec-4548-b0fb-f135226ab907)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         586cc374-dadd-4c93-9988-9c0795e0d651)(content(Whitespace\" \
+         \"))))(Tile((id 17adec68-c584-4f24-af2a-255c4b6fe810)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         57f35783-828c-4ecd-82b8-e42b190adbf3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9e2362c3-0446-48be-baa8-6b47568ae5cc)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         22e3aaf6-2579-4598-8907-9b02e276f049)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         8d06d598-fffb-4bba-8d73-fee038fc32b2)(label(,))(mold((out \
+         40d8cd32-d8c2-4fff-86a7-c7e106534c32)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         21fdbe45-add5-4b43-8500-526cebad8d41)(label(c))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         33eb6c76-1b8e-4118-a62e-a4d0162124da)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aeaefb04-5568-4505-91b8-e1298cce2527)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3a79df99-b9ad-4343-9525-f0d0956b5928)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         549cd45e-7477-46f3-8436-ab2399dcc985)(content(Whitespace\"\\n\"))))(Tile((id \
-         3dd3c404-617c-471e-af35-b5934e2586bd)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         af6cf916-1708-496f-adbf-8f510a06c04c)(content(Whitespace\" \
+         b5f8b2ee-cb8a-4953-ba65-c9aefc48bcb5)(content(Whitespace\" \
          \"))))(Tile((id \
-         b41ab4ee-9519-46be-88f8-ce25a32d0833)(label(keys))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         277373cf-c39c-4690-b12d-35c0a1988c1a)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         f0c835a6-df7a-47f0-99cc-3bd05ee7a68d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f16e0bed-dcb3-4c06-8a78-5ad911410714)(label(get_col))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         854639da-e530-41a1-acab-f184ba2bca56)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         710e5426-ce14-445d-9a59-af88ba72df0b)(label(t))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3e704d53-7cbc-47d6-9421-a5fb4ac4da8a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ee4e2f9e-89d8-492f-83cc-bd3a85036a75)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         bc2bc107-b9a2-4e01-8578-c7364ffa4453)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9e3ffb43-5684-4b57-8788-1b02dcb10c5f)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         26b5bdba-5150-438d-86fa-949b1ef92f50)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bfccfce1-5e1a-4898-a6af-04052d4c526f)(label(remove_duplicates))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         aebefaf6-c50a-42d8-bd9e-19ff8fbe6104)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cd2595d7-f653-40f6-8236-a43b83dda97c)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6bb3860d-33be-408f-ac28-a1e33f8be52d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7f9d8b98-bfb2-4e74-9d4e-37b9884f99f3)(label(table_of_column))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         70351e84-eb7d-4da9-9400-57fc722e50d0)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c6a6b7f1-f6b0-4a22-b494-71c4f2794199)(label(\"\\\"key\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9e294f86-629c-4a07-a748-2ff008b18f37)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         68878200-9b26-4aad-90eb-3202acccd785)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5f1f88f8-aad9-4bfb-ad77-94592dce4a7e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f17abfa6-86ac-44d0-987c-a500b9759875)(content(Whitespace\"\\n\"))))(Tile((id \
-         57a89ed8-8667-462a-95d1-98a912f4c991)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c2113dd9-affe-4058-b49d-29631965aea3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         88954855-d42a-4898-a25c-eb162ed9a217)(label(make_group))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         739cf47c-dd1a-498a-8b74-13cc429546ec)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         8292489b-b95b-4cdc-9d41-be02bb93aa6d)(content(Whitespace\" \
-         \"))))(Tile((id f225c575-8871-4243-8d63-9aa0c2ba5267)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         4b138c1f-5842-44f6-a0fd-d9fe09dee322)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b92514a7-35bb-495a-a732-e72a2768998f)(label(kr))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         1c56c8b5-21e5-4454-b4c5-88c5f32e2f62)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         13dc92d8-edf7-4c2e-9b51-e3d47229dddf)(content(Whitespace\" \
-         \"))))(Tile((id 427d7d8e-a5e7-414a-9019-e02a60eb688a)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         5fa697a0-072d-415d-90c6-2dad66d36893)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4dc1df93-4e6b-449d-ae3c-dbbbaf167ea1)(label(k))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         1aa17ee1-0ed4-4d02-86da-96833b491391)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         69216bf4-ff6d-408f-92da-f81fa8c842ee)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0667849c-e60e-4e77-9aa9-fd4ca5461cfe)(label(kr))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         dc69789c-5589-4cfe-bc30-7285920243e8)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         83cac39d-2ab1-4333-922a-fad6b4848974)(label(key))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         1e26703e-6dda-4c43-a036-405caa6c095a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8365f6ad-c3b7-4fd2-8aaf-9df8501ce333)(content(Whitespace\" \
-         \"))))(Tile((id \
-         58a47442-55d6-4b15-bc9a-521f94954ee9)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cdc6d3d3-44a0-40ee-b828-16084cef6a2f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1c791018-b31a-4553-bace-342c9e2152c1)(label(t))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5a2e6a5c-b572-47e8-bec7-70467b4d3d74)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2681315e-75e9-49cd-84af-e1fcdc11751b)(content(Whitespace\" \
-         \"))))(Tile((id 8128209f-8a02-46ae-be22-9249789f7f62)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         f1640151-c90d-4d45-a2b5-c19ce3de7408)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3d28ad55-5cb1-4e23-9226-2f188ca13633)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         9cc73b63-5699-4d88-96af-0490b700dfae)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         ac529525-a2d5-46ef-89fc-7b265b381b81)(content(Whitespace\" \
-         \"))))(Tile((id \
-         419a7ef1-d264-4ac0-aae5-7e7958992ba9)(label(get_value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         96296ca9-4967-4847-95a2-15d2023a7a4f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f87cb0cc-9c48-4f18-b2e2-f7b7203fefab)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2dbb0cea-20f5-43e6-8ceb-ea4070ae7f19)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         793b475a-88f7-4470-baa7-df4616cdf049)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7cc9e7c7-3dd4-4043-abb7-397a89d55cc4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4e353c14-2968-4658-802f-0f3766cebf2b)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7c2087b6-5844-479b-9979-3cc8906ccb73)(content(Whitespace\" \
-         \"))))(Tile((id \
-         59b8f0df-afc0-445d-9376-450fcbd81c84)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         522c73ef-ade0-412b-8e2f-fe185fcb1171)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         eab9a82f-d3ef-44b8-8174-01c255d3b4bb)(content(Whitespace\"\\n\"))))(Tile((id \
-         1ddced8e-2683-4464-8270-9836148167a8)(label(build_col))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9fd41101-45ff-4965-a6bf-a1fbb4a9ff64)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f546dbcf-0fdd-42d0-82a0-aecdb796fb98)(label(keys))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f025e62b-3595-4e69-9b62-0fa35c21e14e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2b249cda-d489-436d-accf-944fbfe739eb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         99c38221-f452-48a3-8252-12016baacba9)(label(\"\\\"groups\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         430e5e9a-a9eb-46b2-8349-0790e715f4d6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e21540a8-cdf0-4f76-8c2b-c10cc69cf72b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1e32c47a-c1aa-4724-9c3e-b5cfac2c05ff)(label(make_group))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         03f38e65-3cbb-4fbd-a943-064a7cf225a1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         64263b01-c278-488c-b3a3-ebb1078f76e2)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         71678fe5-05d7-4372-ae83-b07d3507f404)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         84177032-8825-4f16-a154-37c0ea22f59c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1c5b2b1-c9ca-4cc8-a4e5-05c17515a862)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1292bf67-2381-4d98-8bb5-2c1a1b5a831f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7d0a077b-049d-491b-80a2-29ba6e96a861)(content(Whitespace\"\\n\"))))(Tile((id \
-         eef1c808-716b-4ada-82b1-e8bb383b4dd7)(label(type = in))(mold((out \
-         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1f526d3f-4a56-4a13-9276-57cc42b8831c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f5555b3a-6525-42df-ba17-ec23da3bb071)(label(GradebookEntry))(mold((out \
-         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children())))(Secondary((id \
-         54bb5ee8-d1aa-47b1-bc36-54e343bc563c)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         3a3df025-f390-4487-b84b-0f47f98180fa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8fb680a5-d7b8-42d4-b380-fd4c10299ff5)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         258df098-fac0-482f-9714-09a16b715204)(label(name))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         29c0463b-f776-452b-a8ab-dfc9e43c9511)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         a1b0219c-bbdf-4bbf-bf8b-5f1c9318fac2)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         94430be1-62d4-4dfb-ba3f-0ae0d6abf355)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dfe24154-27ca-40a6-8cc6-8bdff73b86e4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         474f8cba-377b-43dd-91ed-87b3a5d3d69f)(label(age))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         b9971782-2ba6-484c-91d9-2e60d25f8a9b)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         ef041233-52b4-4438-8663-dd400bb48662)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         3684aaba-add5-40e5-82a9-5f4e11e792de)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9ae58db3-10cd-4892-9d4f-38edb1d68dd1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e198cfde-5315-48be-ab8d-ad0ebb6d436b)(label(quiz1))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         a40734d5-1fc2-40f7-863d-980951a7aa70)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d422b13a-28ec-414c-a608-a2ef3bf5ae14)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         3c5828ab-a17e-4585-9d9c-4ccd6c4a0cdd)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8e5b51a2-d0f4-41a7-9fbd-9634027b127d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a77fdccb-c2a4-40e3-b55c-51beb49f1341)(label(quiz2))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         046a08cf-593c-43db-b01b-2711ac34f2b1)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         0f24f698-5a0b-4100-b526-ba6d18a371d4)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         443a8ef6-559f-47f1-908e-a394c9d705ea)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4b6b3ac5-a179-435b-b10b-80505ece5982)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e8db3428-d999-4cac-8af8-493e9c2df7ec)(label(midterm))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         3bfeb843-2dae-4357-8410-1b54e8903849)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         b1bcdab5-f569-4af9-973e-0de7e5773ba3)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         6365e232-8b93-4a0f-9183-87b786d7a21a)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1a81586f-5a64-4459-8b7b-b4b35e9a2abb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         50a7f8bf-6196-4258-85d2-235a11de89c3)(label(quiz3))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         8ca77906-37c1-44be-9200-bb06f92d703b)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2a0fcdaf-51b3-48dd-97ac-fbe708aec2c7)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         a710eef1-955d-4818-91be-1358bbcfde59)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a7d8c348-d1fb-49d0-8832-df5ace624670)(content(Whitespace\" \
-         \"))))(Tile((id \
-         983e170a-c824-4572-9a71-0507bc8c7c45)(label(quiz4))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         d64420bc-2a5e-4f34-9e26-5ceb4aae9634)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2db8b9e8-7848-466c-9efa-c806502d7c10)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         d571ecf1-169f-4ea3-9da0-8a8098b83465)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c4e2115d-29b7-4a77-951b-dc9c49a40fff)(content(Whitespace\" \
-         \"))))(Tile((id \
-         886e1162-ce8f-458d-8fcc-d65b8664b21e)(label(final))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         4bb02a41-31a3-4592-b22f-d63b20682f1f)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         52595081-9c60-4d77-bc82-1b9358acc077)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         41e83fbb-1b4c-48b8-a842-33048ed08e49)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9573908a-2b29-44d4-af99-1cc88ad56a84)(content(Whitespace\"\\n\"))))(Tile((id \
-         ad0b69be-49f6-44e7-bd15-e2ad0e826a0e)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a84bf77f-9657-473c-88ee-c84a5795b841)(content(Whitespace\" \
-         \"))))(Tile((id \
-         33338e9b-f34b-44de-835d-351778fb43f8)(label(gradebook))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         5d42ed0f-2cb5-42bc-b754-2289fe6aff7a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7da6b02a-9cce-4367-82c9-ed146715d3b9)(label(:))(mold((out \
+         abbd7a05-cd1d-4bf2-bd79-5f1d66180517)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         42aeed3f-2bf8-49f4-9604-b63c4c27d87d)(content(Whitespace\" \
-         \"))))(Tile((id 9624af4c-f03c-45f0-a113-20f2666bc259)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         3d63b278-f4fd-486e-831e-c3bc1e2aafdc)(label(GradebookEntry))(mold((out \
+         265595f0-1849-418f-ac2c-bae8aedb10f6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         43490304-247a-48f0-bd17-5ffec76a0b13)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         52be5beb-bd85-4055-80bd-17bb96abbdcc)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         b20129ff-9055-4c7a-933a-715e213c5c8e)(content(Whitespace\" \
-         \"))))(Tile((id 358c90f4-e152-496b-baa2-899a1fb6fe57)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         62037049-18d0-44b5-bb29-90d038859f4b)(content(Whitespace\"\\n\"))))(Tile((id \
-         722bb724-7c12-4abb-9eba-b5c745a93bbe)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         83a55ec9-d7d1-4f45-8060-7244cabb1e6e)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2854bd8e-8fd5-4839-88a8-e7c4249af25a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1b4c5853-72ba-4cd2-ba8b-7c1400329c96)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6b3b2e94-9dc9-4a55-a252-390f24726157)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9db9ee37-77c0-4cb2-97ac-fe5467a3777a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         44ab33d1-be8e-4b52-8a30-0924dc3fbbec)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f0a793e3-5ecd-4d11-b0cd-367c758e4152)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         afb43fc5-fa6f-4a9b-8853-762eadc751d6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         43a6d0d8-286d-466d-89ed-a5c0b6cca538)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1ba6f7eb-94c7-4154-bf28-971d4a4fcd92)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8f282d5f-3aac-443c-8b0f-fa582a42797b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         207b78c8-7cea-41e4-b480-d0bd403407f9)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         12e2bd96-9cb2-42fe-bb49-82be8eb6eaae)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4c32b1dc-c4e4-4bb1-b668-d6971adf053a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4cfdbe11-e8c0-4657-b87b-e942ae392399)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c3487d05-5b1c-4e0b-8e83-437b1039df49)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         00066311-a745-4da3-996f-c48b30ab64f5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         59a6a9a0-7c4a-4560-b44a-15b70f0070dd)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c63a9237-2342-4a90-b883-d1313fd5b8a0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f83007dd-d05d-4d80-af66-8b08d960e985)(content(Whitespace\" \
-         \"))))(Tile((id \
-         49579d5d-193f-491d-8a87-abcdf9993331)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         737b7156-eb71-481c-9931-0475899d8676)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         085a88b1-d862-4ab3-bfa9-4efad67a5ebc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         855976a7-0efc-4dae-b5f3-b99e2b2cbc14)(label(87))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         14bc7a6e-3090-490f-8e08-9f9c553f1bed)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         660a6a4c-4480-4e12-8e5c-6a4ed8296a24)(content(Whitespace\"\\n\"))))(Tile((id \
-         a91d56fd-df1b-4955-84bf-04ab6ea073f7)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         b6c45be0-273f-4d16-9e2d-a8de5e2804f7)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4d94a4bb-3d9c-4daa-a06e-36fda8c5ea23)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         349539c3-49c3-4933-b2f8-96452dfa471a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         886eb9d6-bae8-47a1-b358-d2290f89fc80)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e3283996-04b8-4e31-930d-30b9b08f7d48)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         822c5eb6-5e6e-41fc-8a85-075e80cb6f53)(content(Whitespace\" \
-         \"))))(Tile((id \
-         01118cd9-0c2f-4979-880d-a189af8fe1c7)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b2c21b5c-3def-484e-a19f-c841d64458e6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5999a718-4c34-4666-993d-034d296aa2c8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         73fc3d97-dd3e-4e18-a5fc-5dcfdc017170)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8f3eb80f-aa44-43b4-915e-c289b38deb64)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1a74e91b-a0cd-46bf-b3e0-38184cbfa1b9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         28a881ce-6d62-4cee-8ba6-ebdb94420c45)(label(88))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         555ad0ed-cbbd-4534-a063-0f712797b576)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a1ac6ef4-6c43-4489-a66b-479aea58f1e4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d4e5d9e2-bfcd-45f6-8185-46a872d6b75e)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6b0397b9-e552-4302-bdcb-bcd22c4711a5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ac3b3a8a-0c92-4cf7-9e63-41d56e3a9100)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f2f581a2-9648-4c0e-bd5c-3d7b43787c5d)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         37796ab2-a1e7-4539-abf2-f7f99b02898a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f24866dd-8e42-4f48-a2c1-00dee48e6588)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c43d2c63-9792-470e-984c-4f4c6f7a8600)(label(85))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         bffbad11-0809-493c-82a3-b7cd952b54cb)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         05ccfa76-52ad-45e0-8242-11c7165966db)(content(Whitespace\"\\n\"))))(Tile((id \
-         069bc18e-9e1b-46c2-8de3-42e7872027b7)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         84a72062-8458-428a-aa90-e3e95aeea4e0)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         eaa44eb2-7d13-4594-9222-0c2fb6a43f39)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d2fc3c72-4532-4728-a68d-9cbc49192e67)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         10f5fb7d-a5cd-4594-9b53-4b63b0f88403)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         35cddca7-c227-4092-94be-16e48cb783f5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         88cf8833-d7bf-47f9-a2ec-2a1f593b2269)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         498d5376-b636-4d6b-9d29-7c92ae0e6774)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6e7fdcbf-f5ce-4b3b-9a88-bee875410383)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ebe2e52b-ff13-4621-9180-bd04c1bdb91a)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2f0d45c4-32e5-491c-9207-8a9cc76e2e56)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c620b0ef-bee5-4c3f-b41b-f9333750ca6d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         60fb2934-2daa-4252-8853-69b6973a5c7c)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         606a061a-a631-4500-9dac-5fe680deb963)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b8ff1494-46b5-47f7-9eb6-5128f9641969)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cb8a2449-bc49-4264-9fc3-5dd17e9089cb)(label(84))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f78824b2-200b-4d6d-925f-75ff132dee26)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f8880b4a-b949-4747-aae9-6dd709e4bb15)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fe188735-e892-47bc-85da-42d29da53243)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0d171f26-2173-4162-8bac-f741148eefb9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b0ec6efd-2624-488a-b1ea-03f5c44aa3a4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a0554b8f-f549-49d8-9250-d42d8277f152)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         439564f1-267f-4857-9a71-a83d05a91398)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c12774fd-37e9-4169-b04d-6b31845ffe3b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f69d87db-6fd6-44a3-bcbc-bc48f7aa959c)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         05334150-1ebf-40fc-a947-6960bd6a3518)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a337744f-93f1-49fc-ba1f-a4ae9f08fef6)(content(Whitespace\" \
+         3ecde72d-bf7e-4e5f-94e6-f6a6b41f1918)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3515573e-b97c-4f6d-a111-57af32e3d89a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         af9539ee-1803-4b61-894e-3d70fa3083cc)(content(Whitespace\"\\n\"))))(Tile((id \
-         29dfb8e5-4d99-4ca4-bf17-e47ceec10d48)(label(group_by_retentive))(mold((out \
+         97d141ab-5a86-405d-ad5a-6b05c59b25c3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         af25029f-29f7-4b78-ae41-c14ef30583da)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c9adcbbc-4fce-4049-afd2-512eb6701fab)(label(\"(\"\")\"))(mold((out \
+         9f0976c7-f64c-4f6e-a0c6-740774cd28d9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8dcb9fc8-bffe-44f3-8241-f9a9ec97ead0)(label(gradebook))(mold((out \
+         83352024-4fe3-40d2-b182-55f70fc18989)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         bf82dd16-a055-454c-933a-e3d6e092c89d)(label(,))(mold((out \
+         d0c3ca2a-939c-490f-b24c-71e05be9b67b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e1edeb6b-6804-4afd-8af0-ca03d5d64bf4)(content(Whitespace\" \
+         0223ad54-41f5-43ef-83f8-cb8fcfabda14)(content(Whitespace\" \
+         \"))))(Tile((id b978b877-5e3f-405f-a0ed-afc7e66ebe55)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         2f72d182-8fbd-4694-8221-56cde6cd8c5c)(content(Whitespace\" \
          \"))))(Tile((id \
-         6787de8d-90c9-4411-805d-9ef2a892df23)(label(\"\\\"name\\\"\"))(mold((out \
+         320d2f35-58e6-4164-a4e1-5362c8b291f1)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5103286f-bc35-4eb0-a06c-7ba8fd19de23)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         581d781a-afad-46b1-a7b7-05ae175ad28b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         272a3807-15e4-4cb6-b743-e74a3d3d4a54)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a3663804-acb3-4367-9a77-553b56feca55)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         59ca1438-3622-4c83-8d1d-813b86073d2c)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         5dc0ffd3-fa74-427b-a08b-698acd914d0c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5aa42a57-7b8c-4b70-ab60-5c9ee8f5566b)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a6680c46-c1e2-44b2-bb9f-62f9480b6d72)(content(Whitespace\" \
+         \"))))(Tile((id \
+         db007e98-64e6-4654-a570-a00a526d47f0)(label(find))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         df309303-67fa-490e-a6a9-9c362cd247ce)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         c62c698b-9098-42a1-847b-89b56e99367d)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         22d2b82c-1dfd-465e-82c8-b21e0fa39c3b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         c21863d7-dc37-4ce2-993a-603f0914781f)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         f385486e-4025-400d-ba14-467a39cde53c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0611329d-6c67-4c46-b983-6b20f44880db)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         059151c7-3942-465c-8603-e7cf3646b6f6)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         0b9820b5-0c4f-45be-86cb-af1fdced858d)(label(l))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         5a0b4ec1-7570-4e02-a37b-cc9f95c1d2a7)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         6eb98a27-f759-4d60-aabb-036ea8c352a9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         66a76015-45e6-4a82-9d77-25601272215e)(label(value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         92e64960-0e95-458e-bbe7-1d7cffb5b11f)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         3a2e5c1a-c257-4545-a5c8-0a03fa2a9c38)(label(_v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         dbca2b8b-1b82-4383-ad33-582975a0ae91)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         eb19e3c9-85c7-49a8-8196-c028ff83860a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4bb933ad-0003-4e14-bf77-83ad23a6de97)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         9865310a-de66-43f2-820b-096c17295102)(label(l))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         37ab1760-3871-4578-bd44-28a14f5d27ea)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e2013695-79fb-4040-95ad-1cd07019f6c6)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c45836e3-5fd4-4517-b388-69e1cbde214c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4bd20670-c3c1-4116-ab14-29e3360a944f)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Tile((id \
+         1355ec86-5c86-4b2c-9737-c576a9a1416b)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         91443a1f-936e-41d7-acb1-706cb9dc0598)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         dcc54102-5e4e-45bc-95fa-e71649fe6dc8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         09d506aa-55b4-4fdb-ba92-b5683958abea)(content(Whitespace\"\\n\"))))(Tile((id \
+         ebb9a6ae-4e0c-4ccf-8ea4-b7574fa72f89)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a23850fb-4edd-46ef-9928-e75b84dbd949)(content(Whitespace\" \
+         \"))))(Tile((id \
+         adb4db93-c742-4a57-a8c4-eeeb9b6fdabb)(label(group_by_retentive))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a5b407b0-87ff-40a4-aeb3-27b0d1667fd4)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         aa118809-7d10-4768-8c23-abef0a2e804b)(content(Whitespace\"\\n\"))))(Tile((id \
+         675356a7-e7ab-4b54-940e-09dd7183496c)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         be522b51-6e68-424f-a3fd-7ef2ee5136cb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7544806f-f19c-47df-9b86-e7421ef4c922)(label(t))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         8c55d7b4-9ee3-4f82-8177-b5e63de8536a)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         dc9e2af6-a7cd-4b11-94ad-e3e515001252)(content(Whitespace\" \
+         \"))))(Tile((id \
+         357b838e-d05a-4a18-ad2e-20ca44f5782c)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         748c3052-ea08-4e57-8835-17a6235a732f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         fb01b3f4-6a65-4e80-bb16-a2be22596995)(content(Whitespace\"\\n\"))))(Tile((id \
+         17b01075-70fa-4394-979e-d33586b38315)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0c70be8e-ac79-4aa2-93cd-9d8f13af2ddf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         71df3046-9db5-4482-a258-15e923164a07)(label(keys))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         fb00271d-795a-4cee-b325-cb25702db740)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         0295e392-37fd-44ea-b812-4649c5831a81)(content(Whitespace\" \
+         \"))))(Tile((id \
+         83fc7073-0f92-4c59-ace1-48e5b9a3784b)(label(get_col))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         924de9a5-b032-4df0-b54c-d17fa7ff7d78)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         14658315-4a49-400e-bf3d-14b23f2f416e)(label(t))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5211cac2-e924-425f-9ce8-305ce947d7c8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         97d80e3a-fe27-47c7-b46f-de2ef8c1c70a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         faef240b-fba6-4c1c-9150-786fd02fb206)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         10903310-8091-475f-880d-4273179d6a37)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c3c71973-11f2-4c1b-ad24-546fe5a27e1e)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         26905569-eae5-43c7-8295-ef51d7cbca41)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1fee47de-ca94-42d6-873e-4b81b6a4ebba)(label(remove_duplicates))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         84cb15d0-9b85-4539-8b0f-2bbad4050077)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cd39d33a-b83e-4116-b2be-b6df469c5a8d)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cbff33ed-2552-4a71-b14f-bd508ea55771)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b73d6523-83e9-4705-bdd5-eba0b5551f9d)(label(table_of_column))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         89cdd5c1-1e66-48ac-b959-84eb8e4ab00b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         6afeec20-a6a8-4a88-ba82-89d05ac2629f)(label(\"\\\"key\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a5b7307c-4b6a-420a-b4b1-ed6c538d0b4d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1c4ad4ef-7b88-4f0e-bb99-1eabe358e1f0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         08862103-8ab5-426b-90e7-3ab19ebc5d04)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         063675b2-f6bd-43ff-8329-d0f7de41fe37)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ffcf9bf8-1f59-41cc-954c-9663b7039a9b)(content(Whitespace\"\\n\"))))(Tile((id \
+         d59b2870-4c00-4657-8622-a560168524d4)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9be0b27e-85f0-4fa2-98ef-89d2965c3087)(content(Whitespace\" \
+         \"))))(Tile((id \
+         54a1d22a-5617-4685-88e7-63b4161f45ed)(label(make_group))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5f83a39d-d41b-4879-888c-ddde2d976f84)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         a437c7ab-9495-425a-8ed9-4ecec0c6d70b)(content(Whitespace\"\\n\"))))(Tile((id \
+         5ec88707-71b4-4207-ac30-a62f4fde1c35)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         0cbbab64-2d0c-4211-bdbe-fd552943d953)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1e494e52-d4b0-4eca-9da9-372e46211b48)(label(kr))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         71da4d9c-e691-4bdb-9efe-ae03d3cae945)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         0f3ef791-8237-4953-baac-81912a25be34)(content(Whitespace\"\\n\"))))(Tile((id \
+         570a8ae5-f19f-4807-8695-60a33bcfdb18)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a2d6df3a-c418-42ff-98e8-412d599fbb5e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         be83b303-8e6e-4965-b008-c0d844f79f33)(label(k))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         8e228598-cb1f-4539-afcc-f934f261ff14)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         183b5d55-185c-425c-9096-7090e1b0a8b6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2da35095-3775-4576-b157-a73df6042102)(label(kr))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4b000348-6291-447f-9f3a-c2da0595b0de)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         0be6f96a-cbe6-486c-8dfb-e5afc7866b9f)(label(key))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e25d37e8-9518-489e-9114-48a51a2ba7d2)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         b9b59222-db4f-4fc0-bac8-f48114765855)(content(Whitespace\"\\n\"))))(Tile((id \
+         36e854b5-4c88-4b5b-b732-022497e0297c)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         318f8385-90c4-462e-a21f-156987fedd4d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0ca8edab-4e96-478c-90ec-578943f1af9f)(label(t))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7b815023-152f-4717-a5dc-1cbb3365c6bf)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5e113fd8-3e83-4687-b652-e0e41b92fe2e)(content(Whitespace\" \
+         \"))))(Tile((id 7842ba22-a965-4f0f-920f-bbd71383b1f0)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         cc426e69-ab40-43a2-ad26-76e22c2a67bd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dc4b45af-426c-448b-bbb7-76f1ff9afe67)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         d5e1b7d2-a435-457b-b1df-efa16e2c81fc)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         765dedb0-6e00-4dee-865f-083b26799c9c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f9b72a43-2569-4aad-8669-9815242c5744)(label(get_value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9f7402e1-3cec-48bd-92a7-61744f0bcbbf)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4384ab5e-01a1-4e8c-bf21-838e6999f15d)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b58e8173-fff2-4ecc-a971-00f3e862809b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         96776ee8-969e-410e-b8e5-2461bf9e17f8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4cbcec51-780f-48b9-94fb-0986f8c2f025)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         ccc44e8d-e803-44a0-834f-644eecf99875)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f50c2c18-01f7-4a8c-9aa6-c206ecc14aec)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a1766a0c-e7af-4d1f-ae9f-08992354aac5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         93988ecd-1c78-4315-b796-ac64812577a4)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         32102ca2-3eb5-44c9-b869-ea19af19d701)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e7ffa037-71e1-4e53-8fae-0943d5014fc3)(content(Whitespace\"\\n\"))))(Tile((id \
+         28762741-c042-4a65-a047-f933a8dfe712)(label(build_col))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         930ee144-3109-4067-9a63-095674c2afad)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         c014ab2a-42f2-4b73-8554-e09e54571aa7)(label(keys))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ee848f1d-3186-4063-8a67-6071cfd94459)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         08cd0f76-760f-40a6-8bdc-62af3f092799)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3a043f30-06e6-4b99-b2fd-5eb4b6861361)(label(\"\\\"groups\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c18d757b-f747-4aa8-88c2-37239c297b87)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         959dc4dd-e0e4-4884-9120-7bfa9d0e2bf3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6bc29f7e-6d00-4057-93b9-5207fa3f38c7)(label(make_group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         be49c3fe-1b26-4c92-9a08-4eb3e956f123)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         b23bc921-d21e-4c91-9c06-d2b44405293b)(content(Whitespace\"\\n\"))))(Secondary((id \
+         4d7fe183-3593-4b71-8705-c129bdde24da)(content(Whitespace\"\\n\"))))(Tile((id \
+         ce5bf4f1-df1a-4231-bc91-01a91c9c0f20)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ed580efd-e90c-4c78-aead-2ae55ac43f4e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c81c3d79-ebed-4a55-a9bc-44a1eee0f17b)(label(GradebookEntry))(mold((out \
+         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         1a690874-b413-4e1e-b7fe-ce931dc32167)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         b945e89a-1510-41ff-aba0-7ab6aee21214)(content(Whitespace\" \
+         \"))))(Tile((id \
+         abcf2120-6651-4c33-9556-dda4915573e0)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         7a821f0f-9477-4687-b32c-f964dec1a0fb)(label(name))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cb05753f-c067-4ca7-97ae-4b66e72a2b31)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3d9dd6a1-d08d-4f7f-ad05-1de1b1c6e563)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         213b0a25-952a-4356-89fa-e4184dfbb890)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c1404457-67b3-4abf-bc42-f91e3b38e211)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         a63f44a2-1b4e-4abe-b0a1-181294470358)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a9e2f887-2ba4-4afc-a553-71918adefe20)(content(Whitespace\" \
+         \"))))(Tile((id \
+         88af7e94-1ab8-4633-b813-abf889f829a0)(label(age))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4c080279-8925-4836-a04d-a61d97ead1ef)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b749cb4c-1229-4a82-9d32-dca11b46bf2c)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         33127704-2ef8-4455-b98e-26ef812de02b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3a90ebdd-8ab6-43a9-8931-51dd28c8e7a3)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         abf1b0dd-6eb7-421f-9f55-fa2e46c39f12)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7c68dc21-bc6c-4a92-8b3e-82fe00d9563e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         900c41a7-323b-46ff-9e5b-dfa3ad181e21)(label(quiz1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6bebbf3e-00c1-4c97-a1ce-3c3c2a9674c0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6f874299-e49d-4b03-b3f8-1866974bb3e0)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         853e31b7-94e1-4eb2-921f-c3349eff4feb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f93083e8-7171-4ca9-b1d4-afe2d494f477)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         d7429d43-2215-48a7-b66a-dfd30c6e9a59)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         aed1a969-dc1c-4f17-ab09-724fed8a64a5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         834ac811-972e-42e3-a1be-36e9fc91f3e1)(label(quiz2))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a342dec1-6892-496c-b94f-fbd164a861ab)(content(Whitespace\" \
+         \"))))(Tile((id \
+         abf186b7-dde7-4908-a278-299ae9c84733)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d2652543-ac91-41c8-a76c-a9d212857f7d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0205b711-a1d2-4ddb-a9e0-9214991782a5)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         4023406e-e336-4bc6-8057-28a97aeb232f)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d399943a-28da-4c7b-b0e7-30be561d2c9f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e4ff0e7c-77ef-4133-8d71-a6041eb47faf)(label(midterm))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         15b6aaf7-bed0-472d-9771-78f5226bd796)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f9dac4b9-a71f-4401-bb7d-fdd3e1b8cb39)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cb62c8d0-96e3-45e8-a643-b7116a1ea988)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f73579ad-d54c-45ec-8678-8454af9d344e)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         05e02d3a-0a52-4a6a-a50b-0a291c74c1e0)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d5e2320e-6606-4e64-b0a3-54bb3ad5fdeb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         902bfae0-cc70-430f-8194-3e00944b2270)(label(quiz3))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         353f1e4f-eda9-42d9-aced-813e0688b40a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0057045f-be50-4a6e-8557-e8ddd3911304)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         63d1d566-e8da-49fd-935b-3e468787c3f6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aa95e717-9e71-46e6-82d1-93bf7af9dbc9)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         b89292ac-9711-48d4-86e2-4a463c3d4cb9)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         291fa73c-53fa-4be4-847d-79406f357f56)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4ef27089-af28-4724-a668-92dc03816478)(label(quiz4))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         647dfbc1-769d-45c5-89e4-558f6058bbdd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b7b3fa1e-3af5-448a-86e7-945878ac5414)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1f591583-9cc1-40dd-b048-fb6a6ae21e00)(content(Whitespace\" \
+         \"))))(Tile((id \
+         76fbe3ee-5b92-4966-9bb0-fc2ce3983bce)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         9b811e26-4249-4daf-955f-e15e9b416919)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8977bd3f-73de-428f-a094-d3cbc0b3709e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e3b8ec68-eaa5-4cc0-8a5d-e2fa93716b2a)(label(final))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8c0e67e2-5100-4c19-9fc6-2ee48ab9de43)(content(Whitespace\" \
+         \"))))(Tile((id \
+         83d2ed40-1510-4653-afb3-6d90000c64a3)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0f8cacaf-cb87-470b-b4d3-e34a2ad93573)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b2770503-57f1-4489-bf4c-d940b19fda78)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         72e1d595-140a-4760-9771-a9e58876bb61)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         273761e8-2326-4a09-a3df-3a7c0f2d3d56)(content(Whitespace\"\\n\"))))(Tile((id \
+         586bb643-8b43-4c7b-b0b7-33e46afb2bab)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         316f521d-ee73-4364-93b5-e0947b947d34)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7028aeef-a00c-498f-8eae-8914dec4b545)(label(gradebook))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cf2ef397-70f0-4856-9fcc-35dbd0aeb370)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b2a1a445-cf67-43b4-ad79-07b67fa35d43)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e0bdb89d-ba8b-4792-9dbc-46f5a4391ef4)(content(Whitespace\" \
+         \"))))(Tile((id bac835ac-410b-4310-9c1f-8baf1bacee11)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         ad6008f1-6c0f-495d-833c-09b31c1729ac)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         07b148f9-e4e4-45da-9c1f-f962e7b930be)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         9985c78a-d718-4646-b50d-8bfa0a026c1d)(content(Whitespace\" \
+         \"))))(Tile((id dddd6596-0806-463d-92a0-c8c7aa8f264a)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         27fa058f-f964-44a3-9e6f-41aece8a52ad)(content(Whitespace\"\\n\"))))(Tile((id \
+         afd8e278-2b9c-43f5-95b9-470498962345)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         4ae0bbe0-7b26-460e-aaaf-6017bfe22956)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9d41a38f-9804-442c-b4a0-899f294fb48c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         65af67f0-38b1-4a58-8d49-c98408d1fe8e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         50fc8a1f-dee5-4eba-a940-f2a7750fa6cd)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a3a14171-977b-4e9e-ad74-252e78598315)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d011c7d5-306b-4478-808f-9a4359011131)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e2f28d17-9663-47fa-92f0-8acd7dbe08b2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6f830b5f-5fca-42f5-9ab1-fba40836c988)(content(Whitespace\" \
+         \"))))(Tile((id \
+         93dbfcfa-5fc8-4d6b-a71b-6732ed08538f)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fda99dfe-9eee-4b52-818b-638acf4e2bc1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cd4733b5-35d3-418f-aed9-bbeb15fe06c9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cb9dc5e9-21ee-4c01-abab-320766240820)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         01cb6413-25af-455e-a6f5-d383fd4354f7)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1a8334c7-ded0-43b7-a600-c6754e45ebcb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8acf338c-8651-47ae-ba81-718f41f398a7)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fb42cb9a-c9cc-4c86-9b88-18284270382e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e5cb2be9-a707-4fac-a3d8-df0ba3f6bde6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9d84155d-2867-4d07-a80f-3f49607eb443)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1ca5eacc-28a2-4b7a-b2f5-117e714c7b44)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         af9d7d7c-456a-49fd-8888-5963c174c835)(content(Whitespace\" \
+         \"))))(Tile((id \
+         984ab31c-647d-4364-82d6-bdeabc5c2e6d)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a765167b-06a8-41ba-8fed-b02f00b1fdda)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6d1db98d-e274-460a-ba04-2eb111484930)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5600812b-a3e3-4b58-b266-e3530026d4ad)(label(87))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         b8c75296-5b95-423c-b413-f734e25d1975)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b024baa5-db12-4ec5-8c79-f71e4ce39f1c)(content(Whitespace\"\\n\"))))(Tile((id \
+         2dd33822-331e-45d1-924e-0be4f704a67f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         dc96957b-d4be-4f04-a997-49ed669920b8)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e4b29577-7d63-4c28-8503-bd2430d2a85b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3694192e-e497-4f74-ad98-48ac98ed6c7a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9661fceb-7fd8-46c7-b838-4ff499ac29af)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         68beffcf-c09a-4b98-a969-471d32c3d655)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b9f395fd-b0e5-4a52-bff3-aea8fe8f1bf9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         42e8f183-60d1-4545-a996-1e71b8c8d155)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         be2a1b74-92e7-4b0f-a4a3-e27329db9e17)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e349e4a8-161e-49b2-8aa1-3165057ed795)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f17e0efa-4cbb-484f-b05d-cffe1053684d)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1c3adbd3-d275-4c54-96d2-75aa7e4e4da7)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3e49c49f-ff4f-4e7e-b924-fbf2a2bc51a3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ac1c5bc1-e358-48e9-a903-98eda1310cef)(label(88))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         218615c4-0c35-47f2-a3a3-a7cb59d2dd39)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ef88007f-ee2a-4e1e-95e4-95a9804a1140)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d68032c5-7a8c-4c06-b76e-e18d0d3de5e1)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5d4db874-81ee-478c-b853-739f47643da3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         09a24073-07fc-43c9-abc7-65f45df119c3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2de40afa-98ce-4d7b-b3e7-f22d4544ed7a)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         669af9bb-e630-4ee9-8262-4944856523d6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a0e6c66d-d576-4383-a0fb-723e44498bfc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d8584013-addd-4b86-89be-0c672648dbf0)(label(85))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         a87fb192-a4ab-45c9-9b13-a0e435a3622a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         edc03b52-4203-403a-9de9-e81ddb273894)(content(Whitespace\"\\n\"))))(Tile((id \
+         85cd216a-90b4-45cc-8b36-c951535bdf28)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         2d42310b-fbc4-460a-9549-b918806473ec)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5d68a211-e3e3-427c-abb4-bca47f1530ca)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         53679aa9-2240-4d4e-ab2d-1732143cf3fd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a2bc82a1-afa2-4c6b-8b17-861712b2f7a3)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ac3dfda2-3135-4620-9a56-c4fe339229d8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         aa8e22f4-6808-45d8-bcf7-a163f7795acf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7c05e5d2-0e50-443f-9ac7-b26da5867660)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         eaa14ade-06d3-4ffa-b28c-accc15bdb5f5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6201d235-a74c-4348-a60b-2cde175b3ed0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8729f65f-a921-4cc3-85e6-6c5b4a006006)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         33355093-6183-4b14-bd00-d672740417b2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         487b5b22-41e5-405f-98e4-6415919ccb6a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         878081ce-d164-43b8-aaa1-3d0425d7d89e)(label(84))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ae4e0ae8-256a-4693-a3f3-1576530c2316)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2f7392ec-007b-4f58-82ea-85bf5f7c6909)(content(Whitespace\" \
+         \"))))(Tile((id \
+         36855f1f-8714-4da2-bb11-b5053e25bd1a)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         06b09d1c-d18e-4610-b878-40022f7321bb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d1accc8c-e95f-49c1-b068-3a76f0c93266)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1e35a62f-e823-418d-bf69-8326d2d3c08d)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cc82d07d-49ab-4c43-ab74-ab4ae24ee5d7)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1f2080f8-1a0e-4239-9cbd-7e4cbfffd3fc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         987450f9-8073-4c95-80d7-6647700bb307)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         8d6cf387-ee3b-40de-961d-fef575e35b2c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         cfc6c006-8868-40c5-b275-6f426def4dc7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         cb88c841-4714-4660-86b0-bec5aebb149f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         150c8066-c454-40da-af57-0c81ac4c6814)(content(Whitespace\"\\n\"))))(Tile((id \
+         ee3fc33f-46a4-4fa5-8f6e-ee3cc053cb25)(label(group_by_retentive))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1ef77ca5-579e-453d-af55-3623c3762aa2)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         54a646b2-e163-4745-99de-ae08996c7c53)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a3e699cf-5235-4c56-93c8-f46ad35a734f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f2e467fb-fb8b-41be-b8ba-97d9f9343fcf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5a85c4ed-e4cd-460f-81a0-0f8a63c357bd)(label(\"\\\"name\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))";
       backup_text =
-        "let get_value =\n\
-         fun (r:?,label:String) ->\n\
-         find(to_lvs(r),fun e ->e.label ==label).value\n\
-         in\n\
-         let add_rows = typfun row ->  fun (r :row, rs : [row]) -> rs @ [r]  in\n\
-         let add_col = fun (t : [?], c : String, vs: [?]) ->\n\
-         zip(t, vs)\n\
-         |> map(_, fun (r, v) -> from_lvs(to_lvs(r) @ [(c, v)])) in\n\
-         let remove_duplicates =\n\
-         fun (xs:[?]) ->\n\
-         fold_left(xs,\n\
-         fun (seen,x) ->\n\
-         if mem(seen,x) then seen else seen @ [x],\n\
-         []) \n\
-         in\n\
-         let build_col = fun (t :[?], c :String, f : ? -> ?) ->\n\
-         map(t,fun (r) ->from_lvs(to_lvs(r) @[(c,f(r))])) in\n\
-         let empty_table : [()]= [] in\n\
-         let table_of_column = fun c,vs ->\n\
+        "let get_value = fun (r : ?, label : String) -> find(to_lvs(r),fun e \
+         ->e.label ==label).value in\n\
+         let add_rows = typfun row -> fun (r : row, rs : [row]) -> rs @ [r] in\n\
+         let add_col = fun (t : [?], c : String, vs : [?]) -> zip(t, vs) |> \
+         map(_, fun (r, v) -> from_lvs(to_lvs(r) @ [(c, v)])) in\n\
+         let remove_duplicates = fun (xs : [?]) -> fold_left(xs, fun (seen, x) \
+         -> if mem(seen, x) then seen else seen @ [x], []) in\n\
+         let build_col = fun (t : [?], c : String, f : ? -> ?) -> map(t, fun \
+         (r) -> from_lvs(to_lvs(r) @ [(c, f(r))])) in\n\
+         let empty_table : [()] = [] in\n\
+         let table_of_column =\n\
+         fun c, vs ->\n\
          let t1 = add_rows@<?>(empty_table, map(vs, fun _ -> ())) in\n\
-         add_col(t1,c,vs) in\n\
-         let get_col =   fun (t, c: String) -> map(t, fun r -> to_lvs(r) |> \
-         find(_,fun label=l, value=v -> string_eq(l,c))).value in\n\
-         let group_by_retentive = fun t,c ->\n\
-         let keys = get_col(t,c) |> remove_duplicates |> \
-         table_of_column(\"key\",_) in\n\
-         let make_group = fun kr -> let k = kr.key in filter(t, fun r -> \
-         get_value(r,c) == k) in\n\
-         build_col(keys, \"groups\", make_group)\n\
-        \ in  \n\n\n\
-         type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+         add_col(t1, c, vs) in\n\
+         let get_col = fun (t, c : String) -> map(t, fun r -> to_lvs(r) |> \
+         find(_,fun label=l, value=_v -> (l == c))).value in\n\
+         let group_by_retentive =\n\
+         fun t, c ->\n\
+         let keys = get_col(t, c) |> remove_duplicates |> \
+         table_of_column(\"key\", _) in\n\
+         let make_group =\n\
+         fun kr ->\n\
+         let k = kr.key in\n\
+         filter(t, fun r -> get_value(r, c) == k) in\n\
+         build_col(keys, \"groups\", make_group) in\n\n\
+         type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = [\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-         (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
+         (\"Eve\", 13, 7, 9, 84, 8, 8, 77)\n\
          ] in\n\n\
          group_by_retentive(gradebook, \"name\")";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/example_programs/B2T2ExampleProgramsgroupBySubtractive.ml
+++ b/src/b2t2/slides/example_programs/B2T2ExampleProgramsgroupBySubtractive.ml
@@ -1,1832 +1,1888 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Example Programs / groupBySubtractive",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
-        "((Tile((id bb27291b-3a79-4741-bb5f-410e399ac048)(label(let = \
+        "((Tile((id 6d46525b-7091-4f8d-bcfa-1308c1f42795)(label(let = \
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         fbd81484-7ff2-4c84-a507-7c5c3fbc8eda)(content(Whitespace\" \
+         a792a0d6-1054-4ec0-b389-9fa6aefef8c5)(content(Whitespace\" \
          \"))))(Tile((id \
-         3ee1b192-a650-4e8c-a5c0-c620b23c2f28)(label(get_value))(mold((out \
+         4296853f-611e-4f23-a071-4bef68974dda)(label(get_value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f9522af8-4e7c-4011-8d8b-d1f0e7681530)(content(Whitespace\" \
+         eecf0a88-07d9-425a-9d02-c27eb0f31d05)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c2ac6eb5-7ce1-48b0-b727-70dba42f9ea9)(content(Whitespace\"\\n\"))))(Tile((id \
-         fdcb840e-0965-42e9-8bdb-c9085999f595)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         9ba53924-2b73-485b-9701-045436b51135)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9af9096c-1741-4e60-909b-36b7a440dc9b)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         ca3b5f34-f69c-4b34-af75-ab55d8e0b779)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         3d44dc4d-984c-460f-8fa7-8530dbd1c8ed)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         cd283e26-0757-43f8-a177-6b9df470ae0f)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         bec9ad5c-c53c-462f-980d-6a800f0f75a7)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         10adadaf-d1d9-426c-937a-0b6a3026ac79)(content(Whitespace\" \
-         \"))))(Tile((id \
-         44a8a093-e27b-4ea8-978e-83b239134d13)(label(label))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         41a255d8-d74b-4308-8637-c674c669970f)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         0806b0d4-b42c-4ca5-ae75-66a8c8ac3cb8)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         b6f5720a-958d-4389-81bb-daa32da63e58)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         6463bbd8-4f33-4e2c-b7e9-4800185c22aa)(content(Whitespace\"\\n\"))))(Tile((id \
-         4800c0f3-de6c-4ba4-b808-9cf39ed59011)(label(find))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a261ca24-05c9-4d5c-9724-8fec94d63a34)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         745c19e1-f080-452b-bb59-7aa0385fc241)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         072549e0-81c1-4d08-8618-317414de90cd)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4a3c35dc-d6f0-4900-ae4a-f1fe0f98db47)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         78badc53-e667-4530-926b-22d80df46122)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6a43272a-5d1f-486f-8587-f8de8dda24ed)(content(Whitespace\" \
-         \"))))(Tile((id 3edf3ff5-8157-4cb7-b1ef-6fcf129afef6)(label(fun \
+         1708c8a2-eb09-4419-a0d5-9e08dc3d59ba)(content(Whitespace\" \
+         \"))))(Tile((id 529aba74-90fc-4d15-a17b-5b245330aacc)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a514a4bf-a57f-4bb1-9c6d-e1ecfeb049b5)(content(Whitespace\" \
+         bc49e7b7-9ac1-421d-8621-3052fcb201c0)(content(Whitespace\" \
          \"))))(Tile((id \
-         f7ea0af8-f639-4d45-ba2c-1f9685962405)(label(e))(mold((out \
+         4c8df240-e194-41a1-99fd-7979e934c788)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         54fb7221-2732-433e-8609-ae5148316e13)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         770160e4-5f59-462f-98c6-1295ac0c52b1)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         191d57e8-1479-4eed-8875-570f4ed66e75)(label(e))(mold((out \
+         00177a0f-dc37-4af3-9de3-c1fe96deaeb9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6437eded-6bca-4363-8610-a48cee3f071c)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         90e138ac-a6d7-4e37-a137-1f36df78ed25)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1f4b54b0-d3d7-4d78-adfc-2b417b34294f)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         b9656c3c-d661-4a12-98b2-b3f0deacd747)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         9f2d800d-d9bd-4cb2-b473-9d0ac147b28c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         277e3168-6d35-4575-b5f2-6793c0ac4433)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5b7c931b-3249-42ea-be7a-e52b6e5accf0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4e2dbcd8-41be-4827-999f-fa162a36db4a)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f945227c-d40b-4179-94a9-495a1fb1c638)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0902f47c-add3-40f2-9f69-1f55fc032d89)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         0c1842f1-8c50-400a-af43-ddf9ba7a5897)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         940876cb-5186-4220-a1db-6a4f9038aa1f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b24c996f-78af-405a-9a77-870944c2594f)(label(find))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         df192a29-a48d-4143-926e-6c17149e1645)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a3319dfc-cbbc-41f2-bd5f-6f89df26afdc)(label(label))(mold((out \
+         30fde9c9-2f9d-4d84-bc89-c54480b50928)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         25dec8ba-98b0-4b6f-9183-9ad6a34ef48e)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         a8af94cf-7643-4103-82e4-c497e53f937a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ac81a7e6-b45a-4c26-9808-285e778b68fe)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         00cb6048-caae-4350-aa28-d5f11abf63e2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a8712d98-9875-4e73-b271-043c75b444d9)(label(label))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         be70445a-746f-42ea-ab8b-00642c67cec4)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         22289023-3cc8-4deb-afdb-c257a3b7fb70)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7f4e4ab0-17b7-4317-a220-990b676f45ba)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f8e38358-f7f7-4805-8e20-d039e5b14ead)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         001e1f68-b1a2-476f-b192-e1d364268e3f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ab8a8d8a-ea02-4685-a8d4-c00ce82f9643)(content(Whitespace\"\\n\"))))(Tile((id \
-         f9cfad9d-1943-4ef2-bee0-5d81df026590)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         315566df-89a3-4d54-b152-7377111806fe)(content(Whitespace\" \
+         ba44a15e-1ddb-4ee6-b3c3-6f8718f8757b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3881c3de-0665-41fa-987e-b3065e91454b)(content(Whitespace\" \
+         \"))))(Tile((id 14f48b33-d83b-4e19-a14b-7903c8249e46)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         48ca43aa-a152-4c72-a727-42c413172936)(content(Whitespace\" \
          \"))))(Tile((id \
-         939a49db-c74e-4612-8816-4b8576578d93)(label(add_rows))(mold((out \
+         f57fe111-da61-4cc1-8cb0-da514dcd639c)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         29d658e6-141d-4dd2-95b2-33e3d9f2fe41)(content(Whitespace\" \
+         ee2d476b-1781-4fc8-a324-d1d6fdf371f9)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         1d6c24be-4ff5-47ed-8acc-b268d2a6e495)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c90a371e-39fe-4eae-ab67-3e5510b94606)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         c1c20458-1a2b-43f2-8e99-00140214ebb9)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6bfaa078-2668-4741-9fcf-4c18e4e5affb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3c7d4fdc-dc69-4647-bdbf-3e7c3bb9b58c)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         36d25323-8598-40b2-989c-0791bf73c0ad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         54587a26-a2e5-406a-b8bd-9c790ccef832)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         e517621a-a0af-40c4-bacb-941f501d790e)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         c95a9f60-a6cd-4ed2-a14c-4c30c7e2d42e)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2e2b4baf-5686-4e5d-adba-12bf4b5dc8f9)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         0b7c4456-3aae-4296-8410-d5ddb2865391)(content(Whitespace\"\\n\"))))(Tile((id \
+         01dee4b4-8bc1-4791-8e27-49686cb2b84d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         100eb1fe-6100-4c0a-8ba9-e826cf00e9fc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b6ca02c7-20ab-4da3-96f7-55cadf5ecb5e)(label(add_rows))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         09415240-f370-4a98-8ba8-3243d3501aea)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f78dbb0b-7bca-4c53-bebc-c3c6408a655e)(content(Whitespace\" \
-         \"))))(Tile((id 31685e53-8bab-4439-b619-8d39ac769465)(label(typfun \
+         6c4f056c-7703-4a5f-9c9d-7796c37d3397)(content(Whitespace\" \
+         \"))))(Tile((id 8329bc73-8359-4ca7-a8e8-3f7ca6a3c536)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         eade4470-f51c-4f3d-9a7c-b7f323aace6f)(content(Whitespace\" \
+         37d0cb3b-9704-4ce4-b8bd-ec288af1300b)(content(Whitespace\" \
          \"))))(Tile((id \
-         619a7377-b93c-4784-9a6b-c21701a379d5)(label(row))(mold((out \
+         354cd3f7-4007-4299-8ba2-4689071a42f5)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         53a1e05c-71fd-4388-8405-a6fb9bac39a8)(content(Whitespace\" \
+         f214297e-5de7-420f-9ff0-97f696756145)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2fad92e3-1d8a-4b8b-a4ad-01892255d4aa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         11b45e23-f800-4a92-88c7-f3ea235d51ef)(content(Whitespace\" \
-         \"))))(Tile((id 76ebd12f-1a9b-4349-b36e-47353dcb069b)(label(fun \
+         244e3dc2-9e3b-423f-a8a1-392e16a50574)(content(Whitespace\" \
+         \"))))(Tile((id 71b63857-dac4-4097-8868-2221784c7d4f)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         9bf05aed-fc1b-4629-8e5c-6470490602dc)(content(Whitespace\" \
+         2519ddff-a276-4624-a674-913851990913)(content(Whitespace\" \
          \"))))(Tile((id \
-         cceb92b9-dea1-4acb-b63f-aa23e05cd37a)(label(\"(\"\")\"))(mold((out \
+         3bd3e417-e651-48a3-9ae7-4dd2eba0f414)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         e5e5ab35-ce81-4e98-b4eb-7c9936d76210)(label(r))(mold((out \
+         bfe24945-0db8-4cb3-9046-75df4ab84312)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         63499197-0031-45c0-a04a-52c0fdc64b44)(content(Whitespace\" \
+         6b598a01-69ed-41a1-9930-61fa10f0cfba)(content(Whitespace\" \
          \"))))(Tile((id \
-         543fee8e-f62e-4d36-8f26-091bd5b4e524)(label(:))(mold((out \
+         d2bcdfb3-54dd-4258-9a49-3523e96925d8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8f89e254-93af-4515-af84-b9080287cb45)(content(Whitespace\" \
+         62e53ab8-f922-4341-9ae0-43f8f2e9afe9)(content(Whitespace\" \
          \"))))(Tile((id \
-         b16f6e33-5074-48d4-8b15-0cc2955d0245)(label(row))(mold((out \
+         f54f342f-e6e5-4f45-a157-8e054920af18)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         19fddbc4-e3b3-4683-be46-49f03397781f)(label(,))(mold((out \
+         b179e52c-ee07-4a61-b625-1df0d488812f)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         45d4167c-2d4c-48f1-8021-d7d9da7575e0)(content(Whitespace\" \
+         0f1fbd8c-b4ce-44a7-961e-a73ccdbdf0e7)(content(Whitespace\" \
          \"))))(Tile((id \
-         12affef8-9819-4227-9151-12079444597f)(label(rs))(mold((out \
+         5e3c3e08-defc-4f6f-8cf4-a99105a9f98d)(label(rs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b7950db0-35f4-4814-9cf8-ae7e3b47ea8f)(content(Whitespace\" \
+         30a980b9-3176-47a3-a87b-32719afbac28)(content(Whitespace\" \
          \"))))(Tile((id \
-         e4596a47-5e82-4cd6-885f-058cd8052c64)(label(:))(mold((out \
+         253255a5-c164-4101-af2b-6bb40ecdc435)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7d600744-2f78-4625-a973-1d74807cc4e3)(content(Whitespace\" \
-         \"))))(Tile((id 6e55e96c-0a10-4472-bff5-33557d5e50c4)(label([ \
+         84f7ebda-09dc-4f26-a957-3242a1243d91)(content(Whitespace\" \
+         \"))))(Tile((id dd859b58-d63e-4afd-942f-54028300389d)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         922e9f66-2401-4efa-acf8-21df116e690d)(label(row))(mold((out \
+         c55b2aa5-e09c-404b-abc3-f975f3853e19)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         938d3e18-06bb-40a9-919c-d31e99a2578b)(content(Whitespace\" \
+         44569de0-73a5-4508-9b20-ba762e5ac1f3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         da1ddecf-a7ad-4ee4-8a4f-4d71c16b82dd)(content(Whitespace\" \
+         6bbc4249-a37d-4653-bb07-777254fe3a2d)(content(Whitespace\" \
          \"))))(Tile((id \
-         6ff27d6d-36fb-4189-bccb-599ea55fbe07)(label(rs))(mold((out \
+         60181810-cddd-4a54-8a46-74e7d9131be9)(label(rs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         68eee7ba-9815-4edd-a0fd-a451ee598448)(content(Whitespace\" \
+         e86c8f1d-9da2-49d1-9562-a0c449686138)(content(Whitespace\" \
          \"))))(Tile((id \
-         8fbfecbd-c310-4c61-b47f-9c034c42b6ed)(label(@))(mold((out \
+         7f234f4e-1f92-4cc6-81be-e3944007cbc8)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         23050bc3-4bfb-40b8-beb6-31d1994b4a4f)(content(Whitespace\" \
-         \"))))(Tile((id decd5c6a-3d00-4f72-8e20-c1f6426fc5db)(label([ \
+         f2d2a47c-63d4-48bd-a576-6303ef267896)(content(Whitespace\" \
+         \"))))(Tile((id 23ec4f9a-53ef-46be-ac53-72a4c7abd9b8)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         27a33498-5dd5-48b6-adca-37e533712fde)(label(r))(mold((out \
+         9c1de61c-8003-4ba5-999e-76251993fa60)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         96567a25-c434-49bc-94e3-9a224bc3c3d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         127e0cd3-8102-4c5e-a28b-36ec4f1a387c)(content(Whitespace\" \
+         0ccebbdc-1816-4d14-bdaa-6249b84fdb5f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7c851f2f-4045-493f-99ab-4f1d0c3268e6)(content(Whitespace\"\\n\"))))(Tile((id \
-         5487e75b-e624-407b-818c-5e81e8e5b194)(label(let = in))(mold((out \
+         d3ad4840-e4f4-41ea-9054-4e8a39760c87)(content(Whitespace\"\\n\"))))(Tile((id \
+         4cf98a23-5d55-4375-8908-bc63b5b4f070)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         74b6f04e-ece0-436c-aac1-eb04ab434f8d)(content(Whitespace\" \
+         905d59a8-a6c2-4b59-9909-66ca87da01d1)(content(Whitespace\" \
          \"))))(Tile((id \
-         44cd9459-d55f-4b46-94a3-afc7349e2182)(label(add_col))(mold((out \
+         35f80b49-c36b-40f3-a5e6-14bd29986081)(label(add_col))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         51278870-763a-4057-b4a9-026580976532)(content(Whitespace\" \
+         6d6920cc-b093-430f-9fec-5cb3799672a5)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4f8453c4-fc03-43d4-a690-1174bfdc47dc)(content(Whitespace\" \
-         \"))))(Tile((id 66a00458-8038-4e98-b139-0bdef031b82e)(label(fun \
+         49f761a3-a79c-4c5e-9fb8-e1c8818bffe6)(content(Whitespace\" \
+         \"))))(Tile((id 4a22b6e9-9445-4253-bfcf-9c422b6cced4)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         7929126a-47a1-4eac-b18b-a90438a9b664)(content(Whitespace\" \
+         60c02469-899e-468a-830a-60f7300766d9)(content(Whitespace\" \
          \"))))(Tile((id \
-         03753175-4267-4e3d-93c3-c18078c94be7)(label(\"(\"\")\"))(mold((out \
+         f5aa4b80-c9dd-4c10-868d-699e5ca53b0d)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         8af5a518-7d85-4272-8e04-fda8a8bc70c1)(label(t))(mold((out \
+         f84a4eb3-2bb9-4a49-b457-48118a6f836b)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5786a257-b585-4100-9954-ba9e9ab4d8ef)(content(Whitespace\" \
+         65e70faf-06fa-4aec-ab26-6d954941d05e)(content(Whitespace\" \
          \"))))(Tile((id \
-         e545f1b9-f806-46c6-a1d1-65012d596e54)(label(:))(mold((out \
+         11d89674-6383-4ce5-86bf-695d36dbb42b)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8cefdc7e-675e-49e0-80d7-267aec4ea030)(content(Whitespace\" \
-         \"))))(Tile((id d91b2e8b-ec46-48e7-9185-1f5762c27253)(label([ \
+         51cdb319-97c8-422a-8a80-a566723471cb)(content(Whitespace\" \
+         \"))))(Tile((id b8607f44-a36c-4a45-b42d-673613905c67)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         e094f953-674f-46e2-baee-ca73a94bb2d7)(label(?))(mold((out \
+         57891838-2f86-4d07-94a3-435179fbea3a)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         0737fce0-b518-4078-8517-4c6c22159993)(label(,))(mold((out \
+         60226783-1f3a-4b32-a003-47228a15e623)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f87c0d40-0427-4eea-9f03-ab4e394c988e)(content(Whitespace\" \
+         7eaffaae-ce1e-440d-ba7c-bdd07d2970e7)(content(Whitespace\" \
          \"))))(Tile((id \
-         bf4ce7bd-a81f-4a8d-a6a1-ac6f993c293f)(label(c))(mold((out \
+         dac1c268-b657-4d2a-854e-e05ec82cd179)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5aaf0d2f-3b43-424c-881c-2d59e341d97f)(content(Whitespace\" \
+         c3e592c4-c6c3-41b3-bf09-77fd0b38a740)(content(Whitespace\" \
          \"))))(Tile((id \
-         9fc1c0c0-9938-4712-993b-3e4aad205602)(label(:))(mold((out \
+         e9d7a399-5ff5-4190-ba5f-2f4e836bd8ba)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2e3caac7-ef13-4cb0-9dbf-8c565133a37a)(content(Whitespace\" \
+         21aef456-1e01-432e-87be-e70134e7d463)(content(Whitespace\" \
          \"))))(Tile((id \
-         e455b7fe-b464-42b4-b6b1-74f0bb7367f0)(label(String))(mold((out \
+         c53a11d7-e145-4af8-98c4-1ae252f2c0e6)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         eec0a69a-3d3b-4a00-9e3e-0c71d83c2237)(label(,))(mold((out \
+         fd6ec4c2-8b6e-4cde-a17b-162f284588af)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         1f3f2440-2630-485e-915a-5c414866229c)(content(Whitespace\" \
+         450fdf77-fc9c-41b1-afa0-5e00122d0481)(content(Whitespace\" \
          \"))))(Tile((id \
-         f884232d-4f93-4180-bb2c-993a69943da8)(label(vs))(mold((out \
+         74f408ce-e691-4972-a51a-4c8716e28fed)(label(vs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         b32676d7-0823-4818-b636-01677daf8827)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f8f643c7-a6cc-4f78-976f-035fe419e994)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5971b0fb-01ec-48f4-89bc-8b37210658ea)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4dd32665-f614-48e1-88da-7fc6bca4f582)(content(Whitespace\" \
-         \"))))(Tile((id 17237def-0933-4eee-9b79-e6ddba4afb0e)(label([ \
+         340d0013-1a2d-4e49-afde-404a0fffeea8)(content(Whitespace\" \
+         \"))))(Tile((id f69aa41c-58da-4e8e-a3e9-c38661e93df6)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         86542c50-8dcc-4cb6-a2cd-d250a15bef42)(label(?))(mold((out \
+         84af2fe0-b75c-4213-83e4-82b3e9c2d386)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         a56bbc2a-90fb-4a97-a904-cc6b3fb9a8f6)(content(Whitespace\" \
+         60001a30-51b5-4685-ad74-585a39f88cca)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7b9b0bdc-0c95-4358-a04c-092f6ed77f2b)(content(Whitespace\"\\n\"))))(Tile((id \
-         6ac9f9a2-40da-495d-8102-2077a2f0fd92)(label(zip))(mold((out \
+         db2425a5-3545-49ac-8cc5-23812c8fe9b3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bb7a2ca5-bf68-4001-90a5-82c2f9784f20)(label(zip))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e59b8647-ca13-4235-9922-d7d81bd36699)(label(\"(\"\")\"))(mold((out \
+         5cbf75ba-428d-4854-b3d2-7c919213ecb1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         67fc4d28-448b-4880-a644-07afa84a092a)(label(t))(mold((out \
+         cf22e3c8-c98c-48f9-80ba-59b89e150354)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         46912f35-3ef4-42fb-a7e2-f7177d3d78a4)(label(,))(mold((out \
+         6522aa78-cc6b-47e7-8d4a-d16d60bb7485)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d587848f-0d24-4a87-b6ad-17e3cc6efae5)(content(Whitespace\" \
+         c9c66ec0-10ef-4494-856d-e7da065a7100)(content(Whitespace\" \
          \"))))(Tile((id \
-         0c5490ed-08e2-4029-8fbd-e3f9f4115f7a)(label(vs))(mold((out \
+         0401fd54-98ef-4651-b8fc-7912cc802487)(label(vs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         45471a1f-f13f-4a80-a43d-791432f490e5)(content(Whitespace\"\\n\"))))(Tile((id \
-         f75e89f0-1290-4d60-a6b7-c60676ad8fce)(label(|>))(mold((out \
+         495f36fe-f19b-4774-983b-c820d175159d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5ed77953-45f2-41c2-9665-043c29dee8d6)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         09f71a61-0e80-4a64-8631-ae1099d98593)(content(Whitespace\" \
+         8674a57e-3c3e-4157-ac0c-79f5bebbda08)(content(Whitespace\" \
          \"))))(Tile((id \
-         c188c6c0-73ea-485e-8e14-a1523ed6f94c)(label(map))(mold((out \
+         464136fe-f3bd-49e0-b8fe-ae4beded0365)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         bc6a04a3-2061-45f5-adb1-0fdc51ec633d)(label(\"(\"\")\"))(mold((out \
+         1d02796d-5a89-4abb-8119-53ea8505843c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f00e4ed6-c684-45a3-afa2-5f0836b0e6a0)(label(_))(mold((out \
+         35675ca9-bf91-4cef-bb6e-35328e7e41cd)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         741dca03-0777-4523-9035-9e263abd8ce9)(label(,))(mold((out \
+         a455b8b2-e9b2-4840-a4f1-bfe23ca2ac52)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1476aed2-4811-43b4-a813-b4b420118519)(content(Whitespace\" \
-         \"))))(Tile((id e196548c-3664-4963-83fb-4492afa4dce4)(label(fun \
+         d2f15a8c-0eac-4ef0-9d52-58a3f07331b9)(content(Whitespace\" \
+         \"))))(Tile((id 835cb3c4-cbfa-45ac-8d71-689ac6d53ce0)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         7d0b3dff-ec60-484d-b314-3b963cbb5d40)(content(Whitespace\" \
+         ac74423b-16c0-4fbb-90fc-97010f86827c)(content(Whitespace\" \
          \"))))(Tile((id \
-         49c735fb-fc89-473e-96bd-1a12214580ba)(label(\"(\"\")\"))(mold((out \
+         a69b0c63-fc71-41bc-9de8-80254d0e7bd0)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         32caf1ed-8290-46af-9f30-47c9b9f0a748)(label(r))(mold((out \
+         3cd13416-0f76-4629-b482-e4fdf6d85b3e)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         b80ebff4-964e-49a4-8dc9-285348d72ed0)(label(,))(mold((out \
+         757dc4eb-7f67-4187-97ef-5cf0726bbd7b)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         4108e59b-76fb-4ab0-a34a-2ae3ba0fed59)(content(Whitespace\" \
+         253a726b-a7dd-4101-aef2-d9e083f1d7b3)(content(Whitespace\" \
          \"))))(Tile((id \
-         6d7677a9-daaa-46b5-a439-e2652f8b19fd)(label(v))(mold((out \
+         cbb525a6-8bf6-4780-a258-39f061e3087f)(label(v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         fb15036d-0683-4299-affb-1765ad0c6833)(content(Whitespace\" \
+         b1aab970-d200-474d-8df4-57a5c6ff829b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         dc47aa76-7a35-4fba-8924-e379cd27d8c8)(content(Whitespace\" \
+         c6667727-40c9-4212-96d1-cb8918bab6dc)(content(Whitespace\" \
          \"))))(Tile((id \
-         2931ad1c-1a3e-4b71-aa7e-f40012421665)(label(from_lvs))(mold((out \
+         10455525-7fa2-4c16-acdf-e615713db342)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4f29d0cf-13c8-4e5c-bb07-e98979bdc7ff)(label(\"(\"\")\"))(mold((out \
+         5a89e317-b011-433f-af0b-4dd4e3929a17)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6bd09353-007c-4377-8e89-85fe6ec7823a)(label(to_lvs))(mold((out \
+         9801a954-2eff-4df4-9994-9d8671f62793)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         72ad8b55-6b75-4cfa-9bc7-d07bdb6ba3e5)(label(\"(\"\")\"))(mold((out \
+         3b859e09-a058-4e4f-9c3c-5e265a51d6c3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         ed55d950-2d80-4d9b-9568-356c4c2a1c2d)(label(r))(mold((out \
+         4eaceb09-3afe-4691-a01d-7bec0754e217)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         28932d87-ba33-44da-9f9f-c90eab03e85d)(content(Whitespace\" \
+         7ad6d2e1-8134-4df1-a198-3ebd700c97fd)(content(Whitespace\" \
          \"))))(Tile((id \
-         bf3baa6d-9f48-4017-abd4-5377e28feccc)(label(@))(mold((out \
+         1c494ef6-ec9f-4895-9dda-ea5a11827065)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         95ef8909-b93b-4a49-9bf3-1e7929e5ce5b)(content(Whitespace\" \
-         \"))))(Tile((id 8e6740cb-867e-402c-b84f-59ab0df5c86c)(label([ \
+         06f633cf-1016-4f65-901b-66d74102f027)(content(Whitespace\" \
+         \"))))(Tile((id a8aa4111-93ed-4f5c-a938-45c4544bbf27)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         655c8352-9cbd-4cb7-8344-9f0594a4a87c)(label(\"(\"\")\"))(mold((out \
+         c65a74c1-3e46-4b81-8377-f913f45c1247)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         62d8ea15-8332-482a-be36-02ecc99e4191)(label(c))(mold((out \
+         4da162e5-4c32-4c24-9f3e-32023e692dd0)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d25300a4-0114-49e0-bf5f-5039f5e0f7df)(label(,))(mold((out \
+         8e251225-1ace-423b-8e8e-c7133608e526)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1182d8a1-e2ca-41dc-a1ab-67f95694339e)(content(Whitespace\" \
+         2b2e0805-f74a-45a9-bb47-793a35d8232e)(content(Whitespace\" \
          \"))))(Tile((id \
-         dfdd9b0c-cf2e-4a30-ae52-96aac056bcdc)(label(v))(mold((out \
+         d1d91ac4-dd9f-4efd-8da3-d6d6a4b4329a)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         7b7bfdae-e6e9-4a52-963e-d5ca0ab2d1ab)(content(Whitespace\" \
+         00f767eb-2ea4-48a3-935e-098239bab074)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         41cd397e-dab7-4074-956e-d8eaf880f4ae)(content(Whitespace\"\\n\"))))(Tile((id \
-         3ed2cb29-a938-4ed4-846e-0d80d3fe274a)(label(let = in))(mold((out \
+         d80e42b8-5b30-47d0-a6c6-31422c95be2a)(content(Whitespace\"\\n\"))))(Tile((id \
+         f481c79e-12d7-4a81-84cd-fb50380ce878)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         dd3b255f-5c15-44bd-8a4a-04c2655d6abf)(content(Whitespace\" \
+         5f40f3e4-80f3-4527-8375-f10b0e27deca)(content(Whitespace\" \
          \"))))(Tile((id \
-         0daadccf-cad1-4f18-8a01-2253385f9191)(label(remove_duplicates))(mold((out \
+         f3c8754b-6df3-4f91-9e13-769a5cecd626)(label(remove_duplicates))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7a671ee7-9e52-4776-81f8-2c7818a8bd92)(content(Whitespace\" \
+         029ac40f-a2a3-4178-8db6-7a187a90adfb)(content(Whitespace\" \
          \")))))((Secondary((id \
-         059f8d89-f12f-4ee5-90bd-8dd51b6dc2d2)(content(Whitespace\"\\n\"))))(Tile((id \
-         6f6f9678-ec7e-49c9-a63e-60b72cecff39)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         d884ee75-10eb-4d0a-9b01-2541f3f77521)(content(Whitespace\" \
+         c0e121b5-0058-42e9-a472-ba7a3490fb42)(content(Whitespace\" \
+         \"))))(Tile((id eb72f0a1-978e-4015-aac2-1fefff751844)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         cff9da3c-d24d-4967-bd78-c0133ef9ee59)(content(Whitespace\" \
          \"))))(Tile((id \
-         d5220564-19f0-4b3e-bf7e-4638b2a9cbd2)(label(\"(\"\")\"))(mold((out \
+         a4bfe587-bbf6-4af0-bff4-d9b884ae1478)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         4387f5ff-fd94-4d39-bfe8-09993a8b6681)(label(xs))(mold((out \
+         643f15a9-09e2-44d9-b1ee-f65cac227eb9)(label(xs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         12e44386-26ff-4c6a-a4df-b8903e353739)(content(Whitespace\" \
+         f0bf11b1-1679-43c2-9d5d-b6786119176d)(content(Whitespace\" \
          \"))))(Tile((id \
-         2aa1446e-af38-4cb9-8bbe-47a1b1be2f4b)(label(:))(mold((out \
+         d8d2debd-0f3a-4639-adec-c92bc6ef14f8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         55db5ee8-0645-4a21-9ec2-4758411b25cb)(content(Whitespace\" \
-         \"))))(Tile((id ed6de8fc-fc6c-40d2-866c-b010c745c3fc)(label([ \
+         b03d7bb9-0237-45b5-8b2b-da485a2db718)(content(Whitespace\" \
+         \"))))(Tile((id 965eaae5-2a2e-4b43-94a1-b069200421d8)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         21e8b719-3a05-4fe1-8422-46a9b8ee8ee0)(label(?))(mold((out \
+         bcfd0fe3-3bc6-4439-a679-c9634baa679f)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         144280ef-3293-4d8f-8562-d44629d6fe10)(content(Whitespace\" \
+         487fce1d-62d2-4e0e-9ae4-4ebd94833ed4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2ad62d37-9617-4fbf-a914-be6ca751cdf3)(content(Whitespace\"\\n\"))))(Tile((id \
-         d783f921-8fb9-461e-b101-61704a091a5f)(label(fold_left))(mold((out \
+         f53f4ac5-e15b-47ec-98ec-d1b31050e1f5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6461a4aa-e598-435c-93b0-bb96333c9c50)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a181e78e-eaf9-4b76-bc7d-4c4ebe714752)(label(\"(\"\")\"))(mold((out \
+         15bf7bbf-bca1-4167-9b11-77d55497a8e3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         991bc802-b419-48e0-a253-bd7bf997c87c)(label(xs))(mold((out \
+         49af84b7-4c21-4bc9-b3bd-3e9b5e9dd1c1)(label(xs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f25551f8-24bd-4de0-96a5-463a70134f4b)(label(,))(mold((out \
+         f4a21a5b-0114-4371-a9e6-f9ba988a1835)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e342b3cf-e29d-4442-939e-d2c085552dbb)(content(Whitespace\"\\n\"))))(Tile((id \
-         0145900c-a5bb-4287-9f2f-8af1f086e5de)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         fd8d2fa3-9643-4d12-8a49-37327c166c2c)(content(Whitespace\" \
+         ce246b74-e278-4873-a4f3-0e7b2b728b61)(content(Whitespace\" \
+         \"))))(Tile((id e5def340-0e46-4c6b-9562-30d04d94e4b3)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         d42c6d7d-2e3d-4855-8513-959d516c2ca7)(content(Whitespace\" \
          \"))))(Tile((id \
-         5916280c-c698-484b-a372-cd298707bd49)(label(\"(\"\")\"))(mold((out \
+         b3bf750d-1fec-434c-8598-9ba8de1da2c4)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         595cee6e-c49c-438f-b945-2620ea32cd8e)(label(seen))(mold((out \
+         1432eef9-e80d-4bc8-9db7-6fda8083a1dd)(label(seen))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         fa625b39-d82f-43e2-b036-897837c18481)(label(,))(mold((out \
+         a5335dd4-1bdd-4192-9505-c091b2db4830)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         246397d6-9be4-4c58-9b8d-1d35cb9f89e8)(label(x))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         7b79d972-47ab-49bd-9a9f-6d99a62fdd06)(content(Whitespace\" \
+         \"))))(Tile((id \
+         23de7252-0c0c-422f-8b98-7e672c67b28e)(label(x))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         7958ce38-6165-411c-a203-0879db89fe40)(content(Whitespace\" \
+         c1e2f223-d26d-4d9f-9552-76de7dcbed2c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d5f0e4d8-2482-4911-ad5d-a68e4e3314f2)(content(Whitespace\"\\n\"))))(Tile((id \
-         3bba3dbb-0023-4b45-8784-dedf32bbee75)(label(if then else))(mold((out \
-         Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         36))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         59c01541-864f-47a8-ad62-f96f03364588)(content(Whitespace\" \
+         4937b337-6580-4a9d-9e5b-64ab035ace4e)(content(Whitespace\" \
+         \"))))(Tile((id e1301191-b4e1-433b-9db0-3439ad39f056)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         b87ce946-d77a-4f62-b8c9-ff3c1030bc2a)(content(Whitespace\" \
          \"))))(Tile((id \
-         b9acb1e4-e83d-440f-9717-f9cc5f44e0bd)(label(mem))(mold((out \
+         7b8b2153-efa9-4886-9723-368b35717fe9)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         72c524cf-33f7-432f-b9f3-133f6d4e4416)(label(\"(\"\")\"))(mold((out \
+         092e035c-3dce-4cee-8ef9-b40963d2b5cc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         49bc0a5f-ecda-4046-b7df-3841944af544)(label(seen))(mold((out \
+         a681e44f-d0a1-4a24-a3e1-7fe47cd3d053)(label(seen))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b10e0c00-224f-40da-81da-d4e26e32b6c9)(label(,))(mold((out \
+         2540eaf7-ad76-4d44-ac9f-16aa36e63901)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c1802b75-3553-4c45-b981-9be5e5a2a316)(label(x))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5450be9d-a9e0-4f53-82fd-409dd2cfd41e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7ccb6d7a-bf39-4cf5-b54b-e8fc2b36bd0e)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b8c967c6-227c-4e0d-ba34-ffdf589f7476)(content(Whitespace\" \
+         e8450a5c-87f3-4f19-845a-cb9921748c25)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e8d82ffa-cb57-4446-a1e3-5ece457952bb)(content(Whitespace\" \
+         3b4f67b8-0a4b-40c8-94d3-2d0e0ec1d1bd)(content(Whitespace\" \
          \"))))(Tile((id \
-         902d5bca-c46b-4bb9-940a-e00b29a39250)(label(seen))(mold((out \
+         ea956a97-bda8-402e-9655-a8da4a2a77e8)(label(seen))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         46e213af-f324-462f-9caf-0dc43d4c59d4)(content(Whitespace\" \
+         6679e8c2-88f4-4e34-9428-981161757ff9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f8b61e81-66ce-4a46-9bba-7017fec49a82)(content(Whitespace\" \
+         b1678aa3-e7ce-4666-b11f-8b703e575340)(content(Whitespace\" \
          \"))))(Tile((id \
-         ff32afbf-7c5a-41f5-94fb-40eb7a30a189)(label(seen))(mold((out \
+         3a6b6d01-e281-4bd5-aa35-db55a4bc6659)(label(seen))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b5d87eb8-37b8-4d49-8537-0382461306b5)(content(Whitespace\" \
+         50f74dac-749a-46b5-b66c-270c8688b5cd)(content(Whitespace\" \
          \"))))(Tile((id \
-         94f65ef4-5396-4f9e-a16a-3999a3fa8cd2)(label(@))(mold((out \
+         383452bf-f57e-4c6d-a888-5b100c8be180)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         062d1d92-40e9-42eb-95d0-a2cfdcff1ae2)(content(Whitespace\" \
-         \"))))(Tile((id 4227cd5d-c11e-4c68-84dd-63d076288c2f)(label([ \
+         4bd4be15-23f7-433e-a1e4-f9d75b1719c1)(content(Whitespace\" \
+         \"))))(Tile((id a3bc24ea-895c-498c-8266-b19dfafa4ae6)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         560beadb-48d9-4307-a6bf-a2748077ba43)(label(x))(mold((out \
+         6d0a572e-1629-4386-9d0b-71dfaedde152)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         f0dddfa3-fe56-4c8f-b0e0-14ab960545c1)(label(,))(mold((out \
+         101896e1-d151-4f51-b6d7-1402893dcfc2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6b52f0ef-4e97-48a7-9d3d-dd48c09d23c5)(content(Whitespace\"\\n\"))))(Tile((id \
-         7e1c2903-3ee4-494d-aeb6-60c364e52080)(label([]))(mold((out \
+         19f830e5-6857-4eb0-8596-0f369bdc857c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         75beaac8-caaf-4350-9cb5-dcd85352f511)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4c75c2c2-c994-4baf-8454-c6662f2eed0c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         72af6ef2-10ea-4e66-9b73-90220e6abd71)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         7bd7872d-962f-4657-b9aa-0114bfa0df1b)(content(Whitespace\"\\n\"))))(Tile((id \
-         d523e02e-955e-412b-8d76-f6e5a4f1e748)(label(let = in))(mold((out \
+         c6a00f0d-3d75-4e0b-9493-2f5f1c228c48)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ab53c3aa-73a4-4969-b495-79195f077f3e)(content(Whitespace\"\\n\"))))(Tile((id \
+         e9bc224c-8b3b-4f1c-91a3-1ac0109c35cb)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         4999265f-6712-40e2-ae00-1cc35203657c)(content(Whitespace\" \
+         a8881bcb-1d31-405f-aa0f-01a2a15acb92)(content(Whitespace\" \
          \"))))(Tile((id \
-         d144713c-1bc5-4d52-8656-ad9b46cf7661)(label(drop_columns))(mold((out \
+         5fcd1ee4-21aa-4c53-bded-8a58176e26c0)(label(drop_columns))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5c76724b-a3db-4511-a49c-a21ca7701ead)(content(Whitespace\" \
+         3621de97-c3d1-4aa2-915f-17939b037c8e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         11e8bc4d-cc55-4290-916d-a1731d2ea3f3)(content(Whitespace\" \
-         \"))))(Tile((id da62afc9-b4ea-4376-aaff-131f3c2496cb)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         8db3968d-f7a7-4e12-a2f9-e5bd8be5066a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f78679df-620b-4ed9-97a6-d7330c4eb354)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         f64d60b6-53ec-4889-b530-745120946d12)(label(t))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         de2ce2a1-499b-426a-8f9e-9be410bd549c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         74c41277-e1a4-4c09-a732-dbbf0889278a)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         eb05dfa4-aeb1-4861-b5e6-359a118eb12d)(content(Whitespace\" \
-         \"))))(Tile((id 0ebf07ce-127a-4c4e-9a55-d2cbda559185)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         23cd45a2-d29d-4381-ab85-883cf4c12f1a)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         9c71c632-1d13-4d1d-8a60-c1d5f6d367e5)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         0e306d15-35ab-4389-a5dd-d2074c3229a7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         858bb003-93a1-4451-bd74-e777dc70cc86)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         fb5ea0a4-253d-4cd2-923b-361a4fab1970)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9621a67c-d3ea-4c96-b98e-f85c05798c4b)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         97acf7cb-3e88-448b-8cae-6b78aab7fec4)(content(Whitespace\" \
-         \"))))(Tile((id 5f1673ec-2943-43cd-aec9-84f2358d1d5d)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         b54695c7-f60a-47ae-b56e-47222d40d20c)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         269dd8d5-d9df-4f11-92a8-31bafc373fe7)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         978b3e57-1a2b-492b-8a24-c7daefd4aac5)(content(Whitespace\"\\n\"))))(Tile((id \
-         592ec5e6-1a7d-460e-bec7-c0bb6c857f63)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         63f5634f-c04f-4bbe-a1ae-de59d2f54d54)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         de48f940-8fbc-44b9-ba31-b9b20c6245fe)(label(t))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e5124a6d-d05c-4447-ba83-c9422701274f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7b87313e-d53a-489f-9476-b3c003f932f9)(label(fun ->))(mold((out \
+         b06560f2-3fa0-4365-96c3-43063756a178)(content(Whitespace\"\\n\"))))(Tile((id \
+         3da2e4ce-d4a6-4f7f-896c-c70430147930)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         dd5d288f-718b-49f5-8793-00f0a503d583)(content(Whitespace\" \
+         bc6a7f6c-f391-4780-a326-344bb6e567f6)(content(Whitespace\" \
          \"))))(Tile((id \
-         377fc07e-e181-401b-bb7e-02144309d3e3)(label(row))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         02e757b2-10f0-4c40-b042-0d703f78c18d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8b3c7a92-2cbd-424d-bae2-6a754124c7be)(content(Whitespace\" \
-         \"))))(Tile((id \
-         035f0338-a016-4777-81eb-e4ba988caf9e)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         209fe6e2-e7f6-4f4e-ac44-fc7b0fd82fbb)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         dc507c7c-1a76-4dc1-834d-1ba4487aa6bb)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         80795fb2-113c-4f68-827a-b044b2f2ba55)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e5b5199e-bee4-4eb3-8be6-3bd9b35eac77)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4fa95b36-5711-4dd6-ac77-e4f71bcaaf83)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b3e47441-6d8a-4e17-b24d-1b8b4c5028e6)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         559c5b73-335b-49c1-a676-aa361636f7f5)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9c933145-c9a1-4599-a30a-72dc501dee28)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         76a2aeb4-217d-4016-ab94-af39186c85a9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         56047866-46a3-475a-929c-135bfeff6c68)(content(Whitespace\" \
-         \"))))(Tile((id 777ccc79-4d5c-4084-9c9a-692c09e7f102)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         e0a6bcce-94e3-4d1f-859d-22fa05c6ec1d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8ac5d870-d675-41ad-b959-802660a8985a)(label(entry))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         49d20b0d-2246-4db7-8908-17f8f679bf45)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c24854b4-f761-4dbb-8f8b-574b5c1d12e5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         27ffa3c7-a386-4607-ac22-d1f6b3b072e5)(label(!))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d346b65c-8b20-42d7-b2e2-88bd06d9d4fe)(label(any))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9080a27a-25c8-4754-8546-888d167f532f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         25224f19-de74-4fef-a2ba-49733dd9f5f4)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cd8ff26e-785c-426e-9610-6ef6050e4369)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4ccd9333-e599-4119-a604-9f77e0e5fbf1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4bd698cf-9e7c-4311-9d3d-6a71137ae45c)(label(string_eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5649ae4e-89ab-4839-b2f3-61a8740a0628)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         04c24673-2ff8-4a7b-85bc-9a5c86c057ac)(label(entry))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cf1dc839-a633-40dd-af09-a6d22525b138)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         899262cd-c80b-4a34-9f67-bf6ab89f4a93)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         722aaeb3-9885-4490-a9b0-ccc41b0c082d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9c2c37e0-ef1f-4853-bd79-0a883fc7e0fc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ac24902b-f945-48e8-b49c-073c23c28e4e)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         81b9b31f-e271-4a38-a6b7-1d4a8013ae60)(content(Whitespace\" \
-         \"))))(Tile((id \
-         930bc1a5-4033-4770-b64d-7e5bbf9b98dd)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3cc003ec-5086-4e98-97ca-55078b46b0be)(content(Whitespace\" \
-         \"))))(Tile((id \
-         20dc82eb-c908-4c25-96d2-0721b921526c)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4cfd17e2-3340-41da-9c64-5d48f7c4e25e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         75beffaa-1bf7-4085-a8bf-4a512f409279)(content(Whitespace\"\\n\"))))(Tile((id \
-         594544ef-faea-4e15-aab2-eda7b8ae7818)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         5084b509-555e-42d4-a46d-3ba538a36777)(content(Whitespace\" \
-         \"))))(Tile((id \
-         060aa325-3672-47dc-9e7b-7c7347a27e7e)(label(build_col))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         39857bd9-142f-4bd1-aac5-f8caf812eda3)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         745af23e-59fa-46d9-a6ab-d3256842a163)(content(Whitespace\" \
-         \"))))(Tile((id c8431f68-36ad-4eb0-85db-a8f14e3e6671)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         569613d1-bbd2-479c-9143-8d81c7f875d5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1bd8b8b9-74b9-4945-9866-57a3e2229838)(label(\"(\"\")\"))(mold((out \
+         48071dd7-7d11-4aa1-ac72-4499f6530f96)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         ad3915b4-061b-46ac-863b-c3845913bec2)(label(t))(mold((out \
+         f9f0c0a8-e8fc-4020-a67d-1052fba1339c)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         930c722f-c5f8-4514-adab-42a382f69679)(content(Whitespace\" \
+         0d3fab7c-dc3b-4f2b-ad4b-0a21ab5fb17f)(content(Whitespace\" \
          \"))))(Tile((id \
-         9673dc8a-c7c7-4dbd-bd3e-e347800b8329)(label(:))(mold((out \
+         95fd5154-f40c-493c-89e1-9c9347b094ef)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         257f6448-4c8b-4f82-ad53-825ad948582e)(content(Whitespace\" \
-         \"))))(Tile((id 87b8c3cc-21be-47e7-90db-fdec17d889f7)(label([ \
+         845bc2a9-f7e3-4f18-8414-d47367d9b559)(content(Whitespace\" \
+         \"))))(Tile((id ecf287dd-026f-41a9-be8b-9bd73b26e85c)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         952094bc-d2f1-4290-9d07-5917a3ea82ef)(label(?))(mold((out \
+         79e3ce6e-3417-43d5-89bf-d1df78ab853f)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         0a506831-fa06-4c92-a0a6-d7ed39073a73)(label(,))(mold((out \
+         18b54f39-0802-4249-8377-8df30c34e253)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         2f3680db-f6cb-4ff9-8003-70deacc34c5b)(content(Whitespace\" \
+         3a93044e-fdf0-4684-85f0-fe53cea65e59)(content(Whitespace\" \
          \"))))(Tile((id \
-         d200963d-d2f0-4a8e-a9ff-a1cdd23925d6)(label(c))(mold((out \
+         f43f66ff-386c-46e0-b072-ca6876cfee1f)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5327c5f2-3007-4e3e-b590-ea994b8958db)(content(Whitespace\" \
+         d0da8f9e-e7bd-4aef-95b8-841227320e98)(content(Whitespace\" \
          \"))))(Tile((id \
-         23bb9c42-22ef-4786-b44b-307fe631f723)(label(:))(mold((out \
+         14ba610d-9d1d-4ed1-9fe6-c68fc1961d1d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f52c3a92-412c-4521-8502-4b6efb061fa0)(content(Whitespace\" \
+         7bd5720f-d63c-4e84-8511-931c2097cf73)(content(Whitespace\" \
+         \"))))(Tile((id 05e4923c-f504-4d6b-8fe5-5a2f57f72fe8)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         877ed85e-b691-4da1-8ebe-3956c39bb475)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         25a509d3-e577-4a8a-9de8-f9e084f2f10e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         980146e3-58c5-4e03-bcf0-a9acf72f918a)(content(Whitespace\" \
          \"))))(Tile((id \
-         b7e26e4c-c924-405e-ae4c-4f675fcbef94)(label(String))(mold((out \
+         ef2d0860-bdcf-4502-b014-eeba24052717)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d0bea236-11ce-43c2-96de-a8b117d63146)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         52d24671-f6e4-4147-af0a-bb32365096dd)(label(t))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f2465346-a22c-4398-9d20-1ca6a21ba41d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0fd81d51-8c67-44df-975f-8fd21089f680)(content(Whitespace\" \
+         \"))))(Tile((id 5599c0d1-9bb0-4679-a948-093caf35f216)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         e943ee10-7b20-4086-ba68-84a4f25f94b2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d3a1d285-e39a-4566-bc16-fa246fefcab0)(label(row))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         62cb0a2b-d911-43bf-ab66-ff7d682f548f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         bc64ff7d-e6bf-45b0-91b2-75b7a5b1d136)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9d45c4fc-6752-4e2d-a8bd-616feb7cbae8)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f2a84168-bc96-4a35-96bb-8fbf0423d45b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         f3f717d3-4166-4761-9a58-36297621524d)(label(row))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         9b585e08-d670-4864-90ca-83b108ed51b5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0360a24d-5fa5-44ea-91c0-78de45124f26)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b0ebe8d4-f054-4203-ac02-0d4b7e9ee7ae)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1b96cc69-925d-4434-bdaf-7dc50a3682b1)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         26f1d5a9-c615-453c-9cfd-4c48d9889a42)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         70d2d2dc-4252-4fcb-ae95-4e0a20576a99)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8bf22ab8-dd39-45f1-9990-623a73d66ab3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2b19a0aa-a016-4e3a-84a0-d926934bdd1b)(content(Whitespace\" \
+         \"))))(Tile((id 59a0fac4-8a89-4705-97b2-b41ef694a67d)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         721edab4-f0fd-4553-a76c-e2032898d89c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dcfbea00-7569-46cb-b075-9b5f8afb0599)(label(entry))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ab4b92a0-8d2a-4d5e-a2ea-d044d254a94e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d60916ee-27e7-4901-b409-f23ea4060be3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c82b6c08-b47a-45cb-a1e0-7fa5dca7a4da)(label(!))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         cd20c6d1-6da4-4316-b1d8-aef8ad51708c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f3aad318-9766-4bf9-b9ac-dbf0d3edb75c)(label(any))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         978c8a67-0b65-4bef-8a2a-74a33a285ca1)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         804abb62-d15c-46c9-aac0-c13e5ba79dda)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1b8b662e-445c-4c37-a988-bf06e8296a59)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         489e7e7f-d8f4-4294-ba75-5425d1945a09)(content(Whitespace\" \
+         \"))))(Tile((id e0a4757d-0250-4647-9f6d-6ba1d5612127)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         07c0a7f0-06cc-4f2d-9f66-b1e2961dea40)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0afc4cac-0eb2-49bf-b0b4-6a93f90eb314)(label(s))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         27413546-abe2-4dc2-aace-9296b4255f56)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         22b3da9c-40e9-4ca5-a872-1bf1e39f4833)(content(Whitespace\" \
+         \"))))(Tile((id \
+         05c51011-1f5a-4b33-8f9c-32d3e878b291)(label(entry))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         912e7d58-5419-4243-869d-15cb59adbb5e)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         8ce3e459-e448-4c7a-a95c-6d6082bc853d)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         98fefaca-ace1-463d-9a89-226fdc62c2c4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         59f71582-aebe-43c4-b606-7b1136564b7a)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9fd6f19b-e0f6-434c-8e06-2e51ce03059b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e780b774-a1bf-4abf-a2ba-070ef8c828ab)(label(s))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         6a3c61b5-55a3-43c7-9ec3-e8e0448bf5dd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         49999462-df0f-4e75-adcb-21db9cca801c)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         520676f3-c213-426a-b065-00960794dd75)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7e49fd5a-2dd8-4ae5-813d-3a986433dc36)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         68096218-61d0-4bf1-8951-71cb34346fa7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c14caf47-f797-4e0b-a068-ad7838576dcd)(content(Whitespace\"\\n\"))))(Tile((id \
+         3670bc77-3494-4168-8978-8b0916d46663)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         4e11dcc7-6063-4d3d-a1ca-923dc50c68ec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         95186851-88e8-48f5-992d-edb8deb5d262)(label(build_col))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         28919d09-7153-4d0f-9a1b-ad2b05709336)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         b426b2fe-7cbf-47b6-bcfd-48081d1b83b5)(content(Whitespace\" \
+         \"))))(Tile((id 0e91a582-3d50-41fc-b743-6ab065760425)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         1ba4a85e-7727-4632-a662-6d09352a2e4b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3c083a78-c311-40b1-a413-021457e98664)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         0ffadc11-b7df-45fe-a334-41bdf4db4d21)(label(t))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         57138167-ecf9-43ad-8906-fa7b040ca304)(content(Whitespace\" \
+         \"))))(Tile((id \
+         171f32d4-340c-4261-b740-a240f466c920)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c703cc14-1b78-49fa-99f1-d12acaa5b649)(content(Whitespace\" \
+         \"))))(Tile((id 16f6dabf-03de-46fc-a649-08fb97535f6b)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         0f7c1d3d-0f2c-40d6-9fa1-29d9413c457b)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         3fcf674a-222d-48e6-a1f7-46cd2faa2c46)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         b949598a-d837-40c6-9417-0f79014443a8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         79dafcc8-227e-4d7e-958d-f3fbf74d948f)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         33d063bd-8343-4275-8867-114c9fb97cca)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b93962b8-9d58-45d6-b14a-78945c3ff8d5)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c535a2d6-c548-4b63-96a1-f6d6b79b73f2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         51458699-ce35-4166-b7a6-3b2e37b806bb)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         c81cb38e-2d4f-417d-83d6-04547a0cc130)(label(,))(mold((out \
+         241c452d-03a3-4bcc-b25f-d1a01c35c2df)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         3af34b25-51d2-40d8-bfd5-b79f44c02d30)(content(Whitespace\" \
+         9439cb2b-178e-4016-af93-4364a590d441)(content(Whitespace\" \
          \"))))(Tile((id \
-         a348ef3c-cb12-4c58-9aa6-b23d73112df8)(label(f))(mold((out \
+         2e65d16b-33ea-4c30-b0fb-df679ddca2ee)(label(f))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1764a443-48c3-48c9-84e7-4beadc0de5b9)(content(Whitespace\" \
+         63f46d34-f327-4f3f-bbba-fc4fc550bb46)(content(Whitespace\" \
          \"))))(Tile((id \
-         e6d2bfff-c01f-424a-b25a-558d56442133)(label(:))(mold((out \
+         e4a6ff57-ca33-4824-a0ef-29bdd4192202)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         082353f4-db7b-44cf-9b82-5acede008e0f)(content(Whitespace\" \
+         d3ff131a-060a-4712-927e-b975fb911167)(content(Whitespace\" \
          \"))))(Tile((id \
-         687c77fe-9df4-4c78-82e5-17eb63ab39e8)(label(?))(mold((out \
+         1d8cc10d-1e9e-4d25-9241-090c7044d08c)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         a4677c89-7e29-4b2c-a666-2207e9c368ea)(content(Whitespace\" \
+         3b0de660-e6e7-458a-ae39-e11392b8f35e)(content(Whitespace\" \
          \"))))(Tile((id \
-         7b2e2bcb-b551-446c-b604-64def47255d2)(label(->))(mold((out \
+         f3afdda7-7d4c-4ea6-b73a-ddad45c9d460)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a7157aa5-2cae-4f18-98c4-4b5db28d65ba)(content(Whitespace\" \
+         716e43af-d726-424e-97a1-2163181d26d7)(content(Whitespace\" \
          \"))))(Tile((id \
-         f7008eb0-196a-4c3b-b28a-e2d870ce4abd)(label(?))(mold((out \
+         3ef1d758-76d8-4c98-8a5e-eb52c60be8d6)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         788cf109-f32d-4bb7-9bd4-9d0973884291)(content(Whitespace\" \
+         b239c456-61cd-4804-9738-d271df79eeb5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c480fcc4-bde9-47c7-8d11-2c1fec044666)(content(Whitespace\"\\n\"))))(Tile((id \
-         ff666c5c-d02f-4f3a-9e62-9e0c16c94d0a)(label(map))(mold((out \
+         8b317119-48d1-4fc1-84b6-d023df0eccab)(content(Whitespace\" \
+         \"))))(Tile((id \
+         06b9a905-7705-4e93-ad41-a6befb8f68f7)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         942e0471-7f55-43d0-9500-065e50cc2f11)(label(\"(\"\")\"))(mold((out \
+         33da6715-2503-4ac8-83a2-254671c60525)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         0b69ca31-b0c5-4dbf-9868-da728bd9401f)(label(t))(mold((out \
+         5c04c362-fd4c-44b1-b5a0-94c8e2d6f1a1)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ff18e5fe-7206-4749-9be5-dfe130351685)(label(,))(mold((out \
+         b55e8d2b-803f-4c24-8a6e-a6438d9c6631)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3a72863c-909a-4916-9d12-bc94b1c2f7eb)(content(Whitespace\" \
-         \"))))(Tile((id 0b0ee08e-9a50-461b-859a-d7cb8aae833e)(label(fun \
+         6f115706-5267-4767-8f8a-c9a7d3d5057e)(content(Whitespace\" \
+         \"))))(Tile((id 84abc679-d40d-4cd6-bc57-e0ed0c6e4717)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         8b919b0d-d46b-459b-8b55-89966376ea34)(content(Whitespace\" \
+         fd7cf024-dacc-4139-ba10-b14bc09b5a79)(content(Whitespace\" \
          \"))))(Tile((id \
-         81b7356e-10fd-49ad-9aea-b1dc1cbbaffe)(label(\"(\"\")\"))(mold((out \
+         fda1ffcc-a900-4574-9067-be1760d9ee12)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         836e2c45-f9f8-4ee8-b37d-d1c1564204c5)(label(r))(mold((out \
+         57227181-332d-4dcb-b445-2f2d668acf70)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         71ad8a55-2329-4dc2-b5cb-3d54ff33d23b)(content(Whitespace\" \
+         fd1521b7-0069-43a9-9abe-2ca7b6c11e1e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f03c0a67-31a2-4222-b033-72147afd28e0)(content(Whitespace\" \
+         f8de4ee6-45b5-4ee8-b287-73dab125b18c)(content(Whitespace\" \
          \"))))(Tile((id \
-         eaa4ec61-87e5-4ced-a082-f39dcc7e4989)(label(from_lvs))(mold((out \
+         9b278b94-038b-4340-8f3d-d04c776c38e6)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b901ac14-d406-40e3-8373-daa35c2e79c0)(label(\"(\"\")\"))(mold((out \
+         15547755-4cd8-457c-b4ba-102db342d74b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         00ce4a2f-587a-4724-b9c1-b253080aeb87)(label(to_lvs))(mold((out \
+         7adf295d-8547-4726-85c6-c14fa32c1c3e)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ed025073-48cc-4ec1-893a-baea9d5e6256)(label(\"(\"\")\"))(mold((out \
+         1bc25b2f-a43b-48e3-bf6a-b80d75b07676)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         da3bc17c-ea35-435c-9fdf-70d00ed66d31)(label(r))(mold((out \
+         47bc60b4-0c75-42f8-9d29-8923a76a4958)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         558553cd-12ec-4e11-8f23-5dc341b6f739)(content(Whitespace\" \
+         f3b2247d-d4ff-4ce8-b7d6-b1375fe96190)(content(Whitespace\" \
          \"))))(Tile((id \
-         0adfc10e-97f8-47cd-a55b-5c7846a557e0)(label(@))(mold((out \
+         e806cd6b-d00d-4163-8ec2-2adefb8426ce)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         26e46817-390c-467a-891c-9a5bd78d597c)(label([ ]))(mold((out \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f3f3d1e4-9e6b-489f-ba98-419db2f0ff3a)(content(Whitespace\" \
+         \"))))(Tile((id b68583fe-1a78-4f8c-a492-8e22da53642a)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         05fc4f1c-c5f9-44a3-9392-2e7be98f1aad)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f7194158-bbb8-4e8b-97c9-a7b43d0e43db)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         84c80eef-16ca-4984-9d93-fe9778b46d9e)(label(c))(mold((out \
+         9bb4a576-4c51-41d0-998f-a0ec3c3aa5e0)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         465bbc96-99ad-47c8-8fdf-e6150ca56eef)(label(,))(mold((out \
+         6be80d0a-b46b-4de6-8316-dd0cce5f69cf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         65969ca2-f191-4bb6-8936-80bceb689245)(label(f))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f023369c-a08e-4a5c-b4dd-52a8a7c1f770)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ceec216c-a40d-42c9-88ae-28ca86305727)(label(f))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         68455ef5-555f-4daf-a406-bad9e201de89)(label(\"(\"\")\"))(mold((out \
+         5ab08a48-75d5-4c7e-9012-bbbe70140bc6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2ca7988a-e7b0-470e-96de-edeb100062db)(label(r))(mold((out \
+         a2f08fb5-434e-46c0-9316-e402035651cd)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))))))))))))(Secondary((id \
-         fb521909-ef40-470d-831d-dde09a96fbf5)(content(Whitespace\" \
+         91e3881d-79a3-4c50-aa8f-919d2eb8aabf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         46d96c8d-50ab-4f94-b7e1-c50857874b20)(content(Whitespace\"\\n\"))))(Tile((id \
-         3199a46a-252d-4b01-9c74-b2c4d55d84f4)(label(let = in))(mold((out \
+         02c0c2c7-0a61-4caa-8576-2e56913222a7)(content(Whitespace\"\\n\"))))(Tile((id \
+         66b6a3e5-75bd-442c-8e0d-8f063206aedb)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         722a0dc7-ec8d-4946-9fa7-36879a341659)(content(Whitespace\" \
+         be85e6ee-4618-4629-87fe-604af982cb65)(content(Whitespace\" \
          \"))))(Tile((id \
-         1bb5d034-2417-4c3d-acc7-30b8e2aabaa8)(label(empty_table))(mold((out \
+         2e523a97-dbd9-4c34-bd61-59dfa22cbb31)(label(empty_table))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         64f5ff65-f0f8-4152-a7dd-c4e5733bcdd3)(content(Whitespace\" \
+         b66c2c3e-3de2-45c8-9db2-013457c68ff9)(content(Whitespace\" \
          \"))))(Tile((id \
-         c3a12a36-a68f-46d9-aebe-f57db3ccb653)(label(:))(mold((out \
+         778eb129-ce26-4804-acc2-838f835979ac)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         23ef409c-3402-443c-8cba-0078d937ed52)(content(Whitespace\" \
-         \"))))(Tile((id c8b3007d-a6c1-4984-bfee-505874d9bfad)(label([ \
+         733cce82-30e7-464c-b475-cd3033dfe828)(content(Whitespace\" \
+         \"))))(Tile((id 74fcc6bc-df27-4ae2-83cd-1f12ab3a8ecb)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         9ae18c25-8a6a-4143-8c70-34dc77f5be21)(label(\"()\"))(mold((out \
+         025645ed-e6ca-4406-87b7-d43a9df4ebd5)(label(\"()\"))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))((Secondary((id \
-         d70cf63f-1a5f-4e5a-901f-07ac9a2a70e5)(content(Whitespace\" \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         4e4cf3da-bd38-4485-95e3-d82f7b2ece24)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         6f5d2437-b578-4185-a5b8-6a659ac64737)(content(Whitespace\" \
          \"))))(Tile((id \
-         d1d81678-4986-4fd4-8b22-53ca0bccf2a8)(label([]))(mold((out \
+         59d088a5-104f-4d69-92d3-9ac2053213b7)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         e572725f-bce6-4efb-adab-cd828fabd5fe)(content(Whitespace\" \
+         7bbd9d18-b57b-4727-8b4a-0bdfe98341f0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e0275bd0-10f3-4762-89cb-3ed17de9e371)(content(Whitespace\"\\n\"))))(Tile((id \
-         c3b61953-11f3-4054-8171-9b3d543c5863)(label(let = in))(mold((out \
+         75f8dd5e-3d40-48e5-8e0b-95657d7670ff)(content(Whitespace\"\\n\"))))(Tile((id \
+         c1a82cf3-d21a-4219-a067-f589b1465cc0)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a9201f05-6ad9-438e-9ade-7960bd124984)(content(Whitespace\" \
+         848edd10-b731-440b-9d75-0648dc43c36f)(content(Whitespace\" \
          \"))))(Tile((id \
-         a64e419f-cf20-4de7-bcb8-a20589e30e01)(label(table_of_column))(mold((out \
+         7ab95bf5-524a-494f-a987-75fedd72f1c4)(label(table_of_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e2d16c9f-2d03-4c93-97fd-967e6876200b)(content(Whitespace\" \
+         3dee318b-068f-4e5c-8344-0ed450cbeffa)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e6a16d1b-2a43-426d-a829-6a670f4be9ee)(content(Whitespace\" \
-         \"))))(Tile((id 0a394b30-9ff1-40fe-9aae-eee1ef3c253e)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         4081e267-14a6-400a-9f19-886f2c7cb9cf)(content(Whitespace\" \
+         fbd44e86-6fd2-4927-9ebb-415aca8bdaa5)(content(Whitespace\"\\n\"))))(Tile((id \
+         4c289b3c-62f9-4b88-ac17-dadd3638afe8)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         6be0256c-d385-4756-93e4-f2c361874001)(content(Whitespace\" \
          \"))))(Tile((id \
-         38bd36fe-dd85-4116-ad58-ad4e4a9d8114)(label(c))(mold((out \
+         6a75b6ea-cc14-4693-a90e-6fa94c99712b)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         010315ed-ba83-4eef-993d-a2c3cf9bb847)(label(,))(mold((out \
+         f0e41160-0129-4aa6-a1f2-c3a78074c28d)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         22c5091f-229e-4c0d-8067-f2a30f5ee001)(label(vs))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         3db39009-90c1-46a8-8970-61f9d8f73040)(content(Whitespace\" \
+         \"))))(Tile((id \
+         450d65c1-dbf2-4f03-92e9-6cc9d8bdf2ac)(label(vs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         34d3136f-1687-4d40-90c4-2d6f9b40835c)(content(Whitespace\" \
+         f3480578-3cef-4352-a89f-f38b5e079d9d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5c56ae02-f6b7-4bee-96a3-9f288a876373)(content(Whitespace\"\\n\"))))(Tile((id \
-         bf91d7bb-f103-4048-8338-90af52337b1e)(label(let = in))(mold((out \
+         32b288f5-8b88-440e-b2e6-bb21b53197ba)(content(Whitespace\"\\n\"))))(Tile((id \
+         3111ad68-eb55-4a6f-9568-47a57302c0c3)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         6f0cf7e5-e002-45b0-9952-63f7f9c0c0bc)(content(Whitespace\" \
+         faacaabb-ed95-4277-81c1-6e8a007371b2)(content(Whitespace\" \
          \"))))(Tile((id \
-         17e5b364-85b0-465f-8574-f8b50f572980)(label(t1))(mold((out \
+         b2e47f51-cb94-46ed-b9c6-a4dea69c6418)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e4eb8f1e-dbf6-4d60-b31a-dd24a18d354e)(content(Whitespace\" \
+         0f77f286-5a3c-4a3c-85f4-2b49da1de89c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         09447f65-455c-40b3-8214-ab804a4902a0)(content(Whitespace\" \
+         5deb656a-6a42-45cf-8831-d3b3923e20cf)(content(Whitespace\" \
          \"))))(Tile((id \
-         fb988f98-963b-4a78-ab07-f2592610a951)(label(add_rows))(mold((out \
+         786fb0f5-5dcc-43bd-ac1d-393562236aac)(label(add_rows))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         dfd2421d-48d0-4f95-8b43-1630a28ca72f)(label(@< >))(mold((out \
+         f51fa8bb-3101-4494-961d-fd1b2fbcafff)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         cf1100a5-07bc-4b52-8d47-1dfe58330b46)(label(?))(mold((out \
+         0e563e00-6e54-4eec-94dc-c8e6f39ff490)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         23b749c3-8968-4181-9c78-85eb9a6409a5)(label(\"(\"\")\"))(mold((out \
+         780d3a18-0fd7-42da-842b-9ce5bedd64ec)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         dcd46131-55f8-410c-9fa3-7a0f51b46ec0)(label(empty_table))(mold((out \
+         f8c37bdc-041f-4123-9269-ebccc8f41e9d)(label(empty_table))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         49fbefad-c250-43ba-bfa6-9a96b3c2c87e)(label(,))(mold((out \
+         ee31fd4b-356a-4cf2-b7f3-4166a6df3268)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10cc75cf-93ff-479c-8bc7-a79c769cd868)(content(Whitespace\" \
+         40f24680-2211-4458-be16-7f8c250cc744)(content(Whitespace\" \
          \"))))(Tile((id \
-         7747e79c-64c8-4394-ade8-0c421ba1e49c)(label(map))(mold((out \
+         b6350144-8de9-408c-a51f-569097ab7ad8)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         9efa29cc-b258-4797-83c7-930500df7396)(label(\"(\"\")\"))(mold((out \
+         08ff85ed-c89d-46ed-96b0-b301f4cc7b6e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1c1f0811-a7ac-4d10-a13d-c248180428c8)(label(vs))(mold((out \
+         8dfe5f48-41a6-4fdc-993e-6ba9e0cc2fe4)(label(vs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         23e48e1f-b3c2-4544-8b2b-4c0670f9d047)(label(,))(mold((out \
+         f3254bdd-eff0-429e-8f3c-95c258ada6e5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3ce8d3b6-616c-48bd-aad5-7c196ce6f6ed)(content(Whitespace\" \
-         \"))))(Tile((id d86af3f3-a8ff-48fc-93ec-30db9257e0ef)(label(fun \
+         59248be9-8ce9-426f-a5ca-c014128c58da)(content(Whitespace\" \
+         \"))))(Tile((id 12202a36-00fa-460d-b74b-a7ce73a84e6c)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f5bdf47b-4d9f-4299-8f90-67f7d4ec2ae6)(content(Whitespace\" \
+         88525732-d692-4b31-a5b4-2482421cd06c)(content(Whitespace\" \
          \"))))(Tile((id \
-         83c2e105-6ff6-48f6-9e76-67619483c7ff)(label(_))(mold((out \
+         ca8a4a3d-22ca-430a-8ae4-6b3d8da777ce)(label(_))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0f404e19-5d8b-4ee6-80a1-1a0c131c5496)(content(Whitespace\" \
+         e5cd0c03-71e9-4bb4-8e28-8257f36d0745)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a9df330b-b10c-42a2-a6dd-0d084db22004)(content(Whitespace\" \
+         0cb03feb-bcf0-49a0-97c3-021026acee9e)(content(Whitespace\" \
          \"))))(Tile((id \
-         3a61e57c-0f43-495a-b066-55b2ae30b73b)(label(\"()\"))(mold((out \
+         bd1ad0c6-a19e-4726-b7d2-a1f478331f26)(label(\"()\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d251f303-5927-424c-98df-fb95f55e00a4)(content(Whitespace\" \
+         ef863973-13a4-4a74-8408-7f081534c245)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9930c511-2232-4f79-b4e8-1e1f482f6997)(content(Whitespace\"\\n\"))))(Tile((id \
-         aca9c09a-d710-4a66-8d1a-69872f54f0f5)(label(add_col))(mold((out \
+         b33a0fdd-abb6-4e75-9dc5-16a37d9cfdaa)(content(Whitespace\"\\n\"))))(Tile((id \
+         676d550a-0da6-4d5c-ad9d-4d55270189f4)(label(add_col))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         07047883-9b8b-47c4-afca-005914dd97b2)(label(\"(\"\")\"))(mold((out \
+         d7c95077-4ef5-4306-af3e-64c29bca7a35)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         81eea535-7304-4146-85ee-7aebd093b92e)(label(t1))(mold((out \
+         3afe93de-7b51-47dd-abcc-70218e6bcf1e)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a64e0356-fbe7-48f2-8476-fbc7ee70b4ed)(label(,))(mold((out \
+         4381f8aa-6e11-4777-93e8-df942c20ddf0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         01034f16-0370-406d-8a7d-c3e74ae2e3c2)(label(c))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         85946c0f-b81f-4c07-8959-7cd51fee398c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bacf7b79-f558-4913-ab32-3291826d29d4)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         47be25ff-ba13-4e08-9617-c9f752067a0a)(label(,))(mold((out \
+         2155713b-b07d-4799-a38a-77c991965751)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         8c2fbc3f-aed1-4e68-ac96-3bf6c113721c)(label(vs))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2d6497aa-93c1-4e7f-9e9a-bda04271c3cb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ee1657d2-e5d6-4671-a88e-f0de59356614)(label(vs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6d643130-eb76-4a53-86b2-b9ba85433945)(content(Whitespace\" \
+         a2451e8c-4324-46a6-8a7a-a5787eccb3c3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         97475ee8-44a6-42e4-b594-d168dbb0ba31)(content(Whitespace\"\\n\"))))(Tile((id \
-         d6f926fc-fd2e-4513-9f9d-4724db5e6fb7)(label(let = in))(mold((out \
+         e77ecd2b-6a80-4c22-ae3f-2145070f58eb)(content(Whitespace\"\\n\"))))(Tile((id \
+         f723856e-f4b8-4883-a3bc-888965dc5ba8)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         0ed2881c-bec4-498f-907d-d5ef718fd1a6)(content(Whitespace\" \
+         ae839baa-32ad-466a-ad08-e58664f32cef)(content(Whitespace\" \
          \"))))(Tile((id \
-         ad53205c-cfb4-4dd2-8182-650ae6ded325)(label(get_col))(mold((out \
+         0a672938-40ff-4aa8-94f2-15846ab4d8e3)(label(get_col))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         288d1a1b-b0a7-453e-aab0-99e5971113af)(content(Whitespace\" \
+         3f11a52f-a4bc-416d-a838-f4ebf3febefd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b9a81828-529f-460c-9076-9cbaa789ada3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6d7b18b5-1607-4bbf-8fc3-9b5352d62327)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e0b87f5-26f8-4ea5-be01-c1a3bcbd452e)(content(Whitespace\" \
-         \"))))(Tile((id a8894c55-9c7f-490b-a970-979c185cb493)(label(fun \
+         1cda2d3c-d02e-4e5f-9aac-7cfeae17792d)(content(Whitespace\" \
+         \"))))(Tile((id 8b087550-6179-40f1-a4cd-0a8c2cb3b1f6)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         695b6dbd-801c-46da-903f-065edcfe55fa)(content(Whitespace\" \
+         fe0b51e3-f5e1-4d46-a14b-506b38bb42a7)(content(Whitespace\" \
          \"))))(Tile((id \
-         60f0c285-e79a-470c-9ee1-d2bc45b4f4ec)(label(\"(\"\")\"))(mold((out \
+         9b48d655-bcd6-4695-9c3f-a123891f18f6)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         997427c7-3b8b-4a4a-9967-6d705db742d4)(label(t))(mold((out \
+         a49edab8-3599-4f7e-8f01-c1bbda3eed1a)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         061172cf-479a-4add-9649-10c581a5b52c)(label(,))(mold((out \
+         12b1029e-6b21-4e12-a0fc-8c88a08ba1c9)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         29354134-2251-4b0e-ba7e-d50c2fc11a03)(content(Whitespace\" \
+         8e03c31b-db96-4462-82d1-e89660adc25b)(content(Whitespace\" \
          \"))))(Tile((id \
-         86cd7592-c675-4a71-b695-a8fac1db39d9)(label(c))(mold((out \
+         532d91a0-e11f-43c3-9a10-dea949642cfd)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         956b48fb-b0a4-4ca3-aaf5-39f93e4a8ff1)(content(Whitespace\" \
+         2ae76f8a-6843-4e87-b6b3-4009e38cba70)(content(Whitespace\" \
          \"))))(Tile((id \
-         6be25be8-6d89-42b2-aed4-c654c8f9a0f3)(label(:))(mold((out \
+         2a76f54b-fdbb-46fb-969f-9967a34207de)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6cd592af-8080-4e34-b47b-426840610040)(content(Whitespace\" \
+         29ab4b86-836a-4a9b-99ee-5f46c1ae26f8)(content(Whitespace\" \
          \"))))(Tile((id \
-         12ab2abc-cb07-417f-a397-2cd49c43c396)(label(String))(mold((out \
+         0d17348b-0271-4740-979d-d55e583ca0e4)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7bc82ccb-34ce-440b-be0c-afd129375694)(content(Whitespace\" \
+         a1c6aa07-9a32-4b8f-a10d-0105b2ae2bc5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         792a89be-e2e5-43a9-b9cb-7a3a4f444abb)(content(Whitespace\" \
+         c80dad87-41ec-49d8-9fa9-7f78152a2848)(content(Whitespace\" \
          \"))))(Tile((id \
-         f600e3b1-cebd-4449-b9de-8b13f9b1e374)(label(map))(mold((out \
+         38d5e46a-f1fb-4cc0-bd27-efab53e8d01e)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a91a3723-7078-4722-b0be-3feb37e784af)(label(\"(\"\")\"))(mold((out \
+         4299e114-745a-45cb-82ce-c89ac5e01a63)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8bee4d68-1f8c-4269-a619-35246709d482)(label(t))(mold((out \
+         4614a3e6-92a0-4094-a550-48561ee8bef7)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c17b2017-f077-46fc-80f9-21346881a041)(label(,))(mold((out \
+         7b87331d-65c7-405b-993d-189ec63b48a1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         345bc6d7-9b1f-46d8-8dca-1d9a439a348b)(content(Whitespace\" \
-         \"))))(Tile((id 3e573365-d6cb-43b7-914f-4be699d24a1e)(label(fun \
+         1e891b3f-54d8-49cb-a8f8-2d6bcf3d3fd6)(content(Whitespace\" \
+         \"))))(Tile((id dc8e4d68-0331-4aa2-a887-a138dc98d27e)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         3295e74d-01ef-4356-a79b-d0c9035ee9a3)(content(Whitespace\" \
+         21a68e2e-76e7-42d4-8f17-5e5066628320)(content(Whitespace\" \
          \"))))(Tile((id \
-         1652a778-7b7d-48b5-8e6a-cff7607505d5)(label(r))(mold((out \
+         7ca410ed-e24f-4f69-ae15-406c71ee0852)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f0884ed0-1a7c-4154-a5e5-230973419d8b)(content(Whitespace\" \
+         94cb370c-68c8-49bf-9f65-1142dc2f3e82)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         06293781-2ca4-4849-80e9-733330cb8bbd)(content(Whitespace\" \
+         1795ddbc-d70e-4548-ba14-d91236eacafc)(content(Whitespace\" \
          \"))))(Tile((id \
-         cac465eb-8f61-4b74-bfa3-45e9c7823da3)(label(to_lvs))(mold((out \
+         f3dbce09-44d5-4b1c-a727-f3d1579261d1)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e5ceebb4-3ba1-4d1f-88eb-2b29089e36f9)(label(\"(\"\")\"))(mold((out \
+         3b334097-cef0-4af1-83ca-a4fc23a03b5c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9bf64ea5-d597-4827-a8e8-f7f17dbe7c66)(label(r))(mold((out \
+         73e37958-d3fe-47cd-bddd-96e4d4823ee1)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         a05e2193-bf18-4063-8a5a-653a9ebe18f6)(content(Whitespace\" \
+         1d4618ca-3be6-4e46-8c22-c5de05ed6873)(content(Whitespace\" \
          \"))))(Tile((id \
-         73096dad-babb-4569-9649-456ddc46f46c)(label(|>))(mold((out \
+         ae0b71e6-f9cf-4e62-9045-0e85746a47d9)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8a73a9ff-5e5c-4794-9d39-40d14a46163d)(content(Whitespace\" \
+         37e1263b-ff05-4d0c-b3a1-6612a93db4b0)(content(Whitespace\" \
          \"))))(Tile((id \
-         543b98c7-0716-4b1e-b7e8-915f95ec0880)(label(find))(mold((out \
+         d72826d2-d2fb-4aaa-b535-e004d4d2c69a)(label(find))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d19acc37-0f9e-45f6-99c3-7d33d3b74fe7)(label(\"(\"\")\"))(mold((out \
+         7b68a4d5-f3c2-4c00-bc73-877b8e8260d0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         016fd10c-5f5b-401b-b0dc-4e0556af40a1)(label(_))(mold((out \
+         c7bf8f35-d18f-4448-aca2-5ef8ee679cce)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         0244a24d-f7d6-4243-9971-a31cb2ac70e9)(label(,))(mold((out \
+         185e0341-6d4e-4a73-8443-a25432579c11)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         db15e373-157a-4da3-9bc1-03dd6668a810)(content(Whitespace\" \
-         \"))))(Tile((id 51d0c97f-6f16-4f59-9a5c-ac45ebb0e52b)(label(fun \
+         d96b474f-266b-4283-8362-e8acbe8b4c76)(content(Whitespace\" \
+         \"))))(Tile((id f1ca6488-3b12-4c2e-970f-97c5d652a270)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         fcfe94e8-8a89-4b9c-8ce9-f8b9a2e41688)(content(Whitespace\" \
+         3e59eb05-88e7-456a-b9fd-e678e5f713ad)(content(Whitespace\" \
          \"))))(Tile((id \
-         12dfa186-df63-4de4-815d-3f8bc7335fdc)(label(\"(\"\")\"))(mold((out \
+         40a210d5-65ea-4277-9e49-7aa700cc6d3c)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         794a52a4-e5da-4e89-a894-c6279f9c749c)(label(label))(mold((out \
+         960cc18a-ffff-4597-9ec7-16a6c90b8834)(label(label))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         5faa8d5b-34a5-420b-a17a-8c5a78fe52c0)(label(=))(mold((out \
+         66962529-0364-4fed-89e7-82639011f422)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
          39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         d81e8782-43a8-47b5-8840-d0c70a450613)(label(l))(mold((out \
+         c530d894-d2e8-451b-82ac-c11f698514bc)(label(l))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         c036d667-a37e-4e71-b4cb-50d95a165602)(label(,))(mold((out \
+         c681fe25-f4d3-4626-9325-f91444e0fcd2)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         e84ceb81-acb9-4e91-a62e-109479df22a3)(content(Whitespace\" \
+         7665bac5-7521-4727-bd0a-0d226902f7b5)(content(Whitespace\" \
          \"))))(Tile((id \
-         c872423b-63af-4fe3-aea9-8bd10c8345d1)(label(value))(mold((out \
+         78ff3430-188c-406a-9bf1-05686e928227)(label(value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         189ca69d-143e-4273-a4f6-d80cfab66377)(label(=))(mold((out \
+         b467cd63-d875-48b7-81fc-98c2160d788a)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
          39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         2f3d317f-4d74-478c-9c6f-6819d1cfc312)(label(v))(mold((out \
+         015e8651-067e-4c9b-ad4c-e80c7c68dcf6)(label(_v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         76a09fe7-5a62-4d01-be35-3d9fcb5aca74)(content(Whitespace\" \
+         f3db0553-b8b3-4dee-a51f-4d2e70b6e39e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3fcf6f27-ae92-4b89-9295-f17c619925e4)(content(Whitespace\" \
+         95de71fd-c74f-48ef-a1c5-cf086a5b8343)(content(Whitespace\" \
          \"))))(Tile((id \
-         b129e0c6-6bec-4d27-abfd-054ac58e1258)(label(string_eq))(mold((out \
+         766b43b0-77e1-4ed5-a114-2a639a3db319)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         e46e1f8e-b59e-4e35-b526-294f9cfaac29)(label(l))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4f867d28-1800-4442-bade-ef31954388ba)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         0b9477aa-d3c1-4ad6-a6f4-2ddd95663fa9)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3a506304-5c7e-482b-8d4e-f3f9eb6c61dd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         358d412d-f02c-47d7-801a-500484759d48)(label(c))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7de42982-acc1-474c-8db0-d5b0e1de33a2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bc28f647-c703-4aa0-96c0-43608ba499f5)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f5e3362e-8530-4c91-93de-5baf729ff80c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         761c0e90-2c71-448b-bb4a-96128090ac57)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Tile((id \
-         513cc6eb-43a7-4dd2-b979-bd0eddb1dbda)(label(.))(mold((out \
+         c2e60ecc-eea5-41f8-be74-9e550fd84be4)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         78492cc6-5c19-4ef5-9a99-d159f24ee4eb)(label(value))(mold((out \
+         e0035ee7-f0f0-4530-a11d-7facb7d8acc4)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         e48a2a1b-6c46-49ef-9481-9aea4a6ebd42)(content(Whitespace\" \
+         5a08e2df-ea6e-4739-bb10-77576f7d3ea2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2ed7351b-4207-43d4-aa89-ccc7f9a4f744)(content(Whitespace\"\\n\"))))(Tile((id \
-         62707089-064b-4a51-8c9a-f9df39e613d0)(label(let = in))(mold((out \
+         837d1aa1-3195-4cb3-836b-345275e412c4)(content(Whitespace\"\\n\"))))(Tile((id \
+         0d08101c-86a7-4492-8d49-802c1490beee)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         ff0fb17d-b086-4c83-9478-322e2f0201dd)(content(Whitespace\" \
+         85d7480d-bf7e-4ccf-a05d-ea587b6711f2)(content(Whitespace\" \
          \"))))(Tile((id \
-         6ff09c52-994b-45f6-ae1a-e02631c75646)(label(group_by_subtractive))(mold((out \
+         9c5cc8af-a075-4d78-b957-e1f892cf6b99)(label(group_by_subtractive))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         68003bcf-6129-4c79-9a4e-88c63f5cdc20)(content(Whitespace\" \
+         92bd414b-7d13-4762-a151-44e899967351)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e56ecd6f-fe8b-49a0-8653-149c117dfa2e)(content(Whitespace\" \
-         \"))))(Tile((id 75128920-141e-4a46-80aa-8956667cf5ad)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         968b07c0-82fe-4b06-9f93-ab1fc37403a5)(content(Whitespace\" \
+         be4e0215-863f-4d65-bccb-db1e35f0bde8)(content(Whitespace\"\\n\"))))(Tile((id \
+         c9771488-067d-4021-a50c-46e276f4dd03)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         76f7e814-cd20-47ed-a863-5527d5a7b192)(content(Whitespace\" \
          \"))))(Tile((id \
-         0e168992-8eb1-4ea9-9b51-469b11f59433)(label(t))(mold((out \
+         e78b309b-99c8-4e13-bf47-a49b56abedfd)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         e457a9fc-64bd-47b6-996c-0511b2e35a28)(label(,))(mold((out \
+         fda5bd20-8865-4de9-91db-77af49a46cfe)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         67a70f5e-36e4-4011-b5f8-6aef12521b37)(label(c))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         d447e4bc-07e8-4faf-b65d-d61b80410a18)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c1def626-2670-4bed-96ed-636ad8c0ba94)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         70502c27-eddc-4c0a-92cc-5c23180f9183)(content(Whitespace\" \
+         0722b8b1-fcaa-423f-b9fa-c252ab168327)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4b83afc2-bcc0-447f-8bdd-063a2d5bd9ea)(content(Whitespace\"\\n\"))))(Tile((id \
-         12a470bf-ae10-4344-8e78-a66108fe8377)(label(let = in))(mold((out \
+         d10a817d-4193-4e3b-afe3-ca4c4cd8c0f9)(content(Whitespace\"\\n\"))))(Tile((id \
+         955ede0e-5234-489f-9d7c-57002f170f01)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         efa7381a-3265-48b5-9d07-642a615d5fa9)(content(Whitespace\" \
+         fc066d77-abcf-49f0-8351-34bb28c7613b)(content(Whitespace\" \
          \"))))(Tile((id \
-         c5458b1b-6ea8-4ba6-83f3-a4edc1f88666)(label(keys))(mold((out \
+         ad7ab5fd-a8e6-4925-ad1f-73446eec7bba)(label(keys))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cc9ecf76-4eda-474e-8a6e-3dfdc774ec8b)(content(Whitespace\" \
+         d43b5510-2313-4197-be91-70c203324e16)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c7f18a29-6441-4bc3-bf3d-c9117c43d8ba)(content(Whitespace\" \
+         426ab6c1-b1a6-4402-8e67-cd640bb20663)(content(Whitespace\" \
          \"))))(Tile((id \
-         532def29-4b86-415e-9ce1-fb1bee3704dd)(label(get_col))(mold((out \
+         20027188-621c-4106-a2a8-90e01a19679b)(label(get_col))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         1ecaebf5-adc6-420c-9324-e5eaf903f4d7)(label(\"(\"\")\"))(mold((out \
+         f13c2c61-75a0-4fae-8765-0305d46fe7c5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         5ed99d2d-4fae-46c8-ac87-6d567efcaad3)(label(t))(mold((out \
+         dda197f9-9230-4591-b3c6-30ab37537df6)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f88b186c-9097-4434-a33f-fad3c61d9112)(label(,))(mold((out \
+         5e159926-73fb-4d34-85d7-d5080b198f8c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0771925e-e002-4a1d-8a79-3a457d843add)(label(c))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         82bd2fd2-a697-4f6d-9f82-1dfc15ce31ba)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e915a28c-6e00-4b5b-9178-80fb61c7c5fc)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d0a3d599-c4c6-4a1d-8b39-afa06a385dcb)(content(Whitespace\" \
+         b9ff8102-8ec8-4418-8a4e-16ffaf12c2a4)(content(Whitespace\" \
          \"))))(Tile((id \
-         1d6e4a4f-24f3-486d-adbc-4009fc394fca)(label(|>))(mold((out \
+         2bea7ab0-1cc6-4bcb-bbb9-1dfcf3c44ef9)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1d0d3e23-829d-4ec6-819e-654c3c42c26e)(content(Whitespace\" \
+         4f7f7069-429c-460c-ae60-dadf12e9db0b)(content(Whitespace\" \
          \"))))(Tile((id \
-         15ed8812-522d-41a9-b34a-c8d6918b0afa)(label(remove_duplicates))(mold((out \
+         5ad20dcf-97c1-4e0d-b940-bb28d42b650a)(label(remove_duplicates))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         8d1af6f7-d482-42ab-b07b-222dee97a4d7)(content(Whitespace\" \
+         e8279fd8-4f90-4113-9529-930d49829710)(content(Whitespace\" \
          \"))))(Tile((id \
-         9e1370f1-a1d9-4a96-9b00-7a51dc09a0a4)(label(|>))(mold((out \
+         a1cd69be-c73b-4cf5-b49d-a5ebfabbede6)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f7913dad-bc0e-48d5-8220-2217525571b1)(content(Whitespace\" \
+         6d34c825-ed56-4dea-928c-f739b8a103a9)(content(Whitespace\" \
          \"))))(Tile((id \
-         f590ef98-a328-49e6-9c40-adac0a333cb7)(label(table_of_column))(mold((out \
+         5fd4a917-fbdd-4e67-a623-8cb819d3a27a)(label(table_of_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5dff5a9b-da06-44a3-86c1-5ae99647f04c)(label(\"(\"\")\"))(mold((out \
+         81247bdf-8420-4bbc-991a-7cd7acac316e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         edf16aa4-c756-434e-bf36-562ef3a2684c)(label(\"\\\"key\\\"\"))(mold((out \
+         94cee064-adb5-4413-b288-893e2705272f)(label(\"\\\"key\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         af59405f-9b7e-46f7-aeb1-8d82c5777b58)(label(,))(mold((out \
+         a03351dd-5a3c-4baf-8121-6f02da416b2d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e27bedee-c67a-4394-a4d5-d035683c558c)(label(_))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5135bc05-d54f-4c59-95e6-3526a1a57c05)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f41afd6b-4443-4e14-9b40-f3a500c7502d)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3f8e383e-f8f0-4f67-b7e6-9e36dc350d89)(content(Whitespace\" \
+         c4e6a42d-d7fa-4f11-8524-d528f7ce92cb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         42252da7-3c18-44b1-b4e0-72cd30c78914)(content(Whitespace\"\\n\"))))(Tile((id \
-         eb67d1b3-5d38-4203-8923-5a96151ee9fe)(label(let = in))(mold((out \
+         7ebbc873-4238-44c5-9336-d10436b197d3)(content(Whitespace\"\\n\"))))(Tile((id \
+         5daef780-68f2-4af5-9154-77cb96b3a4e3)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         cad5be35-171a-450d-9bf9-08d80bbf216b)(content(Whitespace\" \
+         1371fc67-a536-48a3-b6a3-8a50c4de5e97)(content(Whitespace\" \
          \"))))(Tile((id \
-         c4ee6a4f-da7f-49e6-b0f0-bd3776a2f1d4)(label(make_group))(mold((out \
+         b9ef0647-a793-4e92-acff-518bb5056047)(label(make_group))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ec867eb7-adfd-408c-9fc4-669c6325c880)(content(Whitespace\" \
+         49689538-4d77-4184-af8e-ea5ca95442b0)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5fca679d-0439-497c-979f-b2afba174f2e)(content(Whitespace\" \
-         \"))))(Tile((id 1f6fb2a3-cb74-4dd9-861e-2346ff19aada)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         cbc35605-0468-4ebf-a2b3-cb0efab182e7)(content(Whitespace\" \
+         144051a8-af3b-48ff-a29f-15f9ea2ae90a)(content(Whitespace\"\\n\"))))(Tile((id \
+         6ed9ef75-b9d1-4226-8dd5-40c22e2c1b9a)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         3963ecbb-4aaa-438a-8680-f44a4ad65eca)(content(Whitespace\" \
          \"))))(Tile((id \
-         7a2a1c14-bd39-4e4e-b2ac-a7be57e104fb)(label(kr))(mold((out \
+         a5602353-f5e1-4140-b8ee-a2ef4174b4c5)(label(kr))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d8dfe158-936e-44ef-a45a-0d0f543c108c)(content(Whitespace\" \
+         f91b5389-983b-40cb-9638-9c565a94fe1a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         52b236a6-2a4a-4783-8d54-ebda2c8ed616)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d934f63-a917-4794-8839-6d70dee3e8fb)(content(Whitespace\"\\n\"))))(Tile((id \
-         d5495011-b741-4eca-a149-85235f8d3db7)(label(let = in))(mold((out \
+         ce9e70ee-400a-4be2-9993-75c49cf8d2eb)(content(Whitespace\"\\n\"))))(Tile((id \
+         83f0ead2-c9c7-4513-83d8-23634b8950ae)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         aa31ad54-cc76-4523-9441-bd9697992aae)(content(Whitespace\" \
+         b8eb19dc-cdd2-4cd5-9bb2-f4f256761eb5)(content(Whitespace\" \
          \"))))(Tile((id \
-         b9016809-97c1-4a12-9d75-916dd2cb5ed6)(label(k))(mold((out \
+         82f5c297-c242-4ba5-aa36-b33b4b767a33)(label(k))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         323b4a59-68e5-44fd-aa8e-ab0288da6a3d)(content(Whitespace\" \
+         f5b0d5f9-cd90-4933-825f-55840cc36ef4)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7df5fcb7-3e9b-4743-9a9a-ff03146c12dc)(content(Whitespace\" \
+         a209326c-2252-4028-8562-03874ed96614)(content(Whitespace\" \
          \"))))(Tile((id \
-         2523e3c0-0716-45c7-87a2-51e47fa63c5f)(label(kr))(mold((out \
+         53a9b9c9-c542-493f-a50c-d86c2a669a39)(label(kr))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4b236c8a-4f8e-4d14-906e-a21c5d425895)(label(.))(mold((out \
+         d1acdaf3-1ebb-43a9-8588-e7afbca54055)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3137eb95-f8f4-4acf-a86d-a31d78ebdf2e)(label(key))(mold((out \
+         4e2735ba-c8ab-4793-b704-a13f5d3f3f47)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         04c58cc5-d3bc-40a5-a95a-2e2a0b12b405)(content(Whitespace\" \
+         8f44bac8-7957-44b4-835a-85fc7d9551fd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         55fe802f-2cd7-4b6f-873a-adad9be93983)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cef0fc92-528a-40a1-b8cd-1dea31ff235d)(content(Whitespace\"\\n\"))))(Tile((id \
-         bf9427e3-5757-4bdd-b9be-aeeaf69f5376)(label(let = in))(mold((out \
+         bc104872-3839-484f-bf1b-2e590674e610)(content(Whitespace\"\\n\"))))(Tile((id \
+         9467417f-3050-422c-8fa4-90e1338a6fc3)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         12267c13-9325-4a1f-a477-9273e0b4427a)(content(Whitespace\" \
+         4af4ee52-ccba-45e5-ad23-387d51df1b03)(content(Whitespace\" \
          \"))))(Tile((id \
-         ed54375c-23a0-4b7c-99ca-7e734bc54820)(label(g))(mold((out \
+         f3e8e497-ee43-441b-9849-de824f4d61e0)(label(g))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Secondary((id \
-         28e7706b-87d6-42b3-a63b-35fb06721e8f)(content(Whitespace\" \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         74fd7da9-38a2-4b26-bbd1-7db48229f658)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         16036369-51fc-44f7-9102-d716794699f7)(content(Whitespace\" \
          \"))))(Tile((id \
-         ebc717cd-9b62-4c01-8051-ec39864a420d)(label(filter))(mold((out \
+         73a40826-95aa-4f77-8924-e565cd3c597b)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6ca479c0-b986-4aac-977e-9132119b94ef)(label(\"(\"\")\"))(mold((out \
+         2c17109e-1523-4db1-b1b9-f3441d734e2e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d65527ee-ab67-4797-bd85-9eee2a96dda4)(label(t))(mold((out \
+         c6ee6663-3154-4c87-bb1b-f83ec6f0477a)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         9c540c74-6118-413a-9c60-b874e50bedfd)(label(,))(mold((out \
+         314d2922-595d-4e9a-b8ee-d7d7befc26c4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         64951eca-269b-4328-a073-89e33246a4ad)(content(Whitespace\" \
-         \"))))(Tile((id fe5b15e4-6de3-428b-831e-0fe4ebbf8d7c)(label(fun \
+         de210e8e-f53a-4e34-9578-6abcd281f78e)(content(Whitespace\" \
+         \"))))(Tile((id 26604000-4195-4e65-9ec9-b0b7ca750c3c)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         34fe71f2-ff5c-4070-ba19-018c5f1fb805)(content(Whitespace\" \
+         0936dad1-410e-4a31-bfd8-14eded0cb8e0)(content(Whitespace\" \
          \"))))(Tile((id \
-         cde9fcf0-8a09-4f2f-bd24-3214aff132cd)(label(r))(mold((out \
+         f876399c-acca-4641-b54f-83b3dfa20eed)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6b1c5f2d-2b44-4b1a-bcc2-8db319a298ed)(content(Whitespace\" \
+         2c8dc985-c34f-4f6f-9245-dcb06cb27337)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a8d954c1-bd67-4f2c-8240-29125291b807)(content(Whitespace\" \
+         4fe868b9-91a2-47a8-8d0b-b626a0e1757e)(content(Whitespace\" \
          \"))))(Tile((id \
-         a3baf37e-0430-4362-97d1-487a7639cf0c)(label(get_value))(mold((out \
+         fc58bae0-da43-4eb8-9803-e3d17959a4f3)(label(get_value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         2a67b975-aca0-403e-a1d4-9a60f6cb245e)(label(\"(\"\")\"))(mold((out \
+         0d22b488-17a8-4369-bc04-0237eb96b802)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         433c1240-8566-42d1-8892-2b6beecf48d4)(label(r))(mold((out \
+         78d8415c-a915-4673-ad03-064594322357)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         32198b21-2a15-493a-8063-d665346c70e7)(label(,))(mold((out \
+         c1e219be-35fc-43de-baad-70b17001b190)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         dd5d036b-d089-4443-8b54-540ef4715623)(label(c))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         57937632-b7ce-4532-bcec-9b53445bbf42)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4836cf3d-f724-4f85-b42d-7f3d1b8bd8ee)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         0aee179e-f700-4202-b28b-ba8b89fd8794)(content(Whitespace\" \
+         ff51f010-8cac-40db-8f02-88e05478188e)(content(Whitespace\" \
          \"))))(Tile((id \
-         7677bb0d-96c8-4ccf-96f5-060a1ab4cbf6)(label(==))(mold((out \
+         e8e0dcbc-fd8d-4a09-b95a-c0b7ef4f9f4b)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         796a65aa-418c-4fc3-8df2-aab1f7291ccf)(content(Whitespace\" \
+         3a86bf1d-3625-4457-a264-2227a7263442)(content(Whitespace\" \
          \"))))(Tile((id \
-         6a59de02-a4f7-4be2-9b0b-0dd4ab60e516)(label(k))(mold((out \
+         a50f20bf-203c-440f-b3d1-172ccf040bb1)(label(k))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d6ff30d8-75cf-44bc-81a1-6e10bec2ab66)(content(Whitespace\" \
+         2e64ad38-4d21-4865-8a6e-246db06ef6b9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         68e951b2-11e3-42fe-abbe-712f5eb41c3e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         44e77ea6-e43d-4bea-a40d-ef7266e093aa)(content(Whitespace\"\\n\"))))(Tile((id \
-         20387d18-6ea4-468f-8862-edc806edff65)(label(drop_columns))(mold((out \
+         e61d1904-cb09-4bf7-9d40-a09873808527)(content(Whitespace\"\\n\"))))(Tile((id \
+         aaa5a9fa-a8bb-4cca-9611-e03202b977c3)(label(drop_columns))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         68116183-1d1b-404c-b153-acb2fbfa7971)(label(\"(\"\")\"))(mold((out \
+         7541c2e1-725f-4d7f-acca-663802499a19)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         a0a4d709-e2f8-4fb7-be66-d9e152c27fb3)(label(g))(mold((out \
+         7ecff97b-5f95-44f9-9144-29656056e28e)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         beac9974-4681-4020-bb67-05a4eb66343f)(label(,))(mold((out \
+         5b9a903d-1f18-4cfb-ac89-86821f3a7544)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0833be61-a9ac-453f-a79d-c98af1da0b54)(content(Whitespace\" \
-         \"))))(Tile((id 9167604b-07d0-4647-a6a1-8b717c57fec1)(label([ \
+         8c1f4822-0caf-46f7-8571-39ade439cab5)(content(Whitespace\" \
+         \"))))(Tile((id 049e6125-6a32-4b85-a5fc-bb53b466f127)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         0882f43b-185a-494b-b05e-d6f8c5e7d56f)(label(c))(mold((out \
+         88de2ef7-d564-48cd-a327-4c55d4eac031)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         c9e2f7bf-a4c8-47a4-81de-37a9794693d5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e0776d26-1e9a-4ef7-9cca-58b611af859c)(content(Whitespace\" \
+         f5cb9b66-de8d-4cd2-b331-fb18382408bd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5377df3f-aa41-4a5d-9e45-8bd89806dfec)(content(Whitespace\"\\n\"))))(Tile((id \
-         9d3dc932-a783-41b1-a2b5-e984f9ad2550)(label(build_col))(mold((out \
+         905dbe8d-a1cc-4e3a-939b-b75bee21b9c6)(content(Whitespace\"\\n\"))))(Tile((id \
+         032892dd-8525-4639-af9c-a1a61df2a248)(label(build_col))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         cdcf47d2-312f-49f2-8a5b-127228db9667)(label(\"(\"\")\"))(mold((out \
+         0ff71fd7-728c-4996-9d6d-f5ded322699d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b46b6f45-4b55-44a4-b0a7-6a9bdaac1e64)(label(keys))(mold((out \
+         705f8033-900d-4f2b-8c65-fb08bed6ffe6)(label(keys))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         cc7333b6-38dd-49c5-8c5e-517c6a58ca7b)(label(,))(mold((out \
+         dc8f484d-0479-434a-88a2-2ab7a33133e6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7ed1ac8a-459b-450c-9149-4dc4396b4aa8)(content(Whitespace\" \
+         73da7005-fc20-45ec-aba9-0c22cc16933d)(content(Whitespace\" \
          \"))))(Tile((id \
-         5227d537-e0bf-40c8-8185-1cbdbeeed11c)(label(\"\\\"groups\\\"\"))(mold((out \
+         740528ef-1c12-43f6-b8c5-aeac50447ef4)(label(\"\\\"groups\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         cafc2728-ae58-4569-8db4-47b10e2895e3)(label(,))(mold((out \
+         3e99bb76-4874-4589-9611-b5489bb9ffc9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         120369be-ed53-4d41-afac-2318b792f58a)(content(Whitespace\" \
+         26f44db5-b9e2-4728-ab02-89c347e221dc)(content(Whitespace\" \
          \"))))(Tile((id \
-         8004748a-46b0-42f4-83a0-6e852f9e6ce3)(label(make_group))(mold((out \
+         640e737f-5936-4865-a4b7-00ee404788c3)(label(make_group))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         cc1ea179-b0bb-4607-9299-a84edbbb80ae)(content(Whitespace\"\\n\"))))(Secondary((id \
-         63161f83-c870-49a9-801b-b880c6e08417)(content(Whitespace\" \
+         fb4d686f-31a9-410e-ab22-3e00eec8c489)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3addbda5-aecf-4468-97d9-729d0ee52600)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4ddb29ea-ad4e-45f2-8fd8-a588de08becd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8c3ebabd-7212-4091-bd2f-249febb748df)(content(Whitespace\"\\n\"))))(Secondary((id \
-         123d94f7-0525-4d4c-bc53-b7edf17a29f8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         668f2117-f464-4349-978d-3abb6dbbb8d1)(content(Whitespace\"\\n\"))))(Tile((id \
-         79bd3c32-e5de-4aae-8c3b-75fb121f888e)(label(type = in))(mold((out \
+         ef3d0b25-464f-45d3-afe4-375c032cb094)(content(Whitespace\"\\n\"))))(Secondary((id \
+         128919c2-8857-40ca-9d96-13b44a5d71a5)(content(Whitespace\"\\n\"))))(Tile((id \
+         0792ae34-72b1-4fce-beee-b4b3020224e8)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         227dfb7a-6617-4cd1-bb81-3cda26991b28)(content(Whitespace\" \
+         d0365d11-b0a4-4cad-be3c-c911cf3c2039)(content(Whitespace\" \
          \"))))(Tile((id \
-         41097181-01c5-4b0b-b295-06f1f5aa94dc)(label(GradebookEntry))(mold((out \
+         64b3c3f7-3910-481c-91fa-15bedc8da4f0)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         e1af4b97-1d10-47a7-a5dd-a69534794eb2)(content(Whitespace\" \
+         dd097864-1b24-4350-a237-468ec99c71d0)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5f5f1a3c-51e5-4583-a7da-cb0c6ba2008f)(content(Whitespace\" \
+         d9342970-4000-497c-8c1f-8c2245832091)(content(Whitespace\" \
          \"))))(Tile((id \
-         00bfe61a-2b7f-40ee-86f2-381e69cdead9)(label(\"(\"\")\"))(mold((out \
+         809d54f4-0a8c-4c5a-b576-593e796ba191)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         c99c6b46-429f-4fd9-a8da-343de6522e0f)(label(name))(mold((out \
+         2adc0dce-8bdd-4ee0-b0fc-3ebce4cb7654)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         cb50c69f-a5a8-4e4c-b361-771829ce64fd)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c5d7c2e2-2f39-48a4-9b66-cf2fc5521535)(content(Whitespace\" \
+         \"))))(Tile((id \
+         06c14bc3-55ef-4109-a4a1-e55c3edbc75f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         3932cc14-d4c4-41d3-b1e8-18b2852e1d89)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         31430a16-db12-4aa1-b047-7b788605116b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         144d79c4-4c62-4532-9e50-70a5e7328a48)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         ba258991-d2a1-474c-8e1a-70839fceeda0)(label(,))(mold((out \
+         f7d90b55-fa9e-4e0c-b49d-7052281ef8c0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         51f87dd3-9955-43d1-b868-451026404298)(content(Whitespace\" \
+         d915d118-e3d2-4a3d-899b-5aca956c8268)(content(Whitespace\" \
          \"))))(Tile((id \
-         0808ffe8-6f53-4ebc-8c0a-c980cafdda4f)(label(age))(mold((out \
+         43fdb20a-aa8e-447d-b1f2-03ee71f3f264)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         d84c26c5-7615-46f1-912d-32dd437a2a2d)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8f2e66ed-cd2b-42e8-9f41-d468822f6fa2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9d4f0bfb-9254-4340-a0b0-fbb35aadcf25)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6ec792f9-821a-46e8-8686-80820cd0d0bf)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0ef5cb29-c688-41d0-acad-223f1a95ca80)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e924fda8-bb9f-4aa4-a5dc-c96022fd8628)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         ef8e2420-1a6e-4945-ab0f-dcb6ed6a8a58)(label(,))(mold((out \
+         8dfe99bd-2a64-4d37-a7d8-5d5db7d3f7b5)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         55373b7f-6ab5-430a-ab0e-799b6d82ad17)(content(Whitespace\" \
+         967e4f55-9714-4d0d-91dd-f916422bc1e1)(content(Whitespace\" \
          \"))))(Tile((id \
-         ae8572bb-0de6-467b-b6c0-defb79c05f67)(label(quiz1))(mold((out \
+         fbd4c13f-d8d0-4771-bf5c-752ebf43e0f6)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         38dc4333-9f59-48c7-af74-bcbf11bbfa00)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b229b714-41f3-46ae-b2bd-5d62eeafeb4f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         577ffa54-d90b-4902-9bf3-d234b4d64231)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         8638e2c4-d611-4f3f-9c6e-b57b40354f94)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4f0eb220-5dc9-4463-b7c0-f8061c1b3dc6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         25486673-2735-4482-83b9-ed3a0f99d7c2)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         8bc60494-243c-444e-a1cc-faabc5c5291b)(label(,))(mold((out \
+         5bf1e277-bdc5-4c37-a61c-9cf1a9b0d100)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         637a7636-01b5-4b30-a5c1-9c77dfbc29a7)(content(Whitespace\" \
+         d38fa62c-3b64-403a-8fa9-618bc58f687c)(content(Whitespace\" \
          \"))))(Tile((id \
-         2db85571-3f2d-4202-a5a1-8e788d51464c)(label(quiz2))(mold((out \
+         24dc2adf-f4c6-4d03-8088-aa79723ffac2)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         53613c64-9a1c-4dbb-a5a6-fac84c2e08af)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c4b506a8-be43-414d-ae18-04184a49d19e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f849556b-ab2b-4090-8aeb-c24cd3b5305a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         ed8b786b-441f-4e7d-bb55-ba3e9fe0f6cd)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e3b2ca28-742e-4e03-90d0-facad5f47d21)(content(Whitespace\" \
+         \"))))(Tile((id \
+         69456a11-1cea-4977-b663-117041d52547)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         8da19caf-3209-4f1a-bc13-f15f29c8a039)(label(,))(mold((out \
+         542043bd-c212-4709-b777-b7605610c7a3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6c19de0d-0180-43d3-b4ac-7d3d594c43af)(content(Whitespace\" \
+         c741f92c-4643-492f-b841-1f5866b95780)(content(Whitespace\" \
          \"))))(Tile((id \
-         03436d0c-63f3-41df-9d89-0425d23b16e9)(label(midterm))(mold((out \
+         7848f447-1b80-47c5-b16c-813e4393c34f)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         d45d47ea-fed6-4d63-a25e-b5883b2c5f1d)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f6a33117-7afe-45ff-ad5c-74105bf14d35)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e21b1e3b-f697-4be1-a752-af5b15e57c5a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         411d9d02-c46d-4934-bd6c-ca98ffca2f32)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5c180517-78f6-4d7e-961a-6459004ad067)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aa1c6c14-aaf5-476e-ae34-6a88659253cf)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         27c362af-4037-47bb-abbf-b45f77c99071)(label(,))(mold((out \
+         96b8ef47-2cd0-4b2a-a897-a88e20bfd4c5)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b0c4ba14-b9eb-4f6b-a84b-68a4ed5c670b)(content(Whitespace\" \
+         cfa92086-7076-40ab-be58-9ece5465fa56)(content(Whitespace\" \
          \"))))(Tile((id \
-         f55d7be6-c796-4046-ae58-30760e6e62f0)(label(quiz3))(mold((out \
+         8e514409-aa72-4a15-a985-1841c8d491fb)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         740100aa-08e5-441b-a38e-4dd26a541894)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         313451f8-0b11-45e0-a307-1ba3360df5c4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c72b259f-0b5b-445a-b3f4-2840fba9fbc1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         fdc4715c-200b-44e8-b22d-2bdce06c1ba7)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b77d6e1d-d8bd-416d-ae63-478036470b23)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b160617c-52d6-4ae9-b005-41cd635acd7f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         823de602-3df3-46e7-b213-de7e498369f5)(label(,))(mold((out \
+         275dd124-427d-43eb-9d23-3b86eb909272)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c4d5679c-c992-4e13-af32-5a613a248810)(content(Whitespace\" \
+         53a08743-f24b-4da8-a56b-761f33f93e11)(content(Whitespace\" \
          \"))))(Tile((id \
-         96c3d526-6966-4cd5-9599-9351af1d1b0d)(label(quiz4))(mold((out \
+         4c298c2c-3105-4475-9f4d-d61af8535d5d)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         43f7405f-dba1-46f7-97a5-9aa925dc8b53)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3dffd9b1-2f5a-4f19-90f9-12014ab6c58d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         26354a8b-5f33-4636-8af9-afa4d0293d2b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         42089245-10c1-4de5-b14c-07c559e2bedd)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7e845807-b0c5-4f79-85b1-af2eda833ec7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bbfd2ae4-a135-4038-969c-a625418489e8)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         d9c052ca-b33f-461a-9f59-8b672a001fe7)(label(,))(mold((out \
+         8e72af66-1cc5-411f-827b-1d40cf77988f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         af1e9456-0d49-4aaf-bbde-986e80e184e6)(content(Whitespace\" \
+         dda6af38-efaa-4da5-abf1-b028ff6bbce0)(content(Whitespace\" \
          \"))))(Tile((id \
-         f4321c06-fdb5-4f0b-a2d9-c4d1beb5c1fa)(label(final))(mold((out \
+         2ee8d9e3-71d4-4bed-a918-b36cb36b678b)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         ef4c90e9-b385-4275-8e2f-9ead407f6ede)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0d6320c9-02de-4389-9e09-fe9e0213637a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         79a0cff1-c287-4396-a3cf-b637a1b952e5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         8ac6ad06-aae9-4dea-be82-ca6269b7ff1d)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8eadafac-aa81-44d6-9fbc-cd2d364f5128)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c79fc8e4-167e-495a-bbdc-f8a39fc20b66)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a473af40-ca2b-498f-a999-39a0901823b0)(content(Whitespace\" \
+         0a5746a2-1dc8-477f-9c78-98c306c2a3f8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1c622c58-021b-450f-9094-adfcb7554075)(content(Whitespace\"\\n\"))))(Tile((id \
-         ff6ffa78-75cc-452a-977c-f347078435ff)(label(let = in))(mold((out \
+         a4907bef-87f0-4ed8-8355-3db2776a2b7f)(content(Whitespace\"\\n\"))))(Tile((id \
+         3a1fc3a3-9c3c-4e34-b015-27998a2b0da7)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         f82e470e-ea53-462e-8b89-5623ce6686bf)(content(Whitespace\" \
+         6c55143a-4504-48f2-bf48-51677f8aab27)(content(Whitespace\" \
          \"))))(Tile((id \
-         9a0bd5b7-f32a-4c47-a518-dab6dafe46f0)(label(gradebook))(mold((out \
+         c768f92c-6301-4211-a7af-8d9c6c5668a7)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         629b1e1b-5ec8-4089-a115-344fe4508781)(content(Whitespace\" \
+         b34e9a80-2f03-4034-bc74-d1e0e9131442)(content(Whitespace\" \
          \"))))(Tile((id \
-         ada97eb8-6861-433c-99bd-58014d8c8d75)(label(:))(mold((out \
+         55c9ae67-fb4e-47ce-9cec-fdb3fed6c1f4)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         cef0213e-de24-4de2-8321-dd34efc2a929)(content(Whitespace\" \
-         \"))))(Tile((id 583e1067-bdb5-415b-b243-d335d68d852f)(label([ \
+         5811c548-5eb8-492f-b3d1-54c6bfbb9888)(content(Whitespace\" \
+         \"))))(Tile((id 6e4f3692-ea21-415c-9583-2cf079c3adfd)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         2a115fb8-1b23-40b4-bb64-7c5ec769b72b)(label(GradebookEntry))(mold((out \
+         05e23f0e-d79a-4302-9194-75ea7f93b2c9)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         53203b04-7ebe-45c3-a557-5d414132b493)(content(Whitespace\" \
+         1aced17f-0566-44c1-832f-3ecc776c2582)(content(Whitespace\" \
          \")))))((Secondary((id \
-         546c8b5e-ac82-4198-a449-21c1e38280e7)(content(Whitespace\" \
-         \"))))(Tile((id e0a099f1-8ae2-44e6-8eac-d46e593c8bc2)(label([ \
+         52632d8d-af3e-4c9c-9039-8dd3e6a20f4f)(content(Whitespace\" \
+         \"))))(Tile((id d7a83b2f-3e2f-4bec-9867-4ea8f6333fb8)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         3520bba6-7aa1-4e31-adbb-08f6ef5b0cf4)(content(Whitespace\"\\n\"))))(Tile((id \
-         4d85b5f0-64b1-40a6-b9f0-5a1a2434717d)(label(\"(\"\")\"))(mold((out \
+         9319b538-d69a-4e61-867c-98b948a33cfe)(content(Whitespace\"\\n\"))))(Tile((id \
+         1663280c-519f-4e11-b963-f5cc0c40a0fc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b901a73b-35df-457c-a093-e942d4843188)(label(\"\\\"Bob\\\"\"))(mold((out \
+         454831fe-7136-411b-9750-9b0f587493ed)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5ff36cc9-e426-4418-ade6-fa1e093c1591)(label(,))(mold((out \
+         36b4b901-870b-46b3-9fca-b8ed3facce98)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1a5701f2-8bc5-4daf-9e16-962c2a7a145d)(content(Whitespace\" \
+         8961055c-25fe-4b6c-8840-da4752f7bb7b)(content(Whitespace\" \
          \"))))(Secondary((id \
-         07113b87-861a-4dae-ae49-7773c3910c9b)(content(Whitespace\" \
+         3cccda4d-eea6-4d9d-bf6f-442dcc130de0)(content(Whitespace\" \
          \"))))(Secondary((id \
-         7f1624c6-80dd-4207-80a9-7c242df612c8)(content(Whitespace\" \
+         e489d328-3199-465f-93b4-cfdbe3cf3df6)(content(Whitespace\" \
          \"))))(Tile((id \
-         5aba025d-f504-47d5-9559-1a96410ff41f)(label(12))(mold((out \
+         b6ec3527-bdcc-432a-8849-7486d412290b)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         63a1fd05-b910-4bad-b08d-9af90fc644cb)(label(,))(mold((out \
+         1377bf2f-3820-400f-b5de-46143578f2b9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         78aa2764-ce1d-4f31-8ecf-03cad2c7f052)(content(Whitespace\" \
+         5b221e43-e3c6-48f2-b27d-0640ac5cdccc)(content(Whitespace\" \
          \"))))(Tile((id \
-         6a3fac6b-183a-4d0e-bf97-d603ceabb32b)(label(8))(mold((out \
+         a57346ce-1e8b-4099-9f2f-39b2ad36a949)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         09488335-6b9a-445d-a94f-309b5c0fc3c7)(label(,))(mold((out \
+         92b041ca-4414-48d3-8207-40bbb351e035)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9aac1c89-1f41-46cb-822f-cee389e9c1ec)(content(Whitespace\" \
+         51c09e77-362f-47e6-b3dc-e53b6919f2e3)(content(Whitespace\" \
          \"))))(Tile((id \
-         323a8371-766e-4265-b52c-6978b55a27d3)(label(9))(mold((out \
+         b0e775cc-e323-4b90-a53c-baaf726aae50)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a7a9374a-f757-41bc-9eb3-463ebe276fb2)(label(,))(mold((out \
+         21a72042-d748-45ba-8737-c2e241957d5b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8f00c351-4ddf-4e63-ae80-b8bae9c24c26)(content(Whitespace\" \
+         c065ec7c-d856-46ed-a4da-b1050cb3bda9)(content(Whitespace\" \
          \"))))(Tile((id \
-         50493f8c-ed57-4c88-9382-dc705ba973aa)(label(77))(mold((out \
+         5edc0992-9dfd-4b7e-acee-09024b10f027)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c4244932-c9cd-417d-a792-406df6a02174)(label(,))(mold((out \
+         89fe80aa-1ee6-4679-b391-5eb7c7fb1357)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4d38322d-8e29-472d-ac22-96cdd173cf9c)(content(Whitespace\" \
+         7d299e18-8d44-41bb-9959-652c23527337)(content(Whitespace\" \
          \"))))(Tile((id \
-         fdfbad5c-f9c5-465c-aa47-7683a82f62f7)(label(7))(mold((out \
+         cb22b491-7949-42ca-ad6a-c59da0d56af3)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3eed0180-cc8b-4989-8c20-f781265d1f1b)(label(,))(mold((out \
+         e9c60b11-b91a-4d9e-8f3e-9b9bd085b278)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a1e986da-7bfe-41e0-9f6e-c1e18205a90d)(content(Whitespace\" \
+         eb066814-869b-4716-b15c-09c716e1b39c)(content(Whitespace\" \
          \"))))(Tile((id \
-         263676cf-56d4-4825-b76b-544d0c036873)(label(9))(mold((out \
+         2cccc3b4-c77b-4ab3-8c90-79c7ec089b4e)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         616e40dc-cbd3-4799-96cc-f58147059b04)(label(,))(mold((out \
+         210b10c5-801f-4216-a9ac-ab34425edc98)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8f779768-14e1-4978-b01b-ffee8679b0e4)(content(Whitespace\" \
+         59378a82-c157-49de-a85f-4f403471a013)(content(Whitespace\" \
          \"))))(Tile((id \
-         dd699804-cc08-4a1f-8d1a-5abbd88b5d1c)(label(87))(mold((out \
+         a0a72ee8-cd99-454f-8172-bf0130edd709)(label(87))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         424e0e6e-704c-4939-8c24-a0b5b36114c9)(label(,))(mold((out \
+         7a582fae-4b62-4820-ae93-f73ac436509b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e60fb6c2-e7d1-41f7-9c32-5a7785d26a32)(content(Whitespace\"\\n\"))))(Tile((id \
-         9b4cd84d-2b16-4a26-945b-cceb195d8eae)(label(\"(\"\")\"))(mold((out \
+         610121b8-0cf6-4fc3-81a1-61049a02ed4f)(content(Whitespace\"\\n\"))))(Tile((id \
+         24bcf5df-9958-4b9d-b830-ea7d4707e161)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f5cb223d-9df7-431d-80dc-d8cd68e5a59d)(label(\"\\\"Alice\\\"\"))(mold((out \
+         2546d3a3-1b1b-48f9-a9d5-4bf9eae47a61)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c4861d2a-9db1-4c3f-af40-adab564a67d4)(label(,))(mold((out \
+         25ad4e04-9ffa-4274-8926-7410b13aa484)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         85b5b264-b5dc-41e0-b5cc-c7878a85ab7c)(content(Whitespace\" \
+         8a8add6f-97ee-4b9e-afb8-9de6e53e32e2)(content(Whitespace\" \
          \"))))(Tile((id \
-         749f505d-e5d3-44b0-903f-e8899970b539)(label(17))(mold((out \
+         2e01450d-22a0-47e9-9d09-4ecf47af03a6)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         bdf45b36-4ecd-47e0-a748-c2fa4a2cd858)(label(,))(mold((out \
+         7a19eae4-bbba-4ffd-a3f4-03f4515e6ef3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         73f99443-8438-4263-97a0-c7d13a69cbb2)(content(Whitespace\" \
+         35108146-19ad-4138-878b-44aa4a3589cf)(content(Whitespace\" \
          \"))))(Tile((id \
-         b2829b2f-10e0-4881-b6cc-906b98c4c785)(label(6))(mold((out \
+         e9e8bb67-d882-4585-8cb3-0f4cacd0b33f)(label(6))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ed9d7672-7291-45b0-968d-ab7a2de97149)(label(,))(mold((out \
+         15c1e07f-dbb2-45f8-8e6e-d3e943877a21)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0d889771-be8e-4049-bd2a-0198e3395966)(content(Whitespace\" \
+         0dc2eff6-52bf-455b-8953-44377728a99a)(content(Whitespace\" \
          \"))))(Tile((id \
-         59a563eb-8b2e-4308-aa82-1104fb767d42)(label(8))(mold((out \
+         b9b9077e-e9d9-4758-851c-46388edb68df)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         0ac7be43-95d0-4b34-8957-76a1eff98c5f)(label(,))(mold((out \
+         bc5bfc5b-e873-4ca0-b3d5-34ccbaac043b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6874efb4-f0e7-4531-a90f-c58d9bb794c6)(content(Whitespace\" \
+         46e1f6ad-704a-430d-a602-0424ed81d385)(content(Whitespace\" \
          \"))))(Tile((id \
-         53def0f1-811e-451d-bb84-b5973326b8fc)(label(88))(mold((out \
+         bd6d1f68-8cdb-4644-8760-f21000a28a21)(label(88))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         be6004d6-5226-4bac-b78d-bd2a96f57942)(label(,))(mold((out \
+         7af6a17e-904a-47d9-821f-0c7a071b8a3a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         44d1d18e-79b7-4bca-a3cc-e7d9174e6f11)(content(Whitespace\" \
+         73b6ee01-b2fc-46d4-b5e1-d1f71b002f17)(content(Whitespace\" \
          \"))))(Tile((id \
-         252caf67-9c69-4cfb-a2c4-7ccc9df2d874)(label(8))(mold((out \
+         bb63c9b1-6c51-48af-b737-1110fc98a8eb)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         8036999a-bce8-4c8c-bcd8-8b7892cbd89a)(label(,))(mold((out \
+         e4d32923-e1ed-4674-b672-0e4119c6f057)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c4f5b671-eecd-4a05-aa9d-ceeff6e79aed)(content(Whitespace\" \
+         64ed4f58-0a9a-4bb0-a778-ad20457016d0)(content(Whitespace\" \
          \"))))(Tile((id \
-         17be14fa-d46c-455b-a9e5-9d91aa9fa890)(label(7))(mold((out \
+         201b8da8-4443-423c-9bd0-9d246d58ccb0)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c85e7417-b1b4-4068-920b-7d58c6d07c03)(label(,))(mold((out \
+         99d42415-df2c-4bc6-82f5-d721471b8d24)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ac24e740-eb1e-42e4-b7a7-782187bc499b)(content(Whitespace\" \
+         84af4cf6-babe-49fe-b75a-e63daca9ea36)(content(Whitespace\" \
          \"))))(Tile((id \
-         123a8d8c-9427-444c-b31c-85269e01a567)(label(85))(mold((out \
+         a2902167-f9dc-4998-9b12-cb3282847819)(label(85))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         4d32667e-1e99-4441-949b-fe9470c582ed)(label(,))(mold((out \
+         a98e0c66-ee32-4ef0-b1d5-ba17dda31f72)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0b032719-3c83-4419-be9d-fd472280c9d5)(content(Whitespace\"\\n\"))))(Tile((id \
-         8b5b9eeb-3756-4d33-a1ec-60a25001f6b9)(label(\"(\"\")\"))(mold((out \
+         f9c83e66-da98-44ac-91b1-bacbb5cfd793)(content(Whitespace\"\\n\"))))(Tile((id \
+         a48d2396-75f6-4fee-a0d8-25503749517f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f30fee13-8015-4d27-8a8c-d7aadd778c5c)(label(\"\\\"Eve\\\"\"))(mold((out \
+         657de0ac-4f1a-4fb4-b962-1bf0d5f29c56)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3f104528-8c9f-4046-9a0e-019518b539db)(label(,))(mold((out \
+         f7fcb35b-0628-4d3d-a9d5-e041dd871f48)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         614e0068-9e1e-4478-928e-e02398163fc5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33312060-6c63-48ac-8559-f1b9975ad2ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8e4e0d75-fb46-4182-952b-67328a6a68e5)(content(Whitespace\" \
+         bb9d4d1b-5b72-436c-9260-b599980135c0)(content(Whitespace\" \
          \"))))(Tile((id \
-         a1ad059b-2664-46d4-8c63-e26f24681cc3)(label(13))(mold((out \
+         df8a75de-3f56-43fd-95ff-d2d65381c3e3)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         04c30236-6234-4c4d-8a42-9013f708afed)(label(,))(mold((out \
+         ebb043c0-92ff-46fe-9184-f688a5debeb1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2277a87f-75c8-4b65-ae15-5ef4e9898939)(content(Whitespace\" \
+         93a42b5b-5337-4321-96df-497e47f18ef2)(content(Whitespace\" \
          \"))))(Tile((id \
-         cbe3f317-fba2-4371-8d34-c7ec4a0cfc07)(label(7))(mold((out \
+         ed6d6b28-9d13-44e0-b751-8dfe7d568dd2)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e768d80f-65af-4999-9390-24d95f784739)(label(,))(mold((out \
+         1c06a537-af29-47cb-9859-fa3095d56a99)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         07c86d27-d47c-4c7a-ac9c-ddf0d3d40c6f)(content(Whitespace\" \
+         3a3e0746-9832-45f3-ba86-92cdc598206e)(content(Whitespace\" \
          \"))))(Tile((id \
-         6ef78e2a-62cf-4c70-a737-7cea2a22c477)(label(9))(mold((out \
+         f7b2d64b-9d71-4da7-915b-465ec3303306)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5ddbdcdd-9987-4e15-89c3-05c5d52f906e)(label(,))(mold((out \
+         8f3c69e2-0092-4a56-9385-896738fd20a2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1ab09847-0124-4981-926c-ad55df09eb6d)(content(Whitespace\" \
+         c6ae315f-a4be-452e-a8c6-aaa23b605902)(content(Whitespace\" \
          \"))))(Tile((id \
-         347488d2-077f-4738-aae0-185788a26b38)(label(84))(mold((out \
+         3d2b2cc4-41e1-450c-afe8-35fbf4912de5)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         37e895e8-5c3a-4b21-8fd7-74eaa44869c4)(label(,))(mold((out \
+         fee2572b-8159-4b42-9df4-b8798dc4eaf0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dfffc663-4ce3-4617-97b6-eff9bd2665ca)(content(Whitespace\" \
+         8e65c41d-cdcb-4cd1-a739-350db5d2885c)(content(Whitespace\" \
          \"))))(Tile((id \
-         f6ba8d1b-9f37-4071-acf7-7f55e31f6f02)(label(8))(mold((out \
+         c317d782-a27b-446b-8349-e82402acf699)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         438787c8-c9f8-482b-b7e1-8d5155757fd1)(label(,))(mold((out \
+         a97af97f-9993-48fc-9a15-c36c54decf2a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a6c2a559-c3c4-4f23-86e4-f8cd04b18597)(content(Whitespace\" \
+         7c4a8719-f0b2-4770-b671-b398d31203f7)(content(Whitespace\" \
          \"))))(Tile((id \
-         7ae4b566-7af0-4371-a49d-4052a0b1967e)(label(8))(mold((out \
+         1f70ba50-f205-4448-b2dc-37c0088817f3)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5f1f2a5e-724c-4f86-a79e-57b7ad0402b9)(label(,))(mold((out \
+         001bcefc-f0ad-42f4-a554-394aa200d99e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         141ad039-04fd-4cdd-b818-389dc4c0b0eb)(content(Whitespace\" \
+         c0581171-6bac-42aa-bc18-324fb168fe2c)(content(Whitespace\" \
          \"))))(Tile((id \
-         b2bb3a69-eb3e-417f-952e-b15a7bbfe328)(label(77))(mold((out \
+         76a21912-bece-4bce-ac21-ec6c9c701f26)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d466f1e3-100b-422e-acfe-06f7ce0bdeca)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         b071d70f-8a8a-40e4-9954-187fe0f9e8ea)(content(Whitespace\" \
+         92ce52ff-0266-48f4-8d7d-643940755fa6)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         116f77c9-e0ce-4880-9bb9-fecbb80cd187)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         10807edb-5b78-49c2-aa5b-9abfc619ccec)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8ff5d49b-bbd2-4f68-9dd2-743e2ee2cdef)(content(Whitespace\"\\n\"))))(Tile((id \
-         ba0bfcf3-0195-4839-8211-acdd1adde4bd)(label(group_by_subtractive))(mold((out \
+         71d34754-fb63-45bc-9d9e-8ed42213cbc4)(content(Whitespace\"\\n\"))))(Secondary((id \
+         f18dd8b0-cefe-4152-a36a-b06e9d14d264)(content(Whitespace\"\\n\"))))(Tile((id \
+         9475db0a-b793-429f-8125-1b6a1ca2f11a)(label(group_by_subtractive))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3472c68f-3e6f-418e-a97e-2fd2d4ab6ca0)(label(\"(\"\")\"))(mold((out \
+         fd98a8ab-1285-44c5-a704-7f46479d1ff9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         fdc320ef-d6d9-494c-8992-64e8c5248fb6)(label(gradebook))(mold((out \
+         ba8c2eb2-7ea9-42fd-a4e9-a61dd87ec33d)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         93ad5e98-5259-422f-a5ed-cba169b9e98c)(label(,))(mold((out \
+         f4dabd8a-437b-4dbd-b790-996c36d25ac9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b3b8ca54-9e40-4747-b552-e948dfdc1658)(content(Whitespace\" \
+         2cdb888b-b6d7-4205-bb29-910a8ca4af82)(content(Whitespace\" \
          \"))))(Tile((id \
-         93b4017a-29a3-4345-8c0b-fc5799e74291)(label(\"\\\"name\\\"\"))(mold((out \
+         06c3694f-7c3f-4063-aff3-cd44fa176430)(label(\"\\\"name\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))";
       backup_text =
-        "let get_value =\n\
-         fun (r:?, label:String) ->\n\
-         find(to_lvs(r), fun e ->e.label == label).value\n\
-         in\n\
-         let add_rows = typfun row ->  fun (r : row, rs : [row]) -> rs @ [r]  in\n\
-         let add_col = fun (t : [?], c : String, vs: [?]) ->\n\
-         zip(t, vs)\n\
-         |> map(_, fun (r, v) -> from_lvs(to_lvs(r) @ [(c, v)])) in\n\
-         let remove_duplicates =\n\
-         fun (xs : [?]) ->\n\
-         fold_left(xs,\n\
-         fun (seen,x) ->\n\
-         if mem(seen,x) then seen else seen @ [x],\n\
-         []) \n\
-         in\n\
-         let drop_columns = fun (t : [?], c : [String]) ->\n\
-         map(t,fun row -> to_lvs(row) |> filter(_, fun entry -> !any(c, \
-         string_eq(entry.label, _))) |> from_lvs) in\n\
-         let build_col = fun (t : [?], c : String, f : ? -> ?) ->\n\
-         map(t, fun (r) -> from_lvs(to_lvs(r) @[(c,f(r))])) in\n\
-         let empty_table : [()]= [] in\n\
-         let table_of_column = fun c,vs ->\n\
+        "let get_value = fun (r : ?, label : String) -> find(to_lvs(r), fun e \
+         ->e.label == label).value in\n\
+         let add_rows = typfun row -> fun (r : row, rs : [row]) -> rs @ [r] in\n\
+         let add_col = fun (t : [?], c : String, vs : [?]) -> zip(t, vs) |> \
+         map(_, fun (r, v) -> from_lvs(to_lvs(r) @ [(c, v)])) in\n\
+         let remove_duplicates = fun (xs : [?]) -> fold_left(xs, fun (seen, x) \
+         -> if mem(seen, x) then seen else seen @ [x], []) in\n\
+         let drop_columns =\n\
+         fun (t : [?], c : [String]) -> map(t, fun row -> to_lvs(row) |> \
+         filter(_, fun entry -> ! any(c, fun s -> entry.label == s)) |> \
+         from_lvs) in\n\
+         let build_col = fun (t : [?], c : String, f : ? -> ?) -> map(t, fun \
+         (r) -> from_lvs(to_lvs(r) @ [(c, f(r))])) in\n\
+         let empty_table : [()] = [] in\n\
+         let table_of_column =\n\
+         fun c, vs ->\n\
          let t1 = add_rows@<?>(empty_table, map(vs, fun _ -> ())) in\n\
-         add_col(t1,c,vs) in\n\
-         let get_col =   fun (t, c : String) -> map(t, fun r -> to_lvs(r) |> \
-         find(_, fun (label=l, value=v) -> string_eq(l,c))).value in\n\
-         let group_by_subtractive = fun t,c ->\n\
-         let keys = get_col(t,c) |> remove_duplicates |> \
-         table_of_column(\"key\",_) in\n\
-         let make_group = fun kr -> \n\
-         let k = kr.key in \n\
-         let g= filter(t, fun r -> get_value(r,c) == k) in \n\
-         drop_columns(g, [c])\n\
-        \ in\n\
-         build_col(keys, \"groups\", make_group)\n\
-        \ in  \n\n\n\
-         type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+         add_col(t1, c, vs) in\n\
+         let get_col = fun (t, c : String) -> map(t, fun r -> to_lvs(r) |> \
+         find(_, fun (label=l, value=_v) -> (l == c))).value in\n\
+         let group_by_subtractive =\n\
+         fun t, c ->\n\
+         let keys = get_col(t, c) |> remove_duplicates |> \
+         table_of_column(\"key\", _) in\n\
+         let make_group =\n\
+         fun kr ->\n\
+         let k = kr.key in\n\
+         let g = filter(t, fun r -> get_value(r, c) == k) in\n\
+         drop_columns(g, [c]) in\n\
+         build_col(keys, \"groups\", make_group) in\n\n\
+         type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = [\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-         (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
+         (\"Eve\", 13, 7, 9, 84, 8, 8, 77)\n\
          ] in\n\n\
          group_by_subtractive(gradebook, \"name\")";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/example_programs/B2T2ExampleProgramspHackingHeterogeneous.ml
+++ b/src/b2t2/slides/example_programs/B2T2ExampleProgramspHackingHeterogeneous.ml
@@ -6,90 +6,76 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         03101488-a43d-49c8-a300-c08a03f024b2)(content(Whitespace\" \
+         864d0bcb-40b0-410d-aab7-93c823e0100d)(content(Whitespace\" \
          \"))))(Tile((id \
          85f040c9-fa5e-46be-883a-e2d6bce42236)(label(fisherTest))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b7b49de8-149f-4649-b418-6b69f42d73ce)(content(Whitespace\" \
+         ac9b2d2a-0290-495c-b93a-cf2cc5947c92)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9a8ba369-d7a4-4f9d-9e92-db2b55b122de)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b78970ec-f3bd-41b2-afb6-2255d50bd08e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         05feb136-5e63-48ec-9c47-1c9ff73e49b2)(content(Whitespace\" \
+         4df5d01c-b6ee-4b73-a8cd-096debfeee4c)(content(Whitespace\" \
          \"))))(Tile((id \
          0f383d0f-fe98-41af-8ed2-e8c9707e19f7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         2cc1334b-a760-4ab1-9580-8b9df1a877df)(content(Whitespace\"\\n\"))))(Tile((id \
          447de0a0-02c5-492d-8735-f428dc610aaa)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2c1c3b1a-192d-4df3-afd9-292ea8c163ec)(content(Whitespace\" \
+         e6a41f5a-2ad7-4c93-ab74-c6dc1bbcee61)(content(Whitespace\" \
          \"))))(Tile((id \
          9dfbe7f0-34d2-4613-82a6-c9380a97a8a9)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          0c6318c4-d282-495b-9533-61bf322c5171)(label(xs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         703003eb-af39-4dd0-bfd6-54766cbef4fe)(content(Whitespace\" \
+         \"))))(Tile((id \
          6bad725f-308e-4013-b139-bbbb6ec8628e)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         cc069959-12cc-4f79-b126-c12e468111a8)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         84446252-ef38-4baf-ab6b-62f885640a71)(content(Whitespace\" \
+         \"))))(Tile((id cc069959-12cc-4f79-b126-c12e468111a8)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          d83328cc-5c50-4a21-b199-20436165dec0)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          360352ec-be0c-4995-853c-b3f0f26dcd46)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         e3ba9952-a5ef-4578-9519-698271387890)(content(Whitespace\" \
+         389c9022-0df3-4920-b794-17df00bff193)(content(Whitespace\" \
          \"))))(Tile((id \
          669f0f83-d621-4ce3-a24f-0fc92433ad20)(label(ys))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1ca6c1cc-091e-4c09-aef5-c09e9d0cc466)(content(Whitespace\" \
+         \"))))(Tile((id \
          decb2a3f-bd98-4db2-9291-5a735b4793a9)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3c42b5b3-407c-41fe-9bfd-df0f33bcdabd)(content(Whitespace\" \
+         06bc79a4-f053-445c-bb9f-436dcc1e1423)(content(Whitespace\" \
          \"))))(Tile((id 164aab16-15e7-461e-97f7-a31c29c993e7)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          82a8aad1-c584-4935-8106-f5bd6cf795f4)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         9719f4bf-214d-4052-8b58-df9744be0b06)(content(Whitespace\" \
+         16eb9e00-9173-4dee-a113-bce9b4e4705d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         21caa2be-1f09-4c6e-990f-cea6f6401662)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bc6c5c9d-fd74-4473-ba94-238f0db0b007)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9515a5c3-98d3-43ec-98fb-3d73993b9564)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b91b2bbb-c260-49b7-af9b-66862596a040)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f52c0490-9e12-4ff1-9052-005058a90f34)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e8cc282-8467-4bdc-8f87-a4cad8a1f05c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bbb38b03-3add-437c-9d80-c746a1233f8c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         efa643fd-0dc1-4393-ad73-42ed1bb35fd3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c18fa8b-2145-48ba-a4c4-052485a7eaf7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4db24933-035c-4e46-863e-ba41dee3a872)(content(Whitespace\" \
-         \"))))(Tile((id e33e8299-6d12-4604-9410-74eb55bec090)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         4f147d5a-ef44-445f-8f81-1c4302787a9c)(content(Whitespace\" \
+         fa7e6c22-006c-484b-93b5-22c6963621c9)(content(Whitespace\"\\n\"))))(Tile((id \
+         e33e8299-6d12-4604-9410-74eb55bec090)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         321fe80b-952e-4c95-9eb3-472e918e6734)(content(Whitespace\" \
          \"))))(Tile((id \
          42439b5f-ff14-4e5c-b760-3047157935f1)(label(zipped))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d53f67f5-077c-46d1-8c43-1a8abd8db4da)(content(Whitespace\" \
+         8e98bf5a-fbf5-411c-b2d6-6f9f7c86f432)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7ad4ffc6-42e3-4909-8e29-ba74866b9c63)(content(Whitespace\" \
+         690e27c5-cb0e-4ac0-9f15-eb4f64c95e76)(content(Whitespace\" \
          \"))))(Tile((id \
          b321677d-66a2-43cb-87f9-1377c9afc2b7)(label(zip))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -103,91 +89,48 @@ let out : string * Haz3lcore.PersistentSegment.t =
          15b48f18-a1dd-4d5c-b4fc-f76a25b92ad1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         65561687-2b2e-466a-8c99-58bf29404fcd)(content(Whitespace\" \
+         064cc0b4-35fb-41a6-950c-83d925963b66)(content(Whitespace\" \
          \"))))(Tile((id \
          6a485fc5-9c0b-4589-9688-4d1ca5b2fd01)(label(ys))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9a09c40a-1ab0-4262-babd-2242b238aa13)(content(Whitespace\" \
+         b39615c8-ddd3-4d40-8f4e-f742de6b6520)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         328e47f0-11fb-4d7c-989e-2a91db4dcec0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         520be277-5949-4ed2-b6b4-bb813bdd9c82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f4cff939-cd16-4f6d-868c-c23d3a993b8b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         25cd28d2-2229-4486-a936-ce5fc189ab4b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1a675579-c395-4137-ae53-de8f258de84c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b7d603c8-be8b-4a77-9664-fbf1e951a2b6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         091d17be-3e91-437b-a463-b33bf3b981ea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0e18c0b1-21b8-4b76-bb2b-23111cbe071e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4a6cd5de-e585-4025-a524-03ff41149959)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c062f82-8ec8-413c-812f-1f9040d53a73)(content(Whitespace\" \
-         \"))))(Tile((id 71e7d961-33f4-43fb-9e7c-422ea85d200c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         9b25c4a4-c275-4356-9d6e-4e8102baa9b4)(content(Whitespace\" \
+         8d18687f-7fa8-4b5f-8fda-109a8bbd93e1)(content(Whitespace\"\\n\"))))(Tile((id \
+         71e7d961-33f4-43fb-9e7c-422ea85d200c)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         74ea9eca-eac1-4118-8073-25439df740c2)(content(Whitespace\" \
          \"))))(Tile((id \
          77dd49d4-4157-492a-a460-f1527d6bfd1b)(label(contigencyTable))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         65ef311e-b60e-4ea7-a2a8-3281a9f7d57d)(content(Whitespace\" \
+         a30dd15d-b745-4c57-8027-5f7ff87a2e34)(content(Whitespace\" \
          \")))))((Secondary((id \
-         1a83ce36-4335-4b04-a7c2-bf32eef791bd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         64c776d6-bf12-4bef-9c26-b00c133e7068)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         245d7377-ee4f-41cd-9aed-0879ce6b53da)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         71b7cb14-a728-4e23-9b32-50181c2c713b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         39f0f0d2-c80d-4fa5-adc7-3eb731d6b1c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         779eee4e-cc0d-4913-a095-f5b41ce66aca)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         225aa456-ecb7-4a18-93b5-5b7d121fe29d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f25c4798-5958-4d2e-b0f2-71e57ef131f7)(content(Whitespace\"\\n\"))))(Tile((id \
          e80d7372-4044-4e47-8a6a-9351531b7950)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          e89db0be-88b8-4ce2-9b97-486b93f24b57)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         40fa933a-b20d-4065-8c70-657061f409e9)(content(Whitespace\"\\n\"))))(Tile((id \
          85d2c1ba-c1ff-4a26-a53d-16ca15b13e57)(label(zipped))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          2d326917-f7ee-4ed2-88f1-0d21402d96e7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dcde39d1-89ce-408a-b402-a19de905ae4c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2fe19573-e0c1-4293-866a-85d5f58b7b23)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7cad260-7141-40bd-9f28-543f0f875ba6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         28293c78-d36e-45ba-961c-d7adb0dab8b0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b1a7a494-fb51-4c6e-9de8-26c639ad21c6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         275e5416-00a5-466f-98d8-03d0ffa7a1a4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb77aefb-a6ab-40cc-8fbb-a567c434ac8f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fcb31616-a0a1-4abe-8052-b9a59f2e6278)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a51d76cb-95c8-434c-a11f-76465ba64792)(content(Whitespace\" \
-         \"))))(Tile((id f94b5db0-edbb-44bb-aabe-904c002abd5d)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         071abc18-fe57-40e4-a997-6a796da6829e)(content(Whitespace\" \
+         53fa185c-6e3f-460d-9e88-72a45a7b4a7c)(content(Whitespace\"\\n\"))))(Tile((id \
+         f94b5db0-edbb-44bb-aabe-904c002abd5d)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         888afe3a-96ae-40af-af72-9065f20b9e95)(content(Whitespace\" \
          \"))))(Tile((id \
          d01aed38-425c-4e92-9b1c-55041acfa8c7)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
+         Pat))))))(shards(0 1))(children(((Secondary((id \
+         d389736b-bd3a-4bb1-87c2-2c4f7fd4b3af)(content(Whitespace\"\\n\"))))(Tile((id \
          64e41a8c-06b0-48f4-84bf-6eb38e831a41)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
@@ -221,17 +164,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          72be683d-d0a0-40b3-bdef-97c38ed13e71)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         bce6b375-6b3b-4edb-b29b-e4ff23970cce)(content(Whitespace\" \
-         \"))))(Tile((id \
+         fe437bf2-12e1-4427-854d-d37be3cc6274)(content(Whitespace\"\\n\"))))(Tile((id \
          7a01bee3-ae75-423c-9eb3-167b35c8b553)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         da95eca7-ec8d-412c-8bf0-0c93a401884f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         1c044363-df6c-429d-8adf-9c33b4e879ec)(content(Whitespace\"\\n\"))))(Tile((id \
          0333f623-dc1c-4a0f-89dd-d16fc14561bc)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7862cb73-7ef9-4b31-afe2-09c6c1339e57)(content(Whitespace\" \
+         da4cddb4-d6fc-4ce9-a766-5ab1a9364f45)(content(Whitespace\" \
          \"))))(Tile((id \
          0b9a7447-209a-41b3-bed9-e155b5a72ded)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -241,64 +182,28 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          2ead96f9-bc9c-428a-9a26-2f71ee1088f5)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bd823e16-0849-4d52-9e83-f7ac2bf5d6c2)(content(Whitespace\" \
+         \"))))(Tile((id \
          b12bb863-d3e6-4ba7-b338-c61c411dab4b)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         6da568c0-3e4a-45b3-bf6c-2c69287420e0)(content(Whitespace\" \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         70ef5c66-b8f0-4083-b420-5f293f37daf3)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c57e621a-8c0c-4928-a59e-8f3d2b9e7331)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f0d3a161-8be5-49f7-bb39-de8c29d4554e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5ad5680c-b06d-473f-bf9a-5601c91251a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9f16b291-d88b-44ec-83c2-b2a5caac3233)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e43918c-8dce-41e3-ac34-418d30004d69)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         378fe8bd-2944-4e0c-8a1b-663b34e992fb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         55410e5c-190f-4907-97dc-464c5ffdca6a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bd7bd9a7-efdc-42b7-959e-0fede0d3c68c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f63ec225-0b6a-461d-8fa3-51a019943fc9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         45fee829-8dfd-4d40-a829-eeebab2ac02b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         78aba6de-2d46-4e3f-bc89-cae2c5663c27)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c1e905b-d7d9-40f6-a6e9-460ada45b5d9)(content(Whitespace\" \
-         \"))))(Tile((id f4b759ab-1862-4255-88b6-2445a9a28fd1)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         4086f8b7-777d-4fb6-a09b-f2bac4e8c599)(content(Whitespace\" \
+         0aa4a540-e451-45f9-8387-16573c14f30e)(content(Whitespace\"\\n\"))))(Tile((id \
+         f4b759ab-1862-4255-88b6-2445a9a28fd1)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         931e4b92-50d8-4163-a423-70a683abb481)(content(Whitespace\" \
          \"))))(Tile((id \
          139790b9-345b-465b-9cbd-92c7bde46f82)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         4451dc27-efaf-48ff-bc79-8d33fa1e654f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2def55e7-35c9-40d7-a875-f0860324e26a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ac39806-3597-4adb-90e7-60e820700f3e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         edd25447-9816-4ff0-9c6b-aecc58f60621)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         54eec33b-936c-4a2a-9dae-46226df58394)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0a2e562f-6b2c-4ad7-943b-1bce718298e4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2ddee566-e907-4a69-b124-9d8a8e1d27c0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         779f429a-1319-493c-b4fb-206380ec5027)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e71a299-f90a-4383-b6cf-5b4e951e62cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         395fe693-98ed-406e-a74b-9ce6a60adaab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         89cd78ca-5bb4-48ee-bc75-2642770a1141)(content(Whitespace\" \
-         \"))))(Tile((id 359b0096-f357-47a3-9cc3-e44275ef86b3)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         ddbf70e0-94ae-45f4-8b01-bfa6692be29b)(content(Whitespace\"\\n\"))))(Tile((id \
+         359b0096-f357-47a3-9cc3-e44275ef86b3)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          cbc20e84-4300-4545-8f15-4937cc0212e7)(content(Whitespace\" \
          \"))))(Tile((id \
          3feed2ed-b576-47fe-a128-fb1989f32eec)(label(\"(\"\")\"))(mold((out \
@@ -317,7 +222,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          39b774c6-778e-4068-b19b-151079e31503)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         95974c3d-a41a-499b-982a-612a74797c18)(content(Whitespace\" \
+         0a9956ed-ea4d-4200-8383-8dfc8162682f)(content(Whitespace\" \
          \"))))(Tile((id \
          5402165b-0994-45d5-91ee-acce992b5e6d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -342,7 +247,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          91b9ae6b-50dc-4e30-9eff-3864b528fd31)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2010161d-8e5a-45ec-9b1d-96b412948cb6)(content(Whitespace\" \
+         \"))))(Tile((id \
          7bb114ea-e2fb-4baa-b23a-30436f6652dd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -351,34 +258,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          e1803415-ef6e-40e1-a27a-61659a987ee1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         94abc897-3722-4744-96e3-94b6d304962f)(content(Whitespace\" \
+         \"))))(Tile((id \
          63b4d53f-7f5e-471d-9f1b-ac42052f4b15)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         a43eaca9-70ed-4210-97cc-440f9c7f0f34)(content(Whitespace\"\\n\"))))(Secondary((id \
-         07f59c7a-7936-4ff4-abcf-a042f0c6f695)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         40ed4d55-2677-4115-9347-ff416eda4528)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f752496e-2ca7-4af1-a8ed-9be138dd9ae2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb5fb31b-e724-4167-b671-97aee4e34093)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f8c233d-0662-4432-a423-865e9c64c9a5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2548c93a-96d0-475d-adc1-71a47fe05775)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27dbf268-6302-4644-98b8-60fd719b64b6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7278d629-6c85-442f-9096-49f32d5c0cbc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae9977b1-7a51-4827-a374-9d1665e018cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9df37966-79ad-4535-bc29-129b7ace6ebc)(content(Whitespace\" \
-         \"))))(Tile((id 3b688577-8263-46cf-a8ae-17b5004262c5)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         ed3a3f40-2274-4840-8f00-5ca39296f6c2)(content(Whitespace\"\\n\"))))(Tile((id \
+         3b688577-8263-46cf-a8ae-17b5004262c5)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          1a3a9338-6a20-43c8-94e9-848d533b1228)(content(Whitespace\" \
          \"))))(Tile((id \
          af98f283-ef28-4eae-acc8-12db3c6b593f)(label(\"(\"\")\"))(mold((out \
@@ -397,7 +286,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          73e7a0e9-60ac-4583-8744-2e7a5e1741ba)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d770164f-bc20-4622-8f76-cd3fe4d02880)(content(Whitespace\" \
+         dd8b61f2-a502-4991-bf11-7857ede3924d)(content(Whitespace\" \
          \"))))(Tile((id \
          47964371-8155-4284-b421-7da63832e43c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -422,7 +311,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          5fab808f-bb46-4a4b-938c-720704308aba)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         63ff35d6-5193-4117-8a2a-6da42eeca892)(content(Whitespace\" \
+         \"))))(Tile((id \
          a11f6cd8-e0fc-46c3-9c47-b9a7f703e80e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -431,34 +322,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          6b7dc88c-7fb6-423a-b80d-9fdd1a838df0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c13bf97b-96e5-431d-9de8-87d7735901cf)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb9f4106-1fb2-43cd-8003-68ea706ce444)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         090e783b-ff4f-4845-b5d4-7f605a893344)(content(Whitespace\"\\n\"))))(Secondary((id \
-         229751a2-bd60-4695-ad88-f5ce8dd49b72)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         682a9cab-6c10-4c17-8610-0b7084d573e6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1bbbb146-55b7-4660-815e-227e66a3c35a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0523c9c2-6232-4452-a6ae-6c58eb3a3a3a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bea6f3c0-42e6-4d58-b623-f4ba34e07b4a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         065e4f64-5b5c-4bf9-b4c2-88771ccf4553)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         758b2231-2b44-4a21-a4ac-ae263e3382cf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         456a7fec-f4c4-4091-8e52-707680d09e18)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e426a89e-c31f-46a1-ae09-04d8b5b84f3a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2ffdf887-a5ea-4c0c-9227-cbcd16d8f408)(content(Whitespace\" \
-         \"))))(Tile((id 3ac98140-b6f4-4f76-ad54-ae7bfe35b0df)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         9b250f85-70e2-44ee-ac44-cd6e008c9586)(content(Whitespace\"\\n\"))))(Tile((id \
+         3ac98140-b6f4-4f76-ad54-ae7bfe35b0df)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          99e7fdfe-b9e4-4905-959f-7303fd84e79a)(content(Whitespace\" \
          \"))))(Tile((id \
          386f664f-e1ad-46be-b83c-0d942a3b2c84)(label(\"(\"\")\"))(mold((out \
@@ -477,7 +350,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          8eafca96-8602-4b56-b78f-a58131d6b6c4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         390f19e9-cffb-421f-9188-9abf97d247ad)(content(Whitespace\" \
+         e1b9f1d2-3fdd-4ccc-9602-2f5a5a4c0d76)(content(Whitespace\" \
          \"))))(Tile((id \
          95c082fd-bd88-49ac-993b-91fc89dc8676)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -496,49 +369,37 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          9b5e6548-d522-498c-bca7-dc8b4fea6246)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         06808711-9bb2-4d3b-a5c5-f0fc4df4c075)(content(Whitespace\" \
+         \"))))(Tile((id \
          09e4fea6-b597-4150-be39-876a1bc86969)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          02621b98-8052-44cc-bf77-e5d612cd8ac9)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2ea8c55b-e0c3-4cb6-b5d2-722498ca101c)(content(Whitespace\" \
+         \"))))(Tile((id \
          e2bbee0a-d3d7-4f9d-ab20-06fffb9d92e8)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         89359dc3-b8cf-4636-8caa-986b98bac0b5)(content(Whitespace\" \
+         \"))))(Tile((id \
          26f58055-8bde-438e-bc98-77dfeccf3f56)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          53fdf685-a846-471e-b083-5b2c5a40889c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         14b80a01-cda1-4cee-b49e-50496656843d)(content(Whitespace\" \
+         \"))))(Tile((id \
          0da2c90f-2c46-4e36-a8b9-6cefb4d3a04f)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         4a778295-2dbc-49ef-9cf3-f0faeddd242c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         265e75c3-7ca8-411c-9176-30bda915cfaa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d4d9c59f-9363-4f8e-b435-a1603c58cde3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         34e0157d-c800-4361-b4ed-a62364ffc79a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e1cc8253-c249-4a70-8b34-df99fad418b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9084a51-c60b-4624-9375-ee5340f03a25)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36ccbd3e-98ad-445c-8231-bb5da8aea395)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4ec0565f-7cf6-403b-9734-fc2bb03d28d8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a2f9de34-18aa-4c5f-a86d-99adae07b049)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         03bb3fc5-ac61-4c85-938b-bb5437691857)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bfcc8b09-ee45-4b21-8743-ad914efcc2f7)(content(Whitespace\" \
-         \"))))(Tile((id ca57a024-b089-4fc0-b6e4-58f2308141a3)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         a43cce95-7e4b-47d9-81fa-0753dfb3a89f)(content(Whitespace\"\\n\"))))(Tile((id \
+         ca57a024-b089-4fc0-b6e4-58f2308141a3)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          b2b56242-1eea-4ed7-b7f6-b1afca42c510)(content(Whitespace\" \
          \"))))(Tile((id \
          e3ace2eb-a8ac-45a6-bacc-4e5890e83ddc)(label(\"(\"\")\"))(mold((out \
@@ -557,7 +418,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          4855c740-d5eb-49a0-9d5b-44347fab3384)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5ff8752f-cdcc-45d7-93fb-7ea4e5777ef7)(content(Whitespace\" \
+         ea2e0aa7-b5c6-4020-a283-06c5ef6d9cd5)(content(Whitespace\" \
          \"))))(Tile((id \
          bfea5236-2ce7-4849-b368-4efbf76ccc5e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -576,7 +437,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          b127bbe1-e28c-45e8-839f-94435733f36d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         abaed43b-0e49-4af1-86b1-0f0b3adaf6f0)(content(Whitespace\" \
+         \"))))(Tile((id \
          6dd7ba10-8e35-4fe6-99bf-c287f31b092a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -585,63 +448,27 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          8e43cc1f-6b14-43b7-a296-ff6edb010f1e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b03a0405-486b-40cd-90ff-f02f3b3e17b6)(content(Whitespace\" \
+         \"))))(Tile((id \
          78a1130f-d9d3-450c-aada-73923a388e34)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         68ae717d-8705-4181-8a1a-66e76ef9481a)(content(Whitespace\" \
+         \"))))(Tile((id \
          37598455-501c-45cf-b975-ba8d85242748)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fb994006-4f53-4099-9d3d-d2374df65839)(content(Whitespace\" \
+         \"))))(Tile((id \
          6205b39b-0cd5-4226-a827-ef4bfb310c81)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         599b75e6-da40-402e-818b-9ace4ca432f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9f45cf5f-54c4-4ac8-9382-100a7dff53b7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c5ab0dc3-26ad-4a6c-9c07-9ca2fb693989)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5b3ae9b4-eaa5-4bf9-bf49-1663cd3fd37d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0da23ee6-7ba8-4771-8d31-26d4c55e24f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a786d084-16ae-4cd6-a294-16ec71e63b67)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         299badc3-d100-4672-8719-ff5c1bfd4eae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c35618f0-5bf2-432b-9d32-b7cd8ffb571f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae6cafe2-1214-4277-91c1-2ff6283e436f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e67c5ab5-a06e-4009-a801-28e9264962cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         94b2bfe3-cbfd-4ede-8169-d8c7e4abe20a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         17dd8226-39fa-419f-8259-fdb253cff451)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         54b0fdd9-7a64-46e5-bf00-2123f0b21d92)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0fd7153b-6d52-4a3e-bd3a-de9d217900fa)(content(Whitespace\"\\n\")))))))))(Tile((id \
          1e4ac754-350d-423e-98af-578b5d7bff98)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         31f7227d-4226-4c8a-adb5-4a242b610c28)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         45f694de-173b-4ce4-af93-afc5d0eebe73)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5b1036a0-bf22-4a21-8691-c0b995a08b27)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fb7591ae-17fb-4b91-a37e-8213f995e067)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aefda8d0-9978-42c8-bf34-ab8bf033a510)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a9847504-636f-4b3f-bfd6-f4bcf70c196e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         55b89afe-d90a-460e-a616-4527c7580874)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04a85c21-499e-4585-a16a-b72c9b7cda6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         995a9c9e-f892-4e56-92fc-e86a792fb70e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         53cafbd5-48c3-4620-886e-b7a9228838f5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d12994d9-1b5e-4bde-9d67-e881ab0d5360)(content(Whitespace\"\\n\"))))(Tile((id \
          f023e501-92fb-4337-bd01-bf723cd4c9fa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -659,7 +486,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          df8469e7-acd9-48ff-a954-c8acb57a6510)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1e7a00d9-a5dd-4567-bbfe-e8696efc48c2)(content(Whitespace\" \
+         \"))))(Tile((id \
          a1e2bdb3-d5e3-4b98-bac9-19faa333779e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -668,123 +497,91 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          4ce9370b-ecd8-4d01-8a3b-2e31ee09ffae)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         01782194-b0e4-4709-b4ef-45019e8188e6)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce7f5d6f-e832-420a-bb91-70527b7c3a0c)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         dc1c57f4-b531-48f4-83fa-82be5e6a8af6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b71e6f12-3894-4590-a334-b0649c9f5b2b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cc342426-c3b9-4cae-a170-64f7cd54067d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         361fb605-9855-4031-bdef-6d72d50e6b28)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         213be75b-cccd-4c8e-a846-db7c15c17835)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9b25ff1f-c1b2-4821-9b09-80ba4d50de47)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         b49c4ed8-0837-4762-a0b3-00b8b6a109c2)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         9cbd7990-32d5-4c12-bfbd-eba411ecfc3e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         090d4a41-6668-46d0-a342-f74f2fed3a56)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7e1c8023-9207-4355-9f8d-32cc4ac92031)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         70e6eb3f-92f8-45d4-9688-20f3ad208d71)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         feb3290e-91a0-4e6f-b55e-8b9ef4221885)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f8cdb0d1-8827-42b3-9f3a-da339706d5e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3b5f093c-a29d-4f79-8298-6caa0847a6b2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f2508d55-aecf-4e06-aee6-86f9d2a04e49)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         45e9fbc3-f13c-4294-833f-a1bfa4fc1557)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e9fe5183-abda-4acf-a801-51bce70be625)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d3a3ad03-127a-497f-a3e1-0998ab06cd04)(content(Whitespace\" \
-         \"))))(Tile((id c4a85d1f-bf72-4cb0-a41d-6dc6942bce35)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         79eb9201-d69b-4b39-85da-8f1f7edf6a8f)(content(Whitespace\" \
+         1d528a9e-e370-4e81-a6ab-0d08d7b91acc)(content(Whitespace\"\\n\"))))(Tile((id \
+         c4a85d1f-bf72-4cb0-a41d-6dc6942bce35)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         67eeda1f-47db-43de-9d96-4b5eec500007)(content(Whitespace\" \
          \"))))(Tile((id \
          5712f04c-fb47-4b37-ba12-eeec59ce8b3b)(label(factorial))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         99c96602-55e7-4045-ab55-f25d361a7367)(content(Whitespace\" \
+         6ab1646d-deab-41cd-94d7-1b0184846f4b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         053d7393-c350-408b-a946-9653788bca96)(content(Whitespace\" \
+         0ab35c00-d84b-4dbc-8169-4defe3c51111)(content(Whitespace\" \
          \"))))(Tile((id ba40e0e1-6c8c-4185-b2dc-4c286c3ea3c4)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f000d057-f014-4b3e-870a-ece2dae6743a)(content(Whitespace\" \
+         3915665b-1d9e-4c33-91d8-8cf4f03aecca)(content(Whitespace\" \
          \"))))(Tile((id \
          9e456992-1ac1-4f15-8dc4-28620c454e17)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          4d5ff781-d01a-4864-881a-0c146e23bc22)(label(n))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         fff31409-d38a-46c3-a2ae-08e7fa43bb52)(content(Whitespace\" \
+         \"))))(Tile((id \
          e1d33313-db98-4743-950d-3b864704160a)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         84b33ac5-3afb-4737-badc-4148224e295f)(content(Whitespace\" \
+         43ed7ffd-e56f-4d67-a8a9-8d7a66d270b2)(content(Whitespace\" \
          \"))))(Tile((id \
          162c8c5e-bde8-48dc-b61a-476ba6aa17b4)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f568043b-cb8a-48fe-9ead-81c51e82856a)(content(Whitespace\" \
+         5147d882-a946-473c-95c5-6d97620b8914)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         22f0e631-d774-459d-9449-efdf00099de1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         760741ec-76d8-4d68-b031-a9be795f6384)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd1a3d27-8c09-4223-8159-db942c153f91)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         347eb0a9-299d-45db-9962-d684282e583f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9c35aa2f-42fe-4e2c-874a-ab6d128e85f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         84152771-9f43-489f-a361-ce4d6f0ff5f5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36df92ea-6715-4a55-b85b-eb425d92b993)(content(Whitespace\" \
+         c483eeef-4a7f-4375-a76b-80eb215e8117)(content(Whitespace\" \
          \"))))(Tile((id 9a08cd95-781b-466a-8bf0-c22543e64993)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         509f3909-a920-462b-83b9-6768e7a889c8)(content(Whitespace\" \
+         a912a1c5-40f2-4b36-a0b5-dab88b391411)(content(Whitespace\" \
          \"))))(Tile((id \
          5793ec53-b2f7-4d18-bdfe-ed37348e35f3)(label(n))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         917aff11-83dd-4bb9-a9da-9a9f33e9f091)(content(Whitespace\" \
+         2ad506c6-68fb-4046-9b8b-404de83fade7)(content(Whitespace\" \
          \"))))(Tile((id \
          cd173cd9-f2e1-44bf-b746-37217cbeb9df)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         497a2414-730c-4672-b62e-0b63a3d0345c)(content(Whitespace\" \
+         5e8c45ec-f6f3-49b6-9f2c-e7d2c74fe449)(content(Whitespace\" \
          \"))))(Tile((id \
          dbe73620-7b80-4b70-b725-c7cbf8f3bda0)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         9e46332e-4fb9-499f-8844-5b95c82d5684)(content(Whitespace\" \
+         3d35f120-5004-4511-99c0-e376b9f9b7c8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         288de418-9b61-4ebb-9985-69407da7136e)(content(Whitespace\" \
+         8154880f-eeea-4afa-9671-0a8b4a3b3500)(content(Whitespace\" \
          \"))))(Tile((id \
          63c1b55b-736b-4d29-ab98-8b3f1d7d1731)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         3ce7c8b8-8bf4-4dea-8307-428efa32749f)(content(Whitespace\" \
+         f95bcc86-3ac4-4d21-926e-bf1d1a569cb6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         25f6034a-75db-4764-a6c2-e0b93f453cfb)(content(Whitespace\" \
+         83b1c1a9-3c69-474a-b96f-75bc001f51e0)(content(Whitespace\" \
          \"))))(Tile((id \
          425a58e0-e63d-4f42-8837-b47cc7ca4309)(label(n))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         88c0e038-9688-4a7c-bb8e-6e30d5ab0206)(content(Whitespace\" \
+         e8f89856-4768-45ce-bbe7-836dbf3bf18c)(content(Whitespace\" \
          \"))))(Tile((id \
          a0975331-182f-4b79-834e-00e0a40199bd)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ea1d5b07-31df-4aee-bee6-d381f047de05)(content(Whitespace\" \
+         f97848d6-54d6-4085-be07-3d50589caa1e)(content(Whitespace\" \
          \"))))(Tile((id \
          ea74e49d-7705-40e2-88b3-8f4cfe6f40ef)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -795,40 +592,23 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1179d5be-7324-486c-a838-d3e074fc7b5b)(label(n))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b76419db-77d2-42be-8788-db9bc3f22693)(content(Whitespace\" \
+         a7f374e5-5ce4-4654-bfa1-35d4b0d9f51a)(content(Whitespace\" \
          \"))))(Tile((id \
          57439740-08b7-45d1-b24f-733f7cf902de)(label(-))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ddaa9ba3-4cf5-401c-8909-c0560899e833)(content(Whitespace\" \
+         44156306-8cb7-4ac7-9d03-0b6107821394)(content(Whitespace\" \
          \"))))(Tile((id \
          c40852ca-09ca-424b-bd42-7ae4d2e5f440)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b47df0a6-269c-41db-b32e-d2c156cc1aec)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5fe9c618-0721-4dd8-8adf-5138d5e57e0e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e825f374-0226-48fd-9d00-4bafddda4713)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         25b674a0-25ba-4fe3-9b43-a5d16ed9842e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e5a05f4-60fe-45f6-98f8-7746dffca6bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7a721b24-0a26-436a-be12-6584d6c9e958)(content(Whitespace\" \
+         3a34ff37-a199-46a8-840a-4ce3720ad53a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         351297ad-7aa4-48a4-834c-ae88f4e07c3f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fdad82f6-2c2e-4e24-ab40-7d4cac3b06de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         65c5e380-5f20-4bc1-ac94-17adb3a724a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         158e5b7a-c820-4f38-ab14-029e5c8cc628)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7faa3721-c6ee-4fe0-8f18-d16703358d30)(content(Whitespace\" \
-         \"))))(Tile((id 4004dc85-91d9-4972-a4ae-b780807fe883)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d10d9a5c-cccd-4797-8c12-a60e2d991d77)(content(Whitespace\" \
+         8c2e229e-5a2d-4abe-aa78-262298f60416)(content(Whitespace\"\\n\"))))(Tile((id \
+         4004dc85-91d9-4972-a4ae-b780807fe883)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f9bc6ac7-df2f-4aad-9c50-2658efa0f4ea)(content(Whitespace\" \
          \"))))(Tile((id \
          3d98ee60-f844-4e7f-881a-686f4415e2bc)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -847,7 +627,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Tile((id \
          af0d31ed-afdc-4274-a9da-9dff68c06417)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         44bf7ac7-6677-4172-84e5-745ef41165b7)(content(Whitespace\" \
+         \"))))(Tile((id \
          ed9e8bc5-751e-4e4a-8121-0e04d2520cef)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
@@ -856,69 +638,33 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          2097125b-a51f-4a6f-94e6-9594dc145d00)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         1bc95786-9a5a-42ec-bd95-6697cd55f5f8)(content(Whitespace\" \
+         \"))))(Tile((id \
          63e15bf5-0a5e-440e-ac5d-684920f380a7)(label(d))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
-         1fc162c0-f17a-4b9c-b544-6e1aa635b946)(content(Whitespace\" \
+         e46ef190-8e8c-4436-b917-104a50cdd574)(content(Whitespace\" \
          \")))))((Secondary((id \
-         16b46add-b695-4bdf-88c6-0d95dd549338)(content(Whitespace\" \
+         0ffde5c5-19fd-4647-ac46-6b757bf384bf)(content(Whitespace\" \
          \"))))(Tile((id \
          66055d3a-740a-45b9-b6da-9f3fb1759b18)(label(contigencyTable))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         351bf2cb-218f-4d19-a388-57c312563d71)(content(Whitespace\" \
+         680cf7bb-bc77-46ad-8a0c-16d1989e2c5d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e047f056-c00c-45a2-a997-e864ab85adfb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c450cdac-0047-479b-bec7-d54c9f2a38e7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc4482c6-01f1-49e1-83b1-fb0fcbfb1a74)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         850d6322-dd09-4c91-835e-ebda3cd7fe6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6054c010-365f-4cc8-931d-290c2d1549e9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8d0489e0-27f6-47df-a6a9-2f49ed772666)(content(Whitespace\"\\n\"))))(Secondary((id \
-         99428c52-1b12-47dd-8ef7-822a934ef58c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db1ee7ce-5032-4cbd-a191-492985d2c99b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4a450bdb-3713-40d2-ad14-4ddc334bd45a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         adac1edc-8106-48b1-9461-32d84ec43934)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b94e2526-84d9-4a58-9d05-00e6c6dce698)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8d4e38e3-0ca9-4ce0-a32f-a57eb28c3a5c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         12468375-4afc-4ba6-b978-3130c9d0a4a7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         991e301e-de40-4839-b608-81eba41ccdf6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6168322b-90d3-4f37-abb3-5086eff9ca9d)(content(Whitespace\" \
-         \"))))(Tile((id 36cb730d-4cbb-47d0-88e1-a33bb1a55b55)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         524186e8-9bf1-4b31-b6cc-df60f7b5a5e0)(content(Whitespace\" \
+         9ca925f5-87cd-4b74-8561-6f74c25b8340)(content(Whitespace\"\\n\"))))(Tile((id \
+         36cb730d-4cbb-47d0-88e1-a33bb1a55b55)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         61d413d4-f2bc-48ac-b48f-84b2139d0f5a)(content(Whitespace\" \
          \"))))(Tile((id \
          3ad78459-a5ce-4b47-92b0-d4c93eaf0219)(label(numerator))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9a0a68f8-5663-44b2-ae16-2171d6b4247a)(content(Whitespace\" \
+         23c0605b-411c-4d49-aecf-3b06b86f2ae0)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c432af56-30d3-41dc-81c1-0644aef75c74)(content(Whitespace\"\\n\"))))(Secondary((id \
-         36a4a36b-baac-49b8-8d5a-7aba3b41ba94)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         efba76c2-4b1f-4f36-9099-3627ce5a90a2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         738c0052-2391-441b-a117-4d3547ab4528)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9a063af-9a19-4ba9-9661-06d0cdbb7fe3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         000c0721-ae75-432f-8d50-b7ad073d589e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c2cc3417-0e5a-4250-8ac5-f5fb653c1490)(content(Whitespace\" \
+         dd6e80c9-cccc-4182-8854-7ba467ee70ae)(content(Whitespace\" \
          \"))))(Tile((id \
          f35bfa78-bd48-47ae-947d-0a7e1d57fd7f)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -929,33 +675,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1218cb7a-2cfb-40c1-9fe6-f794bd9db50f)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         10a71d5c-182c-4a36-9da4-d476f702444f)(content(Whitespace\" \
+         df974689-58fc-44b3-8061-4747edf1116d)(content(Whitespace\" \
          \"))))(Tile((id \
          4d7536fa-0978-45b9-8aca-87296db74786)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         45f62c05-f07d-4c28-9a78-45f46574670f)(content(Whitespace\" \
+         ffb4d521-34b5-48af-b872-697b7518fdf4)(content(Whitespace\" \
          \"))))(Tile((id \
          10c6eb52-7e8a-4fa9-ac44-62067fae37c9)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         38c91f84-f079-4d8e-bbd1-8deea599cc97)(content(Whitespace\" \
+         bf683e8d-7d53-4724-a0f9-87aa4aa3e2cb)(content(Whitespace\" \
          \"))))(Tile((id \
          31a37683-3b5d-43c9-b652-1f5fea8474e2)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8ef7220b-5366-4dea-b689-ececece78010)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b25366e8-2e85-49a2-98c2-2a0ad467833b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         79ffb82d-79ec-4e1c-aa1d-1e0389abab68)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         568a54b5-fdf2-42a1-b244-26df1a7297de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f6275f2-61ef-42bd-9681-09e2da1c42f5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         966fa625-a4d2-4d82-9aa3-7cda8d157112)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         712aa4e1-cce9-431c-bd30-f937d0018eca)(content(Whitespace\" \
+         d9b9d77e-e2c7-43e0-a26b-306bf9366dac)(content(Whitespace\" \
          \"))))(Tile((id \
          5cf34a39-ca21-4e06-ac40-72ebb6831de9)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -966,33 +701,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          63618894-a2ba-4592-a1a3-a67649c2fa35)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         9af3c82e-77ef-4d5b-a646-d66c184910f5)(content(Whitespace\" \
+         dcd5e394-ef1a-4456-8f4a-8fec1bd38105)(content(Whitespace\" \
          \"))))(Tile((id \
          0f47b269-845a-4753-b2b6-a3345b6703ab)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         98bfdb99-1ea8-472f-b2e4-e691e61c6939)(content(Whitespace\" \
+         ced028a6-9e34-43b3-85a9-3d2b21e9399b)(content(Whitespace\" \
          \"))))(Tile((id \
          7ed876ee-3e6c-4fb6-95f5-b7d8cbe87cee)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3bea0d55-3b5e-4c9d-b9e5-ae5ad4aa420d)(content(Whitespace\" \
+         3199d567-e1d5-4946-8943-5e957d290598)(content(Whitespace\" \
          \"))))(Tile((id \
          26b11a83-36cf-494c-a1b5-db8757a67b65)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6a170d4a-f8f1-4712-8935-ba4ffa6822b3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4e50389d-79af-4127-a6c1-781318b1b870)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1e326b16-980c-4d42-a9d7-39af37f1db08)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7be94ab8-1451-4665-afdc-455c94d5beb5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04a1561d-69e8-4faf-ad03-ba7a74553b1a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         832193b6-3191-4a06-a4c0-65adcc0402a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         060f0b18-ce93-4cd5-a80e-0e84e930ce1d)(content(Whitespace\" \
+         76be90a7-a1e5-491b-8cde-bde403130a0c)(content(Whitespace\" \
          \"))))(Tile((id \
          5910f7ce-8d61-4769-8c01-d0a5506d6dc1)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1003,33 +727,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          34f30e26-2529-4f76-8dad-5a6ac73214a2)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         adefbf7e-50d7-49d1-9f71-4719f40cad1a)(content(Whitespace\" \
+         8f479565-c5ef-4074-bd1a-cbe26a04c980)(content(Whitespace\" \
          \"))))(Tile((id \
          d30a91bb-3748-408a-9c15-5adc70d7c9c5)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8be34501-173b-431e-8615-ada489b27a79)(content(Whitespace\" \
+         611c3b3a-6c72-4ca3-b840-04cb6b26a704)(content(Whitespace\" \
          \"))))(Tile((id \
          f393d22f-a677-4d0d-ade5-85b96963b98f)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d2789768-a7fd-4ba6-b2e0-56ed3374b32b)(content(Whitespace\" \
+         7647da70-e0d9-43e4-abcb-7ba199d2a1c4)(content(Whitespace\" \
          \"))))(Tile((id \
          f958ad61-4b48-49de-b9e9-82e0606706b5)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         64386123-c102-454b-b0ae-e19b257e87b1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5968920e-94eb-46b3-8d3d-cf0374c7b66a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61286c74-a481-4f42-a111-04b2338578ac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e7e42ce-7e64-45ab-bf7b-f065bf883e69)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f589a93e-654b-4d69-8126-719a8d01ca74)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         79fd106c-743a-43e3-adb6-f23eceaf8cc4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f6378441-1264-4d23-b539-6c340278124e)(content(Whitespace\" \
+         bbfd9be4-da7e-4c81-b5f1-aa552cc39cb1)(content(Whitespace\" \
          \"))))(Tile((id \
          b20cc165-a103-4ac1-9a29-efb465498cdd)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1040,58 +753,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9a9a479b-d085-4427-8c09-b9838432f067)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         0939774f-ff62-436c-9069-f80c67bc5dce)(content(Whitespace\" \
+         a5c24d06-e5ac-4724-8e75-cb76a3e62072)(content(Whitespace\" \
          \"))))(Tile((id \
          6a3c3bee-8288-4381-a2be-50981a4fa134)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c2ded85f-73d2-4636-9350-3e077b9cf979)(content(Whitespace\" \
+         d96e7080-5e77-4fca-b757-5488ad95e6f3)(content(Whitespace\" \
          \"))))(Tile((id \
          2d0e1b7f-5fe8-4e1e-9c5d-16ba072a719a)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c8fbfd6f-7439-4090-b6b6-6726efd15a04)(content(Whitespace\" \
+         6305cf09-50af-4b9b-8bff-f02d74af50c8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         330334f0-32d1-4695-95fe-5ad1b3a9b9bb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0a03a6c8-3595-4a08-bff3-00b0887c6b82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eb53ac6f-2701-4cd3-bed0-6ce82d263d2d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d46ed6b-af33-4b78-8d94-7c98d1083cf6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c6787d88-efb4-4dac-bca7-c078924df306)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         00e29e52-c1b0-46bc-82f7-6af203d4258e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         46d9088c-a9af-4c71-abfc-9c40cfa489d5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf7de004-2350-448e-96a7-9538ae2a943b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         652c7c3a-1ce3-40c7-83ed-31ace7fd60b6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2fe45a78-252e-487b-994e-b9ed16c420f9)(content(Whitespace\" \
-         \"))))(Tile((id dc3a9d1b-008f-4a82-83d4-50d30d01578a)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         849cb9fb-7488-49f2-98d1-255ea6072d18)(content(Whitespace\" \
+         9e654239-4a36-4a75-8d2c-66914736b67c)(content(Whitespace\"\\n\"))))(Tile((id \
+         dc3a9d1b-008f-4a82-83d4-50d30d01578a)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0075ce84-ed39-4946-9f07-af272e83ab64)(content(Whitespace\" \
          \"))))(Tile((id \
          30cb301d-abde-4e21-a1b7-a72a42676839)(label(denominator))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         68d7f14e-4817-46b6-bdd4-34f379742a27)(content(Whitespace\" \
+         542cbf51-a6e5-468e-a5de-18dad8a8ee1a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c12d7ba7-2496-47f4-8055-7b4c2f4b2c8a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         57fcf857-737b-4089-9c63-cec1d6d298c3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a36497fd-aaf6-4e30-873f-5a34f75db589)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         69d35f49-b843-4e03-b829-6eb9f8daa529)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a12ca90-1f19-466a-b2f7-f73f75424955)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f1055261-7bc4-45ba-9034-c8259bd6adf7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a37de2a2-85fb-4c4e-866f-857bdcb2f88f)(content(Whitespace\" \
+         560f7232-713e-4027-af98-29b2a0184d0b)(content(Whitespace\" \
          \"))))(Tile((id \
          eebb6265-3cf1-4cf7-a1f2-e5b5b29ee95e)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1102,23 +787,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bebfd1e2-311e-40ee-ab15-2078bbeb8c9e)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8382ea29-8fa0-48c2-b095-2bc18f40acc1)(content(Whitespace\" \
+         16aa0b77-9b9b-48aa-89fd-d57c5c283bb7)(content(Whitespace\" \
          \"))))(Tile((id \
          ffbe3780-7c0b-4f61-9139-6a7c7778da45)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3c910d20-dae9-4453-bab0-bc3896bc05e2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         acfd27b1-43bc-4187-ad70-f8cc8dfae73e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e127bb15-2076-474b-87d4-cfa7c7be1f08)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9ac2928-3eff-406f-af82-2af97a4b17bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b439ad76-08ea-4af5-aebf-e3232c816f20)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         853d7685-3959-490c-8c46-2e442b05382f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1fccb84d-337b-4e61-a652-62bf60432367)(content(Whitespace\" \
+         b867d522-22e3-4e4c-a4a9-a0431abdf0b8)(content(Whitespace\" \
          \"))))(Tile((id \
          f4e52cfa-e0c8-4161-b4d7-49c41c85c5b8)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1129,23 +803,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bb9629cc-9956-46b1-885f-f874a9c7ef09)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         81b8ef2d-927b-48dd-9bc9-83209f4be655)(content(Whitespace\" \
+         473bb10f-d038-45ac-8eac-d31ac0b60e3e)(content(Whitespace\" \
          \"))))(Tile((id \
          221ec261-036d-4093-bc63-5f8a157f8748)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9e2b7e9b-9225-45a1-9e0f-c51f0111476b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4e64a29e-117d-466e-ab7a-82cd68ffc490)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ccff2286-843c-44a2-8b9e-557df3433c9a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         be35d60c-094f-45ba-bbeb-cee888e8f8f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8b79db6d-f40d-4ed1-a8e2-b6bb97541d24)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f935a5f-a457-488e-9bef-e1d6b97d980a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e55f902d-b57a-4bce-b288-416460688683)(content(Whitespace\" \
+         7cdb75b4-af97-4f71-ae07-525281880a30)(content(Whitespace\" \
          \"))))(Tile((id \
          d752fc68-3d74-4d02-86ab-217840aab146)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1156,23 +819,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          05e6fbbf-c4ca-478d-94c3-cb6cb91af06d)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b5283fa6-5a08-461a-80f2-9e22287fcd07)(content(Whitespace\" \
+         52cfec0d-d9de-45a7-8729-d20b15da5cd0)(content(Whitespace\" \
          \"))))(Tile((id \
          86694cca-71b6-495f-8282-2f2e632aaf60)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         009480e1-671f-48ac-b6d9-6ff0eb315aa4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c61c6190-7833-49e8-9faa-4ab09ccec824)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0158743f-9136-45ef-9e30-050e2fa2a937)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d06c1e35-a8aa-4048-8d68-7c9a48757efc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ecf66a54-2e9b-4d4c-a814-19c0fb2c6258)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c5e515f-7d7b-4255-a84e-56e0b1f2c26d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c3cf8471-87cf-4bf4-8df9-228c70d9729e)(content(Whitespace\" \
+         db8d6a1b-eadb-4b9a-8b9b-8961b00548f2)(content(Whitespace\" \
          \"))))(Tile((id \
          ff4ba4cf-c298-44a7-8dac-34d69b81c647)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1183,23 +835,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e6079660-69ca-4db3-97fd-d8c784f05a34)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b86c2837-1efa-4bd4-ba5f-63e8fa9a1558)(content(Whitespace\" \
+         665c964f-1be0-4d4a-aed6-be7c2f666648)(content(Whitespace\" \
          \"))))(Tile((id \
          a79169e9-6b57-45a3-b094-a7cf729fa976)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4ed2b79a-d52e-4c90-9cf8-2cb22104375f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e0d3578b-7d27-4f00-afcf-4eeb630fc225)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         189f04e3-e39d-4404-be08-3c27e74fbda0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1a755c8d-f25a-4187-883d-9f903d9994e1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c3520e25-a06f-4bf4-9906-f1ccad17868f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba86cd2d-d3a7-46be-acaf-fd9996f7641e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         52f49542-9945-4390-bce4-24bcf0db603e)(content(Whitespace\" \
+         c94f04fd-d3e0-477e-bd9d-8202e3a6393a)(content(Whitespace\" \
          \"))))(Tile((id \
          4a1507a7-b946-4adb-bb33-3fa03a9fb822)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1210,56 +851,39 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f2e2a98c-bfe1-4194-bbe4-a6be80c5949d)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         a13cbdc7-24c6-4848-950e-538fd72dddc4)(content(Whitespace\" \
+         82f219f5-ac48-469a-b882-5fe242b10afa)(content(Whitespace\" \
          \"))))(Tile((id \
          4c41f926-e000-4333-aac4-7d8cde770f91)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         de558331-bd53-4bee-8858-eb42b80b7be7)(content(Whitespace\" \
+         981bbce6-e2cc-4e04-9291-7cdc6cb33812)(content(Whitespace\" \
          \"))))(Tile((id \
          15fee5b7-bbb4-4378-a743-198c3e544b1f)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         eea26136-6705-4c0a-afdb-e0657cf358b6)(content(Whitespace\" \
+         6c1304d6-4258-412a-b875-d627f8c404df)(content(Whitespace\" \
          \"))))(Tile((id \
          42e91e71-711f-43b7-9af2-a66bfa5caaac)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c98e7339-05d7-4a71-852b-90a4c0868826)(content(Whitespace\" \
+         21c6ef4c-85a4-4bd6-a1c8-96267c34806a)(content(Whitespace\" \
          \"))))(Tile((id \
          413143bc-a647-4f88-9afa-3b77e8144dae)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         9ba103f3-abca-4329-8b2f-470f951b5058)(content(Whitespace\" \
+         f4085c60-1b7e-44b6-a230-fb55da811a8d)(content(Whitespace\" \
          \"))))(Tile((id \
          5d26c6a5-4008-4519-b13b-f37e9034d3c8)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         848b8561-7287-4591-8a72-c3420fc6751f)(content(Whitespace\" \
+         bfbd5c3c-eef0-4fb4-87e8-da4075aa4b6d)(content(Whitespace\" \
          \"))))(Tile((id \
          15dd2be0-0ded-4268-99ab-fd7518317bf2)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         a5ebca47-1a85-41ea-a782-681bf063549e)(content(Whitespace\" \
+         fde6711a-9fa6-40f2-8a2d-4a274b1e9195)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d9c787ea-8ca7-4075-8535-bb8b95d9f6a4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6a79f3a4-462f-4b6f-b415-516117f89878)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ee9d929a-2c7d-4f07-8f1f-a4ea03e0c41f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9b2fdf45-9d1d-4acf-b47e-23b595479e03)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d207841d-f540-4c36-b66b-b51f40ce9a23)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e70c4b39-5807-4a37-b08a-aeb8ed58dde2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b8ceecc3-d141-4059-88f6-9ce97b510f12)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c855b163-b207-4da2-9b70-f6e94b71b8a5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e7306af2-6b29-4acb-9f24-e8e98db67e09)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         99fbb92b-0ac0-4b01-96b8-1e56ab0e882f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3970b94d-f3f1-41d5-a97d-6489561dc206)(content(Whitespace\"\\n\"))))(Tile((id \
          544794c5-64ee-4f6f-b7cd-792e6647073c)(label(float_of_int))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1269,12 +893,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cf5a77d2-ffc5-4f3f-871c-47c06ef3abaa)(label(numerator))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         efd2bae6-1f72-4920-900b-5287eaca289a)(content(Whitespace\" \
+         c1d50606-502a-436a-b1d6-9ea09edebeb9)(content(Whitespace\" \
          \"))))(Tile((id \
          2696f5d5-8f57-4061-87a8-02c0e4f914ff)(label(/.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a761a305-c308-442c-af3a-89b749167cef)(content(Whitespace\" \
+         f517843b-0bbf-4eed-b19f-6ca66cc7fb88)(content(Whitespace\" \
          \"))))(Tile((id \
          9ebd28aa-4045-46c3-a700-072ce12a6c2a)(label(float_of_int))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1284,50 +908,45 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          ebdd2fee-9ffb-4a13-a7f2-bd9f93d3e4f7)(label(denominator))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         66bfdcc5-4a5d-4ce8-9d4f-36fa0fe711ff)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d93052b-7b68-4dd4-9fcc-c0fafbcd4097)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ada3538f-6e95-40f6-92bc-0329229b2ed9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6bf743c9-b3db-4384-845c-682140f94a3f)(content(Whitespace\"\\n\"))))(Tile((id \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         fd16069f-b7cc-4727-ba88-f92ad930302c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         7fa7e688-9048-4118-a505-1a2dfe0030de)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         fc67ee76-32e3-44ca-96ea-da2147e08a48)(content(Whitespace\"\\n\"))))(Secondary((id \
+         44e6eb89-a016-49aa-a210-a3d21c3c36f6)(content(Whitespace\"\\n\"))))(Tile((id \
          2e67279f-8a92-4ebc-ba1a-d9ebcb2e0d3d)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         9c2ff439-2b46-465c-9a86-d3fe8e10d2d5)(content(Whitespace\" \
+         e505055a-b8c5-4c63-a96a-63df8f8dca68)(content(Whitespace\" \
          \"))))(Tile((id \
          02c8656f-2515-4b32-8621-503f9512566f)(label(pHacking))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a9377f12-4688-46c6-b9ca-6fe6775fe598)(content(Whitespace\" \
+         dd39fef3-74b7-4939-ba99-78685725321c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4551528a-154a-4159-95e9-f39b1e8d6002)(content(Whitespace\" \
-         \"))))(Tile((id ee955c53-1e24-4907-81c8-43d37f0aa0b9)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         d6693762-3c08-4143-9b65-10ba468ae931)(content(Whitespace\" \
+         6a5cdc51-d06b-4463-9dfe-f2dc38d1626f)(content(Whitespace\"\\n\"))))(Tile((id \
+         ee955c53-1e24-4907-81c8-43d37f0aa0b9)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         320dfc49-26ee-4c0f-b8bd-1f8dff23165e)(content(Whitespace\" \
          \"))))(Tile((id \
          bffff6fe-027b-40e2-b2d6-53fed7b2cb72)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         29383bf3-6a4f-4486-9e6f-12845f88cc8e)(content(Whitespace\" \
+         fd344954-cab0-448d-9c10-ff6ac8b7637c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         bf1dc24c-66e6-4ce6-a5c6-9e28c9e26c66)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7d5e66d4-72ff-4c7b-ac29-dde879d5b616)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         47f73b50-4cef-4e2e-b92b-d3777ea3a898)(content(Whitespace\" \
-         \"))))(Tile((id b4801576-59af-4c67-8dea-8ae6f554f5f8)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         7ea70c98-b25b-44ff-b2fe-b3563032bc6a)(content(Whitespace\" \
+         953afd0d-cd24-439b-a278-bc1413dbb554)(content(Whitespace\"\\n\"))))(Tile((id \
+         b4801576-59af-4c67-8dea-8ae6f554f5f8)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a90e3f61-74bb-4065-be2c-79d6d6836d71)(content(Whitespace\" \
          \"))))(Tile((id \
          be7a7b00-9035-48f5-9c1f-1aa3843ee369)(label(jelly_anon))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c9cd9916-1151-4aea-9b49-116d0d5d0b86)(content(Whitespace\" \
+         71380ca2-7010-4ad1-9c41-7febb7c0212f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         98641ab6-a88c-4b7a-a433-388c0998230c)(content(Whitespace\" \
+         bb83cefc-ff99-4ea0-8270-3e4ad75f8fb6)(content(Whitespace\" \
          \"))))(Tile((id \
          baf19383-aa32-40b3-817d-f74b9b0d1b02)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1341,19 +960,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2dd9414e-3b88-4270-8ed1-0b4a47b58356)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7b5418bd-04b7-4f9c-887b-de332439abd2)(content(Whitespace\" \
+         1808d358-0ec0-46f5-8f28-16fc7b60e408)(content(Whitespace\" \
          \"))))(Tile((id c76f8879-b87d-4d76-8ead-c440103da424)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         836c4ed2-7206-4d4d-a51c-0cf3bfb8edb7)(content(Whitespace\" \
+         2e9909ce-6bb2-4f03-8af7-347b23ae7af3)(content(Whitespace\" \
          \"))))(Tile((id \
          f09a73a2-0432-4342-94b7-f11e47f2c84c)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         13947773-c2b1-4c86-9243-db97c1cb2548)(content(Whitespace\" \
+         3317f451-ebb0-4cfa-84eb-fa09a8cbbc60)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9199c9e5-7e3c-4edb-9378-eb96427fe1ff)(content(Whitespace\" \
+         1528192a-6d17-4640-a6cd-75ea5a00d327)(content(Whitespace\" \
          \"))))(Tile((id \
          6ea1857c-83c8-4eea-9e63-b996b996e27b)(label(omit_labels))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1367,29 +986,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7de980f1-f9f6-469e-a062-40fb51779acf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2623be6d-7a56-471c-883c-b7b07e4b368b)(content(Whitespace\" \
+         50c9d263-e1c4-42b9-9f21-ebde55f963b8)(content(Whitespace\" \
          \"))))(Tile((id \
          5926de66-148f-40c5-83ce-896c173925ca)(label(`get_acne`))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         0b0f4f5f-e9fb-48a3-9983-823a99ea955d)(content(Whitespace\" \
+         6e021ac2-d720-4686-a3e9-3974e99888a7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5c4e3d2d-5af7-44c6-a4cd-820ae98c52c1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         dfdb3aaa-162f-4c99-b805-3816eb93fa5e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9fc2b90b-7b74-48ec-b7d8-8f4d721769ab)(content(Whitespace\" \
-         \"))))(Tile((id d74915fb-ca66-48b1-ad5d-903cce612300)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         378fc273-dcd5-43b6-941e-0ad79b1f972c)(content(Whitespace\" \
+         34381842-4292-47c9-864e-1d3546a88ee2)(content(Whitespace\"\\n\"))))(Tile((id \
+         d74915fb-ca66-48b1-ad5d-903cce612300)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5ea786c7-9fe0-4323-bdfc-ad9f8577a815)(content(Whitespace\" \
          \"))))(Tile((id \
          5fa61876-109c-4170-9e24-a9b26b13e2f8)(label(get_acne))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ed6980ec-091c-4ccc-ae15-3aa08a8cfd2b)(content(Whitespace\" \
+         dbddb87b-1d90-40f0-a6e8-7c6ff53be691)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e54cc166-b4d6-4605-93dc-b311ea0cb8c3)(content(Whitespace\" \
+         7fe92809-62d0-4abb-8918-3cfd369c1208)(content(Whitespace\" \
          \"))))(Tile((id \
          ef3a84d3-8389-4eb1-a9d9-a2d4fca99881)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1400,24 +1015,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          47680f69-3a27-47d5-9f35-9147403653c0)(label(get_acne))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         7b367c42-e8b1-4ae8-aaf0-80d630b60d37)(content(Whitespace\" \
+         fbe814e5-a0d3-4b03-bddc-4078fbe0a33e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1f3a2005-e15c-4651-a489-7b7838d4c2f5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4b5d10d8-8ab9-43e2-a086-a4c55d8cd367)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6fa6b3a9-7b6e-417f-9d02-c3d472d7ec84)(content(Whitespace\" \
-         \"))))(Tile((id ee9c578e-370c-4215-87a3-d6744a3ea869)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         5f92f693-7697-4413-ab03-dd071ca25327)(content(Whitespace\" \
+         7bc80657-ade7-4c88-9640-fa2ac80e5e5d)(content(Whitespace\"\\n\"))))(Tile((id \
+         ee9c578e-370c-4215-87a3-d6744a3ea869)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ec0f0f1d-a820-4408-8ad9-7a450f52762e)(content(Whitespace\" \
          \"))))(Tile((id \
          33419a43-c5f6-48dc-948b-79db941dbb9b)(label(header))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1cc76c54-dc0a-4626-a6ee-190cd180b1e0)(content(Whitespace\" \
+         7774379b-adda-4581-a3fc-34cc8c0142cc)(content(Whitespace\" \
          \")))))((Secondary((id \
-         81e21cd6-35f6-48c7-af1f-2e878167bdde)(content(Whitespace\" \
+         64c21b55-c117-4934-874c-4993a98182b0)(content(Whitespace\" \
          \"))))(Tile((id \
          4d5b52b6-b00f-4fc7-811e-0d677f94f0de)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1434,12 +1045,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          12bb9c3c-2c0d-4c76-a513-5fbdd2e04cff)(label(jelly_anon))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d07be6f6-ca4f-4cbe-a41c-f9345b922a1f)(content(Whitespace\" \
+         5478e521-bcd7-4494-a8cf-32a14593f902)(content(Whitespace\" \
          \"))))(Tile((id \
          995d2a5a-e0c9-4f69-a395-30c90fae8b6a)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         05d480b6-27e7-480b-b858-2c955c13b127)(content(Whitespace\" \
+         39a0cd76-2334-4d7a-bc4e-cc54e48f6232)(content(Whitespace\" \
          \"))))(Tile((id \
          090aa2e6-a9d5-4d65-b112-cfbe8676b936)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1453,19 +1064,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c5acc74f-6391-4174-9205-5085a42f7105)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f490cac1-afe5-4a83-8d6b-17690609f06f)(content(Whitespace\" \
+         a7ce5d87-854c-4271-affd-45fee71d19a0)(content(Whitespace\" \
          \"))))(Tile((id 982bbab8-4c4d-41d4-9375-b8f65b93e9cc)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         3d2d2127-0130-4315-8f89-85eef6b2c22e)(content(Whitespace\" \
+         194fb8b4-a202-4062-bceb-a227729f7785)(content(Whitespace\" \
          \"))))(Tile((id \
          c07c5751-3409-4773-a699-22927c6ce368)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         06b74948-0508-481e-839d-7f8823cba49a)(content(Whitespace\" \
+         1209c645-f00e-4426-b270-434b3ed8198f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9ce41564-5f35-4be2-848d-b9e21b2071c7)(content(Whitespace\" \
+         4dd1ac69-b538-4cfe-989c-e1d1f0e5714e)(content(Whitespace\" \
          \"))))(Tile((id \
          8ec0fb0e-26d2-4e6c-8b82-e363a085adb4)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1476,13 +1087,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4a059166-4434-4f2e-903c-6b72d415f481)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ec6670fe-3702-4697-8c86-32ed8902d00c)(content(Whitespace\" \
+         fca688e4-7fbb-4679-be11-78c9086237cf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         897306f5-1980-4dcc-a986-49779f082d3d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b1d8089e-4442-41ca-9e3a-8af1d39160c2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         745d3d90-3551-4f7f-b585-4de0287bba6b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ebecdf0b-d425-442b-b0fa-161d4f962c27)(content(Whitespace\"\\n\"))))(Tile((id \
          62d052f8-9114-450a-a394-516181887906)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1495,19 +1102,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          45f3bc69-609e-440a-a165-f57d8d7fadd8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1280c2d5-e804-4588-bcf9-d18ef2e1b181)(content(Whitespace\" \
+         a4c205b3-4f50-445e-9f32-af96b10171b0)(content(Whitespace\" \
          \"))))(Tile((id f09a019a-9911-4fef-9da6-47d893fe0339)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         1c4ec483-6b57-448b-9247-b1965380e4b1)(content(Whitespace\" \
+         fef13f07-7b2e-4982-9dba-3c8b56b1500b)(content(Whitespace\" \
          \"))))(Tile((id \
          2240fb9d-8828-47af-a01d-fc975bd7f253)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         42fb2cf0-0909-4674-b4fd-11bf392d8703)(content(Whitespace\" \
+         5aaf60e3-a8fc-4111-9092-e8ccabf6533d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3849db6d-d055-4bcc-bc6c-97fc11c05b9c)(content(Whitespace\" \
+         f4a54221-0724-4ce1-b17f-52098967ba76)(content(Whitespace\" \
          \"))))(Tile((id \
          e033cc8e-f78a-4117-9f22-dc42d5cb5145)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1518,7 +1125,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          69392200-b6b1-4eba-9863-af144e50a4a5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         113949ca-3dfa-4eb9-a314-1f8257c0c73e)(content(Whitespace\" \
+         360894a8-0652-4c77-8242-82fc979dd453)(content(Whitespace\" \
          \"))))(Tile((id \
          2527c080-3e6a-4503-a196-9ad23ba04100)(label(fisherTest))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1532,7 +1139,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e8aed96a-ad15-43d4-85c9-898e31a73a5d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3b8813f1-48ad-4460-afc5-b6e8d1909c2e)(content(Whitespace\" \
+         634eed43-a1fd-4242-a949-e746e5fbe25b)(content(Whitespace\" \
          \"))))(Tile((id \
          50f385dd-737f-4045-beba-a40796b964e2)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1546,19 +1153,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          530587ae-a8b2-40e7-8fe7-cee65bdc05c5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         455173ea-cde7-4b9e-8a63-e6db70077cb4)(content(Whitespace\" \
+         c52408b0-6e51-4415-8270-be60166c5425)(content(Whitespace\" \
          \"))))(Tile((id 657a13b8-cc32-4f66-a7d9-d873b2580b37)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         83fdfa6b-e41b-4610-8837-f3cbcf1f5f60)(content(Whitespace\" \
+         db17c544-e81f-45cf-962e-b5fecb30a95f)(content(Whitespace\" \
          \"))))(Tile((id \
          4562fd51-d7cf-4b4e-8cd3-cf0b0e21c07c)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9a26e28c-6e47-43df-bd4a-8184407f9fd4)(content(Whitespace\" \
+         79380959-2655-4376-8253-85bd5b1d5f6f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         28845b2e-35b8-4d67-889b-7e34059701b2)(content(Whitespace\" \
+         ebc8eca3-b884-4f00-ae89-fbfa70c8da0c)(content(Whitespace\" \
          \"))))(Tile((id \
          baeae155-70a7-4ad1-8b11-5e0203095043)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1630,15 +1237,11 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c9c44159-06ba-42aa-95ae-1c6b79e339ae)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         90ca0e65-cbc1-44b6-be87-2fde125c6739)(content(Whitespace\"\\n\"))))(Secondary((id \
-         577edf40-b193-4416-9716-75f79cb00a86)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fe50540c-ca9b-424d-8f7c-45dd3d6d5673)(content(Whitespace\" \
-         \"))))(Tile((id \
+         fbe4152f-a8d1-4b99-83a5-cdfc91636fe8)(content(Whitespace\"\\n\"))))(Tile((id \
          a9bf49af-b016-4e94-9bd7-9c5eab3ec8ab)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         97f82eef-f45f-4564-855c-84e05c3bd74f)(content(Whitespace\" \
+         300938c7-942f-40b1-b5bd-e15bd408131b)(content(Whitespace\" \
          \"))))(Tile((id \
          2f1993e2-b6ba-4b16-8a66-edf3d52eedc9)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1652,53 +1255,49 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c802ffee-4111-4544-8d96-fdfc0cc9702f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cf45cd5f-5166-4191-bdc7-4bd1faf7081e)(content(Whitespace\" \
+         02f2a3b3-b49c-4fa8-9977-8d6701aa79ad)(content(Whitespace\" \
          \"))))(Tile((id 2a6fa72f-338a-4e32-a251-6a747018f90a)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         2f5bd1b3-116c-41f0-ab3e-99b5362496d6)(content(Whitespace\" \
+         642a91ab-22f1-4f5a-ab3f-d8f0cf0cc1ae)(content(Whitespace\" \
          \"))))(Tile((id \
          13ef536e-4fea-481c-8b8c-19cebcb81bd8)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         9b1be530-354e-46bb-bd43-f9b55c27893d)(label(c))(mold((out \
+         9b1be530-354e-46bb-bd43-f9b55c27893d)(label(_c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
          c930de38-aa2b-4f21-bcb7-7bb87e2e6a82)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         6cdc5e8d-9429-45c2-83bd-f146dad285a2)(content(Whitespace\" \
+         b1a4c7a2-1024-4037-ae5b-81971114d1b2)(content(Whitespace\" \
          \"))))(Tile((id \
          38b2d50c-ccc3-44c5-ab09-944513c7a938)(label(p))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         58f638a8-21b1-42d0-a55f-7e868b14d725)(content(Whitespace\" \
+         81993c55-f4dc-4a2e-8c3a-aa1739ecf4d8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0ef263fa-6d46-4a70-86b5-c009876c42ea)(content(Whitespace\" \
+         69cad1df-f106-448a-b5af-b94e57e23433)(content(Whitespace\" \
          \"))))(Tile((id \
          a531575d-cddb-484c-8062-0f0216fe527e)(label(p))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         eef93d85-3d96-4f9d-acf2-049cc1de612c)(content(Whitespace\" \
+         86952159-5011-417f-918f-1efe28f42e6d)(content(Whitespace\" \
          \"))))(Tile((id \
          4c1d4fb6-bb3d-413c-965c-f4dc2dccb772)(label(<.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1e28a598-554d-4a86-8bb1-8963cee42f71)(content(Whitespace\" \
+         3711a365-5011-444b-913f-079bb1d35094)(content(Whitespace\" \
          \"))))(Tile((id \
          5d9f4157-e5f1-4747-80a6-f3bc888c62f3)(label(0.05))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         dd05cc53-ce4d-4209-b711-41371b24716a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5dfebe9d-f32a-4977-9c7f-00826a6226e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         705cc6a0-7f8f-43d5-b490-c598069fc4da)(content(Whitespace\" \
-         \"))))(Tile((id \
+         56ed61a9-a4b0-4ff1-b58a-8c1b022aa982)(content(Whitespace\"\\n\"))))(Tile((id \
          a2af1d57-9f19-45e6-9f81-62009cf5a658)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1123ce98-4640-48fc-97c7-c8a15030acbb)(content(Whitespace\" \
+         f3fa6b04-5375-4e98-810b-ec100d3bfb51)(content(Whitespace\" \
          \"))))(Tile((id \
          0471a78e-eded-4e3f-bb65-a4543e01dea1)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1712,12 +1311,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8938f1c2-d78d-44be-a996-b9086b35fd57)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4429fefb-7302-4635-8d35-056005c7a140)(content(Whitespace\" \
+         accfd23f-7bd0-4e89-96eb-ae73499d0bec)(content(Whitespace\" \
          \"))))(Tile((id 2959cb4b-0974-4cad-865f-19763bd5ae0d)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a8eec033-80ca-4375-9dd5-1da8b4b02402)(content(Whitespace\" \
+         3b50c6d4-f844-44ec-8864-697801efb1c0)(content(Whitespace\" \
          \"))))(Tile((id \
          68e66745-5e8e-4ca2-b6b5-39f470dfbae4)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1727,243 +1326,273 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          2c006bdf-f422-4aa7-9a8f-b65562ea08d7)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         475ffd97-b015-4961-af60-df5901024633)(label(p))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         39471f5c-487c-4d8b-b209-0d68f4634f75)(content(Whitespace\" \
+         \"))))(Tile((id \
+         475ffd97-b015-4961-af60-df5901024633)(label(_p))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         381af702-095d-490e-8e3f-c54fc5392d98)(content(Whitespace\" \
+         37c46030-5850-43a1-9b33-5938e683d26f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         361de52d-21b4-4876-ab1b-0c47ea649be1)(content(Whitespace\" \
+         6127bf09-9e14-4a34-8940-90f1b4652d30)(content(Whitespace\" \
          \"))))(Tile((id 009584dc-a8ba-48e9-bd2e-95365a192deb)(label(\"\\\"We \
          found a link between \\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         ce5589e5-fe1e-4200-a372-a32e0f08c195)(content(Whitespace\" \
+         2b254872-2c55-424c-9c1a-ca10bbb68c9f)(content(Whitespace\" \
          \"))))(Tile((id \
          f4f59013-3cbb-42e6-9664-ae6cb3e6746b)(label(++))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e047467a-d65d-4a05-a65b-5e575ce205bf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c6e23e43-aa6c-46d1-8543-d457df3eccae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         20dff953-5aef-43c8-b2a7-b3ae18c62d00)(content(Whitespace\" \
+         45213cb3-376e-4ece-aaef-f3b4bb8c3827)(content(Whitespace\" \
          \"))))(Tile((id \
          61c4a135-7de2-498b-990f-79b2dfa871d9)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         03a813f2-731a-448a-a154-e3b81aba01de)(content(Whitespace\" \
+         994e273a-8c0d-4710-9ce1-7696ca5ce8c2)(content(Whitespace\" \
          \"))))(Tile((id \
          f2c9aebc-b31f-4480-be75-1efe70c5d374)(label(++))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0f1c8b01-0ddb-4b1d-b4ed-40eb581ba1bb)(content(Whitespace\" \
+         8e4761d6-b6ac-4415-9514-e87b4e621465)(content(Whitespace\" \
          \"))))(Tile((id 09d927d9-4d33-4a2a-a0cb-a7f9950af877)(label(\"\\\" \
          jelly beans and acne (p < 0.05).\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         804b553a-5497-4041-a64f-75b8056407ca)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db15d560-b65b-4752-a795-300d8c0cc3cf)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         9142293f-c66b-48a8-bcd8-4e3b8745d8ed)(content(Whitespace\"\\n\"))))(Secondary((id \
-         29e28ef5-ea87-4ace-a832-742bf43d3ff4)(content(Whitespace\"\\n\"))))(Tile((id \
+         ac27cd2c-ad96-40f6-88b0-c85b92d051c2)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ab5dd451-16fd-41c1-8bfe-64d2f499b7ed)(content(Whitespace\"\\n\"))))(Secondary((id \
+         e2b8c412-7fe2-4039-b4ca-b19c2ab99f5d)(content(Whitespace\"\\n\"))))(Tile((id \
          8d560b44-2316-484d-9f5b-19dc3142fde1)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         4f93ea89-edae-459e-ad54-3a2954913c33)(content(Whitespace\" \
+         37ed705b-6289-4d5d-838c-dba43b15899f)(content(Whitespace\" \
          \"))))(Tile((id \
          3e85f4d5-1f28-44cf-88c1-5f2d810aaa8d)(label(JellyNamed))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         22354b3b-ab1b-43c5-a001-e7dd7973449f)(content(Whitespace\" \
+         4ac55981-7e81-4d39-a1a1-201201d497ea)(content(Whitespace\" \
          \")))))((Secondary((id \
-         43c26c26-e734-4f5f-b70e-ee542a2427a1)(content(Whitespace\" \
+         0db154e7-1906-48e1-8dfa-88fd76a1e7c7)(content(Whitespace\" \
          \"))))(Tile((id \
          caf92b01-6d4c-43c5-a19d-e306057e1c19)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         36cfeb8f-9c6b-467e-b5f1-5d2625929a45)(content(Whitespace\"\\n\"))))(Tile((id \
          14b8488c-c22e-419a-b16e-95f620c96b9d)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c5e79b95-da53-488c-b751-63eb831a86be)(content(Whitespace\" \
+         \"))))(Tile((id \
          d122df61-083b-4998-8a50-8ee60f225471)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d1f13814-82e5-436a-be16-74cf3402f384)(content(Whitespace\" \
+         \"))))(Tile((id \
          788c3756-4dfd-4126-8885-8b1e5cde09db)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5804cabe-d24b-400d-abc8-2e8be9e47845)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c7ae64a9-9cc8-4155-9acc-de9de8286f94)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b528b09f-c769-4f0e-beb3-9241ff9b86a3)(content(Whitespace\"\\n\"))))(Tile((id \
          924c4c40-22ad-462c-96ea-b61ccb23130d)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         31dcc2ab-a4c0-4fee-8f88-4a21e2053145)(content(Whitespace\" \
+         \"))))(Tile((id \
          5099c53d-26f0-4886-bdd2-3eb55ff00d01)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6df1c906-2dfe-45d1-ae10-a31e26b2d6d4)(content(Whitespace\" \
+         \"))))(Tile((id \
          e91cc30c-1368-4274-a331-d448a704fef2)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          be13feca-f70d-4552-9b84-22c9ed019b4b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         eb2ebb7c-af83-448d-a7c7-afd56d9295c7)(content(Whitespace\" \
-         \"))))(Tile((id \
+         51e9d7cf-172b-42bd-9784-cf5cee78d4d0)(content(Whitespace\"\\n\"))))(Tile((id \
          fb35ab35-7756-4be3-9490-946e25d611ca)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         10c01825-f8fe-48a4-a8f3-46c06152f191)(content(Whitespace\" \
+         \"))))(Tile((id \
          9ff2eb2e-835d-4fe9-b572-900000ed4fd8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e5283732-1134-4a10-8c1a-98dab90b4ee6)(content(Whitespace\" \
+         \"))))(Tile((id \
          3151bd0f-68e7-4322-ad85-978ad19dce96)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          57515462-bbf5-4116-a631-ff0faaf63856)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1973978a-3a90-487d-b39a-dea9a7bff226)(content(Whitespace\" \
-         \"))))(Tile((id \
+         771ded12-d0ac-4c2b-b778-3617c090a558)(content(Whitespace\"\\n\"))))(Tile((id \
          2fc5d5dd-063c-4bf3-9902-2b92da68cb8c)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e80d87d0-7bad-4b03-9adb-4c2dab490399)(content(Whitespace\" \
+         \"))))(Tile((id \
          98f216e5-474f-4267-8302-587b5dc52687)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e5a30125-10c2-494a-b61d-267f51f42c8b)(content(Whitespace\" \
+         \"))))(Tile((id \
          43195a76-9b3d-42ab-9e94-1e2cd1524fec)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0c3f33e3-a9f5-4d76-972b-63d4cdb43816)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         40aca605-1b3e-454d-a7d3-1a99cd9bebac)(content(Whitespace\" \
-         \"))))(Tile((id \
+         cabef34e-97bd-4714-ab2e-051a38a3d78d)(content(Whitespace\"\\n\"))))(Tile((id \
          7db593c2-2db0-46b3-b0bd-8d178d3ce99f)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         56550714-4e2d-424d-9055-105fa2cbf84c)(content(Whitespace\" \
+         \"))))(Tile((id \
          42d671da-d70c-455e-a0f6-236fa488103e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         701b1638-da52-47da-8b20-344806a8ac8b)(content(Whitespace\" \
+         \"))))(Tile((id \
          b6c2ae24-1191-403d-b661-ff0a4e9e7337)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          cb12267c-fc73-489d-b8e1-0286d3af9c42)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         aafb7d24-e772-491b-ad24-f837b08492d5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3f7d4030-d05e-4f56-8a60-1ecb34c94615)(content(Whitespace\"\\n\"))))(Tile((id \
          0d4a18f1-a624-44ea-b67d-9f20cf9983a1)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2327a5dc-9a0a-4314-a659-cc7de84d119d)(content(Whitespace\" \
+         \"))))(Tile((id \
          67b8ba0b-c714-4d6d-9f6f-2fe7bf57cecc)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         20c8ca85-fcb1-48e0-944e-3b93ad8ba4a1)(content(Whitespace\" \
+         \"))))(Tile((id \
          4cd93c84-d8ef-4f9a-a10e-3925cc2abef8)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b0f78b58-85d3-416d-b93b-1e1d75527e32)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2562a23f-d132-4f1e-804f-841822f2fbae)(content(Whitespace\" \
-         \"))))(Tile((id \
+         a0184b3a-b1f5-4263-9554-8d333b821e90)(content(Whitespace\"\\n\"))))(Tile((id \
          0fbec8de-8f7a-413d-b2f8-c2e007bd81fd)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         069e3e69-8dba-41df-bea0-3fae65667c22)(content(Whitespace\" \
+         \"))))(Tile((id \
          da0d4185-1f42-4e77-99c6-0220859cc742)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         62a8543d-e8a9-4d0f-b48c-a43203784856)(content(Whitespace\" \
+         \"))))(Tile((id \
          168d9fd5-61ee-489e-88fc-7c966ccb386c)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6e5968f8-17a2-43dc-95ae-974e30c65c7d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9ec4fe95-c1bf-4f25-aba9-3fd0d30dc4e2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         20e356da-679a-4ceb-b028-4ddcb0597534)(content(Whitespace\"\\n\"))))(Tile((id \
          6cc54570-fdb2-4282-9d79-89df1a6b9079)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         889da895-3176-43ae-aa0d-cdc81769c2f9)(content(Whitespace\" \
+         \"))))(Tile((id \
          135b5199-15ad-4a09-a756-b3e57ea670d4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a56c08d7-4a73-4a7f-8d15-b36184bd7242)(content(Whitespace\" \
+         \"))))(Tile((id \
          76c5a2c8-57b7-4453-9631-5299a55e898f)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          61bf39a8-ccda-44a0-8536-720c43e9169e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1d3cf74e-5de6-44dc-9bc0-439ee64ae0a1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ac628466-99ca-4907-b597-49e92204caf3)(content(Whitespace\"\\n\"))))(Tile((id \
          42fca2d2-b720-42dd-8b7e-048bd7be4f81)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3722c655-b418-4510-b85a-5b95ccf20f06)(content(Whitespace\" \
+         \"))))(Tile((id \
          c6f85ebd-181e-4868-a7b9-1940a448149e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3b59852b-99cd-4e13-8382-0c11f52427d0)(content(Whitespace\" \
+         \"))))(Tile((id \
          355fdc26-fdc5-4984-82dc-646fe3d45ac7)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0bb75be6-bb88-4d73-9b1b-8970b2091892)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1dbf7b3d-6f05-48b9-a5e1-c990698ae540)(content(Whitespace\" \
-         \"))))(Tile((id \
+         96a0b33a-ad50-47a9-8529-b337854bfc0c)(content(Whitespace\"\\n\"))))(Tile((id \
          9e43d4c9-1c49-473a-aeb2-61a159333f77)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e2e422a3-ec1f-4dbd-bb01-e0cab4cd9568)(content(Whitespace\" \
+         \"))))(Tile((id \
          08b8cd3f-4fdc-4326-aded-8eefb39ca4ab)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         791197b3-d8d2-431a-ad8b-582de5fe3123)(content(Whitespace\" \
+         \"))))(Tile((id \
          1818ea27-a28a-4a23-ba31-5951cb693fd5)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          04f04e60-7fcd-4272-86ce-771806c479fa)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8ac1e3b0-04e5-4d2e-b566-e3850ef88e2d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f900be96-2310-4fe3-8cba-60ebb5ea4034)(content(Whitespace\"\\n\"))))(Tile((id \
          d2d15a61-d299-48f3-b3d0-6a414dee8184)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9c1177fb-e1a6-4a1c-89f3-f751588a3017)(content(Whitespace\" \
+         \"))))(Tile((id \
          0e6924a5-bff7-4297-acee-2df56d279e8d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4b6e0307-2c0c-4e56-afce-554b9a08f69e)(content(Whitespace\" \
+         \"))))(Tile((id \
          090c2051-1086-4043-b613-2ab58415b33f)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f62c55cc-2fc7-44f4-ab77-0c84fed0b045)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4fb0931a-7430-4f61-98d1-6f7d5868a9f8)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         1de4e9e8-d415-4c7c-8866-d243c11e4c7c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a5f5989b-d680-46c1-85e6-931bd6d2b8ac)(content(Whitespace\"\\n\"))))(Tile((id \
+         8829b5ab-a47a-4c33-9297-d0581bf46505)(content(Whitespace\"\\n\"))))(Tile((id \
          ceff652e-7cb1-4186-9413-b04343d30e02)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         4cb3a36e-857f-4845-8ffc-c2144c1b484d)(content(Whitespace\" \
+         df4b6e7e-f639-4849-add4-a079828fd8e3)(content(Whitespace\" \
          \"))))(Tile((id \
          a06eabfb-312f-4cec-9b5f-faaaf8aff76e)(label(jellyNamed))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0ac7d75b-dd7a-4ede-8134-3dcfa45446b6)(content(Whitespace\" \
+         8074f84e-042f-4fb8-af5a-45cba3649205)(content(Whitespace\" \
          \"))))(Tile((id \
          e7e5be72-8660-464e-9a33-1e6e874e04e0)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dc9287da-4d4e-4c8c-9d53-4c9471e7e856)(content(Whitespace\" \
+         fc4d9ecc-e588-43c5-86fd-10679d330707)(content(Whitespace\" \
          \"))))(Tile((id cb74c458-703b-4694-8ad5-45e426b58ec0)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          faa833e3-89cb-448e-babf-167eae2a541a)(label(JellyNamed))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         18c2d5a5-fb4e-48e4-aab6-cca45d10f76c)(content(Whitespace\" \
+         767446c3-5966-4239-8e5d-854025388899)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f61565f4-07d6-4629-8366-38efd98f8aee)(content(Whitespace\" \
+         f0154969-5c49-4c66-b760-e95af26bcf82)(content(Whitespace\" \
          \"))))(Tile((id 40f625fc-f4b7-4cf1-9eb3-59a21d94e600)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         3136a2bd-7d37-4245-9252-c17023244df7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         64f64f74-df79-4d44-89b2-5304ec31642c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d0f06cd2-7ec0-46fe-a4f1-e738cb43bf1f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         6a813795-a93a-4bd0-8d69-a8f39dc44369)(content(Whitespace\"\\n\"))))(Tile((id \
          80349fca-a35f-4642-a44f-1ee9ab121b71)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2089,11 +1718,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f2ea95c5-5048-44f4-94cf-d33288c614f5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         23a31867-4969-407e-9640-ab6b460100af)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ef989d8f-964f-4700-8588-387f6d930e8f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7d1df2fd-a4d3-4864-9fc8-d6d2df8ae136)(content(Whitespace\" \
-         \"))))(Tile((id \
+         a3f14ccb-00bd-4c55-9129-3c503924b834)(content(Whitespace\"\\n\"))))(Tile((id \
          23b6501b-8fcb-42b1-9bf0-75d8cea74fe7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2219,11 +1844,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ad2152c6-6f60-4ce8-9415-9688b6029a32)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2ff9fbff-7973-4531-b6e0-6b2468a93dbc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9a126b10-0080-4537-a676-5929c31d49dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5270fb8-4993-4f1a-9693-921291a051de)(content(Whitespace\" \
-         \"))))(Tile((id \
+         26ca80af-27f5-4ccc-9c4e-21f79b3e1172)(content(Whitespace\"\\n\"))))(Tile((id \
          f1058550-1e9d-4096-82b2-5b99227a93b5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2351,11 +1972,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b1fec7f5-798d-4420-b67b-e4758eeb776d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         be266b30-0cf3-449d-bbd2-3e3315979a9f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8cfedab9-9b6d-425d-a32a-68ceb510ffee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         527fad4a-454d-4037-8966-e7f7314420a7)(content(Whitespace\" \
-         \"))))(Tile((id \
+         4d01ffff-3170-4304-bf95-66a7b08ed71d)(content(Whitespace\"\\n\"))))(Tile((id \
          7653f5a4-2d41-414c-b4ad-77ea488ca4ee)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2481,11 +2098,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3f2071f0-2dbb-4656-8590-56d0e19c6f27)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         919196b3-5fb9-49ad-942a-aa74d706cc62)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9ba72bb6-af53-497a-9f39-57e5c56a600f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b3b843fe-abec-4a64-911d-09578dd7dcc7)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c184a50a-e7bb-4d6c-b5f7-1ad34aa63a0d)(content(Whitespace\"\\n\"))))(Tile((id \
          250e026f-e417-4b51-b6d9-9fe4fe2c75af)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2607,11 +2220,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          998d3fe9-ea78-4f99-82f0-3a9ff7be61b6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2c5dd4cd-cc02-405b-b7a8-9f668fc28a64)(content(Whitespace\"\\n\"))))(Secondary((id \
-         44cbdc77-cceb-44af-b02b-94a3df7dd5d4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b125e5c7-ea1e-4ba2-b186-499c2dd426d8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         175df117-636c-40a8-8259-d5856f0b44dc)(content(Whitespace\"\\n\"))))(Tile((id \
          299dff1a-2d9d-48e0-b8f9-9d49af63ee37)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2737,11 +2346,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          161e5656-96f6-4dff-9b09-f328dadfee39)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0398cee5-3ca5-4fc7-b1c2-f70692c218e2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c02ab9d2-7090-4e86-a21d-b76dd3f1a588)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c9dcfe03-2a56-485c-ab1c-9d0fa47c3723)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5cb7f784-ea0d-42d1-8430-2dfe9824edd9)(content(Whitespace\"\\n\"))))(Tile((id \
          5e43299d-8726-431a-8379-91c6f957c309)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2865,11 +2470,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          83df112d-2889-447b-8d18-a552946b40dd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         971bae82-6bed-4e08-9cf1-3c930a2fb2c5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5a679fca-abd0-45cb-a11c-477ad88634c3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         01f5775a-845e-4600-b2df-8c2ee5f2a4ad)(content(Whitespace\" \
-         \"))))(Tile((id \
+         a181ffc8-900c-418e-95d0-dccccf175526)(content(Whitespace\"\\n\"))))(Tile((id \
          77416934-1ca0-4f81-8b9c-6389a9c57d7d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2991,11 +2592,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8491c219-eca9-48ad-be68-ac7f61bfa1fe)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a5eb7c36-73b8-4e2e-bcf6-a3f01151682d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5688a020-1327-47ee-ba25-8a95a593314a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         25862ba6-fac7-411b-82e7-3f7b0a9219bc)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8e3c959f-5585-4c30-bf43-28f32b779d1f)(content(Whitespace\"\\n\"))))(Tile((id \
          34205b4e-a14b-48f6-a87c-30bf51cb02ae)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3119,11 +2716,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0ec67328-f8a3-4e94-a876-0a33e2836d29)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a5f6bb91-baf8-480c-a421-0b9d1e58ad42)(content(Whitespace\"\\n\"))))(Secondary((id \
-         41a31c49-837b-44fa-83b8-2575d830d40e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         323e7ab2-6beb-4f00-814a-bd253cb5aecf)(content(Whitespace\" \
-         \"))))(Tile((id \
+         cee37a66-7798-4a09-8019-92ee4a9a016c)(content(Whitespace\"\\n\"))))(Tile((id \
          ddff2d75-524b-4ff2-8635-58203b68faa8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3133,7 +2726,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b99f9e55-053c-418f-86e7-c20fcb249284)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c7897d21-652d-46d9-8059-8405400b21f1)(content(Whitespace\" \
+         d56a74fa-774a-4395-b0f0-75bcf7eadbda)(content(Whitespace\" \
          \"))))(Tile((id \
          4c9173ac-58e2-468b-8153-003728944b91)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3144,7 +2737,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bd3fee7d-401b-4bc0-a42b-2cda0092fc77)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2c1205cf-235f-4469-aaff-44bb9184e79f)(content(Whitespace\" \
+         5793881a-a6a7-448f-926f-63ea744f72fb)(content(Whitespace\" \
          \"))))(Tile((id \
          f6c8898c-962a-41a3-94e0-37f49affe96b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3155,7 +2748,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          302cfc16-f996-4768-bdc4-1e04f04182e7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c14b0d0c-7dfe-40ac-9e7e-7c75b259188d)(content(Whitespace\" \
+         dde444d1-1fe3-4cf8-af47-614910845932)(content(Whitespace\" \
          \"))))(Tile((id \
          ff1bcf31-eda8-48bc-b5cb-20410649f510)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3166,7 +2759,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bb87265d-99dc-4e9b-9e63-c599cd322b4e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7529f0ab-0f1b-4ac9-aed6-6a62232aef6c)(content(Whitespace\" \
+         bc3f0d6a-70ac-41c0-b914-794d4846bcc8)(content(Whitespace\" \
          \"))))(Tile((id \
          b1f5336c-fd35-4243-930a-114ad54a4634)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3177,7 +2770,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d0768c91-0d6e-4a4a-a7f6-031aa03f3ad1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8e1e0ccf-bca5-491b-80e2-afb81cf0bb69)(content(Whitespace\" \
+         e998f1d6-421b-4516-9cfd-6d00a893cd14)(content(Whitespace\" \
          \"))))(Tile((id \
          e51f00dd-5370-4289-8997-50c611e284cc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3188,7 +2781,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          675e1261-528a-4a88-9b98-d5b3c560ec57)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6458817d-aee7-46a5-bce3-00ca5e9ff9ed)(content(Whitespace\" \
+         58f8aab4-87a8-49de-bf2f-6217f080f4d3)(content(Whitespace\" \
          \"))))(Tile((id \
          fb5d3558-e796-4c0b-8327-39f85c85c8b3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3199,7 +2792,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ca8fe6c2-b499-4abb-81fe-9d15f35eb70a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ab1fb21d-2041-43d4-b099-e6799a4fff49)(content(Whitespace\" \
+         86717c5f-28ff-4a23-8f59-96fc97be89f5)(content(Whitespace\" \
          \"))))(Tile((id \
          c739e5a9-d49a-4be8-a965-b02c081a3aec)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3210,7 +2803,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ada0c418-6572-4ad9-bdbe-6908e4ba2dff)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0d89e84d-5b7b-40ee-8ca1-73fd07c03090)(content(Whitespace\" \
+         3dd3331d-c153-494f-8f48-5c6ae49ff74c)(content(Whitespace\" \
          \"))))(Tile((id \
          c75f43d6-cdcb-4d2b-8e63-4846db346f51)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3221,7 +2814,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6554412a-bd53-4e76-b934-da9e3174a841)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         15914cc3-9b44-4847-b5d1-4c39b9a9bb35)(content(Whitespace\" \
+         c865152b-f804-4056-9363-11c2c298caaf)(content(Whitespace\" \
          \"))))(Tile((id \
          1b961817-799c-460b-8a1b-ef124472b410)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3232,7 +2825,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          285d98a8-a4ca-4912-82db-b99e341ae4f9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         61c0ad5f-8c0a-4721-9d97-49b268804529)(content(Whitespace\" \
+         9add4cbb-ac2e-435e-834d-aa669637b0fb)(content(Whitespace\" \
          \"))))(Tile((id \
          f7346a3e-9bdc-48d5-8218-cb1ee4bd077c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3240,11 +2833,11 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d761d957-d84f-4df9-95ca-ce69c2f634a8)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         eab03e6e-1650-43fe-af7e-36f6f72eb770)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         de71ed21-077e-450c-bd01-e2fae4435278)(content(Whitespace\" \
+         c0b049e5-4ae9-4759-91aa-8057cfec4b69)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         942a33f4-c3ec-430e-8da0-8406b48232c9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         80c16721-053d-491c-b120-016f4570d0c5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9e4a136c-a88d-40cb-bf51-216eaa7167a7)(content(Whitespace\"\\n\"))))(Tile((id \
+         4c9ed764-4188-400a-82f2-f5380550f21d)(content(Whitespace\"\\n\"))))(Secondary((id \
+         ab139d37-8992-40d2-9ea6-9a6f9be2d382)(content(Whitespace\"\\n\"))))(Tile((id \
          2fa192dc-1ec9-43ee-b327-80479d54ff06)(label(pHacking))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3263,19 +2856,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          41cf25dc-af68-4bb5-9ddb-cad63d169942)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d1dfc2dd-22c7-43fb-8f53-03335118f63a)(content(Whitespace\" \
+         7c452c8b-3c28-46c4-870e-747fb97d6614)(content(Whitespace\" \
          \"))))(Tile((id 0c5e89a0-36be-46cc-9219-06d63a86cd1c)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         1262450e-e58e-444e-8697-8a9174cb2edc)(content(Whitespace\" \
+         5a3a49a0-6a8a-4c77-8ebb-05aa9890b1b9)(content(Whitespace\" \
          \"))))(Tile((id \
          e927e065-49ea-495f-a0f8-380cea5f0f3f)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9bdb68fb-0b0a-49de-bc12-05387381f9fd)(content(Whitespace\" \
+         d760fd58-ab07-461f-bf7c-63cd461633c8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4ce4c0a3-6fd3-4772-9bf3-2ac2b2781da0)(content(Whitespace\" \
+         84ef3dd4-3002-4c52-bfa1-3469b20985ab)(content(Whitespace\" \
          \"))))(Tile((id \
          b188f0b0-f62e-42fe-b69b-f5ee863aeefc)(label(omit_labels))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3289,85 +2882,85 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8d89e2b1-3c1b-421a-9be5-b24bef553279)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6d484024-477d-44b3-a7a3-319e84580ca7)(content(Whitespace\" \
+         ed31ad03-269c-4325-950d-941c11d76825)(content(Whitespace\" \
          \"))))(Tile((id \
          9172f503-b7b7-4a19-9ff9-d1873187c29b)(label(`name`))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         8891bef4-baa9-40d1-bb35-11f53c9d88a8)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children())))))))))))))))))))";
       backup_text =
-        "let fisherTest =\n\
-        \  (fun (xs:[Bool], ys: [Bool]) ->\n\
-        \    \n\
-        \    let zipped = zip(xs, ys) in\n\
-        \    \n\
-        \    let contigencyTable =\n\
-        \      fold_left(zipped,\n\
-        \        fun (((a,b),(c,d)), e : (Bool,Bool)) ->\n\
-        \          case e\n\
-        \          | (false, false) => ((a+1,b),(c,d))\n\
-        \          | (false, true) => ((a,b+1),(c,d))\n\
-        \          | (true, false) => ((a,b),(c+1,d))\n\
-        \          | (true, true) => ((a,b),(c,d+1)) \n\
-        \          end , \n\
-        \        ((0,0),(0,0))) \n\
-        \    in\n\
-        \    \n\
-        \    let factorial = fun (n: Int) ->\n\
-        \      if n == 0 then 1 else n * factorial(n - 1) \n\
-        \    in\n\
-        \    let ((a,b),(c,d)) = contigencyTable in     \n\
-        \    \n\
-        \    let numerator =\n\
-        \      factorial(a + b) *\n\
-        \      factorial(c + d) *\n\
-        \      factorial(a + c) *\n\
-        \      factorial(b + d) in\n\
-        \    \n\
-        \    let denominator =\n\
-        \      factorial(a) *\n\
-        \      factorial(b) *\n\
-        \      factorial(c) *\n\
-        \      factorial(d) *\n\
-        \      factorial(a + b + c + d) in\n\
-        \    \n\
-        \    float_of_int(numerator) /. float_of_int(denominator)) \n\
-         in\n\n\
-         let pHacking = fun t ->\n\
-        \  let jelly_anon = map(t, fun r -> omit_labels(r, `get_acne`)) in\n\
-        \  let get_acne = t.get_acne in\n\
-        \  let header = to_lvs(head(jelly_anon)) |> map(_, fun e -> e.label) in\n\
-        \  map(header, fun c -> (c, fisherTest(get_acne, map(t, fun r -> \
+        "let fisherTest = (\n\
+         fun (xs : [Bool], ys : [Bool]) ->\n\
+         let zipped = zip(xs, ys) in\n\
+         let contigencyTable =\n\
+         fold_left(\n\
+         zipped,\n\
+         fun (\n\
+         ((a,b),(c,d)),\n\
+         e\n\
+         : (Bool, Bool)\n\
+         ) ->\n\
+         case e\n\
+         | (false, false) => ((a+1,b), (c, d))\n\
+         | (false, true) => ((a,b+1), (c, d))\n\
+         | (true, false) => ((a,b), (c + 1, d))\n\
+         | (true, true) => ((a,b), (c, d + 1))\n\
+         end,\n\
+         ((0,0), (0, 0))\n\
+         ) in\n\
+         let factorial = fun (n : Int) -> if n == 0 then 1 else n * \
+         factorial(n - 1) in\n\
+         let ((a,b), (c, d)) = contigencyTable in\n\
+         let numerator = factorial(a + b) * factorial(c + d) * factorial(a + \
+         c) * factorial(b + d) in\n\
+         let denominator = factorial(a) * factorial(b) * factorial(c) * \
+         factorial(d) * factorial(a + b + c + d) in\n\
+         float_of_int(numerator) /. float_of_int(denominator)\n\
+         ) in\n\n\
+         let pHacking =\n\
+         fun t ->\n\
+         let jelly_anon = map(t, fun r -> omit_labels(r, `get_acne`)) in\n\
+         let get_acne = t.get_acne in\n\
+         let header = to_lvs(head(jelly_anon)) |> map(_, fun e -> e.label) in\n\
+         map(header, fun c -> (c, fisherTest(get_acne, map(t, fun r -> \
          (to_lvs(r) |> find(_, fun e -> e.label == c)).value))))\n\
-        \  |> filter(_, fun (c, p) -> p <. 0.05)\n\
-        \  |> map(_, fun (c,p) -> \"We found a link between \" ++\n\
-        \  c ++ \" jelly beans and acne (p < 0.05).\") \n\
-         in\n\n\
-         type JellyNamed = (name=String, get_acne=Bool, red=Bool, black=Bool, \
-         white=Bool, green=Bool, yellow=Bool, brown=Bool, orange=Bool, \
-         pink=Bool, purple=Bool) in\n\
+         |> filter(_, fun (_c, p) -> p <. 0.05)\n\
+         |> map(_, fun (c, _p) -> \"We found a link between \" ++ c ++ \" \
+         jelly beans and acne (p < 0.05).\") in\n\n\
+         type JellyNamed = (\n\
+         name = String,\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool\n\
+         ) in\n\
          let jellyNamed : [JellyNamed] = [\n\
-        \  (\"Emily\",    (true), (false), (false), (false), (true), (false), \
+         (\"Emily\",    (true), (false), (false), (false), (true), (false), \
          (false), (true), (false), (false)),\n\
-        \  (\"Jacob\",    (true), (false), (true), (false), (true), (true), \
+         (\"Jacob\",    (true), (false), (true), (false), (true), (true), \
          (false), (false), (false), (false)),\n\
-        \  (\"Emma\",     (false), (false), (false), (false), (true), (false), \
+         (\"Emma\",     (false), (false), (false), (false), (true), (false), \
          (false), (false), (true), (false)),\n\
-        \  (\"Aidan\",    (false), (false), (false), (false), (false), (true), \
+         (\"Aidan\",    (false), (false), (false), (false), (false), (true), \
          (false), (false), (false), (false)),\n\
-        \  (\"Madison\",  (false), (false), (false), (false), (false), (true), \
+         (\"Madison\",  (false), (false), (false), (false), (false), (true), \
          (false), (false), (true), (false)),\n\
-        \  (\"Ethan\",    (true), (false), (true), (false), (false), (false), \
+         (\"Ethan\",    (true), (false), (true), (false), (false), (false), \
          (false), (true), (true), (false)),\n\
-        \  (\"Hannah\",   (false), (false), (true), (false), (false), (false), \
+         (\"Hannah\",   (false), (false), (true), (false), (false), (false), \
          (false), (false), (true), (false)),\n\
-        \  (\"Matthew\",  (true), (false), (false), (false), (false), (false), \
+         (\"Matthew\",  (true), (false), (false), (false), (false), (false), \
          (true), (true), (false), (false)),\n\
-        \  (\"Hailey\",   (true), (false), (false), (false), (false), (false), \
+         (\"Hailey\",   (true), (false), (false), (false), (false), (false), \
          (false), (true), (false), (false)),\n\
-        \  (\"Nicholas\", (false), (true), (false), (false), (false), (true), \
+         (\"Nicholas\", (false), (true), (false), (false), (false), (true), \
          (true), (false), (true), (false))\n\
          ] in\n\n\
-         pHacking(map(jellyNamed, fun r -> omit_labels(r, `name`)))\n";
+         pHacking(map(jellyNamed, fun r -> omit_labels(r, `name`)))";
       refractors = "()";
     } )

--- a/src/b2t2/slides/example_programs/B2T2ExampleProgramspHackingHomogeneous.ml
+++ b/src/b2t2/slides/example_programs/B2T2ExampleProgramspHackingHomogeneous.ml
@@ -6,79 +6,76 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         4e474f82-0843-4aab-b822-581a575a3ab4)(content(Whitespace\" \
+         f1898c0f-59a3-47d1-a315-df68105e6322)(content(Whitespace\" \
          \"))))(Tile((id \
          ac6c29c0-8a5c-4e34-8364-e730c4b7fe32)(label(fisherTest))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         991852fa-71df-4a9b-9cd6-6fdc984b849d)(content(Whitespace\" \
+         d9048ac7-a278-4036-a34f-c4d5535c917f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c04298a6-b79b-4524-a485-1cb30511e1ed)(content(Whitespace\" \
+         28215b5b-fd31-4932-a1e9-ee6a7607452a)(content(Whitespace\" \
          \"))))(Tile((id \
          11426ea9-5fe9-40f5-b7c0-32cede08f847)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         562e6542-2c8b-4a0e-a0da-35e78b56bd0e)(content(Whitespace\"\\n\"))))(Tile((id \
          934f7d93-e822-4432-954f-1e6b1ecd9601)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         c6a80b6a-83b5-440f-b455-9645c6b99e2c)(content(Whitespace\" \
+         66faebc1-df79-4dbb-b09d-e5ad01a566b7)(content(Whitespace\" \
          \"))))(Tile((id \
          e9aeae46-2375-4892-b6ff-27ab85737d08)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          041c9d22-065c-45fd-b638-4ad51aaa3b48)(label(xs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         d12c4b69-61d3-43c4-b14a-06f70710c73f)(content(Whitespace\" \
+         \"))))(Tile((id \
          bcd0305a-57ba-4c48-822b-a84253054227)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         8c630b41-b8f8-4b4a-864c-3311e69fa8ed)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ccc4402e-d2bd-4da7-af43-46029821f3af)(content(Whitespace\" \
+         \"))))(Tile((id 8c630b41-b8f8-4b4a-864c-3311e69fa8ed)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          95469652-3a57-4a6e-8254-ab0480793353)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          00f77ff2-0157-47ae-a9f5-498adaad94a4)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         42ef11e1-ce75-4f39-b7f7-2f49d476ffcf)(content(Whitespace\" \
+         f349ecd3-28c2-42a5-a7cc-ec871438b2d3)(content(Whitespace\" \
          \"))))(Tile((id \
          c1e0d5f0-d025-4280-a54c-ec33f226e506)(label(ys))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ac72ace5-c9fc-42b7-930f-55d9bc6506a6)(content(Whitespace\" \
+         \"))))(Tile((id \
          e0a6e9e1-6f9e-4519-81be-e38ac0b74f84)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         698f271c-5c1b-468f-884d-fb39f57bdab9)(content(Whitespace\" \
+         e4236fd1-fea7-47bc-8f2c-6693aea985a1)(content(Whitespace\" \
          \"))))(Tile((id ded75da9-1710-4901-ad7e-0891814d526e)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          aac39af9-5fe4-4736-895c-a11f228fdb72)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         0860ae91-7f38-4d59-ae58-bc66f5370ffa)(content(Whitespace\" \
+         4690df89-dac7-4335-908a-d7ca8380f173)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5f13bb6a-8998-4ca7-9c36-551fcde0bcf1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         19317cb7-159f-470a-ad93-7468b2d1eeda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d347e51f-1f23-4708-b104-292f62bfd5dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33ada802-a6b0-45be-8b6c-1dda58cbce2d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4d8d7ef5-978a-4fec-9672-8b75bc37cef8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57234de4-8ef5-4fa4-8160-632ba83d77be)(content(Whitespace\" \
-         \"))))(Tile((id 47fc6282-5f6b-4543-b153-7f18e1432f0e)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         1a49f42e-99d8-4f6d-bd77-9a82dbfd90c3)(content(Whitespace\" \
+         56e5e6c9-d59d-49a3-b0bf-33e9a547469d)(content(Whitespace\"\\n\"))))(Tile((id \
+         47fc6282-5f6b-4543-b153-7f18e1432f0e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f9e10276-8a52-4713-b012-b72f2a1f42ae)(content(Whitespace\" \
          \"))))(Tile((id \
          d4c1057b-f700-4626-a8d9-3cd610bd52ae)(label(zipped))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b137a7f7-a988-4e68-be94-8c94d4bfc950)(content(Whitespace\" \
+         d33c2197-877a-45fd-ab67-70cfe647b9af)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9ddb958a-8a2a-4a38-90c9-48e5830752f2)(content(Whitespace\" \
+         5d9262f9-ec89-4888-9757-3395441807f2)(content(Whitespace\" \
          \"))))(Tile((id \
          71464002-b969-46b1-b6a8-ff1b7000ed24)(label(zip))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -92,75 +89,48 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c198ae63-d5df-4e9e-a811-24572119862d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cfd408cd-7d68-4fc3-94bc-4439ae40f23e)(content(Whitespace\" \
+         4f1172e1-63f9-49ae-84f5-22e67653df50)(content(Whitespace\" \
          \"))))(Tile((id \
          3d5069d1-9054-4ecd-8d76-e79f2fd58594)(label(ys))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f9afdb87-2b5b-4bbb-8cdc-5e397226d600)(content(Whitespace\" \
+         9be8dcc2-aa7a-433f-bc76-f21735a35d56)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cbc0527d-e023-417b-837d-e16aa8cf470a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f21bdc63-69de-44da-a80d-517b2f44d0bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         568eaae8-5b0c-45de-80a4-417162b6e681)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3202cccc-f880-453a-a573-f687fef542ef)(content(Whitespace\"\\n\"))))(Secondary((id \
-         73807bf3-c4f7-448e-940a-8338a7101574)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e555214d-4af0-4b42-b48c-14655ab31c19)(content(Whitespace\" \
-         \"))))(Tile((id 62120b6a-e806-48f4-b7e4-e301c7b464d7)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e2b2488f-21d5-4dda-a0c4-6126aaa5263a)(content(Whitespace\" \
+         51bad905-227a-460e-ba43-2526b1a8bd0d)(content(Whitespace\"\\n\"))))(Tile((id \
+         62120b6a-e806-48f4-b7e4-e301c7b464d7)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ba26548f-82ae-4380-aaa4-22cd638c5cf2)(content(Whitespace\" \
          \"))))(Tile((id \
          bc70bdcc-e29c-4ab1-bc17-23d138ba540f)(label(contigencyTable))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5e27efb0-1565-43a6-ac39-4144edc7631a)(content(Whitespace\" \
+         0d44d353-71d7-4694-ae20-f5f1103cfd11)(content(Whitespace\" \
          \")))))((Secondary((id \
-         864a4958-8a4f-475d-a360-ba0187b1051f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         44abf4ac-a474-4808-b9d3-5286393a7bf5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36ab762b-2d33-43f4-91e3-fb5832bde642)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f70fae59-0566-40ef-b2a9-a36540714bda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dba1423e-81c8-4a8f-ad17-7196175b96d6)(content(Whitespace\" \
-         \"))))(Tile((id \
+         76043d8d-0b84-4ecc-85cf-5f5f6678a6c9)(content(Whitespace\"\\n\"))))(Tile((id \
          cfe0c64d-ec3b-4c9b-81f0-d098d6a7ef39)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          847aba98-a934-476c-b70d-74a8752bfdb1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         d6508e0e-c2f9-464f-854b-a094eb05c9bf)(content(Whitespace\"\\n\"))))(Tile((id \
          6402f8a5-643f-4bd1-a11e-f40a91385e3b)(label(zipped))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          a31e8a0f-4238-4109-a783-b4e6a7ecb49b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         57d3364a-c2dc-48ea-95e0-de2ba4749b3a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3a00f2fb-5a07-4c71-b012-377b99a11892)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5181aba2-92c3-4448-a5f0-72b5e18437af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7941b7e7-d056-49bc-9b68-60b8dbf241d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9cf71a6a-e036-43d0-975c-6b3d9be99384)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8743c985-3ea7-4e19-b7c8-d1dae26fd552)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         83ffb9a9-28c1-4410-bd6e-164d68c91c5f)(content(Whitespace\" \
-         \"))))(Tile((id 8f173cf9-a211-497c-bec8-742b04c84ca2)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         5d8fd35a-acfd-4477-bea3-20acffe6644a)(content(Whitespace\" \
+         2fc43e20-eca0-47f1-b61b-6c3155d6b44d)(content(Whitespace\"\\n\"))))(Tile((id \
+         8f173cf9-a211-497c-bec8-742b04c84ca2)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         cfb71e79-9ced-40d1-990a-e0ef50426533)(content(Whitespace\" \
          \"))))(Tile((id \
          e0049325-67c0-44b0-a7ee-dd0fea8738bd)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
+         Pat))))))(shards(0 1))(children(((Secondary((id \
+         9ddb2fc1-2d3d-4e3d-a92c-64127d929efe)(content(Whitespace\"\\n\"))))(Tile((id \
          bad92b57-61a9-4fa5-9e85-8a5d05d3ad60)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
@@ -194,17 +164,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          64828c88-cbb7-4076-86d2-1a0308c53220)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         d6c3006e-b50f-4b52-8034-13075fcd2a7b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         1dc4439a-ed72-4afe-96b7-e0290b428d5f)(content(Whitespace\"\\n\"))))(Tile((id \
          2dba60e4-c2d3-47d1-a1ce-aae5ee310aa8)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9dca9985-c746-4779-a3fa-6d3bb49bdf7e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         1ed42acf-1c17-4c0d-8737-fe49637a019c)(content(Whitespace\"\\n\"))))(Tile((id \
          9d077aec-f197-4eb5-b87c-87216e4db1b2)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5c5d4659-d30b-4c57-8945-9ae821a2cecb)(content(Whitespace\" \
+         b6542071-4871-4dd0-8893-57534c92955e)(content(Whitespace\" \
          \"))))(Tile((id \
          06712440-6607-4556-a7a7-366fc0d1c024)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -214,56 +182,28 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          c195c2fe-07e2-4d5e-8357-853dfa9a08e0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1e3c8528-4258-46cb-9d8f-c274821ec9ea)(content(Whitespace\" \
+         \"))))(Tile((id \
          a172775a-c2d0-4bca-ac74-fc136c0e5b14)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         70865e43-6f31-4ef4-a4f4-61b24a3b07a9)(content(Whitespace\" \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         727dc73d-4d03-4158-a471-8a104f77d208)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         11806fdc-c85b-4b0b-817c-a9347bdce8d9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         da5abbf2-557a-489c-b629-18d555efa072)(content(Whitespace\"\\n\"))))(Secondary((id \
-         831aab46-fbee-4b80-bbf3-e970c92db545)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         34cd5f20-009c-493b-b594-3bfac1ec748b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aab05131-1bb7-42b9-bb94-a2510a87bcb4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e6f706d3-79cf-406e-8d37-861901cdeb4b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b13d0fef-7bdd-4d20-951f-d5bbfcf4e61e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         581cff2e-17c6-470e-91eb-ec8d27962d33)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8f260be8-0356-4fcc-aa8d-377f2128ddc5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f0e5f81a-dddf-4ade-aab8-14990400c977)(content(Whitespace\" \
-         \"))))(Tile((id 0e4de86c-5046-4efa-82b1-babbc115329a)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         416142df-af2c-4242-9ce2-06d5cc0b1ef5)(content(Whitespace\" \
+         adaf212e-b77b-437f-a5fa-25ca2b35fd28)(content(Whitespace\"\\n\"))))(Tile((id \
+         0e4de86c-5046-4efa-82b1-babbc115329a)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         b8fadef2-7c03-4321-b52b-67cab6ed15e0)(content(Whitespace\" \
          \"))))(Tile((id \
          e8dd8263-ccce-4658-8691-9be5b60d0ed7)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         868edeef-b5c0-40c5-a3fe-698fe64cca08)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f3d80ce3-083c-4daa-9ff4-ff9cf97d1767)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4df6520a-3ff6-4046-9288-25a1d7783555)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d0e542ff-5ab5-4542-a8da-8d5e99745dc8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b89fd5e-f54f-42a3-a440-20f9bd4b27bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         611200a2-5705-422c-8c2e-99f84cb3fae1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7103d485-09b7-4cb5-ae5d-eaacbb4e88b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8622778-9197-40ee-80d5-6706f2eba38f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         35ea6d79-2edf-452f-a6b6-bccde1c7a12f)(content(Whitespace\" \
-         \"))))(Tile((id ddd4be8d-102a-4428-b837-ea5b3d12b0c5)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         ded786be-8080-4411-b824-503222c47c46)(content(Whitespace\"\\n\"))))(Tile((id \
+         ddd4be8d-102a-4428-b837-ea5b3d12b0c5)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          942dd1e2-858c-48e4-a3af-a27c7963ebea)(content(Whitespace\" \
          \"))))(Tile((id \
          de1e1ac9-615e-4590-b99f-809e5a2f49df)(label(\"(\"\")\"))(mold((out \
@@ -282,7 +222,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          f04333f2-59ce-4573-90d3-cc3a3874f98a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a6ac1d1e-1104-4315-89b1-d26ebf142398)(content(Whitespace\" \
+         6c87aa19-908d-460b-916a-f980754099cb)(content(Whitespace\" \
          \"))))(Tile((id \
          6b1209df-dade-4471-b3f6-b1532d338722)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -307,7 +247,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          014a39d5-f57e-41e9-a2ba-0b473355dd77)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5923f004-b310-48fc-84a7-2e390a395964)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce37e45f-4a18-49b7-82f9-6c592e787a6e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -316,30 +258,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          1a9f0223-840c-46ce-98ea-928171d7a4b9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5ecbabf7-d2e3-4f38-a162-cb6f2864c724)(content(Whitespace\" \
+         \"))))(Tile((id \
          946e08d1-16ad-4bf3-8f33-d077a321c91a)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         9c2383cc-6fcd-4242-80da-e296f3b42459)(content(Whitespace\"\\n\"))))(Secondary((id \
-         06071def-df2f-4ff8-b127-af4ccc2a972b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b8e4e49f-7094-44d1-a505-b2686d2af341)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         18c8e9d6-5eef-4702-8e60-867149a23277)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1cddc3f1-6d95-49e8-8f55-a24c744f5bf9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7781032-4740-48e3-ad95-35cb135a2eef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         37e25678-96bd-4979-9c8a-819758dab630)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         69e5981f-2396-4e37-9355-4a7398cdbffb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9c4a06e-1ef0-4832-91c5-0cf95cc97f32)(content(Whitespace\" \
-         \"))))(Tile((id 87f67039-4e69-445b-bd06-262602d5fd23)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         865a1939-bdf6-4a43-95bf-978b8b25d8ce)(content(Whitespace\"\\n\"))))(Tile((id \
+         87f67039-4e69-445b-bd06-262602d5fd23)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          fbc908ee-80d8-466b-aad0-c7626f51b017)(content(Whitespace\" \
          \"))))(Tile((id \
          bbb9c912-f501-4e45-be2d-8b00f524bb27)(label(\"(\"\")\"))(mold((out \
@@ -358,7 +286,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          f1db2d1c-a463-4b72-9f90-d53f807a6356)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         554a68a9-f426-471e-986d-2c3954852b05)(content(Whitespace\" \
+         46b7dfb8-0ade-45c8-ab06-c3f2d7a53760)(content(Whitespace\" \
          \"))))(Tile((id \
          a9529b49-fb1b-4f1e-99ed-4502384ca23d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -383,7 +311,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          53bd1fd3-cfb1-4d13-b37b-2701482fd636)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3e95fb6e-96af-47d6-9287-7f0b3b6bccd1)(content(Whitespace\" \
+         \"))))(Tile((id \
          277dedad-e993-49e6-834d-dc9bbc0781bd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -392,30 +322,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          41fb8f40-f003-4f7a-865c-25bf8a9d5019)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         da9731c7-5748-4220-a076-9d486c587eba)(content(Whitespace\" \
+         \"))))(Tile((id \
          f463744c-7b61-4ef7-9c73-f0125eee29e9)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         9eb34f5e-4690-4f12-9168-764fa78297fb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8569093d-742f-440c-aa04-2e57637a5e46)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         51c91432-1764-4461-9ff1-a5aa635755fc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         20b3ae0a-45c9-450e-a4c4-ef779591a746)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a28afac-e10c-4b8c-ae5f-020d0eea612f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         65186818-a622-4cf8-8bc4-3542f7509b65)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ebbe954-0333-43f6-8950-d1e850f53ed3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         203840ab-7b42-4a4e-99ae-1b8392e98046)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f0dc9410-1de1-4012-b915-61e7163503a0)(content(Whitespace\" \
-         \"))))(Tile((id 5625f38c-bf21-40f1-8a3c-2ad3439bba41)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         5779e25e-7f6e-494c-8a0d-12679e9201f2)(content(Whitespace\"\\n\"))))(Tile((id \
+         5625f38c-bf21-40f1-8a3c-2ad3439bba41)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          95c3d56d-4eb7-4dd2-9bc1-32180b69052a)(content(Whitespace\" \
          \"))))(Tile((id \
          fd555f31-c09f-4309-8e8b-4483facc8649)(label(\"(\"\")\"))(mold((out \
@@ -434,7 +350,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          14c6095f-a206-4a42-b13e-65b25eecf83e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c44f1b47-d4af-4283-b6f0-b5cbdf7a4473)(content(Whitespace\" \
+         b9f4ccae-c4d1-43bc-a229-10ea385ad441)(content(Whitespace\" \
          \"))))(Tile((id \
          4b087104-4b10-46bf-ac71-1b2e647adcb7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -453,45 +369,37 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          7e2273f9-b641-4ad8-af6e-bc9df656c68f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         71ab716f-a5b9-4734-80cd-774e91d7ba0e)(content(Whitespace\" \
+         \"))))(Tile((id \
          4e3d5c46-e624-4e1e-9ce5-164e69b38c7b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          82e5a226-db71-4ad5-9bc0-7fcbb782181e)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         fb4e26f3-a9cf-48b6-bd3f-f72735de9dca)(content(Whitespace\" \
+         \"))))(Tile((id \
          71dcb3b4-2d90-4042-aba4-f890e4a52fba)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e8ca188e-9118-4fb6-b488-d580b83fa9f0)(content(Whitespace\" \
+         \"))))(Tile((id \
          9b5a0ed1-12b5-4148-801e-f0c5948c4730)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          638d8943-601b-4178-9bcc-a8e2ae9fbbce)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         66429eb2-f1c9-4c14-afe6-74ff78c28670)(content(Whitespace\" \
+         \"))))(Tile((id \
          f412de45-8e2c-4e0a-8c18-47d205ef451a)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         7f0697dd-290c-4297-99a7-70b6c5c3d7d7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ffb3143f-35b1-4e78-80da-e4771f97840a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f984666-b757-4773-9c0e-c13b4afb2614)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8043856b-4e33-4618-83bd-fe2dde6e69b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         617271e6-2cdd-4236-970b-a094ebfc53f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d4b36ba4-5f42-41ab-a9b4-6e517058f0b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a43d6c8b-aeb9-44d9-a024-411dc6c6c44e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab7fe863-e796-4136-bb88-783195b350c1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c0a68b18-3b26-4ad0-9386-0a475bc2b5a6)(content(Whitespace\" \
-         \"))))(Tile((id a7898643-7fac-47bb-ac4e-09bdd35b926f)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         7abe501d-8fe6-42dd-b63a-08a7b5d1601a)(content(Whitespace\"\\n\"))))(Tile((id \
+         a7898643-7fac-47bb-ac4e-09bdd35b926f)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          af9c1dce-6e19-4ca5-9442-533dda79f504)(content(Whitespace\" \
          \"))))(Tile((id \
          f616e9ca-0eb1-44cf-a631-709539fbd588)(label(\"(\"\")\"))(mold((out \
@@ -510,7 +418,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          ad1baacc-1bfe-4168-910d-b56fffecc320)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a15988bb-72f8-4273-93cd-321fbfc0e478)(content(Whitespace\" \
+         50e8adbb-d054-4c5e-8bf2-2480927884b1)(content(Whitespace\" \
          \"))))(Tile((id \
          509dc9f4-20eb-4f85-a80f-a2f786419687)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -529,7 +437,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          ce31a3e4-5a03-4ffa-aa77-1ac391bb62e0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6b009350-ce44-471b-80ad-07a19355fb37)(content(Whitespace\" \
+         \"))))(Tile((id \
          d6d2c7c3-8b9d-4cfa-9f89-6f08e8779271)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -538,53 +448,27 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          121592c8-1190-41a8-87d1-250267d2bc3f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         abb2b0c9-3847-4f8d-b0c7-7173257b4ea8)(content(Whitespace\" \
+         \"))))(Tile((id \
          70bf1f4c-b542-4e61-a282-1b3c7f34f9a6)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         80be7876-41bb-4ddc-b3fc-89d5932180a7)(content(Whitespace\" \
+         \"))))(Tile((id \
          8e8df9f9-d75b-4ce7-8a3f-28810a3e8914)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dc8f0589-dba2-4901-8c32-744b3f2bcf74)(content(Whitespace\" \
+         \"))))(Tile((id \
          775b9a37-b4fb-4bb8-85c2-1a41e22688fb)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         961388d8-e4b5-4882-a096-ec567bad2cea)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0f8a0f47-4da3-4eeb-acd3-19ab9b2129c5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bd5d1ec3-85a8-4a1f-9949-60ae247900ce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ca8c1254-25b3-464b-9a12-6c90c452a5df)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e9baf342-5f39-4ac9-a520-4bef0273e77d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5c79049-4eb7-4e56-9e44-2d755e42aab7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ec7e8cd-52c3-4ec2-b9bc-30b751bd3259)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8b27a6cd-b512-4ec4-949e-85139e8c54d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6c3c6c79-ffd7-414f-bf5d-d43db5b65d67)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0fac7ddc-bdd7-4e44-a330-684445135a44)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b5659bd5-7449-460e-8062-3bad45fac0e4)(content(Whitespace\"\\n\")))))))))(Tile((id \
          747b4d25-387d-446c-bec0-42f48d3d3182)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9c93caf5-2cdf-4525-b546-83ceaf6e97f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7d2ffb0-5c02-4e0a-9aca-9686cff65255)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a9ffcad5-2407-4fab-8f47-ed3dcb42987e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b22ae02e-ca0f-4fd5-b243-c2c1c7dcce07)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea177c94-130b-4873-be12-696ae8883775)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         54d3a495-317a-4638-875c-2a20d0d1b2ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         81c08c6e-1711-499d-9357-0b0b048cbc51)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2a77130c-180d-402b-b105-3da78189a139)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b89252cf-7be1-49ae-bb77-ea09c083c7e2)(content(Whitespace\"\\n\"))))(Tile((id \
          ba340286-6296-4cb1-8bcf-baa43c7641a2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -602,7 +486,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          52ffb1c0-1604-4c9f-9df2-e75ca4ded4e5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ade9e384-5a40-46c1-abb8-b430023463b6)(content(Whitespace\" \
+         \"))))(Tile((id \
          810143a2-90d7-4082-a5d1-2fcb655e6a78)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -611,105 +497,91 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          c19e8580-c36b-46c1-a196-3d0bf7e2ec89)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d3296d5d-be41-4e0d-a48f-c6bccb0e7c23)(content(Whitespace\" \
+         \"))))(Tile((id \
          d9e92e6a-a9b5-4186-99ad-eaa1313484fd)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         ab9b4bd4-cb4b-49d6-a73f-986fa0437d1b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c399790c-1077-4bed-b5ea-f04471716cec)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         434d2fac-322d-458b-95fb-2f88785fbd62)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         cbe239db-4a11-4aeb-8bc1-d397ea0dd30c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         623ba5c9-be8f-48c6-a041-790da9faae89)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4799e09e-b7d4-43db-b588-781f88ee1af3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a3a60c05-c366-4bc6-8132-d9dbf93ee525)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ecaac181-26eb-438a-baa4-ebcc4c5a428b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         56950333-4927-44e2-810a-2710db385aae)(content(Whitespace\"\\n\"))))(Secondary((id \
-         34e01fc3-de67-4872-a427-8aa75e1102b6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57b4bd51-6f6d-4544-95c6-e28f6664eddf)(content(Whitespace\" \
-         \"))))(Tile((id d8359059-913d-40d1-8358-cf80b974ce95)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         33695d34-2621-4826-a964-16a4c86b1ba1)(content(Whitespace\" \
+         b604254a-3962-4466-bc9e-4f098c3f9f1c)(content(Whitespace\"\\n\"))))(Tile((id \
+         d8359059-913d-40d1-8358-cf80b974ce95)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         fc681bd2-cda6-4b67-aaba-4e1ae3e9ccf4)(content(Whitespace\" \
          \"))))(Tile((id \
          8060c73a-376a-47bd-aaae-cf294f98efbc)(label(factorial))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         91e4b9ba-1490-422f-a0cd-32e37f8e1498)(content(Whitespace\" \
+         fb88cc9a-09da-4a6d-b2ed-4eddbb86b93a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a5c9e5b8-d5e9-4e83-aa62-c44bf6ee1eb5)(content(Whitespace\" \
+         1204ee58-8afb-4820-95a0-e24967d267c4)(content(Whitespace\" \
          \"))))(Tile((id 932c5848-ab0c-4f52-be34-65daf7a34c31)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         64f660ce-2e70-4695-b1ed-7ae1f3fd2b41)(content(Whitespace\" \
+         09bc566b-98d2-4045-b7ff-f6e10cb92e60)(content(Whitespace\" \
          \"))))(Tile((id \
          88df9863-739d-4d30-ab0c-d5ea410a74f0)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          1ed56cea-648e-46cc-a0ee-c5675113549f)(label(n))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b039b1e7-2013-4c00-8da9-a6d5d22fa2b2)(content(Whitespace\" \
+         \"))))(Tile((id \
          a2d74931-cada-4e7d-b35d-1824fda847d8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         78674946-cc25-44c0-9fbd-bc47ffbd4947)(content(Whitespace\" \
+         986eddfb-6324-4d5a-a75f-f6d698ddbb25)(content(Whitespace\" \
          \"))))(Tile((id \
          b5989841-a27b-475e-943b-e76383a6842a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a6a06661-1634-4b52-93ab-294d133d842b)(content(Whitespace\" \
+         77552b97-18bc-464e-aa99-792c22adab96)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         afc591b5-b9bb-4843-9770-cfe55021fe7f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2a66f29f-b3e6-471e-b051-6a0211150f0c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         42372b50-ca47-4f8c-b0f8-5ff59732bd11)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         118fe646-b8f9-4e98-a8b4-80afa7007e91)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         887253ee-9d3d-452a-b898-3cb1644bbb78)(content(Whitespace\" \
+         a12c37cf-0531-459a-8686-5d3fb25e143c)(content(Whitespace\" \
          \"))))(Tile((id 67bb526d-7bad-4d6a-987d-aba6d52fc618)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         d381557d-2501-4e55-90b2-374dbb7d398c)(content(Whitespace\" \
+         27f55870-0e60-4831-9943-903a1ed5272d)(content(Whitespace\" \
          \"))))(Tile((id \
          4407e901-0225-4e25-b38a-7713c9baede1)(label(n))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         e03d6436-f403-4c7f-a3bc-6d197501f942)(content(Whitespace\" \
+         85cca894-290f-4473-af2b-704a846fac05)(content(Whitespace\" \
          \"))))(Tile((id \
          cad6813e-710a-4088-a930-363232adeee8)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f8e6df86-4593-4aad-9861-4e0064d53cfa)(content(Whitespace\" \
+         028c284d-3b73-4402-9ea0-3c5d52e8971c)(content(Whitespace\" \
          \"))))(Tile((id \
          06ae0c05-ddb5-48e6-b572-655d1ad07484)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d2edc095-b797-4101-b508-446c159f11d1)(content(Whitespace\" \
+         64c3879c-070b-4c1a-a092-7ef08ca54ced)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c1049841-7c06-42e2-9c24-94feba2b488e)(content(Whitespace\" \
+         f3d2df5f-ea30-460e-b7f1-f9b1011c4501)(content(Whitespace\" \
          \"))))(Tile((id \
          8fe8eb7e-673f-430d-94f3-ddef30e81341)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         18e82082-8644-47e0-a157-b4ec405f216a)(content(Whitespace\" \
+         d2e123a0-c2bc-411b-aedc-503f3fdbb4e1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4c3880fb-f919-4d10-94a2-ff5069a0e42f)(content(Whitespace\" \
+         9e518fb0-359a-443d-9245-36fcc3b508ef)(content(Whitespace\" \
          \"))))(Tile((id \
          ed0f195a-5bca-4ed3-bcc4-9d2b4f84998e)(label(n))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         9a0d9af2-26b4-4752-825d-416884d65640)(content(Whitespace\" \
+         b2eb9050-ef6f-497c-bfd9-75290cbdfafc)(content(Whitespace\" \
          \"))))(Tile((id \
          aa3ec4a3-bbb9-4ce4-a8f5-27102d32045e)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6d4138c5-1076-473a-9f56-7c738286bec0)(content(Whitespace\" \
+         45ac307b-30bf-418e-878f-bf0b2622e927)(content(Whitespace\" \
          \"))))(Tile((id \
          fc0587a0-a071-425d-bfbd-1df6aab91935)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -720,30 +592,23 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d4b02992-eb53-4fac-88e9-7dff6f92ca41)(label(n))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         85a53a28-f14e-4348-adde-286eadb93a10)(content(Whitespace\" \
+         aeaf01eb-241f-4f72-9cb5-bbe430d52088)(content(Whitespace\" \
          \"))))(Tile((id \
          ce2d3e25-553f-4a5a-92c5-a1358a756dc4)(label(-))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4372c187-34ec-4d81-82c4-ae329803c63d)(content(Whitespace\" \
+         4afa1bcc-7b96-40a6-8bad-6602414da730)(content(Whitespace\" \
          \"))))(Tile((id \
          89703e96-c5b5-4c8e-ada8-5bfe8fb8239f)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         43cdf7e0-cd4a-4a87-9325-9831176fcb6e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f2b03e0a-64eb-4efe-a4d4-a535bfc57689)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         920556f8-c4f8-4a81-bfc5-1d139bb3c83b)(content(Whitespace\" \
+         91f39abc-a0c4-41a1-9116-d0cd77fa2ae3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         03a279b8-4ad5-45e9-b1c4-1d43ee41050f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b8f1f0c5-3e2f-4d72-9732-3a490e0459b7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         66b3db43-ad1a-49d8-ac69-997754398559)(content(Whitespace\" \
-         \"))))(Tile((id 73a2bfee-dd52-42bf-aecd-a4525810eb1c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         6ceb0a6a-f22a-4d9e-8298-6becc39bca58)(content(Whitespace\" \
+         670a5d71-5f07-4512-851b-0b6b9aa5266f)(content(Whitespace\"\\n\"))))(Tile((id \
+         73a2bfee-dd52-42bf-aecd-a4525810eb1c)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         3c885ca5-6d6a-4f58-944a-c5e11e345544)(content(Whitespace\" \
          \"))))(Tile((id \
          1f2220af-c4ae-4a8a-900f-80fc6f16f4b1)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -762,7 +627,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Tile((id \
          12cabd39-148d-4093-8d30-3aa56e93cdc6)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         bd6e0702-b148-4972-a25f-ea96fef80300)(content(Whitespace\" \
+         \"))))(Tile((id \
          62a618e5-4d12-490d-8481-82618219a0d3)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
@@ -771,57 +638,33 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          2ef3bd5e-c44e-473d-9d2b-c2e3269a66f5)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         6cf2444c-4223-4c13-9387-428969e4da93)(content(Whitespace\" \
+         \"))))(Tile((id \
          9eec8780-13e6-4883-bbe8-d295d2cc2b84)(label(d))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
-         69a5097b-e0bc-4908-bc80-482899031119)(content(Whitespace\" \
+         3cb74c92-1aa2-460e-b8b9-f785e1f4efeb)(content(Whitespace\" \
          \")))))((Secondary((id \
-         64e54942-d775-42b4-b308-3c94effd2bf1)(content(Whitespace\" \
+         394a4f7c-ab40-4fc9-ab01-78fc93da94a3)(content(Whitespace\" \
          \"))))(Tile((id \
          7c36772e-c3d3-4c04-97ef-2b83af69ad42)(label(contigencyTable))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         73b05e58-4609-4ae7-bf6b-cd403cefd1c2)(content(Whitespace\" \
+         e3c7139b-0d3d-45e7-9656-56101f1fda00)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f96a0277-6ac3-4337-a066-c37f9c27ca3d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57c529bb-dca4-4f3e-86ff-43d5c9acceab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         215b0879-0a8d-4353-8a86-7503725f3e25)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e019a80e-1756-4c4a-93d1-e9c1b0cc6a6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         850185e2-d976-4a2d-b7f2-ff0e77c7707b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         16fc7d13-385e-45c3-9f10-631b6e6b1aba)(content(Whitespace\"\\n\"))))(Secondary((id \
-         32806d0b-6187-4f1f-8271-5f788a21d13d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0a31b9a2-92a2-4cfd-a745-d9b1e4c02cd1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db516a20-07cd-4bfb-b95f-2e1fc09277ca)(content(Whitespace\"\\n\"))))(Secondary((id \
-         806a4dfc-018e-4689-b90f-b5840560192d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8dcc927f-f3de-46ce-91f9-c517c937f50d)(content(Whitespace\" \
-         \"))))(Tile((id 2007a65d-7402-408d-8bc8-6aa5aab0baaa)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d73cebfa-191b-478b-bb79-a5519de32ee8)(content(Whitespace\" \
+         0b370229-9348-49b4-9e22-4b3ca5682e19)(content(Whitespace\"\\n\"))))(Tile((id \
+         2007a65d-7402-408d-8bc8-6aa5aab0baaa)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         fde5a9ea-144d-4c72-ac8c-248b2a3e7dbe)(content(Whitespace\" \
          \"))))(Tile((id \
          d4780fcd-1b4b-4008-8507-cd87db2de564)(label(numerator))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         4c8e4dfd-631f-462f-9088-c01c496b9ef2)(content(Whitespace\" \
+         e10e53f0-6e0e-46d5-b1f1-5cfd94a391dd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         60122e77-6a86-4a71-a97a-9da6740af08b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f5e12f95-3787-4767-a2f9-ab0d81704146)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fa8d2b0a-f3cf-428f-9eec-315c8235463f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         90b7267d-3f67-4cf4-a908-82700fe9029b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         05ffd61e-d985-4a77-be78-ec0c94fc1616)(content(Whitespace\" \
+         74f7fea8-321a-46e2-9a21-8141bdb152f6)(content(Whitespace\" \
          \"))))(Tile((id \
          8c3b88cc-2e3b-4e6c-8c08-70794f823128)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -832,29 +675,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fde1d3dc-3d4a-495c-a6f7-b426a8a92811)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         527edd44-ce7a-4239-8109-f8a68574e812)(content(Whitespace\" \
+         21271052-578a-4af1-9cce-792fc9626dd9)(content(Whitespace\" \
          \"))))(Tile((id \
          6a6bb1e0-08bd-4da9-a7c5-2e6a15fb0e0f)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         feda2943-6650-4029-a3e3-94e578259d38)(content(Whitespace\" \
+         3142005d-2cb7-41bb-ab19-256247929619)(content(Whitespace\" \
          \"))))(Tile((id \
          8ce6a99d-bfa1-4386-9068-f40c1a60cc97)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7b9a5067-3859-4fb9-b7d9-1afd02448610)(content(Whitespace\" \
+         efef582f-f967-4904-b0eb-2eb8aaf65742)(content(Whitespace\" \
          \"))))(Tile((id \
          1987bfbd-90e2-4458-9d29-f138b1260433)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         deab5f9a-3655-40db-9e68-6db85fc27a53)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e8ca7a82-2f60-4eba-b81d-9a47c937e258)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c8830d6-0d3d-4aa8-ab8f-272f31a87656)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ee6046d0-ffc1-4186-a6b7-6e4d60f25b55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7d10bb50-5f1f-4ebb-8f5b-dca9962147ed)(content(Whitespace\" \
+         404763d6-c1d2-4e62-a88c-6dea4e92e9ac)(content(Whitespace\" \
          \"))))(Tile((id \
          d0b354a1-b61d-4fd6-9f37-dd534b60c646)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -865,29 +701,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8319d573-c227-4c34-89d5-9397df1e9009)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         fec475ea-5185-40cb-8eec-7cb9860bc373)(content(Whitespace\" \
+         a3e27bfe-43ce-4fcb-af68-d7bdbe036760)(content(Whitespace\" \
          \"))))(Tile((id \
          9a7fc8c9-c748-43db-87c4-4f47495ed98a)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fa9859a4-401b-4eef-8b83-2d427f49f36a)(content(Whitespace\" \
+         3c39ec68-52ef-40de-b9d9-c32eaf3d4f6a)(content(Whitespace\" \
          \"))))(Tile((id \
          93ceb735-8cfa-420a-ae6c-5be4e71a9b2d)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         17869f65-4970-4b6a-90c1-f17bf0a1bfa8)(content(Whitespace\" \
+         0ba94b40-43ac-43d5-993c-203d82847bd9)(content(Whitespace\" \
          \"))))(Tile((id \
          396a0471-dba6-4626-99b5-08b68c8b2eeb)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         969c76b3-9b7a-434b-b662-53282d163f1f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b13688dd-4325-4605-ae96-3615c5b90e58)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1a31cac1-4769-453a-a4f3-e85c607b8211)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         df592403-2216-4281-8af2-58e5ac34c4dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf3155d7-4100-4716-85b7-f538d8ba1f40)(content(Whitespace\" \
+         acda12b3-c2a7-4f83-b4c1-6a48218783fd)(content(Whitespace\" \
          \"))))(Tile((id \
          07ef763f-9e79-42e4-9878-f515c46aad6b)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -898,29 +727,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8dfbffbf-0ff5-4109-98af-9d00abe45c5b)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b21f7ad3-adc6-4e01-a91f-f429a9d66225)(content(Whitespace\" \
+         df36f85c-c865-412f-a778-8aa27582f808)(content(Whitespace\" \
          \"))))(Tile((id \
          ba7ca073-074b-40a3-aa44-9d9897b4a4e1)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4b332995-bef3-4612-87f7-7e8b217a0998)(content(Whitespace\" \
+         73f77b65-e2a2-439d-be96-89edad56f95b)(content(Whitespace\" \
          \"))))(Tile((id \
          ec088b5f-4301-4915-a96a-7a24eefeaafa)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         084caf1d-20c0-4623-86bc-247e981622c4)(content(Whitespace\" \
+         80ef293d-5005-4d45-a495-ecaf7f369d50)(content(Whitespace\" \
          \"))))(Tile((id \
          4fc0231a-16ca-4fe1-a8b6-4f6a9b74cb79)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5bc40ba2-1b59-44df-a0ae-631f8119f724)(content(Whitespace\"\\n\"))))(Secondary((id \
-         df7df7e0-46f3-4c61-8578-6b8836c5e0e3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         147e485b-6aa5-4f51-81ac-c0ce278234b9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f5cf7911-cbd6-46ad-9e29-2da4de467551)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8b4ac104-5684-4214-af33-38749542a4b8)(content(Whitespace\" \
+         f9e69d9c-caab-400f-852c-1091c570b097)(content(Whitespace\" \
          \"))))(Tile((id \
          e36096aa-788a-41be-84e5-365a155bfba3)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -931,46 +753,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3db49084-2382-4c5b-bf1b-eed94bf13f6b)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         3e369f98-98bb-4269-81ba-dc2c2fcd3c47)(content(Whitespace\" \
+         eb3bb4b6-d004-486f-a66b-61995a34ea37)(content(Whitespace\" \
          \"))))(Tile((id \
          b03580b4-9abf-4235-a613-c6b271d925ee)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8e43bd1e-092c-4fc6-b81b-b5f4c8d4d8df)(content(Whitespace\" \
+         abb109ab-125d-4aef-baef-40f97061c20a)(content(Whitespace\" \
          \"))))(Tile((id \
          14d5956f-cd68-4b06-90b7-ca8fff920542)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         92bffcdb-0730-44ef-b6ce-93b49ce52b9f)(content(Whitespace\" \
+         3a93ccc4-2ee3-4a69-955e-af6073ab16ed)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         29c87dc5-2fff-43d5-ba41-3ad419dde104)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8c062525-9bba-48f6-a70c-41edf4f89dce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc54689f-656b-499c-b5f2-e449d0ce1d2f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f35dadf2-31f3-4f53-935b-172182af50e0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1451f981-8647-404a-8d47-8dfd6e340bb1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         86eec04c-85b0-4f9e-a161-8668714d3128)(content(Whitespace\" \
-         \"))))(Tile((id c7e14fb7-5344-4837-bec2-dfeb99b00604)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         6740ba95-0d0f-4463-985e-49ce0f66d34e)(content(Whitespace\" \
+         a39c2af6-8ca7-442c-895d-766d71568584)(content(Whitespace\"\\n\"))))(Tile((id \
+         c7e14fb7-5344-4837-bec2-dfeb99b00604)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ee8ec3d1-da72-403f-905d-a2b1e91e9810)(content(Whitespace\" \
          \"))))(Tile((id \
          2c63ef24-d643-4679-b9f5-072302961b2c)(label(denominator))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f4e8e326-ea88-4cc9-ad5d-dcca67aee0d5)(content(Whitespace\" \
+         ffb76bca-4d3c-4699-8bb3-c8524a8af71e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         885491d9-da3e-47ac-9a82-6d4a591e7665)(content(Whitespace\"\\n\"))))(Secondary((id \
-         662b9319-7c6e-47e7-b120-cf44ce4a0255)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de944925-bdd0-4ead-a2aa-f02377832429)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ad288f60-90f8-42aa-aab3-9e39594fbf65)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         60e053b6-ea79-47d1-8508-1d75bf4bab65)(content(Whitespace\" \
+         0d82e36c-f16c-43b1-a162-62a69fdb82a9)(content(Whitespace\" \
          \"))))(Tile((id \
          772c1616-1498-4ed9-9cf5-26f8ea46362b)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -981,19 +787,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8b45a7f8-efb4-46fb-af5c-197190f17cbc)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         aadb8ec7-4f8a-4c03-ab2a-cbd99c92f927)(content(Whitespace\" \
+         9750c1f9-e62c-4e0f-b150-b276d6aaf382)(content(Whitespace\" \
          \"))))(Tile((id \
          8cf4fcf7-3055-4de5-92a8-9fd24cd26742)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         29105d73-71f2-4445-a4ac-33bc43c5fad6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c8d0c3d8-9be3-40c3-ad6a-161f82487915)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f2932156-9dae-4126-a8ab-4c84a830126e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8783a888-880d-482a-a03c-5d1092fb5f9b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         54ab8bcf-2ed9-4f0a-9ec2-3cfbc47e7e78)(content(Whitespace\" \
+         514a6654-111f-4f8f-a970-7d2b57abbb4d)(content(Whitespace\" \
          \"))))(Tile((id \
          7576df06-8572-41fb-9b9a-7b7771c3cd70)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1004,19 +803,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a6b39ac7-7c0e-478f-a1f7-c09950da6d87)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         42cb35a6-0ff2-4917-a0c4-23589b8797c6)(content(Whitespace\" \
+         18a1f8da-bff7-498a-809d-0f8a7a4fee20)(content(Whitespace\" \
          \"))))(Tile((id \
          56772a7a-6380-4859-b513-e5b034f91681)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b46bf0f3-02e8-475b-b68f-3b155d6c34d6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c64778d9-7e5a-40ec-8aad-61ba2c945013)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a54742d1-fc22-4520-a06d-f982198b5fdf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d33067c4-5d34-44c2-95f3-c0588d184d8c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         042a192e-6e9e-4bb7-8d53-118f063e8239)(content(Whitespace\" \
+         b414a851-5bec-4c0b-b78c-a1e9e3f47ba3)(content(Whitespace\" \
          \"))))(Tile((id \
          efd580d7-0da9-45d8-b543-bbdc68b12787)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1027,19 +819,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6c5aad8c-d31e-4943-b84e-8be761fbf677)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         351847d8-85b1-4907-ac6d-acb368962602)(content(Whitespace\" \
+         4c083f77-e756-4351-ade8-a35e7b6af746)(content(Whitespace\" \
          \"))))(Tile((id \
          2b88dd04-8716-4a49-b3d6-db648b5f3ca7)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         717c48cd-ee34-49ac-b61c-2687b1d85d8b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6511077b-f519-4a31-9e39-39d8976d5659)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f2648271-c55b-4890-998c-582192421d40)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2d0bc423-392b-4832-9c4f-b3c90030b6a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         495330ba-4ee7-4684-8a5e-01c3b4a3ea3b)(content(Whitespace\" \
+         b256a06d-3864-4b38-944c-611a568acb1d)(content(Whitespace\" \
          \"))))(Tile((id \
          71f14768-dfb0-476f-95bf-567a3c7d5ae4)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1050,19 +835,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          96a440c4-bc55-429a-8971-6ed3dfba9ffa)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         21c59bef-fea5-4f22-b93c-504b52a72e8c)(content(Whitespace\" \
+         c142b992-c468-430a-a4c3-83dc646c13d1)(content(Whitespace\" \
          \"))))(Tile((id \
          f4638bae-f4aa-4e47-b886-8528c36e3bac)(label(*))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         14d97390-8e6b-4d4b-9fcb-661c284761ec)(content(Whitespace\"\\n\"))))(Secondary((id \
-         06b88804-9fbf-4921-9e40-a1ae5845b593)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cfbf480a-3633-468d-8f53-2b391ed05dbb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9549d63f-e6a3-4875-ba2b-925e5697e426)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bed56800-5b2c-4443-b843-b7f611d53680)(content(Whitespace\" \
+         9d1b0f54-bd5a-4e43-bffc-74d727a23507)(content(Whitespace\" \
          \"))))(Tile((id \
          7d6598f7-0a64-470a-bbdb-9209e476788e)(label(factorial))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1073,48 +851,39 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b8837a60-5704-4281-9936-c2d14d485f16)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         1e8569fd-afe2-4eed-b07a-b18e0e8e19d9)(content(Whitespace\" \
+         18f06c2a-818d-48e0-ae77-80167947bd94)(content(Whitespace\" \
          \"))))(Tile((id \
          4ad2ab59-b61e-42b8-a425-c8d5455a773f)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f5d2c895-7111-4730-a585-71ac12599204)(content(Whitespace\" \
+         e79e0fd8-6984-4c12-ae34-be1642130ee4)(content(Whitespace\" \
          \"))))(Tile((id \
          4b87c478-3e50-4d21-bc34-d1431c8c823f)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         e31fa212-1d9b-4b88-b884-046f07510d7c)(content(Whitespace\" \
+         02f84535-1941-4f54-8115-5943c958b645)(content(Whitespace\" \
          \"))))(Tile((id \
          34069e92-0bb9-4fe4-af09-ec20f38eadae)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a05e2902-700e-4375-92a8-1a92d1ed392f)(content(Whitespace\" \
+         415cc132-c158-4a5f-b50c-79851aed7eff)(content(Whitespace\" \
          \"))))(Tile((id \
          f3c36f00-cc87-407d-9fa7-d550e5e92647)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f83c948a-9db9-4a31-9c99-ae16f8524de9)(content(Whitespace\" \
+         5c1c7796-bf42-4a9f-b15a-49d8f9c1ba5e)(content(Whitespace\" \
          \"))))(Tile((id \
          10500d8a-1ec7-4ec3-8b4a-12e439f8fc38)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0adb0938-6a17-47cc-8f33-98790973b7af)(content(Whitespace\" \
+         2fe5fc71-d761-40fc-bd6d-d3662d5e296f)(content(Whitespace\" \
          \"))))(Tile((id \
          c4ab0025-3bad-4c2f-b3d2-8c577dd4be10)(label(d))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9acaf843-7ba1-4465-9069-c7315ece994f)(content(Whitespace\" \
+         6d436896-acd2-4930-a907-c46504cb3163)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         bda7229e-3d01-45df-8f03-b52548cbdeba)(content(Whitespace\"\\n\"))))(Secondary((id \
-         62f95c8e-2926-4a74-9fc3-aab3064e8677)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         523d10df-b3a4-456d-8c66-08aa2b4aa5c1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5f3a4a53-b028-4773-8cdd-aa9c5f902f59)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2dd210c9-c483-40be-8fcf-0db7dc98d0cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e0d532b7-5b38-414f-b179-69020c42b5e9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         24c4fb92-617e-4b82-a2b5-4746d9265916)(content(Whitespace\"\\n\"))))(Tile((id \
          ca824d4f-d44b-4df6-b8e6-8f3ab9e73483)(label(float_of_int))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1124,12 +893,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          42c9470a-297c-4ecc-8a7d-89aaae2e2c8e)(label(numerator))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3ea35699-ec46-45e3-91e1-139a87182c93)(content(Whitespace\" \
+         8502f4d9-a626-4bd7-b89e-5860a6bf8e7e)(content(Whitespace\" \
          \"))))(Tile((id \
          5642d4d2-5003-4777-af0e-af3658bfec8c)(label(/.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c7216efc-15cd-4004-aa24-916f5adbe31d)(content(Whitespace\" \
+         df0d069b-1d26-4af4-9056-28defd603429)(content(Whitespace\" \
          \"))))(Tile((id \
          88247b75-f024-48e3-a3d9-1da70f9cf811)(label(float_of_int))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1139,198 +908,229 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          fe3896ce-4671-4922-9558-9f973402c337)(label(denominator))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         bb3b5b02-1a02-4c86-93ec-6607de23c863)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         92119d90-3bc7-4709-b11a-35cf94082be6)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         0a503eb5-27a8-443e-85d3-007cd74abc3d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1cdcb640-ac45-46db-844b-19898411a9a0)(content(Whitespace\"\\n\"))))(Tile((id \
+         c2a408dc-85a1-4aa6-8d8e-d2a3d0b525c1)(content(Whitespace\"\\n\"))))(Tile((id \
          a05589b3-f513-46a8-a771-6ce27cfe3433)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         87ec19cf-6a4e-454e-a1ad-037bb53698c1)(content(Whitespace\" \
+         54f2f522-7b1e-4839-a270-b187db6f2fe1)(content(Whitespace\" \
          \"))))(Tile((id \
          5f33e113-d0cc-480e-a7d0-e0d3742d0211)(label(JellyAnon))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         0215b988-6458-4132-a651-6d8f08c86fcf)(content(Whitespace\" \
+         a0ba26de-8186-4bc1-9c9f-686a01200dab)(content(Whitespace\" \
          \")))))((Secondary((id \
-         70039476-1147-48f1-b9c0-a38422abcfa3)(content(Whitespace\" \
+         48f0caf8-0230-4c8b-acc3-6d1f3c8feed6)(content(Whitespace\" \
          \"))))(Tile((id \
          7cceabb0-53a2-4642-86bb-d9e0570097c3)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         416a62a8-f504-45ea-9e97-d54c79e7f6df)(content(Whitespace\"\\n\"))))(Tile((id \
          1799b988-2ab4-4981-a94e-9813fd2451de)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f3429c7a-191e-446d-9d20-704f1b7ae697)(content(Whitespace\" \
+         \"))))(Tile((id \
          8ae65d79-9bb8-4175-9ba1-f61964a8b1f4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         976843e6-82b1-4ccd-90d0-065137bed21b)(content(Whitespace\" \
+         \"))))(Tile((id \
          72d012c2-4c1a-413c-9011-7c35013f9ed4)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          3af76ddb-27e7-4d9f-b491-c65165b2c051)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0f117da7-7767-4d20-8211-be3ff36cac83)(content(Whitespace\" \
-         \"))))(Tile((id \
+         81fdd3a0-c9f3-4d5a-bbd9-96318cb36ffd)(content(Whitespace\"\\n\"))))(Tile((id \
          12b79ad6-66f3-4c60-bf12-e6628928027f)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3fd6c7e3-1492-41de-a3a1-bb4ad1f179f1)(content(Whitespace\" \
+         \"))))(Tile((id \
          9592c8ba-66fb-4736-bf5b-8285f259a862)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         57cc27b2-bb91-4434-8b06-e5dff35dfa50)(content(Whitespace\" \
+         \"))))(Tile((id \
          ed086460-50e5-480b-8c67-bf344480b3f9)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          10ba96b8-9cf3-47e7-96d5-e983d4ea59da)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         940bb6fb-c330-465a-bc78-68f9db0d5905)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e19b08b2-a2ec-4ba9-8c12-78f2742bf822)(content(Whitespace\"\\n\"))))(Tile((id \
          ec46ffef-dc17-450d-b5ef-d59363f8fcba)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         074916df-3910-4cde-83f5-acffecb02b33)(content(Whitespace\" \
+         \"))))(Tile((id \
          867255ec-2fd7-474f-9078-f32b053be874)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         62db66da-9c3a-446b-9259-ba577a47e447)(content(Whitespace\" \
+         \"))))(Tile((id \
          adb482a5-1b83-4066-af32-de5517db9fbd)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          71a267dd-52ae-4bc2-ac45-67da6e69cf8a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a9724113-915c-41e6-8953-ff1294b946c6)(content(Whitespace\" \
-         \"))))(Tile((id \
+         582d4635-2b84-48c9-b404-d71cb316f9f9)(content(Whitespace\"\\n\"))))(Tile((id \
          29df3edd-ae01-43a3-93fb-5e5b27464ac1)(label(white))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c0257227-d3ea-4ba3-a6b3-700cb45e6fc4)(content(Whitespace\" \
+         \"))))(Tile((id \
          93556624-d538-48b4-9473-3b9307773f4c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a3b2149e-1431-4bcd-93af-4a011c981ec8)(content(Whitespace\" \
+         \"))))(Tile((id \
          e5d79a50-2fee-407b-abd5-cf55cb2d0983)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          eb90066b-d629-425e-9dbb-bc845963713f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b1aa6ff3-da76-4789-b7fa-7b10546855ae)(content(Whitespace\" \
-         \"))))(Tile((id \
+         273635aa-c840-4d29-b588-7b545d7080ad)(content(Whitespace\"\\n\"))))(Tile((id \
          bb959c74-fae6-435d-888c-5f171df27f18)(label(green))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f194c396-fefc-4aca-8c8b-1975f01ee0aa)(content(Whitespace\" \
+         \"))))(Tile((id \
          42e6cfbe-0b29-4481-903c-47ad3fdc6fb4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ef9c0a3c-9020-4947-9706-e43317ce9019)(content(Whitespace\" \
+         \"))))(Tile((id \
          7f6a7f54-b5d2-483c-baa0-a3c6e1610e4c)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4e26fd3e-6f41-4aa8-9e8d-78641f9d26d6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d627a701-3528-4249-9401-d52c4b04e072)(content(Whitespace\" \
-         \"))))(Tile((id \
+         46cf90ee-11d0-42c9-b6b7-305f11c19723)(content(Whitespace\"\\n\"))))(Tile((id \
          4840c681-12e1-439b-b3c4-a87cb9c43fe9)(label(yellow))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         99f474a9-f702-4293-9b7f-f294f1b321e2)(content(Whitespace\" \
+         \"))))(Tile((id \
          174916a6-dfa9-496e-a45a-86849f77539c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5d9fcf5f-036b-4831-9633-301b74bc5340)(content(Whitespace\" \
+         \"))))(Tile((id \
          a984d175-468a-4989-bc93-3f5847fd782e)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6d311038-6fc6-4072-a2a8-f896092420a1)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a109f8e1-4638-4b86-81af-3629b696a51c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         61c53862-eb24-44c1-b24b-630654eefbdd)(content(Whitespace\"\\n\"))))(Tile((id \
          19f88f58-d310-43c8-a223-e89a4ba721e4)(label(brown))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         856ecb00-7da0-4521-a347-ae330276c256)(content(Whitespace\" \
+         \"))))(Tile((id \
          98e1b06b-6715-434b-b297-aa7e87d41872)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0e7c54ec-ea4b-45e5-846a-3d60ec4fc078)(content(Whitespace\" \
+         \"))))(Tile((id \
          dd22f612-7855-4032-b273-85f603ea1c65)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          31cef794-91d8-4906-8147-13fbd4681701)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fa40f8ed-9b5b-4d35-a346-40e21503ce01)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c560d454-a005-4b34-aa2c-73220e6378e6)(content(Whitespace\"\\n\"))))(Tile((id \
          6e0afcf9-bcd5-41e5-a89b-1116a5b79ae1)(label(orange))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         120f063e-9538-4913-868e-3931b1f29dd2)(content(Whitespace\" \
+         \"))))(Tile((id \
          644e4220-379a-46f0-9f48-a34137385d40)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f2e0e161-c712-46b0-aa22-ce308e3ebd0b)(content(Whitespace\" \
+         \"))))(Tile((id \
          353b9e62-2099-4453-8df9-8fd98451d31b)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f657299f-cb44-44a3-a5f9-c08c04097660)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0d247580-4cec-488b-84db-03e53a618d85)(content(Whitespace\" \
-         \"))))(Tile((id \
+         666fb388-35ae-4ebc-8b1e-d39d51d2f71c)(content(Whitespace\"\\n\"))))(Tile((id \
          b390c7cd-8841-4f4b-ac90-955e2058aef7)(label(pink))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cd11f5bb-1694-4202-953a-00862db2775e)(content(Whitespace\" \
+         \"))))(Tile((id \
          823d637b-c68a-4057-a237-d1517a182de9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a33c8a8c-9c0d-49aa-bc3f-fb611c49dffe)(content(Whitespace\" \
+         \"))))(Tile((id \
          c79782cf-0c48-43c3-a08b-b57240fff1b3)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f8148ac6-3f25-47e5-9e8e-b63e211f6db2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7c291a5c-9fd3-491d-bf41-ce1b028b4a8a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c5ef19fd-e813-48d2-b363-3c58e85e7168)(content(Whitespace\"\\n\"))))(Tile((id \
          ec87e0cc-f93f-464c-9f8d-e0c3b43323b5)(label(purple))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         778d780f-25d1-40a7-959c-58aa852aad39)(content(Whitespace\" \
+         \"))))(Tile((id \
          19f59ff8-4282-4afb-abff-bf0303c29aec)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         76a82fcb-92c6-4d21-8f55-f2ed75ab5401)(content(Whitespace\" \
+         \"))))(Tile((id \
          7e0672da-fed1-4454-96c8-e763a94aed61)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e177c040-2c59-4edf-a367-f6781acaf2b6)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         59f0b930-e061-480e-8e15-bde2bfdb45c1)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         49f33238-251d-423e-90cd-38041f5bd11d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8c990913-3bec-4f20-b24c-e87806dd3446)(content(Whitespace\"\\n\"))))(Tile((id \
+         4b4aee17-6a75-48ac-8cbe-c07988e9551c)(content(Whitespace\"\\n\"))))(Tile((id \
          65c925e0-2efa-4f8e-8027-1b7a463cb65d)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         b69cd4c3-d198-45ec-82a6-0137917bf562)(content(Whitespace\" \
+         68e0b24c-997d-4edf-90fd-7b3449cdb77d)(content(Whitespace\" \
          \"))))(Tile((id \
          94cab63a-69d6-40e6-9f95-69928bf24d07)(label(jellyAnon))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         094251ab-4d98-4437-81be-b7af205143b1)(content(Whitespace\" \
+         dd38b2f3-38b3-41a4-88d3-ccfde3468ff4)(content(Whitespace\" \
          \"))))(Tile((id \
          f375cffb-317c-4ec7-9b0e-1d773dfe3382)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b7aabe35-11ce-4a35-9074-e18d68a8debb)(content(Whitespace\" \
+         8e43155f-7f79-4c10-82b5-de4c42133b90)(content(Whitespace\" \
          \"))))(Tile((id 0a434a68-c471-42d9-b32a-bda2e78244c0)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          a7d2fc86-46ef-46a9-aeea-570b2b7185e5)(label(JellyAnon))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c7b00452-f1d3-443f-bf82-aad7d375b33d)(content(Whitespace\" \
+         88fe1071-8373-4754-8691-19e7eb16f4e3)(content(Whitespace\" \
          \")))))((Secondary((id \
-         527dd537-1461-4fb6-ae31-86f2b7da3440)(content(Whitespace\" \
+         f53558fc-8cb2-448a-ac6d-6937a2f12de9)(content(Whitespace\" \
          \"))))(Tile((id \
          edabe789-2995-466a-a66e-b51f969b0c96)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         b8011e1d-abf9-452c-b350-8cabcc03b1d5)(content(Whitespace\"\\n\"))))(Tile((id \
          3abed616-4cfe-414f-8bf5-762043a12ab6)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         2f17ae3d-3cbe-4c7c-b655-fe55bc3ec807)(content(Whitespace\"\\n\"))))(Secondary((id \
-         07f572f5-d08a-44dd-b831-d67d151fc104)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         96b265ad-b4db-4371-a76b-1497d6b1f5dd)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ae18d735-158d-43a2-9a14-cabb6f19209f)(content(Whitespace\"\\n\"))))(Tile((id \
          47777439-8d52-46fb-a86b-8625d37d2337)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1442,11 +1242,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bfd8f890-ac96-4005-b7e6-650b7091b570)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1a28d841-7578-46a4-b50d-2f4d5058e4f1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c26d6df2-17bc-4d03-b37c-9a18e7b1fc18)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c0afd5e7-0ea9-4392-b9b7-99d67b8d58f5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         7480509f-1102-4991-886b-10e480ca2c9b)(content(Whitespace\"\\n\"))))(Tile((id \
          1a3a979e-efeb-4197-90e1-50ecaec3426c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1558,11 +1354,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bf95f681-9813-4da7-9d15-975c910b0f77)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb4513ae-c4da-479e-8e04-55bf9f410a8b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ed6c5f4b-3048-455a-8532-61bb918e7b92)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2947bf59-7722-4fee-93db-b574d85333d2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         dd57a62f-37f9-4764-b6b2-adedbe8c5e97)(content(Whitespace\"\\n\"))))(Tile((id \
          5f4cb08b-066a-4742-b26b-2887aefd7df3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1674,11 +1466,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          171d0b34-6a9e-48a2-a1ca-d835bdcf22f1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         26cfc906-ee92-442a-a8a0-5741c2a3c56e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         19ac48f8-d6bb-464c-a0e9-2c4e50da2eda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         741d8525-8d6b-4e95-b1f2-370acbaa614b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d9f7a7fa-373d-4ccd-85e9-b0d818defa03)(content(Whitespace\"\\n\"))))(Tile((id \
          7a29de99-82db-4027-966a-a0ce5d8f59e1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1790,11 +1578,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9c45f554-4fe6-4cec-9295-94fa8a7b22c5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ffe488e7-c975-4a4a-9b7a-5a5a20321493)(content(Whitespace\"\\n\"))))(Secondary((id \
-         60fab7d2-9b70-482f-90fd-334400674902)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         80303d9b-afc5-4cf3-9277-2bd8af7928a1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5bfe40b4-99b9-44de-bb32-f9eb2a24c449)(content(Whitespace\"\\n\"))))(Tile((id \
          cea10125-bff1-4d8f-ab81-43119fdcbdaa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1906,11 +1690,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c3fdca53-a1bc-4096-a9a7-7c77af51d3be)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ba4ea7ef-04b7-415f-b1eb-6e8a624108e4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d821069d-9eb2-4b58-aae3-bee8089e1050)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         76918f12-8a2f-4385-af8e-41b2c4da8342)(content(Whitespace\" \
-         \"))))(Tile((id \
+         36ba2fc3-60d6-42b8-b028-e214fcb020b3)(content(Whitespace\"\\n\"))))(Tile((id \
          c8d3b026-4468-4c66-852d-d778369ea102)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2022,11 +1802,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          568cc9ef-39ab-4fb2-a39d-fb43b356de85)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fa4dbc74-ba91-4b36-92cd-dfbd2abd95b2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d1739f86-890d-43d8-a3f6-6407b6a4b9ce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb17e01d-0168-4384-b8fa-de314396ef6c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8a48003b-61bb-4ccf-b5ec-f11ea2e436d2)(content(Whitespace\"\\n\"))))(Tile((id \
          efe58a99-2832-418c-88d3-14578a1a93c5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2138,11 +1914,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8c6921ff-bd2b-43f4-9377-ec404232d51d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c41777df-ee72-40f2-92bc-20405a7fe6f9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2e1fe7c4-c610-45ed-8333-71cac4858a4f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1aa19626-083a-4e94-a726-9c5258d4171d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3df5efaf-6fb8-411d-9ecc-9dcafe76cbf2)(content(Whitespace\"\\n\"))))(Tile((id \
          e4e3376d-1449-4a80-a54e-d90fed61187b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2254,11 +2026,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          eff5264a-02e2-49f8-b249-b3e16d72a344)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fe61a113-9738-4b41-998a-522ce211dd7c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         16b3ed44-0bdb-41f4-aa1b-2f762fb2992c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b05d73da-d0e4-4ba3-80cc-7d6d9b756522)(content(Whitespace\" \
-         \"))))(Tile((id \
+         053eb0ce-eeb3-4f56-bd95-a6e9ab6dd5dd)(content(Whitespace\"\\n\"))))(Tile((id \
          4445fce8-a2d5-4d18-803e-b0e2a2de2766)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2370,11 +2138,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1aa1a23b-34e5-46de-96a6-fb7738d1356c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dfa84ed0-b1c0-4289-b85c-4960aa2636dc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0ea2898c-d25b-40fe-9a10-b91db3e4be50)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a45f10b2-bcc4-493f-8a73-ec7db685ce66)(content(Whitespace\" \
-         \"))))(Tile((id \
+         05f77fa5-2f42-4a41-9633-995f5fbb7793)(content(Whitespace\"\\n\"))))(Tile((id \
          5a20af5a-6ffe-44e0-bc3b-3e75a6776226)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2387,7 +2151,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ae2fd434-56da-40d3-8bce-668a93b78eab)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2003e3f2-a551-4e18-9c45-c977d76240f0)(content(Whitespace\" \
+         ec201ad1-a518-4caa-b7b0-b58b7c316cea)(content(Whitespace\" \
          \"))))(Tile((id \
          63a56589-6c09-442e-bd05-3b6eb95195f1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2398,7 +2162,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c80f7b08-ea35-4534-857a-9a245d93a7fd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         020fb4a0-0144-44e0-87ca-599f984fd8cf)(content(Whitespace\" \
+         0ace64fa-7731-42d1-b256-30283e4f57bc)(content(Whitespace\" \
          \"))))(Tile((id \
          c9fb5592-85c0-4edb-a44a-74e0cc525940)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2409,7 +2173,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          728128da-4c1b-4bb3-9ccd-e56c28a6caee)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ccdc3770-52db-496a-936e-4749bfbead85)(content(Whitespace\" \
+         ea27e9c4-d8f9-4864-9365-12fa2673b137)(content(Whitespace\" \
          \"))))(Tile((id \
          83ae346d-999c-4ae4-a3d4-a46fa0d10fee)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2420,7 +2184,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          893e9d04-6423-45fb-a59b-ab01c628a291)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bf3bb48d-c853-4cab-aa06-ff22625fc7ac)(content(Whitespace\" \
+         24c98bfc-86d3-40f4-b5bb-fbcbcf7198a2)(content(Whitespace\" \
          \"))))(Tile((id \
          5192cd13-ea53-4c92-8cc2-2db7dbfdd056)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2431,7 +2195,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          da7f57da-f7f1-40e2-b34e-00a1d3f90f1f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e10b0808-6774-4977-88e8-b5fc500de63a)(content(Whitespace\" \
+         397698de-de98-4c3b-aac6-24191e5bd46a)(content(Whitespace\" \
          \"))))(Tile((id \
          3abf40f5-26e4-4d14-8ebe-7dbf1cba52ed)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2442,7 +2206,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          17741a5e-b57b-4d9a-872d-653ec85f895e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dbf28c32-9e28-4b87-b959-ec7dd87d2846)(content(Whitespace\" \
+         59286145-9c9e-43b1-870b-658aa9794e78)(content(Whitespace\" \
          \"))))(Tile((id \
          e5c83c0f-97b7-4e8e-ab46-a09d3af31f0a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2453,7 +2217,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          be461874-6e4d-4b45-a34a-2cb52ff719ee)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         21db317e-dcb0-45c2-8e52-41e7929c1824)(content(Whitespace\" \
+         4d512652-4e69-47cc-a209-b6558a9ffa00)(content(Whitespace\" \
          \"))))(Tile((id \
          4e1d9a25-1595-452a-bb3a-b1338bae8a7d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2464,7 +2228,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d9d0da8d-9618-4504-b1a4-8b3595177f92)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aa161cd0-f158-495c-b688-c11cbbf07044)(content(Whitespace\" \
+         a853e6bd-7139-4ba9-a5b9-f7c524b1c0c1)(content(Whitespace\" \
          \"))))(Tile((id \
          b6b9f6cf-84a1-4924-9ba7-682ad8d8c9fa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2475,7 +2239,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ff379d5b-b36f-47d2-9257-afbd7ae55527)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9989aadc-b581-409b-86c3-8ebe2aeeb613)(content(Whitespace\" \
+         91e7e3ac-ab25-4950-8eef-36067a5abb45)(content(Whitespace\" \
          \"))))(Tile((id \
          8501f056-3b7d-41a6-aa94-4f0331ff2be5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2483,49 +2247,45 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c4c91777-fc93-4550-8576-00410379b31b)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         4d69e122-591c-4157-8142-639fa4edd26e)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         352369e8-fd90-4c2d-99ac-e0ce2f2d8503)(content(Whitespace\" \
+         647ad822-3ac0-41ba-83f2-d49d695a107d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         07212a1a-2ec1-47d2-8cdb-82b84f47cc13)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         45f10dd3-9d94-4fba-80d9-4a43601f8def)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         22291468-c0b2-4127-82f1-87f30beddfe8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7c7fae7f-9054-47fb-bdc6-b17e21096d77)(content(Whitespace\"\\n\"))))(Tile((id \
+         a76b786a-0170-4b8f-a4a7-14dc2d46348f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         2cfe2819-1207-4501-8134-c1db9e414d53)(content(Whitespace\"\\n\"))))(Tile((id \
          5e9fc3d2-64bb-49fa-a3df-0a980756e39e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         9aebe0f6-7d9c-4367-8789-79cadabf452e)(content(Whitespace\" \
+         7758a44f-a5e8-46d5-9669-afd427224cf7)(content(Whitespace\" \
          \"))))(Tile((id \
          745c7139-9f60-4824-81c2-bf57b06ea2a1)(label(pHacking))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8e8b9489-73a5-4308-9aec-dc027ea7143d)(content(Whitespace\" \
+         65f22da5-4d9c-4148-a0a0-586f93313d56)(content(Whitespace\" \
          \")))))((Secondary((id \
-         dbbd288e-b76e-4235-8c08-e4b82ee77ec9)(content(Whitespace\" \
-         \"))))(Tile((id 1d30daf2-79de-4659-8ad9-9ae32d122260)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ad3b1464-22a6-49fc-a1ce-592ad6a446d7)(content(Whitespace\" \
+         5165bd70-06ad-4e20-af0c-dbf1a76880f9)(content(Whitespace\"\\n\"))))(Tile((id \
+         1d30daf2-79de-4659-8ad9-9ae32d122260)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         69f4af25-d1a9-43e4-b501-20d968b97377)(content(Whitespace\" \
          \"))))(Tile((id \
          ec89b67a-566f-4402-bc34-78c3908b13bb)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         197d0462-b6e7-42c8-9a9a-52a3d8388c19)(content(Whitespace\" \
+         3dadd2d3-4fd2-46e5-ba7e-51e0461e9a52)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4466dec2-46f5-45a8-9683-efba66c1f43f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         580f7743-8e8e-45d6-859a-b042738fddef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e0d1698f-d779-4e21-93b7-28ac32c0a7a5)(content(Whitespace\" \
-         \"))))(Tile((id 84585b1f-c82d-4e40-9201-2368c1791dce)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         cc9de4b5-6d82-4455-bb4d-d62cdc435a2c)(content(Whitespace\" \
+         e06db437-3772-4fd4-abc5-ffaa10d173eb)(content(Whitespace\"\\n\"))))(Tile((id \
+         84585b1f-c82d-4e40-9201-2368c1791dce)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         20ba28e6-cc81-48eb-b708-49c8f850419d)(content(Whitespace\" \
          \"))))(Tile((id \
          4f7a5a43-f55c-4b06-a3cb-778d2d9aa9ec)(label(jelly_anon))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         06e749b1-1706-41e5-828a-d682b5c0718c)(content(Whitespace\" \
+         aa3a284b-ae6a-4e16-8965-be90d521618b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4c34515f-a7d1-48e3-a4d3-bfd2633dc204)(content(Whitespace\" \
+         b0ec3a3d-c4f9-4a7b-94d3-60dab8f13d56)(content(Whitespace\" \
          \"))))(Tile((id \
          4013802d-c77d-4dd5-aaef-f6b769eaa3a6)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2539,19 +2299,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1ff6c687-6f4a-4d6a-ad7f-4e0c553452ad)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c608efde-c077-426b-bb3a-7c599198a961)(content(Whitespace\" \
+         80a06a41-b429-4bf4-a7ea-781f9b0b61e8)(content(Whitespace\" \
          \"))))(Tile((id dfd9b929-36b9-4815-b184-5a3d3258f493)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         dd8ac5af-a397-4a97-8922-1de16672662c)(content(Whitespace\" \
+         dad065db-9504-4d1b-a4fa-19e4af4f8e4c)(content(Whitespace\" \
          \"))))(Tile((id \
          3c430ae7-5cf1-4f9c-850b-8433bc62e234)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1d971771-72b6-4b79-8d54-a5ec1e63d668)(content(Whitespace\" \
+         987d1fa0-38b8-4e12-b480-4d82601e6033)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         58f0ec0c-9b18-44ce-a3d2-bdcac82f0443)(content(Whitespace\" \
+         7a2e6cec-f87c-4105-b51a-ba12b2b63e41)(content(Whitespace\" \
          \"))))(Tile((id \
          25ebd855-5bcb-4af7-b4a1-e4e676c4ea0c)(label(omit_labels))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2565,29 +2325,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5d1bf605-5f64-41c0-80b7-3efd7b4563b1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c285b231-0c89-4c4b-9ca7-4ce9c85c8cb9)(content(Whitespace\" \
+         24292988-1c55-4210-a1f0-c9b648151025)(content(Whitespace\" \
          \"))))(Tile((id \
          89f0df1a-6c55-478d-abb7-b15c036684a8)(label(`get_acne`))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e6cd204c-f0e6-4b16-b7ef-2f3f934cf86d)(content(Whitespace\" \
+         9b29ec08-ed3d-4ef3-b560-48659b43f003)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7050ad54-d8d0-4e40-9b90-f24ccb16f0ba)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fb06cecb-d754-4089-b92e-30b62ba10f86)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b6d84ed-7f30-42fc-ac73-83df4caa553c)(content(Whitespace\" \
-         \"))))(Tile((id e358fe82-3935-4ccc-a252-88e15cdbf132)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b29812b5-7464-4de9-989d-d30caa26fbe7)(content(Whitespace\" \
+         7c9a0f62-d934-4ec9-9977-e55d21a9f00d)(content(Whitespace\"\\n\"))))(Tile((id \
+         e358fe82-3935-4ccc-a252-88e15cdbf132)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         27031afa-628a-43f7-9b83-1b3b085d04e9)(content(Whitespace\" \
          \"))))(Tile((id \
          0996297e-4fe4-4f3d-9725-cc44894dfcbc)(label(get_acne))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2f4e3455-008a-4ad7-8e7c-8562c12b9cea)(content(Whitespace\" \
+         40993328-e62f-4206-b063-576854492aef)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e571c270-8159-4271-b5b9-460cdb45adb4)(content(Whitespace\" \
+         da362e90-9fe0-4ad8-8c15-d7ebbde7ea97)(content(Whitespace\" \
          \"))))(Tile((id \
          fad09248-2015-42cf-8edf-d7481803d21a)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2598,24 +2354,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          79857d37-4159-42b6-b01a-e5a24d907312)(label(get_acne))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         8403631e-451b-41d5-8cfc-a87671bc71f0)(content(Whitespace\" \
+         01864420-f02c-47a1-8177-2877de046b6d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d28778a3-87ba-4951-b9dd-e832aefcb007)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4b4b378d-2d1b-4ce8-91e5-c989f14ff36a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ec841a9-5533-4a72-a587-a894da71b5eb)(content(Whitespace\" \
-         \"))))(Tile((id 718901bf-55f4-4dd9-bd79-e62b8b51efb1)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         9ee0aea1-0b72-4be2-b3d1-e209c94ad51a)(content(Whitespace\" \
+         bbb28e5c-8f72-4349-8968-f867d267cf61)(content(Whitespace\"\\n\"))))(Tile((id \
+         718901bf-55f4-4dd9-bd79-e62b8b51efb1)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         2cbdf201-3542-4876-8562-f66f9b6fac71)(content(Whitespace\" \
          \"))))(Tile((id \
          04c6b931-7257-4222-942e-662a3f89f29c)(label(header))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3a1917ef-b084-4ae9-bc82-b06fb4af4e62)(content(Whitespace\" \
+         74f9d077-0d64-49d1-a967-329ed1119eb5)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f4c637dd-7ed3-4664-a1bf-549715b9ab0e)(content(Whitespace\" \
+         1e0d6958-bb4c-4ebc-9442-b6792fa0d39f)(content(Whitespace\" \
          \"))))(Tile((id \
          f18b9d42-8778-4fa4-ace2-0db68ca2c756)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2632,12 +2384,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          70c4bb2a-471d-44df-8cd3-f0d9ec0a1b2a)(label(jelly_anon))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         a40cd498-f880-46ec-8b09-263fc747d7ae)(content(Whitespace\" \
+         d8745eb6-83ff-464b-adf7-623670648888)(content(Whitespace\" \
          \"))))(Tile((id \
          2ad6f9c7-5bd5-464f-9e0a-9b121a4fafef)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         94ace0c1-d9e8-4b89-8eff-ca869ce62cb0)(content(Whitespace\" \
+         e563a7a5-9670-41bf-985b-31268fbb4589)(content(Whitespace\" \
          \"))))(Tile((id \
          fba603f0-1752-4414-847b-f7648949d784)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2651,19 +2403,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3e26b265-6d30-4785-896a-565ed27ac5ea)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1b404db6-8bb5-4e07-a397-3c7f29433164)(content(Whitespace\" \
+         f4b3c48a-562b-4097-aa68-a2af735a766f)(content(Whitespace\" \
          \"))))(Tile((id 1086468d-8ad4-4a99-8b15-f365bc7cf676)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         d3648f4e-bbfb-48e0-be6b-79a5620fb510)(content(Whitespace\" \
+         8f0db241-a213-423f-930b-45afab9608c7)(content(Whitespace\" \
          \"))))(Tile((id \
          13ac7a6c-8390-4be2-bcdd-7afaff5594a9)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         16f67a12-6e67-422d-bede-6bf7672566c9)(content(Whitespace\" \
+         b1d5a5a7-f71c-4319-b59e-853d8c8ac7dc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         39221211-2c3a-48b3-9289-614e54f30666)(content(Whitespace\" \
+         c31d01cd-e4a1-466e-a217-3f40f7653fc9)(content(Whitespace\" \
          \"))))(Tile((id \
          f2d86614-c77c-461a-96b5-64a1983f9b66)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2674,13 +2426,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          81bede5a-534c-4b4f-bf87-40d23c4b209a)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b4935560-5c38-4994-9c18-ef564917d474)(content(Whitespace\" \
+         1c23a4ad-b7f1-4e73-a7df-3564923cdfdf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e312ab78-2eb5-417e-911f-4556b09cf3e4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bf5bdef2-8c46-417f-96fc-ea72c59f7ca0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b448ecb8-2c1c-4919-8517-fb3aca26d32e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         cd1b8735-5a97-447b-a622-1604e30e10ab)(content(Whitespace\"\\n\"))))(Tile((id \
          0e40e007-79f2-4bf4-b3a9-eac5fb74e004)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2693,19 +2441,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d8f17645-4e21-43f6-95cf-3fbef6baf39d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         67587dde-b164-4822-8e23-d7f41fa7c9c6)(content(Whitespace\" \
+         e697e227-a50d-4c3a-96d7-2e5ee5b60b9f)(content(Whitespace\" \
          \"))))(Tile((id 15300d64-5007-456d-af26-d1174193ddd5)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         061da9b9-4418-47d5-8cb4-77975a2f3fb9)(content(Whitespace\" \
+         03732a6a-3c24-490d-948f-0fa629eec966)(content(Whitespace\" \
          \"))))(Tile((id \
          48fab221-e8c3-4879-9c27-c563d68e9b3b)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         526a12ed-4570-4d35-a927-8904aca9545a)(content(Whitespace\" \
+         c98ca291-6abc-4560-b834-51a320b162b9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a47f4443-5e87-4a9d-acf0-047692a7204c)(content(Whitespace\" \
+         0af14008-a4c4-4f55-a075-e7c2b86bed3e)(content(Whitespace\" \
          \"))))(Tile((id \
          90380c06-4517-4336-930e-8f66ced786a4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2716,7 +2464,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          12549b0a-1b51-4c8b-a457-1f6c7c9ab0d1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e1b9b9f7-cd1c-4f86-978d-894d5edad664)(content(Whitespace\" \
+         3620c256-4de7-4d9e-a35d-db4d69d84bd8)(content(Whitespace\" \
          \"))))(Tile((id \
          6af14d33-934f-447e-a142-eac79d7dd42a)(label(fisherTest))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2730,7 +2478,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a9417244-f3a7-4a5b-8da9-b02aa08547ab)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         94bebd20-6c23-438f-9cb5-9c5ebb5e42b6)(content(Whitespace\" \
+         00f12330-35ff-4b99-a965-b20165de7dd0)(content(Whitespace\" \
          \"))))(Tile((id \
          2674d249-a0d5-4bc3-ab06-1b21b7e13850)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2744,19 +2492,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4848b76d-750f-46d1-9f21-484a4cd0061d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         81a240a8-b458-4c56-b4d3-83c42c7b2c4a)(content(Whitespace\" \
+         940cf2c4-4328-4267-a245-b893f0dda9f2)(content(Whitespace\" \
          \"))))(Tile((id 5a081359-7f28-44cf-a5e2-fcc037e21d8f)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         5e5c7204-aeee-4dd2-9f05-dedd03ecfe21)(content(Whitespace\" \
+         759a9e06-5902-42f9-af82-ff9a4c729455)(content(Whitespace\" \
          \"))))(Tile((id \
          80b9bdd0-2ec2-4d0e-84d9-03bd889f909b)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9c345df9-08ed-46d2-bf1a-9820ceefa24e)(content(Whitespace\" \
+         0bf03686-65fd-4cdb-93bb-26900aab3fa3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fe281ab4-592a-499b-8f70-bc890674c474)(content(Whitespace\" \
+         62543c62-3106-4876-9010-e6b0d7c64098)(content(Whitespace\" \
          \"))))(Tile((id \
          7ab260ea-2c2a-4f87-8031-39d2e78de64e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2828,15 +2576,11 @@ let out : string * Haz3lcore.PersistentSegment.t =
          00971c86-5600-489b-bb6c-56c02a10819e)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         b7f7050e-0bc9-4f93-ad55-87d395f5554c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         569aae62-7d20-4059-8dc5-07414cfd0694)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e8c5029b-b5cd-4c33-8107-3aa14ae4c5c2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         1d086e19-4849-4b2c-8c49-d577c73812a6)(content(Whitespace\"\\n\"))))(Tile((id \
          98f9eb6d-c56e-4862-ac72-5f503182cb7a)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e21c757b-7e74-4618-b0a9-56aacf381a1c)(content(Whitespace\" \
+         da28aad3-60b5-41c3-9732-8f8b480799b3)(content(Whitespace\" \
          \"))))(Tile((id \
          d4c608bb-aeb4-43ae-a2c7-fb46aa730c1f)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2850,53 +2594,49 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8493ba2b-1d5d-4305-b027-fd580f0f6f4c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         909757b5-d600-4803-abea-6aae998bf37e)(content(Whitespace\" \
+         475ebaaa-a5f8-4b4e-b15f-d65b0c49166e)(content(Whitespace\" \
          \"))))(Tile((id 3791101a-1bd9-4e81-87bd-cace3c42396d)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         931a80af-cf23-4691-88ad-8022416f7e31)(content(Whitespace\" \
+         7f0f3b23-e403-4e00-92da-2b0abfe49271)(content(Whitespace\" \
          \"))))(Tile((id \
          6fb36336-d250-4c7b-a9db-4e5df26ee1b5)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         4a992cf9-d565-4c43-84f6-ca2134ad0141)(label(c))(mold((out \
+         4a992cf9-d565-4c43-84f6-ca2134ad0141)(label(_c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
          055fa83e-becf-446f-aad0-183c97b6ef3c)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         4006e61c-85db-43ec-8635-a6936cbd6fcd)(content(Whitespace\" \
+         b47b3e6e-1647-48d5-a6fe-db6daeb5d13b)(content(Whitespace\" \
          \"))))(Tile((id \
          61bd587c-41bb-4e02-9dc1-6bf4c3ceff2b)(label(p))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         b512a1b8-7e29-4da2-97af-b099ccdfcb42)(content(Whitespace\" \
+         59b364bf-73ae-419f-8a04-8bb71ef247e2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         400a114d-c3da-48a0-8fc0-1bcf2a866cc2)(content(Whitespace\" \
+         c15fbcb0-ebac-4458-bef6-bbc0e5d052ba)(content(Whitespace\" \
          \"))))(Tile((id \
          8e4ca866-91ec-43ce-92f8-3ecd87a15669)(label(p))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         16148f94-8d2f-4582-b19b-1d22bbe7c0ad)(content(Whitespace\" \
+         ced733bb-1836-4fa0-b4fd-1f15f96820ab)(content(Whitespace\" \
          \"))))(Tile((id \
          7884dddb-c7f3-46a4-8489-8c20041b7bed)(label(<.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1c541563-5338-4bd1-bf1b-b998959d6ea0)(content(Whitespace\" \
+         514cb0f2-77fb-4579-9b73-7863417ee6cd)(content(Whitespace\" \
          \"))))(Tile((id \
          e29a23df-cb1a-49fa-8d71-983e3d0c0883)(label(0.05))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         683fe19a-7faa-4f8f-9e35-436e3e98db21)(content(Whitespace\"\\n\"))))(Secondary((id \
-         132390e9-d118-4d6c-a205-af2cab3f5ba0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         69f455ad-a3d0-41f4-bf1f-a9afd405d462)(content(Whitespace\" \
-         \"))))(Tile((id \
+         1eba79bc-c7a5-473c-b3bf-007ad1d21f0c)(content(Whitespace\"\\n\"))))(Tile((id \
          cf85bfae-6fdf-4362-8341-fd6dc5e321d4)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         74180237-3726-4f23-8926-6e5c4fe011f5)(content(Whitespace\" \
+         1e63cb2f-6fba-49f2-b2b5-815198243664)(content(Whitespace\" \
          \"))))(Tile((id \
          e46f59db-d36d-4d21-80b7-a19bcf73f9a2)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2910,12 +2650,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ee224ca3-89cf-49d5-a90c-e32485c93306)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aebd1287-59df-44ce-be67-4ab1c65dd22a)(content(Whitespace\" \
+         ed1a3ecf-aa0c-40fe-8950-69b902356445)(content(Whitespace\" \
          \"))))(Tile((id 3a2c9794-63cd-4526-96d7-e80e681dc51b)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         daa672af-0a86-4898-9ed5-3e3b53612a34)(content(Whitespace\" \
+         3560a05a-96b6-4d06-9f3d-23842e32ce4b)(content(Whitespace\" \
          \"))))(Tile((id \
          418f5b0e-d2c8-4a6a-ba93-42be90632815)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2925,47 +2665,43 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          8b9c4158-5f1a-47e2-b2b1-a025967735ac)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         f51d1d9b-ab11-4993-8005-d6d4c96b7023)(label(p))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         b8698d35-1fc7-4d56-9a6e-0b36e3b8de35)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f51d1d9b-ab11-4993-8005-d6d4c96b7023)(label(_p))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         47d1823e-018b-42f9-8589-29991e344356)(content(Whitespace\" \
+         3b3c0a5f-5d5c-43ee-928c-268bff02674c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         27b68503-614a-4cee-981d-1eda884d848c)(content(Whitespace\" \
+         c50b31a7-4432-4df5-8cde-807bd6251ac6)(content(Whitespace\" \
          \"))))(Tile((id 9e0aba51-e1c9-4763-9c5b-e6264a39f0d8)(label(\"\\\"We \
          found a link between \\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         fcfd9f0d-da81-4fb9-a7e4-8e2dec433c1d)(content(Whitespace\" \
+         9e1eeb67-1e11-4a9d-a644-b91bd43ce28d)(content(Whitespace\" \
          \"))))(Tile((id \
          16ed5bd7-6ab7-451b-b17e-945a8bb3af2b)(label(++))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         83b696c2-7839-4408-8937-13a15e1eac91)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fd839851-9a8b-4eff-81db-a04d9b611bd9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3de6dc08-a82e-4779-ab5b-1b532fa265d8)(content(Whitespace\" \
+         e222c6e7-b929-4132-beaa-370f19c0ce85)(content(Whitespace\" \
          \"))))(Tile((id \
          b910dcc0-72ff-4fd9-91fa-46800099f16f)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         878206dd-0aca-4190-9c85-4e1276825b39)(content(Whitespace\" \
+         0a114fb8-f18e-4240-826d-14c05c27a2a2)(content(Whitespace\" \
          \"))))(Tile((id \
          0236f073-4f0a-4042-9869-9bb17e273623)(label(++))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6ac41a58-c360-4b5f-a7bc-a5ef827658f1)(content(Whitespace\" \
+         44d3ceaa-6465-4b8a-9a1d-b149b39d35ad)(content(Whitespace\" \
          \"))))(Tile((id 466cfa7c-e18c-4a0f-987f-5d058865b8fa)(label(\"\\\" \
          jelly beans and acne (p < 0.05).\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d90961de-998c-4891-8854-95d2288f7027)(content(Whitespace\"\\n\"))))(Secondary((id \
-         95ad005d-5c2d-476f-b02a-72ef569d8db3)(content(Whitespace\" \
+         2f82efab-5a7a-47b2-9eb4-41312dfd70a0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2d225673-9581-4baa-882a-35dee8cd7adf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4bc9efec-56b1-468b-8cec-0142ed6086bc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         86d63831-0e4e-4c62-955d-a0deb4bdc2cf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         591baa3e-b8f2-4fb2-bfd6-e1615ac41a2b)(content(Whitespace\"\\n\"))))(Tile((id \
+         9daf7802-ed2f-4f32-adaf-2518d27d987d)(content(Whitespace\"\\n\"))))(Secondary((id \
+         ec5d5194-33cd-4c2e-a4e8-17e4bc3e8433)(content(Whitespace\"\\n\"))))(Tile((id \
          08382f85-5853-4475-b6ee-54344a2465da)(label(pHacking))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2974,79 +2710,82 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          4e764d77-e657-41f1-9141-cd23ee5fd1cd)(label(jellyAnon))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         512408f9-60c7-4426-af2d-58d50a13cd8b)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children())))))))))";
       backup_text =
-        "let fisherTest = (fun (xs:[Bool], ys: [Bool]) ->\n\
-        \  \n\
-        \  let zipped = zip(xs, ys) in\n\
-        \  \n\
-        \  let contigencyTable =\n\
-        \    fold_left(zipped,\n\
-        \      fun (((a,b),(c,d)), e : (Bool,Bool)) ->\n\
-        \        case e\n\
-        \        | (false, false) => ((a+1,b),(c,d))\n\
-        \        | (false, true) => ((a,b+1),(c,d))\n\
-        \        | (true, false) => ((a,b),(c+1,d))\n\
-        \        | (true, true) => ((a,b),(c,d+1))\n\
-        \        end , \n\
-        \      ((0,0),(0,0)))\n\
-        \  in\n\
-        \  \n\
-        \  let factorial = fun (n: Int) ->\n\
-        \    if n == 0 then 1 else n * factorial(n - 1)\n\
-        \  in\n\
-        \  let ((a,b),(c,d)) = contigencyTable in     \n\
-        \  \n\
-        \  let numerator =\n\
-        \    factorial(a + b) *\n\
-        \    factorial(c + d) *\n\
-        \    factorial(a + c) *\n\
-        \    factorial(b + d) in\n\
-        \  \n\
-        \  let denominator =\n\
-        \    factorial(a) *\n\
-        \    factorial(b) *\n\
-        \    factorial(c) *\n\
-        \    factorial(d) *\n\
-        \    factorial(a + b + c + d) in\n\
-        \  \n\
-        \  float_of_int(numerator) /. float_of_int(denominator)) in\n\
-         type JellyAnon = (get_acne=Bool, red=Bool, black=Bool, white=Bool, \
-         green=Bool, yellow=Bool, brown=Bool, orange=Bool, pink=Bool, \
-         purple=Bool) in\n\
-         let jellyAnon : [JellyAnon] = ([\n\
-        \  ((true), (false), (false), (false), (true), (false), (false), \
-         (true), (false), (false)),\n\
-        \  ((true), (false), (true), (false), (true), (true), (false), \
+        "let fisherTest = (\n\
+         fun (xs : [Bool], ys : [Bool]) ->\n\
+         let zipped = zip(xs, ys) in\n\
+         let contigencyTable =\n\
+         fold_left(\n\
+         zipped,\n\
+         fun (\n\
+         ((a,b),(c,d)),\n\
+         e\n\
+         : (Bool, Bool)\n\
+         ) ->\n\
+         case e\n\
+         | (false, false) => ((a+1,b), (c, d))\n\
+         | (false, true) => ((a,b+1), (c, d))\n\
+         | (true, false) => ((a,b), (c + 1, d))\n\
+         | (true, true) => ((a,b), (c, d + 1))\n\
+         end,\n\
+         ((0,0), (0, 0))\n\
+         ) in\n\
+         let factorial = fun (n : Int) -> if n == 0 then 1 else n * \
+         factorial(n - 1) in\n\
+         let ((a,b), (c, d)) = contigencyTable in\n\
+         let numerator = factorial(a + b) * factorial(c + d) * factorial(a + \
+         c) * factorial(b + d) in\n\
+         let denominator = factorial(a) * factorial(b) * factorial(c) * \
+         factorial(d) * factorial(a + b + c + d) in\n\
+         float_of_int(numerator) /. float_of_int(denominator)\n\
+         ) in\n\
+         type JellyAnon = (\n\
+         get_acne = Bool,\n\
+         red = Bool,\n\
+         black = Bool,\n\
+         white = Bool,\n\
+         green = Bool,\n\
+         yellow = Bool,\n\
+         brown = Bool,\n\
+         orange = Bool,\n\
+         pink = Bool,\n\
+         purple = Bool\n\
+         ) in\n\
+         let jellyAnon : [JellyAnon] = (\n\
+         [\n\
+         ((true), (false), (false), (false), (true), (false), (false), (true), \
+         (false), (false)),\n\
+         ((true), (false), (true), (false), (true), (true), (false), (false), \
+         (false), (false)),\n\
+         ((false), (false), (false), (false), (true), (false), (false), \
+         (false), (true), (false)),\n\
+         ((false), (false), (false), (false), (false), (true), (false), \
          (false), (false), (false)),\n\
-        \  ((false), (false), (false), (false), (true), (false), (false), \
+         ((false), (false), (false), (false), (false), (true), (false), \
          (false), (true), (false)),\n\
-        \  ((false), (false), (false), (false), (false), (true), (false), \
-         (false), (false), (false)),\n\
-        \  ((false), (false), (false), (false), (false), (true), (false), \
+         ((true), (false), (true), (false), (false), (false), (false), (true), \
+         (true), (false)),\n\
+         ((false), (false), (true), (false), (false), (false), (false), \
          (false), (true), (false)),\n\
-        \  ((true), (false), (true), (false), (false), (false), (false), \
-         (true), (true), (false)),\n\
-        \  ((false), (false), (true), (false), (false), (false), (false), \
-         (false), (true), (false)),\n\
-        \  ((true), (false), (false), (false), (false), (false), (true), \
+         ((true), (false), (false), (false), (false), (false), (true), (true), \
+         (false), (false)),\n\
+         ((true), (false), (false), (false), (false), (false), (false), \
          (true), (false), (false)),\n\
-        \  ((true), (false), (false), (false), (false), (false), (false), \
-         (true), (false), (false)),\n\
-        \  ((false), (true), (false), (false), (false), (true), (true), \
-         (false), (true), (false))\n\
-         ]) in\n\n\
-         let pHacking = fun t ->\n\
-        \  let jelly_anon = map(t, fun r -> omit_labels(r, `get_acne`)) in\n\
-        \  let get_acne = t.get_acne in\n\
-        \  let header = to_lvs(head(jelly_anon)) |> map(_, fun e -> e.label) in\n\
-        \  map(header, fun c -> (c, fisherTest(get_acne, map(t, fun r -> \
+         ((false), (true), (false), (false), (false), (true), (true), (false), \
+         (true), (false))\n\
+         ]\n\
+         ) in\n\n\
+         let pHacking =\n\
+         fun t ->\n\
+         let jelly_anon = map(t, fun r -> omit_labels(r, `get_acne`)) in\n\
+         let get_acne = t.get_acne in\n\
+         let header = to_lvs(head(jelly_anon)) |> map(_, fun e -> e.label) in\n\
+         map(header, fun c -> (c, fisherTest(get_acne, map(t, fun r -> \
          (to_lvs(r) |> find(_, fun e -> e.label == c)).value))))\n\
-        \  |> filter(_, fun (c, p) -> p <. 0.05)\n\
-        \  |> map(_, fun (c,p) -> \"We found a link between \" ++\n\
-        \  c ++ \" jelly beans and acne (p < 0.05).\")\n\
-        \ in\n\n\n\n\
-         pHacking(jellyAnon)\n";
+         |> filter(_, fun (_c, p) -> p <. 0.05)\n\
+         |> map(_, fun (c, _p) -> \"We found a link between \" ++ c ++ \" \
+         jelly beans and acne (p < 0.05).\") in\n\n\
+         pHacking(jellyAnon)";
       refractors = "()";
     } )

--- a/src/b2t2/slides/example_programs/B2T2ExampleProgramsquizScoreFilter.ml
+++ b/src/b2t2/slides/example_programs/B2T2ExampleProgramsquizScoreFilter.ml
@@ -1,161 +1,192 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Example Programs / quizScoreFilter",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id b329c437-362f-4e22-9eae-706428d4c901)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         faba3b51-0844-404f-b149-bb771c2bfcdf)(content(Whitespace\" \
+         d8fea264-988f-40b1-b928-f607f13041ba)(content(Whitespace\" \
          \"))))(Tile((id \
          e80947aa-4ddb-40c5-97b2-4e2cdb9037c3)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         c415788f-7ddd-490b-b58b-22112bce286d)(content(Whitespace\" \
+         5317b667-f43b-41e4-859d-d5abfb0518bf)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4b77c310-d20f-495c-9a9e-75a53b2345aa)(content(Whitespace\" \
+         852d53b8-11d4-4763-98eb-05ef3cffb5dd)(content(Whitespace\" \
          \"))))(Tile((id \
          69c36445-a549-4aee-a859-550ef29f466c)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          3332945f-a352-4470-871a-933d6d6b15bc)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3dba22c5-a131-4e9d-8593-ceb8090d4747)(content(Whitespace\" \
+         \"))))(Tile((id \
          1d5cf7bd-acaa-47cf-b8a2-f5088b7faa80)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e42f2c7b-9b68-45f5-b1ad-92d03c17ed09)(content(Whitespace\" \
+         \"))))(Tile((id \
          0fe6ec20-e7e6-4e1e-9aa7-af279e99d1b7)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0844bd8d-cf09-4336-851f-af18c58be432)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         14c7bef1-8e89-4e6c-864d-540d678441ad)(content(Whitespace\" \
+         ddd14275-5c35-46d9-a690-3d996f10b672)(content(Whitespace\" \
          \"))))(Tile((id \
          8fbe0d03-4d56-4089-8727-a92efaac9d17)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d660d956-65b8-4e61-8461-ecf4fdda468a)(content(Whitespace\" \
+         \"))))(Tile((id \
          c7e410d5-8a5d-470b-833e-789602190caf)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         df118b24-84a9-4bd6-945d-f73fd0f604be)(content(Whitespace\" \
+         \"))))(Tile((id \
          97a14f6a-6986-462f-a57b-ad7589ee4d7c)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9d44e3c4-77f4-475c-81ca-4a455eeb632b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         760b4bcf-88f9-4743-9a7a-ebc52661a9f1)(content(Whitespace\" \
+         667f05b2-1a64-4abe-aadd-ed722204b742)(content(Whitespace\" \
          \"))))(Tile((id \
          a030c880-44d0-48c5-886c-595ee178a83d)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b28bf59f-5d34-4923-b331-9a8741138112)(content(Whitespace\" \
+         \"))))(Tile((id \
          3159ccb6-5f9c-46dd-90c7-5a720f652e77)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b48474f0-23ac-4ab2-92fd-c54f4d7306e3)(content(Whitespace\" \
+         \"))))(Tile((id \
          be96b273-5b9e-45ae-a5b8-70b56ed5273a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          3c1d22e5-0091-424b-b8c3-9e939493a239)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f3a56b73-89a7-4da6-9118-9100c9487062)(content(Whitespace\" \
+         1e382b5c-55c7-4da5-93c6-71cbe188cac0)(content(Whitespace\" \
          \"))))(Tile((id \
          0629ce3a-ba27-4b9b-a69a-cab15bbd8818)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bd7b3113-e5ab-416a-b587-d0624b3e4f40)(content(Whitespace\" \
+         \"))))(Tile((id \
          1d87706c-4efb-412f-9910-2376d8bd86af)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bcc2e983-2966-42fc-939c-2db4f2318cad)(content(Whitespace\" \
+         \"))))(Tile((id \
          f6d8621d-f7f5-4599-add9-09d4374577d9)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          2a644d20-5fab-4a7c-8166-6149802ff204)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         749d2745-93c5-48bc-8340-ce7b1b23bf45)(content(Whitespace\" \
+         5b17f968-ecdb-4e21-b237-913f5406ed61)(content(Whitespace\" \
          \"))))(Tile((id \
          77ebb6f8-6e05-4ce2-a1bc-eac0c1a5757e)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bfe4b4a3-06fb-4e85-aeb3-780eec892f3d)(content(Whitespace\" \
+         \"))))(Tile((id \
          75ae477c-065a-4772-8c24-a96d77666fd7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c1e84040-c0f4-42be-ab5b-d2235ac88716)(content(Whitespace\" \
+         \"))))(Tile((id \
          608e0499-ddf2-4add-b36a-4ff7a9f5f12f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          cd76ada1-8635-4086-a0bd-3a87a3780915)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         00e61cc3-9c7d-49ba-bd0c-ac879c3f4d0d)(content(Whitespace\" \
+         2fdb6caf-24c4-420c-8a59-7ba1c238b58b)(content(Whitespace\" \
          \"))))(Tile((id \
          0293daf0-8d62-4198-b162-286fbcb1ab62)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3693ad98-2221-44d9-abfe-0503548b694e)(content(Whitespace\" \
+         \"))))(Tile((id \
          154ea8f7-218f-4748-88f2-4e5249728bf4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4cfe9b98-06e1-4b6b-9a15-e01a7c9ca7fd)(content(Whitespace\" \
+         \"))))(Tile((id \
          f843df6e-7313-486b-8043-fb87eb7e2441)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c76249b3-a4da-4078-af29-035aa9f5fd4c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a9b263d3-0f6a-42d0-a33f-29efe1c13e39)(content(Whitespace\" \
+         279a68b5-1e81-43ad-844e-52e19825f3d6)(content(Whitespace\" \
          \"))))(Tile((id \
          e879fa7d-212d-4e52-8a1f-65199747b866)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f2e37f52-f1d1-4e94-9afd-665465693329)(content(Whitespace\" \
+         \"))))(Tile((id \
          9176059e-7283-482f-ab0c-ff278bdf248b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1b8203fb-be82-443c-87d9-6abd54293f09)(content(Whitespace\" \
+         \"))))(Tile((id \
          4af7a488-c420-4044-b91c-411e34d6d3c8)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f2ed78bf-9207-4d6f-a187-592a20c7f41b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e29e2aea-66f8-4ffb-9ef2-16c6fb1b9025)(content(Whitespace\" \
+         af022ca2-d876-4452-97ed-f9e6178177f9)(content(Whitespace\" \
          \"))))(Tile((id \
          0d50c40e-34e5-4d6f-b0f6-57811e8d75e9)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         17ae6634-c42f-48d3-9f10-3edbd2156d67)(content(Whitespace\" \
+         \"))))(Tile((id \
          e6ac034a-5b5d-488a-86f8-e29f63af7e93)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         12974d1d-73d8-49fa-9abc-2ae42f83ee47)(content(Whitespace\" \
+         \"))))(Tile((id \
          2e917806-fd6b-489f-90e0-57e255904e8c)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1aa74146-bd15-4176-9800-6134be312b1b)(content(Whitespace\" \
+         b1b78ab3-b8a8-4c8d-a6c6-7d6832cffeb0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         abaf686b-7f2e-460f-990a-7af8e6c353c3)(content(Whitespace\"\\n\"))))(Tile((id \
+         e212a5e3-171f-4893-9569-86b0d208a6e2)(content(Whitespace\"\\n\"))))(Tile((id \
          f3f0c1e5-4e2b-41b7-9e1f-7d2c264aca78)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         2bf933db-8a0a-4cfd-bb34-383234be5842)(content(Whitespace\" \
+         c8e1af96-4e44-413d-8035-d569bba22f9a)(content(Whitespace\" \
          \"))))(Tile((id \
          baf67216-bfcb-4925-a33f-23fd7dc4343b)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b902cef2-35e9-4ff2-a400-694ee8c145ba)(content(Whitespace\" \
+         ff51e4ed-d31d-463f-b828-69d1d48189bd)(content(Whitespace\" \
          \"))))(Tile((id \
          893788c4-1ab0-4d21-b8d8-912780030d3d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d4fa1445-0c4c-488f-8f83-36ce47fec54f)(content(Whitespace\" \
+         aa9ad6e7-b21c-4630-a61a-f8ac3798f601)(content(Whitespace\" \
          \"))))(Tile((id aa61c65a-18e2-4275-9bf2-5c3a634586c1)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          71376dad-566b-4eb0-9b73-a9c3459c16fd)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d0db893e-aa67-422d-a8c7-3fd23438a5ae)(content(Whitespace\" \
+         1201b6e5-1c68-4fd9-bde0-bc7112eb830e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c5cb8dc4-a85d-43f9-aa43-a9fa37cdb852)(content(Whitespace\" \
+         3cb35222-5ddb-45a5-8a28-ae2f6bc8f997)(content(Whitespace\" \
          \"))))(Tile((id 822a69f0-a954-462c-bc9f-e15cea409bda)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f52b07d8-d1dd-41a3-a5d4-566419a4e06a)(content(Whitespace\"\\n\"))))(Tile((id \
+         a119e237-9778-4f89-83b2-cc2bc1dfeb9f)(content(Whitespace\"\\n\"))))(Tile((id \
          5f1d8816-60ff-40e9-a3f2-8578259a163e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -225,7 +256,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e28b788d-6867-443e-8195-804bf8fdb767)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         62b5c012-9f14-4c06-9192-47032b32ecff)(content(Whitespace\"\\n\"))))(Tile((id \
+         97406ea8-54e5-4fb5-a75f-8552dc28f995)(content(Whitespace\"\\n\"))))(Tile((id \
          a5961dd2-e1b0-4401-8e46-c065634adcc9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -291,7 +322,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          836c5a1e-1476-49a7-bcca-32b448be6305)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8b508fc1-74f6-471e-9f44-b41726f58c68)(content(Whitespace\"\\n\"))))(Tile((id \
+         15767b12-a427-473d-9c88-31118cf3bfe4)(content(Whitespace\"\\n\"))))(Tile((id \
          c3227a98-4ef4-4489-9202-18a9c966b314)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -301,11 +332,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cf2bb8ed-44e6-483a-842c-3aea5fbfa006)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fc38248e-3feb-46ce-9d3f-19f02c532486)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         452b4b15-c132-4308-8fdb-1d2442dc962e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04814400-d22f-4f51-9c9a-93df79390ebd)(content(Whitespace\" \
+         571683d2-1e96-4558-8bbf-6f8b4e50a4ed)(content(Whitespace\" \
          \"))))(Tile((id \
          d34a435e-d035-4370-9e75-d0b34a2d1e7a)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -313,7 +340,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5d597d4b-9733-4575-affc-7f44d68765b6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         23818e12-9fc8-49c6-b7f3-36502d05b1fc)(content(Whitespace\" \
+         23400c45-7cf7-422b-857d-06970f57dddc)(content(Whitespace\" \
          \"))))(Tile((id \
          1dc6039d-51e0-49d7-a4fd-25bbbbc01182)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -321,7 +348,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0ecbed24-1cda-41cf-9031-2c63b5a44171)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         28cbc529-119b-44c2-87f9-a405eb2590bb)(content(Whitespace\" \
+         4be7ecc2-a6b9-46a3-a6d5-656cfb1c88f9)(content(Whitespace\" \
          \"))))(Tile((id \
          4bde1219-7fe4-49ea-9951-ba17771ec275)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -329,7 +356,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          31a6e9d7-7c5a-4289-87aa-44f2bcc85d8b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5694906f-fa2d-446f-8fcc-663e4139faaa)(content(Whitespace\" \
+         0b26546e-d573-4ee8-b45f-a4a6211f827b)(content(Whitespace\" \
          \"))))(Tile((id \
          8341bbd5-496f-4350-80a7-d2ef9b03f2cb)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -337,7 +364,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a6fbe12c-a481-42d7-a342-c60c78fdf94e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8c85ec0e-b24b-4ea8-81cb-d78b39f15501)(content(Whitespace\" \
+         2f733b1f-c7d9-433b-bdd4-ff229b281bf3)(content(Whitespace\" \
          \"))))(Tile((id \
          42db430a-9291-4b54-8717-973ba04ecba7)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -345,7 +372,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          74d5d37e-66a8-427d-bba1-a52019264a1f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         84448e10-53e7-48d4-a2bb-9ba1115995d3)(content(Whitespace\" \
+         bdd7fb11-9c6e-4327-9238-eb4bbb23a22b)(content(Whitespace\" \
          \"))))(Tile((id \
          108ceefb-3224-4e1f-99f1-a0337539d2a7)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -353,26 +380,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          19040f0f-dfb6-4940-8eef-885412a8093f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d5696a92-848c-4f30-a12b-25103f735e33)(content(Whitespace\" \
+         91398d8f-fc5b-4f47-ba45-ec358983f504)(content(Whitespace\" \
          \"))))(Tile((id \
          2fe9b018-772d-4801-977a-2ce147b280cd)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         93d09066-e122-4f4d-bbd2-baaaca207a98)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         704e505b-a670-4a5d-815e-31ceab2f1531)(content(Whitespace\" \
+         b9666b15-42b1-4d6d-92ab-104f969692fc)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         d39d3784-7a06-430d-8f34-832d59bd0206)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5b245f04-5819-4ffe-84ec-7fe642f9051c)(content(Whitespace\"\\n\"))))(Tile((id \
+         e1431e63-4c2d-4049-9ca0-34c82fa262c8)(content(Whitespace\"\\n\"))))(Tile((id \
          99c18cd6-dbc8-4e89-8531-4189c6382ac2)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         b9c72072-a77d-4a80-9dbb-e2636606bdbc)(content(Whitespace\" \
+         43475ae1-3335-4a78-9693-b496897f87ab)(content(Whitespace\" \
          \"))))(Tile((id \
          b373549b-08ea-44fd-b307-cfd5be30af2f)(label(sum))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f76dfa0b-afe2-47d5-a4c3-e5f5fa6d16ed)(content(Whitespace\" \
+         a1827a35-e6d8-4762-8a35-df263bd0d30a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0aceeb73-33e6-4cc6-adb8-87e058f93d9d)(content(Whitespace\" \
+         1b0bb168-b107-46ab-9f58-eb3598d6028a)(content(Whitespace\" \
          \"))))(Tile((id \
          9e620f4a-18af-4774-92eb-5e0a6f3a8e5d)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -386,7 +413,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          622cfbca-ef5c-4b39-b153-984c86032b19)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1554064a-4014-465e-9273-9ce96fbbeddf)(content(Whitespace\" \
+         a4c52cf9-8ec1-4aee-8151-40cc6568214c)(content(Whitespace\" \
          \"))))(Tile((id \
          1b9bc238-2c25-4552-87da-7b644354c0b5)(label(int_plus))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -394,52 +421,50 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1681a057-284d-4612-a398-c74d654ccdd8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10f9dff7-de35-43e5-859c-b8338bc763f0)(content(Whitespace\" \
+         c487fd2a-bcb4-49d9-94f9-35f0151502b9)(content(Whitespace\" \
          \"))))(Tile((id \
          074f0a80-c1c4-40a7-8d40-7c42c90393c5)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d03e33ab-d4ec-468c-965b-b69c18c982e8)(content(Whitespace\" \
+         f5d21da9-8820-4a01-bb1b-6cf0d3716ae5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1b353674-7d5e-4233-9124-dd9986be46dd)(content(Whitespace\"\\n\"))))(Tile((id \
+         4b811bc3-4474-4528-87c7-c2e9f98bb75d)(content(Whitespace\"\\n\"))))(Tile((id \
          d492e644-70d8-4d1c-be71-2bb4c4d4bea3)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          6c70467a-b427-4324-ad96-a4e1ad162dff)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         4dbbb7ae-eed7-45f3-9a18-ec137f7abc71)(content(Whitespace\"\\n\"))))(Tile((id \
+         9e7a7734-0cb8-48e1-b775-523b74a60084)(content(Whitespace\"\\n\"))))(Tile((id \
          20ee234a-0d3a-48ba-808b-3a5c65b50668)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          101c321b-0ede-43d5-a03d-fbcca85a8c3f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         437fc642-dad1-4678-ad4a-ea001668437f)(content(Whitespace\"\\n\"))))(Tile((id \
+         1f92e443-cd55-4908-97f0-d5af78573e8e)(content(Whitespace\"\\n\"))))(Tile((id \
          e483c927-3e3d-4f37-9512-44dc9e273463)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         5dd9e587-6d6a-4c23-8d32-d10cecb8d204)(content(Whitespace\" \
+         0d91c100-6d1c-4d5e-aa00-edc5400ed377)(content(Whitespace\" \
          \"))))(Tile((id \
          2c01c53e-b3df-47fc-b19f-0d6d9c08c1f9)(label(gb))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6e5f9548-f138-46ee-b310-0eba83653fa5)(content(Whitespace\" \
+         4de86625-9d6f-4b16-9a2d-482c93036fdf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fa0ec08c-de54-4918-8f44-6e5be91737ad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e0035220-8540-4a64-b245-1b286dd85466)(content(Whitespace\"\\n\"))))(Tile((id \
+         933bdb89-65d3-431b-94b0-c0a5aad4aab4)(content(Whitespace\"\\n\"))))(Tile((id \
          e765893d-1787-42e3-b5a3-39ebb920282a)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         23ebd080-1948-46a5-aae9-451c8763d994)(content(Whitespace\" \
+         5222f45b-8872-4248-bc19-4a8e30df9511)(content(Whitespace\" \
          \"))))(Tile((id \
          b943e2d5-a1e0-4ca3-b17d-e9f587cbe321)(label(scores))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e733e27e-8ca4-45ee-b36e-c55cd0f9c2bc)(content(Whitespace\" \
+         3d2e290e-93a4-4219-bffc-99d99fba06ce)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b16e9a0a-0d5d-473f-84e4-4b72b36770eb)(content(Whitespace\" \
+         689250a0-5378-47d4-8928-6b0e9dc6fd01)(content(Whitespace\" \
          \"))))(Tile((id \
          2dc7d911-b22d-421f-ac46-b85d993be0a0)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -450,11 +475,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          af3931bb-c55c-43c2-92e9-b29256a61c01)(label(gb))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         a8b424fb-c855-4bda-a1af-cf51c29c29cc)(content(Whitespace\"\\n\"))))(Tile((id \
+         7d5478f0-abe3-4ba6-9dd3-99683f208e43)(content(Whitespace\" \
+         \"))))(Tile((id \
          cf56497b-4ceb-4629-b445-88bb83a89d33)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         002be436-fcff-463b-8ff6-7a10c690d91e)(content(Whitespace\" \
+         31e815e2-0074-4362-916e-c693e2b80134)(content(Whitespace\" \
          \"))))(Tile((id \
          f7655967-fcd0-48a9-bb11-ecdd022ef56a)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -468,19 +494,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8307f8f1-04a5-4399-8e2e-426e382a54c6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         11e33db3-6b8b-40cd-a2d7-5555154decdf)(content(Whitespace\" \
+         a599e0f7-371a-4839-97f5-a59220c112f7)(content(Whitespace\" \
          \"))))(Tile((id 803959b1-25fd-4ac0-a1e7-4ac4d05b6ac1)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         7b9bf01c-6b6b-44bf-8d69-308618d8563f)(content(Whitespace\" \
+         3b9c65c4-5b62-4134-8649-929d70f58dea)(content(Whitespace\" \
          \"))))(Tile((id \
          ba901dba-7f55-496e-9f48-e498a7007c7f)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f87cedcb-80d7-4b4e-bf09-354e71b6b8fb)(content(Whitespace\" \
+         e10e573e-3b4e-4be9-9e64-ffaf74d1b75f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         05cdb3f3-3640-4ea8-9653-abc4e5dfa797)(content(Whitespace\" \
+         c506fe71-e4ee-4021-b3fc-ec04d564b75c)(content(Whitespace\" \
          \"))))(Tile((id \
          a82b6072-3cb0-4b53-bbbe-5670b6314bc5)(label(string_match))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -494,7 +520,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          77b71965-821d-4d5c-8289-e91bb87084ff)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         226d922e-6b26-4949-90d0-9437ff2d63a9)(content(Whitespace\" \
+         c4d1d834-bab3-44f4-9914-f50be5585932)(content(Whitespace\" \
          \"))))(Tile((id \
          6c2017c4-cd60-45b5-9b2e-793e1ce79565)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -505,13 +531,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7e9d5aa6-06c1-4705-876f-1129ed56039e)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         71fcec07-e645-406e-8d10-fa5baab01634)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d46a5d1f-e390-4e8e-b18a-501e6b8ed75e)(content(Whitespace\"\\n\"))))(Tile((id \
+         c6a4664d-30a6-4216-9293-46d34f64da97)(content(Whitespace\" \
+         \"))))(Tile((id \
          65d40d18-3696-4fee-be1a-457e7b900830)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f494b8ae-4cb4-401b-8dfb-17a09bbdb9ce)(content(Whitespace\" \
+         99e52056-6acd-4503-b8ae-8e054ce44960)(content(Whitespace\" \
          \"))))(Tile((id \
          1dba1e5b-7df3-49d6-9c6a-2b73f2349fd7)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -525,19 +550,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          400c967c-b6e8-4607-a927-407a5a71fa90)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4fe91c4f-f82d-4402-948e-b99ca16d4857)(content(Whitespace\" \
+         41b03cd9-8163-4458-b9a4-df6ba48bb3f8)(content(Whitespace\" \
          \"))))(Tile((id 553c7df5-d5d9-4300-adea-e2e638a6102a)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         b2d1bdd8-b962-4d2a-8750-95d775881af0)(content(Whitespace\" \
+         fba8cf6d-5064-4d08-9238-7cb587818858)(content(Whitespace\" \
          \"))))(Tile((id \
          4c60a007-4c72-4b8e-a1c9-4cf4b00d5e92)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0a6a0deb-4aa6-48de-af7e-bf1d84266eed)(content(Whitespace\" \
+         56bee2b3-35df-4d83-865b-91dbd3d845f3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         77669c21-d287-44e2-8c7d-4c1c47951d85)(content(Whitespace\" \
+         f1359669-2c2e-48cd-84f0-e5cce5e6cf7d)(content(Whitespace\" \
          \"))))(Tile((id \
          f230e385-cbb2-4508-9624-2b9621ecbb56)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -548,31 +573,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a2465fe5-9aa4-4afb-9915-ba7499547ed7)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7d8dc629-6780-47ff-ad1b-631b19017b26)(content(Whitespace\" \
+         a738be27-d7ed-4176-86e4-ac819aee86f6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b17a88e8-1665-4190-b6e3-63cc6e27816e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         da326bdc-05d8-4470-b718-8c05c146ac50)(content(Whitespace\"\\n\"))))(Secondary((id \
-         58d24308-b75b-4d2e-9deb-c1a8a05cc136)(content(Whitespace\"\\n\"))))(Tile((id \
+         084db3cc-d6ab-48fb-be31-2cb16ba40dd7)(content(Whitespace\"\\n\"))))(Tile((id \
          7eb5d1ed-7332-4209-b0c8-5faed661c118)(label(gb))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         aebe6cc6-c27f-4efb-87a9-83db9052a0b3)(content(Whitespace\" \
+         c04bea86-14ba-4212-b6fa-3cf767e55669)(content(Whitespace\" \
          \"))))(Tile((id \
          fe2de545-9a51-461c-bff7-d38607fb221f)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f0c9650d-6f3c-4764-ba56-5bd25caf1314)(content(Whitespace\" \
+         91d48da4-6f20-415c-96a3-fbc4e68fd62a)(content(Whitespace\" \
          \"))))(Tile((id \
          a0fdec31-e4e5-4200-b409-17bb706ae82d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          faf84e43-7d2f-462d-8ce2-df5966462131)(label(average_score))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a7f6cca1-1861-42b2-8b2e-dc55c2940962)(content(Whitespace\" \
+         \"))))(Tile((id \
          4deded7c-0ab5-48f3-abf5-04bc39c20961)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ba2cfd2b-06f5-4c12-8667-506280598262)(content(Whitespace\" \
+         \"))))(Tile((id \
          9d7857bc-0a81-4e75-b7a5-058aeb3ba8b0)(label(float_of_int))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -588,12 +614,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1fb7f61c-f53f-4a85-82df-683308777282)(label(scores))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         fdfdbd65-b159-4a1a-a0ca-c16235325453)(content(Whitespace\" \
+         eddb9a07-0c82-4ce3-ad91-379dedad9d81)(content(Whitespace\" \
          \"))))(Tile((id \
          65f36a26-6b73-4af5-bf3e-c0afac53757f)(label(/.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a9752fd4-9ce3-43b0-a5fb-adf4d443075a)(content(Whitespace\" \
+         3c42a0e0-832f-4a74-94a5-71737eccff38)(content(Whitespace\" \
          \"))))(Tile((id \
          316fe2d2-8d65-4aae-bba0-0b69b0990971)(label(float_of_int))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -610,23 +636,23 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f9eb0b59-4d79-4348-acee-bf581f2afac4)(label(scores))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         54daf995-1c49-4766-b4f8-e41db65e5176)(content(Whitespace\"\\n\"))))))))))";
+         07999fcc-a68a-4bf5-8474-545e56907d29)(content(Whitespace\"\\n\"))))))))))";
       backup_text =
-        "type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+        "type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = [\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-         (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
+         (\"Eve\", 13, 7, 9, 84, 8, 8, 77)\n\
          ] in\n\
          let sum = fold_left(_, int_plus, 0) in\n\
          map(\n\
          gradebook,\n\
-         fun gb -> \n\
-         let scores = to_lvs(gb)\n\
-         |> filter(_, fun e -> string_match(\"quiz.*\", e.label)) \n\
-         |> map(_, fun e -> e.value) in \n\n\
-         gb ... (average_score=float_of_int(sum(scores)) /. \
+         fun gb ->\n\
+         let scores = to_lvs(gb) |> filter(_, fun e -> \
+         string_match(\"quiz.*\", e.label)) |> map(_, fun e -> e.value) in\n\
+         gb ... (average_score = float_of_int(sum(scores)) /. \
          float_of_int(length(scores)))\n\
          )";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/example_programs/B2T2ExampleProgramsquizScoreSelect.ml
+++ b/src/b2t2/slides/example_programs/B2T2ExampleProgramsquizScoreSelect.ml
@@ -6,155 +6,187 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         a50415c0-0a61-47f2-b3fe-4ae81e4e8d93)(content(Whitespace\" \
+         bbec2a77-97a5-4030-b14b-e0a410d12130)(content(Whitespace\" \
          \"))))(Tile((id \
          64fa4750-0aba-41b8-aa74-888dce5451dd)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         128f2908-0704-4b42-bdb3-dd7e8ddc90d6)(content(Whitespace\" \
+         0271404e-0da0-4f1e-9add-7e7a801b5a45)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f159279b-d5f6-4dbc-9173-b4fe641a7cb6)(content(Whitespace\" \
+         eea0bb65-12af-4191-bdfb-25d9cc1d002a)(content(Whitespace\" \
          \"))))(Tile((id \
          447c8c8b-51fd-40d5-9ba3-d5b13fc2accd)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          0ebc4278-dd20-4b76-8702-0c16311d0b56)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3a68e930-f23a-4452-866a-d232a108394d)(content(Whitespace\" \
+         \"))))(Tile((id \
          fd8b1a15-12a7-497d-8661-99946bd129d0)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         17805f4d-4a98-46ad-901f-73944aa2d4a5)(content(Whitespace\" \
+         \"))))(Tile((id \
          aa2dc787-c0bb-4e65-90ef-0571f715282b)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          33912a77-2e6b-460a-a6d8-6a36aea8d492)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         595d2f31-6832-48e4-89b1-516f3dd123ee)(content(Whitespace\" \
+         46e00c7f-eb54-4d18-9e9c-c9d09c32f65c)(content(Whitespace\" \
          \"))))(Tile((id \
          2a95f962-17e7-48af-84da-591830b8e54c)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d58713e8-1158-42f6-9a39-6ada63c740f9)(content(Whitespace\" \
+         \"))))(Tile((id \
          1f8ad14d-7ca8-4a83-a5eb-a4414a826b79)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b725201a-2ba4-43c0-b9c8-dec43258a078)(content(Whitespace\" \
+         \"))))(Tile((id \
          442126f7-0b60-4980-82b2-3227701a6c7b)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9141590d-cc5a-4245-ad12-40f24980dbe4)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         baf157fa-93c1-4e77-84f5-c56a9575f660)(content(Whitespace\" \
+         53f8eda6-9d14-441d-b4ab-02e0ce3f8fc9)(content(Whitespace\" \
          \"))))(Tile((id \
          0858d7cf-bb29-4dc5-bc48-54a6501fce94)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0c82820f-aa6b-47ee-a6a5-5055b22b1c82)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a41e0d6-7626-4091-aa76-62b9f2be47f7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f7a9ae92-eb65-45eb-b577-c3547952b5a1)(content(Whitespace\" \
+         \"))))(Tile((id \
          846ba738-e225-40db-87a2-024a12d65952)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7d9995f1-3fd0-4db5-a864-175d35758c66)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         09930299-6f68-44fd-887f-141a5da53aef)(content(Whitespace\" \
+         ca45c174-6dd8-41ef-a079-7786783062c6)(content(Whitespace\" \
          \"))))(Tile((id \
          d21efdf9-7b23-4353-9d0a-e201d755edc3)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         59e3901e-f900-4073-b893-8c961fca8cc4)(content(Whitespace\" \
+         \"))))(Tile((id \
          360efb06-80be-4ba1-a10b-e8c9810bfe3a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         35b38f32-28d1-4a82-a636-e12cae321238)(content(Whitespace\" \
+         \"))))(Tile((id \
          40292555-d236-463b-9a15-bfa613154e3f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b1446e4c-1d14-4ae6-9046-5779783f8bb3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7a3150a5-0b54-44d4-94dd-6a6bcd22a4d0)(content(Whitespace\" \
+         3e89d71c-abe6-49f7-a66e-83d36b10617b)(content(Whitespace\" \
          \"))))(Tile((id \
          e5fa516b-aa05-4613-be4c-77ed78ee6d3c)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         955fdd19-a344-4fb9-a874-77fa6a95c9f0)(content(Whitespace\" \
+         \"))))(Tile((id \
          58930840-5833-4001-bee6-24edbed2b50a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c48a6cd1-5bab-40c8-bc02-676aded6a016)(content(Whitespace\" \
+         \"))))(Tile((id \
          2b260f46-041d-4d6d-8e90-d051ddc82233)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4a4cdfe1-7ff6-4c32-8f09-5462bc09b115)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7b5812ff-c3b0-467c-80c4-1e197e433bb2)(content(Whitespace\" \
+         7825832b-1990-4030-8fe1-e64ede9c68bb)(content(Whitespace\" \
          \"))))(Tile((id \
          f6eb69cd-08cc-4ffa-8301-bf2f92e322c1)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         18102223-0371-4dcb-a385-578209ef6f4f)(content(Whitespace\" \
+         \"))))(Tile((id \
          9db8126a-6979-417c-857b-a1291406fb2d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         21ebb447-a4af-4375-aa4e-debf10f5750b)(content(Whitespace\" \
+         \"))))(Tile((id \
          60b64a19-cfde-413b-9f0b-47feed45da1b)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          722b0f6c-5a3c-4ac2-9ad1-ea6390b5c9e8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         57a7ff8e-5ee6-40bf-8c52-70dfd7ce2115)(content(Whitespace\" \
+         edbcb0d8-c856-4a1f-925b-276a7c825937)(content(Whitespace\" \
          \"))))(Tile((id \
          80c8d5a7-2bb6-4a6a-811b-0cab65636957)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f3f2a2ef-7f51-4f6a-b34f-9b39da40550d)(content(Whitespace\" \
+         \"))))(Tile((id \
          189090d7-8d26-42a8-bf6a-aafe70a894e5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e2210bd4-15bc-4bb3-9cdd-cd0ca020e9f7)(content(Whitespace\" \
+         \"))))(Tile((id \
          9154403d-4af0-4737-bdfa-ee56ff28e7b8)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          33941c1c-35b6-4a33-8789-cddc364c3aaa)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         91fbcc31-756b-4fea-b51f-d339871a8eed)(content(Whitespace\" \
+         5dcb51f5-d6aa-4336-a13b-503eb9aebeb5)(content(Whitespace\" \
          \"))))(Tile((id \
          6f02ef17-3d9d-4e33-9875-93b059a1c3e2)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f397a1ae-8a1a-43cf-a365-8622de8b8fe1)(content(Whitespace\" \
+         \"))))(Tile((id \
          f3c30b8a-c53c-43fb-852a-a21eeb61f9b3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e4057efb-9026-426f-aae2-c7e5a4f14fb1)(content(Whitespace\" \
+         \"))))(Tile((id \
          1966afca-2395-4551-bd08-1537c189d77f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         452d9edf-81b7-4fca-b3cc-00ff1a508690)(content(Whitespace\" \
+         5fb22b70-0346-4fc2-9e0a-5785dc03c885)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1f5fe518-6562-4b28-8b77-db72b651432b)(content(Whitespace\"\\n\"))))(Tile((id \
+         59a9849a-8c2c-4c62-ae53-2e69eae903ac)(content(Whitespace\"\\n\"))))(Tile((id \
          881201dc-9bc7-4bf5-add8-398ab50b68e9)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         aba607e4-d09c-4784-b9da-549656dcb1ac)(content(Whitespace\" \
+         a7cd29eb-849f-41a4-a4ae-d28b93967447)(content(Whitespace\" \
          \"))))(Tile((id \
          c9023c11-9d62-4843-a0aa-1d2406e0d157)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         509f6787-9a67-434b-bc26-9934d95b4b04)(content(Whitespace\" \
+         a9152af1-a182-494f-ab00-7157d5092b9a)(content(Whitespace\" \
          \"))))(Tile((id \
          a9d48c4e-37ec-4de7-bf3a-5b1bf2af8a49)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f3c34d10-44d4-4ac8-a9e8-c751676ab9ea)(content(Whitespace\" \
+         a01f0ce0-cb22-4cf7-bc7f-1ccde9812f1f)(content(Whitespace\" \
          \"))))(Tile((id e235cdf6-93bf-41bf-80c5-34d61703b21b)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          ed2728e7-08aa-40e0-9c0c-44a49945ab56)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         fc8fb997-36f2-4bc9-97ed-c47ed9c579ac)(content(Whitespace\" \
+         acd8e22a-e8d5-4a80-8daa-6a5bf34c4784)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7ca0f113-dced-43bf-96a6-c71350908f15)(content(Whitespace\" \
+         2a66f7cb-142a-4161-97fb-600e63fbbfa2)(content(Whitespace\" \
          \"))))(Tile((id deaaaac1-7ca6-481a-87a7-4edcfb88ba5b)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         e1095356-5b27-4088-b19a-8ae9b8b8e212)(content(Whitespace\"\\n\"))))(Tile((id \
+         b01e1940-2851-456f-b0a6-67905a3ee028)(content(Whitespace\"\\n\"))))(Tile((id \
          cecbb40a-d48b-43bf-ab68-2bf8c70f7184)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -224,7 +256,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          74db4522-4f85-4c31-8675-f61a71ef82cc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         18fd0dbc-bc1d-43f6-b365-32ce05132593)(content(Whitespace\"\\n\"))))(Tile((id \
+         0ed42ef0-ab37-4c57-8fe3-b556b242cf61)(content(Whitespace\"\\n\"))))(Tile((id \
          41a57636-32b5-4fe5-8f73-e6a796b8d9c1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -290,7 +322,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0c8f9bbb-22bd-49d0-b975-b83aff343a87)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ea966b5b-d7e6-4f80-8c7f-17a0bfcb5a68)(content(Whitespace\"\\n\"))))(Tile((id \
+         aa04b848-0a43-46ea-a61a-32a858a506d6)(content(Whitespace\"\\n\"))))(Tile((id \
          24e0f844-be54-40aa-bcb4-4375043875f7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -300,11 +332,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ba95bd23-a99d-49cf-9ec0-9c88d181d42e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d530634f-2d44-443e-9d5f-6a51b20faaea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5738cefa-6eac-4629-b9db-28dfbef4f0bb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a4b0c458-c830-4107-b8fa-4d5a29dcb82f)(content(Whitespace\" \
+         22edc457-8e80-41fe-a455-b8b41983be1d)(content(Whitespace\" \
          \"))))(Tile((id \
          f50de24d-0b35-442b-af10-e9cc25a0c758)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -312,7 +340,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0759b624-671d-476f-b228-60a849dc76e2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a06d8492-3b3b-479f-bfad-2bcd018ec236)(content(Whitespace\" \
+         d59a7835-8b62-4b73-bec8-b5aefa89d2ef)(content(Whitespace\" \
          \"))))(Tile((id \
          1884b0a0-8a4a-4426-bf7f-7823a513faec)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -320,7 +348,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a635e56a-d92b-4653-baad-7ddc1e4dcc44)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ca57d583-eefd-4353-964f-8c4d7bf6bdbd)(content(Whitespace\" \
+         8e8f0dc3-5524-4bea-b49b-f83793d69c29)(content(Whitespace\" \
          \"))))(Tile((id \
          a41b9fa7-3947-4bc1-a998-0ef06ccef60c)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -328,7 +356,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a3c8ef11-c3cc-41f0-9887-f1555d3774c0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a1dbc977-a8bd-4124-8883-d7c8633275e3)(content(Whitespace\" \
+         67757b47-916b-42cb-8ffc-73336855f9d9)(content(Whitespace\" \
          \"))))(Tile((id \
          c82abdb9-d8d8-4986-9301-b8243f68b7cd)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -336,7 +364,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f0196fc1-f56c-40c6-94f1-2f7df9be92ca)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fbec26ee-5178-4bb7-9e1f-c1d7463154c1)(content(Whitespace\" \
+         572f294d-e59c-461f-81ea-4506d0927468)(content(Whitespace\" \
          \"))))(Tile((id \
          af7c92b2-ec71-44e4-8491-e516d1f3f49f)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -344,7 +372,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b3fcd8b4-7fa3-4d27-adb6-8109b8a2d1f5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         71e6f348-ffcc-4112-9183-8f37f659dbcf)(content(Whitespace\" \
+         3dd3efb0-0f97-4197-8e11-e921a1ae6708)(content(Whitespace\" \
          \"))))(Tile((id \
          79252a16-0548-4a26-a645-051bc8b88357)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -352,26 +380,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          66619896-2163-4d93-b61e-38ecc72af55a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2cca5d5f-c10d-4a97-b686-e8a35cdc6ebf)(content(Whitespace\" \
+         1fb87e29-cc05-4feb-8940-c9910a46f0ad)(content(Whitespace\" \
          \"))))(Tile((id \
          3cbb38d9-c52e-4d44-bf67-9928456f6b7f)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6dcc78d8-9b5b-4633-aa92-1779d3f7038a)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a62db055-7a1e-4c53-a0cb-a604e0cc5ed2)(content(Whitespace\" \
+         67ff2aef-4208-4a48-98dd-c373ea4da564)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         7011c8e0-2d2d-4ac6-8b44-3896e4d0db95)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2fc111aa-c8f5-4b02-a3eb-702f22a90877)(content(Whitespace\"\\n\"))))(Tile((id \
+         f9c18f71-db10-44e8-a6d4-0fc28ea04c16)(content(Whitespace\"\\n\"))))(Tile((id \
          a58eb369-b757-4263-8721-e85f6b5b4115)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         463a3d4f-78d9-497d-b368-a6e0e48173c8)(content(Whitespace\" \
+         84bcb8a3-2010-47a9-8b57-3c1f87855777)(content(Whitespace\" \
          \"))))(Tile((id \
          5aae145c-f3cf-4d39-b1af-dbb066b3e267)(label(quiz_col_names))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         85e86e16-207c-4f33-aa63-3db2d0447c6d)(content(Whitespace\" \
+         3bd0b6e0-b105-470a-83ba-c8c2c9509d4a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         1caefa5d-42a0-46b2-b04e-44125903d853)(content(Whitespace\" \
+         d71e33a2-4d6b-4a84-a33f-8692f7558401)(content(Whitespace\" \
          \"))))(Tile((id \
          8c1ce9aa-ea27-42b8-85f0-8c9261597235)(label(range))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -384,16 +412,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          156c58b8-9369-4206-bc3d-bee9f5ab309c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6862ead6-54b4-4606-a52c-c33e8c2e749e)(content(Whitespace\" \
+         \"))))(Tile((id \
          f94bb429-e2a2-4584-b8e8-e7741f536fb0)(label(5))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         53e03a97-3630-4931-b2d9-f0b6290f61c6)(content(Whitespace\" \
+         9e47e7c1-df64-4ee6-9dae-650c824c4abf)(content(Whitespace\" \
          \"))))(Tile((id \
          02a08205-d435-4771-84d2-a22ca790a3a6)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         40059aa2-b33b-4a9f-9a20-4e2af6eb2829)(content(Whitespace\" \
+         c5adc693-86b0-418d-956a-1f7312185189)(content(Whitespace\" \
          \"))))(Tile((id \
          6a0ce665-4b93-44f8-8c70-9a1a10d55bcb)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -407,29 +437,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          efcb1fb7-9b46-4eb0-ad09-3e4036ed724c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0000ce5e-8853-4e4b-a250-61b1d7a590f3)(content(Whitespace\" \
+         4f1de613-640f-41f4-bb28-76aed1beb16b)(content(Whitespace\" \
          \"))))(Tile((id 0ea43839-5abb-4309-8ea7-d08f932f246a)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         7ddcb1e7-e538-47d4-89ca-bfd8db8b3fce)(content(Whitespace\" \
+         bdde80df-58f5-4a29-ae46-2990991cddf4)(content(Whitespace\" \
          \"))))(Tile((id \
          cab7d29e-09dc-434b-a3f7-0cb39ba08238)(label(i))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         058e6a47-0b67-4af0-8f90-40892105a62c)(content(Whitespace\" \
+         4127e68c-ca6c-42f1-ac87-65f803792f45)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6d7f86ed-38a9-4d3e-bf26-62e2446d51f2)(content(Whitespace\" \
+         cf6bab75-2dcd-428e-8bde-e30c0a1396f9)(content(Whitespace\" \
          \"))))(Tile((id \
          85035617-634c-4aa7-97aa-27bd4d6649be)(label(\"\\\"quiz\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         6985578d-4a3f-41d0-9ca5-aec40907f9e5)(content(Whitespace\" \
+         811785fb-3a8a-4a65-ad15-b08a5ec29d05)(content(Whitespace\" \
          \"))))(Tile((id \
          f81c29bf-949e-49ec-8abd-68ea98013c7e)(label(++))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a146fb25-742c-41fe-a8d5-6fa934e24d64)(content(Whitespace\" \
+         866d804f-6910-48b4-b14c-8d526e762aed)(content(Whitespace\" \
          \"))))(Tile((id \
          15bbe806-f789-4ddf-84a8-7682d9999874)(label(string_of_int))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -440,26 +470,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          52dd3fe1-8747-4e5d-8a36-605d7da9c5ae)(label(i))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         77f87b87-3407-4f62-851a-6c94345b9772)(content(Whitespace\" \
+         eff902f8-5ddb-4ecd-9234-663dd2f0cfc9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b4d42fb2-116b-4a2c-ae68-95ee5db7b6bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         16f44830-c56b-4ff1-9116-c7a27c3bc1ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2dc7dab-4af8-4197-8ec5-1a716eac705a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ee7bd942-4273-45b9-aa74-525f49dcc790)(content(Whitespace\"\\n\"))))(Tile((id \
+         f316e6a1-f7d1-469b-92ab-c620aecac481)(content(Whitespace\"\\n\"))))(Tile((id \
          736a2f96-8603-4a5a-8d11-2000dffdddc9)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         01bf6a49-d200-43d4-96f5-fd0307adaa22)(content(Whitespace\" \
+         ba6dee8d-ccca-4678-9c4d-359d88ad1fdb)(content(Whitespace\" \
          \"))))(Tile((id \
          e41b5bb9-bab2-4844-9e35-380c93359a33)(label(sum))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7e200c78-1a08-4c80-9b96-0ead84e7cf7e)(content(Whitespace\" \
+         0134468a-84d7-4b72-99ab-1148184c1a39)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7f6c5cb4-49ec-4bc7-8e78-7c1d3fda0c40)(content(Whitespace\" \
+         eac40ab0-8e21-4787-862d-d58abc88aa67)(content(Whitespace\" \
          \"))))(Tile((id \
          9ee2f9cd-d6f0-4d6e-a1ce-768a95d487c8)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -473,7 +497,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a51c8e54-f329-426b-83f8-a50140c2e48b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c4605315-864e-4cf4-a3d2-22ccdf1a0651)(content(Whitespace\" \
+         0ff8248e-4a7f-486e-83a2-a5dbc6c19404)(content(Whitespace\" \
          \"))))(Tile((id \
          fd7c4df4-5d9c-4d0e-9c94-c0af844e5925)(label(int_plus))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -481,52 +505,50 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4f77f133-06aa-491e-9b5b-51c2b8c24dfc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         be15c154-c6b8-493d-9e9a-366a75f12073)(content(Whitespace\" \
+         2a34308d-e5b7-4ddf-834d-705afcacb829)(content(Whitespace\" \
          \"))))(Tile((id \
          21372681-afbc-4f8c-a9b5-65ef3c135ce7)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         70ac8d81-41eb-410c-ad26-1a21c8445a54)(content(Whitespace\" \
+         6750b140-a913-4c20-9ec2-05727a6fb947)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f7a545d2-101e-429a-8e4e-099e18db3f31)(content(Whitespace\"\\n\"))))(Tile((id \
+         5f1f185a-6cb0-4798-bec7-0a732a74d9ea)(content(Whitespace\"\\n\"))))(Tile((id \
          36584c78-f06c-4783-9d59-6ee68227d6ff)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          6e77e978-8261-4269-80c0-a52ac4a6ca02)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         c1a11711-82a2-4643-a731-b8180c15860d)(content(Whitespace\"\\n\"))))(Tile((id \
+         8a35553f-6911-4e9f-b8c7-621b664a925a)(content(Whitespace\"\\n\"))))(Tile((id \
          af4f6d9a-38ff-4777-9ecf-501976fe565b)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          40617e36-01c1-422a-b643-06a8655fc26a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         841ed368-2975-44c4-85a8-4288be389e5c)(content(Whitespace\"\\n\"))))(Tile((id \
+         718610a8-b04b-4f26-9673-a13e7e4e0c1c)(content(Whitespace\"\\n\"))))(Tile((id \
          1c0a49e1-9296-4bae-9cfd-7793257afc7a)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         4cee5c1b-18e9-4f8e-a324-f0886d27dfe2)(content(Whitespace\" \
+         9b6436e3-6b3d-4584-af0c-71d4d588df24)(content(Whitespace\" \
          \"))))(Tile((id \
          a56bc957-d889-43e3-8d91-1f206756e24a)(label(gb))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0ea7cceb-3990-427d-914d-4a4e237e4bb0)(content(Whitespace\" \
+         e744577b-720e-4be6-b3ab-8e6447aa6c96)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6d0e9c86-48dc-4e17-a3e4-8f140dddbd55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dc861b26-8fc8-44db-a644-16be2cf0ac7d)(content(Whitespace\"\\n\"))))(Tile((id \
+         c32b64a8-e9df-48dd-97d2-a95758b45e17)(content(Whitespace\"\\n\"))))(Tile((id \
          8b8d1906-1bac-43d2-9667-7e5350fa78ed)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         13578e90-d40a-4e2d-b270-1c56ed3a2980)(content(Whitespace\" \
+         2bd876ff-a028-4416-ad11-544ed2a76506)(content(Whitespace\" \
          \"))))(Tile((id \
          6665614b-b843-4e72-8c60-8e9c991467d7)(label(scores))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7fb5dd8f-7a6f-42c1-b6c1-bb76dc1f57f2)(content(Whitespace\" \
+         2fdb5755-b7d0-4bf8-ac66-c4129ea28b4a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         559f061c-d6e4-43fb-8564-504f71ab49ca)(content(Whitespace\" \
+         8309fe35-4407-4816-977e-e77cb4251bbd)(content(Whitespace\" \
          \"))))(Tile((id \
          e67402d7-3305-47e7-9bf1-a5816d6175a2)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -537,11 +559,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          beed985f-5fc8-4a80-b60f-b453da3f56ba)(label(gb))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1c498d1a-e5d5-4104-aa83-34707cad2276)(content(Whitespace\"\\n\"))))(Tile((id \
+         68c90c5c-acd7-4dca-924c-158f91aa0753)(content(Whitespace\" \
+         \"))))(Tile((id \
          ec2bd473-1359-48a9-86e1-deef23f07cee)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8beb8f4b-6d4a-48d2-9007-bdb75ea32527)(content(Whitespace\" \
+         d19e2860-5f09-4344-857d-fd424e889f60)(content(Whitespace\" \
          \"))))(Tile((id \
          67a02b5d-d2b3-4b76-a81d-f1276b429438)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -555,19 +578,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          91dd049f-bb40-429d-8ee2-5ab8d5d11e5b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4a0c3e0b-90a3-4e14-a7dc-0616efd326d3)(content(Whitespace\" \
+         8dcddf00-d609-453f-9a15-65ecb6441ca6)(content(Whitespace\" \
          \"))))(Tile((id d68e5581-d228-4f73-bec4-cb0d95a09f90)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         26e0c14b-0609-4129-a19d-f7a94013ddd8)(content(Whitespace\" \
+         81bfddd4-3cdb-44a9-bd29-a584abc19dd4)(content(Whitespace\" \
          \"))))(Tile((id \
          cc1d8554-11de-421a-aff6-cfc278550a6d)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         15e0be7d-ec23-49c3-af06-4c2ad8a399c2)(content(Whitespace\" \
+         67b7d8a4-07a9-4de1-97b3-61f3be29ad05)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a297ad51-dfbc-474e-b519-a6963745a27d)(content(Whitespace\" \
+         888680f7-a156-4bfa-8bfb-e55dacd69130)(content(Whitespace\" \
          \"))))(Tile((id \
          19d90e31-7700-413e-a157-52be9d580342)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -580,7 +603,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          0134ac4a-30fd-4bb7-a425-ea58b2a33907)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         26ddba86-d4ce-464b-952a-20fb08600a74)(content(Whitespace\" \
+         \"))))(Tile((id \
          72da01cf-44b8-46dc-aae9-bc73c64e4d9c)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -590,13 +615,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          425e90cb-422b-412c-993e-78315f5539a0)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e7719663-f053-4f6b-ba99-2cb0b87f3fd2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         10bd37d7-d38d-4f5a-bb7d-0ca766a0d4b5)(content(Whitespace\"\\n\"))))(Tile((id \
+         2436f728-69af-47e6-b1b4-d3ad382111ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          26465a77-0dcd-4752-91ee-21e577332653)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         08591994-83bd-4084-ab40-47e43e994e7b)(content(Whitespace\" \
+         4f340530-d13d-4c13-8655-e4c26dad3f8b)(content(Whitespace\" \
          \"))))(Tile((id \
          dc490281-9457-4dc6-b952-4e7963e68be6)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -610,19 +634,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          36637167-22ce-4450-a882-3b2168a56ce7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1bb608a1-82c2-4eaa-a6e2-1edccac0a6c5)(content(Whitespace\" \
+         d3c3b157-6d1c-4c67-8df8-be1a7d3b8ae7)(content(Whitespace\" \
          \"))))(Tile((id a96c55d3-dbf7-4291-bb35-0895f08e595b)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         48cea8c8-9352-480f-9afa-c9560d951aa8)(content(Whitespace\" \
+         2ad64fbb-6b52-40ea-b581-e0c6f1f9b3f7)(content(Whitespace\" \
          \"))))(Tile((id \
          cea24ea3-f10a-490c-bb64-bb6c1e0cbada)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         758f9b07-b3dc-476d-a816-86d0f784f2d3)(content(Whitespace\" \
+         703f766e-e1d0-4d07-822e-c1b643d2d4c9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         919400e5-5b64-42fb-b893-05593571a4a2)(content(Whitespace\" \
+         cad0fc0c-41c3-45b4-aca4-32e1fdf046d3)(content(Whitespace\" \
          \"))))(Tile((id \
          54dbded3-02d9-4d4f-b6cd-337df5717a0b)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -633,31 +657,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          56fd1583-7953-4cde-b3c1-60c88e1cdf18)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1139a8b9-80fb-4b75-ac21-42905cd38e0a)(content(Whitespace\" \
+         3d05d25f-12f7-4a6c-8692-ab16cb522432)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6d250141-851e-4abc-b5c4-38cacb8cd148)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c89f6bc5-1b88-4ab1-b2a2-9e39a5926cd5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         aa82b235-ecab-42ce-ae35-af82abba66f9)(content(Whitespace\"\\n\"))))(Tile((id \
+         4619abf2-cdb7-41bd-8aba-de1524f5d987)(content(Whitespace\"\\n\"))))(Tile((id \
          defabe6a-246a-4d0c-a313-706d03ab9f95)(label(gb))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c2d60117-2c83-40d2-aba3-4498fbf7db64)(content(Whitespace\" \
+         aa812fa1-6162-42dc-abe3-0aebc6263a9f)(content(Whitespace\" \
          \"))))(Tile((id \
          18fb4178-0047-4064-9698-6601832b9036)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         14dc9d50-2cf8-4da1-91a4-524cccda2e23)(content(Whitespace\" \
+         72f9114b-a87d-4a0f-953e-a086de5104e5)(content(Whitespace\" \
          \"))))(Tile((id \
          403ab82e-6ecc-4833-8a2b-96dd321be210)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          3c246f3b-ea18-4bd4-ad9c-bc28433415ea)(label(average_score))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         218e7499-3e8e-4f94-b421-c22b0236530d)(content(Whitespace\" \
+         \"))))(Tile((id \
          06db1895-f65c-4551-96f9-95f8052e5bde)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a755e57e-229a-48a1-944c-a08ca276a475)(content(Whitespace\" \
+         \"))))(Tile((id \
          2a11e96a-9647-445c-b2eb-1488a85912c2)(label(float_of_int))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -673,12 +698,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          93d54011-0449-4196-b3ea-5d2f9ab078ca)(label(scores))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e3599aae-3faf-4cb8-afc5-b31b8b1346b5)(content(Whitespace\" \
+         c3de70ad-ff7d-4fbb-8ca0-e7f141bc453b)(content(Whitespace\" \
          \"))))(Tile((id \
          07723ee8-a156-4918-b342-4e295e79cd58)(label(/.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b8b13a13-6145-48de-ae60-39a56ecc6a9f)(content(Whitespace\" \
+         99cc6e69-b2d1-42a1-b567-8622f8754687)(content(Whitespace\" \
          \"))))(Tile((id \
          54061136-a22f-4a97-a2f2-4be6a0833c3c)(label(float_of_int))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -695,25 +720,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6d1e7b5f-b6c1-4237-8bdd-be993dcf0f5d)(label(scores))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         29063523-c587-4c7b-bf98-4e7a452600c0)(content(Whitespace\"\\n\"))))))))))";
+         a0ffade2-1e72-40d5-9f8d-c2cc2fded0cd)(content(Whitespace\"\\n\"))))))))))";
       backup_text =
-        "type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+        "type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = [\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-         (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
+         (\"Eve\", 13, 7, 9, 84, 8, 8, 77)\n\
          ] in\n\
-         let ^^probe(quiz_col_names) = range(1,5) |> map(_, fun i -> \"quiz\" \
-         ++ string_of_int(i)) in   \n\
+         let ^^probe(quiz_col_names) = range(1, 5) |> map(_, fun i -> \"quiz\" \
+         ++ string_of_int(i)) in\n\
          let sum = fold_left(_, int_plus, 0) in\n\
          map(\n\
          gradebook,\n\
-         fun gb -> \n\
-         let scores = to_lvs(gb)\n\
-         |> filter(_, fun e -> mem(quiz_col_names,e.label)) \n\
-         |> map(_, fun e -> e.value) in \n\n\
-         gb ... (average_score=float_of_int(sum(scores)) /. \
+         fun gb ->\n\
+         let scores = to_lvs(gb) |> filter(_, fun e -> mem(quiz_col_names, \
+         e.label)) |> map(_, fun e -> e.value) in\n\
+         gb ... (average_score = float_of_int(sum(scores)) /. \
          float_of_int(length(scores)))\n\
          )";
       refractors =

--- a/src/b2t2/slides/table_api/B2T2TableAPIAccessSubcomponents.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIAccessSubcomponents.ml
@@ -2,1897 +2,1785 @@ let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Access Subcomponents",
     {
       segment =
-        "((Tile((id 78977ef5-26ca-4aed-a6a9-9571d870d67f)(label(type = \
+        "((Tile((id 961be809-d850-4cf4-86f7-84986624c67a)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         f868ad42-0336-4cca-a8b9-42abf96e4881)(content(Whitespace\" \
+         c91a5c8c-4e4a-4dc9-99dd-d74a246ad333)(content(Whitespace\" \
          \"))))(Tile((id \
-         4657b4cf-7fca-49bb-b17e-4d458ed37157)(label(Student))(mold((out \
+         990f2301-31e7-4dda-a0b4-9b1f46453aa4)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         d96da5d2-d3de-47c5-9710-286da6d59d16)(content(Whitespace\" \
+         29eb824b-0c66-481d-ad6f-d63d16e3b64b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         256931ae-fe74-4100-9017-96f9afbda0d1)(content(Whitespace\" \
+         60ea6e5c-3a1b-412a-b66e-74167f7fe0e5)(content(Whitespace\" \
          \"))))(Tile((id \
-         cfb3000f-3aa4-4ff3-b51e-7d748a6a074d)(label(\"(\"\")\"))(mold((out \
+         81fc9865-3ef1-4d71-8cb5-816c332feaf2)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         b41bb61d-bbbb-41e8-8a39-301f3eb5f1ac)(label(name))(mold((out \
+         ef78c201-4a20-476b-985f-0088acb30e5a)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         db29f1da-25a3-4cd2-956e-43d06fdfcb00)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9b35dc6b-a823-4813-ad6c-01d3322274e8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a031a929-7d1f-4475-bb34-b2044451957b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6298de94-1542-47fa-8ebe-4386b96d29d3)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f09351c6-5cdb-4ee2-b3e5-096d89ad3b03)(content(Whitespace\" \
+         \"))))(Tile((id \
+         80bf6053-134e-447f-9947-b105781c667d)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         ab041a7a-8970-40de-94e1-33f163ac6db4)(label(,))(mold((out \
+         a2a36b15-cb5f-440e-a882-444854f9f686)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e66388e0-a45d-4b9e-98b6-aa4281295247)(content(Whitespace\" \
+         9c7c0374-4c9e-4242-b628-46306992ed38)(content(Whitespace\" \
          \"))))(Tile((id \
-         158be4c3-bc2b-44a4-8f30-d40e0c5a4608)(label(age))(mold((out \
+         fd76b8e2-03c2-41f3-bda9-0b3607085869)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         ce3fd35c-89f5-489e-a805-1ff6af3fb21e)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b5d2f031-0809-471d-8adc-38176567f645)(content(Whitespace\" \
+         \"))))(Tile((id \
+         faf80246-81ff-4ab9-9b28-416eb31a54d6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         143efedf-faf3-4c24-8629-8a0032c3c309)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         680db57a-cfd2-4ef8-bea7-0e9d4fc8b4a6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f5e232bf-5e42-4367-aa1d-cf1fb3eb326a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         53ab6122-57fb-44b1-a36d-7ecc7e590830)(label(,))(mold((out \
+         cf18f08e-1ddd-40a0-b985-ecb3c9fec958)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         142f5e1b-5904-426e-8ea7-7649e6b01731)(content(Whitespace\" \
+         402deb76-6bc4-4448-87a2-b660c80f172c)(content(Whitespace\" \
          \"))))(Tile((id \
-         74157bdf-147b-47e8-b618-7354612a5274)(label(favorite_color))(mold((out \
+         f37fea5a-1ced-44cb-8384-bc9a9ac8f9e8)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         f1c03924-b666-450d-96bd-e90cd8c532be)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         248abec5-49f0-4fba-8dc8-8bd0db33503f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5a4042b9-a9ca-4e4b-9b14-643e5faf8f70)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         bda27e8e-4436-4074-8ed6-bddcbb1c8a07)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ea5761aa-d08a-4f69-bd5c-641807329487)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4ca79aeb-55f9-42ee-b215-513cf929de34)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         ad1032d0-d517-4905-bbf7-211474fc9ba6)(content(Whitespace\" \
+         558a41c2-bb87-46be-862c-af336e24cf4a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c4b7e397-de15-4205-8cf5-a07bca5e3a35)(content(Whitespace\"\\n\"))))(Tile((id \
-         99b9ecd6-c829-49a1-a43c-fad8758440ec)(label(let = in))(mold((out \
+         ac8af5e7-a2dd-4a4c-9b96-3cb8b701fdf5)(content(Whitespace\"\\n\"))))(Tile((id \
+         8ed19577-6133-4e95-9cd8-f0cf7fa07ed6)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3ae8514e-bb13-4faf-9e33-f454cfe60bbf)(content(Whitespace\" \
+         e6765111-62ee-418c-a33e-6228e1dca5f9)(content(Whitespace\" \
          \"))))(Tile((id \
-         f76054f0-1844-4028-96cb-ca4874d10f1b)(label(students))(mold((out \
+         43145e36-afc6-4743-ba2e-9365d41a575c)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ac977198-61ab-4e17-93ea-5f16103f75cc)(content(Whitespace\" \
+         3fa7a737-0a37-44b5-a339-a833e641a6f7)(content(Whitespace\" \
          \"))))(Tile((id \
-         a931221c-8077-4e70-82be-272eb7ea025a)(label(:))(mold((out \
+         3b040fd1-0842-44c1-b7fe-95a81c6c262b)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d377b361-23a5-460f-94ae-30c26d520605)(content(Whitespace\" \
-         \"))))(Tile((id 2a676c12-27a1-4b43-b703-fab546adf4ce)(label([ \
+         6f779584-3313-4c9d-9681-8b83111c9b1b)(content(Whitespace\" \
+         \"))))(Tile((id c69ad0a9-618c-405f-8d1e-cbe25cdd21b6)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         1a695b9e-8d23-4d24-baad-b9eca54fc68c)(label(Student))(mold((out \
+         69601ca9-1a69-4526-b699-c59121f5cc39)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         21e65a42-370a-4197-9f13-8f4a236d0f2d)(content(Whitespace\" \
+         85665c74-e6f4-4fd8-81ae-276c8c2cf343)(content(Whitespace\" \
          \")))))((Secondary((id \
-         41fdabcf-d3bc-4294-8788-f154a5cfb263)(content(Whitespace\" \
+         0009c2c8-e4e8-403e-bd3c-b04d2b7aa5c8)(content(Whitespace\" \
          \"))))(Tile((id \
-         a7179c76-464d-479a-9a04-58ffbb9c6417)(label(\"(\"\")\"))(mold((out \
+         b74ba7b8-275c-4725-adcd-033b038e01e7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         089094bc-9ece-470d-a4ca-6e2bd4c59ac4)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         56dad55b-cd73-42a5-ba19-4d851f73ca49)(content(Whitespace\"\\n\"))))(Secondary((id \
-         717f30ae-cea7-43db-99ad-a87c0d36880e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         24346c90-e311-4f9a-a54f-3c82a53b3774)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5eeaa0fe-47e1-44a6-9852-aff05342d681)(label(\"(\"\")\"))(mold((out \
+         9318fdb4-c902-4c06-9421-6f3addf789df)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e359c15c-1168-457d-92eb-b61e5497f527)(label(\"\\\"Bob\\\"\"))(mold((out \
+         6ca734a0-0535-4b78-9338-0dcf63f9ac59)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         631fbad1-7170-4acc-9bc9-8004960ba3ae)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c8871745-c040-4830-bee4-c3ac1dc03b80)(label(,))(mold((out \
+         384c18a9-2a1b-488b-9426-fe73ce02e577)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb78a7ea-f0cc-4ca8-bca9-8113d9d986f5)(content(Whitespace\" \
+         eae797f6-727d-4a31-a214-94270b18c1cb)(content(Whitespace\" \
          \"))))(Tile((id \
-         32eafaeb-3bea-4845-acad-b8084d4787bd)(label(12))(mold((out \
+         1c45d597-802e-482a-8281-6deed410a908)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         9612ea58-eb3f-49a4-9cfc-610f29354123)(label(,))(mold((out \
+         a94252cb-9a47-4657-989d-31876db123d2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4065c752-7862-4eb2-8ca1-61b2d78e95bc)(content(Whitespace\" \
+         c47bbebd-f4ee-4261-9693-1dde4e40674d)(content(Whitespace\" \
          \"))))(Tile((id \
-         fead893f-7984-4786-906e-6b69e41743b8)(label(\"\\\"blue\\\"\"))(mold((out \
+         ada693f5-495e-4d2a-a92c-21a9cf290983)(label(\"\\\"blue\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         baccc012-8fd4-49db-9141-0ce4d0663fec)(label(,))(mold((out \
+         0eabf77c-6057-49c6-aeb9-df0bea105cb8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bdfc1d64-fd45-4791-92cb-4fd7c3223dca)(content(Whitespace\"\\n\"))))(Secondary((id \
-         34c12a01-5186-430c-88c8-f7d33fc0c9d7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         705934e1-c102-4388-a0b0-c61e82992206)(content(Whitespace\" \
+         68d956a6-1ecc-4803-a8d9-54fb64b38206)(content(Whitespace\" \
          \"))))(Tile((id \
-         fe84c0ee-2ad3-48ea-b9ec-1220de904721)(label(\"(\"\")\"))(mold((out \
+         e50569e2-3215-4219-8e96-5d42de1245c7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         ce73cb93-47a1-42e7-bf5c-bfd00a66e88d)(label(\"\\\"Alice\\\"\"))(mold((out \
+         78adbb1d-1492-409e-941c-db05bc48227c)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         978ba3be-6fc9-4101-9827-c060516d8e69)(label(,))(mold((out \
+         00691a3c-ced2-41f0-a06f-fb18eabf9a97)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8cd98350-cb9c-45ee-af95-bb12e7f1de0d)(content(Whitespace\" \
+         875e991d-8910-4949-ab70-e0a183f33bc2)(content(Whitespace\" \
          \"))))(Tile((id \
-         a25d56b2-9ee5-48fb-a71a-cae39960b016)(label(17))(mold((out \
+         b9ec3d84-fda5-42d0-a914-5b521b835ad0)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c2c3c051-8588-4045-a960-3a134ac5e831)(label(,))(mold((out \
+         11e946c1-aae9-421a-ab79-5685d82e379d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         070ceb48-50ac-4bd1-9845-2600d515fb3b)(content(Whitespace\" \
+         8f29e5e8-0dda-4a19-8bfb-6c46488b6cc0)(content(Whitespace\" \
          \"))))(Tile((id \
-         f0fe076f-af97-48f0-8992-d7bd2c4c0aa2)(label(\"\\\"green\\\"\"))(mold((out \
+         d4a56159-4953-4632-b631-ae919854fb1d)(label(\"\\\"green\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         100d4b51-7991-4679-845f-200552eafdaa)(label(,))(mold((out \
+         d74e332e-c785-4a60-9950-cb73dc1db5e0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1847da66-bd1b-4d0d-8fe5-8c3798e8e44f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0fe0cd4a-7ac5-4eae-8ff1-9ea2784f406e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7286a982-a0f1-4ef4-bd7c-0a9d19e8abfa)(content(Whitespace\" \
+         be817032-c6a5-47cc-903d-2fe973d5a4a1)(content(Whitespace\" \
          \"))))(Tile((id \
-         eb40fde9-c1bd-4fb7-9556-9f59e23f9f5a)(label(\"(\"\")\"))(mold((out \
+         c412eb5e-23ff-4cc3-9e0d-f7723f0a75ea)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         ee26cf70-f9ae-453e-b25c-1fdddcc916f1)(label(\"\\\"Eve\\\"\"))(mold((out \
+         de8841b7-d660-4367-869f-0c80eb50df5b)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d8eece04-cad7-47de-9ca3-99b5ca4b992f)(label(,))(mold((out \
+         2d240f57-0469-4afb-b51d-93706e93797c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d981e76e-1289-43f6-b4c7-a54aa0af24d6)(content(Whitespace\" \
+         626ee912-62f7-458f-9b23-6c9e41737726)(content(Whitespace\" \
          \"))))(Tile((id \
-         77bf08c0-43f0-4f83-ab7b-8ee66074dc6b)(label(13))(mold((out \
+         ba98cf13-8bc9-42c2-bfd3-c8c869a34e12)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         2eb6d4d1-4791-46ab-9a52-b6d0945a4af1)(label(,))(mold((out \
+         54bc8f7c-7ddd-4d6b-a077-8a637942805e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4c15011d-a87a-4327-8e87-0b121ed90a4b)(content(Whitespace\" \
+         321ed7aa-8022-49a1-8e33-d17a17115536)(content(Whitespace\" \
          \"))))(Tile((id \
-         1d033b3b-8570-4e68-8dcc-10ac39cfcbb3)(label(\"\\\"red\\\"\"))(mold((out \
+         f36b291c-ef49-495f-b18a-f0b68223a45f)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e828e279-1ecc-4c19-8f59-f4275c1cfddd)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         c7f2786f-08f6-470f-bdd2-c958bbc7db1f)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         523a18a8-301c-4bfd-acc5-fc6f70ac7324)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         334e3e0e-e5b1-415d-847d-15f2128313f7)(content(Whitespace\"\\n\"))))(Tile((id \
-         aa4e6866-106b-4c0c-ac31-5595a8e8cbcb)(label(let = in))(mold((out \
+         ef11ba2c-f9a2-43a2-a1c0-261b54bcf2e5)(content(Whitespace\"\\n\"))))(Tile((id \
+         9033b735-e398-4d46-b971-5e238203092e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         0c6d99de-102f-4eca-aacc-ac2ee942c476)(content(Whitespace\" \
+         eb49b6b2-243f-488e-a39c-2ba5bb11d1df)(content(Whitespace\" \
          \"))))(Tile((id \
-         6f805078-7d8b-4e07-a4a5-3edee9dfdbbc)(label(get_row))(mold((out \
+         a2994831-25c5-4c00-bd0d-40573740e45d)(label(get_row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         de350b31-8b56-4418-bbf0-cf16bb5f1d35)(content(Whitespace\" \
+         7c199bb8-3cb2-4d9b-a97e-e00d3a0d51be)(content(Whitespace\" \
          \")))))((Secondary((id \
-         feba3d51-f668-4cbe-862d-86d6f0370f68)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ef33031b-6ca3-4752-a10f-ab46027ca177)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9914dba5-71f5-4548-ba21-ea74ca7f6990)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b6fd2cb3-b35f-4779-832e-f5b90ec581e8)(content(Whitespace\" \
-         \"))))(Tile((id afe9c08e-a9e2-47e5-933b-6ec9ce26a718)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         583c0cd7-93c6-4a5a-b50e-fd1586f0ac2c)(content(Whitespace\" \
+         54fc68ae-d3ca-43a8-877c-870b72b43cfd)(content(Whitespace\"\\n\"))))(Tile((id \
+         2adea8df-95de-473b-9b36-1a4bb57ebbe5)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         8fffbb7e-2d50-41f7-a9df-e13e0cf93e39)(content(Whitespace\" \
          \"))))(Tile((id \
-         439cba07-5a3b-4711-a043-b71076bf012b)(label(requires))(mold((out \
+         159491b8-e2a3-4360-8ce5-4e242c122292)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         bd4dc33f-d94b-4ee6-86ba-b6d899ed49e1)(content(Whitespace\" \
+         18141eaf-19ee-4bd0-8984-7ef49faf45c5)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5d1a1c2e-1833-45b0-9bce-865ba0ae9d1f)(content(Whitespace\" \
-         \"))))(Tile((id 132f0a31-a97a-40d1-9bcb-15ebc47020dc)(label([ \
+         30371d0f-9809-47bb-8131-f2f189bd614b)(content(Whitespace\" \
+         \"))))(Tile((id f11f8648-4d88-4e75-9f75-6a20b35009da)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         dcdf5607-526e-46e2-ba6f-f6d3c7ed9c54)(label(\"(\"\")\"))(mold((out \
+         a22c73d3-54c9-4f00-abda-ad388e24f116)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         be0f84a7-445e-4369-97db-6894d3d25a1b)(label(enforced))(mold((out \
+         6b5a225d-8883-48ee-9422-92c67bca159a)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         35a255f4-d4ae-4da8-9bf4-d7d31043d4de)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         07de4244-60aa-4adb-b563-a8071e5baf4d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         072797a2-dbe3-48a4-82fd-d20c3b80a448)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         4f913281-cac2-4d9f-a040-aac626bf9e5f)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bd3675ab-f3fe-438a-8979-f130feb54383)(content(Whitespace\" \
+         \"))))(Tile((id \
+         54f67011-f840-4f9a-b5da-424d619c60f7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         9d6be4f3-6a0b-4e83-b491-a2613ab75d8a)(label(false))(mold((out \
+         e2697e2a-edd9-4f95-bc49-3e19b15d4d52)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         9d98f749-ef3e-47ab-a701-d6cc81883e3e)(label(,))(mold((out \
+         9bf334f4-287c-4487-91de-6af70382ed30)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9ed7af71-2eee-440f-b087-d8488484f3a7)(content(Whitespace\" \
-         \"))))(Tile((id adee9652-a541-4a0a-b61d-84652ca3be07)(label(\"\\\"n \
+         c9969b29-4c1f-43c8-90e9-c96ec7318fea)(content(Whitespace\" \
+         \"))))(Tile((id 75239be0-9f79-4900-b81d-68404aa20002)(label(\"\\\"n \
          is in range(nrows(t))\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         0b410652-5c42-421c-9243-eb9ac1a14531)(content(Whitespace\" \
+         07099e79-2f85-4a14-b4e0-e2fe2b20acb0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3489e623-972e-491f-ac0d-298c8efe26d9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bd172759-eb4d-4b03-80b5-8dad8335700e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         328cdd9c-9f34-4e53-9b84-522f6ce5a13a)(content(Whitespace\" \
-         \"))))(Tile((id 06085a84-52c7-4020-93e9-4b94283cd934)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         4df03a93-0176-4033-bc49-3983a25060cf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         42153c49-046c-4ad8-9b90-9e5c0d5d6aa7)(label(ensures))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         61dc3236-3ce4-49b7-9e11-47abc9ffaaa8)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         27d6e722-2640-426a-b3ab-40a875e4c3cb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         28bf92a5-70ce-495a-a59d-5f65f4806aa5)(label([]))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         28bb7b7a-6280-478d-9775-2b98f81346da)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b0735360-c755-43e3-bbf0-e71db85ff35b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f274dcf6-7170-4a21-a42a-6bdb4e3d5eb6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6b080f4d-1dc5-49f4-85d9-f36909a463a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de6322b5-c2bf-4a69-ae43-bfa9cc271074)(content(Comment\"# Tables are \
-         just lists so nth is just list nth #\"))))(Secondary((id \
-         9f6a5c2b-9619-4349-8cf0-ace2d94f2dfb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c7c71ae4-c757-41b2-ac84-b815c404bc91)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c49b5c14-5754-451b-9343-40f11cc13cbd)(content(Whitespace\" \
-         \"))))(Tile((id 928b0ec3-df95-4427-8232-9735f2d72054)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         431b604d-8c21-4ca0-a1ae-a897a3dc246d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8514837c-cb8f-4d3b-a16d-44d20ca0ebac)(label(get_row))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         99413323-3dbd-46dd-9e83-fcf4408209f0)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         e832714d-ad75-4a80-867c-d4f764cdd4ba)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8c9b2c41-d105-49e4-af93-cd389fc6370b)(label(nth_opt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         1b5325f8-b8ed-40cf-a8e7-503f4a161592)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         685b4467-43ea-4ffd-b1e8-9bf1a1f99ef7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0f76979d-0036-4a2c-baf8-84b0f0f3c15a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2a013681-78c6-4df0-aa8c-92b4ba3f1934)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b010600e-4369-4c93-b9a5-0ffb0e85ae10)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c0b55fbe-6bd6-40b7-ab83-bc5aed42127e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6c9bf7d0-942b-4599-8c2c-73733b8559b2)(content(Whitespace\" \
-         \"))))(Tile((id 762b88f4-7d1e-473e-a3bc-60ebfb3496f7)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         e07fdf13-ac99-4ddf-a9a2-699b8d861b56)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2fccdc71-431a-4a72-947b-69b918b45b23)(label(get_row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         05b9695a-5122-408d-999f-eb44e835aee1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6af7879c-2214-48a1-bdd3-bd43f3c75999)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         b9fe606f-bd3f-4943-914c-f0356608c87a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         695d3413-2359-4f68-af9f-02488d5c827d)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b0d720ab-9186-4fb6-b1a5-005c1d75e473)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         b721c552-558c-46ad-8123-ab39939e32f3)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         68a6f6b1-45df-4017-b683-632fc9a727fe)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         24e14c7f-72ee-48dd-b062-9fc552394cad)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cd12fe65-a29e-47c5-bcc7-a5b2095844be)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ef7d89e2-bb65-4bd2-8c65-ae3766f529af)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9a7154c7-5fc4-4885-905e-ba1470b952d5)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Tile((id \
-         ce631b82-9a81-48c6-95ec-cc6211b616fd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f208e413-ae9b-4c6d-8b08-8206e8273197)(content(Whitespace\" \
-         \"))))(Tile((id \
-         280ab37d-cd5d-4d8c-b04d-b931cf28528f)(label(0))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         98fe05bc-2025-40f1-80d6-805edd6cfbd6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bc18cc35-c73d-4ff8-9cd3-1642540c2338)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         85c72454-a6aa-4f03-a375-c49ea4b446a2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8740e05f-3708-4c56-a2b3-5a01f1809247)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         27997ff7-e65b-4cf4-b5e2-7fafdfbaae17)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         96d90e68-1306-4ed9-930a-f1e00fb8dfa1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         1455c937-1e4e-4100-a8ff-47330c33ab6a)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0b14c64a-d2a6-44dd-82c3-49b7a8445db9)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         4a502e60-26b3-4149-ad65-0cc282b72f35)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         48c3ffd5-4712-452d-b57f-77abe1c68e14)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         55848836-f204-4388-b1c8-14e53ba51f61)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3bad74b2-920c-4a1b-bd2e-cc22580037c0)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         10284c72-10ec-47f8-8fff-c979dbd7e86b)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9258cf88-0d78-4e2a-bd44-e60ed6bd4f20)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         3513cab0-2228-490e-8cce-bd394111c4d6)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         2b6c84de-1c1e-486c-8c2f-1b8213bf36de)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ce8cad22-ef16-44c7-b59b-13dec6feaa58)(content(Whitespace\"\\n\"))))(Tile((id \
-         f0e39817-e6a2-4f46-82e3-16f2868023aa)(label(let = in))(mold((out \
+         b85426cf-ada6-4eb0-8606-cc161509f8a5)(content(Whitespace\"\\n\"))))(Tile((id \
+         09e6c312-f4b9-4d92-90e6-a1a293425f70)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         65d7bed0-73fc-46b5-87a7-cc2444bd052e)(content(Whitespace\" \
+         6ac35b39-4772-49c6-a736-69f4f334a868)(content(Whitespace\" \
          \"))))(Tile((id \
-         d41c7f35-bfb5-46f6-aaf4-d3cf495d0173)(label(get_value))(mold((out \
+         32cf7838-3925-46fc-a687-8d089c7d412f)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2573e9d7-47ae-4931-9150-f0c9ff170aba)(content(Whitespace\" \
+         f9481d34-54fd-4033-854d-c0894560975d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         bb0b0171-8d46-471a-bba8-600a2aced436)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c23375b-7d29-4726-ab74-c70875fa752a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5d7357a2-5c71-4562-9a7e-f9d0b1d288cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         197c2b7c-fb27-4c8c-a822-bc0fbf5c93b9)(content(Whitespace\" \
-         \"))))(Tile((id 08ce3381-2519-41af-b501-9bd59b8098a2)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d34388f4-3893-4be8-ad7b-8dd6c70ed519)(content(Whitespace\" \
+         87947222-dc15-4f19-99c3-8154c0c4d91a)(content(Whitespace\" \
          \"))))(Tile((id \
-         71b022e2-2999-4328-8407-26fe191630ac)(label(requires))(mold((out \
+         842dd7af-7c14-4f62-8b4b-47a2a8124cbc)(label([]))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d5e2f37c-16a9-4236-9b61-ef0749cad9d1)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3b9b55b5-541f-40b7-bb9d-9525648d27dd)(content(Whitespace\"\\n\"))))(Secondary((id \
+         016b4036-3305-4837-b801-bd4069ef99d9)(content(Comment\"# Tables are \
+         just lists so nth is just list nth #\"))))(Secondary((id \
+         ac0add7d-9815-4b17-ab02-13bd7d6a030f)(content(Whitespace\"\\n\"))))(Tile((id \
+         75464bd3-5f4a-445a-9769-9f308f9d7d4d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a004db92-bfc9-4f81-9b45-f7cd502f44e0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1b7ec7c6-bbae-40f6-8b3f-90adc31cfbef)(label(get_row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0a89f8d5-caeb-4ed3-9c02-a26128c6bec3)(content(Whitespace\" \
+         8d7bd9bd-2d3a-4b3b-8e5b-0d5f6adbe600)(content(Whitespace\" \
          \")))))((Secondary((id \
-         70cfaf9c-8123-469d-a505-e30252df3ee8)(content(Whitespace\" \
-         \"))))(Tile((id 6eedddae-d7a1-414e-8b16-26b919a5be27)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d6e9bae7-000d-4da5-a9bd-fc3d8847b1d5)(label(\"(\"\")\"))(mold((out \
+         182478e8-e940-4afe-911e-e81334f562fb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6e8806b8-2984-4d29-bb28-9476e1054fb5)(label(nth_opt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3dad9bd0-2a98-469d-a88a-1293fdbe6925)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d93385f5-5687-4084-b42a-8e2ac61b28ab)(content(Whitespace\"\\n\"))))(Tile((id \
+         d27e8ac2-1aa0-41dc-b758-db661dffac4c)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         6f7e6828-8317-4cfb-b4fd-c78d9b60f403)(label(enforced))(mold((out \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         058e02a1-234c-4dc6-99bc-a0648a52fc9e)(content(Whitespace\"\\n\"))))(Tile((id \
+         9f0db0b3-a2d5-4319-afa2-2a250ff6b8d9)(label(get_row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         2faf9a46-fdc0-4ddc-afc6-d09f6b9bc416)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         17419fbf-0fe3-4b9e-b4c5-7ef8e32a493b)(label(\"(\"\")\"))(mold((out \
+         c787531f-2105-478e-b484-3b5e753e1ea0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         3f5b04d8-a795-4294-87b1-760a9e31b814)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         95933de9-a4ff-4ee1-9e89-ec164a08b238)(label(false))(mold((out \
+         6fc329d5-099b-4879-828a-a75cf4383423)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         68932e8a-9565-4d3d-a492-dab1329fa96f)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         b86707e2-ec8c-41a1-959b-e813bb457fea)(label(,))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7eb2c0b7-d3b5-4f21-8a47-35edc8492f6e)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         0bc95e47-7da5-4c36-8aef-b0f442ce9cad)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         11b86574-625d-4155-ae47-29a1ae34a2c7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         589f01c8-8a59-4985-bc0c-2e2beab09b14)(content(Whitespace\" \
-         \"))))(Tile((id b1688b22-8584-47f4-b0e2-6736c7aaad64)(label(\"\\\"c \
+         e1c02613-9776-4f0b-bfe6-3c24ba961118)(content(Whitespace\" \
+         \"))))(Tile((id \
+         40fd1bbb-5f2a-42b8-a4f5-a5d1532dca2d)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c6a94b9f-1eaf-4b63-97e9-21ca04ea5ac2)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         8c2540b0-4e44-45c6-8ee2-ce4ea457485d)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Tile((id \
+         791f75ff-cd9e-46d0-95b0-68504706a30b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3e52de0f-b364-43ce-8636-a408607b5666)(content(Whitespace\" \
+         \"))))(Tile((id \
+         947e0373-334d-4c71-90cf-88a0f2b01426)(label(0))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         774bf8be-342f-46a3-8c76-076e2fd1af7c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7236ad8b-8add-4fb6-989e-ec7d6f466ee9)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3427c22f-b141-46eb-9a04-a8b175690ca0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b12f7cb5-e9f7-44f1-bfee-568fa782a192)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fdff0dbd-015a-42e4-8fd1-7261e176396e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         637c5486-ccec-47bb-866a-00d308db6f7f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ed844963-6761-40a1-b097-702faabc7a23)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         92f12e6b-e3c8-48c6-9976-20eba6293736)(content(Whitespace\" \
+         \"))))(Tile((id \
+         903240a1-38fd-47ff-8cfe-786125bde6fe)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e15a1cc4-55b2-4ebd-af6f-887bf411b72f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         532a9b8f-e78b-4828-a646-cfad92705510)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5ba22b86-549a-4227-94ee-8c4098caeb9e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f4caeecd-05bd-4aa5-bd08-798e77678e41)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9516df68-8b4e-4c73-af7a-97652fe3f5bb)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2804c0d2-1313-467f-8688-5b2c8649bcec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c06eb4b3-3103-4183-a04f-7f800d9ed1b8)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         785c6818-4ee4-4f84-a441-dfc0bed60f55)(content(Whitespace\" \
+         \"))))(Tile((id \
+         12c08721-6bd4-4ff9-886e-9f584d68e4b7)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         4ac2bbc8-42a4-49a5-935b-540794c10c03)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d5b08723-9e94-400f-8a36-6bed50895228)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         365901a1-1137-4454-854f-da36138a4359)(content(Whitespace\"\\n\"))))(Tile((id \
+         2ca1f1a1-6280-4ee2-8c6b-38e83a33e476)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         d15a50b6-82a7-4c2a-a50e-7bc965ae394b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7cdd810b-4b4a-484d-80ab-9ce1af12d165)(label(get_value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ea394366-23cc-4b8a-972b-1b1f7e599357)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         92b37646-b48f-4980-a5cc-4dad6e1f640c)(content(Whitespace\"\\n\"))))(Tile((id \
+         891a2083-1951-4c21-86ed-e71163d92f26)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         6b90363f-bf97-4fa9-baa2-e7423849afae)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ab27b704-60d7-4eae-bba9-2e25280a1e84)(label(requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         462c79fc-76e8-4fb4-bad0-6c76e35bd27f)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         686d21fa-4c78-41fb-a495-8523c7c10e61)(content(Whitespace\" \
+         \"))))(Tile((id 697e7c15-46a6-4e7f-9550-462a71ab75d3)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         a92d67cb-3ddf-4639-aa81-1b587200b586)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         f32ea5d4-2d91-4762-81cd-7d4714fc54c7)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1f2d9344-9049-49e4-9c93-654af42931c0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         76c1bd67-eb5c-4774-b517-924a41dc66de)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         75fd6ddb-8be0-4af3-a963-752d89a38dc9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         83e37fa8-82fb-44ae-bec5-06b9d53453e2)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a9b59163-0132-484c-bbbe-c5120e1802ab)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         16b13885-72b3-4a34-8bef-a811f917a97a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2ef6ebea-a411-4313-aca9-17f920540fae)(content(Whitespace\" \
+         \"))))(Tile((id 5e47d23f-b7f7-4ff6-b02c-5be6e49290aa)(label(\"\\\"c \
          is in header(r)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b0f93e2f-c654-4641-b983-c371d04ee52d)(content(Whitespace\" \
+         cb7edf2b-d5ad-4278-8698-c4d1bce4bc20)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ef574d37-0760-4c3a-a447-062594eebbf4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         61f2a3bd-7b3d-4fbf-9a38-32e84c3f411b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8471f68-d3ee-4542-a222-90c956092c62)(content(Whitespace\" \
-         \"))))(Tile((id c6d6c1dc-01cd-4feb-93e0-a65c81f9ae61)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         fc8fa36a-7bb9-4661-bce8-6f38fab1d03a)(content(Whitespace\" \
+         c6c1a075-3004-4ba3-8036-15c975aa704a)(content(Whitespace\"\\n\"))))(Tile((id \
+         dd6fbd1b-dbe6-419d-b309-8fd6e665a957)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5c180d00-40a2-4420-910e-e8b0573070dd)(content(Whitespace\" \
          \"))))(Tile((id \
-         5306c7ec-5586-46e1-87c7-8c8643faa157)(label(ensures))(mold((out \
+         642b3749-60b2-42c2-9177-5451b8e9ebe0)(label(ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cbc2b7c0-148c-40d2-8628-baf38299e8d3)(content(Whitespace\" \
+         735d61fb-8daa-4402-b1df-9986258b00c6)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2c1e9a37-11c7-4191-84c1-1275b9bc6d8f)(content(Whitespace\" \
-         \"))))(Tile((id 16511720-8098-4c4c-9058-b00e382eeacf)(label([ \
+         e5443505-69ee-4ef1-b762-6e4d7a844a87)(content(Whitespace\" \
+         \"))))(Tile((id f396e8f7-e13e-44c3-8fb8-a598ce50aab7)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6981d376-aa5b-4a1f-96a5-5e213eb76be0)(label(\"(\"\")\"))(mold((out \
+         60d05d50-d972-46f6-a912-1db5e4e77ea3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         cfa75260-eaa3-4d92-9920-1b4e7f4b7a64)(label(enforced))(mold((out \
+         b2ca12d4-8c27-49eb-bed0-ba09d8915119)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d4c14aea-faa7-4952-bc7a-db8873eec7cc)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1b8f3910-3a98-4bef-b007-cf33aadb09aa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         da71df35-f64d-4bbf-a1c6-fa58baf5b69c)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         afecb437-52e5-45a4-84fd-69f1c721e7e9)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ddf044e5-badc-4d4d-bd25-f47bf15a63a5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         52c0efdb-1ae7-45fe-8849-032428cad8bd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         fdc95407-e644-43bb-b963-af2ea9518625)(label(false))(mold((out \
+         45bae799-06e1-4cd5-9197-2bc721dd7bee)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         e5af8e5b-9cdd-4d28-8aae-31098bada724)(label(,))(mold((out \
+         5748e8ad-a1b4-432a-8f66-e5bc30e08608)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5217e9da-4a55-4cef-afcb-d3278a646a33)(content(Whitespace\" \
-         \"))))(Tile((id 97725a99-96a2-46d3-bf6f-b3c567d2f277)(label(\"\\\"v \
+         ec6fbe05-d133-4c4d-afd1-666e48e8fc27)(content(Whitespace\" \
+         \"))))(Tile((id 935f9716-6bed-466b-af1b-be769648aaa5)(label(\"\\\"v \
          is of sort schema(r)[c]\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         fd02103b-d3a7-4495-8368-6c12a72fdc43)(content(Whitespace\" \
+         9d93642b-1985-4198-9cb3-adefcabf03ad)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         022c53d4-6807-4110-a8e9-794f841bb9fb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0497f364-90ed-4235-b10a-4251d02cd801)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9483357a-8c4b-4809-a09f-ee66ef98068f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         86e8f898-f070-4bf3-984d-eb5986290e0f)(content(Comment\"# This is just \
+         2a2949c2-2dd5-4a46-a430-3998275127b4)(content(Whitespace\"\\n\"))))(Secondary((id \
+         b40de546-3d9d-4978-8273-bef072c7738f)(content(Comment\"# This is just \
          the projection operator `.` If you use it directly you get the \
          requires/ensures constraints #\"))))(Secondary((id \
-         e0807d3d-a805-492e-a6cf-43eae142882e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3b025510-61d0-4fee-b3eb-b8039f40c02c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2d5e37a4-dd1f-41e1-92f4-2d4d1142b027)(content(Whitespace\" \
-         \"))))(Tile((id 04d7af01-385c-4ba6-81f0-620167dfc0a2)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         770d144a-60de-43e5-9c5a-395c8a06a5ee)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6343846e-5a5a-48b7-91fa-bbac0c5e47d4)(label(get_value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         d8d9f2de-0d1f-47cb-8d98-5e786a9a0744)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         a4aaaa88-931f-49f0-b0a4-1bf05a3b25a2)(content(Whitespace\" \
-         \"))))(Tile((id 62863cc7-f3b1-43fb-98ca-f729baa4efbb)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         7b1a021d-115a-4bda-b244-a0496e457a1a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         62c1ae3a-ada8-4aed-a3d2-d27574d4019c)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         58520975-814e-4ff1-bfab-fb26ea2effbd)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         9a5fe821-01e9-41a6-9655-6c31382b73a8)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         cd728205-1faa-4eb5-a614-6f35b4703cec)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         dd9a2718-fc9c-4e80-891e-70864c3183b1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fe40e536-95dc-4576-a9d9-808e361c708f)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         bc2a8ced-7017-4d4d-a488-3b2d206c7d80)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         5b56ac4f-c9d9-4ab4-86c4-95ec1c16b41b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b8a4f3ef-2487-4abc-923c-03d5f7d74462)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e8634b80-37f9-46a9-9409-59572253bc0c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         929ac606-d14a-48c8-8944-8bd756e3181b)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c5c48168-bd9c-4a6e-97df-dc36fc6a1b91)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         5995e52a-3b71-4433-b3de-e5907b95c006)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8de19f11-864d-4ffa-9c5b-472e2cf36a40)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6f2c837b-a850-4b83-a4a0-09c31c6dc538)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         81748a3e-d8be-49ad-84eb-a74fd0a5a785)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4dafa841-2f92-4ba0-a7cf-9c0273703116)(label(find_opt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7028f36c-1c3d-4074-82b9-cb7c0d99e002)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         af7daa7c-60e9-46f5-9c2d-13791312284a)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         67dcf6b8-3982-4ca8-bf30-a9ee9f381c90)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         aefde418-df64-48c7-9701-1eb2db0d0d7d)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         5853f9cb-e122-4523-b9ac-54d39f9434db)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cd8cc403-009f-4e1b-a21d-ca995273acba)(label(label))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         040968e6-bb98-4ec9-9904-2fccbaa125c9)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         0b4d8479-c20e-4231-b405-daf0e547854b)(label(l))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         6052f33f-958b-4ff2-960f-a9fc35c83b8c)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         97c18fac-1130-418c-aa0d-982f07407037)(content(Whitespace\" \
-         \"))))(Tile((id \
-         07a449d2-c78d-4e00-bb7d-c673b278cef4)(label(value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         2306359a-1446-4a07-859d-5fd482fdbb83)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         da3e7e1c-98de-49b1-9079-53f73f03c7d7)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         022ac400-907d-40b7-a9fb-46cfe1a6da1d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         aa0099cc-eedc-4cd1-bc53-c8639660f815)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9edbf34b-bf2d-4f82-9021-d4c2dcdc9344)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         a6603aec-45ec-49d8-b0c7-880d8c97bdac)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ba78bf19-c757-44f7-a512-a34de9df8683)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9c4bc109-f4e6-4094-81a2-90bfdc7c8ad7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         da873a51-0613-4703-a7f6-dd9738838fb5)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b8c2a574-923d-498d-abd6-72424295e007)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f32488eb-cd42-4dc7-9fdf-d3ce48165d59)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1971e951-66b3-44fa-bf00-fb919c157940)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f6fef51e-1af3-4dce-bc72-4244528e908f)(label(option_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0a4f7fab-c68c-4694-8017-eb14720a0f65)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4bc7bc25-0883-48c3-8c15-542ccfc7e38c)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         568c344b-bdb5-4f93-8a44-d9fcaaee2cc0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a3f42759-3bf6-4b4e-924a-7aeca1462a2f)(content(Whitespace\" \
-         \"))))(Tile((id acd46a9c-36e3-4a59-827c-965cc7c516e6)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         fe2853cb-ff8e-469d-942b-5f19f69d434d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5000b073-79d0-4320-8361-a769017b18dc)(label(e))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         919df25c-9c63-49a2-a2f5-83013dc6ee5f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         aa4cd247-72c9-480b-be75-ea7087aee18d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ed22412e-2562-4a36-99f1-f5a35e0ea80f)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f2376078-467f-492d-915b-c345c67d6fa2)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         17fc4040-e6d7-4866-8afe-8d0811147ab4)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3d765bcf-3750-4d2b-8aec-053147cc0697)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0d056ef8-758c-403b-9a69-019e18dc2ee7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5ae1bb52-a869-4aab-9e79-2dec703f8829)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8e4ccd98-77a5-48ee-b623-774b8cbe21e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ad9cc06a-fe82-4534-bcaa-9050b4142e1a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9144c5c4-3413-4d69-a70c-2beb96873350)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ef4ea8ce-8d25-4a34-bb16-b40392007d5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         24404edd-cb78-478f-b04f-09be994f115d)(content(Comment\"# Examples \
-         #\"))))(Secondary((id \
-         da2d5e7f-87c9-40c0-a4ac-dc439c272e75)(content(Whitespace\"\\n\"))))(Secondary((id \
-         698b49a5-fedb-446f-9f10-f44b9f84abef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f150bed-4c4f-415c-a1f3-a4ceba58e2bd)(content(Whitespace\" \
-         \"))))(Tile((id d8106cf1-72bc-4300-bbda-f33c4923fe92)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         be86968d-f918-4a29-8176-af14b866121f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8d3ba283-8c51-4293-9149-5a8b9df9c955)(label(get_value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5879b5e2-262d-43e5-8f0e-1d451501fcc7)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2a2f83b7-e30d-4603-a4f3-06bfbcefa916)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         a71927ee-6a15-4766-a215-5bcb2f61a449)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e8b010d0-bf58-4019-8dc8-5379a47adaca)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c6b25ee2-eb4d-4c78-960e-b8584a4e9396)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         13a68eb7-1731-447e-a0bf-daf68af0517d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         967ad4cb-cc73-4f3d-8f75-99118160ffc8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         31545367-fa17-4134-9abd-0d99b17e9ab3)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d57499eb-a7d9-497a-ae21-491a489efa75)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7d2bab70-b6be-4871-81df-9d900f03ea4a)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         09d58466-0ac3-4892-861b-6c25fc4a1de9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3cb2fa68-538e-4689-8802-15ba75c21033)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f2e8b64a-cd8a-4734-a27c-463700828649)(label(\"\\\"name\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         80e62f82-1b4d-415d-8663-0a737bd0320d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         745b06f8-df16-4195-b03d-bc14e1821c8a)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         76d7ddfc-c064-45d5-9fb8-5c5a5c6596f9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         44789b8b-88a2-43e1-a3b6-7e87d85dd0ff)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d0396f75-9914-4468-9137-02737bbcb4b1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c14215be-c874-47d5-803b-71059a317c00)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         aa6160b7-c8d1-4580-8091-ead7e0c3e0d4)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         f2e9463c-0710-463d-ae7d-c8828952c336)(label(\";\"))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
-         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5982da0b-6c8b-4b6f-af26-863fe439cfe6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d9c78ab3-a326-4a48-a106-d5275d3772e3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61cb9fbb-c9e6-49a4-ac99-35b77cde41b4)(content(Whitespace\" \
-         \"))))(Tile((id c324d5a8-b341-4287-96ed-01c1c1430569)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f4ebc461-b02b-4789-9790-59e1e303bf3e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e04652c4-695d-440a-8b69-b9fdc27478ca)(label(get_value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2ce7fd23-ca4a-47df-93bf-d3efdbf20f4f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1ae14aa2-da0d-40e2-ad9a-fc87fadba13c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         28a69dbd-e671-4210-9415-35c3405d52ce)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f8380705-59a2-4255-a8e8-c9576de2416f)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         826ddab6-7052-4380-b039-d677da460f76)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b979fbef-a53a-4e31-bd81-69686010a50b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5380bbdc-a37e-4727-bbc7-003d52173574)(content(Whitespace\" \
-         \"))))(Tile((id \
-         416666d4-ac47-44ae-8bd5-516b4710a15b)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         eb72e3e4-2137-423f-b913-ef6c83f803fb)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c6c1adcb-94a8-4950-900a-328f551c5206)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         1819d0bb-5a13-4a04-88fd-bcf43166387f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         02addf63-e7c9-41c9-891a-845ae30a1e15)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c9f3378e-99fd-4da2-91aa-a42e767cb761)(label(\"\\\"age\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         cd880bce-9959-40f5-8fb7-c945842c21d0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         95557a18-c245-4d35-92f6-213a0feb4662)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         75a73dd7-2ef1-4732-bbfd-bd198541403b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0a817cd1-5f50-4bce-997f-e44b0170a74e)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a382e690-f3eb-4b5a-93cc-d6816e84c424)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         88c74eb4-dc91-4279-8120-813f24017b72)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         52e518bb-8f11-4137-9a5a-6d2369cc9e18)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         1b8e4f78-c1a2-4585-b5d2-53565ecfc3fc)(label(\";\"))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
-         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9c4aa1d7-747f-4f3b-9a2e-e473ddb34a9a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7926ad0f-4073-45c5-a40c-4f0dfcc3f506)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         50621f7f-8f16-4611-9960-bac1faa4312a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a4e2e428-ef48-40bc-bc5b-723ef0f4dc47)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cf127272-da2c-480a-947a-862157788a9d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8dec7f1-c3a2-4b3d-81e4-71ef0df0092e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ff74ec11-9383-40c5-b8b3-3fab1bcbf8e4)(content(Comment\"# Using \
-         projection #\"))))(Secondary((id \
-         2d7a6f13-a125-45ea-924b-77b97d373af6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5d060a43-7572-467d-9c81-2483da01fd2f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7438ea1-cf40-4575-9a5c-1703f690755b)(content(Whitespace\" \
-         \"))))(Tile((id 0e4c3fda-292c-4749-a391-14963a0e3402)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         09e98cac-20ba-4326-b8f7-90ee039da293)(content(Whitespace\" \
-         \"))))(Tile((id \
-         00949acc-6ae5-4290-a292-ca7df23f10f9)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         14e1256a-cef4-4209-931f-dea36544f241)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1a10b834-01c9-403e-91f6-6d0d6841d161)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7ea0f55d-b1a8-4143-9a77-a16a03dd7234)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1bba454f-a190-461c-a288-849f0f162362)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b9385954-6a08-4b55-8e22-933237a2086f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         46a054cf-10b3-47d1-abc0-85cb64f53ba6)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0d395f9a-47f6-40e1-88e3-2685a9cd2896)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e5e48888-96ec-467b-98b9-0c0680777e28)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         1c88e995-41ef-47b2-92e3-038adba6d29f)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         33334edb-74c5-406f-bbff-a9161d282f12)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         67ddcbf2-c44c-4064-a8b2-5b4253dd034f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         db74b0cd-753d-45f7-bb14-b9340edf7523)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b1e0cc08-6e5c-496f-8cc2-3e0789b7d3bc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0a48d773-3a2c-4dc3-be48-348fc4724a04)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         8aae7eb7-e885-4640-96a0-a7c8d8bf0241)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         9fdf2441-0f2f-47dc-a1e0-562b4d6da112)(label(\";\"))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
-         35))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         cb3655d6-a989-48ac-9b37-1791cad94a45)(label(?))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         3636de51-185b-407b-9668-6e397a809887)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         1b4846b6-98e3-4a1f-93db-f2519eb71f80)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7e3e34d7-493c-4b3e-94ec-33fb1550e476)(content(Whitespace\"\\n\"))))(Tile((id \
-         3ac12131-1a81-4e5c-ac9a-ec82d07b1ac6)(label(let = in))(mold((out \
+         7189107d-20dd-46d3-b382-fcc882780bda)(content(Whitespace\"\\n\"))))(Tile((id \
+         a1b096e3-cd86-4558-8449-e4bc0d8e524b)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8bdb55de-6093-463d-8c08-f0f16a476bd1)(content(Whitespace\" \
+         22d1f56a-ad80-42ca-ae0f-c9c016bebe0b)(content(Whitespace\" \
          \"))))(Tile((id \
-         5bfcbc0f-cba5-42f0-9c0b-5fc856706b66)(label(get_column1))(mold((out \
+         793c74c6-658b-4966-b565-906d0798eef4)(label(get_value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f23fe8bb-4160-4a99-a884-00e0d7d6520a)(content(Whitespace\" \
+         3cf9e6f8-fb3e-4e18-9bf0-16184b1ac32a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         831b9bc0-0aaa-4f96-9d10-315b08b1a380)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d7df09f-33bd-4f89-831e-f8195deff347)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a6be8a11-0f99-44a8-b15a-1dba592a619f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc0b1031-9abb-4274-ba34-fd528270c264)(content(Whitespace\" \
-         \"))))(Tile((id e3b32116-a995-44ad-908f-8929e75ba8b5)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         48940fe5-e281-46dd-b865-bf525a16e7eb)(content(Whitespace\" \
+         a702ea71-d3ad-4662-bff7-ca7438fd8bd1)(content(Whitespace\" \
+         \"))))(Tile((id 3a686d4b-cf57-4da5-ab89-83f58d0577e1)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         8e478ec4-e93d-4a21-9130-ff12393b6c59)(content(Whitespace\" \
          \"))))(Tile((id \
-         026575bc-4c58-4738-9488-1abe3702fb78)(label(requires))(mold((out \
+         845a5781-eabf-4963-98f7-7af401492930)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         152c218b-48e7-4e77-aa1a-d4b93c13ed2f)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         c93e75b0-ff58-4f26-a36f-0d4434074e42)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         312a386f-1d40-47f2-8f6b-2de68e6da375)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1e8aa924-804f-4e21-a3f5-01f2e250f413)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9bc7fc44-5564-433c-b6ec-47320848200b)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         56e24bfa-265e-45d7-9f20-34e68f723f4e)(content(Whitespace\" \
-         \"))))(Tile((id 74204922-e268-42dd-9750-7d71af5954a1)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         86c8e3cc-ef01-4f25-bc1b-759d01c88036)(label(\"(\"\")\"))(mold((out \
+         50a52569-970f-4e35-93d7-3023dc072d2b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ff829c2f-c4a5-45bb-af5b-e5409cd29a3b)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         aa08a4a0-5579-491f-9347-1637cc0ea093)(content(Whitespace\" \
+         \"))))(Tile((id \
+         edd6f114-0cc5-4dbb-a480-031267e64abd)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         2206f760-ece4-4962-b9dd-6c9f9eae358b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c07cac55-c25b-459d-8c28-e1a34ced42e0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d0ffbb49-24fa-4629-a16b-26779de5c0c8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d989a56a-bb46-4d8a-92c2-afe0030d13c6)(label(enforced))(mold((out \
+         76f1f74e-9feb-466d-b45b-0fcb5415dbea)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         67cea810-33c9-4cc9-aa99-5f0985322498)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         947aff9f-a1ee-45f8-8a67-a9e6ebae5850)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         3ca00363-538d-4453-998c-0a5f9bed4589)(label(false))(mold((out \
+         353e8975-a33d-4947-9819-8eda1ae8b42b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         02731e75-594f-4398-86a8-0fa7cc8c9628)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         86318f5d-5058-4315-a81f-98a317344258)(label(,))(mold((out \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         772f2b8d-82d5-4e61-bee4-9eb139f5e2bb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b17c4920-7796-4093-b13d-02f104bd5ed0)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         30fe12a0-9810-47ce-8e78-a62dcc4c18ed)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2a206c27-7f9e-4b50-ae86-c0c789864075)(label(find_opt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8c894595-78b6-4327-a3d2-71f53e45c9e9)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e471375c-3c12-4a38-8690-a88886789ada)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7847abcd-5579-41e9-ad80-9e7694987ae9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         40b993df-3eac-44da-8490-0633e657010c)(content(Whitespace\" \
-         \"))))(Tile((id 0ddd4dc2-3d88-4130-b959-47844b96930b)(label(\"\\\"n \
+         8d3e468e-b10e-4e53-9122-4d5f9b84b17e)(content(Whitespace\" \
+         \"))))(Tile((id 5052d4c4-960f-4a27-9ec9-fd8a497cb7e7)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         5d1a15ae-46d1-4bd2-877c-4b4c6265d406)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e322b016-e540-4c09-a6a1-02c91efc200e)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6065d272-85be-4f76-b9a2-6f48f00ebb43)(content(Whitespace\" \
+         \"))))(Tile((id \
+         738a4093-a923-4c2e-b01a-e2bb60a071d5)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         4baecd43-b404-4d1b-8a54-66730e2a3b58)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cdad933a-fe6a-4972-a788-522632ce6c11)(label(l))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         812a6dd0-8df5-44d2-9c18-858f0280e441)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         9cefbdb2-a9fe-4e48-a6df-7e8074914b15)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0e2f4b4b-e36d-408e-8508-b5a426bf9a2e)(label(value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         fa0089d2-7af2-439a-88ef-dedf53801deb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         330a547c-523c-492f-b64b-d9c9389907a6)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         41278d72-0a12-4b91-aea3-4b93eb9571df)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5b32afaa-0091-4b9e-9fdf-615b75703d91)(label(_v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         056ef8e8-deb6-4512-aef3-9dbcf49bef53)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         cd5f6ccd-eed7-48c1-85e4-cb6cda5eb319)(content(Whitespace\" \
+         \"))))(Tile((id \
+         770dfbee-bb33-4802-84f5-8b09695e73af)(label(l))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7161f269-c48f-481e-8e3c-bf5d8b8e07da)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3ee357c3-cebf-43ff-828a-b99235a37b83)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         90cef980-fe93-4392-9c36-c7858c03149c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d498413f-8380-47e7-ab95-71cb72fd8883)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         5230c901-b281-45a2-a17f-093b3c52c672)(content(Whitespace\" \
+         \"))))(Tile((id \
+         287510b7-c905-4050-81e2-b8e0eae70442)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6235a93d-077f-409e-920a-b13616576958)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9b408def-b65b-4ae1-9904-e04e46f4880a)(label(option_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a1d30fe5-3f53-41c2-bb8b-1582f6887e82)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         ca231a39-553a-4102-9af9-7cdca2649bfd)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         de43a3a9-18d9-44e8-928b-86837e1bb477)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         06283299-1cb9-43a5-bb14-3e6bc1ac87c0)(content(Whitespace\" \
+         \"))))(Tile((id 25ad5716-4413-4ed3-8e55-3bb074f0bdf4)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         e4247e64-8b81-414f-a834-0f452277a4e9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b1ff63f2-1681-4925-8d2e-d737eb081070)(label(e))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         527aa509-e455-473c-8743-28bf87ee6013)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7a04bee6-8c64-4db1-b324-f31abc69c32a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b4c148fa-1efb-4331-b5b4-e8541dff2a97)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0e4c0d2c-ad2f-4b18-aaa1-ad733b862f34)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         668a7a27-1bbe-4eaf-ba39-2fa92ffa0caf)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         aa9a0d58-afce-4084-8f20-4e360957a166)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d467b4de-b2d5-4fe4-a581-42fe6b52dfef)(content(Whitespace\"\\n\"))))(Secondary((id \
+         f5964e8f-44a9-460f-b942-9e1f2e21ad22)(content(Comment\"# Examples \
+         #\"))))(Secondary((id \
+         35ba9961-7835-4732-9ee2-68abd897b781)(content(Whitespace\"\\n\"))))(Tile((id \
+         5fe452a1-f1aa-4f09-9f33-0685fa3802e7)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         e5749096-1ce8-428a-89ac-cd61a6c354c2)(content(Whitespace\"\\n\"))))(Tile((id \
+         8e7f17fc-9cd4-456a-8813-ecfeadb8bf9a)(label(get_value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         91e15ebd-3bcc-437d-8006-2cf6fed2f9c1)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         cf9f3532-8a02-4b0f-bcfa-34c1a258809f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         86f04245-7ff7-4ea0-ab65-b3aaef6b740c)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8dfcede1-15bf-42a4-b16b-5c0a83f661ea)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         04c45abf-ad9b-422c-973d-852172aec12d)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c17e8ec9-a41c-4bfa-930f-67f48fef9a37)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5830fa85-255d-4b4d-bfd2-7b749b322518)(content(Whitespace\" \
+         \"))))(Tile((id \
+         06c22111-0faf-439b-aa48-65f7a698e443)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         53efc3c9-cb50-445e-a5bb-f71818577fbb)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         3b7811f4-1cf2-4156-97b6-fa4d8574b920)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         9875f6b2-2560-4e08-9a0b-6260013afc68)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         05676b39-8ca9-48d2-96db-74be0d5c36e1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3902ae7d-866a-49e4-8110-08372c683350)(label(\"\\\"name\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         2e9d0f5a-9dc9-4888-a837-f828d5accdf9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a4838673-d588-47af-8b6e-06eb812fd3e3)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1ab23ce4-b349-4706-9736-3f91faa5be51)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5641a679-4c07-4075-bcad-a214231dd3bf)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         312f5345-3a40-420f-bc05-8a89ca2f4567)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         315dcfcf-d6d9-44a4-82da-e853ce50cd80)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         1035ca86-8cfc-4379-819f-05802f31f6e7)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         4158b49d-e7fe-4471-939e-dbe93e84607e)(label(\";\"))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
+         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         703ba13e-d874-47f5-8bf9-3f13bbffa078)(content(Whitespace\"\\n\"))))(Tile((id \
+         679d8045-2a8e-44b0-948b-33b55e400019)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         3cfcac14-4dc5-4ca4-b32f-053ffb302bb6)(content(Whitespace\"\\n\"))))(Tile((id \
+         ca7cb000-f50c-4d83-9993-84e9e4ce0834)(label(get_value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         692df5fd-d614-43ff-8c9f-6e321cf6015d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         3a7c97a1-ce5d-4fa0-b072-77613fe144ec)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         6737c394-2c57-4b87-9fa1-89f8123388ea)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         af953f7a-d17c-4fe0-af23-3a299829e325)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         02892a95-c9f4-4119-8a49-6b5dd591c43b)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b43e3823-080d-4442-a010-6174ddd45077)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         572f56a2-f287-485e-8cf3-78f0a9abc77f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e1499f29-17b0-4d53-9899-3b2bbe517788)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         33dfef54-8564-47b6-813e-bb7b47577e75)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         b2591b5e-cb26-4683-ad40-77f8dcdaa45a)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         c9da0600-fa99-468c-a9e7-73bcec548a78)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6b6e2cb9-a3c6-4ee1-92b8-5972bbec1d81)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e4545083-82c9-430e-a6e4-ea9abd3c0047)(label(\"\\\"age\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         13f07847-0b14-41d8-bd6b-24d73833fc92)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a52a0ab4-c259-4eed-ba8b-bafbe7b067e0)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1443d042-3cad-432e-b24c-c5859d4ab6a2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7e0d968a-23c6-4bb7-bf7f-d32b5bb41455)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a3fb7705-b93e-41a7-b478-99620696c800)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e0be09f8-7aca-466f-978c-ae8eb131b01c)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         e75270b6-61fa-4179-8a6d-378aa9f45d29)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         5ba35d0b-db17-4e72-bc43-3685ac6ea0b6)(label(\";\"))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
+         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d6f59473-5408-4d27-b181-a79e74a8d38d)(content(Whitespace\"\\n\"))))(Secondary((id \
+         2afcc439-79a2-435d-9b50-9240db709e22)(content(Comment\"# Using \
+         projection #\"))))(Secondary((id \
+         084a6c8a-22e5-4f40-977c-000eeaabc4e6)(content(Whitespace\"\\n\"))))(Tile((id \
+         e46a77f6-2b13-4a3b-ae9b-f9dc0ffa1962)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         ebb039e9-b0b7-4463-acd5-a505df583b24)(content(Whitespace\"\\n\"))))(Tile((id \
+         ad046304-e1d5-4fac-9be1-14e1a77f652e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         4e02760e-ad77-4c25-b938-7d6284c1cf30)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         740ef14c-787f-449f-b7d5-9b4c6dcd17ad)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         1adc8ca6-8374-4cb6-a5d4-f7e302802642)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         746724de-5fa7-40a9-9449-3166a5123e2e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         826c310d-1c19-48a8-9382-f278402183da)(content(Whitespace\" \
+         \"))))(Tile((id \
+         65fb64a9-a883-41b4-9dac-79c1c0b92440)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e803686f-49ad-4d6a-99ee-ce5abe54ebe4)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         ad4d902c-b41e-41ab-9768-18a5b9692b2a)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         02f40c0c-6a64-4535-b0a9-a2fc85589f2b)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         d8aa661a-e239-4365-9637-0d091d3670ed)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         62a93b89-d2d3-4398-ba9a-fa3e2041b22f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d29aba30-231a-4493-bcd3-d2a294a2fb69)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3e03c82d-7986-43cf-bdde-e8dc2afc35dc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         41c638c7-0736-4c48-ac0d-b0d4e4e90089)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         0c8dde9b-1ea8-4ff7-a81f-f305f15a82e8)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         9f6a11e7-8aa0-431c-ba49-faa6b9cd8a5e)(label(\";\"))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
+         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b9557122-b756-4ff7-b0fa-8eb4fbef8a85)(content(Whitespace\"\\n\"))))(Tile((id \
+         f0a6d056-ff6d-4dd1-a5c6-f6a89b94c41f)(label(?))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2b3bc34c-10e8-461c-9459-76c7c88ab370)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         fbcd1520-0f3d-4275-817d-c672c6b1ceae)(content(Whitespace\"\\n\"))))(Secondary((id \
+         12a55497-bedb-430b-a28d-4563cef4904a)(content(Whitespace\"\\n\"))))(Tile((id \
+         dcc1edc1-c035-4925-b066-41dd310485fe)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         7b02fec7-c091-437c-a06a-5c2b2493afc2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b101865f-6fbc-4441-a840-1db5cbf3302d)(label(get_column1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         91e461c6-cf62-4720-b12f-050ea6d9ab59)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         d7b8effd-4bb6-4ef2-904d-c45434865f64)(content(Whitespace\"\\n\"))))(Tile((id \
+         70754a19-e926-4669-acda-87444d926895)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         451dbf89-545d-4d9f-bb04-edf8a27515d5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ab0ac795-aa52-45f0-8e05-29a52c7fca6d)(label(requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         140dace5-5e90-40f4-bb08-daa053ad5e4a)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         44962005-f840-4c3e-a860-e852975f735e)(content(Whitespace\" \
+         \"))))(Tile((id 03785ca3-cf4c-43ac-97bf-deae38ff1cef)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         14a7da84-817a-4a9c-83a1-55f3fdcb40c7)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         f7294004-c029-4d7b-a2d2-2ff0d0ea0fed)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         43cb46bc-4779-4ba0-9b05-68ad06b262f5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         17126d4d-1376-4003-8b03-f35f53a69e10)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cef59513-1748-4e03-afaf-bc15750dfeaf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8a59eb4d-a90d-410d-82aa-1bd7dabc4099)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         7fd910cc-d26e-4f8b-b685-4b684aaec541)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         3eed06ed-f134-4301-a6f2-75650a25e302)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fa80b382-1ec0-43d4-a0ae-8b99b336ce93)(content(Whitespace\" \
+         \"))))(Tile((id 644877b0-6310-46b5-b246-2f67b2c3ce99)(label(\"\\\"n \
          is in range(ncols(t))\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         4cbcb19d-78de-44b3-be2e-e56e6e119071)(content(Whitespace\" \
+         4421015d-4fd0-40fb-b2bb-7ce9926c0370)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         82263580-a05a-4803-bfb2-8eefb818bf04)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8962cf76-04b2-463a-993e-160542a1461e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e7b805d-6c13-4430-bd53-c5b49ef42f0c)(content(Whitespace\" \
-         \"))))(Tile((id 6d7bbd5a-29b6-48d3-9939-fa5d302fdd24)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         4303510f-bfd9-4386-9ad0-5cdee744344f)(content(Whitespace\" \
+         b6ae6201-f955-4bcf-90e9-b41bf040bee0)(content(Whitespace\"\\n\"))))(Tile((id \
+         8721d5be-d1d5-44eb-8c33-a4c7f8f05c74)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         4d586020-47c0-4ca5-b5f3-f7d4686d1730)(content(Whitespace\" \
          \"))))(Tile((id \
-         4efe70f2-0f32-405c-a9ea-e77e75ea31e2)(label(ensures))(mold((out \
+         aea50010-a0f9-49d7-90dc-926e14836561)(label(ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cb4aa0fb-99cd-4e06-a312-7ec280bb5619)(content(Whitespace\" \
+         c3679cfe-2dc9-48c8-93da-9ac0eb7f2177)(content(Whitespace\" \
          \")))))((Secondary((id \
-         84b21aeb-8e15-43e1-aa16-9e8e203099a3)(content(Whitespace\" \
-         \"))))(Tile((id 785ea510-001d-41a4-ba94-fe464529df0f)(label([ \
+         7a82dda6-cac9-43c4-8ae3-a895bccc9980)(content(Whitespace\" \
+         \"))))(Tile((id 822eee50-6284-4b9e-911d-c1f801a63bb4)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         ba2cdb51-2698-4553-95db-07fab4d08959)(label(\"(\"\")\"))(mold((out \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         64fef220-2f9e-466b-93ea-3254117d0723)(content(Whitespace\"\\n\"))))(Tile((id \
+         885b32bd-8ad8-4b25-a9b0-09b67b5c4afe)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d2c9599e-8f28-4755-94ca-b6133a0eb36a)(label(enforced))(mold((out \
+         266d708d-bb0f-493e-82dc-497852ff2efa)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ece5e546-cedf-4634-bca4-6e770469ed6d)(label(=))(mold((out \
+         3e196449-4fc3-4413-9edb-3845d3034d4d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         6202db15-9cc3-421d-b53e-94896cfd09a8)(label(\"(\"\")\"))(mold((out \
+         5c636249-c6e7-4413-80ee-7ae97a7ad386)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         be39dc56-b08b-428d-8523-1dd8c02968ca)(label(false))(mold((out \
+         1386feb9-54ce-451c-9523-5802429e2176)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         6004f69b-a60f-4f0b-b20a-e089beec4938)(label(,))(mold((out \
+         34f10b3e-bf82-445c-a72c-71e12a97f13a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         87b4a7b8-b0d4-468a-9edd-53098ded6e5b)(content(Whitespace\" \
+         23d90d62-daa0-46a6-8781-c140a24fe236)(content(Whitespace\" \
          \"))))(Tile((id \
-         20efe9b9-8ad2-449d-be4a-7abd24f81846)(label(\"\\\"length(vs) is equal \
+         d7024e7e-2562-46c8-ac1f-31f8d162799b)(label(\"\\\"length(vs) is equal \
          to nrows(t)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         61423b5e-6e2f-435e-a7ee-44685e84657e)(label(,))(mold((out \
+         8f2790af-ac83-4965-b8cb-824a8b8e2b2a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         647a6194-2133-4ea5-bd85-23c862ffe10d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         027cc8a5-1b6f-45e5-aa04-c8f4e78e7422)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f03ac39-f18b-4004-9f5c-86d5b2fa307f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9030d7fb-83cd-4adf-b42d-68970afcec26)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         209d8dd4-99de-4100-ba6f-d8e3b09f73ad)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8bcba2d7-d21a-47e4-8dc5-ad878ef686fd)(label(\"(\"\")\"))(mold((out \
+         90d9c787-7a3f-4dc2-bd94-ef95bb4c88ca)(content(Whitespace\"\\n\"))))(Tile((id \
+         d2ae120b-9586-4022-9ec2-9a6a89f8b546)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         0bb75974-2d18-4a73-865b-a1326d51b44a)(label(enforced))(mold((out \
+         e828fb1c-cd0d-4f11-b14f-a0802f20d8d4)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5adaf4ba-57e0-47a9-b9d7-2fea33e9fce5)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         39f1b777-b985-417b-81b5-fb1905525ee1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2ff72e48-f392-4198-a29e-848ddaf5d374)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7ce99ead-ba37-4d75-ba53-3184ae4e5fbe)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fc2d5f6f-d40f-429a-bc7e-642f9efe2f3e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d7d981c5-5d80-4600-9f94-905364a4502a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         ee2bbaf6-8ae0-4786-b406-923b7d8ded57)(label(false))(mold((out \
+         670db4ba-bf70-430f-b279-d9dba357773f)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         96cbb249-d592-45bd-b6b3-b315c9fba9cd)(label(,))(mold((out \
+         4d72663d-9946-494c-b8c4-0d06eeecc799)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4915a44e-e9ab-4f84-8dc1-bbf8e5bc887a)(content(Whitespace\" \
-         \"))))(Tile((id f730732d-e1b0-43d2-b67e-25ce490dcdf0)(label(\"\\\"for \
+         69191dd6-a986-4540-acec-1cd6c419ae6a)(content(Whitespace\" \
+         \"))))(Tile((id 4a066f81-9ac1-45fb-9bc4-d5e764995410)(label(\"\\\"for \
          all v in vs, v is of sort schema(t)[header(t)[n]]\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         a9d8499a-3626-435f-9931-d300b75b0e63)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         097fa7dc-0bf4-444b-91db-1b7094cf7e77)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         1269e666-1e4f-42ff-ac67-29e1e6cc4d6e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         48db1f01-c740-41de-9926-e1c7d61ecf59)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2e1ff3f7-5bbb-415f-ba2c-75afaa90138e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6d44c1ea-35b4-4f09-946e-523326532eed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c05ee313-fca0-4a46-a8c1-8f92ebfbac79)(content(Comment\"# We don't \
+         3d1765ff-204c-4a32-9951-60450efbd8a4)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d1de1e49-235d-423b-8184-84d9447ef75f)(content(Comment\"# We don't \
          currently have positional projection on tuples as a builtin \
          #\"))))(Secondary((id \
-         75669b75-3804-470b-9b87-c592c6787109)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2216f59e-2727-472d-9edd-4746f6dd5c42)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3456daf9-68ae-4291-8e39-a72b6eaa6785)(content(Whitespace\" \
-         \"))))(Tile((id 6c1be83b-ea75-4a70-aacc-21af3d519690)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         3c221a87-9a28-46ed-ad96-52501535fb5b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5341a1ad-b9a7-40b7-8096-27f858af4872)(label(get_column1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         43f69fe6-ae7f-41ff-89f0-fd8bcec1efcf)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         baf5f63a-e4c4-4ce6-a7a0-573e6bebc089)(content(Whitespace\" \
-         \"))))(Tile((id d17977d5-d18b-4b71-9ade-0e058d8f014b)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         27e3ab20-c4f7-4a95-a379-af28f6521486)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ebff214f-75b6-4ffe-89e2-af6d8e18ef95)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         16583287-833c-4347-b0b7-6b8df70425e8)(label(t))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d0aa2f3f-c2b2-4f91-9911-fe3ebf3f4ad8)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         20d71ca7-44a8-4124-8137-00afc40119cb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e8112f62-cb32-45b4-9bb4-fbfa46eb42b5)(label(n))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         72f3aba5-e627-44d3-bb11-6e2703269db2)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2806e5c7-53b5-4d66-b145-a10eeb59eac7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c9ea3e4c-3b7f-4b17-acba-48288b61f3c3)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d9f90069-8fd3-4660-887f-493bbb728c87)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         3bcc3ece-ed40-4404-b56b-14893706a4f7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1058ca40-a230-48f0-a972-152a8ab2a18c)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         676160b8-bd82-47ae-b4a1-a7d1485e0bf7)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         0454ba89-2478-489d-ad6b-95fba97b1815)(label(t))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         98bb6937-350a-483e-9274-18af2626de6e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bf165161-1b36-4b54-97bb-86f94c778c1a)(content(Whitespace\" \
-         \"))))(Tile((id 3f53d137-4cd7-4818-af44-0ef63f9ddf68)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         eb28d3f7-f663-4c84-9073-5161c166fc46)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ea587822-2e6f-4b25-8871-07a0f0a9ce5f)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         02ddc536-39fc-4974-a5d7-89b9dd7fd676)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b9d2159c-1673-4ae7-8ec1-0a5e49944354)(content(Whitespace\" \
-         \"))))(Tile((id \
-         59c22351-6487-4f3a-9670-07b2b3b14431)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         eb6dc503-dfb8-4f16-8253-b3b265a94a8e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d4937486-04fe-4ddd-9e92-b9bd7538670f)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c7b14d96-7af6-4e77-818f-b501b813533c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5e19ed47-c35c-45ac-93b1-9d8e18bf50bb)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e5f27f90-6d8e-42dc-9c53-13df8e05f66f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6b112a49-574b-4853-8be3-0ca5270dc349)(label(nth))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fce07d49-9486-4173-981a-b6e7107f1d12)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f63c1540-f131-485e-94ff-09dffa955d46)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e44c9f80-7e12-4e99-ba04-88354de9f2d5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         70f35846-6e56-4287-844c-eefe045a9b61)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c622edcf-26b3-4812-9191-e78586dbd8f3)(label(n))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Tile((id \
-         2864cf69-0854-4ad3-9707-bca46e3c9c8c)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         dd3d0536-2f04-455f-8e9f-b5c75aac6e15)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         54a319e7-54cc-471a-ab19-fdd18ba1fd25)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b611a0aa-484e-4736-919e-a4225e43bae8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2c25194b-72fe-490c-810f-d7c3be70d2fd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         12eec36b-7240-4a27-852a-f39ae100b8d7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         690b1381-350a-4457-90aa-bab8889f5463)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d4121bc6-5813-4e76-9745-52fee3521f5c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b29c8e91-42f2-4155-95a6-185f8574c045)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c299fff3-e284-4973-97b8-4d16c33aa5ce)(content(Comment\"# Examples \
-         #\"))))(Secondary((id \
-         08daf64b-3658-42c0-a841-14cc5433462a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ef4fed32-df0d-4c59-91d2-1794d0493598)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         365ea98e-93df-4ba1-9f90-66f63553bb4e)(content(Whitespace\" \
-         \"))))(Tile((id 941018c2-5db4-460a-a751-c3967b8525ad)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ef308430-69b2-4a22-8353-92df462dee48)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aa75aa29-bee4-47d8-9b9d-c2ef292c6f67)(label(get_column1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e603f0d7-9107-4bb7-9c37-baf23dcbbff6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         568e35a0-0e23-40e7-97d3-ca69aafa8b51)(label(students))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f04098f4-7eb3-4595-8234-3b89864bf20d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6c93120f-c58e-4efc-8e28-860283d1c349)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dec5fdf1-b3db-4332-86bc-101921b734be)(label(0))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7bb6f63e-d573-4591-8016-f1105b9e9863)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1d041bee-7a09-44af-9511-0d83b89f4eb7)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2e970734-cc36-496b-82e2-95df4bc2a9ad)(content(Whitespace\" \
-         \"))))(Tile((id 5edb00e3-4f78-497c-9f35-86c2b60d4245)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         17f9e690-5afa-45e8-8ed2-746cd95377f3)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f2e599ff-a3b2-492d-b029-178c9db62e8c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         459b70f3-c871-4a50-b72c-9737451fcc5f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         db01f674-d83b-4305-859f-430b221234f4)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         430f12d2-303c-484a-bbf6-f29c1da57fb2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2e98cafd-5b13-40f0-9c40-f9e965fe4e43)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4f30ff1f-9403-4b22-88ff-38c951e80759)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b7d6c812-3fe0-4f88-822b-8da6091ce09f)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         d40b81a3-4c8c-4029-a257-b785b00d205a)(label(\";\"))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
-         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fcec6b8e-c0d4-4833-b91d-51415323e7de)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2a7f7ad8-3951-4d59-92a1-dbc417207df8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         abb7451c-af76-4fd9-9a1d-c4d07e896b98)(content(Whitespace\" \
-         \"))))(Tile((id 6948e50a-9084-4c21-b6ae-55b326ba5090)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         1806c8ab-33b3-4d68-b666-09aafd29e12e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6e1c3802-c860-4296-a7f1-aa8d21b2316e)(label(get_column1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d8f47de9-a6f5-42a2-b954-511f3ebaba1b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         88f68312-fd12-40a4-88cb-c0b2d1ca6cd5)(label(students))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         48692cb1-f631-406c-af52-92600f4e729f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c780c8f0-7255-46f7-a8fe-afbf51c890c4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5da9d3d2-4c7a-4e8e-a149-46019cd50ea5)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5640d909-7c77-4105-80c9-8fd07d4811b0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         26f4f82a-f190-4b24-9d2d-c235daf44291)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7eaae566-55b0-4179-b272-0ceac1841ff6)(content(Whitespace\" \
-         \"))))(Tile((id eb6ce072-fa6d-46db-9bbd-b5e1804de6ed)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         0b29c6c0-0113-4410-b26a-8979f186a53f)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         456cefff-76ac-4093-b227-7723bf5e6f39)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         73c40605-305f-479a-8037-512e6ff418c5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         34d8e793-3040-48fa-8421-55d21141ff40)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9ffa6199-be0e-413b-93df-a0b62c3c435c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         292888d9-8e00-4567-8e4d-ca9e432610e1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3d344d3b-080e-4ba4-8c62-ac896e4968a6)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e65a60fb-4aa6-466a-94f8-792804218234)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         94a3b489-c1aa-43c6-8c66-e3764f6013d7)(label(\";\"))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
-         35))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         93f4f02e-bb03-4fa5-841d-4ab82415d282)(label(?))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         f8788a54-e21c-4abd-85c9-48f8f0ce81e4)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         f2d34e91-5760-421d-8511-0063ba7daaea)(content(Whitespace\"\\n\"))))(Secondary((id \
-         77ba015f-2a94-4460-98ad-b4f906f4cca3)(content(Whitespace\"\\n\"))))(Tile((id \
-         13583e52-c29b-4176-a27b-e1314e390f32)(label(let = in))(mold((out \
+         d01e571d-97af-4e41-8271-ed92ad2c01b8)(content(Whitespace\"\\n\"))))(Tile((id \
+         728bf1b6-c778-42a3-908a-6a93d63c284b)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         cafd8b72-142d-4d54-96f5-b497fd5de0b8)(content(Whitespace\" \
+         a4853a65-8a68-4ce5-93b5-d621c8b3e64f)(content(Whitespace\" \
          \"))))(Tile((id \
-         26f77bbe-3089-4d1d-a18c-f6cb8adfb9c7)(label(get_column2))(mold((out \
+         6a268de4-da23-4ff8-93f9-559e6a971bc8)(label(get_column1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         44911c7e-e262-4404-960c-155d235d366e)(content(Whitespace\" \
+         b6c5fb2b-2957-42c9-be16-cfd1d661250a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         db11af70-abb2-48a1-af4c-99220d3ae96a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         44e50ad4-3047-43da-9f9b-b11bcc7e90e9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         378b5e60-2a3c-458f-be20-6de62c92df31)(content(Whitespace\" \
-         \"))))(Tile((id 57cbc187-e828-40f2-b19f-b2a059a26f03)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         2836f906-e28f-4a55-b9b0-0afed3aac27f)(content(Whitespace\" \
+         09298578-06b3-4fbb-a5ee-3cdee4fbf601)(content(Whitespace\" \
+         \"))))(Tile((id c04de658-d09e-4c37-9f88-cb8cdaba8c91)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         93c6d934-be2d-4c07-8318-e7ebb9ae5584)(content(Whitespace\" \
          \"))))(Tile((id \
-         5a35fb9d-a9f9-4ea6-baff-665f81d4f856)(label(requires))(mold((out \
+         0e9ae0db-167c-4462-934a-9ce768770b4c)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         2b62ddae-0340-44c1-9da5-2c4c4341b67c)(label(t))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         46495f86-a82a-4cac-8d7c-db543bb5e266)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         daed783b-63cf-4ace-bced-7d9e9b1ae10c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1f3ecf91-255b-46ba-b381-fc86f6fed677)(label(n))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         4be8af27-95d6-47bc-b5a7-0629e9517a1d)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         a486fa6b-52eb-48dd-b7bb-c34232125798)(content(Whitespace\" \
-         \"))))(Tile((id 7e53fa69-2556-49a8-a728-97371ecc29a7)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         aa127fa9-5790-4236-964e-aa51d69de8b6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         37e77f7e-a456-4357-b416-64e50b89a406)(label(enforced))(mold((out \
+         bf9a0898-ee89-4105-b1dc-3df3e7f29ec5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         34a29002-934c-4e7f-a6e9-7c057414b573)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6c5e49e5-9fb1-4cce-9468-e3e5f464c043)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6e47a7c7-36a1-4da1-82e6-478fb34b43c3)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         03e19c2e-7198-40a3-8597-1e265e90af6f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         14f27651-1f96-42c7-8cc2-434a84d78a9a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         341d2c21-069d-4536-8aa8-a9796ca01029)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         cf441cc1-490c-4fe6-8f19-450ec8c44c3b)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         8e391587-1c7f-47a8-9fc0-8dad4192ed78)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         72dadc8f-8382-4c97-8a1c-b4dca64bf400)(label(false))(mold((out \
+         e4f07a7e-84ae-41f8-a91b-a5edadcbe3e8)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         ca188d47-e477-4c08-b870-f51cee4e8c06)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a6d5dd70-21b2-47b0-9617-755bcf3f0050)(label(,))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8b2fd4f1-5963-46d3-b927-55d1f30fa710)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         280266e4-c029-4a74-9f48-511d9ba63a3a)(content(Whitespace\" \
-         \"))))(Tile((id 5bc4bd3d-a51b-4321-82ec-99ba1e50a79a)(label(\"\\\"c \
+         5a6cb4ae-f9b2-41b8-8d59-17e87ab7b18c)(content(Whitespace\" \
+         \"))))(Tile((id f84b8c19-bc4c-4c31-ad30-3eedc88800bb)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         b8a855cd-f72f-4857-b5e2-1a6b9c27b8fe)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c20ecfa2-ae85-413b-9b15-fd87ca36ff86)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         90809cc5-089d-4420-b03c-c7a204b33a52)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         02211805-f7a6-4553-b603-55f85dbaaac1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7fc93a81-1f6b-4468-812b-f2da2ed28018)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4eef405e-2afc-409e-9a44-5b2e061f0d70)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         5391ec18-873b-41e0-9258-4a9f65426313)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         226f5ab2-47d2-4f76-b091-414598e49714)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1d5fbfa6-381b-4a3a-9756-569288911229)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dbbba60e-98a6-419e-8d1c-5da6264cb5de)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a3ba4407-1fde-4877-980f-c962db5d4b37)(label(nth))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8a09d618-5ae4-4dbf-8691-26ede1ba25ff)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         bc6fa966-19e1-4ee6-8b37-dfddf24c2907)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         652f93d7-b3e5-4598-994d-88acb5707639)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4337e903-5f9c-4cee-bd97-a859feff20e9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fd238493-d1e9-4af3-83a0-b80be8a01ea3)(label(n))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Tile((id \
+         df4cbf52-111c-42fc-95fc-a62ab9b0b83e)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         7c9b9b14-a3e9-4a88-ac11-f5105e989c0a)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         579c9e60-e20e-4dbb-b5d5-2dea028dba6b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         329eddc9-bddc-443a-b527-644b9045b3e5)(content(Whitespace\"\\n\"))))(Secondary((id \
+         9adf06f1-213d-47c6-a4ee-02a3cd4d81d8)(content(Comment\"# Examples \
+         #\"))))(Secondary((id \
+         57e711c3-31b4-4e6f-af7a-37bcab5e9fba)(content(Whitespace\"\\n\"))))(Tile((id \
+         494c6d91-edc9-4cd5-bc40-817c4a9f4659)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         c52635fa-ac54-4a15-9dbe-097689c13956)(content(Whitespace\"\\n\"))))(Tile((id \
+         bbd9c157-040a-4203-9072-542ffb1d7efa)(label(get_column1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a281e19a-b7f3-4aba-8381-8f6176b3d5bb)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0256cdc5-ac16-46ab-91b9-2979cab83527)(label(students))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         35734f8e-8fdb-474a-8e25-49396ddea46a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         149d55a9-9894-44fd-9023-0f2afcffa55f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7844d21a-5307-4fc2-b142-f8655572ee81)(label(0))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         faebac39-c357-41ce-b1a2-11e32db574ab)(content(Whitespace\" \
+         \"))))(Tile((id \
+         49e5b0db-9419-4854-80ca-0f65e65200e9)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ab82f523-52de-4844-9bdc-b7779cff1994)(content(Whitespace\" \
+         \"))))(Tile((id 2afc1d55-7cae-4334-94a7-c88828eaa51c)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         3d87ff03-41e6-4ad5-a997-f8cd1be9d170)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d498fad2-03a0-4692-b77d-1e26f6961631)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b55ab84f-effb-4e9f-b096-11e5ddbd875f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b08fa83a-7512-465d-9a6e-325ba0010143)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         90d4a0e0-4dee-4335-8283-c8726ee2141d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2b3c2819-147a-4d0c-b77c-e323db74285d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a76ea7b1-6aaf-442a-9bf1-f644a6986004)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         eeae19a8-22d9-4cf5-bd6d-2f1e13715176)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         9fd6ad2c-0122-4347-9b79-796d95ff18cb)(label(\";\"))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
+         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         630042a0-5838-447c-a92f-43fe44c8b78a)(content(Whitespace\"\\n\"))))(Tile((id \
+         a60e5995-b4c4-49be-a02c-dbc835bba9f8)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         314589bf-315d-485c-8272-1eae7df1129d)(content(Whitespace\"\\n\"))))(Tile((id \
+         78b1772d-89b5-4be5-8b02-fae03f9f6415)(label(get_column1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1da6c46d-7e25-4129-b5aa-b48837cd37dc)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         526d5283-4ac1-459e-9765-7e7f61c42954)(label(students))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         65278499-2d4d-4e78-920e-5ee9d1617db8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c8134112-89b4-44a0-ba65-28242625aa23)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e685436b-0462-4791-94c5-2fc3d4941cb9)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         33cd4f5a-717e-4535-b705-b0c2c356be4c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8a6f7d95-94e9-4dd2-831d-8b60f754156f)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ed2727be-c3dd-49a6-b2f4-6ac5fc63f0ad)(content(Whitespace\" \
+         \"))))(Tile((id 530b4c01-5f71-4902-b300-d600adc3db72)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         b4a68a0f-5152-4ee5-8f80-fa219fbcd790)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         47ba0724-048c-45c2-9481-a333d6cb8853)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c6bc5404-92e2-4b89-a19f-1e0ab85a4eb2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ec4eaa3d-bb25-4cdf-a163-f60e6eee6304)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ff583997-d9ab-427c-ab2d-7db595769aa8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         24b4f873-3e00-4d60-8060-1cbad2085a47)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b7ab4a40-6dd8-40eb-aff2-da76156e12d7)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         2b41f10e-7968-48e9-880d-883564d03786)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         9003ff15-3c1a-4ddf-bfde-8d36a0e65ad4)(label(\";\"))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
+         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         419e4ee8-6cdf-4e02-8cd1-943fbd7a2f69)(content(Whitespace\"\\n\"))))(Tile((id \
+         8f9a69b7-c44b-448c-997b-fd3bffa89031)(label(?))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f126d143-5676-47c1-a4e8-99397f7e15a7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         585b4723-4b4c-48af-972b-4cc09d6d341f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         53d5faf4-fe02-495c-8757-9d5d30479c92)(content(Whitespace\"\\n\"))))(Tile((id \
+         f3d5e005-19ae-4a89-b158-1796346b3859)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         486d1940-d5fb-4ff5-9354-23727ddb6c8c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         da93ed80-53ac-462f-aec5-275bf7c327ac)(label(get_column2))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5114b4db-233b-4667-bb78-be16941e286e)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         9daa4140-a940-4d00-a4f7-c73db642f12f)(content(Whitespace\"\\n\"))))(Tile((id \
+         c265ee00-02a0-4601-bc68-8a0a415dc8a0)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         7ccae070-d1f5-4503-b2f4-c37213ee2b20)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bc387755-d691-4d74-8e08-2b72f37c905f)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         84ecbc84-03ac-484f-9f30-f5fc5018ae60)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         ebdf505b-d853-4365-ac1e-4143fc3ee90f)(content(Whitespace\" \
+         \"))))(Tile((id 835f0ce2-e3fb-40b8-964f-d9f24bfb5cfe)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         6383acb4-c743-4e52-ba06-247900fa202e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         8b210da8-cc3d-49c7-bfca-7c6fa710f314)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8cf0bf7d-b22d-4ae8-a65e-32e8dfd9b4e5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e78671be-ae00-41aa-8134-60081482719b)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         22229a31-8bcc-4eb3-9501-f748e66cb15a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a40bbcf2-b0f4-47c5-a1b0-7bbdfac0d954)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         e8d0f9d8-9453-45c1-911a-42acc1dd8e59)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         61e7b925-3714-4f84-ae6a-57f67d400032)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e7124c0b-031e-4855-84ea-8f3406e06d3f)(content(Whitespace\" \
+         \"))))(Tile((id 4029a288-8016-4fa7-a7f4-866ac6b0d774)(label(\"\\\"c \
          is in header(t)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         f3de4e69-2ec3-4c12-8eca-939b6eeba9e3)(content(Whitespace\" \
+         42aa22c6-001e-41b1-aad7-3ba873d99da0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         38d1799a-61c3-4199-84a8-c351f09f198c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         31144a10-5c27-4321-a6ab-1811ff1a35ae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         56269bc4-84bf-4c93-9583-adf24874f7e2)(content(Whitespace\" \
-         \"))))(Tile((id 3ba40a73-7537-4511-bf61-62cc90224fbf)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         4c284147-987f-408b-8011-1db44edeeebe)(content(Whitespace\" \
+         c47f3fa6-00dc-4a5b-b4e5-dc629b2d8b7b)(content(Whitespace\"\\n\"))))(Tile((id \
+         50409402-930d-4c41-b64b-e1e372184228)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a29ccf0a-ce22-4ead-996d-56e72497f290)(content(Whitespace\" \
          \"))))(Tile((id \
-         8a572102-3f2f-42ec-8a81-778c809d3f99)(label(ensures))(mold((out \
+         b87bed25-61f5-4e57-9fbe-5e49b685d5c0)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d56587f4-1ce0-42a6-9146-a7f409229e3b)(content(Whitespace\" \
+         46bcbb5a-e7bd-4112-aeed-b9c9a2a3452a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c342dbd6-2904-4efa-89aa-7d895e8cbb4c)(content(Whitespace\" \
-         \"))))(Tile((id e4549db7-f9df-4494-b187-68190dd88719)(label([ \
+         3b5e6c35-2feb-47a5-aa61-71e1819a19cc)(content(Whitespace\" \
+         \"))))(Tile((id c5423098-e03f-4395-8a00-db47ccfbad4c)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4b717f14-c3d1-44fe-8b52-8c0708b6dafe)(label(\"(\"\")\"))(mold((out \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ce5ef07d-3593-4768-a3d7-8e146d7e1ba8)(content(Whitespace\"\\n\"))))(Tile((id \
+         73638a5c-803d-4f5c-9e62-e1098a4471a7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         4ab07e06-838d-4945-bead-24c1ad0d6946)(label(enforced))(mold((out \
+         df63efa3-9aee-40e1-92fb-16de4636bb98)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4b0ba2a0-3982-4b77-8f44-8cfb9303af98)(label(=))(mold((out \
+         598e95fd-1c66-441b-9acf-1ccdd9190fc9)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f09eb95f-0dcc-4b7c-bc6e-f16077403adc)(label(\"(\"\")\"))(mold((out \
+         210a6d48-b73e-485d-ab04-3f4a151592bb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         874db4ad-857c-4d8c-a6d1-32e5047c55fe)(label(false))(mold((out \
+         6fef26ca-67ad-4ffa-81a7-fa3f717830f1)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         321be8a0-770c-4f3b-9fd2-c11eef866366)(label(,))(mold((out \
+         4c22f824-2202-4d19-8692-0f5c73bed1bb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7d002101-17ea-4edc-9ddb-3dd45fc49455)(content(Whitespace\" \
-         \"))))(Tile((id 4e83bdd2-47cb-48f9-9aa2-d000e42dad9f)(label(\"\\\"for \
+         cd09d2e9-ebf5-4ddd-b44b-93d6a659d93f)(content(Whitespace\" \
+         \"))))(Tile((id fc109ffb-4217-4ad7-a81b-0ea73aff8efe)(label(\"\\\"for \
          all v in vs, v is of sort schema(t)[c]\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         e72966dd-b3a3-46ec-9246-f07c5d92ad63)(label(,))(mold((out \
+         4a25a0ca-17ae-486b-b032-da4cb5a50215)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         969478da-361e-42c6-8a33-581ce456cb4b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7b4538ec-36e5-4597-b430-df2e3eefdb26)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac7c6ff5-f013-4832-b00e-a3ec6ef23105)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         70258a76-2cf4-4ae9-bd29-95269b0fc277)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         41e49f60-1763-4110-8e16-3e9b7df34fb4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7135c959-0686-4dc7-8d5e-1ceb5d80a6b2)(label(\"(\"\")\"))(mold((out \
+         c5493ca4-0476-4d78-b441-df4e8e0a6540)(content(Whitespace\"\\n\"))))(Tile((id \
+         bbf84940-2982-45c9-861d-24527ea05c64)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         22d552b2-d275-4bab-bd52-cdc77897c906)(label(enforced))(mold((out \
+         bf1425c6-4dc8-431c-847c-f6de2c364d4b)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7c2cdba7-9e16-479d-8178-fe9341356ef8)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b0eebbcf-7885-4d30-8258-270168f2aef0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         df57a7db-9396-4552-a757-fd36934151db)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         61b247c2-e617-4705-b2d1-982ba974ceb4)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         366b62df-c026-46ba-ad61-aa926361cd8e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5343c2f3-220a-4471-b9ec-45f44f28fdf2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         1273d03f-4f1a-494e-9d27-ad9b637c900a)(label(false))(mold((out \
+         23ea8214-3c04-44d6-9303-f6aa3debb677)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         268fb465-31a0-41fe-8ef3-580ac8b3032c)(label(,))(mold((out \
+         b62a9616-21a7-4460-928b-97de3814abcd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         be9168e8-05cd-46a2-ae39-5150439398c2)(content(Whitespace\" \
+         4c1025d7-65a4-4183-840b-71d9a66ec2bf)(content(Whitespace\" \
          \"))))(Tile((id \
-         a1db5721-9b50-4ebb-99e6-927abd5fa398)(label(\"\\\"length(vs) is equal \
+         a5f03beb-9682-4cec-bf85-8a9f0a4f7f41)(label(\"\\\"length(vs) is equal \
          to nrows(t)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         381e1bed-c84e-4252-8852-2b2834d3c35f)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         2fa39149-f9b9-478f-a5c6-8d5aa7e3753b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         df88f454-5b46-4ed7-839b-206ec50a60b4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c449fedb-3ee6-4372-8b7f-2dbf674280b2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eef51f5d-3498-4fa8-be9d-8a199de746e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e5e9b5f-9d56-4af6-b0da-141f35943513)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e8a8aeb5-fff1-4367-b5cf-61b7355b7bb7)(content(Comment\"# This is just \
+         8066c517-d78e-4483-92c9-7f1ff09786f3)(content(Whitespace\"\\n\"))))(Secondary((id \
+         e23545d9-7168-4e23-8a5a-c2ca631f524e)(content(Comment\"# This is just \
          the projection operator `.` If you use it directly you get the \
          non-length requires/ensures constraints #\"))))(Secondary((id \
-         33a3498b-1163-4e90-901f-9b2a6033bd5c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         99bb57fa-897b-4a39-ba0e-c83bc6bfc30a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         99a87565-639a-48eb-9ce3-a93762000cbc)(content(Whitespace\" \
-         \"))))(Tile((id 3bc1f948-550a-40eb-bd52-d87b68484178)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         34c173b3-c89f-403b-ad2d-01bc172eab9a)(content(Whitespace\" \
+         bf03ca23-0e63-4136-b110-2e78d639df75)(content(Whitespace\"\\n\"))))(Tile((id \
+         0fe0fd14-1c51-4683-aad5-e4a303a13f4e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5459fe12-db26-45e3-b517-717ff9dd82d3)(content(Whitespace\" \
          \"))))(Tile((id \
-         02d211d1-b741-42cb-854f-ea94e60ef4c7)(label(get_column2))(mold((out \
+         f4cfcdd3-f01a-436f-9006-8d5b31b560f4)(label(get_column2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5b2bbf44-3692-43ac-898e-c54135f59808)(content(Whitespace\" \
+         74e226d3-3c7f-49c4-ab2b-6074afb3a72b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6acf46d5-87cc-47da-b77c-d19c92865aaa)(content(Whitespace\" \
-         \"))))(Tile((id d8d44a13-d8b2-4d16-81a6-3db735c0bda7)(label(fun \
+         80521761-99d8-4a8e-a414-f7aa9a82004f)(content(Whitespace\" \
+         \"))))(Tile((id 6bc69660-b78b-4686-a0d0-1f78d63d0ed8)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e353a55d-bc4c-4b3a-a345-c7ab6b0e002b)(content(Whitespace\" \
+         7c0e3811-c5b5-4554-aabb-0d0739edef17)(content(Whitespace\" \
          \"))))(Tile((id \
-         1df0cea0-689d-4137-a851-1d4bef2710d0)(label(\"(\"\")\"))(mold((out \
+         def13b9d-2d0a-4e4c-83c5-54fd71b9db7a)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         7efd1a43-bc38-4d3f-9c11-bf6dcf0cc458)(label(t))(mold((out \
+         0f12382e-01a6-409e-b2c8-9a71155b89b5)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         b8573b14-2728-433c-9190-6ea41c0d5ce2)(label(,))(mold((out \
+         c6899f9e-1736-4a71-8a20-44686e45063e)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         7ac41467-7d92-4a09-b213-661fd08feeb1)(content(Whitespace\" \
+         65a7807d-f1c1-4b42-8ac9-d3fed816ceff)(content(Whitespace\" \
          \"))))(Tile((id \
-         5d0996e9-4225-47be-81a6-5ae49b807309)(label(c))(mold((out \
+         4dfb1330-d991-4aab-b6fb-3e91e7d100f2)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         05df5495-f5df-49f6-83b5-391414ddd4bc)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6d750342-0e44-46ad-be65-d09c6936d17e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         56cc23fb-4b9b-4972-8f44-1388d72629b9)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0b04142a-7eab-4636-b34c-bb313d51df9e)(content(Whitespace\" \
+         51fa0bb4-1b17-4dd2-b27e-852f4bfd297e)(content(Whitespace\" \
          \"))))(Tile((id \
-         18c17dea-8c35-4ecd-8543-14b95dd34398)(label(String))(mold((out \
+         a2ec0726-aa73-4b7c-aa4e-71b07e498ed6)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7f8aab05-b561-4571-9996-efd6ffdcc07b)(content(Whitespace\" \
+         2929b835-599b-449e-9d0c-317cd744bd1b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c0e22eca-d4a6-44d3-9720-baa03eaf1755)(content(Whitespace\" \
+         7aecb8a0-826e-4f8f-968b-1c727242480d)(content(Whitespace\" \
          \"))))(Tile((id \
-         9214a53f-8440-4377-a4f3-0e25811a6a41)(label(map))(mold((out \
+         aca2f871-9a4d-4b1a-a2b2-cc0ed74a11b1)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         47301372-1509-4339-b591-e878558c9760)(label(\"(\"\")\"))(mold((out \
+         c31babf8-2159-4945-adec-6ade28bc398f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         a2ec09d0-2a42-4f0c-9c31-e64318f86012)(label(t))(mold((out \
+         ce0269f2-b987-40d1-bcb5-3d1ba7e86d87)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         643e6416-75e1-473d-ae23-8724e224f8e2)(label(,))(mold((out \
+         4cc5044e-9f72-4d9c-b9e1-ca1bbe5b9fc6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5187ff9c-bc11-4178-a158-425288d81357)(content(Whitespace\" \
-         \"))))(Tile((id aab1c664-1ca7-45d7-9f00-32b87ef506f8)(label(fun \
+         e631a451-9d9b-4076-a4f1-ad83e72dec5a)(content(Whitespace\" \
+         \"))))(Tile((id a1452746-a839-4599-b0b4-00110978c3b6)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         dccf517d-b5d6-4fc0-aceb-017b7e300c89)(content(Whitespace\" \
+         ecf1391e-c63f-4386-971a-1546c799c767)(content(Whitespace\" \
          \"))))(Tile((id \
-         76e730ee-d58a-4965-8006-203b97c1d6f3)(label(r))(mold((out \
+         c656b8d2-09c5-4038-9067-5a5be4820564)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8ec4ae97-2cf0-47ea-b409-f70035b3a575)(content(Whitespace\" \
+         e61c1946-c92e-41c6-a457-7949a415ee30)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         10bc8cfc-d707-4e5f-a566-39eca6cb8890)(content(Whitespace\" \
+         68568719-b078-4103-9756-91c6135c852d)(content(Whitespace\" \
          \"))))(Tile((id \
-         e5e91711-4e38-4ee0-ad3b-19f7c2dc9d12)(label(to_lvs))(mold((out \
+         31279fe5-4f8b-4d92-bbfd-d2e6bfa48818)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         917799f4-e481-47c2-b4da-aa85b7a4d1c2)(label(\"(\"\")\"))(mold((out \
+         a9551031-562f-41d3-b892-dea7b55c48cf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         34380359-8804-402b-b580-722bca03b0c5)(label(r))(mold((out \
+         2c7317cc-3f13-4fe9-968a-d3cb98c36720)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         33c9e17f-41b0-4bde-9574-6a5b5cd93bb2)(content(Whitespace\" \
+         585fede7-79ff-414b-9493-3f837777efe3)(content(Whitespace\" \
          \"))))(Tile((id \
-         3dfed0ee-616d-48fa-977e-5b6502fc66ec)(label(|>))(mold((out \
+         f4cf1f3e-4b1f-4e40-a998-413f22397967)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         24b3c4b0-9328-407d-b15e-3e449bbee696)(content(Whitespace\" \
+         8ed27d22-f32f-489f-a4fe-7a6148242eb6)(content(Whitespace\" \
          \"))))(Tile((id \
-         f2665eaa-050b-4668-b101-5b4375304297)(label(find))(mold((out \
+         6dd47279-26be-4179-9ee6-ca66eccc00c9)(label(find))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f36143c1-5a22-493b-99c7-f95a5e002a13)(label(\"(\"\")\"))(mold((out \
+         f129da0e-7db4-4576-9649-3d5e4dbede52)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         63de8a43-9f07-4292-b585-7454ba452653)(label(_))(mold((out \
+         8eaa0af3-8da1-4e99-b8c0-0ea47a2d56f5)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         04034df3-b356-4644-9eaa-abe1e0a1019e)(label(,))(mold((out \
+         7b925244-917d-4438-9f63-c7642b6c2bef)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         d08bcb88-d5a3-416f-a84f-57c347cfc7d5)(label(fun ->))(mold((out \
+         b856cab6-2b80-4321-9a52-90432eaa8403)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         9e6e1ea8-190d-448d-a4e3-2d4b875e6b3c)(content(Whitespace\" \
+         c62ab898-fe78-4396-98d6-62fae4b45a50)(content(Whitespace\" \
          \"))))(Tile((id \
-         faa16650-587f-4fb0-b9a2-ee0d46c5d544)(label(label))(mold((out \
+         c429ec4b-0cc2-489b-b05e-9fcc36d8d2a8)(label(label))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         9f4932b4-b7ab-43c7-9a18-e359c159d3d3)(label(=))(mold((out \
+         a801ef79-8052-4b12-a81a-5886e2ee6c6a)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
          39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         f0fa124e-c7a5-4e12-a935-4e82db0fc91a)(label(l))(mold((out \
+         1b9b60b3-87cd-44df-a557-d279538bab1d)(label(l))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         5897c54b-4bb2-4bc5-b6bb-8cbd58b58a08)(label(,))(mold((out \
+         68729d3e-eb14-4064-8b9f-fd38cc0d008e)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ff34cf4a-d204-482e-a49f-9e77254a9aef)(content(Whitespace\" \
+         528066ef-f2ed-46cd-90d6-c77d862f7f36)(content(Whitespace\" \
          \"))))(Tile((id \
-         7f7c201e-ea4f-4e5a-8103-2181ce55ea0d)(label(value))(mold((out \
+         493a3a73-bfe6-42fb-a92f-70beec9054fd)(label(value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         e846e96d-300c-4b1f-b27a-bccbd953c21b)(label(=))(mold((out \
+         9033d9af-f38a-4e75-84a6-cbfc115ad04a)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
          39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         4a6ac9c0-ab1e-4e85-a62a-a19fd7e2705d)(label(v))(mold((out \
+         6c303622-4c9a-4a94-93b5-3998384860ea)(label(_v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3e7248fd-42f4-4fc2-8e76-021708c48a8a)(content(Whitespace\" \
+         7618a2e0-da36-4956-8263-4a731063d20c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c8833055-0d8c-4bb4-a243-5d02d1dfc715)(content(Whitespace\" \
+         e2ce8366-b3bc-4281-82ca-97a16ac2b2fc)(content(Whitespace\" \
          \"))))(Tile((id \
-         e741f713-29cd-4ca2-884a-d5929e140691)(label(string_eq))(mold((out \
+         9402af0e-9d32-44eb-850f-dfa9893f0547)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         c8439a69-47ce-47d1-ba6b-9c08b2d78f03)(label(l))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b7a2bf51-6189-4121-bf1d-83a3f8b2c2ea)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b101657b-72d6-4bed-81a6-22e3fb181a59)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f78e67de-4341-4f98-942a-12e33427d5a0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         641bfa1e-6875-460d-aa0f-4c2c57c0ac38)(label(c))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f1d234c7-d5ab-4955-a437-9bfb1f8a3c91)(content(Whitespace\" \
+         \"))))(Tile((id \
+         69d9c31d-961a-422c-8c2f-3c1bf06995db)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c717d1c9-ec76-4903-9c21-edc1c7ce0868)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9da6768f-b99b-4827-89e8-fe6fc25fdfb9)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Tile((id \
-         03728a70-7655-4a59-8653-668c4f6cb20f)(label(.))(mold((out \
+         4bc7ec10-022a-4192-ad3f-55867f5447cb)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3dbb1543-cd39-414a-8d6b-2879abeb74b6)(label(value))(mold((out \
+         23f0436f-83c4-474a-8bc4-81966f17d94a)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         51b8c814-00bf-4145-bdd6-157b507964b6)(content(Whitespace\" \
+         237770cc-69e1-4f02-819f-ef70b2eefff5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b2b2b953-605a-4715-9ecc-74ff013d6eec)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bd40a550-a925-4870-bcad-f17c9deefe55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ca1bfce2-3a3f-4486-97ab-a80b3eaabf98)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f1dccf94-0cf3-48d3-968c-4066b022b306)(content(Whitespace\"\\n\"))))(Secondary((id \
-         74be3f39-f03b-4312-a9bf-5650766c2c3f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c0bdd7ac-d6d3-494c-9701-e5f9bc8b8f52)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8384663b-70db-48fe-9b99-083b136937cd)(content(Comment\"# Examples \
+         43e77b3b-00fd-4769-a579-61ee63d8a31d)(content(Whitespace\"\\n\"))))(Secondary((id \
+         77e7d63a-8189-44e4-80eb-85c5ace9bbfb)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         c4259352-81aa-4a7a-98c9-ef0b5d2d7bdd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3dc6def1-0dc8-47ff-9c9d-0718a06e2f9a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e8a5942-26fd-46f2-8038-f4f6e91b7df7)(content(Whitespace\" \
-         \"))))(Tile((id 83c26639-6251-42c8-9e24-d7d18812c7f8)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         dded0f30-6987-4487-a039-e51027d65212)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3864109b-217f-485a-a671-be4edb5a0278)(label(get_column2))(mold((out \
+         b5839ba7-7000-4578-9854-688e097f8d4c)(content(Whitespace\"\\n\"))))(Tile((id \
+         5f8397bd-ba8b-4ac8-a75b-b67de136173f)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         5002fa4c-9c42-4e9d-af6a-225da800e3f7)(content(Whitespace\"\\n\"))))(Tile((id \
+         bae4c5ac-e7ea-48a5-8078-0072aa08ceca)(label(get_column2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         74d45ca9-7ff4-47b3-84ce-ef34ca28f154)(label(\"(\"\")\"))(mold((out \
+         72b91637-01ed-46b2-b940-f5a18b410d11)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9080bfce-bea2-4b4a-b509-eab82f46a80f)(label(students))(mold((out \
+         80d18abe-51d1-4626-9848-230f1c7f35f9)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         52a9c1fd-e73e-436a-8faa-a729cdc11a44)(label(,))(mold((out \
+         d648972e-5108-4594-89d6-c18b9f667aaf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b70e454e-6102-4c66-8fce-3773a5a129e9)(content(Whitespace\" \
+         36ef8b28-18d5-4f80-8528-6f6651a19c8f)(content(Whitespace\" \
          \"))))(Tile((id \
-         65c0da1e-5aec-4936-86f5-00061b1cf3bb)(label(\"\\\"name\\\"\"))(mold((out \
+         06d30cc0-d1fd-47eb-899a-0794dfed1a0a)(label(\"\\\"name\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5488808c-7962-41f4-bd60-ed5453405241)(content(Whitespace\" \
+         1e4d04a9-c7d5-4f38-9a57-102da56b0b69)(content(Whitespace\" \
          \"))))(Tile((id \
-         27e6d859-ff19-45bc-8779-a2aea5f24c4c)(label(==))(mold((out \
+         4272da62-538a-44e2-a034-9dc5bb02ed6c)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f4e9ac6a-392b-4acf-a732-e1228ca5edf4)(content(Whitespace\" \
-         \"))))(Tile((id e4db9101-7cca-472a-a54d-37a4a0543af1)(label([ \
+         da335ea6-2800-47ba-b105-83920cab7f36)(content(Whitespace\" \
+         \"))))(Tile((id cb72d9c8-c47d-48ba-ae92-4c61139a363e)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         3244f7d2-c2ad-42c4-bcdf-70fc2c903bb9)(label(\"\\\"Bob\\\"\"))(mold((out \
+         c22af533-d808-46e8-9bff-9ec3d1236a4a)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f92563fe-e141-44e7-ade2-2cd02d548d77)(label(,))(mold((out \
+         812c567b-726b-4bba-af71-7e074f3d2062)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         70b09da2-0f13-4e47-b530-779001a713af)(content(Whitespace\" \
+         043a3dd7-3054-429f-a568-62d4517491b0)(content(Whitespace\" \
          \"))))(Tile((id \
-         9ef6820d-6b5b-47fd-b7d7-f6860104b776)(label(\"\\\"Alice\\\"\"))(mold((out \
+         0ba088be-497c-4024-9718-d037d778dea0)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c2cdb1a8-3d22-46fd-812f-1260b6c96104)(label(,))(mold((out \
+         00b949a6-68a5-40af-9ce9-ec28a02a44ca)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d59c0d9a-0991-4a81-bea7-792e7b57c347)(content(Whitespace\" \
+         0b1840d2-3b4d-474c-a94a-f038a443defc)(content(Whitespace\" \
          \"))))(Tile((id \
-         fce0be49-aff0-473d-adb7-a211b2322499)(label(\"\\\"Eve\\\"\"))(mold((out \
+         0784eb0d-e1b5-4169-b70f-ffab2bc3211f)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6835dd26-80ae-4cf4-b6e5-8fa2959db838)(content(Whitespace\" \
+         8b10c261-ad18-4a0b-9a27-a31234714947)(content(Whitespace\" \
          \")))))))))(Tile((id \
-         429942c6-5ea6-4497-a6d1-a98805f4d758)(label(\";\"))(mold((out \
+         54fc762a-c4e4-4cc4-a8b1-7ab4701be16e)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         589fff56-7245-4be5-acc1-d0e0803cbfa6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f6d2eacb-af7b-4197-b0e0-3f638851ad8e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32909689-3632-4bfd-a5eb-7a4fd5866643)(content(Whitespace\" \
-         \"))))(Tile((id 4a4d7d59-202a-40f8-94f3-12aaf018c3d6)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         44b9edde-c044-40a2-916c-235729df8bdf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e08b588f-01ba-40f4-995d-3ff319277e94)(label(get_column2))(mold((out \
+         6e8905e6-0a5f-4deb-9564-18ec7be80e8e)(content(Whitespace\"\\n\"))))(Tile((id \
+         d89e5d8d-f113-4e2d-bdce-6e3b19432a71)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         c63a6b8c-f6f0-4284-969a-324fbd7b8433)(content(Whitespace\"\\n\"))))(Tile((id \
+         69f572db-046e-4608-8d77-fa97eb2fd6bf)(label(get_column2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f7ffceb6-5ae6-40dd-8cb5-140c975635e0)(label(\"(\"\")\"))(mold((out \
+         53e6633d-0af6-4aa0-947e-363deec3c504)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         037350bd-87ef-455a-93f1-f45c6bede39e)(label(students))(mold((out \
+         f607f2ad-d61c-4161-8aa8-b9003ae9da5b)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ab0fea03-1d0e-402f-b4ed-badb8a1d5a49)(label(,))(mold((out \
+         c9e1e5bc-98e0-470c-9df4-29be98feb51b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4863127f-61ee-46f7-8194-00004bc0d2e1)(content(Whitespace\" \
+         ac5cb996-f495-4eca-8db1-140692f2d33f)(content(Whitespace\" \
          \"))))(Tile((id \
-         d2665098-0032-4cb5-af2e-5195a9542cec)(label(\"\\\"age\\\"\"))(mold((out \
+         2a883ff2-722e-47ec-bc67-5c9470ad6ffd)(label(\"\\\"age\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9716eab8-5364-41fc-8f08-70c3a0fd9718)(content(Whitespace\" \
+         2878a54e-5981-40b1-b06b-5e5c0d8ce353)(content(Whitespace\" \
          \"))))(Tile((id \
-         505535ef-8055-4e77-a652-40bc53a8ce3f)(label(==))(mold((out \
+         16c35d8c-6542-4e77-abee-b13d3907ef97)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b47f7910-447f-49c3-9c3d-5bf49ab1bd12)(content(Whitespace\" \
-         \"))))(Tile((id 264fa406-3855-4837-a4be-c522a1627551)(label([ \
+         16c7175b-5152-4b28-909f-190be83e9c98)(content(Whitespace\" \
+         \"))))(Tile((id fc8a74f2-d2da-4d67-86d2-84a8b1379fb1)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f4956400-25a0-43de-80a7-7da3c790b452)(label(12))(mold((out \
+         03537c0e-35c7-4090-819f-a61360b12348)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         cfa976a5-ba00-4b56-9485-a99f79891c60)(label(,))(mold((out \
+         6fc88278-d41c-4ae1-a484-3b79add11da8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e17f970f-17db-4c2b-8cb1-501b17d41e28)(content(Whitespace\" \
+         4f119826-72b4-48e7-b018-736957811cf4)(content(Whitespace\" \
          \"))))(Tile((id \
-         ba43d5d8-2249-44da-9238-fc8a1798207a)(label(17))(mold((out \
+         af69c2ca-0f01-48ee-b97b-0a942e0cc6a5)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e156b408-8c73-4804-a229-59bf1bc90abe)(label(,))(mold((out \
+         01bf7f57-1d57-461f-a4ba-7637e4db44cc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f1ddc314-7a7e-4d94-af4f-2437e52bbfd7)(content(Whitespace\" \
+         a67fbbf2-1a79-4017-81dd-b53e91202094)(content(Whitespace\" \
          \"))))(Tile((id \
-         6a9b1bb1-f7c5-49f7-960a-4408716ed2c2)(label(13))(mold((out \
+         750cad62-28af-4e28-97ff-923c1f9cc9c6)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         a177084e-5967-467e-b109-52de8a1635e7)(content(Whitespace\" \
+         fe610ea6-87d0-4310-b64c-20c3914391f9)(content(Whitespace\" \
          \")))))))))(Tile((id \
-         668d7b68-b346-43fa-9ae6-877d8bfbd774)(label(\";\"))(mold((out \
+         9e17724e-3f10-49ba-9b68-274351550481)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dbfb9983-4686-4622-bb5c-2df5e1a404fa)(content(Whitespace\"\\n\"))))(Secondary((id \
-         33045e1b-909c-4d5a-bb94-9cba4070413e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         14e45e98-0946-4b0b-bedd-ee3b2d0955e4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e78690e2-af62-42f1-b63a-fadaab487e41)(content(Whitespace\"\\n\"))))(Secondary((id \
-         af36d20c-af59-4437-b0ea-68b5d89a19d5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         52c6caf8-94fb-4f58-940a-74dd1936374d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b4d98052-bd1f-4c00-9270-37b8578aa72f)(content(Comment\"# Using \
+         3dd58671-a992-4e48-bf70-95b0e13f35d7)(content(Whitespace\"\\n\"))))(Secondary((id \
+         e6dbe316-f440-4e31-84eb-248d97d8447d)(content(Comment\"# Using \
          projection #\"))))(Secondary((id \
-         3cfb7d15-3bce-41de-b520-896525c5b696)(content(Whitespace\"\\n\"))))(Secondary((id \
-         990d1d37-9993-493e-8fc9-c3e8a4a464f9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2df43515-9778-4629-b582-be7225ea92ec)(content(Whitespace\" \
-         \"))))(Tile((id 79896ed7-bf59-4cec-94f8-6fe24ab8a861)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         d5ef3a1c-f746-4dea-9485-cb1cd7532fe7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         65a03406-c364-468d-98f5-e0ff842b3510)(label(students))(mold((out \
+         efb6e580-cd3d-4822-ac47-a2b0c1d2a49b)(content(Whitespace\"\\n\"))))(Tile((id \
+         201dac2c-6d36-4043-8b0b-9fe760066ebd)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         250ea3b7-d372-45e6-ac17-87f3123fc68a)(content(Whitespace\"\\n\"))))(Tile((id \
+         ddc3eb85-537f-43cf-89cf-df871012b264)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         09cc18c7-f235-477b-bb0b-12e5574041e2)(label(.))(mold((out \
+         18c962ef-44fc-452b-a01e-e68bd26f0c1d)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c7f4107a-2294-4aa2-adc5-3b7515c0c1f1)(label(name))(mold((out \
+         6379bc75-fd63-4d67-a799-6cf962df9816)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         ee9c7995-ba82-4a7f-8642-7a8b716d920e)(content(Whitespace\" \
+         2eda5cc8-c1d0-4592-8cd8-687e8e016a1d)(content(Whitespace\" \
          \"))))(Tile((id \
-         335ab471-548e-4569-8a67-a6df20265ac3)(label(==))(mold((out \
+         73e7fb22-6703-48f8-96f2-a644077ada5f)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b7c074ed-439b-4ca7-9e8e-0824029d8644)(content(Whitespace\" \
-         \"))))(Tile((id 9fc0e827-dc23-47de-8bc6-1c3728b524d7)(label([ \
+         3f8d6b7d-ebdb-44e2-ae39-12c60d6a2842)(content(Whitespace\" \
+         \"))))(Tile((id d846413d-a750-4d26-a54b-dc6e1cd93ba7)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c6964e3c-c11b-4e2a-8019-0c3726bd6447)(label(\"\\\"Bob\\\"\"))(mold((out \
+         1a9491c7-bce6-4cf1-a034-9013967efef0)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         436d9b2e-2a5e-4a03-aab6-0bfa7c036f23)(label(,))(mold((out \
+         c81473b4-2e4b-461e-88f8-0266abef6099)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3168e0af-dc7a-44cb-b8bb-a4ebea7bb799)(content(Whitespace\" \
+         186fa9d7-6f9a-47f3-bce3-040242f8bed8)(content(Whitespace\" \
          \"))))(Tile((id \
-         c304569f-2d92-4a22-8590-3886b7029fee)(label(\"\\\"Alice\\\"\"))(mold((out \
+         8a7809a2-4d60-4b6f-93e7-8361b02fcd22)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         1c47c9b7-a570-432a-b3de-713f54e6fa8b)(label(,))(mold((out \
+         b08f010f-87c6-4103-ae3d-feedfdd1ec34)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         328fad04-8e7d-4232-947a-766a2c860a54)(content(Whitespace\" \
+         c31a6d74-aa1a-4a90-aa0f-00cb67c32394)(content(Whitespace\" \
          \"))))(Tile((id \
-         603e5ac9-16e2-4a08-aab6-3af8c21d4c69)(label(\"\\\"Eve\\\"\"))(mold((out \
+         db0e46bc-34bc-44ba-98c7-c398c0daef1c)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         587176db-04ed-495b-af4d-e0200b39fdee)(content(Whitespace\" \
+         3dacc401-ea12-439c-95bf-ea7818d1c8a4)(content(Whitespace\" \
          \")))))))))(Tile((id \
-         ed2c54e9-77a9-4def-a619-d9dcdfe0225b)(label(\";\"))(mold((out \
+         8e5dc986-7cf6-4446-9bf8-af87fe1156b3)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f4d0f64f-3c17-48bc-9b4c-cf6d6cd2bce5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         031ef92a-5b6a-4e08-958e-d8450e768e84)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         df0b8a22-4bb7-4c35-a035-9dc0a486f7f1)(content(Whitespace\" \
-         \"))))(Tile((id 52dc1196-57e1-45ce-85e9-dd2e7cfe589a)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         0031e3de-b097-463f-a575-9e75ef51e7fe)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b87f7fc4-c9ff-43b4-bf5e-96fde4a69e0e)(label(students))(mold((out \
+         3946d789-2e28-4b68-abb7-8e1e7eb733c0)(content(Whitespace\"\\n\"))))(Tile((id \
+         9f7429f1-1c42-4cd2-9546-d749193fb47f)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         4276d83f-b274-4241-bfbf-0ce7bfb027a6)(content(Whitespace\"\\n\"))))(Tile((id \
+         b314cc89-4337-4cad-8430-d77bd4e3331e)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5e169680-687a-4968-9e67-6007486fd3ad)(label(.))(mold((out \
+         40e535ea-028b-4359-b404-952365fc4141)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         6680fbe4-8f02-4635-a5d2-0ee532bdbfcc)(label(age))(mold((out \
+         8c9ca33f-e830-441a-8b41-bc12689ca1d0)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f700789a-3bb9-4c5c-88d2-cc877500bd88)(content(Whitespace\" \
+         afac60bf-0567-41c8-9b8a-571a7f6f10f4)(content(Whitespace\" \
          \"))))(Tile((id \
-         163f7655-bae3-4b0e-9c51-237c86374047)(label(==))(mold((out \
+         368a025c-36c0-4e88-b869-4a71581135ed)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4173ed76-2891-478c-8fb6-22cfcffe2aa9)(content(Whitespace\" \
-         \"))))(Tile((id 306998db-5ce2-452b-9933-443d496cbcd2)(label([ \
+         1493c9aa-7e42-4f75-808c-bb97f4702659)(content(Whitespace\" \
+         \"))))(Tile((id 5cf9782d-12b0-40f1-8938-d0f78def262b)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         46703864-2f2a-418a-962a-9e0ab4cc480a)(label(12))(mold((out \
+         96573823-14b7-4516-8df6-c95bbb644ff8)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         97ab1d65-3d3b-4154-96af-a6f7e1ecd548)(label(,))(mold((out \
+         be80717e-b45f-4f95-a163-33a996448236)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         eccf168b-73dc-46b0-a13c-aa3eb24cf3d9)(content(Whitespace\" \
+         1375bc8d-25f2-4eb5-b5f9-74a458f3e018)(content(Whitespace\" \
          \"))))(Tile((id \
-         e212975e-cccd-4838-bd38-cbed07b30cbf)(label(17))(mold((out \
+         eca43b55-cd9f-4436-9c8a-c98274e7db4a)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         63186578-9471-43d5-880a-669e9e44936f)(label(,))(mold((out \
+         7f2a6bd7-bb2f-4cb5-95ed-556c0ac3b846)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         60bf1db6-f7d7-4e4b-81be-a4f2f901fb50)(content(Whitespace\" \
+         b98ee88e-b057-42db-a58e-f8bfd7ab7689)(content(Whitespace\" \
          \"))))(Tile((id \
-         4d20148b-e385-4794-b439-7d8171b9b230)(label(13))(mold((out \
+         864c513c-8db7-4306-8e95-3be97467542f)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         09bef3ee-419a-49cc-a8ba-60cca59739c9)(content(Whitespace\" \
+         d2b00259-13e2-4d1f-9b99-01ea06699426)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         682a1610-e0c0-4ba7-aef1-f94e5edbaf8a)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         acb53b6f-eab6-4f5d-8128-a3eca20494ef)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5b66040d-a458-4d8f-b353-d563ad9100ef)(label(?))(mold((out \
+         006ac845-6173-490c-8578-fa35a9347efc)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         963ee0d0-2854-4839-ab48-d337fd07d036)(content(Whitespace\"\\n\"))))(Tile((id \
+         644ef993-068b-47e5-b116-f05abe47ebd6)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         8504accb-7cee-45d7-b756-1861522f3339)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
-         let students : [Student] = ([\n\
-        \  (\"Bob\", 12, \"blue\"),\n\
-        \  (\"Alice\", 17, \"green\"),\n\
-        \  (\"Eve\", 13, \"red\")\n\
-         ]) in\n\
-         let get_row = \n\
-        \  let requires = [(enforced=(false), \"n is in range(nrows(t))\")] in\n\
-        \  let ensures = [] in\n\
-        \  # Tables are just lists so nth is just list nth #\n\
-        \  let get_row = nth_opt in\n\
-        \  \n\
-        \  test get_row([(name=\"Bob\", age=12)], 0) == Some((name=\"Bob\", \
-         age=12)) end\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = ([(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")]) in\n\
+         let get_row =\n\
+         let _requires = [(enforced = (false), \"n is in range(nrows(t))\")] in\n\
+         let _ensures = [] in\n\
+         # Tables are just lists so nth is just list nth #\n\
+         let get_row = nth_opt in\n\
+         test\n\
+         get_row([(name=\"Bob\", age=12)], 0) == Some((name = \"Bob\", age = \
+         12)) end in\n\
+         let get_value =\n\
+         let requires = [(enforced = (false), \"c is in header(r)\")] in\n\
+         let ensures = [(enforced = (false), \"v is of sort schema(r)[c]\")] in\n\
+         # This is just the projection operator `.` If you use it directly you \
+         get the requires/ensures constraints #\n\
+         let get_value = fun (r, c : String) -> (to_lvs(r) |> find_opt(_, fun \
+         label = l, value = _v -> l == c)) |> option_map(_, fun e -> e.value) \
          in\n\
-         let get_value = \n\
-        \  let requires = [(enforced=(false), \"c is in header(r)\")] in\n\
-        \  let ensures = [(enforced=(false), \"v is of sort schema(r)[c]\")] in\n\
-        \  # This is just the projection operator `.` If you use it directly \
-         you get the requires/ensures constraints #\n\
-        \  let get_value = fun (r,c :String) -> (to_lvs(r) |> find_opt(_,fun \
-         label=l, value=v -> l == c)) |> option_map(_, fun e -> e.value) in\n\
-        \  \n\
-        \  # Examples #\n\
-        \  test get_value((name=\"Bob\", age=12), \"name\") == Some(\"Bob\") \
-         end;\n\
-        \  test get_value((name=\"Bob\", age=12), \"age\") == Some(12) end;\n\
-        \  \n\
-        \  # Using projection #\n\
-        \  test (name=\"Bob\", age=12).name == \"Bob\" end;?\n\
-         in\n\n\
-         let get_column1 = \n\
-        \  let requires = [(enforced=(false), \"n is in range(ncols(t))\")] in\n\
-        \  let ensures = [(enforced=(false), \"length(vs) is equal to \
-         nrows(t)\"),\n\
-        \    (enforced=(false), \"for all v in vs, v is of sort \
-         schema(t)[header(t)[n]]\")] in\n\
-        \  # We don't currently have positional projection on tuples as a \
+         # Examples #\n\
+         test\n\
+         get_value((name=\"Bob\", age=12), \"name\") == Some(\"Bob\") end;\n\
+         test\n\
+         get_value((name=\"Bob\", age=12), \"age\") == Some(12) end;\n\
+         # Using projection #\n\
+         test\n\
+         (name=\"Bob\", age=12).name == \"Bob\" end;\n\
+         ? in\n\n\
+         let get_column1 =\n\
+         let requires = [(enforced = (false), \"n is in range(ncols(t))\")] in\n\
+         let ensures = [\n\
+         (enforced=(false), \"length(vs) is equal to nrows(t)\"),\n\
+         (enforced = (false), \"for all v in vs, v is of sort \
+         schema(t)[header(t)[n]]\")\n\
+         ] in\n\
+         # We don't currently have positional projection on tuples as a \
          builtin #\n\
-        \  let get_column1 = fun (t, n: Int) -> map(t, fun r -> to_lvs(r) |> \
+         let get_column1 = fun (t, n : Int) -> map(t, fun r -> to_lvs(r) |> \
          nth(_, n)).value in\n\
-        \  \n\
-        \  # Examples #\n\
-        \  test get_column1(students, 0) == [\"Bob\", \"Alice\", \"Eve\"] end;\n\
-        \  test get_column1(students, 1) == [12, 17, 13] end;?\n\
-         in\n\n\
+         # Examples #\n\
+         test\n\
+         get_column1(students, 0) == [\"Bob\", \"Alice\", \"Eve\"] end;\n\
+         test\n\
+         get_column1(students, 1) == [12, 17, 13] end;\n\
+         ? in\n\n\
          let get_column2 =\n\
-        \  let requires = [(enforced=(false), \"c is in header(t)\")] in\n\
-        \  let ensures = [(enforced=(false), \"for all v in vs, v is of sort \
-         schema(t)[c]\"),\n\
-        \    (enforced=(false), \"length(vs) is equal to nrows(t)\")] in\n\
-        \  # This is just the projection operator `.` If you use it directly \
-         you get the non-length requires/ensures constraints #\n\
-        \  let get_column2 = fun (t, c: String) -> map(t, fun r -> to_lvs(r) \
-         |> find(_,fun label=l, value=v -> string_eq(l,c))).value in\n\
-        \  \n\
-        \  # Examples #\n\
-        \  test get_column2(students, \"name\") == [\"Bob\", \"Alice\", \
-         \"Eve\"] end;\n\
-        \  test get_column2(students, \"age\") == [12, 17, 13] end;\n\
-        \  \n\
-        \  # Using projection #\n\
-        \  test students.name == [\"Bob\", \"Alice\", \"Eve\"] end;\n\
-        \  test students.age == [12, 17, 13] end\n\
-         in ?\n";
+         let _requires = [(enforced = (false), \"c is in header(t)\")] in\n\
+         let _ensures = [\n\
+         (enforced=(false), \"for all v in vs, v is of sort schema(t)[c]\"),\n\
+         (enforced = (false), \"length(vs) is equal to nrows(t)\")\n\
+         ] in\n\
+         # This is just the projection operator `.` If you use it directly you \
+         get the non-length requires/ensures constraints #\n\
+         let get_column2 = fun (t, c : String) -> map(t, fun r -> to_lvs(r) |> \
+         find(_,fun label=l, value=_v -> (l == c))).value in\n\
+         # Examples #\n\
+         test\n\
+         get_column2(students, \"name\") == [\"Bob\", \"Alice\", \"Eve\"] end;\n\
+         test\n\
+         get_column2(students, \"age\") == [12, 17, 13] end;\n\
+         # Using projection #\n\
+         test\n\
+         students.name == [\"Bob\", \"Alice\", \"Eve\"] end;\n\
+         test\n\
+         students.age == [12, 17, 13] end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIAggregate.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIAggregate.ml
@@ -2,8894 +2,7672 @@ let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Aggregate",
     {
       segment =
-        "((Tile((id 3525c579-8510-4244-811e-736024ceb886)(label(type = \
+        "((Tile((id 682830c1-ea02-4872-b5c9-8a3f2cd8e500)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         b927aa58-219c-454c-9f47-e3846608c694)(content(Whitespace\" \
+         b83c9c74-f90e-4024-adf4-5ed7ea888033)(content(Whitespace\" \
          \"))))(Tile((id \
-         3cc42a9a-96d0-487e-b0b2-cbf0c793afdc)(label(Student))(mold((out \
+         6fb1f1ea-1af7-4049-86a1-e667edb25bcd)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         dade6a0b-8208-4f46-973f-79f20e1411a4)(content(Whitespace\" \
+         e5bdcc02-ae04-470e-97cc-1d74db735255)(content(Whitespace\" \
          \")))))((Secondary((id \
-         aa231130-1d94-4ecc-ab31-2a325d2e6970)(content(Whitespace\" \
+         df5e4be6-03ba-4363-921f-c5af837a123d)(content(Whitespace\" \
          \"))))(Tile((id \
-         926afd5d-78da-469a-9d19-1228904c0563)(label(\"(\"\")\"))(mold((out \
+         d87a8170-eb3b-4ab8-b617-27edb1e62be3)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         d53ebe24-4b30-4a8a-bebd-dc4ff6fd00e9)(label(name))(mold((out \
+         cfbeeb5a-379d-4df7-afe9-511bdd81915a)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         9526eb23-47ad-41b4-81a7-c1ef9800ecc6)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5c0dcbae-a740-4854-bd07-67c4894d0747)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3bfd2766-56cc-431a-8bdd-778c6cc43297)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         917b5532-f495-448c-8070-b67f35c3626c)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6449a151-f3e6-415f-b163-9e71479736aa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         283ad247-0721-4f7a-908b-0007c337ba0d)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         cf31c1eb-795e-46f5-9e0b-f3ed1768270b)(label(,))(mold((out \
+         69cb186e-fc2a-49d5-adee-a02279c4ce2a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c6bec814-77ef-4f12-8a32-f3413e7e99c4)(content(Whitespace\" \
+         f02dc79e-b7b1-40b0-b0fe-fe068024eaef)(content(Whitespace\" \
          \"))))(Tile((id \
-         07612f3d-3313-442b-8b03-f3e8d5284601)(label(age))(mold((out \
+         aedbbd82-bd29-45e8-a1e7-c09629d70986)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         785e6c7c-2d6b-4109-a5d3-805ebee62b04)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dbc14570-4af5-4854-9054-328e89e65cbe)(content(Whitespace\" \
+         \"))))(Tile((id \
+         07c287b9-a76b-44e8-82f0-8cbcf08439e6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c2acbdfa-d269-4eca-957b-3d83e517a00a)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f957ec63-b039-4204-a81c-b60107502a7a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5c6aed72-1316-425d-9cc1-1fa7686b927d)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         13702f6c-c37a-43d3-b9e6-dd670fdfc94e)(label(,))(mold((out \
+         87c98171-6b09-4882-8a21-5388990f6b18)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         75916980-d5ae-476e-bb94-9ca64b26d2e8)(content(Whitespace\" \
+         f7f54713-437b-4f1c-a58c-44cae17421ea)(content(Whitespace\" \
          \"))))(Tile((id \
-         6d8bd372-b318-4247-9c38-1714c39a4a4d)(label(favorite_color))(mold((out \
+         be25d8a3-8914-4cad-b0b2-b58684259eb1)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         f729e67f-bf23-4285-a329-1ae6390cd09b)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         69cdcc35-d7a3-4696-a576-d03cfbaa6168)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c3ab8070-7918-4b54-a7d6-86b428285c16)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         30a5455f-67ac-4660-aaed-f57c426513c7)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         885dc144-2617-4e1c-a29f-1d6350a718a6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e8361e82-03af-422b-a83b-272164321eca)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f7f8f750-4fa8-46ca-a0dc-113fa412c3e0)(content(Whitespace\" \
+         0b04321a-32cf-41ad-b516-a4e590332f74)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         31c45d4d-98d1-4a95-8163-9ced76831019)(content(Whitespace\"\\n\"))))(Tile((id \
-         188f625f-63e9-4024-bf15-a974da3468f8)(label(let = in))(mold((out \
+         2cc472a5-354f-4333-9bb9-f9727bea8941)(content(Whitespace\"\\n\"))))(Tile((id \
+         d910f445-354c-4add-968c-fd579e36a6ec)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8b00d57b-8276-4d92-96a1-0ce1f1d1de72)(content(Whitespace\" \
+         893c0201-7d05-4507-9005-0cb1449d13b2)(content(Whitespace\" \
          \"))))(Tile((id \
-         56b1e229-4172-4e80-8c06-b56766fc64e9)(label(students))(mold((out \
+         36eb3fcc-37c6-4997-91f0-071877f26814)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         72b71920-7368-4e78-b7e7-3baf41a25c84)(content(Whitespace\" \
+         a868bbd7-21ac-4f40-a3b8-36713fdbe632)(content(Whitespace\" \
          \"))))(Tile((id \
-         ae63ae2c-cddd-420b-9735-0fc1ad15dcee)(label(:))(mold((out \
+         1fd2f938-e856-4c02-843c-530fd11e6fd9)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         037cda33-b27b-400c-8295-66b088b1c683)(content(Whitespace\" \
-         \"))))(Tile((id 6963f124-f0b8-4a0c-b177-59ca123ede2e)(label([ \
+         6ab66087-f3b9-463d-b838-b2e9ba4a6a44)(content(Whitespace\" \
+         \"))))(Tile((id 3e163a19-b349-4308-899a-f4da68eaaf1f)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         a792ce02-4d7d-47d0-9c6d-85f3d3c437b4)(label(Student))(mold((out \
+         cbb76341-d6c2-45f0-9037-3a55299e482b)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c767fb1a-e13c-4e71-90c9-ba084d1e590f)(content(Whitespace\" \
+         81a3935b-f405-41c0-8d3a-6e9215a988a1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8f610a71-389e-46c0-b530-b893635432c3)(content(Whitespace\" \
+         a09c15e5-9d03-4841-8034-18c4323ecb88)(content(Whitespace\" \
          \"))))(Tile((id \
-         69e307e8-123c-41b0-b0c4-3471d7d964a1)(label(\"(\"\")\"))(mold((out \
+         4329cab7-25cf-4d38-becf-108bcd9428cf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         62951095-6011-423b-96ab-b3547fa72cc9)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         ce317543-e379-403e-8ebf-600ce0e3f9fe)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d1e7f26f-7de6-44cd-b7b5-981ca381b9ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         701a1ac4-db82-4c59-91f1-09f9198ac05b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3cd85cd2-d203-4355-8218-67a4d28df024)(label(\"(\"\")\"))(mold((out \
+         85475b3a-54a8-4622-bce4-757741804407)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e9cfe1e0-f7c0-4af1-9cf7-3ab2431db8f5)(label(\"\\\"Bob\\\"\"))(mold((out \
+         92591715-8f68-4019-9b8e-5874d6921d8b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ed4c2496-1df8-4a0a-a008-f9d275c26915)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ccab84b7-c4b9-4938-bd88-e96967e81b69)(label(,))(mold((out \
+         ceb07d94-924e-4cb5-afbe-692576f2eff3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         435e901b-492b-49a4-9174-c4831a9fcc38)(content(Whitespace\" \
+         3f18dde2-a873-4479-b6e9-dcc895a3be3c)(content(Whitespace\" \
          \"))))(Tile((id \
-         8e1a0d9e-4f2d-4968-a1da-85d9d5e90731)(label(12))(mold((out \
+         bfc52a47-9b84-426d-adfb-d0cae0dc2952)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c95ee2bc-5b44-47ac-93c9-ad4d87cae896)(label(,))(mold((out \
+         87833a5c-6a53-4744-8cbe-0657840d5a47)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         867e0f05-3dbe-48c1-bc1d-12f5b667bfa2)(content(Whitespace\" \
+         a381a42e-6ca6-42f8-a326-845c3581744f)(content(Whitespace\" \
          \"))))(Tile((id \
-         ba902d3e-35fa-4201-bad1-2cb4a47ad02c)(label(\"\\\"blue\\\"\"))(mold((out \
+         41922ed3-04d4-412b-9550-c53de5cfa2dc)(label(\"\\\"blue\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         c3962858-a91a-490c-af8e-a5f3c26503cb)(label(,))(mold((out \
+         019f12ba-8a1c-4ce0-8bd5-aa1a91200f6f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb314eb3-f739-4f0f-9593-eeb07d07c788)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7c9eb0a7-ce7c-431a-a8fe-e330cc61da50)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a76db964-ad25-4f66-97fe-c88346e4fc10)(content(Whitespace\" \
+         58e0a673-13a0-4184-8271-e103f3d190e6)(content(Whitespace\" \
          \"))))(Tile((id \
-         5a75194f-a134-4b01-bf10-669feaec71ef)(label(\"(\"\")\"))(mold((out \
+         28ecead6-5474-4ab0-9f86-f0e90450f82f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         464e8cbd-c947-48e8-8119-ff6389cd3205)(label(\"\\\"Alice\\\"\"))(mold((out \
+         189c20bd-171a-4bc9-9821-4c09206db8a0)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         0cd35d20-275a-4d76-861a-2733694117de)(label(,))(mold((out \
+         c74bf776-5ee0-46a9-8958-dfbbfc1c897c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fb400012-8699-4937-ac48-ad91db7cf930)(content(Whitespace\" \
+         bda52db5-f98a-4af2-a781-164cf4080b6a)(content(Whitespace\" \
          \"))))(Tile((id \
-         ef8645f0-9cf3-444b-bbf2-59fa0ddcf091)(label(17))(mold((out \
+         20eb1744-55db-464d-bd2a-6ec15c74acae)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         9818b6fa-d367-414f-bb03-46ad0e3f5ecd)(label(,))(mold((out \
+         30b0d12b-1ae1-4d4d-951d-e425e19284f8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2da38afb-76a2-4df0-8155-d455212d8bd6)(content(Whitespace\" \
+         acde70fc-01a9-4ff7-975e-82866a7fa42f)(content(Whitespace\" \
          \"))))(Tile((id \
-         2a465178-4500-4825-973e-15ac04824efa)(label(\"\\\"green\\\"\"))(mold((out \
+         a752b313-67ac-42f1-bd76-de7aa7c473a7)(label(\"\\\"green\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d7d88875-dc8a-4b1f-bd18-0b260d43b55b)(label(,))(mold((out \
+         223604d1-13a3-47c9-a509-16b75e4c3456)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fb30d75e-a147-4a05-a9ff-abc803c5d1c7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         12a6b85e-0cb8-4d87-9943-020f98d49c5c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0ab60cff-d740-4f06-9cd9-1e79dc38035b)(content(Whitespace\" \
+         7f1e230d-b94a-4338-a0d6-5fbc8c4f176a)(content(Whitespace\" \
          \"))))(Tile((id \
-         af7239d1-995d-41ca-95a7-e24d2ddae22b)(label(\"(\"\")\"))(mold((out \
+         822d8543-ef1c-464f-b129-1bcb11772e61)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         37243363-0315-48a9-bce8-8b5489c4a781)(label(\"\\\"Eve\\\"\"))(mold((out \
+         97420c11-adbc-4ef0-84dd-e02a6b7b1d39)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         bf71d8ec-dfc9-4794-b8f0-640caba7fb35)(label(,))(mold((out \
+         363ef7be-e2f9-431d-b303-8a173dab43da)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         89a284d4-8919-4d33-b8a3-b861c6ffb879)(content(Whitespace\" \
+         c5bb34db-a721-4acd-b918-3114d6dfacc8)(content(Whitespace\" \
          \"))))(Tile((id \
-         64c64c0b-cf69-4e60-886d-4110f464a9a7)(label(13))(mold((out \
+         0c59e448-7417-49e8-be5b-f3949331cef6)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5c0784ec-2cbb-4396-9266-3e17c32fd931)(label(,))(mold((out \
+         076ca006-f147-4837-9e26-64a239838ac5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ed9f0349-66d3-4c69-af7f-c0944c7e2671)(content(Whitespace\" \
+         61e5fa6b-8d72-4110-aef5-df741100e5f5)(content(Whitespace\" \
          \"))))(Tile((id \
-         bea2512d-2892-46e4-ab8e-96516e56fb74)(label(\"\\\"red\\\"\"))(mold((out \
+         e768740a-fbbb-4949-9553-a502feafd7f1)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ca8e5596-be36-4be1-b7db-eaaa2f3f6365)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         e694ea73-a07c-4c21-b3a1-19ec898d2b4c)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         6677f45b-e22b-42e3-af3f-9272bb618e94)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fb39cd5e-6f1a-4059-ba21-a327cd35285c)(content(Whitespace\"\\n\"))))(Tile((id \
-         0b35de69-2b21-48ed-be23-27e3ef8e8139)(label(type = in))(mold((out \
+         22a43f0e-0a78-4ec5-a925-8c7b41947f54)(content(Whitespace\"\\n\"))))(Tile((id \
+         e197a9ed-b4e7-4066-a9f4-67f04318d3cc)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e7538d50-5c28-4efc-8158-5d208154ad94)(content(Whitespace\" \
+         73206d2a-3806-4876-b39f-f5e4ed312208)(content(Whitespace\" \
          \"))))(Tile((id \
-         84a56790-e376-4803-a5a6-c237afc9d3bb)(label(GradebookEntry))(mold((out \
+         7c0f3917-7523-49a6-a83b-7fc54b0ae366)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         5f49f015-8575-4131-9660-743a5cd51b9b)(content(Whitespace\" \
+         1c71620e-a004-4002-899a-67c697220fcd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5e3eae60-7d18-4d2f-bb55-648981ca2f2e)(content(Whitespace\" \
+         6241bbd2-271a-4f2d-ac4d-3b765dce2da5)(content(Whitespace\" \
          \"))))(Tile((id \
-         ecae2cce-0e9d-40fc-b7ca-dc92cffda187)(label(\"(\"\")\"))(mold((out \
+         5ca1e859-d0c2-4566-9ed3-09b6498d65dc)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         be54008c-dd56-4578-a2de-78cdc7f2f83b)(label(name))(mold((out \
+         ce8a9a81-eb16-47a6-8566-d6a285fcf133)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         0e607f9d-0131-4cf0-9f2c-fefc12507ffc)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1cf4a9f0-43f0-4058-93e6-f909683a7ae4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         15dde201-d94e-4730-a743-6b97529289a8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         489c1c31-4831-4235-8ece-db3c4a4fb1a7)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a5f21912-49eb-4484-81fb-ac0ae5a2e106)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0388a2f5-1b82-4320-a7d3-e318cd0edffe)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         00bd36a3-2373-4fe3-a4e4-2d6de1ebddc1)(label(,))(mold((out \
+         c9cefbdf-0a82-4ba6-ad4d-d46975b5578c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         97b1df65-a989-48d1-8077-466ce7cf119e)(content(Whitespace\" \
+         68cc4d03-f42a-4c73-977e-222d648effa2)(content(Whitespace\" \
          \"))))(Tile((id \
-         d38df5e4-528f-4740-8938-dc4b250c94bc)(label(age))(mold((out \
+         3ea409b9-bd2e-4a79-85eb-69465b43dcd6)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         2049e46c-7ebd-447d-ae51-624f607b162e)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         794dca89-4971-4efe-a5ce-47a25169f1f7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         684780db-3416-4374-bb35-37e5ff2bc0a6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         bb5ef5e5-a3ec-425e-8ab8-6499a6244708)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e7d69acf-6632-498c-b32a-1f31385c831e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7d6342f7-599a-4736-a4d5-660017db69b4)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         a3d22774-f1de-4761-9dc0-d825d9a4275f)(label(,))(mold((out \
+         b65fa351-ed99-4b17-ae9e-f248b16226f0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         338081da-e6a6-4b61-ae46-499f9f0ef3fe)(content(Whitespace\" \
+         23d974d3-18ac-4257-ae3d-9a5ccce12ff7)(content(Whitespace\" \
          \"))))(Tile((id \
-         0390b933-098b-4a15-8b88-600abbcac052)(label(quiz1))(mold((out \
+         e808cb16-5832-4cce-a952-65988b9d7724)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         990e247d-bf62-4e13-9d4a-13ca1c41788c)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         419546ab-9d6c-4c48-89fc-f6ce8045ff37)(content(Whitespace\" \
+         \"))))(Tile((id \
+         be0119f5-7e5f-4444-bab8-e4aaa5cacf7c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         1f1dde33-ed73-4934-beef-bbf5b33e836f)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         157994bd-b668-40fb-9610-2b906d95a4c8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         45b5123d-c8e9-4e2d-965b-520a59886acd)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         4cfb2413-c745-4df4-90d0-fbe320c8fdfe)(label(,))(mold((out \
+         0e031b84-2292-4a63-922f-4c04ba5cde0b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4842ec57-a310-4ab1-8681-818151484835)(content(Whitespace\" \
+         6eb7db20-f561-415d-bf71-11adfc45c73b)(content(Whitespace\" \
          \"))))(Tile((id \
-         de681e01-c75c-4a06-80b9-0319a69d687b)(label(quiz2))(mold((out \
+         5cfeae1d-fe8a-458b-9117-88d67bbb0b37)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         1a235094-f48b-4942-9883-5082b18bc6b5)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e69be9e2-f950-4f45-b48f-50622e5a8859)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a2a0841c-990d-4201-bfa3-7e40e663ddb5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         55b0c4fd-41d2-421c-9c0b-002d64c545fc)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7e654405-15ad-4c4b-bf9f-427898b8557d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7f8ab453-2766-4c4a-9356-91dc262ff0df)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         ce0cb0d3-e234-463c-a5e2-939066904246)(label(,))(mold((out \
+         e7303c6f-11f1-48ad-8fc6-ab99707ea9d6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         79b7c69a-1c10-4a6b-a9a4-3c86427867b9)(content(Whitespace\" \
+         a59668cc-af4f-4f56-b968-edc70719b7e0)(content(Whitespace\" \
          \"))))(Tile((id \
-         2d19ff11-adc4-48bb-a9ef-fb7e0914d55e)(label(midterm))(mold((out \
+         e6c166a3-0950-4d87-8eec-7a57ccea8ee3)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         c6b5fb5e-d205-4949-846f-1f04ea469d4c)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4bf0555e-b429-4eb7-9af3-724a467bacf6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a26d89c9-838c-435d-8ea0-5108b729617a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         5ffbbe28-10b6-4583-ac98-7fbd2ad5df2a)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4cb0b119-b570-4003-bc93-ac21b8028204)(content(Whitespace\" \
+         \"))))(Tile((id \
+         21a09c56-345c-4c85-b0b5-38e2a366a8dd)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         14fc9982-c3aa-4a18-8590-cd2ceee37ea0)(label(,))(mold((out \
+         74898ed8-e43f-4435-901e-2563f87ec9cb)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4c7e45eb-2c0c-471c-8cf9-f361bee0d3c8)(content(Whitespace\" \
+         55a975dd-68bd-482e-9791-c28b6c4564c4)(content(Whitespace\" \
          \"))))(Tile((id \
-         9ce73e1d-fd89-4399-968e-ea3c7f8290fc)(label(quiz3))(mold((out \
+         84ebc4a1-bb2a-44cd-b6d5-71e93c333710)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         93cce992-7ef2-4eef-b6c2-d058c39e8de7)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         27e1458e-bd99-4fbb-99b3-bf5a1373ddcd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         85bf7bb5-47bd-4f93-9b35-561ca41c7dd1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         5e48a1c2-379a-4971-90d8-de62edc3b67f)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         182570ae-961d-455a-901f-bebdbd9e4f72)(content(Whitespace\" \
+         \"))))(Tile((id \
+         657b17e6-19af-4d68-9f0d-23471abf023f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         2bdd7e7a-0dbb-4bdc-a77a-b597fda44c0f)(label(,))(mold((out \
+         176519d1-44d7-409d-a1c0-e8760f1fdb44)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         912fda6a-f289-447d-9d27-a0a9ed5c750e)(content(Whitespace\" \
+         96a906bf-a625-4fe6-9f0c-76e1a0e8ea30)(content(Whitespace\" \
          \"))))(Tile((id \
-         08bf73b4-502a-4b13-9af4-9e9ae8ae5b9b)(label(quiz4))(mold((out \
+         76eabc60-68bb-46cb-bfc4-dda9205fce5a)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         85add83b-2bb2-4cab-8cf5-189d5599b9d1)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c0407f82-2730-447b-b55f-a579630b0b2a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eefc0a21-dd46-4013-a90b-247035491c53)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         f852b35c-9ad7-42b3-8224-82421796f296)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         abb5048e-3065-469a-8147-7d2cadfad0b9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ba508374-1220-42ca-afb3-a85257812f23)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         c0b356de-8f62-4c69-8157-b667c3142e2c)(label(,))(mold((out \
+         9abd85b5-4e81-41d8-84de-907f5625b1e5)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         279bfe24-c021-4734-a3c0-d07be40d7480)(content(Whitespace\" \
+         d69992eb-ea99-4c0f-8e0c-2ebe8c173977)(content(Whitespace\" \
          \"))))(Tile((id \
-         71df7f72-2baa-481f-bd78-ceb7e34920b4)(label(final))(mold((out \
+         ce27ab45-cafe-422e-b741-ab8c178bdf9f)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         6038df46-7c79-4779-8dbd-83df787db488)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9edccd76-8b74-434e-9b93-5b50794d4ef3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b28981f9-b114-45fc-89b1-37e3cab59d0d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         029feb59-d064-4ad0-8016-02dc819477ee)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9984347e-24c1-42f8-a936-06d8bc47e385)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9a072bb5-02ec-411e-b351-9d75743f7da6)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         41c0ed7e-2a7b-4624-9eee-e492fe39d992)(content(Whitespace\" \
+         c3263c60-d91d-4c82-9f67-484c323bf9ad)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8e412654-cf51-4ec3-9245-c202cfd3eee6)(content(Whitespace\"\\n\"))))(Tile((id \
-         af0fc7a5-7aa0-4c98-93ad-bde008149a9e)(label(let = in))(mold((out \
+         e059cfc5-1617-4119-9474-c319acbad0fc)(content(Whitespace\"\\n\"))))(Tile((id \
+         cc51d8ce-2730-4d3a-9720-c6f0392b5010)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         172440e4-a862-4e4c-8f1b-7b44610a7c99)(content(Whitespace\" \
+         1d673b35-eb68-4b5b-80b2-0694a96c7c9d)(content(Whitespace\" \
          \"))))(Tile((id \
-         b3210c83-6340-45ac-9860-fa87842398b6)(label(gradebook))(mold((out \
+         5dac77b9-49fb-4aad-bf07-281949d88936)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d706d943-df26-4f89-847e-ce3bc930de39)(content(Whitespace\" \
+         2e54e65b-3553-42ae-aeba-63d656c2e34b)(content(Whitespace\" \
          \"))))(Tile((id \
-         32b9b814-7e90-4843-9966-f94b56eec05c)(label(:))(mold((out \
+         d53f34de-644c-48d4-94ed-1eadfc91bd28)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         df915426-6620-40a9-8dbd-9f857894a370)(content(Whitespace\" \
-         \"))))(Tile((id fda7219a-eb96-4d3d-b964-282483664f7f)(label([ \
+         dc98a1c6-901c-41bc-9b6e-f2a5022e44db)(content(Whitespace\" \
+         \"))))(Tile((id 1e57df58-06a8-4ff1-827e-cf61ea62af0e)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         66004bee-f6d3-460a-ac12-d7f4cb439f8c)(label(GradebookEntry))(mold((out \
+         4a352280-5a26-4c51-bafd-b4c6b86c6cd6)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         b8e1302d-24e9-4fa3-85d4-b099681f23c3)(content(Whitespace\" \
+         7c4f5a9c-6ff7-47f9-9d6b-e5040dc224a3)(content(Whitespace\" \
          \")))))((Secondary((id \
-         78e4b0a8-6a8d-4e0e-b662-eea53829ff4a)(content(Whitespace\" \
+         f629bdac-220d-43f4-b1b6-a328e0758564)(content(Whitespace\" \
          \"))))(Tile((id \
-         a7d00bbf-a627-4cbc-99ac-e55394e11ef5)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         040f29dc-1c20-4ad7-8d94-85523992d75b)(label([ ]))(mold((out \
+         9833505a-0569-4f50-a27d-23772e6af189)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         1acdbb0c-e989-4f74-8622-e7a8fc3a4a02)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d1a07892-f767-48f1-a3b0-5d7baa526fd9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e63ec9bf-f5a2-4456-baa7-875726315757)(content(Whitespace\" \
-         \"))))(Tile((id \
-         be10a274-3e72-44d7-b985-0d49fe952453)(label(\"(\"\")\"))(mold((out \
+         baf25cf8-9f11-4a53-a908-31de6cba2982)(content(Whitespace\"\\n\"))))(Tile((id \
+         d793559c-70e0-4723-bb1c-665a97d912a1)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         7c36c83b-6710-492c-8786-272ce36f4e72)(label(\"\\\"Bob\\\"\"))(mold((out \
+         13be4932-4734-46b8-86b7-ce189ea180a0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         6dea2807-fd43-413d-9241-82f24c450995)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         10cb18c1-41bc-4a07-9936-176439b05841)(label(,))(mold((out \
+         d250fad5-4437-4774-8713-4627d89d81a3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4825e2ad-0aa7-4236-85f1-33ba2bc00eab)(content(Whitespace\" \
+         56d3a752-3e2f-4d70-a387-7cb3f921edfe)(content(Whitespace\" \
          \"))))(Secondary((id \
-         e18961f2-6132-4cad-bd48-f31172d31b55)(content(Whitespace\" \
+         c690dfd3-9528-4d0e-b240-8fbe35c3a072)(content(Whitespace\" \
          \"))))(Secondary((id \
-         c7d68f9b-7295-4189-b359-c885ac551bd5)(content(Whitespace\" \
+         e15a2a3e-35c5-4020-8a03-845bed1ced6c)(content(Whitespace\" \
          \"))))(Tile((id \
-         95a75017-bc6a-4056-8928-60e6f70cfea8)(label(12))(mold((out \
+         c587a5e6-b589-4a62-b7be-24e322e7c9b0)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         bd9309f9-1728-4ce8-9d82-92ab7b57afaa)(label(,))(mold((out \
+         491a76c6-b64b-400b-acf5-cc2d6896609b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7600c6f6-829c-4554-a42f-cca206c99473)(content(Whitespace\" \
+         98df76b5-4287-444d-a8ec-07788abedf2f)(content(Whitespace\" \
          \"))))(Tile((id \
-         eac964e6-7272-463d-b473-51ff4404c2b5)(label(8))(mold((out \
+         985bbf7a-1241-419a-abad-c7d6b4fc3369)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         983e31aa-8dad-45c7-b8d1-c7a68daff18b)(label(,))(mold((out \
+         818bc476-7a5c-42f5-927b-f51e714fb10e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         35f8ed4d-5373-41f6-8e09-489b694002a7)(content(Whitespace\" \
+         f6865c79-a5d3-4b6e-aacb-2ea802aa42f1)(content(Whitespace\" \
          \"))))(Tile((id \
-         8c3b1c05-e534-4686-a119-bf348b3b3fcc)(label(9))(mold((out \
+         df8e2449-519a-44de-bb58-81b829252951)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         1faf25f8-b8ca-4528-8e67-1cabafd4d137)(label(,))(mold((out \
+         af086164-f8f6-40b4-9768-c61eb8e9447e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         11aa775a-71b4-4516-980d-d16dfa3b8f35)(content(Whitespace\" \
+         077884b4-904b-4fb9-a166-02803f1606e1)(content(Whitespace\" \
          \"))))(Tile((id \
-         289cba2d-b7ae-43e8-ad4b-5a58a5f2a5ca)(label(77))(mold((out \
+         f4457bac-dc0a-41a1-8446-7be924562ea7)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4f1c6084-4340-4437-b236-c7dd5ce28cc6)(label(,))(mold((out \
+         1277e817-ec3b-4c13-bebe-84e2999dd64f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0fc1c33a-b0a9-4f91-81d1-3ac4bfafca92)(content(Whitespace\" \
+         50afede0-7e8c-4288-9698-d0e09501f722)(content(Whitespace\" \
          \"))))(Tile((id \
-         36338e04-f821-4c01-ad18-9fb034f79172)(label(7))(mold((out \
+         9a942848-7b06-422a-954f-d5d5c618d25c)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a45d857e-1be3-48f9-a4b0-15ecbfdefd3d)(label(,))(mold((out \
+         28d3a204-9f13-4d1b-ae77-ce0727ab7e33)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         12026ca0-bb63-4ec8-9762-2c4db3801895)(content(Whitespace\" \
+         763734a9-d02e-4a7c-bc1c-6579a2b820a0)(content(Whitespace\" \
          \"))))(Tile((id \
-         1722d034-282e-44e7-95d3-d28abde417b3)(label(9))(mold((out \
+         27d0d8e1-6ec9-400b-800f-9cbcb3383fe4)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         64232a88-f160-402a-86da-50435dc61b24)(label(,))(mold((out \
+         9e5e591f-e344-4cc4-838f-c76b4b515b8e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         384d7f0f-ec9b-4c23-b7f2-6d9fd140b5bb)(content(Whitespace\" \
+         affbb439-c336-45cc-ae8c-6255761d6cf3)(content(Whitespace\" \
          \"))))(Tile((id \
-         63e02caa-c4ce-403b-9525-46608a075acd)(label(87))(mold((out \
+         7746f4b3-1b38-4af2-a826-732059b80024)(label(87))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         43398375-48fe-4c0b-ad07-51d3cb5eb53b)(label(,))(mold((out \
+         3433782c-aa17-4bf0-bcb9-7e2e05621e87)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ed8d56e6-e2c2-493b-9bb2-0a7930ed700d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         abac30aa-f58c-4970-9e59-1f588bfa0b28)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d709566c-6257-48cc-995a-a1370257c509)(content(Whitespace\" \
+         34ecc5df-cfd7-45cc-8930-377d6af81077)(content(Whitespace\" \
          \"))))(Tile((id \
-         0afb812c-dd12-44d9-84a1-edafa3d44eb3)(label(\"(\"\")\"))(mold((out \
+         1ffb8459-0632-4444-a43c-d1cef6b95f3c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         da2f0f38-b43e-426d-b6a7-bb8782c11ad5)(label(\"\\\"Alice\\\"\"))(mold((out \
+         6136042c-dfe4-405e-bc0d-587ae5cf1266)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         74dc479a-f4f1-4b78-b3dd-754aeaaf2ed5)(label(,))(mold((out \
+         fa179bde-58f8-4cbc-b368-cdda79f09662)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e4bbf344-4c67-452e-af94-56520d8213a0)(content(Whitespace\" \
+         e3052920-e702-42c8-ac39-147ff30a21df)(content(Whitespace\" \
          \"))))(Tile((id \
-         0a43bc22-97d4-4495-a632-1a30c25764ca)(label(17))(mold((out \
+         35cb8a54-1afb-4bce-86ab-a61c2a244c79)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         9e06383e-91dc-47ca-ab65-ab5867c9aba1)(label(,))(mold((out \
+         dbe50ad7-ebf6-4536-802b-dc0b5e924c45)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6c44b93e-a743-4e39-a499-822f9f52621d)(content(Whitespace\" \
+         fe5937da-a450-4c55-be0e-b2b3d05f83f1)(content(Whitespace\" \
          \"))))(Tile((id \
-         3be910ea-2dc9-4040-97ad-dc2f805d7ba6)(label(6))(mold((out \
+         df508eaf-0b9b-4ee9-8f6e-10e084ed3f73)(label(6))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6e6e1fd9-7c15-4045-969b-8ed2e15ae366)(label(,))(mold((out \
+         0d363f28-34c9-44df-92b9-c59caab231c8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         34247b64-edb0-4890-82d5-49612f441b29)(content(Whitespace\" \
+         68746746-edf8-4f6d-83ae-80a4949ceed1)(content(Whitespace\" \
          \"))))(Tile((id \
-         fc6ea20f-678c-4aef-ad28-d87d7501b50f)(label(8))(mold((out \
+         33859e08-3962-4b57-b41b-2808c9459b67)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         276dcf11-c2bd-4cd6-8418-c1fb6868f0f8)(label(,))(mold((out \
+         e03d6f75-042c-4e69-9596-7f53ce80e0c7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5460401d-7dd9-4f88-a7d0-a39fe8b5d0f6)(content(Whitespace\" \
+         02633631-b485-49cb-b53c-a62a163e572e)(content(Whitespace\" \
          \"))))(Tile((id \
-         9214c06e-d5ad-4bcb-af9b-2f4ace8a6ca6)(label(88))(mold((out \
+         9bfb20a7-6695-4a7c-838b-17057cf34659)(label(88))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4222a370-7c10-468d-8614-d90e0d1a5828)(label(,))(mold((out \
+         a292837d-777a-4a98-a5f8-53ce4e0cdfee)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         62a204ff-0880-4859-a0a8-b76a80f2a46a)(content(Whitespace\" \
+         96c2088f-6ce1-47fb-ab32-5dec6eba24e4)(content(Whitespace\" \
          \"))))(Tile((id \
-         c2aa4f42-027e-4a1a-a903-179aaa7302dd)(label(8))(mold((out \
+         f42eff22-4f68-49be-b743-4a5db48fbc1a)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3a8c3279-c804-4c28-9e6f-b3fe672e4f00)(label(,))(mold((out \
+         a4d1cd3c-48ca-42f6-891f-5dc0ba483dbe)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         89621493-29fa-490b-93a9-b7a041c4333d)(content(Whitespace\" \
+         2e5d7a22-ee50-41f3-a92f-d80e83cf1392)(content(Whitespace\" \
          \"))))(Tile((id \
-         1570e10a-9e10-4108-ab85-198a1fe78168)(label(7))(mold((out \
+         d53d77a8-b442-40ed-8705-32f761373e7a)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         2c1e47d9-8bb3-4b0b-8849-f9421ee5e697)(label(,))(mold((out \
+         2c31b209-9275-4a45-b41f-07a0dad8a6a4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e2315579-dd30-48eb-ae07-1ae76830c62d)(content(Whitespace\" \
+         42d6bb5b-7e3e-44b6-9409-640e9f97beed)(content(Whitespace\" \
          \"))))(Tile((id \
-         445071fd-6121-41f8-97a9-6d21578a28b3)(label(85))(mold((out \
+         09c4ab3d-f28a-4c6e-9a5a-12f88acbbdb1)(label(85))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         1e0e9400-1951-4ddf-a7cf-2c83ac54f5b4)(label(,))(mold((out \
+         9478055e-faf2-4a33-a2d0-f305a3b71a0c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8e2feea1-9cec-46b0-9f74-f63fa774ebcd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cf573f75-2377-45a9-9eb4-e4a746ce43d8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ade77d25-475a-46a4-94d3-39eeb72c7955)(content(Whitespace\" \
+         8e0f6728-67f7-419e-85ef-57fb52990938)(content(Whitespace\" \
          \"))))(Tile((id \
-         bd424eb1-2922-4d8b-adda-af785336321f)(label(\"(\"\")\"))(mold((out \
+         e04f5359-9f16-4bf6-982f-1e478bc98afc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         fc250981-9aa9-4c52-bab0-b944eeff0166)(label(\"\\\"Eve\\\"\"))(mold((out \
+         964974c8-5014-41c4-9f21-57700772607d)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ed57a516-2849-460b-a93f-1eef18b89050)(label(,))(mold((out \
+         67d40bf1-3fda-4835-afca-b579afab8972)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10a490f7-f5b8-468b-8cd5-3e5dab4ef1ce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a1e45130-21b9-4038-909d-7644c4993531)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d10e23e8-f741-4cea-a67b-f18f97a9a354)(content(Whitespace\" \
+         9dd0690f-a4c9-48ac-aaa3-5884b01d54fe)(content(Whitespace\" \
          \"))))(Tile((id \
-         42aa11be-c850-4c27-abea-8995b9642508)(label(13))(mold((out \
+         1b11f9af-1c8a-4959-b170-a6cad2a670e8)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c6a265ef-1f39-4ebb-99ae-e74705d881d7)(label(,))(mold((out \
+         ed1185ac-1d96-4c94-b5dd-0143a93edaa6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6e7e6586-127f-493f-8e46-7dfd22972799)(content(Whitespace\" \
+         fcf41f4e-f37a-498b-a465-6fa15a3db2be)(content(Whitespace\" \
          \"))))(Tile((id \
-         89e59816-7a8c-4c82-8427-2e3391f4a758)(label(7))(mold((out \
+         63b84fda-ff65-424f-8327-e241ee61e4e1)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c0a17583-9144-488a-a696-1e694d74d095)(label(,))(mold((out \
+         01d2c649-3784-48a1-b68d-8cc4f9ddce64)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5f4591ce-bcc6-4227-bfc8-d28964a339af)(content(Whitespace\" \
+         136c5d78-f452-46d2-8b35-0746351444e3)(content(Whitespace\" \
          \"))))(Tile((id \
-         5cd77c2f-3500-449d-8f01-2c0acf7e4c79)(label(9))(mold((out \
+         8064dcb4-c0bf-4ae4-ab1d-7c677b7a784a)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         70a71b02-6acb-4d04-be5f-c802614366fa)(label(,))(mold((out \
+         0b8708aa-8e39-4070-9d89-9b934f89bdaf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1eb10c31-8bbd-408a-a303-7a08b8de55e4)(content(Whitespace\" \
+         9d08125c-daa4-4876-b640-83212bb7daf1)(content(Whitespace\" \
          \"))))(Tile((id \
-         c89f22cb-ee5e-49b5-bfa9-c1658a377795)(label(84))(mold((out \
+         73456b70-b0e0-4a76-9bc6-ad6d3dfa293e)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e8338771-b046-4862-8e17-417b60e2a31b)(label(,))(mold((out \
+         3cc66a83-ec60-4fc5-b142-cb1a9c3170c3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         93d847f2-bbc8-461d-ab80-67da44740fd7)(content(Whitespace\" \
+         3a4c4f88-00f6-4a6f-94d8-20dd6e8933d0)(content(Whitespace\" \
          \"))))(Tile((id \
-         2dc32f27-797e-459c-89fa-15db2431bd75)(label(8))(mold((out \
+         8c3d113a-b2d0-4be3-af69-ec89f1510bad)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         77b6da7d-ef36-4c56-8097-03775b1b9824)(label(,))(mold((out \
+         c45fcf0d-1769-454e-a743-5e8379761ccf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4cc957ef-1998-4975-a109-4137e1267a72)(content(Whitespace\" \
+         854365bc-bb6f-46a6-be07-c1ee750f1217)(content(Whitespace\" \
          \"))))(Tile((id \
-         34763828-410f-488b-9d77-9ad7c5d9da5e)(label(8))(mold((out \
+         c6c80415-8809-452e-a697-ed51698e647f)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e993ebbf-bb90-47d4-96c2-391b0d81b12b)(label(,))(mold((out \
+         a294f3f5-8d97-4460-b7ae-8e76a850f082)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         87d47eb2-ceb0-4b3f-8e40-6764281cb316)(content(Whitespace\" \
+         054b1678-bed3-4387-8cc5-2f2493b074c3)(content(Whitespace\" \
          \"))))(Tile((id \
-         5ed56b07-c410-4650-9af8-c3631810b1da)(label(77))(mold((out \
+         6b2a4618-498d-4ffd-a8fb-5f5e6a923d75)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e22624e0-8e08-446d-92e9-2bc681f2d6ad)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         03144dfd-375c-4c59-8df8-e007ba30a43e)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         65ea7949-a831-4909-a964-4c6a48cb16e4)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         e9fcb21c-c93d-4f2f-b5f3-30ee68e93861)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e5894c5d-6826-4348-bc53-ae5cf6337838)(content(Whitespace\"\\n\"))))(Tile((id \
-         05da61ef-5835-408f-bd88-f38e5788bc31)(label(let = in))(mold((out \
+         5ebc5969-0c34-46ac-b58a-9d11e9e342f9)(content(Whitespace\"\\n\"))))(Tile((id \
+         82922be5-da04-434e-a735-51a09bf7db89)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         22df57aa-47ca-48e9-865c-e22367917ced)(content(Whitespace\" \
+         096cdcfb-8ed7-46de-b201-5aaddf03c442)(content(Whitespace\" \
          \"))))(Tile((id \
-         c8ac51f2-1a5e-446f-900e-51a64322d89e)(label(count))(mold((out \
+         858e8eaa-f3a6-4042-8b5b-91f22f6f5d2b)(label(count))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9f619989-4475-4a05-a081-8632a368e7cc)(content(Whitespace\" \
+         14f9d40a-7333-4359-9c2d-3e2f2bed272a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6de9fa20-2113-4b89-92e5-c05f27fe14d5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ddbe9170-7222-4d68-8896-c9068f5efc61)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db0b61e3-9809-4ef3-834d-e32ee5b0943b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         446670a1-4d3b-47f4-9d31-88d7754d515a)(content(Comment\"# V1: This \
+         fb84d3f2-9ba0-4859-a296-ae6e8f835d38)(content(Whitespace\"\\n\"))))(Secondary((id \
+         67e63261-a49d-48c8-ac5c-dc73deb62162)(content(Comment\"# V1: This \
          version is more idiomatic and uses a higher order function to project \
          out the value. #\"))))(Secondary((id \
-         69b4b1cc-f8ef-4aca-993d-940006bd8960)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0201db71-27fc-4f67-a5e0-dfd52b1a83cf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f973de85-85d7-447b-8aa8-8cf1868708c3)(content(Whitespace\" \
-         \"))))(Tile((id 84ebb7ff-4aa0-48ac-b2ba-d1e56330b254)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d64fce6c-402a-49c5-a9e7-0f03f73c6037)(content(Whitespace\" \
+         a4117cb2-25a1-46f4-aada-7287df921fc9)(content(Whitespace\"\\n\"))))(Tile((id \
+         a5a71571-b323-44a5-81c1-71fcfa28d895)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f3e7b3d3-a60d-4df5-8b88-e4159b71b0ea)(content(Whitespace\" \
          \"))))(Tile((id \
-         ead3a378-acb2-4952-a6ee-101f50b5616f)(label(v1))(mold((out \
+         add32b0a-7705-417a-8ddb-85c978e87ecc)(label(v1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         bb01745d-c73d-425c-bfdf-5ced8c1975d2)(content(Whitespace\" \
+         3165150d-2e4e-431d-ada5-726b0f6b6e63)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c065ee14-8532-4c78-bb8d-0673cfc0f55d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         04e6e2e7-f514-4bb5-a9a9-04921b06c290)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3f2dcf1a-78cd-4fb3-8094-6b779f64077f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc9682a5-9162-407b-9d72-7ea3b9fbf444)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a14b864b-beb1-438b-a86f-b1940a255e0f)(content(Whitespace\" \
-         \"))))(Tile((id ec459bee-43af-4912-bb98-26ccf8054183)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         1abb6805-d0ce-484a-82f6-90f5b0cbe26a)(content(Whitespace\" \
+         10304f6e-c5cd-4b77-9084-bd7e507f574a)(content(Whitespace\"\\n\"))))(Tile((id \
+         9a1991d8-52cd-4cdc-8f18-6d1c7f31b53e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ed3d311a-8df9-4113-bfad-b9fdc34129d9)(content(Whitespace\" \
          \"))))(Tile((id \
-         a042db59-534e-474a-8584-5eeb4bf98b87)(label(requires))(mold((out \
+         9536f712-392c-4511-ba99-9b9749bdb7d0)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         cfc9583c-1745-483f-a7c8-e10254ae9253)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         45b00092-71f2-46dc-9360-526b2b5bb3ea)(content(Whitespace\"\\n\"))))(Secondary((id \
-         54018325-05f9-4d68-bf36-22c4ac42a748)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d83d25fb-6c8d-453d-8e58-74caf78d90ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61bc94e5-8ca8-41ac-af9a-ca4340a13772)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a6377096-eb3b-48db-96f8-7add0030f87e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c61124c4-1ca3-4eb2-a421-6fc7f51339fd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ced7bad9-de95-40ab-8060-b8958aa4e0f7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c22d5528-e2e1-4439-9226-675793c210a9)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         df5a4654-f7df-4128-be48-72eba8b93bda)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         fa49f0c1-5b62-4f24-b385-7467d365b87c)(content(Whitespace\" \
+         \"))))(Tile((id 01296f51-779f-4010-936c-8415965974c6)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         3e14b9bd-cdc1-4ebe-8642-593a695ab998)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         cb45edde-c30c-4024-9a32-bde2a5e2f35c)(label(enforced))(mold((out \
+         fdb161eb-0cdd-4efc-864d-0ec9264fd91d)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         66be2222-e5ea-4cd8-af98-4d433791d040)(label(=))(mold((out \
+         f636e8bd-9eca-41ad-9913-fa70ad6acc24)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         fa133940-6d64-41a5-b657-e673b3d8a4e8)(label(\"(\"\")\"))(mold((out \
+         f34c4cf9-2b0b-44a7-bc0b-0de18cabdf37)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         9d5b01b1-0d6f-4b32-ac97-150cf8b2f18e)(label(true))(mold((out \
+         df5004bd-2ecd-4402-be23-ebfa11970ce8)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a58f5ee3-01d1-4ea4-b61c-6caa7bf7d449)(label(,))(mold((out \
+         0dd825e7-540a-4420-b9c3-f88d949486ed)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8f4b3c59-a7bd-45bb-a3fc-e40f2077c750)(content(Whitespace\" \
-         \"))))(Tile((id 7b034403-17cc-47bd-8127-51323b64f271)(label(\"\\\"c \
+         d9a8da9e-a229-4628-9522-133ef03140f7)(content(Whitespace\" \
+         \"))))(Tile((id 803f73ab-2f4d-4f18-91da-5c47b627c778)(label(\"\\\"c \
          is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         c573e2c4-966a-49e8-8063-5d62c76f7171)(label(,))(mold((out \
+         1d01ba03-2385-4042-82f0-3b9e742a6a9d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4229fe82-eab4-4f9f-aafc-e079a8abd22e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         feab7e23-1985-407c-a425-861049350443)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9dff1d63-cb1f-43e6-bb77-2314c906cc65)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5a0d1c1e-4e2b-4cf3-814f-d00bd6fbbc40)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         402f1d52-07b2-4126-8592-b6ab949054b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         158f9426-efe9-467e-af13-b0404a159589)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a4da728d-f4f5-4a17-ab94-5f77a2b2c2c2)(content(Whitespace\" \
+         f78e4c27-bc55-4564-ab2b-b8955a04c0f0)(content(Whitespace\" \
          \"))))(Tile((id \
-         30f0f75b-edbb-42fe-91c6-87fea5692350)(label(\"(\"\")\"))(mold((out \
+         1b83ae66-d17b-4b64-8588-905df86c26ff)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f8f1e52b-b30c-456a-93ad-effec7a72892)(label(enforced))(mold((out \
+         f810d380-5d96-4605-bc59-38df4cc45812)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c6bc1f20-d752-408a-8829-16390deb6ca6)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         5155ce24-bc96-4430-b33b-e2a1c6c4afbc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         31c45846-4498-4df9-9fdc-7e46865f4ea8)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         5c999d59-a223-4fe0-9e47-4095e09600e9)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dacb6d5a-d90b-4731-b88b-9001dd45e42d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fc10c633-664f-4e61-98da-37d43dc77b48)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         14d6c173-c56c-4814-b2e1-51abb0dd2dd7)(label(false))(mold((out \
+         321fc7fb-52a6-4344-b7d9-333a795982bc)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         57066ffb-8561-46ac-ae68-b76eb4dafdc7)(label(,))(mold((out \
+         c2cb1926-3cef-4c83-8897-34aca06a94b7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e490bd70-4e3c-4ed3-becf-57bac6b37ecb)(content(Whitespace\" \
+         0fe0d8fb-0112-4002-ad87-b5b88df831c4)(content(Whitespace\" \
          \"))))(Tile((id \
-         82f7399a-6c32-42d4-9053-248dbeb56bac)(label(\"\\\"schema(t1)[c] is a \
+         d8beceaa-24ca-4f62-b94d-10734eba04ee)(label(\"\\\"schema(t1)[c] is a \
          categorical sort\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         895f4aee-bb0d-473e-b688-ea1f28ba32d4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         10249495-9abd-4e9d-9bf2-78495d87ed97)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8560bb0-42ea-4633-bd42-7d6ed1645a38)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d9a606a1-bb6e-4f28-afea-c8175aea7813)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6c002e63-21b2-4281-8aba-2f0dbcae2e50)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         58fe53ae-bdb1-454e-9f47-c417462411e5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2a0aa752-d2fb-4adb-9858-1ae6217bd54f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         16a2e0e1-8faf-47da-bdc2-ac7c9eba7967)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0a469645-b02e-417f-8013-d6d80be9935a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         93161a2f-beb4-4b63-8e0a-e35a7d9f542d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         62f6b759-b7bc-4614-96ee-ac218b40e3d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9dbecc47-e157-4aa7-84b0-7251c30e03fc)(content(Whitespace\" \
-         \"))))(Tile((id c14860f8-155c-4aad-b4fc-7353586e72b8)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d3c19bb5-ffe6-44c3-9ead-343cedd6c930)(content(Whitespace\" \
+         df9dc3d9-beb1-46a3-a866-13092af58810)(content(Whitespace\"\\n\"))))(Tile((id \
+         2404a547-c013-4bd3-8195-2edf6b3a0e7d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f984b2ef-bd64-4845-8f5a-cf87e3168429)(content(Whitespace\" \
          \"))))(Tile((id \
-         6a70139b-5094-4a8d-b3fa-8ed7c669dafe)(label(ensures))(mold((out \
+         85b089ec-dbe7-49e5-a08d-09c69c4aa635)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         94d52ca5-aab9-4af0-84af-33cf8f4ab4a7)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         9d2e0061-d8ce-454d-981b-9f3b26bdebae)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ca2463ce-db98-4d4e-a225-3a8d5d20cb20)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58c8ce59-0a82-4e0c-9168-738af160ad47)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4609b7c4-116d-4593-a67f-ea9ba3d4915a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32285a0a-5a12-4486-856f-88937aec99da)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb8ef84b-deb5-4bf0-90df-df231966fa38)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8ddee270-b564-4627-9f3e-e8af2e445ff7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7593d252-5b2b-44dc-8ead-358c46a22be8)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4d7aeefa-ca61-462c-9183-54165f377915)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         c74f1b94-577e-4b34-ba0f-bd59e7722503)(content(Whitespace\" \
+         \"))))(Tile((id cf4f2bbc-f74b-450c-986b-4642217d4091)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         fdb586ab-12e2-4f16-9528-cbc2119ac63b)(content(Whitespace\"\\n\"))))(Tile((id \
+         e50475af-6c38-4080-ae67-30cf20c19bf5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b9e36471-f185-400d-9976-7337e021abc5)(label(enforced))(mold((out \
+         1c07e470-e0c7-4b19-afa9-4a10957071bb)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a4a8685d-70a4-4b4c-8b67-bc4ddbbc3638)(label(=))(mold((out \
+         40e3e5ae-2e08-46f4-9d4a-1a31f9d8f493)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9eae86ec-ac7f-4175-9211-5597b714fff1)(label(\"(\"\")\"))(mold((out \
+         fea8d1e0-bc84-4024-b672-12b53f301c7f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         ca169e68-6665-4ad4-98c8-a95c3ecba6f9)(label(true))(mold((out \
+         0e85d86e-bfb8-4802-bfb3-458142676354)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         23aff38d-e321-4841-8b01-32e36096d1ed)(label(,))(mold((out \
+         cfd9de91-573a-4dd4-b815-97b31d3ca5ba)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0f30faf6-934a-498a-83ed-8882fce8abde)(content(Whitespace\" \
+         b93b68b7-fbaf-4467-a78e-9574de2708bc)(content(Whitespace\" \
          \"))))(Tile((id \
-         c51af328-7f11-411c-a535-5baf77fc7abb)(label(\"\\\"header(t2) is equal \
+         42217d02-3b76-438f-af97-20038e04c7d6)(label(\"\\\"header(t2) is equal \
          to ['value', 'count']\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         2047b1d5-45c2-4711-8aee-2dcc013b5c85)(label(,))(mold((out \
+         d2cf906b-cd52-4118-ba5c-f1d0fbba6d80)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         499624df-622b-48aa-a87e-0bf527c93e79)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4b2e9660-5fdc-4353-859d-0166d7930c55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         545c25dc-81d8-4b9f-b695-df52b57cca11)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         040df83e-df35-43c3-bdab-483925540f85)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         13fc81bb-e1f5-4697-b491-97c8ad36ef9d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         39af4a07-68f3-4b40-89b1-89200856eb5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0436efb3-8602-456d-8a03-00fb4f5f7612)(content(Whitespace\" \
-         \"))))(Tile((id \
-         268eba76-03bc-4aa3-9802-3824c5eae7a2)(label(\"(\"\")\"))(mold((out \
+         a92d2015-2cf5-48ec-b479-d4121df56345)(content(Whitespace\"\\n\"))))(Tile((id \
+         3fd7a3bd-6f53-410b-9f83-6b6f08f09613)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f6e0bd88-b864-49c6-a8b5-ac84f67e398d)(label(enforced))(mold((out \
+         12b4f445-f0ad-469d-b336-1076bf026337)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         aecbeb48-a470-4396-9390-b1c027944c5e)(label(=))(mold((out \
+         76ab59a2-0c6f-4d09-98ff-7bf1953471da)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c848d864-a5d4-40a6-8938-4c36100d4f96)(label(\"(\"\")\"))(mold((out \
+         ba0b7128-7c94-4ed5-8424-815a89f63df3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         6c33b96f-28e3-407a-a062-d571a153ad4e)(label(true))(mold((out \
+         4ac1df4a-aef2-485f-a1e1-da3b8d80279a)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         522424f1-ac67-4007-886f-d24e4d9cefca)(label(,))(mold((out \
+         ba2e022d-8e54-48bf-920a-a7724f7db656)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fa8678be-090f-4366-b334-38c47cbf1242)(content(Whitespace\" \
+         8ba969d6-5579-455d-8efe-f42d2a56f88a)(content(Whitespace\" \
          \"))))(Tile((id \
-         56b8d6f7-03b6-4822-ac56-6f3a24f97787)(label(\"\\\"schema(t2)['value'] \
+         05b562fc-f6b1-4033-afaf-6664a2b40fc2)(label(\"\\\"schema(t2)['value'] \
          is equal to schema(t1)[c]\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         08ba8d1c-65be-4fbd-8293-0086bf0405ed)(label(,))(mold((out \
+         805bb0e6-a0b1-445a-999d-f2cf081e9bdf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8cb9c27a-39a4-4d44-a511-21c978807dd4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9f540726-d35b-45cd-9e78-861e8a7e0ffc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         028651e6-76de-4d0b-818e-9135391ffb89)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         16fe4864-8ca0-45ca-b388-cb6fde836c8c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d008bf0-5fb2-4cea-a1c3-54df1e507f5e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f3bdd862-fb8d-4f04-8616-dfdd189e8ba8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b0313265-2452-4fe3-be97-263dd705eaed)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7788eabb-ec7d-4062-93ec-5b6115d128f9)(label(\"(\"\")\"))(mold((out \
+         441cbfd0-8a7c-40c6-bca2-c3684e93aba1)(content(Whitespace\"\\n\"))))(Tile((id \
+         8c8abd34-5a02-4c4a-9421-6c3058930edf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e0843733-af80-4fa4-b597-5bd839a936b1)(label(enforced))(mold((out \
+         e1cfdbbb-6be0-4ac7-a29f-4f3490af424b)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3e7327c5-928f-41df-b436-cab9539c5101)(label(=))(mold((out \
+         e36bf653-8db9-4554-918a-91f9cbfe8b50)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0eb718d8-b5c0-4e1d-9a9a-7d445221173c)(label(\"(\"\")\"))(mold((out \
+         0c2713b4-f495-46ab-9ab8-f1893fe04412)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         872115e6-4f27-4838-a58a-156e44281094)(label(true))(mold((out \
+         a0de9b60-7ebd-4ddf-91eb-a4a08fab8714)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         0d228c39-b2fe-4ee3-bfc9-a5c43695a3bc)(label(,))(mold((out \
+         90af293c-bc0d-420e-9a63-d96ecd812a7d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         935cea40-bf5f-482a-bd2f-df13ef4892c8)(content(Whitespace\" \
+         8e8a37d7-6fa6-4266-91b3-9a323bb20946)(content(Whitespace\" \
          \"))))(Tile((id \
-         dcb5ba31-c67a-47a0-a4b5-80175b3af20f)(label(\"\\\"schema(t2)['count'] \
+         2e0472ef-30f4-4276-8db4-19bc794e30dc)(label(\"\\\"schema(t2)['count'] \
          is equal to Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ff4b9c38-1505-4256-9783-912a3c07a9db)(label(,))(mold((out \
+         9c87ffcc-cec3-453c-b0f0-ed8a15d2b447)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b17dfd68-70f4-4ee4-a9e5-f1f73a678fdf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f122e37b-1d1f-4559-bcdd-f78d15285115)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9083a2c9-a1ea-41dc-aaea-40c1d7f51cf2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         152814be-9187-45f7-99ea-c9e34d9337c4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6677f791-d4b8-4cbe-ba01-f35ac7d0efc4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6654f8ec-2c78-45db-ac20-ad24415c767a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ecb74c2d-bd33-4abf-bc33-77fcda967a68)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e4214e7b-2738-4846-97ca-170402f5c69e)(label(\"(\"\")\"))(mold((out \
+         367ebb5d-c3ef-49e7-bcd6-2248e08aaee7)(content(Whitespace\"\\n\"))))(Tile((id \
+         645a1d07-18d0-4d90-baf7-26b073855c4f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ad40159a-4dc9-4151-80dc-4245e149b92d)(label(enforced))(mold((out \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         c5c7f791-ada1-4656-9ef0-cf764a0d3903)(content(Whitespace\"\\n\"))))(Tile((id \
+         c9e1719f-9c3e-4a1c-934d-b4f6aae1a2d7)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a0f4473e-98d6-400c-8683-740141fad11d)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         333be55a-0539-46de-b350-b2d99a54cc55)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7c581af6-1f2c-4351-813b-cdff21acb809)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         aaf133df-847e-4ade-a9d4-c0cc67170da9)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         45f53939-fe3c-4175-8d92-ef2a8c61532a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eb077d5f-f157-47d8-8e81-2663041b247d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         fee1e527-535d-41fb-9a9d-8500c621a284)(label(false))(mold((out \
+         ed0d2098-8495-460f-9969-b8b330b9a927)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         94fd2538-e4da-4d3c-ac9e-082dbe82475f)(label(,))(mold((out \
+         835f8157-3b37-486b-95d9-4b874e8b3858)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e674177a-3adc-4631-8afd-3b22b5ab5762)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1c53ed5a-bcfb-4b3a-bc05-cee9e94ce67c)(label(\"\\\"nrows(t2) is equal \
+         e0cf1fa2-1019-4384-bb5f-4b5b4a1cb172)(content(Whitespace\"\\n\"))))(Tile((id \
+         96f50aca-83c6-44e2-8c80-304c856d28ae)(label(\"\\\"nrows(t2) is equal \
          to length(removeDuplicates(getColumn(t1, c))) \\226\\128\\148 Note: \
          if there are missing values in the input, this constraint requires \
          one row for missing values in the output.\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fa04181f-6ce8-45d9-b469-645a3f2b0aff)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9d980284-76c0-4601-993e-4cf0f39d9467)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dbd0a5ac-682f-4ca2-b181-c6d2524b5e5f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fc365b46-bec3-421a-949b-75a5bae8ad66)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8b680f2-6782-4c6c-b884-d809bbe65386)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8d6a98df-030e-4b59-8332-f7c3b985747e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c6be2499-8092-4740-a4ce-05eef09e2123)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         80455d1d-d198-4e41-8f09-a4e2427600a9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cb7ba8e4-a8b6-47b8-aa91-fe00f2a227c4)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         ff50488e-2b0f-4d00-aa73-80cf7715e310)(content(Whitespace\"\\n\"))))(Secondary((id \
-         580c7c03-9f83-42ba-81b2-2294a6491e0c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ee3e79a-a8ea-4284-907b-de397d7d6657)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b44ae0bd-fc29-4d69-bbc5-755f0c0ef4dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b1b0d833-6222-4a97-9743-6900669ec0ad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         11ce73c2-2110-416a-9b5f-f23a51e2d030)(content(Comment\"# This \
+         aff8b39a-5787-422b-be66-8c96c21f6f94)(content(Whitespace\"\\n\"))))(Secondary((id \
+         99d3d106-8eb6-4845-af09-414ee7f95431)(content(Comment\"# This \
          utilizes the primitive_pivot operation to group the categorical \
          variables. To work on numbers another method would need to be used. \
          #\"))))(Secondary((id \
-         f3096be1-2606-4d18-a0f9-d0856f96dc4a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c760aef6-1e14-4e8f-ae8f-79248e22cae7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         79932ff4-ce24-4b5a-85ac-fc3a49cb4f74)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1edb76bc-a0ef-4695-8f51-ddc584d07823)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b975ff24-575d-455c-9bd6-7b69253fa511)(content(Whitespace\" \
-         \"))))(Tile((id 948b2938-ede2-4c70-adec-f70b12c6aae9)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b68b42fd-3fe0-4f74-8ba3-1bc7a1ca775f)(content(Whitespace\" \
+         e4a93ba3-dde0-4e2f-ad8b-9dd81ade79d5)(content(Whitespace\"\\n\"))))(Tile((id \
+         7199baf7-a635-4bbb-a200-0ced045265d9)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5918f23e-48f8-44e1-82c1-6b79c23e07df)(content(Whitespace\" \
          \"))))(Tile((id \
-         17b73e6d-a2c3-4c64-bb66-ebc4357e2a53)(label(count))(mold((out \
+         105055a4-ae5f-4c17-aaee-31eea2946ba8)(label(count))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1cca2cd4-b4ef-4374-8a63-d0ac1cc37b08)(content(Whitespace\" \
+         bc9c6452-3848-4431-bf80-0f43f9530e31)(content(Whitespace\" \
          \")))))((Secondary((id \
-         20f56c6d-30df-4a06-8728-fa4ce3112e11)(content(Whitespace\" \
-         \"))))(Tile((id c2982936-0a72-45f5-97d5-608993fc26a4)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         e82d0409-c917-41a5-8076-f17628a18cb0)(content(Whitespace\" \
+         908906f3-5cf2-445d-9d33-721b44fc54bb)(content(Whitespace\"\\n\"))))(Tile((id \
+         4057d9ae-47b7-4641-8d08-3bf36e670470)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e5a3de92-f568-4f84-9d30-0e489deff75f)(content(Whitespace\" \
          \"))))(Tile((id \
-         9d7623b5-569a-4707-b9e5-4ca3ec16b813)(label(row))(mold((out \
+         1cfccf21-a15f-4804-a925-1211b5a80b09)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         a3633294-cc04-4ca6-b9c0-aea2103afe37)(content(Whitespace\" \
+         5af1b2ee-9736-4842-8b83-0abc41eee496)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8b459115-eca8-42f6-bd85-363e4c83ae31)(content(Whitespace\" \
-         \"))))(Tile((id 17d57bcb-61b8-46d5-88cf-bd194205b7b0)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         5b9d7780-c8dc-4d9f-824c-d193daa921ec)(content(Whitespace\" \
+         bfde70d8-708b-476c-97e3-26f1e40dfb18)(content(Whitespace\"\\n\"))))(Tile((id \
+         a609dcf5-a095-423e-beaf-19a5516deddd)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         3604c97b-6850-4e52-b24e-3d35aa213cd3)(content(Whitespace\" \
          \"))))(Tile((id \
-         d7e71d1a-7372-4777-99f8-ddee8650120a)(label(key))(mold((out \
+         9d369318-8bb1-4733-ac40-2b011fece22a)(label(key))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         de533cdb-e3a5-43b2-808e-b77b6d6e4937)(content(Whitespace\" \
+         6731292e-dfba-41fa-baab-e981e89e5b61)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e312812a-eaab-49ae-991b-47050aa7eb3e)(content(Whitespace\" \
-         \"))))(Tile((id 37a7464f-ebaa-40e5-8f7e-5100c296f5b6)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         7f3c0954-20b0-41d2-a014-7a9662a426e8)(content(Whitespace\" \
+         3984fba7-028c-4d5a-8d34-eac6bca98fb6)(content(Whitespace\"\\n\"))))(Tile((id \
+         7f82d32c-61ea-4dce-9650-fd13f397eab4)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         64085e87-246e-45be-ac99-21add99c9535)(content(Whitespace\" \
          \"))))(Tile((id \
-         973a8d25-a8a9-4e4b-803a-c75a6c8e5f27)(label(\"(\"\")\"))(mold((out \
+         9318b539-6abc-4a2e-955c-5cd7a9af0c14)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         b8d92c2c-76cf-4873-9ea1-28da60686511)(label(t1))(mold((out \
+         1e378b3c-57c3-44cc-aa03-d37f01a72e77)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         fdf03a8d-d4e4-4a19-b252-a8bb240c7762)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a2e26d29-98d3-45ba-942a-55553d5cc431)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c068e97b-d981-4cbb-83fd-0b6da4a1b9f0)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c2b1fc4c-7180-41ed-b19a-6178c883536c)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         76a0b6d2-4345-48a0-a4f0-650cb0fa84d0)(label(row))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         15579386-2d6d-4812-a39e-97dfc5c081e7)(content(Whitespace\" \
+         \"))))(Tile((id c0e3ffce-cbb2-46e7-a104-f407f2b97124)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         e3cece91-7957-43ed-983d-1e41cf65bfbd)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         2c38c4f0-01a2-4981-b55e-d61bc75cc1a5)(label(,))(mold((out \
+         437ce1b9-46e4-44cd-a16a-5de04704c3ba)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         71439e69-f6cb-417b-a4d6-e309bd5d714a)(content(Whitespace\" \
+         c9dc2195-3ad8-44a1-8beb-9aed222306f0)(content(Whitespace\" \
          \"))))(Tile((id \
-         d885ccef-b8dd-46ba-b722-ec4fd34e8d2b)(label(c))(mold((out \
+         34f1d6fc-8643-434c-a207-74ef7a9babc0)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         6b33fe44-97aa-43ab-8a71-f2d266c65252)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ae1f9d5f-850b-45c5-917f-cad222218025)(content(Whitespace\" \
+         \"))))(Tile((id \
+         19fc6b5c-90bf-42f5-94b0-279fb77c7ce8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         45b1ec55-bbc6-4f54-ac7a-94fc7103ade2)(content(Whitespace\" \
+         8f146e54-bb2e-461e-9653-2737b2ee0f33)(content(Whitespace\" \
          \"))))(Tile((id \
-         fc8251b7-4647-4bbf-bd29-578851417f93)(label(\"(\"\")\"))(mold((out \
+         de6d9d78-f809-40f3-b77c-0b0dca1497c3)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         cc3c1e22-be71-42ad-b4ea-dd1aadf801b5)(label(row))(mold((out \
+         03787423-9b95-4170-8131-79e36f373456)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         49fa5c68-2312-44eb-80e5-68daec700516)(content(Whitespace\" \
+         7ac6fafa-6711-452c-b4a1-d1fa1a44fa14)(content(Whitespace\" \
          \"))))(Tile((id \
-         eb14bf20-3396-4c53-8107-5c7ccf9be4e4)(label(->))(mold((out \
+         0a25920c-82b5-4619-8cb8-f584170733da)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b80f0090-1269-4b6e-9659-3822a7f99fde)(content(Whitespace\" \
+         e7a4187a-5962-4965-b83b-0b6ae2dd7047)(content(Whitespace\" \
          \"))))(Tile((id \
-         d74dd5d8-be89-45d6-b5da-a829c6e0fcbe)(label(key))(mold((out \
+         608c0cec-6ca0-46a8-b763-3db259141d63)(label(key))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         1e6ec597-9df9-4f76-8989-c23b1b1e2bee)(content(Whitespace\" \
+         4a8a1995-68d9-49de-9811-7a7b3c5f3d78)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e19527aa-9c6a-4099-b769-6a4a3d79381a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eba16c7f-228e-4b18-bb0b-faa3c91c9a9f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a86968d5-de74-4651-b17e-8dc4b2f3198d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         95d2d586-9ae8-4fb8-a366-722fe3e14b1d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3eca16bf-7ad6-4fbd-acc7-374ae97fb835)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         03736eb9-c940-4dbe-88c2-e0af0432cd55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2ce9bbd8-48d4-435f-a3a8-024ee2a02231)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         515a130b-afce-49f5-a2f6-817b214007fd)(content(Whitespace\" \
-         \"))))(Tile((id aaf3ce80-9b13-42a9-a2f9-1e3a71cdd7ca)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         0a55b835-3db3-479f-ae54-7dd9679d9a2e)(content(Whitespace\" \
+         342b3791-15cd-4219-ac6e-f09e0c9a9ddf)(content(Whitespace\"\\n\"))))(Tile((id \
+         b61c3560-fcf9-4fe4-ab94-c91c541b9a2c)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         37fd2767-3856-4760-88a0-715ff22681e1)(content(Whitespace\" \
          \"))))(Tile((id \
-         5eba2432-8657-417c-acf6-7d83c086e31c)(label(t1))(mold((out \
+         80004de4-146a-401a-86ca-00f79641cfa8)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         846e8d7c-ab43-4def-9790-2bba391d5fbc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f12fb073-3ef4-4a1c-a3d1-044e78ae95d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2b62460-0439-47f0-9959-60638d5708b7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         83c0946e-2a87-4428-bb9d-aeaa4e4b14b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         41f65bfe-e2e0-4afd-8d4c-3491fd518493)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2da0aa94-4600-4df1-ade7-61e545e09eba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         18a8973b-601a-4026-bbcb-d9ac3c182ab8)(content(Whitespace\" \
-         \"))))(Tile((id e51faf5d-489e-4f49-b057-59d6b647ca85)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         92964707-7b76-466e-8fb6-cd623e5d577f)(content(Whitespace\" \
+         3e0240c4-e84a-46c6-86cd-c9778e0ba328)(content(Whitespace\"\\n\"))))(Tile((id \
+         98967104-0d70-4ff5-8b1c-5e0469e8588d)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a0a1bf9c-3b61-4c7e-93f7-8c6ec30753a2)(content(Whitespace\" \
          \"))))(Tile((id \
-         24c817dd-79fe-40e1-913c-3c2ecccbaf9d)(label([]))(mold((out \
+         83e56594-2a0c-458a-abbf-906c68b772aa)(label([]))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c513a552-e9cc-42fd-bf4e-40a98ca19f95)(content(Whitespace\" \
+         8babc55d-072a-47dd-a01b-c1ea81c0a86d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         29f76b00-d12e-45cf-9c54-dadf8057b5da)(content(Whitespace\" \
+         3c443112-fe29-4264-8e08-ed5a66951894)(content(Whitespace\" \
          \"))))(Tile((id \
-         b2cd0fc4-8d83-4c6c-96c0-73c40b90f873)(label([]))(mold((out \
+         4567cb47-d5f4-46d3-9f74-ef1377f91153)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         ecddc9e8-ddc7-4ad2-85b9-8ae0498e1b53)(content(Whitespace\"\\n\"))))(Secondary((id \
-         da7dfd52-432b-4499-baf8-867b998d5a66)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         39771b42-3cca-4185-a94b-6b68cdc08bb8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         30ed7f10-64cc-43d5-824a-10191d11ebb4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a2dd5569-afb1-467b-973f-a3459883c1d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1e4cc137-a1cd-4a13-b426-9112e823a27b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3ac0c543-7f0f-41ea-9e03-482da5fedded)(content(Whitespace\" \
-         \"))))(Tile((id 65a7556a-9569-4e42-a7dd-51e8bace2009)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         d07894e5-678c-45b9-b1c9-2bc939768226)(content(Whitespace\" \
+         11b004af-b33d-41ca-8d35-25a4521b4f02)(content(Whitespace\"\\n\"))))(Tile((id \
+         21307af5-bf8d-4efd-a99d-28f16415b85f)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         fa4a85ea-3fc5-4da2-a867-99a603fb50a4)(content(Whitespace\" \
          \"))))(Tile((id \
-         cb411be6-7ac7-4469-8658-2dd5052af8d2)(label(\"(\"\")\"))(mold((out \
+         77b4d839-cecf-4802-8ea6-3fee8ba50b6b)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         1a3db2ea-78f8-4169-9b89-edcdd9219116)(label(r))(mold((out \
+         04393bc4-5fae-4853-90ad-7c7600f84b69)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         198f937a-2539-4138-8fe9-8b1d31106b52)(content(Whitespace\" \
+         d0d2c354-a424-4555-9691-2f25ef598534)(content(Whitespace\" \
          \"))))(Tile((id \
-         4d1b9682-3791-4fc5-9b80-8f6fbf93fb9f)(label(::))(mold((out \
+         3df90673-c68e-472a-9414-33c25811da39)(label(::))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 29))(sort Pat))((shape(Concave \
          29))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         4997dc3c-1196-4c58-ac38-bd7d3f33212b)(content(Whitespace\" \
+         6c3545ed-1fd9-4516-a9f7-2930da1ea2f8)(content(Whitespace\" \
          \"))))(Tile((id \
-         a153ff73-215b-47ab-9698-ddfcda1f18d7)(label(tl))(mold((out \
+         ee6334be-6575-450d-a359-00ed26f952d9)(label(tl))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         99939bd8-343f-4912-a8bc-52448cfb8f2e)(content(Whitespace\" \
+         c80a204b-3137-4fc8-9165-8f4b699c174a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cf48c8d6-1b3c-4796-bbc2-9b8f1322ad1a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b239fc31-129a-4695-be67-676df72fb6fe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         26ef479a-0784-4a22-be43-40f38fc6b0d5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cd6b60a4-20e3-4097-a530-d49f1ba4c74f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9a330bf6-d510-41b3-971d-0e3ba4557db6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         840811b2-7f73-4695-865e-fe9a12c8ca06)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f13b4850-68fe-4ed7-9303-16b73d802248)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b95b4e62-45ed-4530-80d2-66c2e8c93474)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a282b519-9312-4ff3-b2d7-b3f20a766242)(content(Whitespace\" \
-         \"))))(Tile((id 8db731f7-b752-4460-8a65-aef9557710d4)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         777e5b1f-0a85-4d96-a1f1-e6bd7d9fa54c)(content(Whitespace\" \
+         448e9757-5551-4acf-a77a-b549f2e72ee4)(content(Whitespace\"\\n\"))))(Tile((id \
+         7b2f077d-080c-4591-b06f-401180c8b59f)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         6c252a7a-bbd5-4f41-9ce7-912f5bb4194f)(content(Whitespace\" \
          \"))))(Tile((id \
-         141516a5-e867-4c8b-8a6d-4ec68b45dc54)(label(k))(mold((out \
+         ddffda80-f856-4a8f-b987-bc948087beca)(label(k))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5d316c17-a7d5-41e8-a5b9-6fe66dddbec7)(content(Whitespace\" \
+         5ba6a9eb-fa0f-4cd3-97e8-f542849d01a8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         044f854e-bf98-412d-88ca-b7aa71290266)(content(Whitespace\" \
+         cb5ac0ec-3210-4887-a212-c8346903da39)(content(Whitespace\" \
          \"))))(Tile((id \
-         f6ad9eaf-4f77-415b-9bf6-15c26d1317c4)(label(c))(mold((out \
+         b6cabe12-402a-456d-a996-30c080474870)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4bf25f0d-d1ab-4b57-bd75-d8f7a5e05ec4)(label(\"(\"\")\"))(mold((out \
+         e1e9fe59-9e71-46f2-a117-07b2355a39c4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d19bd331-6b1d-49ac-bf22-685f53d259a5)(label(r))(mold((out \
+         bd72ff8c-5066-43d9-b7b2-fd318b8f04f2)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6402452a-b74c-4d0c-8cb1-5db81b100878)(content(Whitespace\" \
+         5374ec05-02e1-470b-82bd-0dc5e79918f8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2d44bcd8-63a2-4f97-ae33-2c7e18ad97cf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         25a45cf5-26dd-4c25-b6cf-c8525e3b22c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6ef14a50-e05f-4893-9213-409afe2a7fc2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d79a9b46-d8d7-48b0-97b1-6318fca73c33)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b33f712-b15a-4781-94ec-f97ff31263ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2bbeefb4-aaa2-41ef-952f-fd188cdc7cc1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c07810a5-bb3d-4e85-b90a-f4005f01bbe7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         48ec371d-d6cd-4290-8bf0-6b017e372b1f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e39b0466-7313-46e3-b460-dca07d04a6c6)(content(Whitespace\" \
-         \"))))(Tile((id f5612ab3-ad13-42a4-a9e7-02ed8815344c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c0620d31-cc4b-410f-b214-e164dd3b370c)(content(Whitespace\" \
+         2435f1d9-d16f-4373-a425-2e13122fdc2a)(content(Whitespace\"\\n\"))))(Tile((id \
+         b99f8ae6-3d5a-4eba-af28-b6bf436572a7)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         97625e68-688f-44be-91ac-2ec5e2d5fe39)(content(Whitespace\" \
          \"))))(Tile((id \
-         e4e54c70-5ebd-46cc-9236-6dd04e8dcc87)(label(counts))(mold((out \
+         c1b3d665-39ad-4a0c-bce1-60f6e3369ebb)(label(counts))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5c7a175f-291e-4891-8083-bc70ef5aa3b5)(content(Whitespace\" \
+         27b8967e-1f1b-424f-9fd1-0e60fcb5856c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8484cd4d-6e6b-4757-9323-7c2305804d9f)(content(Whitespace\" \
+         cdf7a3b0-416e-482a-95de-1839cb517b4c)(content(Whitespace\" \
          \"))))(Tile((id \
-         138b3da8-8c10-4088-aa62-fa51e7a4a5e8)(label(count))(mold((out \
+         5aa896db-1a7c-4995-b2df-dbe59304e237)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6ed2d806-2dd4-4d89-8a15-7f29660985f5)(label(@< >))(mold((out \
+         8c44cdf4-715f-406d-abd0-2dcc37440d7c)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d44ff3ae-9641-48d5-9dc2-8857fafe8b48)(label(row))(mold((out \
+         c359e720-a24a-4df5-8b8c-d2d17f8ad5f0)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         480eeec6-94f5-4db5-9ec7-b0c2e394320e)(label(@< >))(mold((out \
+         972ac285-09f7-4b33-9d41-86590aa3a998)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4b339f5c-6b66-47d3-8d56-7d40aac68b69)(label(key))(mold((out \
+         8313eb72-6492-412f-8e5f-3f08677368f1)(label(key))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         d098fbf7-f6c9-4029-a19d-95dd4ef9be49)(label(\"(\"\")\"))(mold((out \
+         d1d21c6e-53eb-45e2-b18d-5c5c6921a92f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4405b982-a708-47e0-a5d1-e3bc43b83b4e)(label(tl))(mold((out \
+         ff6094cf-e1bc-46ab-9cd4-3eab6f8bc08c)(label(tl))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f145e763-2d18-40d8-aaa4-f108d854ce67)(label(,))(mold((out \
+         8f87db9d-e75c-4694-ae9f-7ea08ea957ae)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f8cdae5e-7777-4f97-b243-7e843e17a1b6)(content(Whitespace\" \
+         5fd6edfd-0f07-49ab-a4d1-e1937c4fbaf2)(content(Whitespace\" \
          \"))))(Tile((id \
-         b6fa7878-7158-434d-a370-a1baf1d5ec1e)(label(c))(mold((out \
+         80e4ab74-e368-4849-ae6b-6a04a47ad852)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         16c20094-321f-474c-8b04-5c0e848e516f)(content(Whitespace\" \
+         95aa4614-75b4-4cdb-ae41-b0e6d1e3f40e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         254fb468-4434-48f5-9532-25d90eaeaa71)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f9efaadf-515d-4c10-88db-97048fde95c9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         88e6b0b1-2374-4727-8521-acf2a72e73b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         25e51ca7-beb6-417b-b279-6fda0e4676b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a1b4a8a-2a2b-4c0d-adc3-d839016b288c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ee3674c4-06ff-4197-8ccf-dec864a36582)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         40969108-af4c-46fb-bed8-9580da0b7fb8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         abcd6736-14e7-4632-aecc-08c6730e79c5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         15d0974c-dc6e-4a61-8b4e-c2271ec4ce7d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b7e93268-030e-4d19-9b93-b89a21e90b56)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5de3c185-3412-4362-be4d-1947ad398d1e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf826379-042c-4d09-b355-f1b68dbef5db)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         39d15e55-6f4a-4bf7-ba7a-54868dd81782)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2786b86f-b600-4843-b667-ee9b63436303)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7dd3fe5d-0cf5-429b-85f9-244329cedc2a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3ba28438-ba42-491f-a6e3-6083c58751cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de485a61-a947-41cd-acbc-1b9fa82946b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9d68119f-e8eb-450b-8a2a-c2756fb2616f)(content(Whitespace\" \
-         \"))))(Tile((id f062953e-935a-456a-8994-05af443f9ac7)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         97f07168-94cc-4bcb-aa54-1b63c2ec2b40)(content(Whitespace\" \
+         df84241f-4367-4f47-af08-3f9bdb662a3b)(content(Whitespace\"\\n\"))))(Tile((id \
+         fe667521-167f-44ec-a1f9-2ef0350ee88f)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         25010233-1907-41e7-9b8f-d548cb94981f)(content(Whitespace\" \
          \"))))(Tile((id \
-         2a1acfa0-bcec-44d5-9eef-ad2b08563adc)(label(find_opt))(mold((out \
+         2013d381-3c29-4008-83c4-f8b168e5faab)(label(find_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4efb3c22-5eb1-44e8-bf92-c0c052e04f9e)(label(\"(\"\")\"))(mold((out \
+         073ecf8d-1baf-4b36-a7f5-938e1bf9c7b8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c87a611e-6486-4e48-8261-3e3b3aea59ff)(label(counts))(mold((out \
+         b11b2895-2704-46ef-8833-0c22bb273ed1)(label(counts))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e070319d-c69a-43a7-8664-5304aec8f2c6)(label(,))(mold((out \
+         0ac00c0c-4b78-4ab3-93ff-7a260e36fc37)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d22af7ae-d98b-47aa-a8f5-0411a9b5bf40)(content(Whitespace\" \
-         \"))))(Tile((id 2deb3e74-c80e-46d1-a7a6-7a6adaeeca64)(label(fun \
+         49954d4e-4373-46d7-9b33-8bac3d13caab)(content(Whitespace\" \
+         \"))))(Tile((id 0fe9f2ad-2fa4-4b17-b4c5-39541c3431f7)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e6c78e8a-29ed-4a92-9db3-e6cf55387f8e)(content(Whitespace\" \
+         729246db-48d7-453e-b990-400957cb315e)(content(Whitespace\" \
          \"))))(Tile((id \
-         36e1fb13-bce3-42e0-ac8c-535045ce3944)(label(entry))(mold((out \
+         cba5d43e-5bf6-4965-b1de-07971ed84c4d)(label(entry))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d6b98190-98a9-4d6f-8a8d-790f61afe240)(content(Whitespace\" \
+         82e642c2-e777-42dc-884c-a9a3c4960fac)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d16e4835-3ef8-4327-94f7-9a6f82d880bf)(content(Whitespace\" \
+         aa1c6ae6-e190-41d1-83a0-dffe6eee394c)(content(Whitespace\" \
          \"))))(Tile((id \
-         67f74b52-0c43-4792-96ae-e61de0522eaa)(label(k))(mold((out \
+         de86b5aa-7b55-4f30-beee-b4c4d026c8dd)(label(k))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         cd172aa6-20f4-46f2-8f6d-2fa53662337e)(content(Whitespace\" \
+         a38e6118-4978-4588-baae-f1bf251c517a)(content(Whitespace\" \
          \"))))(Tile((id \
-         18d00da1-3b7d-4299-a33f-eb46d536ec43)(label(==))(mold((out \
+         6ab1b486-285c-4ca7-95e0-651538076e28)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         68e262bb-6ee4-42c2-88b0-b60026d2189e)(content(Whitespace\" \
+         ffe75a07-99fa-456b-978a-77ddcb7277c1)(content(Whitespace\" \
          \"))))(Tile((id \
-         e9766b5f-be6c-454b-9371-48f3228064f4)(label(entry))(mold((out \
+         211d260e-1ebb-4d3b-8975-7fa4e2a03d14)(label(entry))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         0c48956d-9f32-467d-9bc6-ceaa8da99633)(label(.))(mold((out \
+         7190c8be-1837-4605-ad14-5a58ded09af2)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9332c58f-44ed-4b88-8a83-d4e39b13c477)(label(value))(mold((out \
+         bb0eb7ed-2533-490e-9c7a-3be7eea2b4fb)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7f96eb09-14c7-4fcc-8a6d-6178ff613a00)(content(Whitespace\"\\n\"))))(Secondary((id \
-         85646a4b-ee27-4d80-ad80-95bbaf262681)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3b2cde28-5c62-47a6-822b-199adf1d9dd8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46f95714-6641-4c85-8d2a-dbbbbff2e1d5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         48b74d7f-67f2-4ec4-92c2-4252c8b1a2cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e71d9bc6-890e-4b52-acb6-b736f5e06d08)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8ebaea4-08af-4aed-99c6-bd417d51248f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         855f36d3-30db-4b48-8dc0-c99c425db80f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         24aae2dc-39af-43fd-8690-d0806c34c117)(content(Whitespace\" \
-         \"))))(Tile((id 92119153-3997-4e74-97a9-85c1d9e3d562)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Tile((id \
-         01def9d3-d0d7-49b6-b612-88b149515767)(label(None))(mold((out \
+         bae4d1aa-ea06-4e81-b848-f3cfbd6accb1)(content(Whitespace\"\\n\"))))(Tile((id \
+         18891c5c-9d1e-4530-9976-1a17fcf4ba49)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e1737e6e-e98e-4e5c-acf4-63486705053f)(label(None))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ce95d177-b59a-4356-967c-4676cbdc9a48)(content(Whitespace\" \
+         5d246fe9-ffe9-464e-9b75-2ce58612fc48)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         922cc0a2-8c8b-46e3-b4b5-3c25a3c84ef5)(content(Whitespace\" \
+         71da33fc-a638-4188-aa41-20b966ba062d)(content(Whitespace\" \
          \"))))(Tile((id \
-         056e94bb-ac93-4747-86b0-eb217e999be9)(label(\"(\"\")\"))(mold((out \
+         1cafeec5-9df8-4b0d-8686-eacb3825e3c5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         1d8b4475-23bb-4ae2-a710-28c5092496bb)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a6de4c4a-357b-46bc-9437-53f6ec183b86)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         6aa717f5-d8b4-4ba1-80b2-a2803ac69370)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         64acbcc2-3696-45e7-8053-527ea5c59d61)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1f868331-6461-444d-8eb5-231b36125195)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b0c3755b-939a-4948-a6fa-e6585a478beb)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         508be86a-36c1-4180-8f7a-9ebd7b4fca28)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a47262b7-63d7-4c77-8a4d-0c216f8d3037)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         505c70a9-c027-47f8-bc89-22022d5b4953)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3c749c77-1111-42be-a6cc-2a5d809d1b1d)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         046f1986-ff11-4100-8519-b98816a41807)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0529dff9-afc1-4e21-895e-b0ee64963d24)(label(counts))(mold((out \
+         8bcdab82-66ed-4f5e-b330-343963660a88)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         2cfd7b78-5040-4dfe-8d80-5c1e56402287)(content(Whitespace\"\\n\"))))(Secondary((id \
-         399ad741-a047-40bb-9b1e-824908fccc66)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33e3b963-66e5-4670-993f-1f0b7932d140)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6412c91c-8608-4c1d-b881-6dabdb7b8513)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e866af33-5cdd-4993-9c09-9c54adb6cf51)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e70cf4f3-3802-44a4-9745-7609323eca33)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc7b6b51-4970-48f6-a901-d4be5a45e1f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c8a72fa-d96e-44cc-b8d8-a0bf959dbca8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c0c9ddbf-9d61-4644-b5bd-26288dc6e35a)(content(Whitespace\" \
-         \"))))(Tile((id f776f342-7b7b-4ed0-a77b-4e218dd462cc)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Tile((id \
-         292643f3-d4bd-4fcc-b6ad-f62bf0ca9cf2)(label(Some))(mold((out \
+         a6a99a9d-67e8-421b-aac9-50661eeac47a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f944fc90-da84-489e-bf8f-b3fdf2e0a094)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f8e6b252-eaf4-4840-b12d-1b67fc7452c9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2222c1d3-2cfb-42ce-9c7d-242986b8cfc9)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7a957d94-7529-4200-a9ea-a80dae6e8976)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d5f28b87-a890-4a97-aba4-82db3883016f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         78868d5b-3f74-4bb5-b2d7-2db8d2d68340)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c1875839-da4e-43a5-8d16-25bf68c8a73c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bc3d99e7-7797-4429-9ceb-c3d35e9f5fcd)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8e7f360b-bdf8-4892-b519-801105f5dc7d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f0ddee93-91b4-49ed-b8fc-19d5addc6eea)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         dce6976f-e9e7-478c-bf57-0e9173b8780d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1ed9bc31-7051-4fdc-9230-a7072d1c0700)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         108b4eda-4ef8-4f52-94f4-dd8be3327923)(content(Whitespace\" \
+         \"))))(Tile((id \
+         faca5edb-8194-4f8e-8223-94bf3bc15a6f)(label(counts))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a36ed14b-dbae-49c4-9dd7-c2e509897dc7)(content(Whitespace\"\\n\"))))(Tile((id \
+         16356293-6123-4544-9826-3b57c09c46bf)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         88d53773-16d2-42cd-9502-70d95ff1afac)(label(Some))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         68506f6a-4c69-4651-9faf-1dddfba0f4c5)(label(\"(\"\")\"))(mold((out \
+         2d88f79f-a2b2-42fd-bcbc-32a6f8e0097e)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
          Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
-         2fb040e0-dc70-4997-a0f4-da15693f3513)(label(\"(\"\")\"))(mold((out \
+         32653d29-20bc-46f3-b18a-5eee702bd215)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         504b0917-aa64-4ad1-b431-d7356cdb38c5)(label(value))(mold((out \
+         d0255bee-7e44-40c4-93c8-64b91f19ddd1)(label(value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         cb6d7f1f-c887-4dc6-bbeb-ce3c5e2dfc23)(label(=))(mold((out \
+         0c8a93b2-f97d-45ed-855e-f4adebcfde13)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
          39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         1fd14bc3-05f2-4038-b439-e2f9ccb81a04)(label(key))(mold((out \
+         02b197d2-b1fd-4cd8-bcb3-297121afaa60)(label(key))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         11a9291c-d48c-42d4-aee8-e4f1558e2914)(label(,))(mold((out \
+         5d787d9e-df26-4d3a-bf55-3547199267b8)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         c86ed272-6513-4b94-945f-33998a6c62c0)(label(count))(mold((out \
+         2606cfdd-afdd-4b4e-99be-71daf87efa70)(label(count))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         b5d91269-525f-45a1-b43e-ee369c4fe863)(label(=))(mold((out \
+         9523c8b6-8fbc-4ba6-a37a-8a35d86e4056)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
          39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         3b1a849f-6d66-4482-a35b-d3deb2330dc6)(label(c))(mold((out \
+         3e6885e8-ca29-46db-b9ed-217f601cc7c4)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
-         09443781-f2dd-4233-ad3f-84bd09c9e7b2)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         86fa3a5e-16ba-474c-900e-c7830b30e490)(label(\"(\"\")\"))(mold((out \
+         00b6ee57-8a22-45e4-8ac7-d33af7962b5d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         8471c4e9-e9af-4a2b-975f-c42f200585a7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         89876be7-625b-44b2-8a10-74dc2622a2ae)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e720f2c0-d920-46e3-b2c7-33cafbd98c83)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         66bee036-ced1-4776-9912-9ac318d344f3)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         77a6b773-8f45-48d1-9652-f87b64ec8047)(label(key))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0999038d-f70b-4f78-b871-bacac91d183c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2ccddccb-9a7a-4342-bc50-61d2fee5bd55)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a1cbb62e-05f7-49ee-a342-6191f744d5ca)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         282d9d53-17b0-46f2-a592-b4aad0d6a3d8)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         dc3b4314-2083-4a70-8b14-6314d487a3b6)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         98a0f637-8004-4ffd-b124-af28872bf007)(label(+))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         359fc4d5-fbed-4320-9fc9-fb57241adb93)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6a812dab-239f-4fbb-995f-d2e30a74c514)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bd802007-bcfe-4aee-9cdb-fa37f6916547)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f256aa38-e7a4-4feb-849a-a488e563dd05)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d7cea2b2-4d8e-4ac8-9d15-32caa1c26047)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8b07c59e-3b6c-4239-ab64-d2c72e376a81)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         42d6ef89-6d42-45bf-89ab-7e4a7601abc7)(label(counts))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         382574ee-40d9-4fb9-8c57-cbcbe4845712)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1b02940c-39b6-4a04-bf9c-23649baa00ca)(content(Whitespace\" \
-         \"))))(Tile((id 6aad13d3-bfa0-43ad-b45b-c919ff6900f8)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         02907c06-48f4-4239-a31d-4a1ad148864a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cc7bb330-abb0-4ac1-81ca-76230a5ab81a)(label(entry))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         6227f049-2c47-499e-ada5-74a17f855c0c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b36e1bdc-67d0-46d6-a6b0-c637f7a04edd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         272b5226-1e08-4c47-9533-0bca9325dc60)(label(k))(mold((out \
+         f72c6a36-2a67-4a2c-b8fc-00fa91006a60)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d079d4f0-cbbe-420c-939c-54aedd89fd81)(content(Whitespace\" \
+         cc732beb-c7b3-4df3-a8f0-da11a9b49712)(content(Whitespace\" \
          \"))))(Tile((id \
-         1d8b62ac-c031-493c-b1af-f9991905757e)(label(!=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0c08fe5b-b0fd-450d-b13d-d8fd4b4186d5)(content(Whitespace\" \
+         292fa059-2912-40ee-9a16-72b936ca3cfe)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f8ba585d-5875-4d13-99da-efd0cc54d010)(content(Whitespace\" \
          \"))))(Tile((id \
-         d42481cd-7f6f-4268-9c19-32c05bb84afc)(label(entry))(mold((out \
+         2c97ba59-ebe2-4d3b-b6f8-46c6f91ac0a3)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         83a3f618-12d2-4b39-81f1-638cf71dccab)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         d80c1747-08f5-4101-babc-d781451c8c44)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4625a8e2-47c0-4f31-ae3f-72dbfb11fe9c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         78e8508d-3cb8-4f28-8448-35f99779c705)(content(Whitespace\"\\n\"))))(Secondary((id \
-         030e7f43-0782-4786-a806-6873ded7fa49)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         72c52c87-7ad5-48bd-9b38-fe7d39bcd27b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         acbafff8-7cdb-491d-a2b3-a225968b44dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1bc3ee98-1e5c-46d4-9fff-9ed93ff044f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0e64694d-837f-4415-8ee2-dde7fec45874)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         85e50d42-cce1-418d-bd11-7cace13737e1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e5b28d01-bb67-4931-813a-9a8970c63519)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e14a9817-efdb-4cf7-9f4b-b9aefd2988bd)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9d66ff22-2296-4737-916c-d1a4f57e698a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f21aec8f-aeed-46f8-acc3-3ad1c6737f7d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7732c2cf-80cd-4c02-84ae-4bc2b661c0ca)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a3bc6c4f-ceff-4423-8403-2d44b2558bbc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7910da3a-31a4-4150-af78-fdfa8c9a2bcd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ff756eef-809a-44e3-b1e0-533027e7307a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2aa8246-9a77-4b88-ba34-b2088331d00a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         32e92444-d363-4f5e-9fa9-c060c2ce5f19)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2fe0b1cb-4e0b-454b-9e6b-3e60028f480d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c6cdf447-7c39-4321-8763-f96f0dd76218)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b6a47398-8e1f-477d-b191-9f67706615b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f1cff58-f308-4077-a180-a83d9a604427)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab6af70f-a1a3-4a95-9df0-a9d516e36e95)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0de2f24d-0e8d-49a2-93b5-055f21bfd586)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6e0f9795-917d-46ba-b51e-9b7f0867e6f5)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4a195d00-29d3-4928-80ed-2ec37d2ca55c)(content(Whitespace\" \
-         \"))))(Tile((id d4244de8-b6a3-4350-987f-a7eb7509c2f4)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         7f516877-a0a4-42e1-b05f-89859d9b764f)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         67dd7d72-751b-43f6-8a36-1f49c83bd9c7)(label(value))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         ef95e5a7-5b21-4d78-9e25-ce7746c0c055)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         4d9835a8-f28e-41ef-a135-111398f8b197)(label(key))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         0c536c2e-db00-46ba-89fa-3afa77e20549)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         41349a99-1388-46fa-b1e6-2913ee303d42)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0a198b7b-d7f4-430a-a238-3365bf603dec)(label(count))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         555ec972-b6dd-4472-8933-33d7f9b8aa3c)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         80757cfe-1a56-402f-a35e-7ae18ce58b9d)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         15d4daed-6f5e-494e-aadd-479392810518)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         56edbe24-68b5-4273-9d83-7bf50cbd426d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b4c8385a-5ffb-4cfb-8cee-ee3a0e5b75b2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         febecf74-0ab3-4844-9586-b722eb025a3d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9fe38539-53f8-4256-92ed-82fb51d3f04a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4994df4b-bb73-4e17-9306-cea9afa30f9a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c9290abf-8e85-454d-8070-506deb989d66)(content(Whitespace\"\\n\"))))(Secondary((id \
-         13708606-a2cd-42e7-ba39-3070e3dd6d3e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         149a8275-338f-4193-b527-d75d889cc219)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dd46bb52-00e8-4579-a2b6-997457d24c24)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e8d5e9f7-0761-4305-a0c7-4f31bdb25fe4)(content(Whitespace\" \
-         \"))))(Tile((id d0dad19d-c8fb-48e2-accd-7250d200b0fc)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2b85a723-c44f-4fe9-b01c-010ff9191c45)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c3ecac01-e534-4a79-a7fd-654c385924ae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         951cc64f-94e4-4098-aafb-e56150975d44)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3b8a67aa-b1e4-4375-9415-1b4717d3ded2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         17138bfb-8537-4517-878b-39f1c0476b5b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2863b7dd-9f60-4ae2-98f9-7eb393c8fa62)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1e87b8e2-57ad-4c1b-a8cd-75963e79d604)(content(Whitespace\" \
-         \"))))(Tile((id \
-         89048f38-be3a-4346-bc2d-9d7c3ff0f593)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e2330b73-ba0c-4d75-b9a4-8f1b01a70948)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8a96605d-759a-4399-9e91-8710e878b675)(label(Student))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         103d9d69-2064-46d3-adeb-91f1a1c19e71)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         66cca3c0-40e4-4785-8000-7250257dcbae)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         92d63a2e-a140-4e05-85da-d7733aab413a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         fc135aa6-36db-42f6-9e78-3f7c9e3b818e)(label(students))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         803caf54-e5c5-4c52-8427-4f79ae3bd7e9)(label(,))(mold((out \
+         376f7192-95b8-4585-97e2-e98668bde25a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f806e52b-a2a8-4dfb-b1d0-f4cd2791d57f)(content(Whitespace\" \
-         \"))))(Tile((id f1a90a86-f017-4a66-b122-bbfbf429470e)(label(fun \
+         8dcf1fa5-79dc-4167-abf6-bcaac683b022)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c8d2dce6-50a1-472d-a9ae-d57785f231fc)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d0a6032a-bdea-4bd4-848d-e76cb47a6281)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3a409ac4-5fba-4053-9ebd-68d1cac2e231)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f7759116-c93c-4891-8305-ca23d745494c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         881c6099-9362-4749-97ac-65369ac04b2d)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c53f5427-61a1-4395-a84b-5f02f8072dc3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         22ff101e-5d3d-4e3a-abcc-5589afee6167)(label(+))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bb5ceea9-c680-454f-8419-cc6fb4d16f48)(content(Whitespace\" \
+         \"))))(Tile((id \
+         731b5ef1-1b58-430f-9cea-ac663503db7f)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         74f80f0b-7e8d-4fac-9dd0-41d26b2d97a3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2a14fbf1-31c7-49fb-906b-3501e3a29665)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         40ef1d91-16df-4112-8065-6c83d3fb652c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b45859e9-c0df-4077-a470-69f88f8164dd)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         20ca0cec-50d0-4b18-ac1e-91675487a6f5)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         6cbfb6a8-6344-420d-816f-5858f613070a)(label(counts))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         afabe0e9-8a0e-470c-a8ca-47e3810f0ecf)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         432cbf7e-b1e4-4433-b4c2-51d788c4be30)(content(Whitespace\" \
+         \"))))(Tile((id 762d8d2f-255f-48f6-a647-bd09901d3e8a)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         3b9a5eda-7592-4b09-b34c-03b8b1722d45)(content(Whitespace\" \
+         6b70aa02-d051-4fef-81ca-9087c4c9a858)(content(Whitespace\" \
          \"))))(Tile((id \
-         cb2a05c6-0c6c-4daa-8aeb-2ceee6b366c0)(label(r))(mold((out \
+         5c9645d1-49ad-45e4-996b-59160844c8cb)(label(entry))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f1e29a42-9b6f-477d-a7fe-9935cbd81dbd)(content(Whitespace\" \
+         48f1f2d8-c1a2-4394-ad8a-e83a78859075)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b5b98556-6a81-4c8e-9fd0-27c35382e0b4)(content(Whitespace\" \
+         f6db596b-c4ce-4210-8c93-fac9972b264a)(content(Whitespace\" \
          \"))))(Tile((id \
-         cfb7448e-9267-4a65-99a7-a5dd3eeb757d)(label(r))(mold((out \
+         9cafa4a5-5ccb-48db-97e8-004d08adf147)(label(k))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7e4d6e09-5253-41b6-8043-f5a1c3769345)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ed133c15-d73e-4680-8e82-7a83621961c2)(label(favorite_color))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1c333749-9a1f-4bf9-ad71-5da9b9e5efd2)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9cfc25cf-f4cb-41cd-a14b-335d39719886)(content(Whitespace\" \
          \"))))(Tile((id \
-         cbef0532-663c-4859-bde9-e8b1192c0b84)(label(==))(mold((out \
+         5babfe12-787f-4e8c-aca3-f2b09216b2f8)(label(!=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         00393e18-fcb2-423c-9088-73213a067486)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d2e556b5-fe4d-4913-a864-ec8e3ebd2b61)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2b5a9c4d-0612-4a88-81c8-c4e961863a1e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4b9cfe47-df68-4220-a771-bc578100b74e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2caab016-89ef-439a-b02f-90d966c9b80d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc9595bf-206f-4889-a8cd-7f4548ed70d3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2cc336c8-240a-496c-ab20-ff63fafac9da)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c779417-c568-428b-99df-b7987647b06e)(content(Whitespace\" \
-         \"))))(Tile((id efefe009-686f-483b-9083-a32bd4cc8ae1)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         63cbf3a7-f246-4d18-a4e6-766dfa032e6f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         b578d59a-e248-4043-8221-f114b997ff1a)(label(\"\\\"blue\\\"\"))(mold((out \
+         f12822ed-8d61-40df-8809-73a4aa47b62a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         306c04ab-fe36-44cc-9eec-a452e52cfe2c)(label(entry))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         0de1e859-50a3-497d-b81d-bc30cb74ec51)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a27773ca-9f6b-4f06-aadb-eff36889e402)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9ef21011-2230-4d50-94ca-c659c8019737)(label(1))(mold((out \
+         7904f9da-254a-43f3-a329-05e1ee4eaf9e)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         352964d6-9b95-47ce-be44-5b6fced072de)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         5cf4d315-d146-4e2b-96ae-2cb06069811f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8602c60f-c63d-4418-8ea8-759a1fa5af12)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bbfd79ce-5298-4b8f-8774-79e7c398a4ac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8bb308e7-1a13-4a81-aa48-8863a5e1b073)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f2b2a5f-4abe-438f-81f1-7738695dee0a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c54f15b1-e28d-4d0e-beda-af52e67dec7a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3de672bc-190c-4b56-8456-45fbafe63c95)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         319a66fe-b26c-48c7-8c1b-b600ca925a55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c6a40bb-a9a8-4ca0-b64a-c5e07d3d21e4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         245233b0-320d-41c8-ab2a-0070b49186bc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         916d6e3c-6215-4961-8d55-45e5bdc625e1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         28cff61f-f590-4b35-a1c2-5f44eff528e1)(label(\"\\\"green\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         48acc216-9b71-4252-a55b-e4ec99fae7b6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         73b806eb-bb7c-48ea-9961-df630f4e3dcf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f67d46ac-62c3-488e-a96a-066940ea31cc)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         64e7762b-c256-4344-8ddd-db0292644a7e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dcfd3b6a-46e4-47ea-8bac-f29c6aa1a1a4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         35fb9001-96ff-4fa0-9f97-db257f61fdd6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8a5def29-a626-4660-8466-b156f3505b2d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         207cfed8-57ee-490b-9274-6948806857ff)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3252a6ef-85a2-4199-a976-1fd0776f47ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9fb2aecc-46c5-4a19-8863-91818a5528f3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         18a1d741-7015-44c5-8cee-7389cd847663)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         af9bd108-576f-4dc4-b4fb-b2113da16ee6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         987e1c0e-1bb7-41ab-b902-176fb75544d3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f589ffb4-0c23-4bdf-9b04-de64e4705664)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         31b6b8d9-8356-4b16-aea0-46cbb32c05a1)(label(\"\\\"red\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b7dea6eb-fd7a-4ddc-8d81-224922b36302)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1d856dc0-554b-4222-b4f4-9e9f9a2ffbb4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f315e887-1b26-4253-9731-5dd2d893cadd)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         98b3fa1f-a7ca-470c-8635-6e29d6686f8f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3ca4fef8-2450-493e-8976-20d79ab87f3b)(label(:))(mold((out \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         68c3aee1-4535-4dba-a7fa-66ea659f2b2c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         dd88a529-7477-420c-98b2-f70e89fb339b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         70595bfa-15e6-4f03-baa7-0fe7dc67c7f3)(content(Whitespace\"\\n\"))))(Tile((id \
+         fc8d82dc-f535-4890-8fcd-c49700724101)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         33a4826b-d6b7-4417-8937-99e0abaca488)(content(Whitespace\" \
-         \"))))(Tile((id fbb83d1f-9e96-447f-81ff-90701260c5a8)(label([ \
+         dff22b5e-53c5-4dcc-80e0-861c8de58756)(content(Whitespace\" \
+         \"))))(Tile((id 78ab4794-d4cd-42bc-8212-1d9c75f4b9d1)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         19c4d0bf-23da-4fcd-b8f8-674ea76c0acf)(label(\"(\"\")\"))(mold((out \
+         1e4406ca-a183-4a00-899d-a4e135c92f5c)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         ed7eae4f-4471-4a55-8181-3bf0c2412f45)(label(value))(mold((out \
+         31dee547-26b5-434d-8255-46045448abdd)(label(value))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         f7c4ae13-516e-4a75-b9ca-5a5be7c68812)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c73bbdea-1b98-45d9-a7af-c5c14c655d4d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2d2d9f24-964f-47d9-ac44-f728a685faa9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         06bae668-cd08-4dda-85f0-fca242e64608)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e543a208-6962-40ba-b295-7d47cbb58385)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d994c7dd-8626-439f-834a-568bff0dc0dc)(label(key))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         32385d2f-5484-43ad-83af-6dbd0d93baac)(label(,))(mold((out \
+         d6de5156-0819-4655-a185-e7f1db54aac6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6a3722f0-46ad-4bda-9809-ac2ba38c3231)(content(Whitespace\" \
+         7775f7b5-c693-4772-a60a-2efa703a66da)(content(Whitespace\" \
          \"))))(Tile((id \
-         caedbf5e-7ddc-4780-8ac5-416203d42e37)(label(count))(mold((out \
+         ec1c9e34-7ca1-4b3a-be06-6b3f1e230fae)(label(count))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         6b638ef6-99de-4659-ac4c-b80624f470c1)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5db5e0d7-338d-4e2f-8070-5ff65ad98a2d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f1dff66c-84fc-436f-9963-f8616d356e9c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         cdb9dc14-bc50-433f-9b3a-25f3a7e239a9)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c21f6e46-55c7-4ef0-951e-3f57b23bf7b0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5adfba91-8ce2-48af-b8c3-4ba67a73fd9a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         fdfb094d-afb0-419f-addf-264056f50a6e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         95e38591-5a8d-46da-ae0f-2f13eaa42207)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         47a9557b-be7b-4242-a9f5-52b6af52bd3a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8b6a0bdb-cc79-4228-a385-7391ccfb3b5a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         24788c41-87d3-4661-b635-d2bfd068b426)(content(Whitespace\" \
+         e1ff2a0c-9396-4cdb-a2e1-3c36f63a7c26)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         face881b-ac4a-4a54-8b45-fa5857e69eb2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b31b3e0f-e5b2-4ad5-9778-0f9735fe2bf3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4147073b-3768-406e-93f9-596f52bc21df)(content(Whitespace\" \
+         fd122a30-45c7-4e37-9b0d-d5bd5de3103c)(content(Whitespace\"\\n\"))))(Tile((id \
+         70bb9e35-9c3d-4cce-bdaf-ca85991fcaeb)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         c7adab9e-79bf-4a04-bcca-b4d60e3c4014)(content(Whitespace\"\\n\"))))(Tile((id \
+         56fcc0ad-ce75-4804-a967-9a5358b0dc3a)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d0d3debc-cf8e-4e16-8593-45136872735f)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         520bbe9c-f75f-479f-b47a-b6469f876227)(label(Student))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         a0f93807-dcdb-4644-a4ca-dbe724e8ed69)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         1c5ab717-2b74-4ff6-ba69-fd2031e56f63)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         0c4997f9-6199-448e-9f16-3275c232e85a)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         9707f01e-10cb-4b37-8308-cd9fa395d364)(label(students))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2639fb2b-b0e1-43ac-ba18-db17fc7f6fd3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8fb12478-b316-43c3-a604-0816cd5a70a0)(content(Whitespace\" \
+         \"))))(Tile((id bc7c0e54-1d27-46a6-a663-14901738dd0e)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         ec32fc06-64f0-4abd-a6ce-fd031ab37a5d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         75519e74-c1dd-447e-883b-cdc1b42298bd)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         645433d8-b75b-4443-a8e8-c4466f610672)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         90256abd-3982-4336-8c97-bdac30b4b890)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a854dd81-1946-453d-b2b7-74085e3efb6e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d3a0f602-226a-4391-a474-4d8babccce87)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         97b73465-6cef-415e-83ae-f042701bacc1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3017e47a-eb09-4a12-a50e-f8d9bc586767)(content(Comment\"# V2: This \
+         8ab1f1e6-5266-4c85-a1f0-220b419eca8b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ce016e31-43ff-43b2-a6b2-32cc32b5c858)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         62212d86-be43-42de-af1e-a9c8df4bc2bd)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         4cc75b97-c507-4906-99ae-8f863f7a03a7)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         c31d0630-b713-4bb8-b6fe-d73a804e16d2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e891b6fe-ece9-4fc1-9ae0-0a37163b0fa4)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8d79d2f2-1f86-4bd5-92ce-2ef1304e8fc3)(content(Whitespace\" \
+         \"))))(Tile((id 301f28ad-bd16-4185-93af-220ac9086afd)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         70ea5cec-e745-4903-9104-4317ad0ac7f7)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         379a2632-c248-42d0-a33f-4499bb8e86f6)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f40fa3bd-7fc8-46d8-82ee-e88a2eb90be1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         025e36e1-155a-42fa-bd57-e32412f5922e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         51ac11f3-c5ba-43b4-9c08-fbf084ea3fb6)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         06b42018-7da2-48f9-ba67-de52e3a861f9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a1650cf5-dbd6-4500-9cef-877e8eb43638)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4db1fed4-03a8-4f03-bdbf-e59497608d74)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a1f32d0b-d2d1-457d-9362-46d1ccc34ec5)(label(\"\\\"green\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cb5d0ed1-4228-47f8-add2-ac98b90b2d3d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e11eaeda-567d-4d19-9033-071055b39050)(content(Whitespace\" \
+         \"))))(Tile((id \
+         affb152f-61f0-4377-8f51-ce40da749e69)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         0c4e3eb2-c207-4376-bb4d-730d23592748)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c8e761b7-2d88-42d9-b3f1-e35f5f3fee8a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         402917b5-5021-40d4-9249-bc2f2496dce7)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ad8c694c-97cc-4b21-95f5-a02a963f8d42)(label(\"\\\"red\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fa6a96d1-8de4-4e7a-96fc-6ab9d52d4d50)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9c9d8c92-9924-495e-a9e6-de320b73a4ea)(content(Whitespace\" \
+         \"))))(Tile((id \
+         86e01fa3-9c7e-420c-91e2-b099c6b1a1f8)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         dbabfc13-f3e7-41a5-943a-457a8b247e42)(content(Whitespace\" \
+         \"))))(Tile((id \
+         691cb3df-80dd-4330-ba2c-3aa73fc64e16)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         217e376b-336a-4eed-938a-b41e13080a82)(content(Whitespace\" \
+         \"))))(Tile((id 869e7c2e-3879-437b-a654-b1be465d9d8f)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         6ebca597-6d50-4abb-8696-a782f666366d)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         77b34ac4-0030-4fd0-b8ee-9cb19745adad)(label(value))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1b769053-4833-4349-b8b5-ed1d17e9240d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3b3c7adf-9f20-4bef-b6db-1f47d721f47c)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2707c42a-14c2-42a5-81de-f96c06cb6177)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c1efde2b-4da9-4ba0-99ce-27efd4b50df7)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         e7f36e6c-8cef-4135-a9bb-6af87e644c8f)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c478f3ab-975b-4d91-a027-bdacca9b19f9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5b9f162a-467f-4451-a111-1d1127da28bd)(label(count))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         adbedcf5-336d-4a9f-9dbc-c85a4929d275)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6bf50af9-b6e6-4d49-ac0b-56e37d17508e)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2d6ae915-c660-4d27-ae5b-8108aa6da0fb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         03b1a4cb-ecbe-469d-962a-79592d035fe0)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         16c0bc67-cb06-4e9f-b040-7d9e2d8cecaf)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3afd8e47-ed93-4b9f-b725-d4417ab6a626)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         983a5cd9-f8ef-41cf-9162-120e753d21dc)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d6eeb34a-656d-485c-9608-a529046364ac)(content(Comment\"# V2: This \
          version more closely matches the TableAPI and takes a string column. \
          Given the lack of row polymorphism and first class labels no \
          constraints are ensured #\"))))(Secondary((id \
-         74c6d141-cdda-4285-a535-54aa6783c503)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fee43975-3b82-4458-adb1-bb7f570cc4bb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         81858669-93b1-4e2f-b6a4-c605475f5742)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7901613d-97de-4558-b8d7-dc13a874d816)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         431da462-458b-443a-a3b9-7321a85ea85c)(content(Whitespace\" \
-         \"))))(Tile((id 96b4fe64-da25-46bf-8928-4d15b15c154c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c3fe991f-f6b5-4f0f-bc61-c34133c66e4e)(content(Whitespace\" \
+         fdb406a7-3a9e-4a11-8c78-ceb8645d54b1)(content(Whitespace\"\\n\"))))(Tile((id \
+         c3a645ab-3733-4ba1-a4a9-141b2c61f516)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ab3ca8da-4221-4751-922d-79dd1f0ff97a)(content(Whitespace\" \
          \"))))(Tile((id \
-         bce51e9d-7718-4436-8110-59f71257f6b2)(label(v2))(mold((out \
+         c69f3ade-727e-4f48-ad14-76fddcb98b30)(label(v2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8a585091-ece1-4bbf-a211-8adf774e9940)(content(Whitespace\" \
+         bcfb02ff-87f1-46ed-b585-66bf0d249b37)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3eb9599d-125e-4ffb-ae09-6843220c9dca)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e8e55167-f96b-4858-880d-71b02b4e85a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dc9e67ca-8732-4e36-b0d0-cffaf287e934)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         92480f6d-00d1-432b-b1d7-8245e3456ede)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2cd0c8f-01c8-453a-bcd7-4be6bb346c65)(content(Whitespace\" \
-         \"))))(Tile((id e5082931-0a7c-4e63-805b-1f20b59680c4)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         bcf76173-a756-4725-977b-00c2ea3e7df1)(content(Whitespace\" \
+         51498681-ea17-44b5-9920-ec3adb286bc4)(content(Whitespace\"\\n\"))))(Tile((id \
+         8d54fdd5-9a88-4470-95c5-9f3c1aa9c6db)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a19bbde9-7772-4746-ab27-6c1c8516b0bb)(content(Whitespace\" \
          \"))))(Tile((id \
-         8c70a794-73c2-4da1-b0da-4a4482d45139)(label(requires))(mold((out \
+         0bd8fed6-7b3a-4aca-9b21-8ba2930cc25c)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         9af87d1e-ff9b-4fe3-8c86-1b61737e00bc)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         63c5ce83-2161-406d-8949-6f6a49414c21)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c26d8576-3fc6-419f-b908-326de77b7e1d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d1fbad9c-7c58-4eb6-b7f6-4c730e7f9052)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         60b3a6d0-a5ff-4451-8c33-d35aec052678)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac994a76-7308-4166-abbb-f013b36a89de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         26398478-f239-4706-9e83-771c17aa0e80)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c6178863-0a5c-4855-b7b1-a16618cc9898)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c90a6a75-911d-4742-858e-6151e085bd93)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         68f9c7e1-1a1c-4b1c-ad6b-402638c42325)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         1a477069-d2ad-41b9-b11f-3411b9122e38)(content(Whitespace\" \
+         \"))))(Tile((id 8a263643-e81b-419d-8725-f2fbad75ab1e)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         226cfd48-bfc8-4910-92a1-43c7266892af)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         c0f0a2eb-9066-4374-9b07-fd8e12886624)(label(enforced))(mold((out \
+         a03907e5-b041-470c-b301-8125e9453989)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a912c67a-ff61-48d4-8183-ecf015412550)(label(=))(mold((out \
+         d166fe2e-fb54-438a-9368-555109e98bfe)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         1fa1ca9a-2487-45cc-a7b7-552893036e50)(label(\"(\"\")\"))(mold((out \
+         c150d86a-8278-46a6-8e56-c5f3733dbb0e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         c1ec94cb-7fd8-4bd9-b112-9856508218ad)(label(true))(mold((out \
+         177eff3b-1c6b-41b7-bab3-5ff05ced61d6)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ed4dc285-f859-4f42-a4a1-71f88256eac4)(label(,))(mold((out \
+         b3de9897-1ff1-4170-9ee5-36f76e001a3c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0d46e8db-7fa2-43a3-825b-d71e519c143c)(content(Whitespace\" \
-         \"))))(Tile((id 70f4a62d-45d5-47ba-8afd-ef41d0fda8a4)(label(\"\\\"c \
+         32e2e040-b1d4-4ec7-bc90-3b2f7766cf69)(content(Whitespace\" \
+         \"))))(Tile((id 65952d4f-eb91-46db-addd-0153eb79599d)(label(\"\\\"c \
          is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         61059558-58e0-483b-9263-36fae8f5f35e)(label(,))(mold((out \
+         d86cd828-8900-46c3-af6b-a15a188e8426)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         037cf8eb-fb13-4dbe-a573-0c23661c46be)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3d451b4c-f271-41d8-9547-0357284ea121)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2253fa94-4512-4a4c-a6ac-84e700b49377)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c222c401-dd1f-4b5a-a32e-7bba832330c9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f87d020e-6681-4836-a5c0-4fd352d978e9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cbe365ee-9212-427a-a8df-7b53e2d78105)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae58d5dc-cb4c-4b91-a225-b4c6756dc446)(content(Whitespace\" \
+         28194a1e-ef97-47f1-b186-003b1b267d8c)(content(Whitespace\" \
          \"))))(Tile((id \
-         afad6625-9c8a-4c96-9690-f90248970cc7)(label(\"(\"\")\"))(mold((out \
+         d79f89d3-b5e7-4c7e-adfc-8e70cef3855e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d27be7db-7a38-4ba6-86ab-8b69af1db379)(label(enforced))(mold((out \
+         cde44849-d11b-404f-8430-5708d23a8044)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a44f51bd-ad09-45e3-9f46-11d46da90493)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         464a8e49-fa31-4d92-8655-cdfa354eab18)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a5db0163-5ce8-4d5e-b843-46b8080d15b9)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         2d3f692f-f9aa-4951-b776-a442f28b5517)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5dc5cb16-5a32-4d7b-8898-75e773ce78b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e1fa753b-0eab-4662-9df6-4e2c218c5a2f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         427b7c39-7f8c-4eaa-b254-1da48b2efb14)(label(false))(mold((out \
+         e3ca2ae9-40b2-4bb7-925c-a5faac776612)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         eb0b28b4-5553-4ad8-9151-db314ab6f047)(label(,))(mold((out \
+         fee41375-6418-40d0-8758-27eb86de0e23)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         492dec9f-1b4d-4ade-a329-8075da08814d)(content(Whitespace\" \
+         c437a8b4-e29d-41d7-a0d0-a3e4b435c906)(content(Whitespace\" \
          \"))))(Tile((id \
-         7f2257d0-f33d-4b87-b6cc-bfd0a0f44719)(label(\"\\\"schema(t1)[c] is a \
+         d657214e-0307-433d-8d1e-36aeb2c5616c)(label(\"\\\"schema(t1)[c] is a \
          categorical sort\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e78c6dc5-6898-48a9-9bdf-42089f99255d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1a534774-14b8-4480-ac5a-2ffb61dc53ea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a4094e2f-63d6-4bea-bef9-9ae5b263f552)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7144de2c-8e3a-4601-8d8a-6399b620aa12)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4c9896ca-49c5-4842-a10e-08d4fa242795)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         48e4ebe2-dc48-4172-89b3-fa3ca1c04e51)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3064f9dd-a50b-4e8c-afdb-5b7b12e1b83f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         75491a36-94c7-4d63-b424-411fe4cb6689)(content(Whitespace\"\\n\"))))(Secondary((id \
-         dfb27088-139e-4a4e-9a8e-9666db8cf87d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf24b7d5-c4a8-4069-8eca-5ce1eb05ba4a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0351f4c7-f279-468a-9a0e-ed9aa8064b0d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e73df407-d16e-48b3-9d43-5cf1158396fa)(content(Whitespace\" \
-         \"))))(Tile((id 8254a762-fd69-42bb-89f1-31b29843b20b)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         8ff31d76-d3b1-47fc-b606-811e6a3ccbcf)(content(Whitespace\" \
+         9ae20f63-cfe8-4ebf-8b10-64e1e1c9ed75)(content(Whitespace\"\\n\"))))(Tile((id \
+         c9b1d8f4-9fd6-44ce-a46c-474d1a061e29)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a987de20-328f-4765-a28a-b96be06ce9b3)(content(Whitespace\" \
          \"))))(Tile((id \
-         156cd4d2-be5f-4025-8bc6-528da6dac9f9)(label(ensures))(mold((out \
+         1851cbfb-4566-43c0-8e04-ea32e009f092)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         9282637d-9080-4b69-8b01-200ba0ded920)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         67c92827-78d3-4fab-b490-51fb8d1558e4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e1fad2fe-37d8-4a35-b0de-461bc09cbdb5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ad6d9ec9-6ab7-4d84-b643-6c7a407b1c58)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         739d4ea5-1f92-4090-86c3-75abe08a3f0e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2184fd69-20c9-4b2e-b611-b3637ff98573)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c59e5171-6f0f-419b-aae3-dea0d6dced20)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         15a887ea-2865-4288-9e67-543215f89d08)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4894d597-c2e4-4784-8678-d64ccd64a0b3)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         9a7b6b7c-ac39-4ae2-baa0-9ac50399e609)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         b940480c-06cd-4c38-a06f-367b1a6cb77e)(content(Whitespace\" \
+         \"))))(Tile((id d94d48c5-734f-474b-a1be-e9fc1c2252c0)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         807d5b92-9872-4910-82ad-dd33b6045687)(content(Whitespace\"\\n\"))))(Tile((id \
+         a9fb4820-61df-42ec-980b-c2bee8def913)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         78a11214-63b3-410c-84e7-b3ec8b907f1d)(label(enforced))(mold((out \
+         07a86270-a72e-4e59-b7fe-9bf895f3e895)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b025e433-8bd6-4fc8-85c5-db110a98da56)(label(=))(mold((out \
+         e30cfdd4-876d-44ff-a750-48479781d039)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3e074369-85dc-4630-919d-0502b235a0cd)(label(\"(\"\")\"))(mold((out \
+         801640a8-3292-4267-9aba-4ccd6f7b3f01)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         de0b2920-d3c5-43f7-b337-0a0a17acbcaa)(label(true))(mold((out \
+         2ad3f9ab-8354-4d32-9492-a82a629fc4fb)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         3c9dde1c-adef-4747-a912-f9c6d4280da9)(label(,))(mold((out \
+         05e4e282-7c1e-4ea1-ba17-25ecf7fb815e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e584bd53-055e-429a-8f9a-24fe30bc9ee4)(content(Whitespace\" \
+         447c46ac-27be-4c29-b250-40f5d3cab65e)(content(Whitespace\" \
          \"))))(Tile((id \
-         dcc7bafd-616b-4515-9b03-1d04772096d1)(label(\"\\\"header(t2) is equal \
+         409527db-679f-4bab-855f-cf4e092dda14)(label(\"\\\"header(t2) is equal \
          to ['value', 'count']\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         55fc63fb-8fdd-4e79-a31d-cbb025994ff0)(label(,))(mold((out \
+         77c3378b-9bcf-4bae-ae94-ecd322574a60)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d98e6d6e-e662-4abd-8fe3-654af24028ed)(content(Whitespace\"\\n\"))))(Secondary((id \
-         be520eb3-d043-462d-86f5-e8b1510a50e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         388a3d95-4b6a-4873-95ff-6b8a2b80d83c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e1ae40f-5857-468c-8043-ce94f78f9fd0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         343374ac-e040-41ec-ae7f-23fb790af141)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         259ef28f-4356-4305-b98f-71952ac68b89)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d85f99c-90bc-4060-801b-42da7de88569)(content(Whitespace\" \
-         \"))))(Tile((id \
-         833da0dc-dcf6-4570-b102-60016b087378)(label(\"(\"\")\"))(mold((out \
+         2ff809fd-c0b8-4b7e-940f-fa667cbcaf75)(content(Whitespace\"\\n\"))))(Tile((id \
+         ff277bf9-5a68-4d5d-9907-85819fb24f08)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e5f570e8-b181-420c-a17b-0cb398715554)(label(enforced))(mold((out \
+         1b233afd-2695-461f-8e45-224abbcfc320)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         704e324f-9d0e-46ef-a93f-72fe77a4cd74)(label(=))(mold((out \
+         d51e8106-aa95-415d-b98d-316d3290c961)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c8e23bd1-8506-4e2f-b8a4-0ba593268265)(label(\"(\"\")\"))(mold((out \
+         43cfff12-cd8f-404d-b4fa-ac67c7804ec7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         76f9e74e-6bd4-499e-a96b-b1c5f92ff316)(label(false))(mold((out \
+         6f53466a-837a-4a92-959f-8c0a0c2ec417)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8a0becab-c6eb-42d8-a458-4862cb70f59e)(label(,))(mold((out \
+         58254b49-d8da-4d73-815c-8bf4b1b66b18)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f8226941-6ce5-41fa-b103-2f9df2751401)(content(Whitespace\" \
+         b0e15e1a-9b23-42f3-ba6c-21c253218987)(content(Whitespace\" \
          \"))))(Tile((id \
-         4266fcde-3502-47b2-a7e2-e945c00c59ca)(label(\"\\\"schema(t2)['value'] \
+         10d0f90f-9f42-4838-af88-c4d59a4b330e)(label(\"\\\"schema(t2)['value'] \
          is equal to schema(t1)[c]\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d850940a-fad4-47bc-81fd-1f01132e77ab)(label(,))(mold((out \
+         ff0e9a9d-ddde-4013-ad4c-a17431679f65)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e9559a2a-30fd-4991-a5e1-590305dd6ba6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9a0f71c1-b838-48cc-9b25-1dd721cde2b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d709477-42bd-475d-8a43-63423e7bb1f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6a126cc9-1ef3-4600-8fe9-62846c49e290)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6b5148d6-4dc8-4ca9-96cc-f29fe368bc31)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c19c79f1-da85-4ebf-aae0-2821f78a4646)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32cd0dcd-c4d4-481c-832d-d702a63e9156)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8b86a85c-00e0-44b2-9625-0b091a6e3f89)(label(\"(\"\")\"))(mold((out \
+         6f98da1e-7143-4ff1-bd37-169cff30b062)(content(Whitespace\"\\n\"))))(Tile((id \
+         eea70655-05bd-4e08-9553-d1092375ce85)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         17846325-6131-4d15-b60a-0ed9bd254ffa)(label(enforced))(mold((out \
+         e3c8331c-0166-4983-9ddf-e2ae1195ae51)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         956453cc-4a0d-4619-9467-67ce2b68bf2d)(label(=))(mold((out \
+         7e1b331d-5f46-4f44-bc77-0cf130f241de)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         84fda9d2-41a6-49f6-b11b-1e39753f03a8)(label(\"(\"\")\"))(mold((out \
+         7d3f6e7c-c0c0-48bb-938d-7edbe2a8d47b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         73fdf48a-1f1e-4aee-8dbc-17650001f78f)(label(true))(mold((out \
+         9830d524-d8d3-4bc3-9924-ce26eda96dcd)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         bad0f604-764c-4282-a948-ccaf3a6a17ce)(label(,))(mold((out \
+         3a0f713c-c7e7-48c7-b6aa-775c60c8ae89)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c29b867e-0215-401f-be14-70e2202ece86)(content(Whitespace\" \
+         2690c51a-62ea-441c-8512-a1010fe02173)(content(Whitespace\" \
          \"))))(Tile((id \
-         7dc16a13-015b-4b7d-a593-38cb6e0a96c2)(label(\"\\\"schema(t2)['count'] \
+         99b6b84c-4ba7-4716-b939-3d1e8dce5f65)(label(\"\\\"schema(t2)['count'] \
          is equal to Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d37620ee-a93f-415f-ba53-2e521f45419f)(label(,))(mold((out \
+         8b56b7b8-463e-4f39-8e6f-c7a10d793800)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e30ad0d1-66ce-46a2-968d-24e28d9eefb7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cc6c1106-055c-4247-b888-71d1ce9de1ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8b0e2210-c3c9-47b2-bf2d-a54b31e8ae34)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dc909dc2-8be8-4ca3-89f8-6da3fc5f598d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         692b04c3-9333-4afa-b5e1-6ace646e2da9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         456240f5-8118-486b-9a0a-2917662b0b94)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e85da9a4-bc82-4ba6-9541-10af7cae8cd2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f7d1ca31-df2a-4130-8f2e-eb53fee4ae13)(label(\"(\"\")\"))(mold((out \
+         caaccfe6-63c0-454f-a186-34fe84f50360)(content(Whitespace\"\\n\"))))(Tile((id \
+         50964744-6eab-4b77-bd29-b56cad5976c9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         a6f76594-d020-4e56-b9e7-0dd55c0c65cb)(label(enforced))(mold((out \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         7e572db4-d319-4aec-8061-1a0f9d2a1cbf)(content(Whitespace\"\\n\"))))(Tile((id \
+         9ce8f321-f38e-45ea-9f89-d6a3d060c030)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b3216eb4-e27c-4de0-be74-01db2a117d81)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a5117a31-81d2-4a49-905e-efc0fd1dc8b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f6af36d3-c23a-4587-8e3d-2f112d7aefae)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         097ef2a6-dce1-4caa-81b7-03ff292521d2)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ff8d4d2d-b95d-499f-be4a-bbcc29d0b60d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a5bc6164-01a1-4e6b-aa98-d799ef7dd9a1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         96dd9379-f66b-41b5-8aa5-f2607d804bac)(label(false))(mold((out \
+         bec422de-73c3-47c5-8f2c-8132730d723a)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         5d1d927e-804d-42eb-86b6-cf28f7fe3f65)(label(,))(mold((out \
+         5a873049-d3a0-4424-80d4-318c9f0b183a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         109a96bc-c14b-4786-8e52-aa035dc7184e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b5ef0aaf-8414-4f19-83f5-1e8e2ea768f0)(label(\"\\\"nrows(t2) is equal \
+         4471238e-5bed-4719-89b3-f5b66011bc91)(content(Whitespace\"\\n\"))))(Tile((id \
+         59855e41-f45b-496b-9c75-f6a6a6817604)(label(\"\\\"nrows(t2) is equal \
          to length(removeDuplicates(getColumn(t1, c))) \\226\\128\\148 Note: \
          if there are missing values in the input, this constraint requires \
          one row for missing values in the output.\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f7aea527-58c0-480a-9aec-82dcfc2250ae)(content(Whitespace\"\\n\"))))(Secondary((id \
-         071c0b66-e4fc-4320-964f-0dce69c15951)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2b6bc849-dd8e-4b2f-99aa-52689a90a94d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e4bad444-6053-4fbd-9631-ff8ff870f87e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c617b9f7-56d6-481b-ac68-3224a2c555ff)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         93b7c8f1-6113-488c-8f72-6e4d853ba2e2)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         b8546543-d197-4bbe-866e-503b5c70ae22)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         20a72a86-8711-4792-bf2b-9fd2dc4f3726)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         41b07130-8c5a-474e-931a-d9c6b18b7c20)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0486433d-193a-4042-b7ae-c363961bd0c1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5ffabec5-be13-44b2-957f-3e49074db15e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e4c362f2-7f7a-424f-b447-8c7d4dc8e8e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         88eb9548-ddb1-4f4f-b9c5-6351c31ec071)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         68edb2ca-ced6-4f6c-8ea6-379152b85b76)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e707c07-686b-4323-b014-c2717031781d)(content(Comment\"# This \
+         a866301e-b397-40b2-8da0-66b88f428b09)(content(Whitespace\"\\n\"))))(Secondary((id \
+         f2fa2c88-e13a-4d9a-a05e-d4149b95641e)(content(Comment\"# This \
          utilizes the primitive_pivot operation to group the categorical \
          variables. To work on numbers another method would need to be used. \
          #\"))))(Secondary((id \
-         cab824cb-85da-41c7-a29f-0b6a38341e0a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b28ac473-a4a0-44b0-acaf-81de27ecb96b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4030dc7b-4480-4ab2-bd5f-5fafbdc8d764)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6a73462e-112a-47b9-8ab0-efeba613e31e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         73ddf506-02d4-4a8b-a980-8e71e941dfae)(content(Whitespace\" \
-         \"))))(Tile((id 2386b683-3e02-44dd-9adc-3a6c0a49023d)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d6a5e335-f3e6-4fdf-a508-949426de6fac)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f8f67712-00ff-45cf-b650-5acec3c7374c)(label(count))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         37e1b4dd-24cf-4321-926e-f2d55c2de210)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         7f85fe5e-5116-4eff-ae6c-3351689d5ae8)(content(Whitespace\" \
-         \"))))(Tile((id 9b79c0f6-bd0f-41b2-bfd1-9002878d5200)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         b4ec5b24-28cb-4e2a-812a-13abe8904af9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         eb693741-e8e4-4f38-991d-5da4c99e48a2)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         35ec7d69-a62e-4598-bcbd-dcd538b6887c)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         35f4e9c5-8d7e-438b-b0eb-27b851217538)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6f484546-b17f-4e04-9939-9c7b9bfdddde)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         4c448aa8-3624-4340-bf9b-31a10208980e)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         ccf645b7-8ed0-41c3-a06e-a3ad9f1aa35f)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         559b2319-4df7-48ef-851d-7dd71a269ea2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5f56240e-bfb0-46ba-98f4-fc46e4b78b75)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         2dd14ecf-794f-49a6-bb38-da3091deec1d)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         7a23aab8-2905-412e-9314-d2c01df42a0e)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d7ef9672-9390-4f2e-83e5-bc08143197c2)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         78cec067-c56c-451b-a2ea-72e0fcaa03b3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         369e3ed2-a218-43a2-8f10-095625abc70f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b265ec55-48ff-485a-a605-4fe3ff4af10e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         63557904-cfc8-45f1-8b55-bebc878fa331)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         52e51d7a-9939-4a43-998b-2cb0d84364b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d1ddc17f-be34-4a04-95c8-b2878d774480)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c14ba05a-3bef-4f76-96f8-349810458047)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d49f31e9-e47f-4d6d-8a76-68f55ed27245)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         5d37aaf9-363b-4ba5-831d-117b46721887)(label(flat_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ee133238-d4ff-44e5-8e10-baf777ce8583)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c14b7fe8-4d63-4206-8e4e-266b525bfb45)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         97b9a475-a8f4-46b3-a545-5037e20e7cf0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         739aede4-f259-4fa7-b61c-83fe4ca7a7b2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7830dcd2-1e51-425e-9a2e-70091078e3b8)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6cb3a3e3-4ca3-45d7-9284-2ca038d9d865)(content(Whitespace\"\\n\"))))(Secondary((id \
-         005beeac-3fb3-47c3-920e-a27979404537)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb05c90f-79a6-4092-a476-6f2cde44c950)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         69f4d78f-4019-434d-8584-088d9b8d788a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         821d28f6-9ebd-4852-8209-58c66b52183e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5abf16b6-db33-4022-a7de-63db655ce63c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9aaa51a-f839-48a1-b555-a4f271ddc00f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a18941bd-44b3-416c-a197-c6b009a6a3f2)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dc6b974b-fde4-4e25-a796-4a4b0f3823ee)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e98280c6-f685-4617-bdc2-71601d3ed0d5)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7ef1935e-4895-45c0-9a0f-e6d57746bf00)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         678d1993-acf2-48e2-882f-46129abe5947)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         75aa2556-26d2-458f-93d5-87a2b01b7a01)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4210bfcf-d714-4699-ada0-958bb992f03c)(content(Whitespace\" \
-         \"))))(Tile((id 08675b50-0bcd-408a-ad5e-0c41cf0f3961)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         698e9dc5-eec5-48a2-8df1-83475c175f4b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7d6e46a8-0ba3-465d-a895-3156bcc797d1)(label(e))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         332256fe-efb3-4fdc-9f9a-6b0e8e424db9)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         a05157d6-a647-4fcd-9f8e-94dd5ff6fc40)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b9734187-c4ec-4469-aacc-387d19649092)(label(string_eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b8528a66-8ea6-4180-8833-5cdc3aab6529)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         51f9f9bf-db3f-4bc4-a9c3-797b09ebc23e)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6c50cb89-b443-4f8a-a453-d177a940c1f9)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         83d52be7-7887-43c6-8717-d895dd667343)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         dd1da82b-a59e-445e-8e3d-6fc51de21de0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f6ed7c51-4c93-40dc-bef4-228a4a4b5e67)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cffff65c-a39f-405a-badc-b66f4b6f77b9)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         db6deb38-8634-4961-a8d3-1c15d0535bbb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c5cd91c7-b53f-4b81-9532-7d8e1406443a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         94a623ea-3d53-40e3-a24f-95ef431038af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         22e040b2-947e-4d11-86dd-4acca4aa98e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf4a279d-08c7-43f0-85a6-cdea3b188e8b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         30b8a419-5343-4ce3-981a-3cd447134944)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         38a2ba72-af66-452f-862a-e966c723c91d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ae89385b-e096-4ffb-b53f-dce9c928f445)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         deb25158-4486-474a-9945-51f4242b8c29)(content(Whitespace\" \
-         \"))))(Tile((id \
-         590b0a19-d457-4ff7-b793-c0dbd8d2d310)(label(group_by_label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f4399e1e-b16c-413c-9c83-b3487e19b6a1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         145a0579-d77a-4491-9ca7-dbb4748330e1)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2f5b282d-69c4-45ca-9e9a-22b517197aa6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e4ed9be7-5f02-4c89-b5f8-c080437bfcb1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         26dd68e6-62a2-4086-9dbf-faadb08728d7)(label(`value`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6bf6a4a3-74ff-46a3-b7a1-c5cd2ab4fcdf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         108ead8e-381b-4ea0-a1a8-47f00a5e8174)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b4ece5a5-110d-4e84-8fd4-e3800c1d84c9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6bafec9b-ee9f-4516-ac85-69b1dc6563ee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1cdb80c0-4f0e-41e3-afaf-848d121f2a2e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b5e92692-b11d-44fa-ba9d-0db892c6f0bb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d1beeba-bb6c-485e-a2de-796082b41e5b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7367a749-7d0a-4aa7-8964-8bc1c7185fe6)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ffcc1c0f-685e-46a7-b48b-04c67479f877)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0c910228-f409-4b2b-b469-da49fb0bd99c)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         b71e3abf-b5a7-4d81-9398-974b99b5b401)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8ef6068d-4277-4039-b500-2dd64bd838ac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         68830b2e-1be9-4d42-85e1-5eeacd4df468)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e5c9b81e-843e-4d08-bb32-cc763fd6238c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8ff6839d-968c-455b-ab37-6a821fa28f91)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6b1a6bb4-638a-4175-8cc8-b8389e2200df)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9e9fb030-5ec6-4c67-8323-64970e962213)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e2ff3a14-b354-4b99-85ec-b425fb735d62)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d0ddd5e2-a3cd-4a13-b570-f152df9e6282)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c9c9a8c6-6461-4d16-85a0-009ca35090de)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ed04df46-831d-4a93-9fd9-1db4079a1843)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         3c319139-f052-4d3e-b9af-b8df5bda93b1)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         33902105-7406-4138-a40d-afdc3843091e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         46784502-1586-46f7-8e90-e2d9327f0337)(content(Whitespace\" \
-         \"))))(Tile((id b0005e70-8152-4ac6-a61f-bc1a67df9360)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         d5ef4aa6-d51d-492c-a19b-f9a36fb6fd99)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ef4f52fa-1a23-4133-be4c-0d5e935a1369)(label(e))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         7792850b-93e2-4161-98f5-d47d3c06c535)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         991f922c-2f80-4140-b0af-61f8cfab7619)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3a932f25-ac0f-45d1-97b2-ca57a3465c3b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ef21a30e-f0b4-46bf-b03f-e091bb92893c)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2532fb00-0343-4f7c-a8dc-2eb200bfd024)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0329218b-fa84-4273-8e12-87a25b04336d)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         11ffdc7a-0339-43ec-a1fe-9dab459bf843)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         06476c0c-c888-49c7-9069-4a4be49b1da0)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5405cb20-ad16-4690-a72b-f8863ec3e298)(content(Whitespace\" \
-         \"))))(Tile((id \
-         14ffe3e4-ba2b-4a51-9b7c-b1f6311f17ac)(label(...))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10dd07bd-c78b-4be6-9190-a0a26ec8d545)(content(Whitespace\" \
-         \"))))(Tile((id \
-         787fd109-a893-47f5-8cad-736844d7bfb7)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         aeb45d62-3238-462b-977a-0c402b713c7c)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         51bb88ed-fe7c-44c0-a0f3-bbefeabdc244)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3e25f024-a3da-402e-98fe-355053397fc0)(label(length))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         dd7fbc48-145c-4424-9d33-902d80d405ac)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         78570ce5-0a3d-4e9f-a005-f14de7e3b8b1)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3dc13511-8fd9-44bf-9623-525855ce963a)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c1740a6a-8a59-400d-9353-01000a231f58)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         463bfd4b-533f-449a-bc77-a8941c52617f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d842a12b-547c-4728-a80d-b07104bd1665)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         13663d0a-89e6-4593-b5bb-4ea148118b59)(content(Whitespace\" \
-         \"))))(Tile((id f1a0bf2e-0276-43d0-81fe-83a640428b5e)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         fdcfe4b2-5fa5-4ad4-9f25-14b974b36498)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         684290e8-600b-414c-867d-2b60c0a85dcd)(label(value))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         86ff9c65-df9c-4306-9ac8-8507a89e4c3a)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         0cd57c1a-2294-4a39-be62-a71d2a3e201e)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         1571ed57-6d76-42d9-b209-d8287644f5e7)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0a44868d-bb2e-4ddd-80aa-342ca3dcbbe8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aa4812c4-43b1-48c5-8690-1891185bb910)(label(count))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         ed68180e-e4c4-4d10-95b0-a2ecc568fa19)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         47c2aca6-9fc5-4eac-a52b-91d8c528f74c)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         213bab35-86fa-4f14-90fe-75c93a284d39)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         62b94146-bc32-4e77-a367-3fabc244ae91)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7082e823-ef60-492e-8f1d-23ad040f9df5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9e96bf54-b870-408b-a97d-de685e04a53a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         038a775b-276a-4ccc-aa66-fc4481e1e714)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c321fa9e-c182-47ef-8ba0-c8a6b5276aa6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         29b42101-4ef2-4572-8bfa-c870aba8a013)(content(Whitespace\"\\n\"))))(Secondary((id \
-         324ec9ad-7e73-418d-a5da-57b2586f1cef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         654d8f4f-66b1-4d20-bde9-64c10c9ccb24)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         da4170e1-1b8f-4a1b-a39c-213092b01666)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b4502d89-e816-4cc1-9bc6-5854a5027dc1)(content(Whitespace\" \
-         \"))))(Tile((id a03b3b89-e3eb-4d70-a36b-e2b7a79c233a)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         6c151f91-9cbc-47cb-8857-ba19ccc79a95)(content(Whitespace\" \
-         \"))))(Tile((id \
-         87297359-bc66-4bed-8563-283cafef1d52)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c0a8b502-7e22-41bc-9735-ec0a2a708728)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         efc5dda5-19c9-4e71-a9ae-d03807fcdf8e)(label(students))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9c44a42b-02f7-43f0-b088-e7ef53bad032)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ed2e1891-cc88-4fb8-b902-9f76764848ff)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e0af38bc-d76e-46e2-aeb0-278348e8cdf7)(label(\"\\\"favorite_color\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6844cf56-f095-40a8-8c42-9eef3d07b10f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         787fbbe1-5367-47d2-8258-b7426d2572b0)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bd450cb0-d649-49a7-abf5-8bcc17d630ac)(content(Whitespace\" \
-         \"))))(Tile((id 589c6a40-bdb7-4ac7-96ba-db4c388d8424)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         709243d6-5af9-47de-85dc-1a7f946e5fbb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3a97ae66-21f5-48af-962e-22b10fa6636d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b16e2bb1-ca27-44a5-80e3-1491a55fff51)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         df802dea-2ac1-42f9-9fed-06f09653ac7a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9dd4ce1-3c79-4ff3-bb2e-1d5e15040b9e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         49bea43c-9460-4b8e-9a12-2cff8dfb4567)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b084272b-76c0-4857-ab06-09deb99a89a3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         86e75c6e-eb51-405d-9804-046952a9d7b1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         4a1bb5cf-597e-4552-b8db-7189787b71d0)(label(\"\\\"blue\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b7e8c76a-0497-4196-805a-14c53575bdd3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         794185c4-b0f4-4da6-a991-59aa149768a7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5ba21717-1051-48a4-ada5-4c0754c3ed30)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         b3ec5748-74aa-4364-908c-17adda07e135)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dd14392f-3fad-4117-afb0-51075121d83c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bfaf0436-8653-4b12-979b-130fd52d8a61)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         153ece41-9f85-4526-88f2-f3ce85bd9318)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e3235c3b-833f-4037-b70b-670dbb4c0443)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d324a2bc-6afa-4055-9780-0a8973256360)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         05a33f30-8e9c-4502-866c-f35514ad1825)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0bec95bc-2774-4fe7-b065-f253e7adcb30)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a2a6109c-6b28-4b0e-97b8-ee5ccacbf0a0)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         d915fc4f-9414-450d-bb63-8cd3ea4e174f)(label(\"\\\"green\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f1aa6603-6a09-4bd3-9433-6da7bf3c82f9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b530488c-6030-4609-a5e4-bb9e79446505)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c90a1e0a-6b10-423d-8434-56ceb085cfec)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         775b86ec-9bf5-46ef-959e-473f675fd4ac)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b22ecb9d-25c9-4ae6-83ad-abb8f3dbe7f3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         441ffb50-13ed-4287-b8fb-a666fa4ba6b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8b28222e-4ad9-4f82-a2a6-fb98071f8079)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         180a76fc-d611-438b-9e92-5ecd2dc6c0aa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0fb038d7-7adf-4c55-a76f-0a51da041bff)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a516c7fc-8e1d-4e59-bffc-ffc530ddf087)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5f087bfe-3819-42c1-a03a-9971147750e7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ad2b24e4-a984-4164-a169-be779dc385e9)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         144d12b6-024b-4fca-ae9e-beea1fde6d9d)(label(\"\\\"red\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c1b1e268-d2b6-4dd3-98d7-ed2eab4d2530)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         50ae20fc-cf52-4468-b6e6-e9d138c2f6d7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aae81892-e6bc-4e71-a92f-ee5672678282)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fbc7a755-a937-4581-a292-0455d4362453)(content(Whitespace\"\\n\"))))(Secondary((id \
-         75798855-2d59-4406-aab7-436660c19aab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a7af772b-b46c-4c20-95f7-fb29862c0aa8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d3005ba5-3dd3-4c0e-a580-2e40a3757058)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dbda4862-92ba-4bdc-8100-c3ca053ccf40)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         29a7f426-4362-4e07-9fcc-e0a1e1878954)(content(Whitespace\" \
-         \"))))(Tile((id \
-         80609f50-1454-4331-b4b1-14eec2e914a6)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         23b7fcc6-da49-4a9a-896e-e6c0b3b1f00b)(content(Whitespace\" \
-         \"))))(Tile((id 32db49e3-ec83-4f21-a112-9f05344f7065)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         b6b06e12-90da-4b55-990c-e5adbeac3e94)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         3eb12a0c-79b6-4f42-b676-a6405519eb89)(label(value))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         131c3e65-634b-4b1e-ad99-4193582d038f)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c7d1c195-957e-4367-9d84-d5b8f4188112)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         dcf542d2-6ca6-46e3-bb46-380c4f93e204)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e81f2969-4b1d-4a5f-9432-05613e444a11)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0e0a2a76-a85e-4ff6-bd8d-9ca0c24a1f19)(label(count))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         de55a7e8-7904-4744-920e-6526b7175ce4)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         920df39f-ff2f-4b45-bb83-29a357f2b883)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         8e1b96c2-f1f2-4eda-91fd-1b190adcccf0)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         fdd12d13-855e-4375-a12b-2bb543153a10)(content(Whitespace\"\\n\"))))(Secondary((id \
-         be117251-4f34-456a-a650-dbbe8803501a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9a0adbab-3bbc-4699-9e11-e2442eafcec3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f0445d55-c927-4337-88e1-e87bdec097c0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3de7c80d-da17-45db-bb87-7ed0ed4bf2f0)(label(?))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         3d29473a-2df3-41c1-ad52-a2e1c9f2526c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         dd9d7d5a-c6fe-497d-b430-a992aaa3d354)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         af6d1823-e989-4624-92cb-34fd5453a1c7)(content(Whitespace\"\\n\"))))(Tile((id \
-         418d23b4-929b-4e77-9b9a-7cf5dfcd2e3f)(label(let = in))(mold((out \
+         42c3494a-f873-47e3-b1b6-deea85adade0)(content(Whitespace\"\\n\"))))(Tile((id \
+         af2cd18f-8e47-43d2-8b37-21c845fabe93)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e71f29c5-3378-4294-bc20-73d98f49acae)(content(Whitespace\" \
+         12d9f8dd-aca2-4dcc-bab0-58cb312f1057)(content(Whitespace\" \
          \"))))(Tile((id \
-         2790351d-8691-45a9-955c-4172f46b7657)(label(bin))(mold((out \
+         67990c89-a47d-4617-9472-f1e0bc902a11)(label(count))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         81b3f8b9-f667-4249-abfd-df5059f2f4bf)(content(Whitespace\" \
+         bd2e677e-7fb7-46c5-9c46-b851754fe606)(content(Whitespace\" \
          \")))))((Secondary((id \
-         717c21c2-92e3-46f0-9fe3-299a9c9f3a3b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         13518b9e-a749-4b92-add3-3308229cfbde)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4db4b826-c107-474c-a220-142a34252620)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e4d99679-098d-4cd7-94f6-92005c5fbb5e)(content(Comment\"# This version \
-         takes a string column name and can't guarantee the column is a number \
-         #\"))))(Secondary((id \
-         b714bff0-6f26-4a1e-a7ec-f65a390c15f8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a99106d4-8683-4280-8331-076eed46d000)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0ba7a073-e48b-44fe-9cba-95a8eb57070a)(content(Whitespace\" \
-         \"))))(Tile((id 6d54bb64-d9f4-4058-90cf-1bca91a8406b)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         407584df-2452-4196-a464-1bf62c686be3)(content(Whitespace\" \
+         e1806973-a268-4ef6-aa5b-182871e8e820)(content(Whitespace\"\\n\"))))(Tile((id \
+         05cfb570-eee4-4f9a-a911-2c1fbf1b33f3)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         60db3551-e215-422e-85d2-69f8a4ec0c89)(content(Whitespace\" \
          \"))))(Tile((id \
-         075914bd-d1c3-47d0-928a-880b0c188dde)(label(v1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         a04a9d76-9487-4d0e-b5dc-f68522dbfd72)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         d617d1ac-1220-47a3-b506-312557927f54)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0993d841-910a-4539-a98c-fb42023cdadb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d734719b-82bb-44ef-b512-2c24baf50ab8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1543d61a-8c08-4c84-9544-94c9b124c01d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         da6399eb-9403-4d0f-bccd-66c568123f7c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4797431e-7ebf-451e-9148-e41979492ba8)(content(Whitespace\" \
-         \"))))(Tile((id 4a4c9289-43b1-461e-98c3-ba8957a811ff)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         552ce6b3-018e-4f41-b6a5-71217dfa3499)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d1eb6cf8-49f4-4571-9852-84ee5a290094)(label(requires))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         491decc6-ca7b-4a3b-b64f-ad01a6e8bed7)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         fcb51149-ab83-440e-8526-40316af01a9d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         90405476-9c03-4a4b-8134-ba0129bd4d60)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32f8d41b-8978-4b25-bf69-31b191c2fc06)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5d26d2dd-5896-4ec7-a685-0cc794974646)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aa41ffc9-83f5-41c5-908d-37faef571cf9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6a05de6d-1912-475c-9391-7a92d4e8aebd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9528a246-f3d6-483d-8bf7-f49f47329ca8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d612039c-d86c-496f-8a27-428c1e461f98)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         13a76759-7969-4488-bac1-bf390ed26ff0)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4cc17987-7773-4b53-86c6-8441b05779d4)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9d237107-fa02-4520-a25e-0f5b1e10cda1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         80992335-ece2-440f-b877-a0e79c1b1357)(label(false))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d909b59d-bd20-43dd-8f10-32f3359c5062)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         098f51e7-2b5b-462f-9753-79e05184ada5)(content(Whitespace\" \
-         \"))))(Tile((id 9c73b5ad-24ff-4a97-a237-6dc64e68b6b9)(label(\"\\\"c \
-         is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
-         Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         64b4c730-0e1b-4e49-998e-3e34a0c4cffd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         35780aee-7901-44e4-b8bf-1c489d2ff1b7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7e9f0693-bb16-4378-a162-25a5cdeb61b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         740bea55-8447-48f8-b204-1e55dc5f6db7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fb565b4e-3c97-4e4b-a78d-0adb2affe1ee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5cf368ac-7efb-44b3-a4fc-3a7ca931f602)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ea3477b-1b47-4f1b-9b18-bde186bdc3e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d6b46236-55bf-48cc-a911-2d3c88257c54)(content(Whitespace\" \
-         \"))))(Tile((id \
-         66274663-0ba7-444a-86db-2460664de681)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         3a501c25-d229-46fb-9645-4b6bb14fd21b)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5052b9f0-08c6-420b-992a-95129aaa61cc)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         2f5c9ad5-c5dd-4edf-89a8-d6d6f3b85687)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         d9ff8ffc-9b98-425a-bee4-195a7f522bf5)(label(false))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         1ab7aedf-166a-4a24-bfbb-2e0805dff773)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0706211e-5d71-405b-b2fc-701c96cc883c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f073bedc-7402-443f-9b97-5f42ad40b34b)(label(\"\\\"schema(t1)[c] is \
-         Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         552cf684-c4d9-410d-a69d-f6b30ce56f53)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ba350e55-935e-4645-ac24-f90f3b6af22b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b8a54420-46e2-486a-badd-560ab82aeb7a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba2e28df-193a-481b-a5c9-ceb1633f0513)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a70b32fb-f34c-4034-8a46-38b40e98d201)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         077511b2-4fb2-400f-8314-5121b8a75a43)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         5e9a1ee1-64d2-4d66-85de-69de993aa844)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8937f1ac-2cfd-435e-a82b-cb3cc9cfbb3a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         532f320d-2b9c-4e5e-83f5-5d32e1333b2d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de7851d8-35a1-4c9b-9cbf-f060f1fb77f3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c374029a-105a-4838-b85a-b90aa70f480b)(content(Whitespace\" \
-         \"))))(Tile((id 45159bfa-de7d-49ea-8ac7-5806ceebc0ed)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         67fdba9e-29e2-4d28-98ad-ec054628e1fa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         62e031bb-d13c-4c5c-8b05-1382622cbb0a)(label(ensures))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         cf86bf6f-b169-45f6-85f1-1abd19f5978d)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         7f7fdc43-ab4a-4f21-9937-51c6c01b708d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a3cde4fa-d915-46f3-bbf6-5b7a4de26a22)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7dcf3165-c136-4299-a4dc-0c517604f20c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3390d69e-9ae5-43ae-9961-3d95ae0c7571)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d4839275-f45a-44a8-ab54-7a8042598f03)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dae287ff-c8e4-48d3-becb-d29315b30c67)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33bf1987-f195-4bc4-bf03-b51036ce7646)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ba923525-3cc8-43bb-9c4a-77a1bdbf9dbe)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         286cbc2e-7a5c-47a0-bc60-e454609c4ab2)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         146289d5-1dcb-4daf-aaf4-0cbe5a302965)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         efd0566f-e213-4277-980c-52a42a9c4f36)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         30af7f1a-c63a-4ddd-ab98-64a7f69b8250)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         fec4320b-8269-470f-87ef-210d0c92866c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c38bca45-f2b6-416d-932c-17296e0448d4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e304623f-c7cf-45f8-86ad-14a94ef9b3fe)(label(\"\\\"header(t2) is equal \
-         to ['group', 'count']\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
-         Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         aa60daed-d6c2-4d9a-a0cc-d963bd34681d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cd7341c6-ac3b-4257-9509-5bdf7cd05f57)(content(Whitespace\"\\n\"))))(Secondary((id \
-         85b7b787-489d-47aa-b2f0-c37a66ac9660)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3d5f5c89-4c96-4214-a2d8-d17f4c36c6b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1671219b-3d48-42f0-a37d-6076cc534e2b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fa0bbfeb-41f7-4c69-8354-198e72047986)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8018d7b9-319e-45d2-a460-f49f817fcb02)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fa3b8aab-08cf-4f7d-a6ff-155fa62ec8f6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         371dacc0-7c39-44d7-874e-3f76cac24db6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         0a0b4a61-0542-4adf-81ec-13103b26101b)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d183e2ac-fe33-43f9-b9ba-823607b9911c)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         036bd8fd-d883-4c81-b8d3-2b4c743850d6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         6821054d-2891-49bd-8066-f59606e6a6e9)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         e135c4c8-2040-4dfb-824f-aef4515f0709)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d624e200-cf41-41aa-96c4-cb0187b0ead0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         974f4d96-342b-4210-a48b-840dcc3982fe)(label(\"\\\"schema(t2)['group'] \
-         is String\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         69a6a1ab-fd61-4dba-90c9-92113a3d0550)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         95370017-7a88-4504-8e20-106e75d63a8f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c4b87273-a6f6-464d-960c-3596a1c9c019)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0c4ced70-faa2-47f1-a287-6f6cf7bdfddd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f8cb65bb-a7a2-432e-99d4-ecfe1cb98750)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2715ea8c-8161-4b98-a111-212221cb2c1e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c00bd0e-122e-404c-9d54-fbc4924baf7d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82cfc2e6-08da-460d-9f8a-e98d58754935)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b4992401-e7c4-4231-8fcb-bfdd4e9b69df)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         9168d875-f6c8-426e-97b8-5683ce25a3c6)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         df89fbe4-b31d-4f64-80c9-589e6accb856)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a33a2030-92e5-4857-b21e-56e9f136ef7e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         950cec76-b59b-4749-b605-9017b129be8f)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         49309fe7-42bf-4c94-8ff9-979434b8c53d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0e2ca627-882d-4637-abf8-925cab9ff822)(content(Whitespace\" \
-         \"))))(Tile((id \
-         97bf6c1a-37a5-4936-9b29-f647c9ad01a5)(label(\"\\\"schema(t2)['count'] \
-         is Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         2930fad3-bf54-4a4d-baec-c4e6438293d5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         12a83cf7-ff55-47d1-b34d-c4dd49b5c28f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d2f87272-1d26-4256-b617-3ea9415ccb42)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         898741d6-65c6-437c-91d3-2fcc50fa9071)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         87986fa5-d5cf-4397-bcf4-bcfa2b4825ce)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         7622f786-812c-49da-8bc0-4e09031830d1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e5d519ff-d85c-4de0-8a00-c9180ad329c5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         17566bcd-b555-4563-973b-b9d02fc691d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9af9ed6f-4b05-429a-846a-c15f3b50e5d5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8cbde338-f0af-4dbe-9548-f0a186463c44)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b3a7fd25-41ef-4750-96bc-68bcd6bad8c2)(content(Whitespace\" \
-         \"))))(Tile((id b61445d1-b824-4606-89fd-82b4b9a29129)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         49175f86-136f-48ff-aad7-ede079326da1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         40397cf1-6e90-44c3-a0fa-bf1eff6c16ed)(label(bin_int))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         2dff218f-c31e-40f7-bf1a-12d66c7311e7)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         168f8ee6-bace-4cc9-9403-5450b5406b63)(content(Whitespace\" \
-         \"))))(Tile((id b7352744-eebf-477d-bdd6-158828f5d0f9)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         261367a7-1003-4bc5-a9a6-3e57238f570f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         db73a74e-cb32-486a-94c5-e25d8638484b)(label(\"(\"\")\"))(mold((out \
+         dfaabc36-49b0-4e07-85cf-8cf600159007)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         015cb8b7-d077-4d0a-9370-7677baef44bc)(label(is))(mold((out \
+         e242bea5-6e0b-4eab-a796-f6eba7cba36f)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         7f0a7c10-c346-4c7d-b5e6-8529b10cb78f)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f429dc14-e45f-41a3-9624-da918acfc3f4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         091f0b03-dfae-405c-828f-7761175a28a7)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         7c9a1731-81ca-4ad3-b262-f1b8e7149ff7)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         486ffa74-d8a0-473b-9795-05d8f163dc9a)(label(Int))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d6c98eb1-1863-4a08-ad83-402fe3f1be85)(content(Whitespace\" \
+         \"))))(Tile((id f05a1bef-89a2-42ef-bc8b-a84efb4f98c0)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         af7c4742-71d7-4eef-b861-c4a15c3d40ff)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         afc65075-39e4-4331-bbab-3869175e1c83)(label(,))(mold((out \
+         dbace0c5-371d-49ec-a9d1-3c5befeefc86)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         d5c861bd-6824-48f0-b789-dc25e45851e5)(content(Whitespace\" \
+         5fb9472e-f1bf-4dd6-bce1-f6527082d5f0)(content(Whitespace\" \
          \"))))(Tile((id \
-         458a9582-b8b1-4e84-ab82-5524153bf482)(label(bin_size))(mold((out \
+         da8b43eb-385c-43bf-ae4c-7b65ea1f22c5)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         165ea84d-8db7-4284-b487-fe544c5d280b)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         2cb1ff5b-54b3-4c65-8068-55c13c8a8849)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d4f0560a-cba2-4b1b-877f-7982b4c26879)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         44ef2f25-fab7-4cc3-8881-84d52369e17f)(label(Int))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ecaaa66c-a19a-463f-bd29-f265798cc298)(content(Whitespace\" \
+         \"))))(Tile((id \
+         28e1d6a2-5d90-4f2c-ab1c-eb5b5e4d8df9)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         6e21cbe5-5532-4fb1-8679-97864003972d)(content(Whitespace\" \
+         82cbc3af-d8ee-46b7-a651-a78faf731a47)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b9c30f58-6e65-451b-8572-03bbddc945b5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         390f01ae-3fe1-4d60-8455-5b2aed6be4eb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3093003a-ca80-42a9-a591-19b5ec3eb45f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         12755098-0125-4af7-981a-195cb68d9967)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         afe7e799-bd28-4f1c-af87-3df8456d870f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3c8d8679-60db-4c7f-9bf9-b682ad08255f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a2d51f77-deb3-45a9-9130-60dfa2690abe)(content(Whitespace\" \
-         \"))))(Tile((id c544f45f-e1f2-4fb0-9699-b90b52f983db)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         27851a43-868c-4837-bc86-34319b4d94f7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7cb8a1bf-d39a-496b-a21f-151f0351381c)(label(floored))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         7aa0164b-5b7a-4aa6-aa2f-73c746396bce)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         76e81a0d-d018-4c33-93b8-05a18b43632b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f0dbb549-9a7b-4cb8-b096-3c28ebee05e6)(label(map))(mold((out \
+         8ab881f7-50ce-4f23-9e9a-cb81ad4c8512)(content(Whitespace\"\\n\"))))(Tile((id \
+         df98881d-b0ff-4341-99c5-f60498ad6b0c)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         4f7489d3-244d-4f7c-82b2-e9a9a03703f1)(content(Whitespace\"\\n\"))))(Tile((id \
+         cd867569-88aa-4ef5-a38b-d7dd43c3c35e)(label(flat_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         24b04a90-4a16-449b-a603-210febb5bb26)(label(\"(\"\")\"))(mold((out \
+         c1c59480-be24-4bd1-90de-f7b4e08aa4db)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1d884a39-0649-471b-b9b4-e91f901d0ac3)(label(is))(mold((out \
+         4a00fa9b-94d6-42d5-aa8d-53ccf4720e6c)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         adc27c43-576b-4dd8-8058-5b454b03da21)(label(,))(mold((out \
+         1685fc92-e7ca-4a11-b320-4a5e926d3726)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         303d25bb-88a7-4efd-aef2-e28c5b5c478f)(content(Whitespace\" \
-         \"))))(Tile((id 22dee0ca-fa9c-4b39-a75c-93ca401cd819)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         0718d512-9f9b-4bcc-8267-911f03fd9465)(content(Whitespace\" \
+         f7813c02-f470-4227-96c2-e6e1fe4e15db)(content(Whitespace\" \
          \"))))(Tile((id \
-         b29d2493-00a7-43e9-9ec3-762ec44d9cbb)(label(i))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         40d6c177-2f1a-430a-867e-3f08eb8a52a2)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         aced83e3-3790-4e90-8668-04c984174acd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2330f1b3-1d9f-4161-9b5b-915fda9ec7ec)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         fd9d9341-9178-43ab-bd42-b733fdd87421)(content(Whitespace\" \
-         \"))))(Tile((id \
-         68b6824b-a386-4de0-86ff-cc37fba85b7c)(label(/))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
-         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7c106f89-dd39-465f-83de-62bb9258b7e1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         753dd48f-b324-4606-ae69-2f38051eb23e)(label(bin_size))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         910dca06-06a5-4d01-92c1-bf9e11b05d94)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ab7863ad-e3ac-480a-bc17-163193b30166)(label(*))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
-         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c8c6eb07-cc98-4335-9569-be84b27ab56d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         404ada6c-46f1-4c2d-ba29-8622786e5779)(label(bin_size))(mold((out \
+         bad7c3cd-81e7-4b79-a890-5c7a30b29b5e)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         44ee44f2-c4ee-45ba-8d77-1afe6045f6ff)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9ec53021-8c82-4423-ad76-804e6703c2ad)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bceb9a7d-c897-405d-9cb0-7153eb85058d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d56a6dfa-beb6-4c6d-b67a-f5ca90393371)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f792c11c-3d61-49a0-8fa6-cd648d31e952)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab2680ca-c494-4cc5-a75f-84d7a1ed4384)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dbe89cdc-5b42-43ab-9e5a-f359c7ffe24c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4748bd5b-bae5-4bd4-9b7b-2ac7a93ffb36)(content(Whitespace\" \
-         \"))))(Tile((id 9c441dd7-6e07-4c8c-84d2-ace1632e51e5)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         9fd7f12f-d75b-4a38-8c7e-48777ea143cb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0714ad98-836e-44e8-bb00-00a15172d734)(label(grouped))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         5a5c4683-24fc-4d4c-9d7e-2a99bd771e7d)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         6ad336a3-60a4-4077-984e-d9c9928b3a29)(content(Whitespace\" \
-         \"))))(Tile((id \
-         48b3026c-4de9-4165-bc88-6caf57cc337f)(label(fold_left))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a9ebcdc3-138f-4b60-a49f-a888bc1cf653)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         829d4dfc-efe5-42d2-b8d2-5016cc83702f)(label(floored))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6e5f0704-cf1e-4569-b94d-5f7f587ad19d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2623fb18-7983-4a02-82f8-a0125ad230df)(content(Whitespace\" \
-         \"))))(Tile((id 2855e2a2-07ec-4ec8-8047-3d5ccc3f4b7e)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         69422da6-437a-41dc-aec3-a8ca1b6fcae9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d1c638a9-12d6-4917-bc08-a3bc36eb6923)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         cc0cdb2e-927f-480d-b550-58bb59a0a7d0)(label(acc))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         f8055db8-1dfa-4c3b-87c6-299337f16c2f)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         2a807754-0e60-48ae-b380-c816a398869f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3a7c4f71-4f74-4644-ad26-0b786b755adb)(label(i))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         9b0b98c4-6a04-475d-beff-b2d108d3f6a5)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0f16f72d-7193-491c-942e-bebae0f86e55)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3ce45b2b-6f18-45e5-975b-678259e248f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db92b20c-9d1b-498a-bafc-81f09a1f3148)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         111abb41-e8dd-46f2-a34d-8bc57a74d285)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6aa7d638-a2a7-4fca-b232-7a8dece5352f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b6af62f1-7bd5-4044-ba9d-51ea6c37ab88)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd76d3b5-8c06-48e4-bf1a-d5a87a1f1641)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         76dac258-fa0a-43b6-97c6-836c9079b964)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         685d8a47-524c-4382-ab64-5bb29ff9ff55)(content(Whitespace\" \
-         \"))))(Tile((id 3c052556-7644-43d6-9d59-a98be0eb317d)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         00b6c0bf-60f8-4620-bc65-6c29333ce859)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f820c77f-dc78-48fd-a07d-85686a24e06e)(label(find_opt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         eb4da835-bb0d-4567-ac38-a7d95683db4f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c4829eec-cd23-498b-9460-261615d3e941)(label(acc))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         913732c7-a578-47ae-aafd-8bcf794aa956)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a162caab-6759-456c-a776-98df35c0dedb)(content(Whitespace\" \
-         \"))))(Tile((id 16e9ffca-2766-49cd-aa7b-295a720b992c)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         34a4311c-5dcb-4324-afb5-f5b986e10d21)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d1675b39-85c2-48d5-9468-fdc4b4ffd7a2)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         286fac45-7679-4807-9ad0-b77ca56344b9)(label(i'))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         eb0d68a6-3e89-42f5-a152-c2c721d60eb3)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         7364f5b1-e826-4d86-809b-12d315004de9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6e6e616b-97e3-42a2-8711-c757a97627b0)(label(count))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         47ee4c40-7586-4097-ab72-8d989654c20a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         19e646be-b6b0-4a92-9508-cdfd265efbaa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         695fe434-2cd0-41c4-8e6f-417e88dab184)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         71f91d55-605f-4c0a-8d5c-067b5dd385de)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ecd931ea-618d-4b24-8840-234182466f6c)(label(==))(mold((out \
+         296179a2-8ffd-4715-bb49-011edadfa11b)(content(Whitespace\"\\n\"))))(Tile((id \
+         75fd56a6-f83b-4f71-97ed-1887cbfa0f0b)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a24e59db-0f11-4ba1-9f58-0e1b298c912c)(content(Whitespace\" \
+         331da2d4-f190-4044-b44d-6754636de481)(content(Whitespace\" \
          \"))))(Tile((id \
-         e85ee7c3-7263-40f5-87fb-1d740176e288)(label(i'))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         adfcd68f-f2a6-4fc1-a200-387fd9cac83b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a69a6e96-59ba-4a48-bb67-41b0aac9ee7d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27800ba6-1969-4709-945c-024b9454d64f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8f9a0b10-6145-4753-8e8b-6525bb5f7e64)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27b17cb4-8d73-49d4-8cef-51d61889c62a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f077b783-f58c-44a5-a79f-03990f983765)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2b36c6c3-dbcf-47c8-8568-5483393343ac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0c71381d-12e9-4f46-8d74-e673750b034f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bceef278-8bc6-4a15-a8a9-f9c7eebaa84c)(content(Whitespace\" \
-         \"))))(Tile((id e564fef8-da94-4729-80ea-9fee8f905119)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         e2a75ac5-14b0-47e3-9078-b871b9c5b5df)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0ebd959d-2166-45b2-8585-14f222c24558)(label(None))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         845fa21b-3130-436f-baa9-34d9fd77744b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         293ee8e4-a8bd-4cc2-bbc6-d056fb9b6e70)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b9333893-f78d-479a-a146-687ea4f28a32)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         c2d38050-86a4-4e2e-8913-0dc543715162)(label(i))(mold((out \
+         4790e979-27b7-4b42-8585-9450ea451fa8)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         1998f216-6603-430c-a250-d64d3f9c350f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b47f7e7a-e546-44d4-97a9-d0b7c32f9d73)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a334c4ad-eabd-421b-acad-e0fd3b3f05a0)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         74572fca-519e-4af3-bd0a-3fa56f9ef202)(content(Whitespace\" \
-         \"))))(Tile((id \
-         de9ab7d0-93fa-4079-bfe9-6e2f59ac9ad6)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         95bf6b37-35c0-47ec-a03f-378204fa0382)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6bc86114-fea3-43f0-91d7-623bd423a3ab)(label(acc))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         12f65b3c-7ad6-4eb3-81c7-de14a1a7ab8c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         db0f9de0-0c9e-482b-add9-9558d60d7602)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9dda2a3e-2504-439d-b33f-a6d5bfad3807)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c575cd95-4476-4c96-ac1c-687686b2f729)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d241b2e-150c-46bc-bce1-7a9ba863380a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         87162f92-413a-44b7-a503-223fbfd5e5e7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         30486902-19e6-485d-99e7-16a706fc568d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d16b8834-1fe5-44b3-b7a1-be7e992a2493)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b94b7342-410e-473d-b044-d138af3ef434)(content(Whitespace\" \
-         \"))))(Tile((id 036f2e5b-18e9-406b-b899-8c2044f3ef16)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         bf226d13-ac7d-410f-9e74-d9870ae4baa2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4d9db1de-f560-423e-b8e3-9013954e2509)(label(Some))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         b3863896-346e-4f48-9935-b82e9a1c5880)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
-         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
-         3a1024e7-1259-4801-8c4d-73808a4d1d0d)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         be94110e-18a8-47a3-84a7-6671a4694817)(label(i))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         6706559f-15be-4724-aada-bbba6922a60d)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         aeeaa148-4f9c-4413-a1c4-f6cae66eae28)(content(Whitespace\" \
-         \"))))(Tile((id \
-         44360563-a950-44bf-84f3-a01f481efa31)(label(cnt))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
-         866cdb00-7bbb-459d-8fb5-18b4f3fc18fe)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         399dff6b-13f2-4ad4-8e76-1a8357dbcc1e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e3acf5d4-cca1-4e97-9e7d-bfc98edca425)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         138dd2e7-9339-4d9e-9b65-7aab72884ecd)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         60dcc07a-8e53-4528-9bdf-53ae2c8ef43b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ff7515d0-a0f7-42b5-abc8-0706363f91a9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8f7d70df-e350-4d9d-be14-6d832ff394bb)(label(cnt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         98f1e8da-73d4-4151-9e71-795e963792d1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2e8c31e8-6329-4b87-9212-a7a72ed35f48)(label(+))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ae67c2bb-4773-4bc9-8b57-6aacf5e93b09)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e4ac1234-f32d-47e7-abd0-22ab2c21f293)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f8f2d696-cb79-4d12-b623-3e4557cc13ac)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7e8c5a6e-d621-4e22-ac9c-87fa2963ac4b)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1426d1a2-daa8-4f42-8101-14f21e54a8f4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         abec59e2-ed12-46be-8240-2d73c88d510a)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3efa5de1-fe53-4335-af45-1341a23287ae)(label(\"(\"\")\"))(mold((out \
+         35b189bd-edf3-451f-8298-3978fab54740)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         7630deb3-62ba-4ee4-b89e-154dc1648970)(label(acc))(mold((out \
+         b4558b69-f60e-480d-a7a3-25de361bef31)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f5e030c5-31e6-48bc-bb99-04e832e60da0)(label(,))(mold((out \
+         d2313779-ab32-4ec4-943a-9d8127fa55e8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1d41b1b6-06da-42a4-bf40-2fd2b9d8a110)(content(Whitespace\" \
-         \"))))(Tile((id 32dd7e5d-36bd-449f-bdcd-7a47aee3c8a0)(label(fun \
+         b07a6119-30be-4960-bc3a-a3db8848c137)(content(Whitespace\" \
+         \"))))(Tile((id 2f137fb4-0b22-4486-aa6a-60c0b1ae38b7)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         9d15782e-dd0c-4e6a-8c26-f7818db88ef0)(content(Whitespace\" \
+         1c263d71-412b-4c08-8776-c8f4e3539168)(content(Whitespace\" \
          \"))))(Tile((id \
-         87ba0440-c2f0-4e30-ac4e-6bb03338f1f7)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         863e29e2-e1ae-4a6d-b504-c7f6e39dacad)(label(i'))(mold((out \
+         09441ad6-9e54-4dcf-8c24-2d31a207cb6c)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         144d5e13-e50e-453f-a98e-7d0c797d7af0)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         3881acd1-170d-41b7-8e6d-1d051cd020c7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         330dcd26-5744-44fd-b209-a453c95611e0)(label(count))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         e66a54db-8d74-4928-b809-3c9e8b2f4403)(content(Whitespace\" \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         8a2df8b5-e312-4dd9-b388-e49831ad6072)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3ac18020-f4d9-476d-abe0-36847ef96d76)(content(Whitespace\" \
+         fb648057-ae58-4080-9714-adf9459f955a)(content(Whitespace\" \
          \"))))(Tile((id \
-         2d71e954-25e9-45ac-916c-0496aefc967d)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         1f7950e6-a249-45a6-bf6f-31be5e10cf12)(content(Whitespace\" \
-         \"))))(Tile((id \
-         119bbb25-aa25-454d-aa8b-47ded7c021d8)(label(!=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b5908883-274a-4ccd-8ee7-0ce04ad9ccab)(content(Whitespace\" \
-         \"))))(Tile((id \
-         761de631-facf-4edd-b382-0953ec1c3fa3)(label(i'))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         99804d69-5ac1-421d-b2d9-62f1ac744862)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a4f657a0-705f-450e-9084-49e7a1e7da55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7738715-e6dc-467a-8c50-f5603b4fa659)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f1f08bff-84d4-4d02-98d9-9f17d5dda75e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         341fe457-38bf-4362-8f19-efe80d2d58dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         703fe2bc-0889-46b8-b66a-890dc996828f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         44a298e6-364b-494b-a8a2-029a403719e4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4942d9ad-f38c-48af-aa83-b167dcd544ef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c706876-9e71-4eb6-b00e-4db25c458a2f)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         cded91b2-5932-46d4-b3f0-36090d313128)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f28bbb69-785a-4a16-a499-ce8c14f0dcac)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6c66f0a7-ee3c-49ab-8212-033d2541a394)(label([]))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         879ff4a8-a165-40db-b40c-fd0ed105082d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         86d2dc66-651e-4f9e-9acf-6e5fcd07375c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4031c4c4-0065-4c06-8715-243b303d863d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c805eef-2d04-4530-9222-b681755d0c58)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8d6734c-b572-42c8-a6c9-18063ec0bde2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         20b1465b-11f0-41c5-b1c4-5934e58fdf93)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         56d7750c-6c93-465c-9b04-23f99c7cea51)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         827c6679-2526-4eef-88e7-edbda25d0fe6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a544d616-51b6-4882-930a-da4db8b3d8ef)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         23bf92e5-557c-4437-b7b9-3a224b4e784c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c266b02f-30a5-4099-b182-fbfdf3bc42fd)(label(grouped))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a3ce53db-7d1c-4119-9725-75236bf955c2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e6def579-c60f-47bb-9b77-2f823032c26f)(content(Whitespace\" \
-         \"))))(Tile((id 95396297-b0bb-48eb-a3f3-a7d7bbe4adb6)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         16671705-9e63-4869-ad62-6bf7c793366f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b2cd2d87-5098-4948-a583-3211e0b3c324)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         12f50b8e-2e62-4187-b410-380657a5980b)(label(i))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         e2fea5d6-7f9d-4a7f-ba4b-cb93d8818002)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         c4797c82-91f9-4f50-a770-8ae7319945ff)(content(Whitespace\" \
-         \"))))(Tile((id \
-         277360b5-a862-4682-b845-f5d621e9ac22)(label(cnt))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         0078d889-30bb-4d85-9d7d-c7420b08011a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         95bd86be-cba4-4d0f-aa96-e2e8d3e76d87)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c3a635b0-37e0-46ba-a948-ce16ada65396)(label(\"(\"\")\"))(mold((out \
+         f7dab12b-f9ed-48f7-9738-453841011346)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         68b72d80-0a9a-41d8-b502-0086cd9f7e13)(label(group))(mold((out \
+         9f41ede1-21bf-425f-ae14-f3f919e75939)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4ef7ec23-0a7c-420f-b3dd-819dad8b0532)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         97b63add-d470-4693-903c-09b51122b8d3)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         16810ea8-5bb3-4346-a14d-0f4e9eb926c4)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b56e9e11-e15a-40c6-822f-972f38f62216)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4d30254f-c7b5-4e75-86c0-1198d3fa02b9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         25b9c643-2140-43e5-9477-d824a598a7fb)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         1817d0f9-2209-4037-8e24-d34509e8aba2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         daa89836-ab40-4341-a955-c7df25f9b630)(label(+))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         67234826-42e8-4a1d-9c05-fbb14d19b3ab)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2db6835e-ac1c-4c5c-ae36-4ed9ffc0b485)(label(bin_size))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         b1946c75-c491-41e1-ae7e-85b9285db3b0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2752a197-03e5-4b09-bf27-33e4de3f21f5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         adf47080-f47d-4a7b-8f6b-f201f9a1febd)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4322d0d1-28d5-4d08-86d0-bbc3442f4f32)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         6a402fb9-0020-467b-9e21-aa5d9acfd468)(label(cnt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         a09a8341-5cf4-4cf2-9099-43c0a695520c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         233ba540-3c4b-4701-8cf6-46a810611f12)(content(Whitespace\"\\n\"))))(Secondary((id \
-         248f9fc2-d0f3-4850-98bc-8079a9524774)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e89150fc-b0b4-4b00-aa84-3555df9382e1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         310c37df-5d68-4e62-8922-8d6d931adb5a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         df6d48f7-1349-4fd1-8111-5687b9dbebb9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4df473ba-b575-4808-b700-46a611efab80)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5cbc3162-e02b-4922-af8e-0a2aaf76102d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d2b80f5-0775-47d7-b9cc-15a7ace9ba1d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a81f7d8-e940-4aba-ad62-c5cb5b86d065)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         03e61f1b-8031-413e-9859-a82230fc7591)(content(Whitespace\" \
-         \"))))(Tile((id ef90e20a-605e-40b6-a4fd-18be75b41670)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ec7f7a52-c463-4087-9c6f-46b1edf179ff)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d5daa853-f6d9-4c5a-bd15-5b3d5ebe90c9)(label(bin))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         e3599d2f-3a8c-48c6-9033-17b5ccd9564d)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         d477a2a2-8260-44ce-84e6-d9c0b63c4368)(content(Whitespace\" \
-         \"))))(Tile((id 992dcddc-179b-4057-979e-822f7e3bdc07)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         cbfe1545-e054-45cc-97d1-e7f105d3e0bf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         eb2bec9a-355c-49be-9577-ecdf18ac8cdd)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         87c81bc9-36f6-45ed-b1a7-abe9b9169831)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         2fde934b-a00f-4b0a-ab77-52830863182c)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d4705368-b566-4ef0-a4db-72de5af6471b)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         5787b898-951a-4e8b-835d-9216e5a2c9f1)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         888d2d11-74df-4812-813e-c8c8d238c908)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         56848c40-8945-429f-9815-95f7ef336765)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7f84ea96-350e-419a-93e8-98441c5028f1)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         a1693c25-5827-4354-b52f-a0d1b9f72bcb)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         1a3e3acc-7d27-4bdd-83c6-8777fa7ddb56)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         1713da52-32a7-473d-8c81-d434bf8cf496)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ed3bea52-99c6-43f2-a212-2749b382a83d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e3cd7c14-ddc8-4562-b15c-410cb5171b23)(label(n))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         5f48ac5e-b1f1-4809-b14c-29be6cfeefd9)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         53e73b30-375e-4d45-8ec5-1efe8328d691)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         6d930422-0772-4f5e-933e-028e47b649fa)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         73909cdd-4701-4340-88aa-2a2c0a11094c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         34f8e7f2-8ce6-432b-9803-c527319dc4d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e22ba35-827e-4e4f-a7a7-758706c6074a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1a3fd784-b464-4be2-853e-3d28d88714de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7fad20a1-a530-451f-b5ff-e4eb1c591141)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c59beb2-628b-43dc-82e4-d2051f946e9b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d3e333aa-5796-4ffe-8cc0-269341795652)(content(Whitespace\" \
-         \"))))(Tile((id f2392a21-c329-4ac8-a132-d9fab100aab0)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         f622670b-4e88-4dbf-8721-1bfa13078610)(content(Whitespace\" \
-         \"))))(Tile((id \
-         19899f69-6ded-4a2b-a9eb-e321daa2589d)(label(entries))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         56eb9e6f-381a-449c-aea6-f03b4ec68ae5)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         d08041b0-d908-4986-97b4-19f71819db29)(content(Whitespace\" \
-         \"))))(Tile((id \
-         33d0eb0a-234e-4628-a158-656ae4462764)(label(flat_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c3bd6d2e-9e6c-4bf2-aaa8-7d9acffa46c4)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         68453834-2fdc-499c-becc-f051adc9418b)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a5effc40-b9f7-4a9e-8b01-02c0bbf02147)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c0fd954b-1ceb-4725-a4bf-b9235e715c83)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f5e44b7d-11a1-449a-8ec8-95f9c7cb4352)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         00c2e31d-801f-4b9e-9335-6fd04e3aa745)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e8b726ee-668b-4cea-99e8-af2a3217c65b)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d2bfa4d8-0b0f-4658-af46-4b17ecd55603)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2bc8eaf8-fba7-4ad0-8768-7be8c2308f1d)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ec3e8def-1a5e-47a2-8144-7082865d83d1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         526309f0-dc1c-4612-ba16-58ddf9b49100)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         618953a3-db53-42d8-ae4e-7c9c07c444ff)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e4e412dd-0fb9-4a20-98da-f0e360d5bfc3)(content(Whitespace\" \
-         \"))))(Tile((id 202a56d7-3a04-4aaa-b7a3-0ecbc63cb6cb)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ca06f976-49b6-4714-aaba-ade737b5e2e7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bfe3c624-c7d4-4041-9c23-39dba53b8893)(label(e))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         1cee761e-b733-4e2b-8b7a-f51d69165b9f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9c85d669-0aeb-426d-8c20-56a7f2d2e856)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3bf69997-12d1-4c6f-b578-90f303e4d526)(label(string_eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8f82fbb6-04be-4435-9cdd-3912ba1e62c2)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1dfba188-e3ff-49ea-b28f-c4953da41117)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         18c60b32-5c7f-4c9c-a0cb-a7baab009091)(label(.))(mold((out \
+         ab10ef9e-b3f6-42c3-8bed-811efe1853eb)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f525affa-e0c3-491b-b343-3edc87e38412)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         269da726-d530-4dea-9881-0fabfbdd1e38)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69c0a880-7d74-441d-81ca-dab2bd1abcfa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3ae998f8-f69a-481a-93ad-93059d91b439)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         2d65c665-8bef-4529-8a58-a919053157a6)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0a6f0d5d-dd20-47d2-bdec-c2edd2a084d4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3d056fc8-aef0-4281-9258-a17213bb8496)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5026da97-1480-4224-82d4-52275ebb0c7c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7bb67c57-aba2-4b6d-b752-c894604af747)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         00b752c2-2674-4847-9f8b-8fe768bd12c2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3fde9739-1a2e-48a0-abcc-f50583104260)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         74176746-6270-40de-866a-29110e63c382)(content(Whitespace\" \
-         \"))))(Tile((id c998ab3d-1e20-4473-bdcb-110628401569)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         57fe084c-ca2d-43ae-a27a-52dc7941f58e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         154c2287-f763-4a15-b374-b38be12cbf53)(label(vals))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         5f89108a-c9b7-4a7e-a614-497fbc2fb49f)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         c35a2746-9ae3-482b-adcb-4a77c76036d2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ca34cbb1-38cf-4e65-8cc5-61554a985a8b)(label(entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         083aabb9-3a12-4302-aa1f-ee9fbb511c8b)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         41f8e2c7-939a-4151-b497-358b7ae73eff)(label(value))(mold((out \
+         ce35572a-7fc1-423f-b078-16ae0966bb45)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         4e90bed9-9f21-4064-9d2c-48308b7235f2)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         495c9db5-3596-4363-b204-513d289273fa)(content(Whitespace\"\\n\"))))(Secondary((id \
-         45d5d924-c50a-40ad-b94c-e98ca2066a5f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cee9711d-f1dc-44c3-82be-ba64a1168299)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3897cb78-98bb-4ef3-9177-d3cc226f4392)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7cae0f67-da05-4aa4-a34b-edfe6fd4f5e6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4b3c6ce6-1b3f-4e79-8f08-11bfd53b1ff3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b41cf6e7-9b69-44cd-b804-f135e1cc9a4b)(content(Whitespace\" \
-         \"))))(Tile((id 395d1f66-0a4b-4921-ac97-e9f46d20a004)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         38634649-6d2e-47f2-8e35-45b169bc0bf2)(content(Whitespace\" \
+         774c4f52-0202-40e2-bba6-cbd4a6ddbdc8)(content(Whitespace\" \
          \"))))(Tile((id \
-         8120850d-028f-4e68-b71f-8c55df10e9e6)(label(bins))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         5f50b396-5cc2-486f-b86f-1758c1958ed2)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         668e3f9b-0500-4b37-9497-77e5ddb191fb)(content(Whitespace\" \
+         908c03a0-a374-4f2b-b207-8def7b6ee693)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a29498e0-9d72-4669-93db-619ba115855b)(content(Whitespace\" \
          \"))))(Tile((id \
-         fc3b8845-7b12-4dc8-ac91-704e75055042)(label(bin_int))(mold((out \
+         6c73df0e-b5b2-4d58-9379-813e51f6cf87)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         28082122-5798-425e-8ec5-4665fe80c7d6)(content(Whitespace\"\\n\"))))(Tile((id \
+         a94d2bb3-ed45-4b44-b17f-b48dfb15dc42)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3db95993-2e91-4b69-995a-b47764a4c2e3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6c437c29-e8c6-4fe5-a85c-c7e5ffc0df1d)(label(group_by_label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         40947991-1787-4086-9179-f3063b30c863)(label(\"(\"\")\"))(mold((out \
+         230ea4c8-342a-4160-ac5e-ea7f8748ab8f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         add93234-5a91-48c5-81d8-3c8308021f90)(label(vals))(mold((out \
+         096f087c-2708-4faf-9641-5b24af75752c)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         04d37956-7f64-4bff-a144-fb92b1e7c2a1)(label(,))(mold((out \
+         973653ac-acba-4bc6-baad-54054c92ec17)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ef97e1fe-e715-4667-9fcd-fc319a48a8d3)(content(Whitespace\" \
+         8b682a46-2358-4dbc-9853-56b9180513e3)(content(Whitespace\" \
          \"))))(Tile((id \
-         59201ef7-bfad-44d2-8c73-636033106e06)(label(n))(mold((out \
+         5ab6f6a9-5b33-4327-bec5-ee2cc4aaee78)(label(`value`))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f4e120e6-da5d-4ba7-a0d9-571780f4f5c3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         1b5a0efc-164e-413d-8eba-9d3e05d97515)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c958eb28-b48c-480c-b7fb-2cb62cee10b7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9576b91d-4f31-4b92-b7fe-076e67abc9fc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8f2b4e95-f2ab-4145-9e4e-90573f378caa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b004ab3b-b974-4333-84b1-d2f80e5b9c88)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         185f1ccf-3be6-4b85-b9bc-bfb6483db2dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7eda4f8f-fb0c-4848-9e81-811267d7c923)(content(Whitespace\" \
+         1241aa9a-0dc1-4112-95da-10466f66b51d)(content(Whitespace\"\\n\"))))(Tile((id \
+         7c7805ba-518f-4706-b25a-d2a96a88c52a)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cb16a80e-a8b0-4bfa-9ad8-64352ed26b63)(content(Whitespace\" \
          \"))))(Tile((id \
-         6d7f6f97-0f99-4afd-9a9f-f25eca3fb88d)(label(map))(mold((out \
+         aced7376-19bf-459d-8ab5-177a3741188e)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         edf04655-caf5-4820-825a-fe2f1ccc7dcd)(content(Whitespace\"\\n\"))))(Tile((id \
+         dd4e2ec7-3fb7-47e0-ab0d-2d844b8c7832)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ebadb987-e35a-4636-b27b-ab4abd36a982)(content(Whitespace\" \
+         \"))))(Tile((id \
+         482482a4-443b-4bba-8838-bf78bf1e99a6)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         bf447d29-1746-4dd8-9a86-4f4f92f2cfb9)(label(\"(\"\")\"))(mold((out \
+         14ad0b94-7071-49d4-b181-de66e6b3b12c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         34dd88e4-5d95-4fed-bfe0-80ee10028be2)(label(bins))(mold((out \
+         852d6147-9893-4c49-b2e3-56a42fe395e6)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         8dbf02e0-85fc-4e0f-a961-4834c2f4c65d)(label(,))(mold((out \
+         bd98fb22-03ed-438f-ad02-fba3a39e9bf4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6dde00de-147a-4044-a6d1-eb88cb681777)(content(Whitespace\" \
-         \"))))(Tile((id 3d3ad2c0-a9e6-4b58-8b88-84aede574c30)(label(fun \
+         bcf50d79-7820-4620-a3bb-b12e57cbd7db)(content(Whitespace\" \
+         \"))))(Tile((id 956669f0-e4d2-4491-a667-2413a9c53e30)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a6a7d575-c0f1-49f5-9175-4350bba41e0c)(content(Whitespace\" \
+         4901028e-ecd2-4a38-9dfb-9e8126d1a90f)(content(Whitespace\" \
          \"))))(Tile((id \
-         93a2990c-6ef0-4e22-8e12-3800d473b565)(label(e))(mold((out \
+         a4b22e29-4d64-4aec-8cef-ad99cd79ba57)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         bef0988e-c461-4ad5-b8b2-859bbd0bc030)(content(Whitespace\" \
+         6cdc0ece-1345-4729-b368-f85a64a7f3bd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         46b246f3-5915-4e4f-afd7-20a4b42a84f5)(content(Whitespace\" \
+         b0b9721f-f005-46a1-95b8-bdca5a3f71d4)(content(Whitespace\" \
          \"))))(Tile((id \
-         cdd09ecf-0b45-45e7-baa1-7d1f1043d322)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         6521b234-9e45-4345-adf8-3d35edd5d507)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b8945563-172e-4116-9ea6-b9b791d549a3)(label(...))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7fb1eaf6-83c2-4b7f-8006-06bf41a7289a)(label(\"(\"\")\"))(mold((out \
+         b4680764-3c4a-4cba-89b5-69c8ba4e925c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         ae7dcbf5-61c5-4fc3-86af-bd1263772d8d)(label(group))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0920f66b-e661-46af-bdd1-156dab43f83b)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         8d6d4049-83fc-4e88-9733-283ce535bcd3)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         07ca706f-6015-45f4-bfe3-d55bf35262b8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0f56722c-4ddd-4b3d-b1b3-edfe5cff97e5)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         9d4822f8-4067-49f0-9021-c575e28457cc)(label(group))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         fd18375e-fd79-4711-a3af-abe58783f9ba)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         ac9a9236-93a7-4ec6-bf81-bc4ede5113bf)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         796c00fd-b3b4-4a67-9d80-8d7cf67da620)(label(min))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         77bfb61a-9dde-4d82-b8fd-5f12e6cb2968)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         7f86120b-ef6c-4784-8ff3-fa117af659a7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f63df169-0ea6-4e5b-afb7-8b8fdf0af5eb)(label(max))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Tile((id \
-         79c52092-79c1-4dc4-8100-8d25fb55e5d1)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         d4179eb1-a15e-4547-864c-1cee989de4a5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         abf6ae7e-49f4-4d0d-8695-46eef9446289)(label(_))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         ecfcc2f3-3713-4aa2-8617-dcb4484dac22)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         7ed75135-8b8f-451d-93bb-f42eb1f8569a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         94b39f10-a795-41b6-afa9-da69600a5648)(label(e))(mold((out \
+         d99c7ea3-8dad-4b31-b23d-2fc83725f0f2)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         e2ac6d00-dc4f-4c4b-9911-d1ba14f8d71e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         7b2add98-b940-4089-a8d5-0e332bf76ed0)(content(Whitespace\" \
+         bd0e96ff-2a30-481f-8b67-66872a346e58)(content(Whitespace\" \
          \"))))(Tile((id \
-         1a4c879b-0b24-41ec-b0fa-41a7cf6afa7e)(label(string_of_int))(mold((out \
+         65f37eb7-66d1-4a24-94e8-b890f5f397c6)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         01d2e70d-2ecf-4080-89af-1b82ed0013cc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6dd88bd5-b4eb-440a-a76b-ddca05aa4af0)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         846a0429-bc40-49bb-82d6-3a558add88c2)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e93d3ffe-8075-4785-b628-41efe85f195f)(label(min))(mold((out \
+         87ae1f78-ea7f-44d8-a242-25201c905266)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         32c3de8c-8859-421d-b476-23132af3e87d)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c755cfb4-658f-4afb-bebc-1b7a23b527ce)(content(Whitespace\" \
+         8c0842eb-53d1-4519-ba1c-53a5dd493522)(content(Whitespace\" \
          \"))))(Tile((id \
-         dbc00641-aeb1-4466-9133-ce54c962a9e0)(label(++))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5c8927a7-e1c1-4e34-ac9f-6bd3713daa60)(content(Whitespace\" \
-         \"))))(Tile((id e999d2d9-3004-4a34-a700-81a15d251763)(label(\"\\\" <= \
-         \\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e020dbf3-6916-4c68-86e4-808c06de4af7)(content(Whitespace\" \
+         00278586-ba37-4662-8847-56e29960fd9b)(label(...))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         95890aaf-b5c6-4aff-84b2-2fc1e552b67c)(content(Whitespace\" \
          \"))))(Tile((id \
-         d8984f4a-3446-44cf-8aa7-dc58bbb5d4dd)(label(++))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8961c63c-bba3-4550-a0c7-b1940a2beb3f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         310afc9e-0f56-4236-96dc-f1d2a4c8b0fe)(label(c))(mold((out \
+         6d02de7c-8365-4d66-9660-59e442ae4d59)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         9e35e45a-1953-4799-9bd8-69607a08d34b)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         46f9cb9c-2c09-421b-8e53-c349a26e07da)(content(Whitespace\" \
+         db94549e-eb52-4548-8130-494fd03adbf5)(content(Whitespace\" \
          \"))))(Tile((id \
-         5b288d8a-c516-4807-baf7-c9007b250325)(label(++))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3cee70dc-b880-4d2f-b596-686bd65f99ce)(content(Whitespace\" \
-         \"))))(Tile((id 8cc93d2b-198d-4a97-ac9c-93f82c01bdb0)(label(\"\\\" < \
-         \\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4169adf0-62f7-4866-a13a-a9b6f4ed4611)(content(Whitespace\" \
+         172cca2c-09ab-41b7-a066-c5c4364bc609)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         12240b03-9c08-41cf-b559-b1caba98ebe8)(content(Whitespace\" \
          \"))))(Tile((id \
-         357b4b80-50a2-4f00-97ed-36b99ed1689b)(label(++))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bb6e4b16-d475-4a19-b400-6a7bd47c83d6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         67cb80c0-3c6a-41f3-b636-aedd77b4b8bc)(label(string_of_int))(mold((out \
+         4afcb254-b0c6-4bb7-a084-13909f9d314d)(label(length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6b213fb9-c1c2-4305-9f4c-635e5b96f80d)(label(\"(\"\")\"))(mold((out \
+         ff09b034-be02-4ea8-89b6-92bc4b7e2029)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         95e26b43-4503-40ae-95ec-f56eb2c10d9c)(label(max))(mold((out \
+         cb912ffc-962c-4949-8058-f15a350505f0)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d89a384e-1ea8-4c52-ae5b-d16d714b26a5)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         8afbb871-f195-45a9-ac98-50a4402f9c3f)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         0b5d0c54-6b9c-4e58-9ff2-57e30c3d3156)(content(Whitespace\" \
-         \"))))(Tile((id \
-         16736f95-2411-4fe5-8fda-b50cf1b41d5d)(label(:))(mold((out \
+         65cefd24-301a-4157-8cd2-ac7250cbaab0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         368adcab-b847-45e8-94bb-e363f1a84d52)(content(Whitespace\"\\n\"))))(Tile((id \
+         2205d66c-0ab3-4be8-b9cd-1dd8102beff8)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6c7aac50-c3a2-49f4-b811-0def7708e886)(content(Whitespace\" \
-         \"))))(Tile((id f0c6ac77-fa93-4975-adf4-f5e987e20d49)(label([ \
+         62124b6b-ba23-4613-9b07-606f4d3c07ef)(content(Whitespace\" \
+         \"))))(Tile((id 12cc4dbb-448c-41d3-a373-d94f8e3f27ac)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         6a2b63c7-ecc6-4277-824b-0942ea3f795e)(label(\"(\"\")\"))(mold((out \
+         11b042b7-89a2-487e-b197-0298af3a393f)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         5146266f-56db-44ad-8d72-080f95a68603)(label(group))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         fd832d34-bfbc-4d51-beee-86c3b829fe7e)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         db119d82-8df4-412a-a756-53824ca69e0f)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         95b08964-63cb-4c52-aa67-eed50abf8e23)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b70f2843-35f0-496f-ae1d-e71b626205df)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c4186ae5-d277-4c0d-a92b-25efc7ecba71)(label(count))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         edeaf480-4294-4c26-a9fd-ac96e0e77d03)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d211c9c7-7cc2-416b-b573-e58583eb552a)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         daaa2878-703d-435e-883d-9e55cb17475b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         2151d726-50fe-4e25-98c0-730290b11e7a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bb2490d5-adbf-4247-a43e-6a8cdb9c9418)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         75bb8b1d-453c-4242-bc8a-b8e0cb209898)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e7ad53fe-efb3-41ba-83f0-9eca912c38a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7bc440e1-98b5-46ea-bc87-a7c157d0f60b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         86d011df-3e3c-4451-a2c6-f78b80f4447b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4eacf0da-5ecb-4a35-9062-5932e8606ca6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         485f4326-2a79-4738-80f8-0b940e9bd4e7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         87943e7d-4360-42e5-ba18-32d9a7068226)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6ea1b269-3472-48a8-b6e9-a85b813648d8)(content(Whitespace\" \
-         \"))))(Tile((id f27960fa-4fa4-449d-b54f-792854d8420e)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         db8593aa-2d18-4486-bf9f-ea9c4272319b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dc77266f-e962-483f-aebd-ae08e1e76159)(label(bin))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bcf286da-2f70-44da-9669-9e7511f57907)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         99228c2d-baa5-41e0-8d6a-fa41520bec6e)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d5e7591c-669a-4dde-bde5-76fe69064006)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         48fe5f6d-3dba-40ae-b4be-5b8044d23799)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aeedd5b7-591e-4382-a7ca-ff1bf406bd95)(label(\"\\\"final\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         172ee4b4-bbe1-461a-be7e-392696065ea6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3d197a85-354f-4722-b705-3f1ed1f6149a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c1f2543e-dd77-415b-ad24-522aa41bbc7c)(label(2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ffadcd1f-b84b-41d2-ae96-3a4c6f656393)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fb93980e-3c3e-42ce-baba-a44c43c54a15)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f6ea4a7e-e894-4b84-976b-eba53a202b85)(content(Whitespace\" \
-         \"))))(Tile((id 95288234-ba45-473b-9ef1-e984652f8ff2)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         808e3c7f-ffad-4f25-8339-08cdbc7e0689)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1c18884e-384a-4577-a9ca-0087d3283ecc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d952f16-a482-4780-8b74-f0542f2a721f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57f9faee-0155-4dbf-b78d-927ed783325e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d929f49d-f95e-4c7f-b9af-3745f6ad6d2e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9facc788-3d32-40d8-8fee-f27cd0e3cbb6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4a360475-408f-4dfa-ab84-fa13458f28ca)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ccfa0794-eee0-492d-b728-c329c3b366bc)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         fd51d534-73e6-4803-9f86-6ccd4f23670b)(label(group))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         71c252f3-a41d-443b-a5cc-db7c6136ca1a)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7bedabfa-5963-4045-9091-408592967fe2)(label(\"\\\"76 <= final < \
-         78\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3f4e16cd-e7c0-47af-8451-be342347be32)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d20c9efa-a815-4c9f-83c8-5caa048ba39f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0976276c-1535-467a-ad2c-e2daac464def)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e796b5a0-8b55-4456-b178-819540a3747e)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f2cc61f6-9e45-4155-a90e-ebf7b1ae393d)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ebb54657-cad7-421e-a3fc-0be5e8ea2b53)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7bead7f6-c832-4c07-bd7b-5084f368fa53)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7f372cf5-8025-4813-93b4-19b74ae79b77)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b50ed0c-4c58-4b16-81ac-9569ac1fe9eb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         071bd220-8d2d-407d-8931-bc52136ef85c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         86a6757d-a381-4130-97e9-65ebb358b3c5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f82b48e6-a113-418c-987b-e3cfa7930d19)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5f39ecd6-9aeb-411a-a861-5d0eb8202533)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7d1d3dd3-74de-499b-b902-d4c83de5e7e6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         5e897376-9220-40d8-a85d-12c1beee2c08)(label(group))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e624329b-f0f9-49cf-8ee8-e3395e02f767)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         45c12c5a-403e-4e89-af3e-208d37d6e3ec)(label(\"\\\"84 <= final < \
-         86\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c155f619-2283-4dd5-be89-9a3c253fae68)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b5845f10-faad-4020-8d40-ffe126d652d4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8dd6187f-756b-4133-8d96-2c00b99c5e16)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2fe8935e-6ffb-4966-9efc-dde16935610c)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         edd17b64-affd-4c13-8da4-1f9c219aae49)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         3bc12621-1a41-4e7f-a781-3431b6a6369e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7e83d95e-d2a8-44b8-b819-2112e6a77fe2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8b60eac7-76d7-4c75-ad47-d22b0faa09d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0556ab42-0ecb-4423-a98f-af5f60b7f865)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dc46728d-6588-4652-aeff-d4f356625076)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f77f049d-0f6d-4395-a75e-ed4ce1387e36)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8bcb9122-8976-4c8a-837e-3203e4752b7a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0074172e-da69-4dac-b73f-884cbd39177a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ff941ad2-901d-42de-8861-a32e90262fea)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         62f810ec-916f-443e-a855-189ae885c116)(label(group))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b3ceb6ae-b092-47af-a4bf-471a166dba3f)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9fe7469a-32cb-4806-b478-25cd262c4546)(label(\"\\\"86 <= final < \
-         88\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
-         bcc85a6c-f96c-4153-8821-4d512004cad0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         928ba452-2916-4188-81f0-43964c3e73f9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0594b949-5934-4bb1-a175-22dd37486453)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9493c44e-3a5d-4754-b0ca-d7c05503381c)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         44bcba14-a195-44b8-b9a7-6a5633673711)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         a8302609-d9f5-41a8-97c2-d2ee0db59e61)(content(Whitespace\"\\n\"))))(Secondary((id \
-         51b03bc7-a5cb-416a-9f5a-0ca1521a8461)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         60ecfc89-f1d9-447d-b28c-8bcbfd57494e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e2498736-5777-4817-9b50-e732e16e061d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d7244f85-8577-4cfb-902a-abe036532268)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         64ce3a48-4c04-41ff-b5a1-e36c763af3bc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c959abd5-d9e1-4289-897f-c05769745151)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7305a5a6-daa4-4c5f-a8bf-0b8e5a6f27ed)(content(Whitespace\" \
-         \"))))(Tile((id 761417b7-3820-4d8f-91c8-6db3a488e4cd)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         3bbb784d-89fd-4185-b9c5-7d7897aeeb84)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         7d042bf5-7a3e-4b24-bf36-27b7c5e3982d)(label(group))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         e7fbd265-2890-4621-a8a8-9ff708014bea)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         40f5e081-7211-4d0b-9366-d99bfd689e70)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         b7a93402-50ab-4eba-878d-e103fd71e2a3)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8ce55d60-fd99-4c86-a748-3be57c823570)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d1a6494a-15e1-4427-bb1c-2fb0cad9d6ee)(label(count))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         20077deb-5033-408b-9138-a4c55ce19983)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         e044dc3f-8d75-4fd7-86c3-611331b7fdf2)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b7b1ac24-c3b2-469d-9d1e-329e5985f55d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         6f8516d7-ce4d-4d9c-85f6-a96dbb3e041a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         491c25dc-7433-45d8-85b4-39bb408d040e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e320e4e6-3690-4013-b4cc-d57c65d22c23)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d0ad1bba-379c-49e2-81d2-977f30c34287)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5deea426-2eb0-4770-9810-84e785b3a545)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9697a6cc-9b91-402f-a92b-720f76f1e178)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         65629a14-167d-4065-82be-6cb2e3c0d5fa)(content(Comment\"# This version \
-         takes an explicit projection to gurantee the requires \
-         constraints#\"))))(Secondary((id \
-         c4c1ad20-a4ce-4ba6-8357-8142b0eaaa3c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5932fa10-f73c-4da1-aeac-b652254e393a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dd449553-7596-4492-8b18-dfc407bae67d)(content(Whitespace\" \
-         \"))))(Tile((id 2f394938-7d98-4042-aa4a-71ca878f8a6c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         1dc55262-1fce-4418-bb08-81aa68999142)(content(Whitespace\" \
-         \"))))(Tile((id \
-         319b6c1c-6e7e-4c60-873f-86f3c3e1ef75)(label(v2))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         ce5fe868-b80b-4844-9786-083cbe07a697)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         da74fc78-654e-49fc-b525-474bdd3ec81d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         afabb755-4b14-408d-8067-af77f97a406b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         694da757-58c4-4ac1-85a2-a2afdfd3a707)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8b147f39-2aef-4fa9-8339-53b08c5ac7d9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2908d2ac-0092-4847-8014-8fb41e15b443)(content(Whitespace\" \
-         \"))))(Tile((id b56d5c6d-a5ed-4b70-845c-eecd5ed3f193)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         90b6ec94-0106-40bb-a01d-323239bb0e10)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d9254ec9-10ca-404b-b5a3-4bcd43722f7e)(label(requires))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         2dd1d545-72ce-42a5-b4c9-17e7252c0a5e)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         fdf80778-ed73-4937-9a4f-6f132a5177e5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ad374795-e3a6-4874-97eb-79ce2c76a90d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0963c5b8-66ae-40cd-a8e6-cabe740c350f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1cb9aa97-845c-4a3f-9774-9918797c4d32)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         848534cf-779d-444d-9b0c-9440c95645b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         55146c03-b1cc-439d-a8bb-583b1276d402)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ecf70c0-7604-40d6-83fc-2bbe290b0bce)(content(Whitespace\" \
-         \"))))(Tile((id \
-         63d52a12-ca85-481f-9855-e00b7ddbb8cb)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         1c8e3671-3c20-44cf-b25c-e807fbd742d4)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9432082d-579e-489d-9cba-68fa98d40b11)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ba40782b-6852-4f8b-b59a-ebb9d0ee35b3)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         62860f77-ba27-46b1-81a2-aac72831e6e2)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         80d9e335-a9e8-4562-a996-1e0de4d156ea)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         80af465c-e4ba-4a2d-aeec-062459e0777d)(content(Whitespace\" \
-         \"))))(Tile((id 58e4e022-a73c-447b-8db6-a2534f6cb071)(label(\"\\\"c \
-         is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
-         Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         14f01554-560b-424a-b3af-5385c2d47b78)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9d01670a-d352-4058-93c3-cc8b4e711fc9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5fcfbd1a-3f8a-4651-8ed8-55f4e97186da)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac6a3e9e-04d5-45a5-8865-89c1c8efa082)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         851eaaf5-3c22-465b-a81c-e5fdbb35fb81)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f56a279-3524-4e4a-98be-1416aee2d4c3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3fdd698d-dfc0-4e4b-a0b5-c76d0035ef13)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2435584f-b80a-4f69-9af2-43229eaf3e2f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7416d4aa-d499-4803-9051-ea0b5ea1d533)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         7c8b0b7c-691e-4327-8f47-6f8acadbc5f9)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         37e83b77-c4e6-4078-a763-cf904325c144)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9efa2c1b-8e5c-4059-ac02-37ba71899adf)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         2abc502b-e981-4982-9d32-c96a650345b9)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         84eced04-cbc5-49a0-89d8-1aebbb398cf3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         74e37b36-afa9-4a03-9429-e94c39fdfec2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         56ff7a06-c319-4021-bc47-30f343f2db98)(label(\"\\\"schema(t1)[c] is \
-         Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         83b0f4f1-6fd7-47ea-a21f-b2a10e707e41)(content(Whitespace\"\\n\"))))(Secondary((id \
-         73f42e2c-4cba-49ba-a17e-2dca3f2f4d3d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e1cda42-e082-4101-bb1f-2656cf223640)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         142d3834-8f68-4afa-a809-bb0393eb9847)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e1f0652f-3b2c-4a0a-a1e8-5d8256e2d010)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         fea02ccc-3c26-482c-95d2-b528c014b3c7)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         507ea362-01fb-4da6-a79b-06705ea0f0b0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         88a2678d-a89e-4897-b1fb-2cff1e8480f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         85ae78f9-58ba-4857-adfd-5a676c696e26)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e64395b-ed91-4501-b414-0a723f72f0ce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         89576811-9e7e-47f0-8134-56213fdf5a21)(content(Whitespace\" \
-         \"))))(Tile((id e1427d58-d2cb-4489-9e03-0077ca207761)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c11e419a-b209-4983-9505-059a8b891d97)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fb9eec07-f956-4dea-a3ad-76c9de6ba764)(label(ensures))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         b0a2a926-de97-4225-bdf9-687a1bbacd46)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         a6b90b2d-5c97-49a6-a691-19f6a741d4f5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         42a21d5e-7266-4799-89d2-3b663f639733)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a94bf56e-df9a-4f1b-8c9e-36df81c79987)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         59b23826-222e-4f13-9cf2-f002f8cac4c0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d63c1f90-2e5b-4046-b098-75e39f1fa294)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4a148090-f111-479a-9ae1-422c477df35b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d6854055-19db-4000-8ee9-fed1d659e6f0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3fec160a-64e0-4648-b3c8-3da88e4fd27f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         dce08e3e-5d2f-4eab-a8a6-4525a26e381d)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         52666cf9-11e4-4599-8124-30d86211f9d5)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         23223b16-00ba-4690-afdf-8314a924af59)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         35088c0d-07b2-438e-bfe5-250f72697bc6)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ef77754a-57a8-486a-aca1-3df32c69d261)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2097a135-d354-4cf8-bd28-8d61be016cf6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         274bf56f-9ea9-4981-8e6c-6b1f2ae0f77b)(label(\"\\\"header(t2) is equal \
-         to ['group', 'count']\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
-         Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         475f8fbe-8451-4d6e-8a82-a347c27c289c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         885fc3aa-f7dd-465a-89ee-e936674fadda)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7f8d3ac5-a976-47d8-8243-16a32e8a601a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         11390213-534a-41ca-92ac-bc59c8ed61cc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a900c705-393f-41a8-a709-7de2d9ef5574)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         386a739a-2665-4b67-b985-60df0105af13)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         34194fba-3263-41c7-a790-1e5ca1a9a407)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         441f2228-6b03-40f0-8f95-673e32cb8f58)(content(Whitespace\" \
-         \"))))(Tile((id \
-         13b017fb-b50d-4387-a7af-6f0edf88f67a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         9f6ec24e-7173-4af9-bc4c-7b1a42b208db)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9d73ad24-c7aa-4692-8b7c-d01ce9ae1476)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0f8754ec-958f-4d9e-b090-f46c36ad3766)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         178ffa8a-7cee-49d4-97f5-56dd4c53c2f2)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         81defeaf-9dcb-4dad-ab9b-30305c984303)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b5936638-4dee-47f2-bf63-6c818c4ee6b9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c8135176-4cd0-4649-b8bf-ee4ed34febfb)(label(\"\\\"schema(t2)['group'] \
-         is String\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8aa7b9da-13dd-44e9-bec3-4797ddd20247)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d7b3687f-f5e9-48bc-b885-d570c564487d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b91217ec-a475-4e7e-9324-04a04486d914)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         13b063d5-378d-453a-a3ea-cd1357063e1e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         484114f1-c398-4045-a323-4014ae2c1aa6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         93c80de8-7f64-4f9a-a1a6-e366207e8703)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b71a8396-0839-412f-85a5-8ffbda9f74f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d1e4b779-a5b8-497a-a3e3-b3d38ad5b576)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d777c82f-ab8d-40a2-911d-5d08b457431b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         8889b8b0-bcf5-484d-9b4e-019df1ee5675)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         69d3633a-e92c-4b96-9473-96cb63416068)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0195e7cc-3b4f-494a-a28d-4a4df7fe25f4)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         e4b66b05-c475-405c-9b37-f7e19c7c0b05)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         109b0f39-d975-44f2-b220-f16c60e639a2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         83f7d688-76ad-4766-8c7e-caf19e7d5f63)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1e88103a-829b-4ffa-af1f-f2c70a4195c1)(label(\"\\\"schema(t2)['count'] \
-         is Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         29007689-fa7d-4489-b44b-ebe0cca63367)(content(Whitespace\"\\n\"))))(Secondary((id \
-         382ecd0c-b525-434e-97a9-f99ad1c2efa4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7aa09f5b-739d-446a-a690-30600b2bf7b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6a23cbd1-47e1-4a8c-b7b8-f2fbdaeeac75)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         51083f0b-b3ea-41f6-97b2-ca9d3ae8c790)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4fa5f8c3-2bc0-49ca-9501-11f0f45e7c2d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         875370c8-cd64-44e6-b941-af8453de2078)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ae33bc0e-4216-498e-be1c-3a66a230c368)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f7a8788-1ac4-47b4-b730-ff75de98b8fe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c6dff3a8-867c-4390-a3af-214084a145b2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         963de507-4326-46db-ae0c-eb8427a2c2cd)(content(Whitespace\" \
-         \"))))(Tile((id ab43bc76-4f8a-48cc-9a40-051876301b53)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         79e3b011-4936-4d15-a990-8bc440325ee3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         19cdb7a1-9fd4-4788-b8cf-82d46d9281ec)(label(bin_int))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         db8d2e50-4d36-42ed-a823-f3156a629a80)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         38010d52-5463-4df8-8dd3-b502960332cb)(content(Whitespace\" \
-         \"))))(Tile((id 57c3dd79-5dfd-4ea3-9e08-c9a341a43f02)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         06bfe394-35cd-4c27-b4f9-462dd027350c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         703137fd-30c9-4ecf-bf56-1d07cd4ca5f6)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         4cb657d3-9e97-42c4-8773-2492b8add20a)(label(is))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         a5c81d6f-4104-44ef-b74a-2a25b927dc7f)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         9088c6a6-fded-4f1c-b156-9fad9d012a42)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         e6f9838b-325a-4843-877e-9bda5ae5ac5e)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         e1f1d31e-b632-47f6-88ea-f67b82f2c4f2)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         84cf5c8e-5eb4-4e39-9fa3-e2887c5e988f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5f9b8d29-9ed2-4c33-b47f-710a783b6779)(label(bin_size))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         15810cce-798f-4762-a412-07d48dcc8f7a)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         ff622324-0053-40c8-bec6-2fa8bc1024f6)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         07640b30-a487-4be3-921b-ea4a47fd76ed)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d7147cc9-c9bc-4138-81ce-8f6c46b3f87e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         44dfc6c9-aa32-44f9-bf1c-297060383c66)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5b2ab445-9149-4801-80aa-632824d25ae9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e55610f3-676b-4ff2-aa55-4e0d39477c78)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         01ddf2e0-d181-4dae-8464-2fb27aeb68d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         90e28014-1272-4aa9-8626-2d3295c9070c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ce9e5091-9d4d-4b13-8bf0-a30f70571bd6)(content(Whitespace\" \
-         \"))))(Tile((id 0b9b098c-d78c-416c-ac99-4502f6ea3917)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         6461f37c-7d44-4644-b073-8ee9409ee6af)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cf424f5c-318b-40a9-88dc-4f5cf708ee6e)(label(floored))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         38296152-59c0-4fd2-8d3c-3ecf47e9ea78)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         3ba4f9c4-e4d0-423a-8e74-b33f53f07076)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9389b5a6-4881-4ef4-a0f1-3dd8bc864038)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9119aaeb-07c4-421d-8ec6-2af72d84a061)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         bbbb7bf1-1c28-4314-857d-61da57b8418c)(label(is))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c9e2a99e-3e2e-430e-98d0-9ff72527a74b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         deafff84-5ac9-4148-b4f5-cb26a0d7fdf7)(content(Whitespace\" \
-         \"))))(Tile((id 4395ad97-4994-4a05-a8e9-7437813d0296)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         e5233e4c-5573-4346-a257-bd0cdc4c765a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f7d0c067-aa80-4b1b-b3b7-d86de6152336)(label(i))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         4f834a62-5919-4943-8397-ddd445ed0d3a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4528063f-88cd-4df4-8d1e-442bb5342086)(content(Whitespace\" \
-         \"))))(Tile((id \
-         23fbac52-f779-410e-ab15-21f0f47a0a85)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         95b3442c-cbce-4cf2-bc9e-d4bd05dfa287)(content(Whitespace\" \
-         \"))))(Tile((id \
-         99280877-a3fc-4092-aad5-a50d2ec59702)(label(/))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
-         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7b1380e8-890e-4eda-9e88-a031f54f99cd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a41f4136-ba27-4324-9b09-c42fc55ba73c)(label(bin_size))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         83663bcc-aa5f-47a0-a775-cf93b59b8e41)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1960f198-d357-4618-9df6-fb4016beaf12)(label(*))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
-         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2b470905-d84f-43b8-aca6-fdb4aeb318d6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5bc0eff4-cee0-4607-b563-2308a07feaa7)(label(bin_size))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d4b40484-a6be-4a74-8258-b93757688beb)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         3b472998-ac0b-41e6-a5d9-709aea167ff1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0b3fdd38-fff5-4dc5-aa43-1f6dbd1343a4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5081f086-28d5-46ed-95f3-e67b3f09d1c9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         75b2131c-fa73-4545-9260-e4009d3e5710)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         62b6ce72-929f-452a-b6de-4d44592eca85)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a7abeb0b-f20c-424f-ba07-1164302dd137)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0e25d71e-743e-4c51-8b7f-6e918b2cd1fd)(content(Whitespace\" \
-         \"))))(Tile((id b91e5590-52a1-42f5-bf9a-d41b5f3736fb)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         40f48655-e4b1-4579-b3c7-3d6eac0453fc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5fdde080-897f-44b7-8bbf-dc23d8ddfb69)(label(grouped))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         f054473d-24ee-43b9-b73b-7aefb03ab7b5)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         389e6763-222c-4af7-b296-e1b26bb7075d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         68d3163c-f1f6-4f55-85dc-a27ea2b6a723)(label(fold_left))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7343957d-3a3d-4def-9e62-c35c3591fe05)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         ae611309-1207-48e6-9c24-7af5899f43f6)(label(floored))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f00c77f7-6ae2-43d6-862f-f399e66713d0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         daf4a864-5cc6-42e6-93a4-361d630a85e8)(content(Whitespace\" \
-         \"))))(Tile((id eb482f8c-3c4e-4a38-be31-c41b73a84384)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         7c141527-316e-4454-a112-26b5786589d3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c0922adc-c56a-4adf-83e7-c5dc7bf63cdc)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         31b14e6b-fc4a-4ab6-9f29-da7705eff628)(label(acc))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         9e4c63f5-3708-4597-b5ba-792683632c73)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         77ecd8ef-70e0-44dd-b0b6-63c6062cb41d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d166d6ae-8e8e-4c3c-9c06-854ab83e0d30)(label(i))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         828e6403-2cca-4960-ae36-1c4ff62c4526)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         03162345-2bd5-435a-bef5-08d1324adafc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d954b32a-200b-4f10-be5a-c89badeafcd4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3d4a2224-5458-4633-8df4-f4241851c6a7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82651c62-6337-4202-8713-d175929631e1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b215a91-73fe-4a49-836e-99d5dc0624b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c76765bd-5c83-43f5-ac18-15ceacfec1b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         15604e2b-c834-4658-a3e9-93a1ddbf1df0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2af589c7-3c49-432d-8ccb-1076b5286fb5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c4ca369-c92c-4d09-a30b-8a54cd259a58)(content(Whitespace\" \
-         \"))))(Tile((id dfec1415-91bb-4936-93e1-ef073370c398)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         22979a38-4494-486e-883f-2c0632d27878)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a0477bec-eeb3-4636-a9eb-2eb9ff6a7c0a)(label(find_opt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         749d1eb5-729d-4397-9386-1d01d10dfc2a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         dd8722b3-4d8b-4443-980e-8f238e6fee55)(label(acc))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c38e57e9-8aa4-4ef8-a79e-47b9a25beaaa)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         30b8bcd4-1fb7-4987-bbee-084ee2b1c623)(content(Whitespace\" \
-         \"))))(Tile((id ca8d549f-a4f1-4d2d-9835-cc2772bf53ba)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         a6813828-010f-4d60-ad3a-a6dbe68072a1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7d4b40ad-b046-4c71-9dea-3d35547564e1)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         30a1fdb1-5723-4e64-a436-9ad464bc096d)(label(i'))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         57ef6164-9a46-45ee-bd2d-fcf1079dbf9d)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         95edc085-af3d-4628-b33d-8342d194c47f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         14ad589c-3e58-4c7a-aa6e-7ff95b6e7f2b)(label(count))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         1e3e2129-c726-43e6-bffd-fc6fd8d4a539)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         a12dc3cf-ce0c-485c-ae98-ff0312230838)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2385fbb0-169d-4d50-934c-9c49e588ca6a)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         6295fcbd-8a9a-4242-974c-82c163b52c72)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0dda8ffb-ec8f-4c2c-b67c-23fd79af2266)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4d13219b-219f-47dc-9358-d7bb049e41a1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2e3379e4-843f-4337-a208-f32b54a9dcc4)(label(i'))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6718fe4b-6c3d-4d09-9da5-c787fa6374fd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         092549ee-8a44-4482-94e2-876b40847346)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a0a961c5-c6eb-4878-af89-ab23d037eb2c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         faea8ca9-fc1c-4449-80a0-e88a938e84e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4813f107-9c0a-4220-a86e-b533a7ba2fb6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4fb4edd9-d9cc-4594-806a-d0007148fb36)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c21b258c-9365-42cc-afb6-e0150f33df9b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c07dfe82-0e4d-4c14-82c7-027cbe4f6d63)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         627627cc-083f-4372-a089-689c7a2fb1f3)(content(Whitespace\" \
-         \"))))(Tile((id a0e1fe2c-aff6-408e-bbe5-e4cd3dc19f7f)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         48c5e423-d32d-4420-bc6d-94e79b53cfb8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3806d314-49d2-4248-983b-67adbf46fd06)(label(None))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         0181893e-5075-4872-8430-1619675ad199)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         cc3d8c06-baf5-4f22-82dc-b85ae9acb37e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e4fbb8f1-586a-43c4-b296-47d1677680e2)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         37e65659-60ce-4778-954b-d6c8ded454b2)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ff0ea032-f18f-42c5-8280-8ee3882e9dc8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fd4a670b-f63f-41e6-aa8b-95db8d84bd3b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c8cfe21f-de71-418e-b886-df3a26316805)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9f5d38d6-a0f8-4734-abf3-8aaad3a9e51b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         427a2a73-d230-456a-b733-36c1b3048659)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e106a5b9-3d25-4788-871e-37413f0b33cd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6e0c65d9-1b67-4a5e-b18a-9326c90dc1d8)(label(acc))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         ee5fae53-ac16-4289-8d3c-d56d99eb5522)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4285b67a-844c-4f07-95e9-74b7ac005e3f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ea1e96d-3e65-4ce5-aa03-b9206eab53af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc4858ae-89cf-4e53-85e0-bdb03924824e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d6986bc-0e44-4b87-a96d-16e88b90d21f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         85a05a03-cd43-4211-bf7c-c26762059941)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6b867536-6ae9-4e9f-b0f5-8f1a5bd1d3f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0cf68684-c597-48df-b6bc-2c66a1e15012)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ad5d568-b56b-4d33-9bbc-33dca12fb311)(content(Whitespace\" \
-         \"))))(Tile((id 7e897489-8f0c-4d77-8ba0-f658be215368)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         15506e93-680d-4b43-9f8e-4f33c9716cc8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         75ef8771-31ee-4a0e-8aa9-c4d9dca36be5)(label(Some))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         736ecfa1-9127-4fd8-8092-5ca4ca2c47fc)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
-         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
-         f4697468-4bfa-405f-bee5-c0942f156fe5)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         e16d2b01-75ef-40d3-bd99-1219541e8d27)(label(i))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         3608b71c-0822-464d-9729-f2180b75f641)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         23f96fcd-3115-4c6b-9be8-7a1c346fd18a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ea36d659-3400-40a0-bb5c-b6fc56b73c0c)(label(cnt))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
-         95c7c112-b210-4bb0-b456-1eba46def63f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         5e5917c3-0d86-4530-ae16-9cd62b915836)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dbf80ece-a415-4079-b74a-af551cbf5d81)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         386df033-1a3e-4ea4-9f44-8f1e6cc5515d)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6ecf7780-53de-4b5d-a909-c9a08c67e90e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fec2fba1-c6bb-4eb8-a1ee-8b41730124cc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1a785ec2-a12b-46c3-8b11-ebb2e8fc3fa3)(label(cnt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         2609bbe8-211a-4719-9158-c24f6525e9c2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f2c6b9e3-c705-466e-9dbb-5e4938ef50c2)(label(+))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e14ea4ff-ca5a-4c84-9dac-c00a80c925d7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6facd0aa-b44e-4f73-8a20-8835c5d911cc)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c3121ada-ed7a-47af-a3ce-3388c38529cd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d617b830-6199-42f3-9fb6-2982f7c6332f)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dd4fc358-1002-4b41-8e64-0ab9401637c4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a044ef26-f1af-49a7-9148-a3cd3519a83d)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e30c2afa-11ec-44da-9455-bcae32fd0a21)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         14a3e081-c3eb-4942-9dab-7ded960d37e6)(label(acc))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7b2ff2f0-773e-4f29-840c-6d55af4e5d9e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d5263669-f95b-43e2-a489-26bdfca495e5)(content(Whitespace\" \
-         \"))))(Tile((id 676d5445-003d-401d-87ad-f830f0b16990)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ae3c6853-3761-4ab0-9df3-fd250adb0af0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         71ec5e45-9ea1-4a4f-aa15-4e0b43a79a1a)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         77ecf3c9-1172-491e-a04c-5c99b17679eb)(label(i'))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         c74a6741-aee0-43f2-afb4-5307a2554115)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         21a4b095-beb8-4aa7-8e20-0428fbe575c7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c4e35d1e-8615-41bb-9ed2-961ad48dc448)(label(count))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         c33f4448-69b5-4d77-9c4e-e7cefadf6d2e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e100c906-ccec-439d-b481-4211f680e68e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         500ec272-d2e0-429a-9da5-d52648a4e573)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         659d1f59-5e6f-481d-a978-2a6e7acefe8a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6894b1c0-3eb1-40cb-869d-79aae4f38a46)(label(!=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         be9f701c-469c-49f2-b7e9-050139b9716a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d5e7e0d5-75c8-4b2f-a552-8aaaa87b8e7e)(label(i'))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         70d397d3-083e-4789-8156-3feda4df52e5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b3917a80-6eaa-4c99-8763-7ec4bf055167)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b8c82ce6-a58f-49a0-a1bd-b5c727cecd62)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         697b4b92-7edd-48a2-8e27-2fc0fb3b69f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a31e83f6-3417-4d83-a5e6-8315c02048f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f857b77e-5b10-471b-bde7-510f6ddd5a16)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1de03440-f9fb-4984-bb17-cb98f495f232)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fa22a069-f4cc-4c19-994e-9c245f58ecd5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7945ae3d-bc13-47a6-8f44-fa24fbe39ee9)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         d029884f-72a9-45a1-ab5c-b2bbd496fcc0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         32de35bc-fc11-4e19-87d6-02713e0863c4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         32a9d950-e120-427f-a26e-3c6f4602c0ee)(label([]))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1c86e4a7-4ef7-44bc-a2ec-e97d71e26aa7)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         fb1e87b8-ed90-4c6d-bf43-f875683acd2f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         50896989-efd7-46dc-a69e-79c2a7fa94ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         af1a75f9-0b97-469c-aa3f-e12278ffe46e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5fee9127-9a72-4303-a718-0d28e1f3e121)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0055f50b-f7e8-4a78-bedb-e1e96eb9d8c9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6fb20808-a87f-45a9-b4dc-e1261d5a796e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         20fc300e-ef42-45af-a455-c18607184b1f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         74976b99-c384-4352-9597-7723c23b3457)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         968604d7-9be7-4396-96fd-c3b03f70e3ba)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d98df85d-5de6-4a36-a137-ef3adcc03b8c)(label(grouped))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         eb2cd09e-9e0a-48cb-96a8-6cbdb31bcff6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         75d1d48b-aa39-4c05-9cbf-d57169988620)(content(Whitespace\" \
-         \"))))(Tile((id a3b27ec8-a3f8-4be9-8ea6-546883b1e417)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         3c460397-f2cf-4050-a908-67946a921927)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6ef6de20-971d-4bb2-bcc9-41daa67af639)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         98b7a921-d886-4666-b063-93b350babce3)(label(i))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d034fa08-3e9d-47ea-bfb5-6f83ca0c2900)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         746a63d5-b8ba-456f-a5f9-b8ce3d0e4c60)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d70258e5-36fc-4d4f-83c6-f90567ee467f)(label(cnt))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         8f1f5246-12d0-443e-9df8-5c05d4dab783)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         05915bd7-a1e1-4e43-bb33-8647d49fd1e2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ce337c3e-4cd5-46a5-88f8-c34f228fb929)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         8433a7a9-a806-4aae-a82a-90b1fa02f286)(label(group))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         426410dc-63b0-481f-9abb-577540aaca8a)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         593e5ff6-09d8-40af-a474-370e258caf20)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         4de157fc-24d3-4e74-9fd3-9f6ee4780eae)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6debebd9-4d46-468e-a4c9-a9665a0313ec)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0a033e5a-b590-4aa8-9e03-fa230aa8b6e1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bdb8d2e2-e7eb-4156-8dab-a7cf9ce6db59)(label(i))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         ec120710-cecd-4491-9452-96243a4ef425)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aacd987c-09cb-4760-aae6-1552c3035d09)(label(+))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         24c06adb-94ba-4195-ae80-5ba5645ecf0c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e781ea84-c7e0-4405-84bf-f1e2a00ba84f)(label(bin_size))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         0853e6f1-2413-4ace-9c7e-62fe3881afae)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         58497ace-2ecd-4cc9-8eeb-46ecc2fd87a8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2189013b-af1d-4088-8ad0-f05084b6080a)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         93798474-787d-4c35-84cc-6b9b7bd0723f)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         d85cb83e-36f7-4e15-9763-30b697ff1c87)(label(cnt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         1191d0ff-a3b2-4a1f-b834-550bd8d6a73b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         df092cb5-5cdd-439f-bf95-4e16d54f114d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6da0a71e-6154-437e-ae9b-1ec850781e7a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6aa74b6b-9d2a-4892-bfbc-1c364c22e0fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         84e8f973-d184-44f6-a3da-20a02057e9e9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e505adb-0bc7-45bd-849f-b9a4c9331685)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         63404711-09df-46b6-a189-7cfb7ad5a5f7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         90f8d41b-7877-4923-8912-30351f9c380e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         01a59272-d162-4d73-9935-6f24e3feda7d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1e4dda0a-3a23-4bb2-9fe5-d468bf179248)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         97991ebe-953c-4d91-ac8a-c58bd990a7bd)(content(Whitespace\" \
-         \"))))(Tile((id 568271f3-122a-4e04-a11d-bd2d517ac2db)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         95cf31e5-8644-4048-b01d-80f98791c8fa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         eccc057b-1fbe-42ae-8811-1e79d94a9216)(label(bin))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         febf7780-1528-4d49-80ee-70cc1900d00e)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         ad8a1a18-b0ef-443b-9c96-88dbad10b660)(content(Whitespace\" \
-         \"))))(Tile((id a1ebe3b1-ac05-44a1-b3a5-56494d729483)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         a3685ce1-26d2-462a-9d3b-f6b58754d227)(content(Whitespace\" \
-         \"))))(Tile((id \
-         11b1e0c7-cfa8-4f64-bea9-19a2755fe002)(label(row))(mold((out \
-         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children())))(Secondary((id \
-         d4e98541-2fbf-4cd7-bd7a-0780b5355f6b)(content(Whitespace\" \
-         \")))))))))(Tile((id 7aa5f19c-62b2-4fd1-9bdd-2a7acce4c000)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         7d0504d2-2cf0-45b8-a93d-7b6e9914c91c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5df5f7e8-b9a2-4d84-a77b-cc1956221788)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         2b12c74a-5fab-472c-a43a-ba008b437ec5)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         3f55449d-665f-42ad-afd7-b9ddb65660a7)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         fd1697fc-48a8-4b20-a3d6-ba87d0ea4e61)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         38ff52c5-df59-413c-882b-0e508318b34d)(label(row))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         377da353-d244-4bba-863f-b1df84d298a1)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         b9979a7a-3b8c-4204-a9a6-8731c65e80f6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dcc49566-598b-4af6-8f08-9882f08b1182)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         c070f67d-91f9-414b-8dfe-b399b9117ea7)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         9efb08c9-2716-465e-bb20-05b944098a51)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         f8c9428f-6e0b-4ba3-aa09-0ebc9fe456f7)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         cfc80f32-cf9f-4442-bc6a-17efa6ecad5b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9bb558cc-08f8-4d37-a995-0349972bc343)(label(c_project))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         e2e82ae0-021a-430f-a585-958d7b233ee5)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         067bf5b6-592a-4db1-92a8-4f0fd2f16dd5)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         1f571daa-a6ad-441b-95be-77efc1bca22b)(label(row))(mold((out \
+         5947258b-894b-431d-9352-c9c2413f1353)(label(value))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         75081279-3f34-445b-b834-97dee6e2d03f)(content(Whitespace\" \
+         779dd4d5-990e-415a-83c8-7c94b5f69c96)(content(Whitespace\" \
          \"))))(Tile((id \
-         5db2dda2-127f-4efa-bc82-fa4881e72a9a)(label(->))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
-         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1f4de8f4-c0a5-44e2-afc3-09bfed4b027c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         18208053-adf3-4c49-8d5a-7766344cdd5c)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         8937dc13-73f9-48fb-8441-15173c08b535)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         c7597c39-4fe7-4f43-ae98-d5a435d7d650)(content(Whitespace\" \
-         \"))))(Tile((id \
-         014fc85f-078c-4009-9bdb-dee3bf2a7713)(label(n))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         1cab25b9-5266-4668-8d4b-5535f414cd19)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         634e4dc4-0962-4882-a384-d0ecf33e8fbe)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         543eddd2-2b48-44dd-b61e-bc21ade8adbe)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c2a97718-68cf-4594-b47d-f9eb7ce48b6d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         527658bb-1fbb-4987-9d8d-715f29d146d3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7a7a1149-101e-4bb6-a276-8a4d5737b06c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba9bfa74-0f29-4a08-bffd-88efb5e61976)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cbf80524-4b1e-46e9-9601-45b15a9ef0e7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         63419da1-a3a6-4547-992d-0a97cd710e1b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae15fe0f-e283-4719-a3e0-92684b56b38a)(content(Whitespace\" \
-         \"))))(Tile((id 8f3dbeb0-b118-40b7-ad3a-43867f0b90b7)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         5503fc67-984b-4a14-b999-338e4643d718)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8a471637-41f5-4a72-ad74-4cb33e6be785)(label(vals))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         36b28bfa-781c-4fd4-b75a-dad84200a09b)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         2be93c52-a4c1-47b3-9a4a-f2052ba5e6fb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fef4dea6-4c65-4e88-9892-6908d363b782)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b87387dc-0bd1-4877-9874-d458ebe16b40)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         30322850-ad4e-4038-a86b-005013f7753e)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a6dc3195-600d-473b-998e-e1610c058dc4)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8da7bcfd-9e7a-4ae4-bccc-8a684a8334c8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         37f44efb-1185-4ec1-93c9-1475e3bfaba4)(label(c_project))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9e594358-bba1-4b1d-8d28-da01d3fe3dfc)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         56d6bef8-cac2-413a-883e-c15c31f41ee5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         08d96653-41dd-4833-b6fb-7732e49654a8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         073fe460-5fc2-4c4e-95f0-46136c2d2959)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2b7b184b-9717-495e-9eba-6e60739c0190)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         14a8eecd-a6f0-4538-89f7-e99b727d3a6f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8b2e6a41-0842-4bd6-8fdd-040683a3d27a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         491e9817-e92d-41d2-84ab-535d6d158273)(content(Whitespace\" \
-         \"))))(Tile((id af6a6f4f-9a9b-4abc-a32b-9e77fd1ab19c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c7bacc8c-f8b7-48e8-8c1f-53bc91df312b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5dca8b5f-9e4c-4ce5-b39e-49ff849774db)(label(bins))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         a5819938-3781-49f9-aad3-6aebe89b162e)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         f400160f-1e31-48fe-92a9-513a277c25f7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         33680360-9eb9-47a0-a0d0-f933dcab7590)(label(bin_int))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2148e241-22a3-47c8-995f-e0097b19fdbc)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b535203e-c52c-4f02-9dd7-219331507129)(label(vals))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8015fd54-a02d-4dec-bcbb-7edd772795e1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         32d7d957-fb77-4a7d-a599-16bd58e38128)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5d14b638-c024-490a-8db3-edf31d145385)(label(n))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8dbd874d-3ba1-418b-8652-8fcf87ed2346)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8e952c8d-43e5-453b-9a4b-1cb5ef325ae5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7733502e-cd6f-4073-adfd-d95fbf063940)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9f41bae3-8da3-47dc-ae60-85ae7c901a19)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3c087623-da1a-478c-adb0-62c04e744357)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         be816c41-70db-4f0f-ab7c-07b041f652a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b706dfca-0fad-40b1-810a-f1d14549928d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         28a125bf-66c4-456d-aa7c-ca520b61d862)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e14dd28b-548b-40f1-8d3f-914519e3ce7d)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4ef0a58a-47a1-49da-b950-756872283f09)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1997fa1d-7dca-4ea0-94a2-e9eee54ca449)(label(bins))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         39b59b12-5546-45cf-9ecd-c4f2407f3682)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         79aca299-f022-40ed-9d4c-a2b84e3c0a87)(content(Whitespace\" \
-         \"))))(Tile((id 6d4d8afc-b726-4f64-ad98-a08066487a22)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         733b5898-9cdc-4762-ac92-1232d92ab387)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f28123a4-432b-4aa1-9bc0-65d4d5de3d3d)(label(e))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         2ffa784c-eb41-4c40-be1d-6cb0f72f44d1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e4cfd183-5a0f-424d-b245-bafc1a3317c1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9f8951d9-d6d7-4b48-99e5-721bd46dd166)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         4419de65-27d8-4d72-844a-afdf14a79e26)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ad511bfb-21e3-4465-a9ae-d5582b75c22f)(label(...))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         6fd0133e-8814-4526-9c39-c84b73269d16)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         5317b481-0ddb-42dd-b78e-744f1eee76fa)(label(group))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1356879f-95a2-44f2-9fb4-4030de1a5b79)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         39bbae63-4c41-4197-b7bc-c4595e788ddc)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         da156a44-e3cf-480a-a0f8-3154e9e09307)(content(Whitespace\" \
-         \"))))(Tile((id \
-         68c33774-a18c-4b0c-8c4e-405db028f6e6)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         d2a5bf28-3a9d-48fd-8ffc-57bb321cb1ba)(label(group))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         1a76a0be-858d-438a-b82e-d7cd0ddd63e5)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         7aad4777-8065-4114-a7bf-7bcbbf758c45)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         15d69868-4bba-4dce-b052-a548c04b6714)(label(min))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         3cf455b6-9f4e-40e5-8ceb-44b7142be276)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         b0dbb17b-cff8-4951-988e-57d5cbbcbf04)(content(Whitespace\" \
-         \"))))(Tile((id \
-         11adefdc-f32b-4f8b-beee-73b12aca430a)(label(max))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Tile((id \
-         936195c3-634c-4a56-888b-4c7b797e2f3d)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         61c1ed12-2e1a-4637-a1d5-87c66cc02206)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8054524b-ab5e-4524-ab11-88a7f5176361)(label(_))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         2e38ae9a-bc3d-440e-9bf8-a36bf1b91c38)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         dfa85aa9-7145-421c-91f7-2f6d07a23488)(content(Whitespace\" \
-         \"))))(Tile((id \
-         96d5c264-ec4e-43fe-be13-ef5599716df2)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         cffdfa01-1ff8-44e9-8784-fc2044bbbede)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8ea4833a-a737-4708-8742-d7e3d18082e3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8f3a9343-5c56-4ac1-86a1-715ffd1d9c0e)(label(string_of_int))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0eb77f9c-ad72-456a-8efd-8c8ec894a3cf)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         3014846a-1c9c-43f4-ac55-a087875edc40)(label(min))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4e2cb947-5a60-4f86-9ba0-be761f052be7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e3f5d724-b943-4781-8eae-1fcb6f7de49b)(label(++))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         809c1876-7639-4338-bb9a-24a114d45a37)(content(Whitespace\" \
-         \"))))(Tile((id 793b3480-ace9-46a8-9d23-046aab3cc314)(label(\"\\\" <= \
-         \\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5b997b4b-6b18-4bef-b46b-3fd5081fa92a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dc11e501-3997-4989-971f-e8ca00a40ccd)(label(++))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7733456b-b98f-4efe-8517-5a8b74a675bf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         14dbff12-f329-404b-96af-66ea2b03185a)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         9e5348ce-3c98-4d09-ad79-ce211a58bfe3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7e073dad-733f-4acd-b363-77dfde3c927e)(label(++))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a6c83b09-abc6-4156-b3e7-83892aeb18d9)(content(Whitespace\" \
-         \"))))(Tile((id cf3cfb83-6971-467f-b241-eb4a49cac481)(label(\"\\\" < \
-         \\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3be0fe01-c4ac-4629-83be-5aa663fdd5f1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         315e4f21-a723-4880-9228-4df6009fb689)(label(++))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         952fbccb-3c04-427a-a13a-f62831fa8b2d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3960b8a5-3fd3-4cf1-a0b8-1c84d9aca8eb)(label(string_of_int))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ab574243-4574-4411-8a9b-44a6393007ed)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e92f6068-7098-4023-b379-c9f354f77fa1)(label(max))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         e867b1b5-7adc-4062-bb61-8b9cf7863153)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c831e33b-2213-45a9-b4e8-879bc32393c2)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3b6ca4d2-de33-41df-bd3e-be4489ed504a)(content(Whitespace\" \
-         \"))))(Tile((id ff989cd2-6101-430d-8e5f-0755ba9e7342)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         147b90dd-33ce-4a91-ae17-8ce5dead01de)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         d4077e3b-b272-4867-bd2b-c315628aa0c5)(label(group))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         393ce7ab-89e1-4f48-82eb-473d12d99202)(label(=))(mold((out \
+         c436850d-4dd8-4e26-ae8c-6ce5252f692a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         ea303ba9-ac6a-4dc6-90f6-79d976ac4e20)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bbd6290e-0616-4c52-b1a0-b35359f5a5ed)(content(Whitespace\" \
+         \"))))(Tile((id \
+         18642a20-7047-42c8-b08b-baa355c44f34)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         8180191c-f28f-4f0a-8703-bc0b89fb3bf7)(label(,))(mold((out \
+         c3326f2d-9742-42c6-9789-14a19b151afe)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fce84706-096f-4991-a436-2bcf7995811a)(content(Whitespace\" \
+         cdd362c0-8404-4580-ac48-3ea5bde91aad)(content(Whitespace\" \
          \"))))(Tile((id \
-         0a7eeae2-68d4-4bb3-88ba-e23a082f2611)(label(count))(mold((out \
+         6a895923-7e47-4e2e-bf67-18f6223ee822)(label(count))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         25188265-7ac1-48de-93d0-313ffba9e286)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0bf2df7a-3482-47b9-818b-207f59ffadc1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d437b9b3-9a20-419f-b8ce-637899b92474)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         dc5ae78d-6e37-4f1e-ad8e-849d30ea5a79)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bad71e26-99b7-4303-92e8-a1695589226b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         075a872d-3842-4754-96f6-bbca4904f917)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e6612714-38a5-4a82-a820-f97fe855a9cd)(content(Whitespace\" \
+         381c6193-90d0-4c7e-9e25-d2c0a5629cee)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         73467702-a12c-4758-911f-d995348624a6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8c4cf5d4-6e48-4681-a210-89251369eb4a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c36eed62-0b52-4ab2-a317-55257f36312b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         655abc04-9f53-4614-8401-4bb1a92e987a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ddd621b8-cfe7-4918-b660-990e8e284065)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c777c53-dec0-4e83-a2d1-fa7c8cb33edf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9d59a876-1e43-48e3-951f-1a3cbd9aa209)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2390b124-b9d1-4001-99be-d91f29a8a28d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ea90800-3fef-4c21-94fc-d23cee6d7ae8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c83d2098-e272-40fa-b8a4-1f383477edd2)(content(Whitespace\" \
-         \"))))(Tile((id 5f0efdce-013b-4249-84f5-72f41675cd1a)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a93524f5-a60e-49ff-bbe4-e5e672740da5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         40e4439d-436e-4b73-8f83-c61f188f178a)(label(bin))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         94e510b4-ffd0-45bf-9309-4e8bae970d76)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1233c708-33d0-473c-b54e-8da369686edd)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         2e6a3607-42f2-4b77-9000-7ca7ae700cca)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         46844e86-b0af-4e00-b130-856df3e99090)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4d97209d-cfb7-4ad7-9116-889db81f292e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         08f7c931-3ce3-4a59-b4ff-d5a18d81f7f4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         38e5549e-4de6-4af1-945d-047484af6693)(label(\"\\\"final\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         30a44a2c-0534-44c1-a708-182e436edf39)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         20066232-e0fe-49fc-9384-e7f194b99b27)(content(Whitespace\" \
-         \"))))(Tile((id 835bc256-0cf1-4a5e-9800-a989252297f9)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         643ea7fa-c98b-402a-ae79-1e604e44241f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         731d8b40-e59a-47ab-9bc8-ff5b30e7f3f9)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         fe029040-120c-411b-b14c-e1ad5065ad79)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         a2ed38a6-a364-43d1-bf48-7e75d2ba5e64)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         49867512-c82d-4162-bb40-bc0d5db0e3ce)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3e332ce8-60af-4321-9c59-040d223dbee4)(label(final))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9282f8a3-8b6c-4472-9e24-5c79b259f15f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         85f6494e-7e13-4aa1-ac64-e25a40ff6688)(content(Whitespace\" \
-         \"))))(Tile((id \
-         595c3209-1002-4e34-98aa-931b577fc67d)(label(2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         79378f4a-55c4-473b-a5f2-20727575e3fe)(content(Whitespace\" \
-         \"))))(Tile((id \
-         70164be7-99fe-405e-adbb-6424224549b1)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         be205e37-1af8-4391-b761-6115debc56ff)(content(Whitespace\" \
-         \"))))(Tile((id 05713b2e-17c9-4661-99fb-3ff3cef14ece)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ddb7f95b-b9d6-48c9-873a-271827be0644)(content(Whitespace\"\\n\"))))(Secondary((id \
-         edc8a69b-5333-4631-972c-01de81d2ba81)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         08865418-a7d5-4630-b6f1-ba78df9b755a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9a0b9add-0648-4a6d-b537-0c1b97b3fee7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ce379e9a-3b31-48ca-907e-b58e940ba2d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f6d28b7-e68c-4c2c-a943-a20f8ab821c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5116eab5-e9ee-438a-b631-25036265f5d6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c514d794-bac2-4bf1-9c47-65fec03a06c6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         d113f19f-e7cf-44bf-84a7-36da68789a7a)(label(group))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ec56bc93-a526-40ec-a376-8d5d25b2eb17)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         226851e9-df49-48c1-8d0d-03e1606ac72d)(label(\"\\\"76 <= final < \
-         78\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7b2d58d2-e218-4c2a-9a93-db9a4f5f2a61)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         60b12eaf-f44c-4aff-bd06-23e2145195cd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8740673d-032a-44ae-9046-51a72191c1ae)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         da9a83b6-e125-4952-bf55-7f6885b723f2)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         447f0d34-5b7a-4599-94a3-dfd12974fee1)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8ffa7096-c0ac-4b96-9a41-296bf39555d3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aebf97ee-593f-4a12-81ef-8d9eed1ecf99)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a1edc166-a1c3-4dd7-b6d3-495cdb745ef0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         804c03db-95c8-4e9f-9049-57bcc7bbb972)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         955f8125-1c9e-490e-944e-5aa2be401d57)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         148c8176-9801-4a96-925d-1c8681d7efa3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1951b61c-c987-4803-a78a-b35b2cf79cd0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b5752a23-cd4a-4c9c-8ef4-c79c07ae5bec)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fe3b56ce-5f61-4476-95f0-592ff7807a18)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         3a334645-82ba-463e-b1f6-d6006069b9d6)(label(group))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bba2af78-32ea-4851-8bf4-699ae929517e)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         8fb4de1b-2aac-4210-979f-97d60fd0bdd6)(label(\"\\\"84 <= final < \
-         86\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a34c4720-3dd4-4065-a404-a3fcb0c17aa5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         48f990d0-941f-4587-92f0-49a6ede3a2af)(content(Whitespace\" \
-         \"))))(Tile((id \
-         63c6cbdb-e6e3-4fd3-a5c9-ccf82c7422ef)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8a3ce110-42ef-4750-be69-e51bd3a0cfec)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a7d3642f-6d62-4adc-9296-569bb1feeb91)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a6090f90-8da9-4f9d-9456-bfa65860c4d4)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c806d384-8928-4fee-a980-6a21e4221b17)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1035bf97-8080-4182-99b6-beafe8b5a104)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fb7227c0-f091-49a3-a917-9b714368ee88)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         403726f7-13f7-463d-93a4-795caba7f0b7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c74e3953-ad94-455f-99d9-a23fe1a70e0a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a756bb6f-2610-45e0-8b08-d0e70879d0b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         22f2e13c-b28b-4184-934f-fa5d64e72eb1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bfb05f84-edfc-4816-95a7-73a7eb45e29d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         66095af9-9b45-45ec-ba27-f1ba5ec60e2b)(label(group))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1f71defb-14fb-4c3a-b9c9-1183e9f15caa)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         37f3e25b-d216-40de-90cd-360d17240c92)(label(\"\\\"86 <= final < \
-         88\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3209cc86-e084-4607-9878-aae3e1341d0e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ae24128c-cae9-4a12-94f3-2979ab12c2b7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8a9cbe01-144e-477c-8be7-49d1e7a62a45)(label(count))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         37e5e261-12ee-406e-af2f-8563fa7b471d)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f4d34c2d-dc4f-420f-8acc-c462117d5680)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         899e031d-e586-4293-b8db-051b5991a01f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         31a3bfcb-3976-468e-9f18-bb9146589044)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         81837014-0313-4080-a568-51dcc230cb55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36e941dc-6764-4666-8857-28786c84e16c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b0efae7d-31ce-403f-9519-59a89608e78b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         2056d464-c70c-4a5f-bb5b-c4f25c8f80f3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         de487d1d-19a6-4425-9e9a-7805093c4944)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dbc4fdf4-2f36-48de-9f2a-9dbb2eb603b6)(content(Whitespace\" \
-         \"))))(Tile((id 9eae4265-059a-46ac-ab97-33f079a76c1e)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         b2732c82-05fa-4f37-86bb-4dcede3401c1)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         c303e014-46f7-4201-9618-ac45b83b6f58)(label(group))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         3b20c419-98d5-4258-955f-2b22f99e10ac)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         31b95503-3ce5-4022-8d69-6e24bef81a9d)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         b53f296e-af7c-441c-976b-84460799640b)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         88655955-04af-40de-9dc0-83c4a04903f4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4adbb08d-fe88-485c-a7a6-ed0794a36da7)(label(count))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         814c5752-6423-49c7-9e5a-2fd4a9bf5192)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c049fac9-3207-49bf-aab9-4aa0185ff495)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         2cde00bd-b5c3-43fe-b14a-b90ecb7bc712)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4c63ad52-971c-490d-9107-8e812dbd033c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1a3f1d4f-84a0-4bf8-9e21-c6acada56749)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0eea2a14-8da7-4c7f-9a55-503891b3935d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         030f8510-064a-4e75-a722-fbc47370c8e5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7138446c-d766-4e5c-b4e2-2ddc59b09386)(label(?))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         46c7495e-9bac-45cb-a12d-7f37dbaf589a)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         33809a0a-9763-4378-a379-c560bee6bb06)(content(Whitespace\"\\n\"))))(Tile((id \
-         3569952a-1339-494d-8c92-0b1a0dc87d9e)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         538a370f-4498-47a3-9df8-f71e53054e2b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         77e686ff-9468-4ad9-89d6-8cc44d420195)(label(pivot_table))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         1e224baa-675f-4d8c-b6d7-20642ec47267)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         81dcf951-a1a1-4524-b146-801076acdbae)(content(Whitespace\"\\n\"))))(Secondary((id \
-         595c5e2e-5f93-44bf-8bbc-7323a787a6c1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aabe5051-9f23-4556-a577-3467568f3039)(content(Whitespace\" \
-         \"))))(Tile((id 9a67f212-a194-4c19-a9fe-aecc4ac3fdbc)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         8fa414db-1044-4dab-88b3-7801181c5d7f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cfd6ccd6-c138-4ddb-8530-e87408e30f6e)(label(requires))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         4bf4f285-4eec-44cf-bc0f-f7d260b1db60)(label([ ]))(mold((out \
+         f4d0fe10-a656-40c3-b949-3b807b5bc742)(content(Whitespace\"\\n\"))))(Tile((id \
+         16157cc6-8886-4e58-93c7-fe79b76008b6)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         6f84b3f8-6d68-4a73-94fa-e2c1b0b296c5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7761520d-cbbe-4ff5-949b-573f0f905b98)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ffb113b-7bc4-4094-a0e1-1461323d056e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d544cd11-e01a-4555-a4a1-89a0789bda5c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b71f3590-0eb0-4797-92c7-9adbffef5a8d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cec76931-3ea5-48b6-9f71-b443eb551cce)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         2f3d13c1-38a0-466b-a694-218d6ecf517f)(label(enforced))(mold((out \
+         12319bfb-0a6e-4f56-8f32-b7c90df30183)(content(Whitespace\"\\n\"))))(Tile((id \
+         70ad934a-528f-4c7b-9dc1-29de279c5630)(label(count))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ca81cb9d-08c6-4278-ba88-25ed2163e941)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         eabc6901-20c6-4211-902b-d9acf2a09944)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         cc7c1f56-1ec4-4336-92f7-be7b5a2b4b54)(label(false))(mold((out \
+         a39a7eea-5210-4601-a806-8960c07ff27d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         93df6509-f173-4263-9553-74b7b8978e5a)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         34f93814-0aae-4734-887d-5d42a7e3815c)(label(,))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7f80683e-6f80-44ce-a506-405dc2ea8c8c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         11215554-17d7-4b91-b97d-570505bec43a)(content(Whitespace\" \
-         \"))))(Tile((id bc08ad28-b226-44cf-aab7-4eb7ba55b55a)(label(\"\\\"for \
+         5daee97f-de63-4826-a17c-aa70ad53e106)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7abfe868-cbf4-4a16-94a7-d30e0545e6d2)(label(\"\\\"favorite_color\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         0482db82-3a3d-4303-9495-a8661922bc69)(content(Whitespace\" \
+         \"))))(Tile((id \
+         49333514-4653-4113-8187-c80cb309bc83)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1fabfcf3-340e-4808-baae-ad4bb09c272b)(content(Whitespace\" \
+         \"))))(Tile((id e24b5195-de91-41b9-88ba-0191971c203d)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e7e2d275-4b28-46ce-ac9e-91b8c1405b24)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         b0513dd5-9a34-4b84-b7b4-c80ac8ebef39)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         77af2620-bb7e-48f7-b15c-17500068fb92)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b36f2579-79ea-46b9-b726-f66beaac1058)(content(Whitespace\" \
+         \"))))(Tile((id \
+         081540a0-97c2-4b95-8dae-44dcb199a897)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         ba0cc5be-de13-42af-9482-b16e70494729)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         362c8dd3-b187-47f2-a72f-59091379a020)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1bb92cae-ae5a-4096-963e-d12411747f6e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         9115ea89-1ead-494d-920b-308a158b70a5)(label(\"\\\"green\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         20ee3d55-ce9f-40cb-b806-99f7074d47e0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         143531d9-01ea-44ee-aebe-a8d4c289487c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ac24f576-0a17-4b2c-ad8f-1caeb945427d)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         6326f6a5-416c-4874-a22e-420ae77bff03)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8b9d2ee2-1399-4298-a46b-0a3cedddacd0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         30545382-fdeb-4e8d-91db-28c32bff91ef)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         4c618261-eeba-4be1-9a7c-6531d268a417)(label(\"\\\"red\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4c5d7feb-29bf-4f93-812c-1d9cc8da37ec)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         89900a2b-d51a-4e47-ab27-c7b097e4b788)(content(Whitespace\" \
+         \"))))(Tile((id \
+         15e16b9a-c02d-4c60-b1c5-37229132dd20)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         ec64272f-2dc6-497b-80cd-6c7593cb45ff)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2c095375-8b94-4c88-8938-acc090d6e5fb)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dba52216-074a-4c38-b191-e0dd909ebac0)(content(Whitespace\" \
+         \"))))(Tile((id a9567d81-6757-4765-93a7-08ff293011aa)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         a40a09b7-9dc4-4585-b8a9-9d9fb0374dda)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         e60bce42-d0a7-4ff6-bb6d-57c494174426)(label(value))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6fe20dc1-e2b0-4e79-b610-1b4b8055dd94)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4d9604d4-cb0d-41f2-a8ff-b58a58b647d5)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         99ed4e78-eb1b-4189-887a-42340ff81926)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bed47000-352d-48dc-b8cb-f4376c1ad3e1)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         07f65ef3-5066-428a-b987-e8a45e67d5d1)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         20f10fb1-5394-46ee-88d9-1f33cb92d64d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0d173e76-a1b8-4b54-9069-2527cf761ac3)(label(count))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cfcff9f2-12f5-4e8f-a73c-3506e9d1bbb3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b351f7a6-d6ab-42b7-9628-1e10b860ec1e)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         68d2fdd4-8352-4aa3-8756-1d79857ea63c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         53286b57-b25f-4c1b-b3f5-f06d6b58f89a)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         5f90bfa2-f9cc-45ab-bf7e-1e0b7de281db)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d7be4b3b-78e8-4d26-b382-3b4eeca3bd37)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f611aa0f-1cfc-494b-888d-2ca6c24a6573)(content(Whitespace\"\\n\"))))(Tile((id \
+         d4500a1c-61bb-4f26-8712-45780a424ad4)(label(?))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ce7ad40b-67bf-423b-9f86-343925aa5da6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d6d476fa-e19d-43c3-a168-6bb390d37698)(content(Whitespace\"\\n\"))))(Tile((id \
+         ae86704d-b88c-4b5d-b660-9d24e7904f10)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e874bd75-e0ae-41fe-96e7-6aaa3d470338)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8ea1ae93-a26b-41e6-832b-ede1850f34e5)(label(bin))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f1ca9827-8d49-420a-95df-9f4b66a1e813)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         fd0b9834-9981-4f67-b5ea-5910b92852fc)(content(Whitespace\"\\n\"))))(Secondary((id \
+         61a3e2ce-66ff-42a2-8874-7466c525a86f)(content(Comment\"# This version \
+         takes a string column name and can't guarantee the column is a number \
+         #\"))))(Secondary((id \
+         b264e63c-64bb-48f4-a0dd-baeebc0e9783)(content(Whitespace\"\\n\"))))(Tile((id \
+         c3e5909e-8989-4350-8d56-1adb9252fed2)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5ce3a35f-33fc-4fb8-b84e-f68818001b50)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4ca299c2-9b7c-400a-b6db-8552e95b1324)(label(v1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ca2cff0a-9ab7-40fe-a316-dc94474a6a8e)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         64ae11a3-b173-4399-ac55-19a7766848be)(content(Whitespace\"\\n\"))))(Tile((id \
+         6bf9ac1b-8ae2-4374-b78b-608206bf4c37)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5862f23b-f656-4f0e-b94f-7b6cdf02e1f4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9ea23438-e25f-4156-86c2-83dae11af381)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a16124c6-3135-4a9a-98d8-8e72eb74b9b6)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         8e2c1f45-1f14-489b-8f54-4903cbb3cae2)(content(Whitespace\" \
+         \"))))(Tile((id 3f39facf-bf1d-4284-894a-6163124bdce7)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         2bdd3f67-4b55-4b73-be8f-580c4d9ce6c0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         4f4c89cc-4301-4be6-bb26-1693caefe6d8)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d533197c-ab52-4ec2-80a9-370675d8767e)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         50cea535-a1dd-42e0-8d9b-9cb29b418577)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ae7b9a45-4dd3-4ced-9910-f68d84f64082)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         d6b5b2c6-b5c4-4fe2-bd70-4cc8d42a4689)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dd6ddfe6-8ee8-4d08-8228-d8d18996d27b)(content(Whitespace\" \
+         \"))))(Tile((id 6a50955f-a00c-4c3b-94a2-290d228a1506)(label(\"\\\"c \
+         is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
+         Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         5462ff4b-5d7f-47c3-a0e3-be38f19e4686)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c00be544-8482-4ad8-bf9f-07f0dd83517d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0abe5eda-77d4-4b3e-868b-07c46208c51e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         53a6744b-c353-4786-9f78-632cc4d7a82d)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b56ff122-7fab-406e-98c7-a9724cc6e33c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0ebae0e1-af8f-4a9f-b226-f8101ff81b80)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bca6dd5e-e0e7-41f5-b9e6-94d9c93f6b15)(content(Whitespace\" \
+         \"))))(Tile((id \
+         461fe067-9216-49d9-b68b-7fbe61a5e0ba)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         4ac4062c-69a7-46c7-b23e-ff25a5e76abc)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         9d7fa416-996d-46a6-abb7-289258088ecd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         89e648cf-79f2-4b9b-8deb-2e8d3a45a477)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8d9d2f4f-aaf6-48cb-b856-73d80463d5f5)(label(\"\\\"schema(t1)[c] is \
+         Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         27852735-5cf3-4e48-8b85-d7156d596db2)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         52abda74-736a-44ca-b902-40fdcd7ec268)(content(Whitespace\"\\n\"))))(Tile((id \
+         5eb95fa2-e070-4a94-8980-f3cbcf08dfb5)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5f985e66-2745-47ff-a450-b324c10b9b91)(content(Whitespace\" \
+         \"))))(Tile((id \
+         353a08eb-2686-4095-96cb-f453910d886b)(label(_ensures))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         06742405-fb49-46b1-92e3-0a998395b9bc)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         96ec08a9-871a-4605-9489-a29087c64f3d)(content(Whitespace\" \
+         \"))))(Tile((id e0bcb6d3-41ec-4d6a-a5af-56db5c1e9910)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         fb444e85-0c55-48c8-ba7c-14deb6a68aa3)(content(Whitespace\"\\n\"))))(Tile((id \
+         cf8f39bd-03fd-4398-9afd-e5c270f03c66)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         5f8283ab-f650-4d5f-bc40-1e83fe39c76c)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         97259551-4d7e-48c6-acd8-750e9e0945ca)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         c135bc63-d195-4a30-97da-2d02f8554626)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         99e13089-85cd-4659-b37f-725fbc4e26c8)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         186caa3b-147e-4bbc-a96c-6cccc0c50b1d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         76cb0761-50de-4d6b-b2d4-14f4279472c5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2c013982-24d3-463c-9157-b9d3b87ffbcb)(label(\"\\\"header(t2) is equal \
+         to ['group', 'count']\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
+         Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         a0185614-8529-4007-ad33-e3b01f502bdf)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8d9c65d0-cf10-487f-b13a-d95c68079215)(content(Whitespace\"\\n\"))))(Tile((id \
+         f55665ca-d1f1-4652-adb6-a15037e2d463)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a5fc58b8-e5ae-4c36-9ab1-859f9d29ea67)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c90a1ee6-09f1-4b7b-8699-137f4148e61a)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         4af01a72-4902-46dc-8068-17f2e694bed4)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         96305a08-bb7e-4d13-9961-05e7cde819cd)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         62c6559f-d9d8-40f1-af63-a3ec70a2efcb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         71440c12-f0be-47a1-9508-97f473284714)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ab9b69dc-ebc9-48cc-9273-d77c36f9e779)(label(\"\\\"schema(t2)['group'] \
+         is String\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         f81f1d11-dbac-4881-8c99-535fda5323cd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4c9e57db-88ab-4eba-8240-fbbaa7646c1c)(content(Whitespace\"\\n\"))))(Tile((id \
+         0cddefba-ef67-44d8-a5f4-3b143c96ee2c)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         b5e70487-70f3-43d8-8816-812d4c70ce13)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7f979cda-f554-4677-81ba-121104a4da26)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f452f231-7aa6-4f93-8429-70ec4275243f)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bdaca3eb-758e-4f15-b154-bef8145fd208)(content(Whitespace\" \
+         \"))))(Tile((id \
+         572c1b6a-4ecd-4ea0-99e6-3beffb5e9cba)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         aa7c1afe-2085-48c3-a24b-f1419273ebfe)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         7cc98a74-3ddd-4015-9fca-e6445a37a891)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0a0ecde6-2428-4c4c-8517-b205c051b234)(content(Whitespace\" \
+         \"))))(Tile((id \
+         24aa17ee-8e8b-4389-b7bc-8a4b6a4c7cac)(label(\"\\\"schema(t2)['count'] \
+         is Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         a659ebec-eb77-48eb-9150-147ee8304340)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         fd4d016e-4dd5-4017-b271-bae75badd2e6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         272ff8e0-afcb-47b7-ae59-75acb96c20bb)(content(Whitespace\"\\n\"))))(Tile((id \
+         2c66a8f7-cd2b-4d83-8f30-0937fa475256)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         fcfc8e2f-f79d-4128-9e16-155c672b77fe)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a1480a2f-5790-4ebb-b888-c6959b977c7f)(label(bin_int))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         aac2b966-1551-4d04-b841-8948aab6a8bf)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         65c108e1-dd7f-4f81-9994-44d3db56e201)(content(Whitespace\"\\n\"))))(Tile((id \
+         796acaa9-d34f-4198-963f-18f5249d5381)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a21865bd-a2b3-4b6e-b8bc-2f0c0b8f6eac)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f97a2204-96ac-40a9-a0dd-8c384420eb6f)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         a3b1d62a-47e5-46e6-a5af-471c5bf6ce52)(label(is))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         64b579f1-6681-4234-bcd6-3f0f0a5110d1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         33985c13-7cf0-49fd-8682-f4e35f0f2867)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9d87bbd5-be72-4f03-bb4c-c5002a4c59bf)(content(Whitespace\" \
+         \"))))(Tile((id 718f1e2e-561c-4b3b-94fa-a3fc8d3f5eee)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         9018020d-309c-43fc-89e4-bd91d1505898)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         8f4554d8-cdb0-4cc2-a5ed-e01b2b58b02d)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         eb3841be-2758-4096-9a54-ae908192a5b5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9ccc9636-ed77-4aeb-956b-52a5f64a3f8b)(label(bin_size))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0d8cb240-12c5-4429-9204-06cc99e8b95a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         78fd6feb-58e9-4eaa-b261-6d4b78d6227b)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5c053049-0397-4d67-9d96-46c1510f5063)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0652ab59-2bbc-473a-b0e0-8dc2976583ff)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         e1c13124-ec76-4c71-b052-5e1e5b4f5fb9)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         276c8c31-624c-4d33-9bf1-8da089f05f76)(content(Whitespace\"\\n\"))))(Tile((id \
+         0f67c81c-4ad2-44c6-b215-7ecb66251ca8)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         18341374-cfbd-41bb-898c-690dd0c10896)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bf055690-a004-455e-9c3e-68a0cc5a0ab0)(label(floored))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5914cb91-3903-44c0-9b3a-2195c1b9e8cc)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         d576006c-a1a2-4a5c-969b-568338318ab2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         76729f86-dc86-4166-9e14-62aa0374d6b6)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         aadb60de-4e19-4d64-8e09-88e97402c6bc)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         36d299f8-5a7a-4413-98d5-eb53ae130a0a)(label(is))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         31f3f274-3e07-40d1-9477-7f78163b8d10)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fdee3ef9-e269-4ce5-b5c9-c30c0bcbdeba)(content(Whitespace\" \
+         \"))))(Tile((id b6e64364-d75a-4153-8a75-9c22f82fac47)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         1003365c-96d1-4ad5-ac6e-b1b3b3369701)(content(Whitespace\" \
+         \"))))(Tile((id \
+         81ab42e0-ad04-4e03-869d-31cb67d46379)(label(i))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         84014eb1-1a68-4b6e-a343-2e0d3b8ae8f8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2edf963e-88ce-4b40-8df7-759bbff4ca77)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f7e79c88-4146-4cb8-a94d-e6002a5cfd6e)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         62ef569b-4429-4bed-a9df-db505abe7136)(content(Whitespace\" \
+         \"))))(Tile((id \
+         821b2a1b-abbb-4499-8149-e15a92ebcf6a)(label(/))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
+         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bf304fac-2b66-4dc4-b8dc-d178f1e10a53)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bae15822-cca7-4026-bf11-c52568bbe898)(label(bin_size))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6d752c06-8d57-40b5-a920-5ccece1ad43a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4b7d5271-cb85-4e4b-9a68-fb5b3d377865)(label(*))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
+         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2c771dc2-a585-40e3-9746-c0b74e516bd9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ddffd522-e969-4912-a8e4-c55959e45d7e)(label(bin_size))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         655a88c6-73e8-42e0-a1c7-f11ee39417dd)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7dbc9780-6c61-457f-9133-bd9e0f7a602e)(content(Whitespace\"\\n\"))))(Tile((id \
+         e9e21d9c-5cb6-4357-8457-a6bc7c1a37e4)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         b186959c-ad0a-4d34-804a-701e7f52e404)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d874347b-c799-4da6-9d18-a17b703d4797)(label(grouped))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f1252248-c659-4dcb-abc0-62d8d73625d8)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         b71f9ac4-6a42-4f06-b92d-b8d4ea2f82d4)(content(Whitespace\"\\n\"))))(Tile((id \
+         5ef3e615-0854-40dd-97c2-9dd3f51d667a)(label(fold_left))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7d0acabe-4491-4ac8-8878-f632f3b458b1)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         148f12aa-9737-494b-b22f-dd132d8fb027)(content(Whitespace\"\\n\"))))(Tile((id \
+         a2691d49-9cb0-4521-9fde-6cb14129ac5e)(label(floored))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         243b6c66-a698-4e3f-8387-8cde4cb5243d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         851e82e3-45e1-414a-a3a8-1e18fe22cfea)(content(Whitespace\"\\n\"))))(Tile((id \
+         3b2ef9c8-73d5-4a32-9f87-44c845a3e898)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         1012d69d-0911-478a-9bb8-3f701021393c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         da7d96e8-affd-4ac9-806c-877a68be477a)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Secondary((id \
+         19a5a66b-2d0e-4930-852e-d41b5b58c8e6)(content(Whitespace\"\\n\"))))(Tile((id \
+         32cabe0b-7138-4c2b-b530-6979f6c6a8ef)(label(acc))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         fd7162a2-42ae-4c9c-8707-700e6a3ea654)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         eff18a37-d4a3-4df2-91c3-d4ed5a1f09e9)(content(Whitespace\"\\n\"))))(Tile((id \
+         c7cf5096-7fe4-43f9-a315-48ac6e7c03d1)(label(i))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cc4c5f87-2532-496a-b454-d5723d5dbe61)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         9865d718-06ed-4893-bd63-64502aac2b64)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         809f43a4-e6cd-4864-937f-73af25e79fa2)(content(Whitespace\"\\n\"))))(Tile((id \
+         8f1bb03c-7b5c-4372-8db1-cf5b2aa7a63a)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         c4e3bfbe-410f-4009-ac62-98eb614457ca)(content(Whitespace\" \
+         \"))))(Tile((id \
+         657b4d57-abde-42cb-8808-e56af4c429d9)(label(find_opt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         62b75402-8a8a-4e65-b710-33874dce256b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         90c46664-40e3-47a1-85da-09e1019d13c0)(label(acc))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         93489500-02ea-483e-9cfd-ce78ecaf20f5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ce2788c2-e03e-4303-a35c-0a93c7050fbe)(content(Whitespace\" \
+         \"))))(Tile((id f0ab5352-6980-479e-a791-689749325ff4)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         d04449d0-44ca-4f02-80f9-1b0ccf781e8e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         87fa992b-2b94-4d43-b92f-2d60db7b06c8)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         68f65898-b7aa-4519-bb3a-ac970f14b1a8)(label(i'))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         84f8de91-f5eb-438e-b43e-6036fcc8dac8)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         95e7ee7b-4660-465f-af16-36837d868934)(content(Whitespace\" \
+         \"))))(Tile((id \
+         600f43f4-46ff-435a-9c36-972892d4effc)(label(_count))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         379e978b-ac7a-4b7a-94f6-b0676066d6f3)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         bdb12d1d-2bb4-4783-b824-22bad1f068f2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b600ed70-f812-46e3-9565-c72b4abbfa09)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         bcfff186-49fb-438c-9cbc-b992eac9410c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ec2dbe8b-fe6b-4dea-a161-f944e05c15d6)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9d8a518e-6500-4359-9b8f-7446898c050e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         906e35cc-048b-4cde-9fa0-a959b9cf6480)(label(i'))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         30ed037e-8f73-462a-a622-0af7374ba977)(content(Whitespace\"\\n\"))))(Tile((id \
+         53121ed9-8542-4214-bb19-820579f1f4a7)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         f0d0f353-1e15-4f42-a3a3-fb9411ca8fa7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         981dbbe5-ef50-47e9-8726-a7cf8f4cb03c)(label(None))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         bd5b9431-3a86-4a24-a206-7b541ea61ff6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         dd95736e-3ebe-4e1a-9be5-dd8c7fe89f9f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a52b1282-68db-4838-abfa-a8240de4d0f5)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         affb220f-e4e2-45a4-a78c-aeae8d1103be)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         952b9be1-c2ba-4dd1-833d-c6050c36cc60)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1576d95e-0d1a-4353-9794-b61e2aff2660)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f8c026c6-0ea0-4ec6-8964-9ffdeb7997b0)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         e90f7ab8-ad08-4035-81ea-7a492ecd98e1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e608109e-d9f5-4f16-bbdf-92cb64e2468d)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         00053433-cb83-40ae-b310-34606f641f3a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9694ed43-a1de-401b-993f-f38c70510e5a)(label(acc))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         51f97e89-6427-4cfa-82ef-611052ce7d8c)(content(Whitespace\"\\n\"))))(Tile((id \
+         327beb4e-4175-4ab5-ba85-af30efc38400)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         8880f166-f39f-4a95-9305-98407111774f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c5611315-a6aa-408b-a17b-9bda4a8c3d2a)(label(Some))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         de65b5a2-5443-47bc-91b4-106d2337364b)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
+         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
+         80cb4eaf-c08f-48d4-b311-a6669033cbc1)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         6cd11940-0ab5-4215-9380-990bcd6119ec)(label(i))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         04907d53-61db-423c-adbd-2fc74342c64e)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         2920598d-770d-4550-abae-b160ae872ba6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         56a556ee-cafd-428c-899e-75269376cff5)(label(cnt))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
+         24759ab9-387e-40f9-ae9d-a8cf621698eb)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         88183a00-46f2-4ccf-9d5a-b283ae514582)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b9494c5c-4d31-42ac-ad71-4b07ff8f5aa1)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         6673c93e-882c-4ab0-a519-3cdf7a7d2b6c)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         033907d8-2542-4b4c-b1a7-c49c16c9cbb9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4d7eff37-3063-4e54-9ab1-b4edf70833fd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d0ebbfd2-0595-46d7-b521-f46fb02f7472)(label(cnt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         0923e99f-4bdf-41d2-a195-81b2755fd73a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         be0e96f0-2e60-43f9-9181-2400b1d8fa4c)(label(+))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         556ed0b8-c708-4262-a0f9-53e4a3402fbe)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a1d3a04f-bb8e-4f05-ae48-4296a93d08fa)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         a865a64f-3d89-4ca0-b10a-ba9f20dacecf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         69f4c62b-c1a6-4a47-b1b9-67dcadf5f550)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6421f693-f2a7-4d15-a38e-b5d7ef9ba6dd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         27277f94-b343-4ec9-9cec-b23f6f31355f)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4adcc499-756c-40ee-bae8-463e0b18b878)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         af8a106f-515c-4bab-b82c-f43a4860c718)(label(acc))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2aaf6a93-c383-4cb3-a1b6-ae5460130df8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1c61f12e-eb4b-41c2-bd48-5fa093c9b5c7)(content(Whitespace\" \
+         \"))))(Tile((id cc6332f6-80f8-4667-ac44-9669fb81827f)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         9a9abdd1-0f83-4b5c-a1ff-385caf0b89e5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         02328512-17ac-4887-a589-167f0b3fcef3)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         2289978f-cbe7-406d-8a26-0e3401bcd813)(label(i'))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         0892857e-784b-4078-86f6-b6f8058717ed)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         8db38e7e-16ab-45e3-83b6-ad81259b3f2b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         02504a45-26a8-4e8f-ace3-ec123529830a)(label(_count))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         22ac05f2-2972-4c58-b5e7-126cda833678)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         8864b420-ad86-4552-8e4e-075eb479962f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f22e1a19-0d65-46f6-9191-55f765e99f1f)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         725aa7d9-bda3-497d-88a4-ba4ebd12071f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2e943e0f-aa8a-4a16-b268-06809857ac5d)(label(!=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1011ab95-2ecc-4378-add4-4ed05bbbe21d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5116971d-28e0-404a-9f80-05762c63905b)(label(i'))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         92d57758-fcf2-4788-85fd-030ad5cc471c)(content(Whitespace\"\\n\")))))))))(Tile((id \
+         a7167512-9ea4-4114-b58f-bc7a5b7990c9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cd85187b-8d77-40ae-8c0f-1b8cfee8af03)(content(Whitespace\"\\n\"))))(Tile((id \
+         d0c860ff-b395-43ac-bbf0-7f9bc26a80cd)(label([]))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         60cb39ba-571f-4b2e-98b7-04cf6d8af615)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         a0c48b8a-ae1a-499f-b87f-bfb4240febd9)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         36ce7743-c731-4703-9592-75368cf2ebc4)(content(Whitespace\"\\n\"))))(Tile((id \
+         c7d46631-7b2a-435c-aa98-6f93b6c21e3e)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b43e74d3-0512-45ab-89d9-e1b88b7fb1ca)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         917d8d80-044a-4afe-bd5b-542a5bbabe15)(label(grouped))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         691e8180-e6e2-433a-8b3b-e2bb4883d702)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         15a0ec7e-89fc-4656-85c5-2c5de7edc530)(content(Whitespace\" \
+         \"))))(Tile((id ac24a5f4-e345-4c10-bfcc-71b7b4365260)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         57c2ed14-9e3d-4a28-b0f3-f0332553f434)(content(Whitespace\" \
+         \"))))(Tile((id \
+         73bd4877-2449-4b25-b8ac-d740bc73a617)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         df6c622a-325b-45ba-bd8c-eee34f2f57bf)(label(i))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         a2a139a0-b115-4995-b08d-9ffbbeb115ad)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         1dd493e5-58c7-42e6-b1c7-23a49c939c0d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ba463721-715a-40c5-9cba-645dda941004)(label(cnt))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         4763b610-c319-4c37-8c3e-18ddbf6d03ea)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f22e0a53-5c4e-4a02-ad34-4dade650e93b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9e915cf8-ee6f-4cea-ac1f-8abfd00f8d06)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         eb341b07-7d85-456a-8b05-aadd0791049a)(label(group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c25e4a14-0abe-4574-8f4d-48d9e7a07a9c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c2c105c3-fe4a-4bac-b037-2201bf3f40f5)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8a84280f-3ab7-410b-a1bb-be2b8714c93f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         899ac1b7-93f4-47db-af70-93ee2103243e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         8f9a1b60-9cfe-4040-bc63-e55f64dc668e)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         eff5e91f-2284-43df-a398-e316e809d9dd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5f058517-a8d6-44a7-aeb3-5559ce1eba0a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4d01dc1e-5115-4346-97d9-132bfc8b86cf)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         76d2d047-5d23-4adb-b8c3-89e64f0c2ae3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d8f63b15-e8bc-4535-9f4f-bdf3d0c15aaf)(label(+))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7753bff1-d883-4ede-b63b-4a4dff440396)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8765e03f-147e-4895-9149-b46d9ef7e393)(label(bin_size))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         4f614a86-d55c-4eb2-9091-e2356729a837)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4e34aa4e-a7a8-42ad-98b0-1a6d02ce25bc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ba660dbe-7feb-4b2a-8ce7-397c8eef9ea3)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7459dd3f-18dc-489d-91d3-22dbef7e8c91)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eff24a88-f9b5-4a3c-952b-0711bb064e3b)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         aa7e5e6d-a971-427d-8acf-18d6db23a454)(content(Whitespace\" \
+         \"))))(Tile((id \
+         08be0a09-e17d-42b3-9961-7c0bc5ff1118)(label(cnt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         b9af39f2-68c0-46ca-a7d5-9c6ee38ddd4c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c23ba785-566d-4877-97c6-3bf21adc0adc)(content(Whitespace\"\\n\"))))(Tile((id \
+         c993f0c7-21c3-442c-9e85-f5587819ce71)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f3e01b0d-e56d-442e-9ba4-afaf480880a0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0b5aa845-1fb4-4416-a254-e9d18e7c0c86)(label(bin))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b21a865a-1c81-4386-a267-6dd87a1329ac)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         95a8ad19-67d5-4fa4-a4a8-0fec9999b66d)(content(Whitespace\"\\n\"))))(Tile((id \
+         8444ea73-54ea-45f9-84c9-91221d911f9f)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e05d89ae-31da-498b-b43b-947be8de616d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ab424299-e829-4a69-b69d-99b0cd7f44bf)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         f0626f39-53b8-4739-9db8-2670d4ffe229)(label(t1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         733c90a1-6e9e-4c04-92ef-45c342779707)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7de39bf7-272c-4904-b217-7d26956e8510)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7f69e5b9-3766-4d90-8407-00b75ee446fd)(content(Whitespace\" \
+         \"))))(Tile((id 69d3c72b-7f14-44dc-b878-ca974c4ff506)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         021d9efa-e1b5-4752-a98d-7b740214c3d7)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         cfe13e20-34ed-480d-8591-84aa08b322f9)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         b90ad259-1045-4078-baf0-823eab82de56)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d7c85d6a-ad68-48da-83ff-32b97cd838c5)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ed601f94-e539-4abe-a72f-921f6d07cc55)(content(Whitespace\" \
+         \"))))(Tile((id \
+         403044fb-fab7-43ce-acec-d5a3091b493f)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d95efb61-fd6e-4a1e-9e3b-f12b7316a401)(content(Whitespace\" \
+         \"))))(Tile((id \
+         492e8c63-c227-4ead-9b2a-d566522ab926)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         1d7ff67d-3e6a-40da-a5e3-d9a8346b5310)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         6856d01b-b265-47f0-bf2b-a60ecb47d960)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7ad64593-6002-4a77-a78f-a68970787ebb)(label(n))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         072716df-9214-486d-af2a-4d5f75874133)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3febdc7f-71bf-4365-80b0-19dcb2c4dc75)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5dd45255-974c-4d1e-927f-670c272e7939)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b9264dff-3378-4c57-84ac-d4d7b82675ea)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         9d602ee8-1f9d-4c79-b4e5-31e9b78c2275)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e994ba20-4e2e-401a-9980-6d6d0635e597)(content(Whitespace\"\\n\"))))(Tile((id \
+         5bd985bf-9a47-4a9a-bb74-11a630d7f45e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         3317d4c8-d1b1-432f-afc0-9c99070eb280)(content(Whitespace\" \
+         \"))))(Tile((id \
+         02a17b43-8985-4ff4-b9da-50edc66423c5)(label(entries))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         521a3f90-859d-4cc4-a914-6a38c7b0786f)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         d0487687-602e-41cf-99d1-cf4626cda708)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0fe6a36d-ac15-43de-beed-be8cc1914691)(label(flat_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         12ce3f28-de4a-4e50-b2c5-71a323441b93)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         fc653bd8-3e02-49cd-b731-8b9759f30b58)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1d5856fd-acb1-4373-8ca4-9875fb15076a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         834ce37b-1aa5-495b-ad03-4efbe47fee40)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0192d37f-54bb-4e21-932a-e990e8fe7745)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         3f1ea01f-3f12-4048-bc6f-0c4e90fdd71e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         be9f6304-7ddf-471b-9bda-bea1b3daa5db)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         151661b2-9e81-4d99-84f9-b7c1b607f1d3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1f6c8794-d17a-4af7-96b9-8363f72269aa)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f25ec197-d58c-4adb-a005-c57aac2e4ec0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         a90284cd-4405-42e7-9b38-617b453c6060)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f3fcdcfa-44a2-4e9b-91f8-3f0f876da774)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         33e8e4ad-05f6-421a-992b-721e992af7f5)(content(Whitespace\" \
+         \"))))(Tile((id 6e919fe7-99cd-4079-a54b-66ce5a76c213)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         2f5d37e5-3eb5-40b0-86a5-7e76a2872e2d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f60ca670-2d27-42a5-8712-7bd68d9d6408)(label(e))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         20724ce4-966d-481c-bfa7-a6168d10ae5a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         77c134d7-0a79-4331-a149-27f6acee24b6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9ea67419-9ab9-4b11-accb-3485536f0893)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         61860a6c-2ff3-4f1c-bbb4-fcfbf9aeecc2)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e1ca3018-d71e-4b80-82a4-ce083aa43338)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         18b40197-ebd2-4c21-a3ef-dfb09ca0be03)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         55c32649-882e-41d6-b3b0-effe8461f9bf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         56a6720e-c6f8-4d06-b9b6-4a083a7f3943)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3a6e6c80-c6d1-4ec3-85fc-28b0f6983cf7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bc545a1a-e6ad-450b-8eef-aff72cfe2116)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         1bec7311-3e95-459b-b1cf-a9bee9bd4599)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e7025510-0228-4ac9-b265-e9890c4c660e)(content(Whitespace\"\\n\"))))(Tile((id \
+         ff224483-2196-4cfd-b390-194b7be787c8)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a4234089-8ce6-45c7-8803-47b2bae09164)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c88485b0-f8f8-4fec-8068-4dcf3cdae992)(label(vals))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e7e72f9e-c455-40ae-a7fe-e35b7c58bd18)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         0d957739-44ca-43e2-ac4a-72eee88ab44b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         43971d46-1518-46c1-bc00-e836dd6f79b9)(label(entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         64b5f54d-d634-45c8-99d6-9df9527b597f)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         a1f8b857-74d7-43b0-9f7d-db54433a7dac)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         4de296ad-8d4b-433a-9827-85abe970d6d3)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         90760c81-5060-4bb3-a0d6-77006294d33e)(content(Whitespace\"\\n\"))))(Tile((id \
+         fbd3fb0b-a35d-474e-acd6-ca9b4e379aa7)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         cfefc8fb-7c87-4e89-9b50-13b602f46d8b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         90ebf174-16b1-4dd8-9a53-04d2fa3c0354)(label(bins))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         8106c4de-1202-43e3-895f-b6b622ad4621)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         b93e3166-dd13-4da2-80df-b943d4819ca4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8415ebc6-b136-44cb-b3a0-22a2e7afb494)(label(bin_int))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2d34f2bd-8866-4ec1-9ca2-c9090991b798)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         85bd06fd-71a8-4f08-9405-f1d4ff409600)(label(vals))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         68ced70a-5eae-4fb5-8e05-8bb567ec8fbb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         314cb1bf-b06a-406c-89ac-17347b7a94c4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         644d05bd-1337-4050-8b9f-40fbde005765)(label(n))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         91b699c4-c796-403b-a51f-d9d1742d2029)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9e0492ef-fb6b-4feb-90ac-fabb133c0a3b)(content(Whitespace\"\\n\"))))(Tile((id \
+         8e8b5dd9-7dd9-4c36-9f58-8b767de00269)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         304c86a2-91ae-4e7d-ba7c-919cebcb0bb1)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         9151c0b5-afbe-48b9-b27e-efa7efe4a11a)(content(Whitespace\"\\n\"))))(Tile((id \
+         138a75e5-a655-4bce-8278-3aec274fdf21)(label(bins))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         805c343b-e592-4150-96d0-6fe8a0e569b4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         02dd853d-420c-44ff-8ea0-37c63954fc0a)(content(Whitespace\"\\n\"))))(Tile((id \
+         249c3bc4-165e-4dcf-9ff0-bbc04c04fd7e)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         0e9d9894-9e70-47eb-9a3e-bbb00aa39725)(content(Whitespace\" \
+         \"))))(Tile((id \
+         94c88042-2348-4c88-9359-c5ad4f9b904a)(label(e))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e803105c-be2c-4699-8c4a-fe718d1ca4b0)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         916fdf68-b58d-4779-8d26-984e3b4eb295)(content(Whitespace\"\\n\"))))(Tile((id \
+         23192233-9389-445e-b167-7ad41679c9bc)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d7168ddd-62b9-4a66-99eb-3967fea5044d)(content(Whitespace\"\\n\"))))(Tile((id \
+         bc6f61d9-41f4-4f8e-bec3-983ac04ffd43)(label(...))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         841c6786-a01a-4cea-b7d5-fc2e0799b6ab)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cafd1642-31e1-47f9-a544-5f361a3b17ba)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         bd97a028-713f-4544-8d3e-061c06dbd59b)(content(Whitespace\"\\n\"))))(Tile((id \
+         72ce0db9-6fc8-42b3-bf8d-8dc2eda24c7d)(label(group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d2008f38-1719-4079-9218-f7640cc81509)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dff61661-ebe3-4bdc-81d2-5cfce38a94c9)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8899281f-ef94-4268-8f70-cabde0a21a52)(content(Whitespace\"\\n\"))))(Tile((id \
+         e7047d89-a340-4fcf-94cb-0c5541b788df)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         33e234ad-2b89-4509-8223-49b877843191)(content(Whitespace\" \
+         \"))))(Tile((id \
+         191f7e39-780b-40bc-abed-7c1a35392d5c)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         23fe78e2-9fcf-4307-89da-ca5b347d87f1)(label(group))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0edc15bc-7fa6-4064-946e-f1d9811ca1b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         634626fa-5fa6-44c0-a04c-c0ee2cbe418f)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         c29cb217-22fe-4034-bc5d-97d3766b3140)(content(Whitespace\" \
+         \"))))(Tile((id \
+         089f6c2d-dae6-4661-b48f-9b279d51b42b)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         d932b6e5-f348-42a1-9490-3f497c18bc31)(label(min))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         217a3a11-09a6-4317-b410-d85e53e8c278)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         c85b7367-fa59-428f-a60c-e42f692ee467)(content(Whitespace\" \
+         \"))))(Tile((id \
+         12906b43-2514-4ade-ad91-32ffc6da06cb)(label(max))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Tile((id \
+         c0248d6e-666e-4d09-91d4-adbe5ee125ae)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         b27fa75f-a17f-455e-ba57-67ffcddcc7f1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cd4868d3-f6cd-4f80-a53c-1e7b32f4836b)(label(_))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         b61e9820-161a-43bd-b371-23cccced2ae5)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         c8eb3ff3-7684-4ca9-b3f6-c4a1b3bed2c6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6a806295-b24b-4f13-95f1-543ae9a50fb6)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ab2a2099-2e7a-41d8-b4a2-3fd644fda38b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         63cca569-e196-4f56-9acc-b7178c5f71fc)(content(Whitespace\"\\n\"))))(Tile((id \
+         0c8cfe38-d6fc-4aad-bed9-96158b61e001)(label(string_of_int))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d0cf35be-632e-4d78-a072-796572988f09)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4c42a252-c09a-441b-86f4-e6c9ee9c3e35)(label(min))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         58e88fe7-5c27-4885-9d5b-1fa2e0dfeb64)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5ae5f068-d7fa-4bf9-9f8f-676ef7110620)(label(++))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         838d26c7-a7c7-400f-b78a-74918c83d558)(content(Whitespace\" \
+         \"))))(Tile((id 3ade8381-a2a3-436c-ba4e-82e6adb6d204)(label(\"\\\" <= \
+         \\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         67e6e4d2-4c70-4d9a-b2f5-2ff265d1a3d4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8d035f28-4e79-4c7c-b125-ab3e4eeb5cee)(label(++))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         25b00237-a67e-44bb-ba5b-438abb0f9d0d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f78744bd-8bd0-47ea-bf30-d35c1042d66a)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d4cf5ca9-3352-4850-a25b-209aad6a4239)(content(Whitespace\" \
+         \"))))(Tile((id \
+         85fa89a5-c9a1-45df-bedf-64b85817696f)(label(++))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         67361b6b-8531-4d1e-b0df-16c366fc47ed)(content(Whitespace\" \
+         \"))))(Tile((id b68741d9-4c51-4811-a37b-c0602ff9e827)(label(\"\\\" < \
+         \\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         28bff25a-1687-44db-ac97-4b8822b20d3d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         663a5e48-a128-4eed-bab8-19f49fa3e93a)(label(++))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         55b2ba51-7d30-42bb-a84b-da25c2d226d7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8525c9a0-6212-4bce-9b08-f1a89841d04b)(label(string_of_int))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         50b6e15d-29f4-4376-bf66-333647e33a26)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         9ea840b0-3a76-4142-b6ba-0068de962038)(label(max))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         4a10454a-be86-418a-8545-c6d67ad10814)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         1dba3a92-2ce5-4033-943f-9f2dca9e942a)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         457e1924-808c-41a1-8d11-f051267a2c3d)(content(Whitespace\"\\n\"))))(Tile((id \
+         edcb5b13-decb-4057-9d77-694f53035c05)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8c3538c3-113b-47da-96fa-c37e63b92325)(content(Whitespace\" \
+         \"))))(Tile((id 8ad048c1-0f7c-49f8-9f5c-a34dc2d75027)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         ddfdae37-483b-4e17-9862-747aa37d85fa)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         fc88e2c9-b0e0-43f8-a560-609a7363dddb)(label(group))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0ea0ccd1-9327-45e0-b5b1-70b15f7ddbc3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1ae3a8c3-52db-4a9f-a0b2-cc5447313acd)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8c579930-0de3-4da4-9dfe-939bbf06703a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4c942d84-f410-411f-b861-3b4f718bef63)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         2a8cef86-fc04-4484-bd02-439b1bc8c194)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         709ec0ce-cac9-44c0-bd77-d42d02580565)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b863428e-0181-4a45-acc6-9c7347867d39)(label(count))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         520d9865-d6de-46ae-954a-39fbd22a168c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1af987b6-bace-4d4b-9188-09ba503d597d)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2480c60d-5ef4-40b7-a94a-c2c5cdb1a211)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b2b547e0-d4a2-4d70-b790-c2bbbb642093)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         fa069447-e6f2-4bbd-a196-999690861593)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         841d7978-b383-4d57-828e-0c391f99efce)(content(Whitespace\"\\n\"))))(Tile((id \
+         a56b991e-f43b-408f-b8cd-e5600c557921)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         10f81670-3474-4861-b514-a318203690ef)(content(Whitespace\"\\n\"))))(Tile((id \
+         47560cbf-d823-4cb8-b5e3-644138233dcd)(label(bin))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         30ea037d-c3d8-4906-8ded-505d805114cd)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e4b64595-1c48-41a5-83b8-f5008653de3e)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         320b99de-3729-49ac-b5be-fe8b7adec1e9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3a4a51d2-097a-4e3c-8fee-fe2295af5fed)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a1de1655-8f29-4476-9c17-e0aee3ce9a8b)(label(\"\\\"final\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         036cbbf4-24eb-4ba7-bdb6-5faec6a671ca)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         70c8717b-7101-49bf-bc08-39f65055daa2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         46332dd1-2cd6-449b-b5d9-2ffa13900929)(label(2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         7c33c98e-c909-4bd1-93d4-6f3be0f8213a)(content(Whitespace\"\\n\"))))(Tile((id \
+         573585c2-d756-4453-aecb-c77954f60eb4)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5182587a-a721-4d9f-9e1c-c662620d8515)(content(Whitespace\" \
+         \"))))(Tile((id 99f68e55-01b2-4746-959e-7cc7c00bfe02)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         272a905d-a4f8-4aa3-9683-627bfd01829f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         7aa45445-88e5-49c0-98e5-2a5bcbe8398b)(label(group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         05fea31a-b916-4d90-94a4-db07ff12c989)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         15f5cbad-8d5f-4236-a525-0639da919dc5)(label(\"\\\"76 <= final < \
+         78\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         722dcf07-4867-4efe-82dc-72843936d39c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         323e605c-a09e-4377-8756-7ce4a73b6d6b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9e48c281-ec07-4672-9ebd-3a97d5c2cf00)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d8cfa756-a790-45ff-b2de-8519accbf5fd)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         38c1e36f-87d7-4653-b253-ccc96bf30c3e)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         dc1b8027-6cf9-4101-b9b5-5eeb52253c26)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         553bdad0-77db-4743-9769-e9474e2db2d7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5795b30f-8cfa-437a-a749-47bba9476fc5)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         f31017d0-5a73-477a-bcaf-98b2635f9000)(label(group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         29f9870b-2cdc-4bab-b04f-418e230bad4f)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         79a62e01-b843-4d58-b193-fb5316870747)(label(\"\\\"84 <= final < \
+         86\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         9891577d-5d29-4354-bb86-6fc1b54f8925)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2791c4c4-21f7-40e8-b3e2-1c7a3b844b57)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c69b4334-d7bf-489f-a22c-f5914f6d6454)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         85b6305e-20d6-4b9e-9834-e0b03e5456fd)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         ffee503b-8d5b-4b10-a357-3455870673b0)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         6300316b-ab49-4855-b208-644b94a22a14)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9054bca2-dfae-4cb4-b253-f354188b98b6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         94f0cbe4-51d9-4cc3-856e-cce7050bfba0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         6f49a1e0-cdd4-4f05-b416-f5f4d180ccfd)(label(group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         caaf3087-4c69-45e1-a3e5-97e2538428f8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b12c699b-45eb-466b-a37a-b343e1bd9220)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a0b71b30-39f3-4d47-a6b6-88a2ff932343)(content(Whitespace\" \
+         \"))))(Tile((id 33523aa3-9a77-4a0d-9c96-c9612e370c9b)(label(\"\\\"86 \
+         <= final < 88\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         a8634855-1e6a-4f80-b0a9-23985cf3456c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0249a943-89f4-48da-ac1b-63d0e878ec55)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dd7d71d6-d3bd-4080-9980-522546351810)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         bacccf53-b4ba-4e6b-a2a6-ef5607ece115)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a1a19773-40f2-495d-8ac2-95cdd6297f9f)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6b8bc1d5-06f3-46c7-9b56-cdd874dc8c6e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         417377fd-754f-43f4-99ce-ca4c455f4b8b)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         59b37b2e-615c-4e87-b8d4-0e22427780c0)(content(Whitespace\"\\n\"))))(Tile((id \
+         fa521070-9ca5-4af8-bcf6-8b821257bbc9)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         39c8f3be-80e0-4392-ae54-e3259e7f1964)(content(Whitespace\" \
+         \"))))(Tile((id 0625203c-adb9-4f3c-bbf8-7054eb947cf6)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         8e91b52a-d2f8-4096-bbee-3f1800125e97)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         dd1a9c45-7111-4a0e-b5bc-5bf7ef75bfd1)(label(group))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         33dfadc8-3d3b-4793-ab95-abd75a210025)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e0fd4b20-311c-4412-999f-186bd4cb24e9)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         211e9163-9254-494a-9c4e-331f1fa6aca8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1480f384-4e35-41bf-b1d1-4c51ace855e0)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         81932b81-26f3-45e1-885a-9e437a58285a)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a3e4dfff-4670-4f72-abfa-3b247c6a04a4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         25861097-6bd9-4d30-8489-d3fc982a4d11)(label(count))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c6577032-0c30-443d-8933-6ba2515b0c78)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bfab0ebb-9ad8-4860-82a3-c4812769354b)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7ca15cda-f395-441c-96a3-d2d265037d94)(content(Whitespace\" \
+         \"))))(Tile((id \
+         55467f01-f3c0-4f82-9d40-25ae860cdb57)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         21cb934e-8ee0-48e1-be57-8606065c931e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2ae6d847-773b-492c-b5f2-0a732dd5c023)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d797333d-c3b6-4852-add7-2e21224ca966)(content(Whitespace\"\\n\"))))(Secondary((id \
+         9bea8740-2032-40b5-96f6-455d29531021)(content(Comment\"# This version \
+         takes an explicit projection to gurantee the requires \
+         constraints#\"))))(Secondary((id \
+         35242c42-80cc-442d-ac5c-9295d640f73b)(content(Whitespace\"\\n\"))))(Tile((id \
+         a37e7ee2-98e9-46f2-9b3f-ad817a10446d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         96d6038b-4063-441c-a6af-39e8f8987add)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d438fdc5-e324-47a3-97c2-c6479d046614)(label(v2))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         368710a0-3236-4912-9218-67b9f04d14d2)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         df3adee9-78a3-4554-bcaa-60637b61a4d9)(content(Whitespace\"\\n\"))))(Tile((id \
+         d8349996-b89d-43fa-b5ab-55bac785eff7)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         bca9ad11-e04a-442c-81ec-fb34683e22d7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         56387f0a-ff44-4bbb-8db5-7d90a2bf89b4)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a9b4bb2e-c820-42ac-bc67-bdbb4384c803)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         98b6d6bb-c316-450d-8d7e-b467870cec89)(content(Whitespace\" \
+         \"))))(Tile((id 719197a8-fd27-4637-b36c-b5219278acb2)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         64f44f18-f701-43bf-b6da-c41ed71cab05)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         1c774d0e-b217-4e7f-b37f-e83c84af0ab0)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4f6226c7-665f-49d5-b9c2-bae6932153f3)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         b00c339e-b0dc-412b-912f-486d3d29b2ad)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ad3394be-a1b5-48d9-b2e3-ff3b201cb8fa)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         21556202-29fe-4529-9457-2c17f1406a03)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         afe2bd42-e212-4ff1-b062-eab2ace16d1d)(content(Whitespace\" \
+         \"))))(Tile((id af6955a0-bed5-49b2-bdcc-cafde40118ec)(label(\"\\\"c \
+         is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
+         Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         8d19ed3a-8e0c-436e-9caf-9a401eae61ed)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         47ff33b4-2b8a-4af1-aa08-965d823d9c7b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4fe52e78-1301-40ff-a43a-8f9e9cc73bbc)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a4226b02-d341-4f2b-aad6-57f564c8680e)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         37e99090-c121-4a36-af5b-9d115a2b1e84)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aa8eecdb-1053-4d69-a367-8c31d6abcb8c)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a45b88e5-5288-419e-899f-b572e8b4568e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8877859d-b7a9-4a2e-a8ad-f7ce308c1061)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         46988e7f-1f3f-4bd3-b1a9-a34868efbd87)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         df870830-00f5-475d-b27f-22eb2af4cadd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3840db41-2418-4924-b66f-ebf3d25c6eee)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bb95a478-faff-4b80-b5e8-cdd0b9461372)(label(\"\\\"schema(t1)[c] is \
+         Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         4e4e30d2-190b-4d5b-a4fa-ddaebe0d43d5)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c9919e7b-f244-4555-9a9e-2a44cf943c13)(content(Whitespace\"\\n\"))))(Tile((id \
+         6db0a802-2a04-42b9-a096-d6d6161c9fe1)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         58ea7060-c9cf-4dcd-8ba9-62fede659fde)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f30412fa-3869-41fd-a2f9-4afebcf26957)(label(_ensures))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1ac2bbbb-4535-4be4-865c-a9c5f2ca0a02)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         8cd19c1f-e47c-4dff-88f9-e11fdaf2ea8a)(content(Whitespace\" \
+         \"))))(Tile((id 5da679da-fb22-44d4-80be-da29ac2b4dae)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         b91fbde0-5a5a-422b-8720-922cd62e1472)(content(Whitespace\"\\n\"))))(Tile((id \
+         ff3772c2-d6e9-41b0-a5de-004bb953fc7f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a0b2811f-d808-4498-b5ae-3e08192e857e)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3eba49cf-c443-48f0-987b-0ae405fa9ddf)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         b2ee7c62-abba-42c7-8d3b-6d5b989d5fe7)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a402113e-9b0a-46e7-aaea-76d5a6992722)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         13a7a4e1-78fa-45b9-ab83-2dbb5b533f4e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6398dcbf-1c9d-479f-b3b9-cbc27bb6090a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         86ac1af5-6801-4ddb-9f34-789615f9ef5c)(label(\"\\\"header(t2) is equal \
+         to ['group', 'count']\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
+         Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         e6aab8e7-a335-43ba-805b-50a2ba895ceb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d6e05c9f-b68a-4810-80a3-1d0ef7932494)(content(Whitespace\"\\n\"))))(Tile((id \
+         af7d6cc5-d4d2-4288-bb4e-cd23eeb5c128)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         093b3cb9-bc98-4a8d-9e29-f0f5e93a45e7)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c89b0dca-9476-4b06-8d01-68cfbf7c9df2)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         046e8ba9-c2da-48e3-a53e-4416441369a5)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         eb62ef48-c71b-4bcc-a0d0-5badd3776580)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         fec13e9b-84ec-48a1-bb8b-ae18dc671ac3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fd946270-1c9c-4dd7-9056-6215b2ae03fa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f5554731-0456-4640-81fc-9b787709695d)(label(\"\\\"schema(t2)['group'] \
+         is String\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         86cc2c16-352a-4fa6-af0f-bbdeea24cb7e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         79f7fa50-3a6b-4707-b795-39e4aacc3b47)(content(Whitespace\"\\n\"))))(Tile((id \
+         f5d67f95-22b8-4da1-b6fa-d5cd7a6624b8)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         efa45fcf-ae64-45d5-bc58-2dc9d9a9cb87)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b40bbaff-4e81-4f7c-a712-f4ffcd2ffce4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6b2cae2b-7ae7-4478-b3ca-d6839bb5f2b7)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3d7eeba8-62fd-4932-8756-91914f11afa7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         621ed336-f0ca-41b3-8d9b-6e2a4ffbeda3)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         3cc9bf1b-abd3-43dd-bbe5-f3674c217afd)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         2da6cb42-de0c-41c2-be86-112aac4e0d97)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8ee5d485-c1bf-43ea-bda3-b87d6f6d43cb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5c08fd79-42e2-4e2e-9889-a2b20fd19e62)(label(\"\\\"schema(t2)['count'] \
+         is Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         550113d2-3919-4bdb-9afd-b9f09c4ac52e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         78c3e9f8-3aac-4bf1-972a-692d23165968)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d168a94b-12da-4ee3-8d55-cc412044c1f9)(content(Whitespace\"\\n\"))))(Tile((id \
+         c68df88a-bd32-43fd-8b5f-c41f338f1903)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0a9e2a60-efd8-4bb2-bab6-f42db91cf5dd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5cc0668d-2cea-4227-a62a-2e8a19ba5e89)(label(bin_int))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         8a10de5b-c2a8-4fb8-8d1d-29a6bd6fb5ac)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         aa281435-15f4-48d3-938a-7cead2b6d6f3)(content(Whitespace\"\\n\"))))(Tile((id \
+         a874cf54-aa2e-4e7c-b684-b735fe5d2349)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         c15591f8-eecb-4710-be3e-e5be75bff37a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         479135a8-69a5-4ab7-8635-663f46ca9132)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         a5d73e59-b8b1-40c5-a7dd-824e2668916a)(label(is))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         991a8f52-f2cc-4769-8133-dd639b5abad6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         beaabe07-c504-485b-a04f-1c629a81ce29)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cae9ae8b-0464-43d1-a184-e7faa8e8d669)(content(Whitespace\" \
+         \"))))(Tile((id f5228afe-d292-4b99-b5fb-a628b47aca5f)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         e7f9f28f-3cb0-4356-a2b7-66264384b5a9)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         90e19c2a-26a3-4a03-b363-114c91c83f62)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         6d9d7ed6-6562-4f18-842e-afbe3f613c82)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d8525c31-b82e-4b3e-a8dc-1a623072226a)(label(bin_size))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0502a89f-38ae-42ba-ade7-811815934030)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f29bfabd-12a5-44a5-9559-3ebd94718be4)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         194db216-68b9-4809-aaac-8040f0e0fde0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         40e63d33-c667-4be3-999b-a8f18bd3d365)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         a55b4ae0-b28b-4b31-9479-635467c2cae3)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         700776e4-3642-4613-8b75-c8cb100dfd63)(content(Whitespace\"\\n\"))))(Tile((id \
+         4894c20e-9caf-4f1f-a2ed-6048563adf80)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         4b9df15d-2b42-4856-b000-f25e8e9242a6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6651fb57-c602-4bad-883b-84ecf7932944)(label(floored))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         2874149b-7afb-44a9-a9ec-bb9b3671c0cc)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         78afaece-7dcf-41ac-bd2e-8a6175b8c099)(content(Whitespace\" \
+         \"))))(Tile((id \
+         93f5535b-43af-44b8-838b-7036b58b1b7b)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4e40c4a4-e7e7-47df-8d75-846655590b50)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         74f1a48b-8b6c-44bf-96b3-8d1b8d16a6ee)(label(is))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c90a35ed-b829-434d-adfd-739b567fde8a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5deaddab-5756-4fa4-97e7-e33344eb8710)(content(Whitespace\" \
+         \"))))(Tile((id e462d2c0-05a3-40bc-8d01-2d8cd40fdc2f)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         71e269c3-706e-4c32-b425-6153e9ee176f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b3089075-1add-4305-a28e-b06fa1f5f7f2)(label(i))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         57ca8fdb-c59e-4488-9e2b-8705ab2777a7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9b295492-7dd0-453b-ac06-fcb21ec08b45)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b49a3161-ac1a-4d3e-bb20-d4dab4f72c3d)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1bcc4a3a-a37b-4fa8-8016-7966e4d4c4dd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8234acce-50ed-43c2-9ea9-414f50b44b38)(label(/))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
+         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         93d8d078-870c-4de6-8c84-03c05b822d8c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eae0e5c7-ae35-4df8-9357-a9b3bace0b26)(label(bin_size))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ba33d547-aa3e-4b9f-8349-31fbca2bd7f6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9bd7c754-762a-4f32-94e6-b828f1e4dada)(label(*))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
+         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7781efa9-667f-42f4-80d6-7f1d54508720)(content(Whitespace\" \
+         \"))))(Tile((id \
+         80e15829-7d6f-421e-8e30-f30c123c907b)(label(bin_size))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         4945d7ce-8f27-4ddb-b319-9a88ee24682f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         314e3d93-df8a-41b4-8c7e-8197741571cd)(content(Whitespace\"\\n\"))))(Tile((id \
+         2e20f91d-f8d4-4729-893b-52ee1414fba2)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         d8ca109f-b61d-4edc-a781-38e94e3e984a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e57a58f8-7bc3-4d5f-bf0b-766a9c2f6bff)(label(grouped))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         65d8c588-3df7-4b07-8dc2-120bb4ba78aa)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         041ec81d-ce16-40de-9f7d-9c290e6be560)(content(Whitespace\"\\n\"))))(Tile((id \
+         35b01f84-133c-4191-bffb-f0265c7b9599)(label(fold_left))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4ddfd457-c612-479d-8e91-a46d0a02a1e1)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a52590f9-71d2-47e5-a9a5-213a881ea43f)(content(Whitespace\"\\n\"))))(Tile((id \
+         ba7f7585-6313-4751-a418-f43bbcc05363)(label(floored))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2ed27396-a800-4800-a589-801579cbd838)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         46b5d824-3aac-4410-942e-cad96af3bd90)(content(Whitespace\"\\n\"))))(Tile((id \
+         3ea52f7d-c095-436c-b33f-3f18f8f5ef87)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         4c8414c9-945e-4a9c-8ef8-41819aa35507)(content(Whitespace\" \
+         \"))))(Tile((id \
+         45071d77-b49c-4a69-bbf9-1bd1ce13f2db)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Secondary((id \
+         766fbab8-9cf2-46c7-bb44-01109c804fbd)(content(Whitespace\"\\n\"))))(Tile((id \
+         74d228e8-caed-4058-a803-0815148bf8bc)(label(acc))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         a94927d1-552a-498c-b2e1-a1d624975fb5)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         36fd0291-1ff6-400a-9a5b-7cfd3fe1ba14)(content(Whitespace\"\\n\"))))(Tile((id \
+         d7370179-2e1a-4834-b558-ab9c97c972c7)(label(i))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ee67bae8-7017-4f59-9f32-d4eee4055229)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         6c6d4ad9-0c65-40d5-a794-0e44c78a01f4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         62ee7b2b-5439-4b62-ab97-a0d0dd72d663)(content(Whitespace\"\\n\"))))(Tile((id \
+         3b5bc1fa-0311-45b1-801e-fab7b92aecbd)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         d6a56c09-e51f-416d-ae68-ce9c780232e5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3a66e4e3-3a8f-458f-a8c5-d73b898d14d1)(label(find_opt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         676ee041-f1bb-4581-b248-2af70d97fc3b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         dc9fa1e1-d273-4f66-a7b2-b82ae0ae78f0)(label(acc))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b97bfa39-162f-4ffe-bcd6-0ae308c8d64b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3e2e06a4-29dd-4b38-b433-40040b327f65)(content(Whitespace\" \
+         \"))))(Tile((id a4b3e15d-996b-42f0-a16a-10f51ecb8c9e)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         cad68f81-5bdd-4b1c-a156-76d80cf1609a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a7a34c48-fdef-459e-a46d-d243f6f9b087)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         e22658ae-569f-473b-a6b7-ee942f9387a7)(label(i'))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         8bd3b973-e1ee-4874-9ce9-824efdd67561)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         7d8356ca-60fb-4ee9-b731-5f3b285c4de3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eff0a8ab-9f21-4b0f-b66f-62c1a8aa2af2)(label(_count))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         a936d2af-fee2-40dd-93ab-3c483fb8b3f2)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5322ecac-1845-4e86-9912-00ee1edebc97)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e94865c4-27ba-4fa8-b49b-7c797368014d)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b1452ba5-35a5-45af-a193-a3bf8f42b981)(content(Whitespace\" \
+         \"))))(Tile((id \
+         77626780-065e-4a89-b73d-e23d2402df9a)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fc817538-f816-4aaf-99a0-464eb0a4b864)(content(Whitespace\" \
+         \"))))(Tile((id \
+         89bdeb80-49e5-4bed-b96c-7c8a35735045)(label(i'))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         1a6e312c-5681-4627-b08c-473a112e0a57)(content(Whitespace\"\\n\"))))(Tile((id \
+         5286d7c4-3148-46f4-84d3-37417525a133)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         661cb7ba-d8da-49ce-ae62-efaf523d5ac4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9291713b-a53d-458b-ba3d-92326eb446f2)(label(None))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         170031b5-72cc-439d-bd38-429b892723ba)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f42bf1a6-0dff-4b3f-9a6e-cbe6edda9e74)(content(Whitespace\" \
+         \"))))(Tile((id \
+         53b2eb82-63b0-43f2-a15e-d51c3477d2a0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         8cbf8d6c-5834-4a84-bf5a-7ae3d2887216)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         20efc73c-0797-47d9-9816-8942cfd686ba)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         eacc4a71-93cb-4bdb-b334-c10e2959c7b3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         43b5c409-97c6-4ba4-8e57-29b2ed33b6ec)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         89d2a406-5293-4303-8350-81e087176bde)(content(Whitespace\" \
+         \"))))(Tile((id \
+         789e8727-839c-4f70-af4c-74fe70ec9f07)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d0eb44d1-838f-4558-bd81-b573738ce551)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fcbb64a5-9488-4fc7-ae7b-ec32751f3e22)(label(acc))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         02048293-658c-4ca7-b0a6-5819d6eea253)(content(Whitespace\"\\n\"))))(Tile((id \
+         d798a6b0-a5d5-4a30-a70f-1acfc19c5c36)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         effe950f-b253-4b28-af7f-9ecbaad281b6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4813f4ed-57ed-4db9-b0fe-fafa23d48495)(label(Some))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         f6f24d2b-cf08-45cf-80ea-643286220c73)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
+         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
+         ab9a716b-8b18-47d2-b538-45b7672ce54f)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         d6ca414b-740d-42a8-8446-51d5f6b7b562)(label(i))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         e3246599-054a-45dc-8031-63f553b2812c)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         a2da0831-fc98-46b0-86cc-24e59b84a67f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c567fb7b-829c-43ff-b167-f4313d0e8201)(label(cnt))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
+         a6c1c9db-64f7-4208-ad1f-6ff3dc606be6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         1b14dbe3-0b4b-4007-b815-d3c92a76f9de)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0f6b7030-27d1-405f-896e-960115f9f5ee)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         11d7b41a-90d4-43e8-b622-c2d5f29ca46b)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8488c30c-a21e-4b0d-a15f-f4b989f1d778)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         93cda984-30e9-44f2-b464-3236f558b3e1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6b04ffe8-2591-4deb-8b71-f8d8e2330f41)(label(cnt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d65f2729-66a3-4aba-968f-7136a4819e33)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a04dafd2-1bf1-45e9-8d66-e7feb611e8a1)(label(+))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ad1b6122-0578-4791-b491-6409a6e2e739)(content(Whitespace\" \
+         \"))))(Tile((id \
+         987faff6-2942-4b15-bbf3-151ecdc54209)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         b06807de-2a0f-4d7e-986e-d35ab570c1e2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a5775dba-fd5c-4675-9ce5-a04f35d408b1)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7c076fbe-1598-4149-9f61-c026de4d335f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7f5c4234-07fc-4479-b9ad-bd965f563145)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         331c83cf-0600-468c-a334-6e555923eed0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         292c6b1e-534d-4070-bcbb-e5a4b9287e91)(label(acc))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bf7bd847-5603-4e14-9c04-f56ebad19e94)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         61a806c4-35ff-4885-a6bd-5fd5376ac25f)(content(Whitespace\" \
+         \"))))(Tile((id 8355224f-070c-4023-b947-cb7879c9ff4f)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         dc1182e9-2fef-46cb-a64a-b964be839862)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f7b42e92-aba8-4aad-ae5d-fa441b558633)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         b356c867-d62d-4eed-9a72-1ae4a852c361)(label(i'))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         2adcbc44-a6fc-4b56-8e23-db784462225d)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         8a11e6e2-522f-4c35-91e9-fc3e860adf8c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ccedf1c9-8241-4907-8362-84d983ff90d5)(label(_count))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         edfa4714-57cb-4060-a79d-fd2035261a88)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         33b40589-aa1d-4596-95e2-41018023fb0f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         09c84b34-6719-4e4f-bacf-c759735ce015)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e70d1b66-a656-4368-8b00-da6162cf8ba9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e0509e2e-328f-42bb-b758-0a8126a87e10)(label(!=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         002bdef3-1682-413c-9931-5fbd79d0d704)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ba3347a0-3417-45b1-9ced-9f5adc9fd76e)(label(i'))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         046dd352-47cc-4bd6-9886-a925ad577fca)(content(Whitespace\"\\n\")))))))))(Tile((id \
+         b72bc09c-9929-4e37-a247-ed9f6e3cc6b3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f8f52ac2-26a7-4072-9ebc-91bc50dc1d21)(content(Whitespace\"\\n\"))))(Tile((id \
+         ba72c368-0c71-4d33-a371-d0c0231659fc)(label([]))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         0c7a2a36-acf8-4597-b427-26d733b30430)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         897662c0-c420-4d51-a5f8-1a3c1cf4bcd4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c4ceb0f7-7b63-42fd-a1e9-7bb6b65fb784)(content(Whitespace\"\\n\"))))(Tile((id \
+         3550dc5f-57f6-47e9-b231-c2cfe3206a29)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e14d93c6-a332-4ee1-a2a6-611487292a8e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         eef497a8-7a27-4a47-8e47-d3beabe9d01c)(label(grouped))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ca0c6c21-7adb-45fe-ac13-71daab9fcd15)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8dd1e0b6-6563-4777-90ab-b9300cfe3700)(content(Whitespace\" \
+         \"))))(Tile((id 5d0c0b6f-426f-4669-8d30-9d89dbe01302)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         bd1ec6e2-38e7-495d-ac38-59abbf17e431)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e0bcf73c-9934-4ceb-82fb-bf3568b7609a)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         222f4aa6-f21a-45cb-b4c3-745d5bb8586a)(label(i))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         f8af8bd5-4a8b-4e0b-89dd-93b636918aae)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         f65581b8-ac22-45e0-8495-a0bc1fcd0c81)(content(Whitespace\" \
+         \"))))(Tile((id \
+         82b76613-bf0d-4e74-a8df-ee2f5d61e5c8)(label(cnt))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         b0f34905-fc8e-4b52-931b-029f62891974)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         23f00e01-3a71-451b-8d11-d365c08c4ec0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         07f1cf66-fdbc-4db9-8c97-865a4721d188)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         8bd1ed91-ab41-47b1-b2fe-fe96bd84f398)(label(group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e4066d43-45d8-478f-ace0-df1cf1b002d3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3055be50-541a-42e1-ab59-2817a455d31b)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8e79e940-461e-411e-be82-7e36b52da849)(content(Whitespace\" \
+         \"))))(Tile((id \
+         03065904-0de5-4402-bb46-50b98789fe5c)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         698a2160-46ad-448b-b14f-857340beaaac)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         811463f7-eb90-43fb-8210-12c8b93e1a8c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2474910c-faae-4e03-b6ae-26e6dac242b9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1e88fb7b-bcef-484b-9729-4106f61052d4)(label(i))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b02a7362-9e04-48c3-a2f7-746b069b3edd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         59764925-cfaf-49e6-9d73-56cc50132bcb)(label(+))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6902a261-b443-49aa-96ab-eeaefca62fb4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f214d280-9f5d-4768-b375-280fb847bd06)(label(bin_size))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         dcca1a68-d17b-4abc-a38f-06ef9274f168)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         447e6847-5972-4f97-890c-f2de777b3772)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fca40cb6-1775-4095-a612-84cda95ed52a)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         44c3839a-83e6-48f9-822f-74154c116242)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8637814a-983b-458d-a7dc-c6a9feb6a44a)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4a82e52f-3a40-47c4-95b3-88b98c2a2fc0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d3a760b8-a74c-4ddc-83aa-04d7ac45794b)(label(cnt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         11bae21f-d9a1-4838-8767-aa3eecc73d52)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         b19a2ea7-be0a-4e71-9c7c-4978932785be)(content(Whitespace\"\\n\"))))(Tile((id \
+         b226f865-a6fb-4d54-a6c0-d24d764fadd4)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         d7874235-64c6-4943-a713-57260056d311)(content(Whitespace\" \
+         \"))))(Tile((id \
+         56153434-7217-45c8-843e-33b13f353545)(label(bin))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         918b82ef-8008-4b92-a636-03d5324f4327)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         4bbe3745-df59-49a3-99c2-17da2fbc1199)(content(Whitespace\"\\n\"))))(Tile((id \
+         c277e371-e6de-4e72-9276-d4946d9c5df9)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a5b799ae-1774-4ae7-a471-696b1c004691)(content(Whitespace\" \
+         \"))))(Tile((id \
+         129e7d7a-b40e-4d00-85bb-c3a20a8d2e87)(label(row))(mold((out \
+         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         4d8350f7-0e24-498c-a16d-1ff2e9b3a5a2)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         77e256d7-88e1-4e9a-8cbc-df19ccccc84f)(content(Whitespace\"\\n\"))))(Tile((id \
+         23f944fd-61e1-4e8b-9836-c6131c460919)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a54cd08f-3370-4fd4-8def-0e17fc71c15e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         03de5e7b-51c5-4ddd-8fef-7c261d3abd6d)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         c7144896-665b-43ea-b32b-331f2eb263e2)(label(t1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e24cf2ac-4df2-421d-89fe-df50d7f12d65)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9455f9de-a5c9-4d3c-a76c-d3293a65ade0)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3a6ad6d0-88ac-410a-82ac-e1e37fe1e53f)(content(Whitespace\" \
+         \"))))(Tile((id 52dd1f5b-6417-4162-9632-75f23f688117)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         cdd1692b-598d-4242-b31e-440015d1583e)(label(row))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         8a3b8590-3255-4b84-ada2-cb0e9f0d36c9)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         62226343-d390-4c56-a868-144021c503a4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b9f5254c-425e-4127-95c5-d7833a7ea75c)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         18aa8fa8-b4eb-45a4-b4dd-42556e9d01ec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ce773a9d-d10d-4f92-9493-d83478b80615)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ac1e404e-962e-4ab3-85ee-4d4bc4217fd7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         629c2a54-e3d8-40e3-9458-c1293b7bdccc)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         a3dd1231-7a21-4984-8c4d-71ac7521873a)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         849d4fa4-ac9a-4443-a2ac-bb434000a078)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4ba391b1-56ca-4bd7-ae20-e8099031ae84)(label(c_project))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5d090594-ab02-4eb9-a76f-db78d4795503)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9f4d5a3a-79aa-45fd-91f3-3c5dc4ecb47a)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d50f971a-a738-4300-a444-85fff86c070e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a44908de-f518-441a-aff9-37a26c846ab9)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         774e664c-825d-4d5f-bb54-0ae3b46aaee9)(label(row))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1826f40f-80a8-47ac-a97e-4238c2247d2b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b4779985-fe52-48d8-940b-cc11b027284a)(label(->))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
+         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         80537062-afe9-4233-a16a-d43a6d9ab12b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9d6cab98-91de-433c-bb14-4223cb216fe5)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         531d58d8-ebca-4af0-9bb6-bbc40338c174)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         229d762e-606f-49dc-89d5-794c3dfc1b0e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8a2cdadc-6efe-42e3-aa3f-d12d33518b38)(label(n))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         654703be-35a6-4bbc-83dd-4e31763bdf6d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bd1863b6-c92f-4dce-85b3-9f75ef5009cc)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b0c813d8-456a-42a3-b482-a3c036e744b9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b8d4856a-a87e-453c-97c9-2278de85cd02)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         a1f5e257-7a4e-4f93-ae53-294053ca349f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         a91904b0-164c-403d-9172-600bdd6bedad)(content(Whitespace\"\\n\"))))(Tile((id \
+         b40c19cb-fdc8-4c07-985f-e155c9020bf9)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         166a8881-17ea-46fa-aa91-85acc4c9da86)(content(Whitespace\" \
+         \"))))(Tile((id \
+         977186ce-585e-4775-a69c-c6ac4fa25f63)(label(vals))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b162c7b7-4ee3-423f-adae-56693051a304)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         8571c9d7-a4c4-47ea-a037-0f94c02625c0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3c182b5c-6014-44e6-8545-c2b1357b7806)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         561734a4-fd80-483e-afae-13d796ee28d1)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e54bb48b-70af-49d2-baab-dbf9da235322)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         41cecbd1-af6c-4b50-9977-2ed449b08b3d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c7671e8c-e845-4818-9000-abbe31e8ff80)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a9a58c05-6e2e-427e-aca0-0409479b67f1)(label(c_project))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         81c5dab2-95f7-49a6-835f-814bc287542a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7f689b55-71f8-4cde-b4bb-2fbc71c68429)(content(Whitespace\"\\n\"))))(Tile((id \
+         e75eeecd-6b0f-4c88-b8de-89bd0ea42179)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         60c779a1-70e4-4af8-902e-f4b97c065198)(content(Whitespace\" \
+         \"))))(Tile((id \
+         084915ea-2689-41c8-97e7-9f23f9c1be72)(label(bins))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b4618baa-13e4-48f2-a1ed-362cec4b995c)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         90225424-a4c1-41db-9652-1e0d86244881)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2fc44b85-7c52-4441-9460-99077fb5bc0e)(label(bin_int))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         919775f2-1a9f-47ef-916f-91fd51eae1c8)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         aae646b4-aa11-4845-a47e-10b32212e6d7)(label(vals))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         87ee6d5e-3fbe-495b-99d0-3ee3e87eaded)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0a35ce1b-d5b3-4a31-93c5-ebba78e3c60c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b390cab8-7320-459d-961e-7bbdafe4fa32)(label(n))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         be6c5687-341e-4140-bae2-bc276e17564d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         14cce19c-5c26-488b-b77a-c1d15810a4d8)(content(Whitespace\"\\n\"))))(Tile((id \
+         f87750c6-0b04-458b-a05e-9337a633888f)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6da9e20a-ab48-4b6d-953e-9b31de1516dd)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         43fadf42-0945-468d-80a6-e49599900b55)(content(Whitespace\"\\n\"))))(Tile((id \
+         91285b22-9942-44cc-9269-5df44ea0685b)(label(bins))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         26b1f1fb-f020-43e7-8aea-254756433dd9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f0029c58-8a89-4319-898b-e516bb4d3ead)(content(Whitespace\"\\n\"))))(Tile((id \
+         ada1f97f-6ce1-408d-bee9-609317a374d3)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         d96faeac-2f07-4dd3-88de-23ca527cd47e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b3e5e771-9c03-4510-80c7-4197ae27437d)(label(e))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0fd12a50-5b7c-4589-bb86-e97836162ce6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         74610887-d104-4ac8-b7a3-3837c15bfbe9)(content(Whitespace\"\\n\"))))(Tile((id \
+         bbecc54d-f294-44f0-bb1e-9e8e99b772cd)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         50a3c6d8-ed6e-42b6-95b1-7181dcab9ef0)(content(Whitespace\"\\n\"))))(Tile((id \
+         c9821578-8fec-4fd1-b473-c7484d7f17ed)(label(...))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7c8470c0-497f-4295-b717-d12743cff69c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c9230be8-92ae-47da-96b4-a6e9d7e1746f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         e2e45c94-e6c6-4b0a-bf61-159ef9ce0995)(content(Whitespace\"\\n\"))))(Tile((id \
+         fca6843d-fe3e-4cd5-8e72-984c65fdb9d1)(label(group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9ffda755-f3d9-4483-b537-b37b2787eaf2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         74b8e601-e1d3-4231-9e94-511b2a7de8c1)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9849eedc-774e-44c7-87f4-f1440bbc3214)(content(Whitespace\"\\n\"))))(Tile((id \
+         8ba81067-18b2-48c6-95d0-56e4db3d231a)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ae90df29-5e67-4a56-97a3-308d5f783553)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1cbb015b-9813-44da-8c37-b6b3426c3543)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         674b242b-08b4-4563-9214-03da54d34315)(label(group))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         04a0acff-3597-4495-b40f-633feac9c30c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         51ac5bdd-c4e7-4d5a-a5c3-7b27baf4534f)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         23891069-6ed3-4085-8c8c-b82a878a8fed)(content(Whitespace\" \
+         \"))))(Tile((id \
+         77b9887d-f7ad-4973-9b75-4b380174123a)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         51fb4a73-8e70-4b90-95ee-19e060aeaf41)(label(min))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         da6caaa7-14ff-4ce3-8cb3-7c213318759b)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         23924294-c793-46dd-a209-2af859f10a49)(content(Whitespace\" \
+         \"))))(Tile((id \
+         62059068-4efb-4529-abc6-cb2bf548e6cf)(label(max))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Tile((id \
+         55d39fc0-366d-4fcd-8cd2-c12c2002433a)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         a8ffb820-e0ab-46b2-9917-62525219faff)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9508f800-17fd-4278-8164-c1d588f97bb4)(label(_))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         8b8c30cc-2504-4f4e-9492-1a29dc8fdf05)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         225e5032-1e2e-4475-aad0-4c83373e2af6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1754ebf2-640a-4cb7-95dd-9ed1918e1cab)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         27f73b3d-c414-4172-ae81-6582b0fbc259)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         fa6ef312-de0c-4e1f-a189-719148aa766a)(content(Whitespace\"\\n\"))))(Tile((id \
+         397b1bd4-3dfb-48de-9deb-d031e1ef8805)(label(string_of_int))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         520dc8f6-e8bb-4c64-bb6b-661267e366b9)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         f98b18ae-f842-4747-a458-48b373be2e93)(label(min))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         f925c57c-b684-40fa-963a-00c8c369ae00)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1fd8157e-2ad3-4031-ab06-d88650d17a3f)(label(++))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1f92c638-ac00-427f-bc44-a90c8aaa6879)(content(Whitespace\" \
+         \"))))(Tile((id 4a47dcd6-291b-4cb5-a1c4-2af158c0274e)(label(\"\\\" <= \
+         \\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c8d16627-d7ee-4895-819c-0df9e014be77)(content(Whitespace\" \
+         \"))))(Tile((id \
+         03dd0429-4af9-4ef6-a26b-c7919f2387cd)(label(++))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e9f262ca-a6c2-4e44-a02f-8523f77ddda0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b4bcdf5a-325e-4f66-bbfb-587a68b77ce5)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3f6661b4-3a6b-441a-9512-9574f475c573)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d1af0f45-f665-4b0b-aec6-101d5ad8340c)(label(++))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4faca0be-598a-4368-9f0a-bf2e3e6d5c41)(content(Whitespace\" \
+         \"))))(Tile((id 3d52f2bd-3000-4683-b30b-9b1a2983f0c7)(label(\"\\\" < \
+         \\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f4eda2fb-4499-46e9-be28-2b91e92b6f27)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7cf3e95e-dcf3-443d-ac6e-66499ed245de)(label(++))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         15298bd1-e724-4963-ba5b-8ac561f0cfd8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e8fdbd68-34f2-4595-b0e7-f2b35a02fad6)(label(string_of_int))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0c254f30-41f7-4351-827a-1c953234cea3)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         9f96893c-0c98-4dbc-b829-0844249ee8d2)(label(max))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         cbc9acaf-c989-4853-bf2b-f39c1ba0fecc)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         1be29eae-c03d-4733-812c-14d2f1445674)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         0413cf30-f120-45f4-9a03-ca15a1f98aa2)(content(Whitespace\"\\n\"))))(Tile((id \
+         e771e1ef-821b-4978-8be5-de18beb70d98)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d6fa28fb-dba7-4acf-96b0-d1f48ab1858a)(content(Whitespace\" \
+         \"))))(Tile((id f362c00a-9013-4b1c-aceb-8ab3ed094721)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         a11fb767-e800-4ea0-b04d-02fd68a6c85d)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         70e26671-e32f-4c54-94ad-99811adc978c)(label(group))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         401bb804-3c42-404c-a1bf-b2471aae205d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         77dd22df-d282-4ded-9fe6-224b610e081c)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         25a83f2a-4cb1-4afc-9fc8-593a3476ff62)(content(Whitespace\" \
+         \"))))(Tile((id \
+         66252cf3-aca9-407a-b3a0-cec0c345d372)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         5386993d-0c7f-4f82-8c44-b476c5c2b8e2)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0ace63f9-d8ce-4bef-8618-8de7442b1f4f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5aaa81df-70c3-4cb3-8272-dbab2960a5ff)(label(count))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ba55c76e-140f-4e5c-bfde-7e2d106d2b89)(content(Whitespace\" \
+         \"))))(Tile((id \
+         76593c90-4d49-41c2-9cd7-88e7d27f0d2b)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c991a6af-8e85-41d2-8fef-e2660526b806)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1d0385b2-7bb6-4350-b6c3-00fe63900f16)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         666950a2-8d42-419d-a6c5-5730b5510ba8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         fc40ef34-f4d0-484c-9511-55e70d456457)(content(Whitespace\"\\n\"))))(Tile((id \
+         869305af-1ff2-4316-ab61-4751800ef04e)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         3f57442d-830c-4c8c-88e5-503060e6f328)(content(Whitespace\"\\n\"))))(Tile((id \
+         59a75335-e3e0-4918-9dfe-f5d3c0f4a300)(label(bin))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a33599d7-5a89-4f3e-a1d1-3176df017d85)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         160f8a43-bef5-4dfe-91f2-438fdf30156d)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         238b95dd-806d-4de0-83ad-9c80b5a190cc)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         d2762c4f-90ef-4e57-b2b2-8a27a9168a32)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ea339234-24ca-49eb-b1a3-de6360ae0f12)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6ff149c7-d651-4bb0-bb65-401819d5c4d4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f348dba7-9748-43ff-bb53-00d9e2871fbd)(label(\"\\\"final\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5217ca84-708a-46fd-a8df-fc5c6f1f392a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c74204ca-9750-4aa1-813a-b079ca0d3558)(content(Whitespace\" \
+         \"))))(Tile((id 6481fceb-177f-447e-8c3d-83cc5bb5bdfc)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         b3593433-65d0-4a5a-a982-3f1c017f8ef1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a0788423-44a2-47ab-9dd6-884a50b428e7)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e3a24510-9f96-4ce1-9a9f-9836253f3aa7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         609d9a97-0b7a-4a39-99e2-72d8f213e21b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bb7dfc08-a05e-421c-8321-e459c417ced2)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         baf031ec-4f48-4017-a35e-a705910798fa)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         a12fa69b-aba9-445b-8d94-a32a2a731d99)(label(final))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e2081820-690f-4920-acfa-4ef0d56f91a2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         38552f4c-de23-4896-a08f-74037380d2c3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         da35dbdd-b898-49b4-9ef5-a7353b9a273f)(label(2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         3293f327-1ae5-47a1-8a76-21ea2923b5c8)(content(Whitespace\"\\n\"))))(Tile((id \
+         e4cc7fdc-673c-4819-bb6e-5cf31271db1a)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e7c9c93e-305a-4252-82ef-d52d8e235d74)(content(Whitespace\" \
+         \"))))(Tile((id 92390c80-3092-43ce-90b9-a2cf96324184)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         5dc0b3d4-285e-48bd-8d67-4acf10e66b64)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         7164a4a4-e021-43c3-a05b-e0172287daea)(label(group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2a611b5d-28ee-4a99-b3b1-ec7bc35b4e88)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         fac7fb07-1562-45d0-bcda-bca6e4000ba7)(label(\"\\\"76 <= final < \
+         78\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         34ef71e1-425e-4670-9d5f-e3eaf3ebebd3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bce04913-8e8a-4e55-90b8-899955686bca)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6fd9b2fa-5970-47ad-85a0-991a91c640d7)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e9134d4e-5c7e-499e-a8cb-388b9c21f41b)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         5eae62c6-94e5-4774-aafb-bce9d6977d92)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         d194e89e-da5b-4e53-9491-dfc4d9dd1633)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8fecee8d-68d1-49ff-ad18-991e625bfa39)(content(Whitespace\" \
+         \"))))(Tile((id \
+         516ea0b2-2286-43ab-a39c-61b8e62c973a)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a294a7f0-1464-4f21-9c20-ea1271edcb4d)(label(group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         34f2c30d-c9e0-4469-8f7b-912e50f66196)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         8836c330-1481-4bfb-97f6-ae310f3c0881)(label(\"\\\"84 <= final < \
+         86\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         6eb86593-da2a-435a-9ee8-821642927518)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ec3dcbea-f869-4f76-92da-e9b5d887b53c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         532ebd5c-fe1d-4058-bf37-b487a6018038)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5c0ff8a0-3994-443d-9b43-5902c8ef3da4)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         511ad350-9fd9-4f6b-824d-14dd1fcbae4e)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         768ccaef-3830-4244-beb6-60fdeec34d83)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         31c8dde8-93e4-4500-8061-e219e429fe51)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2f5c2593-f76d-4197-bb11-ae929309dce0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         b0b9e315-a93b-40f4-842a-fe27586c9a11)(label(group))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         418dbb85-b6d2-491a-8970-44640fa65c55)(content(Whitespace\" \
+         \"))))(Tile((id \
+         82e29417-573f-42dd-b6ba-826451cab254)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         72ef2e16-aebd-4c26-a079-fdbe572c1d5c)(content(Whitespace\" \
+         \"))))(Tile((id 45d94254-360c-4a9c-9307-ec1a18363fc0)(label(\"\\\"86 \
+         <= final < 88\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         9ae3b835-f7f6-43ab-a618-a7ec87c4f4d9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         46085ab4-24e3-4339-990d-772f3cc6d6c4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8ab169cc-1454-4e69-9789-e7e9bcf0efc9)(label(count))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         acda786e-3871-4125-8de7-36aeec73697b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         910c096b-67ba-45b5-bf2d-57274479d540)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4e5fb152-c94a-4c14-b20c-fccd50ae7a21)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e4ec83f6-5d79-4483-8f7f-e91eeed9e410)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         53ac2a3f-05a5-4c10-94e3-d9f7a65b384d)(content(Whitespace\"\\n\"))))(Tile((id \
+         5da3e07d-b546-4ba6-81c4-b0e51f1f4347)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f30ece91-bf14-49b5-949b-d57b6c039af9)(content(Whitespace\" \
+         \"))))(Tile((id dc9d7344-5380-4247-886d-65017184bdba)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         6d5364ad-9f64-484d-9ce8-0ae963eb8558)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         20bea5cd-0c13-4f42-8c52-cad926db877c)(label(group))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3e2fc7f8-7bc4-4293-bcf6-6aef37a72955)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0dfa3748-4d9d-4366-a5f4-14e5be9dd8c7)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dbedff08-1cf4-43b6-96c4-ae38bcfc1109)(content(Whitespace\" \
+         \"))))(Tile((id \
+         78c432fe-0e61-46d7-bdbb-046b0d4a98c6)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         491c87c1-f5c3-44c0-b6ba-c176f470faba)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3b0566e7-136e-4f9e-bce5-b32ea5d4716e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7450cac2-3f64-4158-a269-5d15d8eea5ae)(label(count))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4c4caf60-df0a-49bf-8e8b-abb90fa92a07)(content(Whitespace\" \
+         \"))))(Tile((id \
+         454c89ce-b68b-4718-ac99-b6b1d40dd488)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b63db59b-45f8-4574-ae4d-8304e2a8a307)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bc3b91e9-d3df-42d1-a4aa-e432e085b0ac)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         4f0c39b7-493f-447f-b616-23069ebe7735)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         cb0c3fdb-9195-45ef-9559-53f644a16d72)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         b19aeac6-6624-44eb-b1c5-be26f341c610)(content(Whitespace\"\\n\"))))(Tile((id \
+         2da39b2b-4877-4df0-8038-bd811a12117e)(label(?))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         dcbf6623-1da9-4b32-ab88-432387e6473d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         fb5be042-a10b-4e09-913a-eebfb507cb80)(content(Whitespace\"\\n\"))))(Tile((id \
+         6af4687f-603a-4215-a94f-5481e76d5e28)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e0430ef1-4bae-4ef6-abaa-230e066e0098)(content(Whitespace\" \
+         \"))))(Tile((id \
+         58bbeb01-d5d1-48cf-841c-4edc72fc1272)(label(pivot_table))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         2af9479a-e207-491c-a7fc-a24fad82e7d0)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         e089acd4-48bd-4b73-993f-caef0ab3b876)(content(Whitespace\"\\n\"))))(Tile((id \
+         017261f0-3767-4255-80bd-3af9feca5a24)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         d48576ea-4e1f-401d-89f6-5a25c051ea9a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         637fccf2-2581-4c3d-96a2-43d714accff1)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e60cdebe-fb52-4b53-91be-abee9b94dc8a)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         8f319e24-5488-43a3-84f1-bacdf119eeb5)(content(Whitespace\" \
+         \"))))(Tile((id 30b7c081-ab34-4358-83fd-be151f062e2c)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         795c3f94-0f38-439f-a8ae-bcdc02989816)(content(Whitespace\"\\n\"))))(Tile((id \
+         4aed623a-409e-4e41-8da9-d212c1b877f1)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         22368610-b492-4f45-90cb-2cfecb43a112)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ea7567c2-039c-46ab-a304-dffbd836aa34)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         8c42eb85-6148-4d16-b79b-0b6e6fa4f272)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         730a3277-8847-4b4e-8334-ffa8b74e3ce4)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         7dd7cc9f-7b0a-40e0-9458-e89a04b18592)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a28b4ebf-0ba4-430d-9330-a612e27dcfcd)(content(Whitespace\" \
+         \"))))(Tile((id 19789718-1365-4e6d-a8c2-312b24c0a74f)(label(\"\\\"for \
          all c in cs, c is in header(t1)\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         5c5b24c6-2a24-4e39-a6f8-f8fd5c36f28e)(label(,))(mold((out \
+         65729b05-523f-44d5-a516-ccc125d5687a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         89df1ad7-592d-4cd4-8eb7-1a39e985141f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         80678ff1-59db-4d71-8b75-47db14ba3f0f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         43bfa57b-14b0-408a-9b5d-569e1122b548)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eea96f48-c123-4d8b-ba79-081ccace64cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         21076daf-390c-45d0-9ca3-da1e9b21f4fd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ce7c6c1e-e078-4001-9903-9cf1c4968700)(label(\"(\"\")\"))(mold((out \
+         95b379bc-2f73-4428-8242-9028ca56c74a)(content(Whitespace\"\\n\"))))(Tile((id \
+         ca88fa10-63f0-4b58-89f4-6fa10e029e0f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b420e483-fba2-43e7-b96d-7d7be476dcde)(label(enforced))(mold((out \
+         aa3a9887-0f2b-4c43-8af1-75ffbb1cb890)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7b473395-0ef5-4904-80fa-8ec7c1d171f6)(label(=))(mold((out \
+         a7f1d2c4-a406-4737-905a-1be3149007bb)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         70d8002d-7144-466a-81d7-4e20229b09a8)(label(\"(\"\")\"))(mold((out \
+         df954d8c-351f-40c7-9cf2-978095a6ea68)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         6c113b5e-f46c-4240-a66a-3bc9bf74604c)(label(false))(mold((out \
+         2fcb8b9f-18f9-4b1a-bd1a-3ac5f8777e39)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         b1374536-1eff-42c2-8867-fbfbb90e2c42)(label(,))(mold((out \
+         04c0e722-c25a-4b33-a10e-5a677f8d49ab)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fb3b2f54-0205-4268-b56f-75607c0e95ca)(content(Whitespace\" \
-         \"))))(Tile((id d59646df-4e39-415e-8e2f-d33f269158c3)(label(\"\\\"for \
+         343bd175-d80e-4c86-b5c7-ac3415ded58c)(content(Whitespace\" \
+         \"))))(Tile((id 8737f1fc-7932-4068-8a49-c39a4e35f321)(label(\"\\\"for \
          all c in cs, schema(t1)[c] is a categorical sort\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         23a236ff-7f08-486e-905c-00b6665b5ef2)(label(,))(mold((out \
+         c6f59d47-6586-44ba-acfd-83ef11e3e346)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         366e7b3d-baab-4be4-9fd6-8a389f00e112)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7df667d3-6560-472e-b94b-6d4b59da1133)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fdd42210-c2c5-4d28-a926-a86bccab33b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0a659766-e8c6-4e55-b47d-42b6aeca4180)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ce82b107-26f7-45e8-bcbf-33cb992f31e7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         355bfc98-6087-4325-bc39-1c7ebedfaa56)(label(\"(\"\")\"))(mold((out \
+         d6690d28-e4ab-4596-aa5d-cb5dae2793d6)(content(Whitespace\"\\n\"))))(Tile((id \
+         8fdffa82-cadd-4aaa-98da-686bc58c8a57)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         0467e4b2-f833-4870-ae07-dda3e56b0c28)(label(enforced))(mold((out \
+         95a0a902-6656-4ee0-966a-29d1ddb9e97d)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d30ccdcd-8967-454a-b75f-2c58ab166aa6)(label(=))(mold((out \
+         7421205c-afc4-4d7f-9709-89977746183d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         4ccf6680-3ddb-49b1-8903-c9f5bf57fd91)(label(\"(\"\")\"))(mold((out \
+         88b5254c-5560-4687-ba7d-b3d294abcaeb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         9eaca512-5e17-4913-a210-48b5b6808306)(label(false))(mold((out \
+         ebb66dd1-4a65-4e6f-a18a-85c0f56638cb)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         9449c316-9103-4ac3-82f7-7e6187baf32c)(label(,))(mold((out \
+         21c32375-20cf-4596-8b37-4ccad30f7b35)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ba4fe869-d7dd-42e1-931f-dace38049f8b)(content(Whitespace\" \
-         \"))))(Tile((id 6281b8d7-5d52-4408-ab2c-30bbe005c1e5)(label(\"\\\"ci2 \
+         adf18db6-1cd4-47ee-982f-d7f73b267ac7)(content(Whitespace\" \
+         \"))))(Tile((id d0fc71c0-d9de-41e6-819a-b84bab0db4e0)(label(\"\\\"ci2 \
          is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         b29bdcaa-1f7e-4f6a-9490-df9d80a1d49a)(label(,))(mold((out \
+         dd356729-a43e-4e96-9133-adced8dde930)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f4c02efe-9e23-4a28-ab28-772045004463)(content(Whitespace\"\\n\"))))(Secondary((id \
-         38882606-9202-4767-8cb5-204e16475ad0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e1ea879-ee1e-4650-aed2-6abdb48e3d64)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         87f0154c-5aae-423c-945c-77a5f33fde2b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3c528e0b-69b7-4136-be71-6b086542c22a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e4482ade-d300-42e2-b83a-a9413a566abf)(label(\"(\"\")\"))(mold((out \
+         e1b67d24-ce7c-4cc1-a67f-9ec079a4f767)(content(Whitespace\"\\n\"))))(Tile((id \
+         fef53f31-4e37-4130-bd65-a6d64ffd5122)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         791ea692-9694-489c-aee2-e770e283da87)(label(enforced))(mold((out \
+         7ca27546-a784-4682-8cd2-60066d420402)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8302d4ad-8b1b-4f86-9a5f-401dc7ec1ebd)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8f96ad53-9aa7-4cd2-aeb7-465aea8b4c45)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c7e4e092-7bba-43ba-8717-909006b35748)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         496d5399-a327-4c1f-948c-9779243b816c)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0df80723-797f-4f06-a1be-a56e5ceb1653)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c95d8893-cd92-4af2-9897-1279af8ef704)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         9000459e-b524-4bf1-9edf-02d561ba5ab3)(label(false))(mold((out \
+         02f3ccff-bd35-4313-93d4-88ddd1c5f5d8)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         446b6916-6d30-4af9-8362-8a536a358e85)(label(,))(mold((out \
+         c8352c86-a79c-4ed3-a65f-286dcdbfd0e0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b572d727-97b5-44fb-a552-3b59e5862316)(content(Whitespace\" \
+         3d40335f-942a-4f2a-b07c-bbd6bd9b5ca8)(content(Whitespace\" \
          \"))))(Tile((id \
-         a80b2e44-da69-489a-8aa6-d6a8e8056454)(label(\"\\\"concat(cs, [c11, \
+         46e94a63-7526-43b6-af85-f20cdc933893)(label(\"\\\"concat(cs, [c11, \
          ... , cn1]) has no duplicates\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8972b3b7-632b-4a59-aa56-001cadd645d5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         509b6c9f-1455-4d77-be47-d468fce5192e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6f458307-1aa9-43d8-8d01-a9cd05ab06ff)(content(Whitespace\" \
+         2599b425-266e-4816-bcb4-8b5a5d82b4c5)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         f4b0a8c1-2b76-4c9a-9527-e9401af87974)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3a790cdd-fb37-4815-a9f1-dc5a4bf8c0cc)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         6c1d0aff-4932-494a-ad94-f88dbc406137)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5f665ad7-4c11-4a13-954d-82aad8a92846)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         802a0393-f7df-45e4-bf3c-4c138fdcc594)(content(Whitespace\" \
-         \"))))(Tile((id ef0f1784-3c32-46cf-8026-49ffdec23001)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e491f161-d973-4ab9-b44c-3123e7966eff)(content(Whitespace\" \
+         1d7c3ea5-ec6a-4a9d-a0f8-af3d8158e9a8)(content(Whitespace\"\\n\"))))(Tile((id \
+         26a95c2d-271d-4661-bf63-884cf2355fa0)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         36602f29-2203-4c88-b21e-32215b24af54)(content(Whitespace\" \
          \"))))(Tile((id \
-         951eb21b-84dd-4644-981f-94bda229bb1f)(label(ensures))(mold((out \
+         e2942a9c-fcfb-47d9-9cc6-2e3a0631b9e1)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         f583ba60-915a-4fd3-a0f7-6ab988ed22d3)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         341d0e9f-f49e-4c3c-b2de-73bb6a8b886c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         954db5f4-655b-473f-a10f-bc3513d9e3b9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6a798b52-0d9d-4600-851f-9b114cd3d0bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8472633-8f3c-465d-a000-96220c137e55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9abf303d-200b-421c-bb66-511cafd8851d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         85dbfcfe-2466-4a33-adcc-a37928124bf2)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         50f7869e-e880-4d50-9f92-153f9dc79909)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         da2a461a-763a-4008-8d4d-d6f127ec60ec)(content(Whitespace\" \
+         \"))))(Tile((id 69765799-0998-40aa-8ba7-6b8f57ae0d1d)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         bbe6fffe-1989-4a01-b3b4-2ff6b4f77fc5)(content(Whitespace\"\\n\"))))(Tile((id \
+         30598c06-2c7f-413e-ae66-580724d49f91)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         47e1f4aa-9d85-48da-aa89-4d5dfc5f82dd)(label(enforced))(mold((out \
+         fba7ce89-d898-48c6-b994-46c327605145)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d95f28a6-c126-4c47-981f-5ef28f381edf)(label(=))(mold((out \
+         8869d123-9a1b-4e7e-9e6a-89b22fefe521)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         783613ba-7a11-4f29-bdc3-ced1308bd803)(label(\"(\"\")\"))(mold((out \
+         d0639df0-9aa8-4cf3-9293-2bb8e3fbafa6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         74c75a6f-53ec-49de-ba79-ecd76cae0c44)(label(false))(mold((out \
+         8e4706c7-3d66-488d-908b-d7f7766655a8)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         6993a8b2-d192-4bc1-a8af-4730c0b0a42c)(label(,))(mold((out \
+         9d19f454-789e-42eb-8539-e11325b92320)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         503a4098-419c-44b0-9dd6-b47eada705ee)(content(Whitespace\" \
-         \"))))(Tile((id 07991045-4abe-45b0-bf78-0e55958a89e3)(label(\"\\\"fi \
+         0128adea-4ed4-452f-8442-8b24cc49ac61)(content(Whitespace\" \
+         \"))))(Tile((id 0aac1286-54ae-49f7-8f12-8882a93a9b58)(label(\"\\\"fi \
          consumes Seq<schema(t1)[ci2]>\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         49995595-81a0-4d15-9101-051472217f37)(label(,))(mold((out \
+         b45afcfd-6b80-493f-befa-7a9a3b406a5b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0ef4b989-a012-4a5f-bd44-4fdd4fed0bd9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d96a72b2-84b3-41bf-a18c-0eb3fad6f96b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7787ae30-2a0c-4791-a328-28b11f49d6e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         19e4ffc3-74e9-4030-927e-37e10a2b53d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba05bf2f-351a-4325-b1a9-dfaf8f0502f9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         03342739-a392-4efc-9405-b49da08a9dbf)(label(\"(\"\")\"))(mold((out \
+         e25c5763-261b-49b9-8d29-405fd9ccd073)(content(Whitespace\"\\n\"))))(Tile((id \
+         e289ec41-12d2-42e3-a51c-4a9319b3f9a9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d4dd44d5-597c-4d27-9716-76a3a2bae52a)(label(enforced))(mold((out \
+         3409251b-9ada-4553-944b-cca0ce4e0df2)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         19dd23f8-d15b-46da-a5b6-278be1117a5b)(label(=))(mold((out \
+         0e0bfb40-aff3-45c4-a123-5b66d5340b21)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         52729392-794f-44ea-aeec-6f65ac0619ff)(label(\"(\"\")\"))(mold((out \
+         765ef705-af9d-4452-a05d-56a0ceaf52af)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         616059a7-21ee-48a5-a48e-171d02aad225)(label(false))(mold((out \
+         2b7eac6f-a647-420c-8b41-16738f21f098)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         9a6115c9-06b1-4313-9933-f6ca4e5cab93)(label(,))(mold((out \
+         d4cf7955-165b-47a7-904f-29d6d505988b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e4c708a7-722f-4eae-bc2f-382fa231243a)(content(Whitespace\" \
+         9ed42299-ac6e-4ab4-a681-8624df28d6f3)(content(Whitespace\" \
          \"))))(Tile((id \
-         0d4c9bb8-0775-48d8-bc59-cc8d32c20c1c)(label(\"\\\"header(t2) is equal \
+         a2ff2c3d-192a-45ac-bc5c-e522891015e4)(label(\"\\\"header(t2) is equal \
          to concat(cs, [c11, ... , cn1])\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         12374cdc-d297-41a3-a8ec-1d9c2e4887df)(label(,))(mold((out \
+         1e1907b3-9409-4690-8e40-4205bee0d698)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6c621c71-ac5f-45f6-938c-68303e4f9265)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6a7cf33d-4309-4a89-b0e1-5ca27e93ce5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         989338af-f120-4b91-beb7-98a4fd81002c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9b08004-9064-46e2-ad09-a1626d86925f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f22705b6-b4eb-4d61-9826-5b0dd1b21a8f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         81fc0593-3a55-457b-862b-082bae494d47)(label(\"(\"\")\"))(mold((out \
+         4f89a684-4664-4824-bd11-078c3c2e7739)(content(Whitespace\"\\n\"))))(Tile((id \
+         724f1e2a-5d3f-4d38-a67c-b27efd97bb5e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         be570c5e-9e5c-4efd-8c86-cf36e3e6d0be)(label(enforced))(mold((out \
+         e22c8b05-aebe-493b-9304-d887ec3a8d11)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ec801d79-485d-42f5-8609-d55d2ae1a9fb)(label(=))(mold((out \
+         2c477f25-6711-4e71-ad53-b19eaa8b7afc)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         095dc94e-a82f-4ad6-bfcb-f8398dc6d418)(label(\"(\"\")\"))(mold((out \
+         b520fc89-1707-470c-a6a2-94857006a9fa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         12eb7e1d-ca60-4d8d-a474-5bc28e167964)(label(false))(mold((out \
+         8e0e58d8-dfd6-4336-947d-b8c30e5eb374)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         2f2ad4ae-4d23-4694-8022-1665672676ae)(label(,))(mold((out \
+         2ca8ac52-8b94-473d-929f-6d9d77079ee9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a3bc95e5-8add-493a-86b5-961b47ee9a97)(content(Whitespace\" \
-         \"))))(Tile((id f9520b75-0ae7-4a89-8801-e98364bd2e7f)(label(\"\\\"for \
+         f37d93ed-8ddd-4254-866f-e700eda124b4)(content(Whitespace\" \
+         \"))))(Tile((id 444e855c-6f60-4d01-a31a-19222dfbe386)(label(\"\\\"for \
          all c in cs, schema(t2)[c] is equal to \
          schema(t1)[c]\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         6f1db909-38bd-4ef2-82c0-1d6b89624ac4)(label(,))(mold((out \
+         7d401229-f035-4845-984c-fe01be5639e1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6ff62f5a-4f7b-463d-89a0-5c547ebdc48d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8807ae36-8c5d-41e7-b370-85a00959ab9a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e408e571-cbed-4b8a-b538-c71d5282a598)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         00ca0edf-3930-4ab8-9300-755b97ea6e17)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         931a1d3a-91fe-497a-9449-1a0629d91c69)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1bdf682c-242c-4a1f-a196-c05171ca0a5a)(label(\"(\"\")\"))(mold((out \
+         5159596a-6b20-4d9e-8fe1-f533f40a88d5)(content(Whitespace\"\\n\"))))(Tile((id \
+         7f28d753-8891-4438-8b5e-b3d976403053)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         780577d9-dc07-4a82-bb9a-5d2ea42b4868)(label(enforced))(mold((out \
+         3a7585ce-93c7-4247-a84b-411c1b71fc9d)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d49b5ad5-4f33-4179-830b-664bb59d5d23)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         31ce8e09-01ad-4e9a-a35f-6699cea65d53)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6107e8c8-05d4-4ce3-b2cf-66b5717cf56c)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         564e3b10-a293-4da2-8f73-34084fcf3ba0)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8e5506a6-c5a7-45b4-b0b8-085b4361a0d5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1904bb6c-2ca1-40f6-bbe3-50c10a48ad2e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         7f11bbef-b9dd-4b58-b2ac-058b7b42a9be)(label(false))(mold((out \
+         77314ed2-7e65-4d94-8a01-ae249c06ec91)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d8997fa4-dc8a-406b-97ca-0497cb1d540f)(label(,))(mold((out \
+         f91ef353-3ad3-468c-b8d2-b296df4c70c1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ded05954-8a2e-419a-b47f-12eceb47144f)(content(Whitespace\" \
+         49e07aac-e8fb-49d7-a202-df15adb266cd)(content(Whitespace\" \
          \"))))(Tile((id \
-         f7f9c658-0f38-4ca5-bbd4-3a305aebcfea)(label(\"\\\"schema(t2)[ci1] is \
+         2c0e9fe1-46df-426b-b8ea-61150e502fdb)(label(\"\\\"schema(t2)[ci1] is \
          equal to the sort of outputs of fi for all i\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6b6c7819-399b-4d60-8d5c-92b3ec36d4ef)(content(Whitespace\"\\n\"))))(Secondary((id \
-         46c11911-25b7-467c-90fb-b05bc2f77d7f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fb0b6a9d-9940-4d53-975b-35ec2b6f95bf)(content(Whitespace\" \
+         d27e8704-62d0-4896-8d02-553370a252e3)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         db1ea773-cf80-4be3-8f47-1cf84e9ae135)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         89ab6e52-f076-4c29-bc16-0de05dfe3005)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         04c92eba-2202-4115-aec9-9b37d96badd8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         93f4cb5e-9d94-4c10-9232-38b9eac0ae8f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e70e76c5-6350-4de3-9be7-0180da91d303)(content(Whitespace\" \
-         \"))))(Tile((id 3abba534-3adf-4eeb-b2b9-8e13c360fa5d)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         769b13ba-e32b-4614-b27d-5a81f060625f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d58784fc-5b13-40d1-ab36-312344a28ac9)(label(pivot_table))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         8ef5752d-ba76-4135-abd6-e8110ad51fce)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         a9c86003-e681-4709-bab3-5743e5472392)(content(Whitespace\" \
-         \"))))(Tile((id 42be1518-0fe8-4f9f-8e00-e5f560cb714c)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         90f11d43-8787-4eb9-adc7-cc9fc73c66f2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5150ad16-c361-4afb-892d-71937700a287)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         7c000997-51d4-4ca7-aaf5-d10dd77bfa4b)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         678e5658-c95f-476f-95fb-bc5be14e2b1c)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         e23f615d-9730-444f-a3aa-2bbe9c8862c4)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         41c066a7-2533-4103-b9c8-0ea889e690cb)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         61cdacb2-5c43-44a4-b32c-15341a91baa1)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         87a5af70-351f-4496-bcab-2947cf13000d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7cdea7a3-52c9-4a67-a9e1-98fcb9613f0c)(label(cs))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         44c3ac8b-fb22-41c0-b43d-c877b124bedf)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         0b295edb-124d-49e2-8fe8-2618ff62b8a3)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         86660812-811f-459c-8c82-3288d037871b)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         6dc40c4d-5455-4ded-a7e4-c8d7b7e28070)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         564d2a64-514a-4b32-a305-87a4c5c11d0c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3f9e9037-6964-4708-aba1-3173c7e6fb0c)(label(aggs))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         b4b187fa-9afb-4316-91da-0ff91dab9002)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         1de0411d-6160-46c6-930a-764c644b5237)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         9a9d8f78-fa84-431e-ac18-1b4b49aace34)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         d9291743-03cc-4cb0-88f8-1b72193e4013)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         e36a5556-e060-437b-8c02-14f5f5c2ba0c)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         48a1dea6-c149-4b66-b80e-a3f9ad79f409)(content(Whitespace\" \
-         \"))))(Tile((id \
-         409d0a9a-9b33-4d4b-9585-fc91d8a2eed6)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         6c8d38a3-70fa-439e-bf5c-e753b7937dec)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f0bda588-5ab6-4031-8d2c-ef3e61695c3f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         55799188-52c6-461b-af95-b00c9b4eeabd)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Secondary((id \
-         67b7ea7f-67dd-4a6c-a6b4-e13aaded0b85)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f273e62b-49d9-477d-8e4b-3207344f8997)(label(->))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
-         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6818c1c1-fa9c-47a3-a530-ce61ec3726d4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         19c26e3b-22fb-453a-9ec4-7d4df1fc4949)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         bdd4e7b8-14b9-41e3-8cfc-d173269d76b7)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         98fedaca-6f56-4ad8-9fca-12b9b94a9c42)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9a693e2e-970c-42df-95a1-18b2af5b98a7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         08e6cbf0-af2b-4c2e-bc98-0c1849033759)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f2436c68-5fff-4b32-99d7-fc76f375cf62)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         712c1d4b-1781-4064-885e-fd9700216ad5)(content(Whitespace\" \
-         \"))))(Tile((id 8ad62f68-5877-41d0-a760-a226185f4825)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         1993516e-31de-4d2f-a29e-85e441c75c10)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1b5930f4-3f5a-4259-aff6-c0d63157382d)(label(groups))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         8b4de2e4-ac5a-4870-a03d-b25d69695b84)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         73da88af-92b4-4382-8fba-6639a94ad87c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ce2c7e4f-2b21-4678-9a21-42994ed18841)(label(fold_left))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6d8555cb-8a76-4877-aff4-84eade84d811)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         bf28d90a-2443-4498-9359-64dd1c99886a)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3dae01c7-38dc-4fd6-a7e8-eeaf2173de88)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bb2ef621-6b9c-40b3-b9c2-b4895a1f4731)(content(Whitespace\" \
-         \"))))(Tile((id \
-         396ea764-cb36-41de-8da4-4cf4ebecbf9a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         c5857053-3914-4d38-8ec5-af000a8c99c5)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         6338f553-f8ae-4454-b834-494ee7883fc5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d7399965-4ff3-4270-97fd-adc044e8c22f)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         4a233371-a6d3-41b4-a0af-da386e746d46)(label(groups))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         32b3502c-cd78-4271-9510-da695354fd71)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         38ae36f8-4d46-46b1-8fbe-ae9d6e668864)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8cbdc11a-4040-4685-a31b-8d2e8352a288)(label(row))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         d62974ce-69be-47ad-af25-666273743e2c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0ea67639-2293-4ac5-a663-d4209379695b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e81d47e6-6391-4be4-9d52-c7530295ed1f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         98d314bd-19ad-498c-bfe2-59a2a1cba5ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4b35ad99-29dd-49f7-a910-c2b1d6266d75)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3b979132-6d93-4532-8c70-590b9ead2a25)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58efb315-b5e2-45c1-9c6d-5b9101839871)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         59f4f72c-e77d-4e35-8065-fa3ffe8b1213)(content(Whitespace\" \
-         \"))))(Tile((id 6f6e4394-1be2-49f0-aae3-46c40f2f2723)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         00ee9dd0-c282-431b-8b75-cee34a95bf5b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8ad30623-4ea0-429f-a120-6772929bd499)(label(k))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         b18fcaf9-8f40-48d2-b291-d6944669f48c)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         e771cd42-2e12-41f0-937c-4ac4ad03efe0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ecf7bea7-3366-4c85-98e9-4335cf4a6e12)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f3ea8a2c-2d56-4015-b0eb-484cdfecb37c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b4d677eb-1f3a-42b9-b535-14458ae0c126)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         70db22c5-3c1d-472e-b7f2-4c2052eecdab)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         01a199ee-517b-4942-bb08-faa4008d84c6)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         c73dd82e-a684-412a-a7ca-e7e411e0f7ff)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ba52b9d2-8ee1-4618-99e1-d97d9f575911)(content(Whitespace\" \
-         \"))))(Tile((id 41dab00e-6186-401c-ac6f-e82f98c04eb4)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         9eb157d3-2fc6-4d18-b9ff-9331ef03febe)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1f413c28-e29f-4abd-a15c-2833680d4091)(label(e))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         c1e71c30-3a2a-436a-9785-40864481ab6f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         dab347a9-b1ff-4902-8308-770dc5fd304f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f8158321-83a2-4667-bc2d-854239a9cdc5)(label(mem))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9f91053f-c2a2-4c70-9d9f-95f7941ec99f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         83e66c86-a155-4ebf-9d93-23ca3bf1b706)(label(cs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a63ba3b2-de0b-4dd7-bba1-f030ce77c55f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d6d52027-28f4-4539-8bfa-064e06ec34c3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5166ab3d-daf5-4293-9594-ca66f8819dae)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f05fa9e5-00d5-4d0e-8973-06d1c262aacb)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         193628f8-1ba4-4dc8-bba0-d9e85c58979a)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         8e1f854a-ee9c-4ff6-bc03-a32cc92e9619)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0e97d62a-e46e-43c5-94a2-8a8930124989)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d554ec32-0998-4713-8871-19f09b6cbbf3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         85651126-3a84-4526-a18c-cc7161d8c590)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         3051448b-9773-4342-b1d7-a56ac0373e04)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         6f09a4f5-9ea7-4ee9-8d29-5f1d5f32a4ba)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fd17e9fd-ac87-4842-9f50-2ebe90350445)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e5b17d35-8ef2-464d-a37f-36ad5ce8b7d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba2c3043-7ee9-491e-9ce4-5183edc96c52)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         07066e9d-8134-4a6c-808d-cc77ce566fb0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         00a41806-9f51-4e54-9ae5-6785c4317fbc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b81ed0ed-1782-4f16-9bc7-7162129cea02)(content(Whitespace\" \
-         \"))))(Tile((id e3cc2ae7-d9d5-4cfb-89ff-d91cb37f7022)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c7061288-ddf0-42e6-91ae-7454df65459f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cc1b8353-c0fa-4ed8-9a9b-bd194abffefe)(label(group_tup))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         b7df7be4-9bba-485b-88c3-ccf5cad423b3)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         ff93e533-cccb-4aba-ad4e-541a342150c4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         53567aa2-48b2-4ea1-a563-d1cc59ecca64)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c7498190-d7fb-4b60-ad8c-df33f96a796b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         144da3e0-397f-4e56-b977-14ad34454233)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         65ba0d1e-a9df-4f37-9f53-7e0e338b725f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         cd5d0eee-b9dd-4219-a221-309b088554de)(content(Whitespace\"\\n\"))))(Secondary((id \
-         248646bd-e2ac-4c60-9cf5-927ecedd946d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a3060edd-e6b2-47ad-b134-747c21b0eadc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0199f712-3b54-45c6-aee9-2cf19760c50e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e8d0485-7696-4b59-a7c8-2e4a066ded30)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf181dfa-7e64-4134-87e7-4ec9e629b5e6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57f59b36-f092-4122-b482-afdbc66becdd)(content(Whitespace\" \
-         \"))))(Tile((id 3873c192-f417-40c1-9d67-8b116890f3f7)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         7396aecf-8dcf-424a-82e1-a8bdf4e41d49)(content(Whitespace\" \
-         \"))))(Tile((id \
-         112828f0-5552-4156-8fea-d2f79ce117a4)(label(find_opt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fec0caec-19d8-41c5-a1d7-821b032f2bd5)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f0f24137-2881-4d41-939d-3e659a1f5fdc)(label(groups))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         63fd2945-7400-40c3-b6fb-8a93c22ea7de)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8c0d9ec3-0b67-48ef-bb9a-0a26568ea3e5)(content(Whitespace\" \
-         \"))))(Tile((id cee02cad-cc4f-4cef-a35d-02638753a8b8)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         80673ab9-add2-460e-9d7e-72060dcfb511)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f4b14b42-fee8-4b76-99b9-ef7ff960135f)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         a3ed027f-b2a3-439a-b1a4-6ec6927e9a89)(label(gk))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         9f59e67f-2717-4240-a9a0-9867821cf8c2)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         3ce1ff9e-c126-41a4-a02e-8637d6dbc09d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c14a7062-c98b-4252-a782-9f57dddd595b)(label(_))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         cbc0b138-f1c7-458a-addf-908993935545)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         3511def8-c137-4f74-b69b-3c146e1fe926)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c446be61-5332-4a7c-b257-396acef6bc08)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         95e2c7aa-f68a-43a7-95b0-556d351df045)(content(Whitespace\" \
-         \"))))(Tile((id \
-         73dcb0a8-4208-428a-8cb6-4db91dbac082)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a66cb25d-f91a-4f46-88a2-53bc9e929305)(content(Whitespace\" \
-         \"))))(Tile((id \
-         69e242b8-15b7-4d92-8455-15718ddd6060)(label(gk))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ecc9c4af-4b6b-45eb-9909-a21b73caab60)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2f440c23-db0c-419c-9096-49b13413ecab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5489a3cc-e090-4fc3-8e4b-c4438114ce0a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1bd6ac17-3f5a-4f56-aa44-3aecb2c458e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6ec3435f-bbe6-4a9e-826f-9ef76041632e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2cb36e6a-e3d9-40d9-9320-14b106106d80)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         80344751-323e-4a8f-b8e8-c934992e1fb2)(content(Whitespace\" \
-         \"))))(Tile((id 422939cd-1b7f-41c5-be3a-a17503584b0f)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         dd18d597-5a43-4478-8a06-7ca5da2561d3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9a9d2a96-1cad-4d18-b2ad-3e6745620924)(label(None))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         620f62a5-e09c-4a44-ab69-8ecd7b5c713b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4606a730-5411-4d80-9e60-832c2adc2921)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0fef7f39-3501-4a50-ad6d-640a84189580)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         0a558ca5-8fef-4c18-b47b-540c8b3faaed)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3ff5389a-f887-4dcf-b8a9-0a3a391c0a0a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         63187679-20a7-4cea-8f5c-27e6c0c3315c)(content(Whitespace\" \
-         \"))))(Tile((id ed08b53f-85f5-4bd4-8418-8fb40707249b)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9e036baa-1d3b-4640-a953-e26bc8df20d8)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         6009341b-f58e-4b6d-bbeb-55ba6ec64fff)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5e280b26-7ff4-4519-8784-4af7b98ea019)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         39c5002d-a414-4159-8cf7-ff6ab4917aa9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f6bda004-4561-4de0-ad63-2d7430143830)(label(groups))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         3a882516-27ab-417a-98bd-4ffbe83ccbd1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         453072de-99c1-4eae-9f15-d915ee0df57a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fe5caa43-9c37-4dff-ab4d-bcc04d61be7d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cfb409c0-a179-44ab-bbaa-d0ee2e094446)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c4cbbe22-4745-41ea-a683-c1046b0290de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         484371b8-6aec-43be-8427-ef5847b394c0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         53afd21c-c5a3-44b1-923f-ded4fc7e3c88)(content(Whitespace\" \
-         \"))))(Tile((id 40b16f14-9f61-4853-8ca2-d78e7250bd84)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         22febe79-c7cb-4572-9141-6cbe632c8b54)(content(Whitespace\" \
-         \"))))(Tile((id \
-         01d7e6c1-6bf4-4218-b75c-c11823550286)(label(Some))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         ffe2c33e-7295-426c-93c1-235ba861025a)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
-         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
-         9f2a6d49-bf9c-40dc-a2fb-5805a7a03963)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         00a310d1-a54d-44be-a6f6-da78afeedfba)(label(key))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         11950dad-70d5-4ae8-8335-cf3bff8210dd)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         7b3bd7ce-80c8-4711-a6bc-51fd3f398381)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bfd3a81d-77bc-4b1a-9f9e-83e5397465f3)(label(rows))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
-         1e767769-9bf6-499e-9dfa-12079ba7ff6a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4510a597-a937-49aa-8337-093f2a5435dc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ed641983-a93a-490e-8d22-e1093b40f680)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         4ac92cc8-55e3-4098-84a5-c7bbe81bd692)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e5e0769d-fef7-4646-bee4-b443a0efae4b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         36509f99-9b89-4378-a8bb-dd3b0f2ca47b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         58d88839-cd29-4d71-85d1-4f8192d1cc76)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         a1615f0d-51a0-42ab-9966-64d6c58c3e5d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f4154cea-a363-43db-932f-51576cdb5a5f)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5996997a-69fb-4fd4-b8ea-c3e0363b8ae4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         191002bb-544b-41b5-ba2a-d0c175c784be)(label(rows))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         aeafc63c-fc51-42b2-88b9-496eadb95954)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0cb28fa7-2d1b-40dd-ac83-a81fa9db6bc2)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6823c7de-9c66-4eba-968d-d30cd06494aa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ba0a2db7-9d6e-420c-aeca-185a760325be)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         78575cbb-b571-4029-ac7f-5ec4cb260957)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         dd65e360-f2c2-4e9a-96cf-ab56fbd44786)(label(groups))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         16c54e2c-f220-4e68-9b4a-58a1ce192908)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8cb21fb5-d39c-4e63-a48d-db443fa1af19)(content(Whitespace\" \
-         \"))))(Tile((id b11c7645-fe72-4507-9585-631dd99d1261)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         f10f57bb-562e-40c3-bc61-56b6c177b611)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ba2aa1c3-7d33-4215-b632-e1418b97e6d9)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         953e48a7-644e-4cb3-8b23-5bbe92ab57c4)(label(gk))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         ebf5a593-89b5-41b6-b8ce-361a8914e428)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         3a2f6e26-c2c7-49b4-9196-df04666556b3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b707945b-887b-48d3-ac8f-1635a159d8af)(label(_))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         a987b601-aa0c-4d5d-b412-3bcb2e198b54)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9f53cb16-d577-4e96-9124-4a425591bf1c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         47ba82f6-a91c-4cda-82c8-df1dc2c61d1e)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         0d9f8c5a-33d1-4556-8e84-5967ae2c27b9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         eeff8855-2287-44af-9929-f5addd71bccc)(label(!=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         19d903a4-0641-4b43-afc0-07f73684178e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8b4b2e76-52bb-4d22-b77f-cdf13fbda6db)(label(gk))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b4e00ce5-e83b-4944-8249-8a7d5d7c3faf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         477e0c2e-b48d-49dd-838a-2e7129b3aa01)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e2f33fd6-d7bc-4aa3-a612-e0344d40afba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         35ecbc7e-3513-4994-a440-451551689741)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a0b2c469-3564-4bd2-93b6-d2c8b89925bd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c0b1c0fc-a07f-453d-bbf8-82e6ca2105af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4c5a9e70-8195-45dd-a2e0-254b02d0e364)(content(Whitespace\" \
-         \"))))))))))))))(Tile((id \
-         4807a2fd-d078-42df-a366-6f0ff6a91f54)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c760d218-ef8b-4362-a41b-33d290467f0c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4a5090a4-1bfe-4500-9c2a-4ecd760261c9)(label([]))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         0c795d85-33f7-4f13-9879-6535a8296df1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         bde6e53b-dbb2-4dd3-8968-8f920aa67ed4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         83c8b95a-b912-4031-a2ec-7a8ab5c10e13)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea5e41a0-18e7-4fb7-9695-3c5062df6483)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c88adbc-fbcf-45ac-ab77-72d50c3f36c6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         923af5c7-9321-44d5-bdbc-6d5c232c50ea)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a67868d6-cdcf-4fa5-8710-4d82c877a02d)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e92f58da-81d5-4ce2-9106-5ee7911cdbce)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c57f7e3d-e48d-41fc-9f26-b07931e4cb53)(label(groups))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8c4d4034-dfd5-4586-8b34-39e03280f6c8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7c72681e-9abb-456e-9bcc-29ab12d82ab6)(content(Whitespace\" \
-         \"))))(Tile((id 10d9cdcc-3fe3-4fd1-ae55-230e92a5b2d2)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         c718f440-f316-42a1-8e20-873f86b395d8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9e3839a0-f851-4667-82b1-a03ca447db7a)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         b1be15f3-fb3e-4bde-8e4f-9e98a359eec6)(label(k))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d8db2ae3-cabd-4dbc-875b-f3ca3871c6e6)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         b1f215e7-c9e4-43e6-93fe-573e0a5fcbba)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c717ebec-cb8f-4899-a3d6-718d0f06f571)(label(g))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         50b8d2e5-fc3c-4945-a3bd-c4522b652051)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         bed37a75-02b4-4803-9534-ac33bb8f8bf3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         873425c0-d131-4a3f-89b7-ce131819b26b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d7a1b9e0-523f-4344-ad63-56717f07bee3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         31025aa5-13b3-4f72-9933-bd12fa69e8bd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         948880d5-de18-4736-a92e-898246ab5cb0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9a3957f1-03eb-4f59-b31c-ca7a4276dd1a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7b9406fc-29f1-4b16-8aa4-5dfa92f7b029)(content(Whitespace\" \
-         \"))))(Tile((id \
-         20073019-8bd6-4d32-98a4-dc927c37bc37)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         2e6f3989-83be-46bf-9f01-2208426e24fc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         80c86d34-106d-41ea-bc65-4a1028caade6)(label(...))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         8a399812-1a02-41e0-8342-24d66e0173dd)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         8a36e451-acfa-4c7b-9a2c-18f0f51f33fd)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c18603a1-c651-48e4-a83f-b64bcfe8ebf7)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c42e3b70-5302-40bd-9f32-4773be69fd48)(label(aggs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         37eec372-4416-4adb-9658-b52de6fcfed5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9f494aa8-6cc5-407f-be0d-caa466d24114)(content(Whitespace\" \
-         \"))))(Tile((id 6fb9a0d6-5c20-481e-9458-1816d63c8892)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         199762f1-f8c2-45c0-a9d9-7adf005f7fb5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3fd74756-4d1e-4ab0-9b6e-6a4f362e8bdf)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         f8a9231f-df2a-4c37-941c-44c2a600c685)(label(dest_col))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         b25502c9-861e-433c-a674-8945a442b679)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         27a03e0d-fa1e-4601-bb7e-64dac341b8ce)(content(Whitespace\" \
-         \"))))(Tile((id \
-         729cb4c9-7a13-4473-8061-31898d812bb7)(label(source_col))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         f85daaa8-0102-45da-9f5f-683e22e19240)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         292fe0fb-7f15-414b-9b8c-18d53a2457bc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b223bdd8-a46c-4d8e-a466-6be2702c0741)(label(reduction))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         093bf2fd-d463-4d3c-9a18-b6acd730d87f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d887de27-c5fc-43c1-876f-d5e1f173ca31)(content(Whitespace\"\\n\"))))(Secondary((id \
-         87f56a4a-460c-4edd-9139-05642ed29d28)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f43c678-3121-4a36-bd0e-c25701f940e4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         274966e4-0c89-4b2e-9c83-61a03f53752e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c605dc05-f211-4f26-a44b-0c7fffe0410d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         758e0f9f-6e30-43fa-8425-5b37f0a163c9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2493b84e-2cf6-4414-80ac-15f3b31683a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9fa334f-a0cc-44b7-8d93-ea7971eee70b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5331d1cc-275a-46a6-836a-063e5ed31e96)(content(Whitespace\" \
-         \"))))(Tile((id 40cb712f-62cc-4b02-b69e-8b275a7af3e0)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ef6fe55a-2a78-4e18-8d0c-2220154f30df)(content(Whitespace\" \
-         \"))))(Tile((id \
-         45c44bee-3c04-482d-b549-53bd06ef6a84)(label(vals))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         8dcf18ca-b406-40df-8517-261909abf705)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         d2d0fae1-f65b-41b3-9a66-aa65e7a92e60)(content(Whitespace\" \
-         \"))))(Tile((id \
-         68452fc1-1c11-4bb5-948b-e6e14aebc9f8)(label(filter_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         abbe7c3c-13b0-4cf2-b7bc-01455de43e30)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         79f9909e-629e-4c76-9b51-94a0309590e1)(label(g))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1aad9ee7-b879-4214-ae74-753f4ba3a64c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6edee3ad-e9ac-4336-9855-11d97581e547)(content(Whitespace\" \
-         \"))))(Tile((id 33c25fdd-a219-4b10-999f-105c788e1aa7)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         41a2d38e-cc22-4c3a-9968-564bf68160a5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         52d6189f-6c9c-42d4-9340-4d5e56020e32)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         f78193e8-b665-4d13-b0d5-dcad7f2b9b02)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9f73f073-d9bd-4d1c-a698-99d11e9701da)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d2f405f2-0e9b-40e9-a80d-5caaaab646de)(label(find_opt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         dc020615-dab7-44d8-ac02-5a75dc4e7e3f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e6954916-3648-4d55-8a1a-aedc20d57260)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fe23bd89-e850-483c-a7c6-fbd50a402bfc)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         11da4cf1-f6d0-4a6d-ba25-e1f0d0e1b58a)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a170f0cd-92ad-4090-90d3-e72e05e6b49a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         949f3ed7-13d7-460f-8838-908038d5dc55)(content(Whitespace\" \
-         \"))))(Tile((id 14b8f4f4-5108-476a-8860-ab134c12729a)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         7a56979a-3f8e-4a54-9c8a-64be24892124)(content(Whitespace\" \
-         \"))))(Tile((id \
-         624ae3e2-17b3-4377-a0dc-2bed0ef7bdf4)(label(e))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         8e9a6966-dd4f-4e36-a0ca-6b731710a4d1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         a5497ddc-8845-4f3d-a9e1-bdc3ff15afb4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         70ab7ad6-ff8b-499b-a8e6-8180d31012d8)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         14f5da9c-dea7-4a28-bf67-b6923d985030)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         6b08cba2-290a-4ac0-ab51-2e94a71dd43e)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         a11795b0-8aab-49ea-8db2-a218827d9dfd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         60c5ab16-86b1-4a32-b892-7e65b642e03d)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a3d96888-5029-4e43-8aea-86ba0dbdda6b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3eb0c902-0aa4-4e89-9e31-310e93b2072e)(label(source_col))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5081b0cd-7780-428c-a93d-3d4d716e5181)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c568f15c-5d11-4637-9c3a-f03d9003dac5)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5dda14e0-eefe-4700-9992-1ca82e16a3a6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5ff61a47-c3ce-4291-ad6a-8acff5ccc3dc)(label(option_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d208de30-3823-45c7-bfed-c084af454790)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         eb061331-271a-4802-9930-d9a981a3803f)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         77ebab5c-0675-472d-aecf-753b40d8bb43)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         356ea488-a88c-4463-981c-8e253da30a09)(content(Whitespace\" \
-         \"))))(Tile((id 7b16f0ee-7bea-494d-9deb-67b71e5f1e63)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         33bbd89f-ea0a-44ed-8b6d-0f7c119400e7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1ef003e3-796d-4758-970b-ca6e9e7ff45c)(label(e))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         9f6f513f-6cc0-4269-a4a2-6243b75b6202)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         bb84e068-23c7-43b0-aec0-89184f8a92b1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         84ea7dc7-72cc-488a-96ff-e5932a58d2a6)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6e94dccf-9925-433c-bc33-a8f8dd436b82)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f12b4097-cf4e-445c-a1d9-5a24ea9be552)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         8926b290-8452-4970-9486-92ee9050ec53)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9871cfda-120c-4d43-b33f-32c8f8cbec5b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0e0ec3a3-311e-4d0f-9d97-e900ef6a78dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f886a668-ea78-495d-8795-8a58f1ba6829)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6dbc43ac-216c-4219-8a29-db254869302e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1af27584-8920-41cd-b7a7-05476b1b2f32)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         37b611bf-3463-43ae-96b1-23c5f04ef7d8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46e47025-dfc1-40e7-8336-c5d5e0b143ec)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db1e1094-e4e1-46f4-85ce-3ec755a94438)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         07eb773b-71db-46e6-8d84-305b7e22c940)(content(Whitespace\" \
-         \"))))(Tile((id fe4609d1-da8b-49e7-a47f-e8830e1b55db)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d1c5a146-a0c9-4e48-a7e7-abca309d297c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c2184591-2f7a-46ca-af58-6322da770c37)(label(reduced))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         a508fa0c-a085-4f48-a774-7832104421c6)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         1d30d630-c2a5-45f4-8fbc-f7e8840f9464)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9f615885-f297-4f0f-b236-62956e469b87)(label(reduction))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f6498dc2-9b3a-4028-bd76-f07acc0aa27f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b2bb857f-e301-4b59-9ff7-7c5ce9910e57)(label(vals))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         49c2bdf9-accc-420d-88cf-a59a6faec68b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e20df7bd-9e2b-4200-92e0-bfb3d96834d5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         273ddbc5-0e5e-4188-9d1b-380341b7ba21)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fc03029a-347a-4c6e-b79c-cac812ff5370)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e9518f3f-702c-4e78-8c21-689bc4e9ad5e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         29c475a7-4fac-4032-9157-e77b4a93032d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5aafabc4-65fe-4587-9417-8c666db96448)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6aebd477-dd11-4048-9e0c-45fcd005c4ce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3f1252a3-5181-4271-9d8e-bd2ff7f88849)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b0539b1f-9fc4-4631-96d5-e3b726ada748)(content(Whitespace\" \
-         \"))))(Tile((id \
-         869218f1-642c-440a-bc92-2ac7257b9159)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         9666b63d-20dd-48d1-b91b-d54338349917)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f0f06479-4460-42bc-94d2-fffd669ac218)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         5ffa2d07-33d7-446f-a763-7b2f982623a5)(label(dest_col))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e36d0ca7-2477-4396-a3a6-8f0af7ea7292)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         be490272-02a8-4cd4-be9b-a4be841054b3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aeee9f48-8faa-4e52-ae85-6d9f2c17fad5)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         08cb0d33-b8f1-4b79-8d3e-2215c111cc05)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         43743a95-15d7-43b6-965c-669ecaa9da26)(label(reduced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         379262e4-3940-40d7-988c-0d9bedd9cccb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6aa40f7a-03f1-48f0-97b3-25ccda1ce19f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         76f578de-e1c0-4bf0-bcd1-6c474d51a32e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         051bb2c0-bb04-4b27-bd8e-f9487dc0b4e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         908c08c3-1dd8-4470-8b20-b9f565698b5f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         95b19677-a10c-4bbc-a24f-b370dd583496)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ee69d2b-0b3d-4100-8ee3-a35b60773ee3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         2201e6a0-665c-4e58-a394-50c057dd75c5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7f70b7c9-c415-4d8b-90f1-be68d7b97ac8)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         55b454e5-86cb-4b65-b3fc-00f652b87468)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f244106a-d34f-4fdf-98ff-905bd5c5cd3b)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d2f6689b-0dc6-4c25-8aa6-2f5885864a11)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         5dc454a7-e124-400d-8fdc-d97b5610c17a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f6b6a551-fecc-4124-803a-b2d13e45f6bd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         437b61ce-5d23-4a34-9abb-a4c8c74244cf)(content(Whitespace\" \
-         \"))))(Tile((id 27f58105-0759-4d48-b3d7-2b7187d5ace0)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         52dfcf38-a45d-4bf9-89a6-f385d2d919dd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ed149b6c-e169-4283-b5ad-896057a87d92)(label(average))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         a9683ef9-a156-4de2-bc2a-4ae0f1153850)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         5a22cb07-865b-434f-9cbf-39f0bf585ae1)(content(Whitespace\" \
-         \"))))(Tile((id 44b1604c-ddb5-4548-b222-e0d9baf8f912)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         0fb45289-8818-4569-abff-136275fd52b5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7cb4f009-2df0-4e9a-8224-85cd06b1a976)(label(ns))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         75cfb0ee-61ef-4cba-87f7-c7b144fee611)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         50b38bfd-30cd-42c4-8261-0c8b69516ab0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d04d2bee-487e-4951-a42c-398b4d1dce09)(label(fold_left))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e41bcd5e-3cb6-40ab-ad2d-91fc1fe4ee1d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c030ad15-ef07-4737-8f65-c1cd368f7f76)(label(ns))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4c6ade72-4e74-462f-ba87-6d1292b65dd2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         53d927b4-20d1-4026-a4e6-dda2d2315cb5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         40e11ac2-babe-4c81-8f1d-001e20430cdd)(label(int_plus))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5cce27ad-da5b-4c3a-b7ac-3b9c3705a46b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         807ed48d-f92b-4b37-b6b5-df318bf65e87)(content(Whitespace\" \
-         \"))))(Tile((id \
-         39657f9e-a130-46ca-a956-acab018880dd)(label(0))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         66d0ebff-5c9b-4770-960e-9e7f9f3c825e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b6109454-9ab0-4723-ac9f-fc4b594272d1)(label(/))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
-         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1911d490-c6a5-4d06-9d26-b3b278088b8a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         13823ba7-3e33-43b2-80d9-ef372b699454)(label(length))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e995bade-3d0c-4d23-b89e-d11a0961d0da)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         15b8303d-effa-4684-9b65-83284e85c42c)(label(ns))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         eb8e4246-629a-440f-83e7-bf5f7ab18512)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d9e31350-1381-4921-8dd3-f68daaa16a15)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d1d8732f-3dce-4d26-9c68-3550d8fb6781)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5aa49127-2217-497d-a1d9-1fc710d086bd)(content(Whitespace\" \
-         \"))))(Tile((id 00487217-469d-41b7-acf5-03912b85c831)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         98617b9f-e719-47a1-874c-58466f958211)(content(Whitespace\" \
-         \"))))(Tile((id \
-         270b433d-5fe8-4fd4-8603-47d2cb1a3d30)(label(pivot_table))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5ec92f43-8429-4ed2-9a8d-2e86057935cd)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f609376f-40ec-4271-8f43-68dd1451fc87)(label(students))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2c1ab68b-46b0-4891-99cd-4ba3b266dc83)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         12de8b36-bf24-4f1b-baed-064f882459ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ff8d9890-c327-46e2-ae99-2d1715a2e029)(content(Whitespace\" \
-         \"))))(Tile((id 20fa5dad-e676-48ec-874d-0338694132a7)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         3560e220-75bc-4db4-b833-09140355f94f)(label(\"\\\"favorite_color\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         301980bb-c4a0-4e84-9d01-dbd2ab3b72b0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4a115183-fed8-42bf-ac9c-b3f94b6e86c8)(content(Whitespace\" \
-         \"))))(Tile((id ae61c3f8-74fd-48fa-ad75-817c0242b60f)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6cda4d07-8f13-4c41-9d7c-57f477904990)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         80c60f99-6ad3-42da-a474-c613215524a1)(label(\"\\\"age-average\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bfb6e970-480d-4249-8fd3-6a77c437bda9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e8b73da0-f279-4b8c-ab60-108349463e20)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8458b9db-fa1d-48d9-bbcc-512d79ce9174)(label(\"\\\"age\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f74ba739-5d09-4b93-8d93-0964403fa343)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         88a45703-3e06-4dc7-8c10-1af85922dd56)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8eb7d59e-e2bc-4144-ba85-022f171b6751)(label(average))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         5c132581-6682-4fb4-90aa-847cada3a91b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c3c56d42-fe74-4656-8cd7-eeade1181332)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         79a225ea-f988-4ac1-b967-2a928bf99130)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4b626fb4-b832-4644-8d38-c8f41924eba0)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e2a0ad47-5689-4024-9fa6-5698461ba450)(content(Whitespace\" \
-         \"))))(Tile((id d31ce94b-0a25-492e-a22d-64e9abfa06f5)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         71b2f6aa-06ee-47b7-a0ba-3cedc21b16cb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c4ec176d-84ce-448c-819d-99f58a5cbb09)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         767eb5e8-5b6f-44a7-b2a7-e6e19abe3bbc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32537274-596b-4da0-a575-f4d156c626dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f404dda2-20b4-4db7-bf15-8485446eb0bf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         763125a7-0309-437c-a2b5-ef5fbe38afc6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         3472f871-e212-47df-bcdc-8f29b036e4e9)(label(\"\\\"red\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e828ab83-ef15-4bb1-9eb1-dc73c517b694)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ec0dac70-498b-4a6f-b388-96b9d4a65272)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3db045f9-da67-4cc3-b9f9-55220f98c482)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7251c5fd-2a6d-4111-a7ed-7045ea34808a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         05f1c8a7-0c8a-4421-9e2b-b237e4818ae0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a1cca640-53fc-4460-a131-d993cda4100b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36bc5f7a-631d-4891-8ade-7da4ab2d1a19)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2af15456-f687-4c5e-b4a7-dcef8fb85d63)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         47fc8a9e-46f3-40dc-9ccf-6e9321f9cc04)(content(Whitespace\" \
-         \"))))(Tile((id \
-         df35953d-873b-4e42-b772-e268975ac58e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ea436bd5-55bd-4f00-b742-6780fa85d834)(label(\"\\\"green\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         419d4379-40b3-45a3-9903-05c59bfc8711)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6ba11bc6-d400-44b0-a6cc-ff6ba9154590)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cf57d7d4-c3e0-45f6-8eb6-3f5cf045ef59)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7e1b0ba7-be79-46b6-b094-fb09d29689c2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8c780bbb-4eab-401d-a02b-80b5156c6ee5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         97b28c5b-7725-4d1d-bb7b-9132d0ed96e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9b26148e-a452-41bd-a3c1-4b61d453e256)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5b2ab534-2ccc-4737-ac53-b7aadb01863b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c627a5ab-8494-4803-ae78-d1d7cfa2eee7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         714fd19f-6c97-419d-867a-e03a4f990d05)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         fe6f12d0-a77e-4968-91fd-9b30b9988cb5)(label(\"\\\"blue\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4b8c6d06-353d-40e6-935b-4768fbc16b82)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5b9e9171-a9be-49ff-8a11-4d11945c7332)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a60be817-f6e6-44f4-809a-6333c928406a)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         dd34a1cd-438d-4bb8-8273-4c29cdd56710)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5e2f21a8-5131-48cf-a5a2-60534125986b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         294a2748-1028-48f0-bce6-1cc1c49241af)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         ad77667d-4c6b-4de3-8e90-8ccb8c488c58)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7ef04b1b-01ad-486c-ae21-fa41a3cd498a)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b644df2a-1bfb-4276-b697-4266158fef97)(content(Whitespace\" \
-         \"))))(Tile((id 6d639cf4-76be-46cc-8021-740b6ef5984a)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         e3aa1458-7c75-405a-a14b-b698b01eab52)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         81642b67-e14b-4054-99c3-64fe61abcff6)(label(favorite_color))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         52629a8f-56cf-47fb-932e-6d1e5ce6f0a0)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         57be16b5-0f59-46de-962e-68f56a809f07)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         c45093a0-3a8e-456a-82c5-98e51e0082b5)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         19efc092-5669-4659-a40e-34aa87ecb9da)(content(Whitespace\" \
-         \"))))(Tile((id \
-         608a0614-e708-4ff0-8a1f-b25601b39d08)(label(`age-average`))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         64bd2f8c-0ec4-454e-978c-80229eb8d3be)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         a52de9cb-94a7-4d50-9c63-788bb5d669f5)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         6ac0bae8-311a-43eb-a719-4c2797ff2be3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         add9b66c-7c7b-424a-be75-07981a9f93f5)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         5dd3e938-0750-419f-be88-eede754d22c0)(content(Whitespace\"\\n\"))))(Tile((id \
-         70008b85-cd21-4cf4-9b62-79e986280f92)(label(let = in))(mold((out \
+         d5cdf769-fec7-4b69-ba8a-749664bc82ed)(content(Whitespace\"\\n\"))))(Tile((id \
+         c4e95ab7-ece0-422a-9899-86374964b336)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         57511dc1-4c13-4822-9f4a-b1a447f7ab41)(content(Whitespace\" \
+         567dd460-2b60-4af7-bc60-6c1f01819c39)(content(Whitespace\" \
          \"))))(Tile((id \
-         a42ed83f-dcec-4388-9a31-c56b4ba11e17)(label(group_by))(mold((out \
+         6c968cde-4317-4677-8eb7-394df7e65b64)(label(pivot_table))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1832e9ee-e732-4008-80e5-a2d70cfbc25b)(content(Whitespace\" \
+         700c117d-9ff9-4d2b-86b4-3acd426f67b4)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9caaf391-433e-42b7-b100-e4130a7157a7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         547f8aa7-fcdd-4e9d-acea-09ae345e2ad2)(content(Whitespace\" \
+         e1af07e2-98f6-4d75-9eba-c86a89f92e76)(content(Whitespace\"\\n\"))))(Tile((id \
+         998eb425-f710-41ec-9185-37aa29cc12f9)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         708b57bd-3bb4-4c7a-8e32-27f9cb71ca29)(content(Whitespace\" \
+         \"))))(Tile((id \
+         40b82cc7-53e0-41aa-9cf9-34cf89c3758e)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         962f25b2-0e66-4e82-91eb-310748923d87)(label(t1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         72da3dd2-8c49-4c24-8652-9012e301cc1e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aa46b201-1ebe-4b62-bc25-382fbe831629)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3e9b9e77-f9ae-4e11-b9be-27e1cb730fbd)(content(Whitespace\" \
+         \"))))(Tile((id 188715c3-c146-482d-94ce-f78bc181b817)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         8bab11f6-8785-4eca-aed1-11ba674256c5)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         985d93f7-8b39-4bb5-84cd-ecfb8acae7d4)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         a1f08d64-80ce-4144-9258-420d99341c58)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1c30edbc-ea21-4967-ba0b-5a2ed4bdc1ed)(label(cs))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0721f511-1a42-45c9-8157-f2852cec10ab)(content(Whitespace\" \
+         \"))))(Tile((id \
+         637a3d68-9013-4074-8183-c75e4dd65315)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2440f7e9-32ac-4eed-8e0e-2e18cc7e4dbf)(content(Whitespace\" \
+         \"))))(Tile((id 099a250b-a42f-4b5a-8037-44127ae22435)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         d8f387e8-6042-4ddb-bc6c-8bfae83ca8fb)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         28344aea-ffd8-46e2-8067-5487a485fc1c)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         15830e6a-dee6-436a-93f1-7ccb609dfd19)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bf7aa441-33d2-4288-9cf5-137b1ceeb81d)(label(aggs))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         185833d5-c190-4c09-86fe-6da600f95cf5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         95bfd472-250f-47f6-91ea-82fe0d39f9cc)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0001fa39-a031-4a8a-a663-ecef9eb8ea8e)(content(Whitespace\" \
+         \"))))(Tile((id 34c6adaf-fae5-47a7-8e90-f05765b6eb05)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         18fce18a-a432-4a17-885f-b5fb8069fc3b)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         25579082-0732-4a7d-be42-3d156916a887)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         57f444ef-69ab-47e8-9b4e-a8e3b3c85d6c)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         72fa7a67-1f4c-4ddd-aee1-2ac0da57cc54)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fe3c6312-600a-4ad1-8b2b-eb2300362d83)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         4ce564c5-c34d-45a9-9c2b-c65cf6255725)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         205be3db-c634-42f1-8c20-3ac543c5e693)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bb43d89e-88d3-4872-931a-dac447254225)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2700b00b-17a7-4130-a115-7b152d7c02de)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7beac992-bb1d-49cf-acb4-501fa7a08081)(label(->))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
+         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1be19d62-5f1d-47f7-a16d-ee445b663d8f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d07d4ce0-857f-400d-b9a1-817b4d761044)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         b15a1245-9207-4ff8-8aa1-be57bda3b835)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c40bf774-c249-47fc-9dd1-9952763965bb)(content(Whitespace\"\\n\"))))(Tile((id \
+         c3a415d2-8fc8-455d-8164-242a62e79472)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f45a84fe-3462-4e58-ba8a-77d651d0bc24)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d00656ac-0d87-406d-9444-48e68fc2d08f)(label(groups))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         47623c85-7c15-4701-8551-c004ef0934d5)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         1a5c2200-99fd-406d-9c68-7f9096cfa607)(content(Whitespace\"\\n\"))))(Tile((id \
+         e6adabd9-a4fb-489b-a488-37fe3a1e5380)(label(fold_left))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b8a28f81-eb7a-4fe3-a0e3-c9a4479d8f9f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         465f9e75-d402-4750-bed0-a59de1718c7e)(content(Whitespace\"\\n\"))))(Tile((id \
+         b40d06ab-d4d0-44f5-a54a-fddc714ea51f)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         45b7b933-e445-467e-b736-703d780be559)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         10fcb720-affa-430c-aea9-61ec97bd4e3d)(content(Whitespace\"\\n\"))))(Tile((id \
+         7e4e6fa3-f13d-4174-b065-072ead499923)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         bc9b9848-4992-43f7-a785-a3ad069c0219)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         cb876732-dde8-476f-82a0-b46996255d44)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0bcd342b-1b4f-4a2a-a968-17845a4b880f)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         4028f6e2-d594-400b-a5aa-cd0b5a6ed5dd)(label(groups))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         19071660-9122-43b0-a2a5-47db114fb269)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         b2fd809d-3a81-4791-a3ea-d7379111d872)(content(Whitespace\" \
+         \"))))(Tile((id \
+         75025bad-a817-4672-a6da-62b2e226a2a7)(label(row))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         df5a4f01-0e69-40a0-97a1-762c108d131a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7a6a4386-5c33-4e65-9919-667da969b265)(content(Whitespace\"\\n\"))))(Secondary((id \
+         bb74a72f-ae2d-491b-9f22-db294abcbc91)(content(Whitespace\" \
          \"))))(Secondary((id \
-         a80331f3-b4e0-4fe9-9879-c7884f33874b)(content(Whitespace\" \
-         \"))))(Tile((id 8a5545c5-3a3d-4e3d-93c1-99f1fc4c7816)(label(let = \
+         f8b44603-5d5f-415a-8d93-f685290bf823)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         36f7134c-dec7-4ff5-99b5-68a78a91606d)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         9518a4dc-3c9e-46a6-89c7-4e9a87d53925)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         6ff424f3-97d6-43f1-b01d-61347ef28c9c)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         88958d8e-1926-46e5-a4c8-fc979da2aea5)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         2ea74b67-5f99-4e3c-b681-b642609951fa)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a03366dc-0962-4d6b-9d96-d0a2c0526eb4)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         56bc720e-8896-4ff9-82d5-01aac5193a14)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         aca43f23-4c6e-4fc0-9df6-3a55884aecca)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         4c6d6b40-974f-4a19-8c7c-82341334a432)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         698263c4-39ee-4f27-b153-f877673182f9)(content(Whitespace\" \
+         \"))))(Tile((id c64532ec-5cd0-4130-b89c-8c63d6f97195)(label(let = \
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         e6d61571-1bcb-426a-bfbf-134d2ad77f29)(content(Whitespace\" \
+         e11a0f65-2867-436f-8dcc-b84eaa634901)(content(Whitespace\" \
          \"))))(Tile((id \
-         4755b5d9-9cf7-4a08-b829-a46362376e76)(label(requires))(mold((out \
+         ea00a9c5-105b-4fc2-9909-fe520a20d3e5)(label(k))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         211c812e-2a1a-414f-8b8a-5963d73a66b1)(label([]))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         7f0fdd61-3c18-4423-baa5-2501b5eb3753)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         6338b6cf-8124-4b75-b3f8-2d62848c1a26)(content(Whitespace\" \
+         \"))))(Tile((id \
+         99088b6d-1112-43ad-8f8e-d3657f6529e3)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c7112c6f-1abf-4488-9fb8-983af0c03810)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         5f146438-cc8d-4880-88e8-0f60fc91c37d)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         44cab28a-6dec-445b-a1f7-64cb3bd92bcd)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         934fd3b9-66e6-4823-9b39-ba1b776b7668)(label(row))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         6d01f394-5c6f-477c-b8ca-2211a3912bbc)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         38e4be33-07c9-40d0-91cb-05de87d375b3)(content(Whitespace\" \
+         \"))))(Tile((id e90fdb33-2a4e-4d89-b60d-8494c55e1141)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         3a88f8bb-5cd5-47b3-ad3e-431f46024bd1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         efae4e10-b7cf-4ba3-b5b2-2d2e0ad0ff89)(label(e))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b0ca326b-f4ff-4629-b4d4-e441e89a9c86)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         0355e1da-2fe4-4fa0-9f8c-6f8e9f120593)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2e552350-61c9-4b4b-a485-184ede069603)(label(mem))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d5a2d3dc-d03e-4425-ab9c-19a7917017a5)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         bb3a085d-6c0a-4baa-89f9-658b906697c4)(label(cs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2be03bc1-a338-4a1e-bff5-708aa3e5ef89)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         53779653-9a32-4142-84a0-f76dd70d2c44)(content(Whitespace\" \
+         \"))))(Tile((id \
+         669dfb9e-6ab6-473e-b115-453849772b99)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d8bfbd32-2215-4c66-b857-e16c042d3b04)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         90c216c8-2c32-4f88-90a7-4d58289bf4a5)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         fca04381-b130-4682-9eb3-77f610122ecf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5da7a726-3e1c-4ed5-bf92-7499225f3f2f)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1e761f55-1025-4afb-8800-19a90d0433e4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1b3aab1b-a95e-4a8a-81a6-e91fe62f4fcf)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         697bb7b3-7282-47eb-b141-a59c52689c7e)(content(Whitespace\" \
+         bdd047e6-a1e1-49de-9b12-4b922a54634e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b47a26a8-7b39-4241-8c4c-de425b65fabe)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4aa71fdb-cbd1-49f1-9f11-982850a11045)(content(Whitespace\" \
+         86690ebc-e66e-48ea-a621-64d3385e29ff)(content(Whitespace\"\\n\"))))(Secondary((id \
+         903c113f-8d7a-4b4a-aaa6-7284e2e1ee81)(content(Whitespace\" \
          \"))))(Secondary((id \
-         3db9b337-6a78-4af4-90fa-17e9ca935a8a)(content(Whitespace\" \
-         \"))))(Tile((id bd60dc1d-b843-453f-b766-a90bf6441653)(label(let = \
+         28609335-e25b-4ac4-8fef-3d4c7c58ad3c)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         04d5f417-2a4b-46e9-8426-6146713e0851)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         2748d239-92d2-4df0-bf77-c044a114d197)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a7adfeac-a787-44bd-9552-d45123f9b20b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a0feebd2-9847-48ea-82fc-764f36511b37)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         e861d80d-bf85-4dbd-ac88-6a8aa145934c)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         0b936c87-16e3-427c-8d25-991c7004b300)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         d6bd6b66-047f-4a9d-91db-2d7d7e6e5ff6)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         7ddae7bd-a825-4eb4-8716-192d9c9623d2)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         d35092af-6210-434e-8aca-6958475db556)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a31b38c9-882a-429e-883c-983e4a697275)(content(Whitespace\" \
+         \"))))(Tile((id 5179e99e-dadf-478b-9038-f7bc4ddd2e24)(label(let = \
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         2db017b8-0cb8-4cec-b9a7-4f046d783241)(content(Whitespace\" \
+         96cb1696-3e3c-4a7c-bf07-cb5b261e684a)(content(Whitespace\" \
          \"))))(Tile((id \
-         07c24d3b-034c-4bf1-a910-62e402fab629)(label(ensures))(mold((out \
+         172dbb9e-03a3-4607-9975-e75beeefdcc8)(label(_group_tup))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         72ca73e0-9fdd-4f16-9d91-830d31d3c134)(label([ ]))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         edd655fc-4470-4568-8bbf-a99516d88747)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         54ea0bd1-6558-47b4-a1a5-05133f50fc06)(content(Whitespace\" \
+         \"))))(Tile((id \
+         efc45bf8-6bad-450f-b5ca-002c76dae0c6)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         deff678a-dfba-4bc8-8e58-c72cafe15bd6)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         90d5a9f8-7eca-4cc9-bd5c-b40dd357364e)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         041db514-cf38-447b-8b0c-8b5ccfb50458)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         875ccb57-3a20-4eb3-83bb-1d39c4ede41a)(content(Whitespace\"\\n\"))))(Secondary((id \
+         ca1d5a18-b2f2-4a7b-bd6c-2ba73b86d325)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         cc239e08-02f9-472f-b9c5-94ac4560934b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b5a59bf3-2231-47e4-a6e1-0f6fabac8e14)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         61839e1d-80a6-440f-99e2-11232bf9b107)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         362511c6-94f6-4e2c-8a58-b1ae4351f43a)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         59e198cd-f8fb-49da-95c7-070a6fba8808)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         7fbb39c6-773b-4890-8f20-470bf2ee0c02)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         781d12ed-39bd-4684-a1c0-afca9ec7991b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         93dd20c6-9a6f-4b43-9b3b-45a023160a34)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         1cc780cb-1909-4e47-ad6f-9a0c8d2257fc)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a1d24518-5eaa-41ef-888c-ecf973ac4efe)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ced16ddd-d5c0-4734-9c95-8177a0c134b9)(content(Whitespace\" \
+         \"))))(Tile((id c87aff6a-cfe8-4fff-a83c-3ad725e0dad5)(label(case \
+         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         dd7131a0-9924-4284-a4ca-161cd5ceae56)(content(Whitespace\" \
+         \"))))(Tile((id \
+         77be800a-1cde-4584-8740-2848b5645171)(label(find_opt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         286d01fb-506c-4546-a982-08d6e4c90ee2)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         b9f0903a-fc9a-4662-b4b8-be5a4448e32d)(label(groups))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e256cbbd-6015-4a68-a3f5-fa9b19a11c63)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cba8cf35-4403-4189-9887-a8f9b1a78660)(content(Whitespace\" \
+         \"))))(Tile((id bead428c-6a3a-4be8-8e5e-404f71d1bf38)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         65675cca-a537-4e4e-8bd4-ff46577d11ff)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a086c258-b124-44d8-9de3-0c12b7ef3fd9)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         571a4ffd-f8af-42ff-9996-0a6668dcdd7d)(label(gk))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         02dfde4f-b615-405e-ab8e-4dd1a848dbfa)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         6555d88c-4e4d-4d86-9036-a21d25e6179d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3689689b-8735-4bcc-b025-b1ae212d34c4)(label(_))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         c0d66cb0-78fd-458b-8b9b-747c6681ebe4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f142462c-6bc4-46f4-a76d-eb55e278019f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f517afd3-2bad-47b3-af72-70a130f9dbd5)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ace5e52c-0a8e-4a44-ab44-7a61bdf81695)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6fa762a9-9fab-489e-a8ec-e92d05267dbc)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4f0e2e3a-79e7-43c6-ab63-887b169bde0e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e3638a0a-1de5-46a2-9683-4d3df3a9ba2a)(label(gk))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         5efefc14-d866-4574-bb8b-64c4f9228a52)(content(Whitespace\"\\n\"))))(Secondary((id \
+         94a4bc5b-c7e8-4d23-862c-1cff91ff8d48)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         1e569503-1cbf-4203-8c09-58e0f61bc744)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         8295bfd1-0305-423d-a4ad-5c7dc2975d35)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         1fa28e50-6741-49b6-9427-dac805b216eb)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         7d1ef0ec-a934-4f64-9113-5e9dd46cfc91)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         29137c5e-6259-49f6-995a-3ba47b91928e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         43579893-a882-4c27-96c0-4218583ee7c1)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ec4e5534-82e5-4e10-8e9c-e99ab24d5be2)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a5338c52-0a54-453f-bd48-18074b9b9904)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         501f3cdb-80fd-4957-85ed-383d7dcc232a)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         e4e128cc-1fa9-42c9-8db9-742abd23de61)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c1da70e1-86b6-430f-b7a3-09559ece4557)(content(Whitespace\" \
+         \"))))(Tile((id 96887348-9e5b-4748-9605-bb7aa5915ae2)(label(| \
+         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
+         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         8e3d83a6-f8f5-4f8f-9fe5-101977c7915e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6a1e6806-ddab-4d3c-81fd-8e6af1809904)(label(None))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c1cc4d25-2f44-4d6b-9d1a-bc3d17c7ac3d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         8a22dd4d-400d-445e-bf22-c1d653f4952f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8af4433b-ea71-4fbb-b6e6-34c605c14c9d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         4e804296-c6ee-4855-b53c-f4a74fae5f8b)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         79f0bb71-aac6-4ed0-9357-35f723faefb4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c3be1a75-0c4d-41ae-bb2d-35d7a43f4619)(content(Whitespace\" \
+         \"))))(Tile((id 25cbaa06-51fc-4587-91a6-abb6be6f60ae)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         f22d13b0-9ce6-4082-8dc7-1392046ca6e2)(label(row))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         39903cbe-2fff-4679-9a37-6c6ef2a8b2de)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e94a67f2-e0fb-4a4d-a200-332f3a8383c8)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         81387c1f-7e92-4d0f-8868-f4d83ac586ba)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8222bfee-fa27-4fbe-8249-87ce12246b79)(label(groups))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         0d28b391-25fc-4e10-9e32-4cacb3be20a7)(content(Whitespace\"\\n\"))))(Secondary((id \
+         72cc1ebc-6d0b-4fb2-bc86-f4364ff46e83)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b33c9938-3868-439a-8799-f30ad5c10bfb)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         837830c3-ea2e-4f41-99fc-38ca58b77c9e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         fdfafb58-ec7b-4f57-8fe1-3f572c0f9963)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         d892b420-22d0-4e18-8be3-0691a1db4f5f)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         f3f9026b-e130-4286-9952-eaa7aebf866e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         f3f0dd8d-cb8c-4555-a41d-699c9a58c859)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         cc03f0a8-c22d-4825-bf28-195c09e21f8e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         7883e0fa-d68b-4695-a619-227e1c85620a)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         7a8ebcb4-ad51-4e89-9ece-5a28405c070e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         3aec740b-fb40-4bc0-a5cc-47ee9a2bf108)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         57ae3e83-8446-4906-911a-75e467eb7a65)(content(Whitespace\" \
+         \"))))(Tile((id f6d9f51a-18ce-4366-92f0-19c7f562b325)(label(| \
+         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
+         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         4424e56a-325f-41af-987d-4e996491d946)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b0652646-6a14-4608-a777-348fc0b053bc)(label(Some))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         09cea6a2-4cd4-4858-b4db-6a8b531f05ba)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
+         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
+         daaf950e-c6ed-4324-8255-1240bce488c9)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         b7917385-ab8d-4806-9578-59789fb68427)(label(_key))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         9eff9dda-4813-4445-8d45-3dc6097a2fe5)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         2c89fb82-2ca0-44fd-a386-e41c58cbb9d6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b659f986-fcfd-42a4-ba6e-c6cd48808088)(label(rows))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
+         260b1fb3-71f0-4889-b9f7-f61ae1d52a23)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ab1b8b07-e4b6-4f94-98c8-008984f64518)(content(Whitespace\" \
+         \"))))(Tile((id \
+         691241f0-16dc-4b59-ac7a-f8a871cd6112)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         0369151d-8593-4899-896b-c0886355987d)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1025512f-3cc0-4474-8ca7-f8e0df39ae26)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8e852f1a-9dcb-41f8-a62f-e943010fc17a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a7bb7039-ba2b-4157-a18d-e9f32214c377)(label(row))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         569fa6e4-f288-4bc7-a157-b32d369f3964)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fd3443e5-8f68-4b0f-9232-ae89372b6720)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         36afc5e2-ff0b-48ae-894c-8094aa9483ab)(content(Whitespace\" \
+         \"))))(Tile((id \
+         be4d5721-fb1d-42c0-beb9-d52c6fc5a7c2)(label(rows))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         c710b670-515d-4408-baa4-1b4304c850ee)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7e35113a-9f58-4b90-b2ad-910fd15e1e97)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         86a0b8af-a433-4e07-a289-34be570fe6c4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4cd8c409-899a-4b56-93ad-05a3cb762be2)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8ded0e1b-e709-4f3d-90a0-00c60ee4c409)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4b2af04e-649a-4c5f-b3be-585a75056db0)(label(groups))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a3f50c4a-5061-4d9d-a6fc-e276151a1de2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4266a86a-e4c0-47c1-a11b-1b1b1d517182)(content(Whitespace\" \
+         \"))))(Tile((id 39e9fe96-a2bf-4395-b0b6-8b9f7839aa4e)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         55ea403d-69d5-476f-8da6-961d7c572487)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f16edf15-a1b1-4523-a343-258538b91927)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         e1448866-4866-4eb5-a3f2-f8e8c529cccd)(label(gk))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         354274ca-5fa3-440b-8732-3678896ec987)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         201ef681-8eda-44b8-8816-8e560074e51f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cb558fb3-686d-4581-bc6b-e14f55120c03)(label(_))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         0550ec09-ce76-46e0-8717-2d90d3bd6e6c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9b353d4d-ccbc-4e8b-8990-0be3a0433d19)(content(Whitespace\" \
+         \"))))(Tile((id \
+         44a2456d-c238-4ddd-9240-b4490cf29c8f)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         4f2a4923-c4da-421a-b954-20229214921d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         528d62b3-2a02-4696-af72-dc96d3e29ce8)(label(!=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4715f743-b6bc-431b-a2f3-0113589c8bce)(content(Whitespace\" \
+         \"))))(Tile((id \
+         76b2f137-6ef8-4d1a-9f1d-a17d987307b4)(label(gk))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         1c857256-928b-48f4-972f-7d4abd9c4f32)(content(Whitespace\"\\n\"))))(Secondary((id \
+         c800f72e-0794-4dbc-9778-5fd011a15e21)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         84f2a381-64e0-472b-bfae-bc66f2a15ead)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         bf4b6c74-0666-4a51-9a6a-1244cdba194b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ffcc6f33-4899-43af-a591-a504549a5d6e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         4c248339-dbf9-4482-9406-fbabebc4483a)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         26ceaf34-de6b-4981-84a6-d5ccc7762e46)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         d3cce2e7-69a8-46d8-9a08-823dce354bda)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b9caa67a-3661-468b-b41e-39df095f4321)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         f6c3f7ba-9901-4999-a77d-4f2ef9875654)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         1b78e1c4-9134-46d3-b1c5-73fb1de73275)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         464113f7-bfeb-4d57-a61f-e54e407c7fb1)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c90fc11c-a098-4444-9aa2-1f1687098232)(content(Whitespace\" \
+         \"))))))))))))))(Tile((id \
+         f8092d9d-7c4c-452a-a0da-74c67d7630cb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         538da92c-1ddf-4ca6-b3fa-ba50f9651b6c)(content(Whitespace\"\\n\"))))(Tile((id \
+         248dd735-04d4-4a26-956e-807ffc9b87a8)(label([]))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         255b6097-7232-48a8-946b-122beaecd8e4)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         95f30a09-0279-4023-8dde-e8e355ce6aaf)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         54a0d2e9-58f2-48ff-8c51-005a219a1907)(content(Whitespace\"\\n\"))))(Tile((id \
+         da6baeaf-a084-4238-85be-9d5008d06733)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         20a24490-72b9-4503-9065-c068a62438ec)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         4ba8d708-c099-4e7a-830d-2b0aaccc4427)(content(Whitespace\"\\n\"))))(Tile((id \
+         81482e11-a332-426c-a416-9a538f713216)(label(groups))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4b06ba66-5e39-4d3c-ab34-255510049b41)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         88849449-7dc8-49d9-9c84-64523702a12b)(content(Whitespace\"\\n\"))))(Tile((id \
+         fa0ee450-b5e0-45b4-b815-342b38343e78)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         cd2ae295-5130-43ea-9673-befea94a5634)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a9c91741-61d7-4c4f-8b90-3604fbd9cba7)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         c544357a-c1cf-442b-8789-26bf11ba8708)(label(k))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         5fa79d68-a162-4532-8d8e-93bfea34c5b6)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         ee12c41e-8083-401f-8272-668bee194062)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a3de1f21-53c3-4dc7-8b01-dd4eccd6affb)(label(g))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         41752cc9-39d3-436c-91ce-3530951c307f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         053c117e-026a-485e-9c68-c3931ab8f230)(content(Whitespace\"\\n\"))))(Tile((id \
+         d4553378-7db7-4e6a-803f-0839ccc72215)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1cfe1d01-e680-449c-b004-82a5fe02e50a)(content(Whitespace\"\\n\"))))(Tile((id \
+         5eb672d6-214a-4107-8159-d5ddf7ed50dc)(label(...))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a3fec653-fa2a-441d-ba74-8d85be9ecaff)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d996e86e-7049-41b1-9d46-a4117c44c66b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         e0272099-dc68-4b81-8e29-928d9ba97746)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a218b06c-9f5a-40fb-9ce8-0b0c7983f77d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5b9a6963-1f2e-482c-9eba-f354b7a334e0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5699a549-dbd2-4346-ba89-a46bc66dcd71)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9f2d05dc-a9c1-49aa-a151-f2c1d8799943)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f9d2db5c-7416-415f-b8bf-6eae80531db7)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         1c26eaef-ba66-498a-99af-1a1b0df16b42)(label(enforced))(mold((out \
+         14e4df8e-6f48-4f52-a48b-ef92e963d4ae)(content(Whitespace\"\\n\"))))(Tile((id \
+         4f05b745-cf44-431d-9d21-c2cde6b38e06)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         cab27c29-be0e-4208-9e79-e315255f87e7)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         20f62a0f-c84a-45b5-af7a-29bf4f65adf1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         af974a29-f765-47ae-9e1a-76b1f8027e89)(label(true))(mold((out \
+         b76c9e18-a584-439f-b4a4-acc6708eccea)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         f6bdb8b1-3247-46f2-9702-47e7166210f7)(content(Whitespace\"\\n\"))))(Tile((id \
+         9e5390c1-3a0e-4881-835d-676f38843e7f)(label(aggs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a75f2fdf-6d33-4e44-babf-2c2e3cef96f8)(label(,))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         63caf0aa-d2a4-4a9b-87f8-a01e6a5adf20)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8fb9541d-cdb7-4936-a922-c9a411f5ddae)(content(Whitespace\" \
+         0c9ef081-f7f2-4686-be7c-2ba81509e793)(content(Whitespace\"\\n\"))))(Tile((id \
+         f1646d94-97e7-4e04-9bce-6904a9402f48)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         4ebaed8b-2bba-44ec-b587-b2d609bd6e13)(content(Whitespace\" \
          \"))))(Tile((id \
-         4f4687c1-f85c-4a48-94d9-2b7c284d6b47)(label(\"\\\"schema(r1) is equal \
+         c4818a94-c14a-431c-83b2-3a437c20f56d)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         2ba20f9e-90f2-481d-8eda-fd9ddcaf2c58)(label(dest_col))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         49490f3a-0694-4387-b784-472d8960d90f)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         2004fcfd-4f1d-4212-b040-625ab7a5b624)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f5c0835c-801e-4ca8-aef2-5506915cb3a7)(label(source_col))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         fff104e0-7119-4af3-8910-30226aca5f1c)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         2b81b4bb-e72c-48ff-9fd2-4d8667f5c9c8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ea4045bb-27a8-416a-a024-a34b3f5b89c7)(label(reduction))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         a956cc82-0515-4db2-9681-55cd66860e02)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         4e25599d-8b22-4760-bc96-77faee493b96)(content(Whitespace\"\\n\"))))(Tile((id \
+         22ca748d-26b0-421c-9bc8-b3ee23701350)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         3d7b83eb-d5cf-4b4c-a2ee-fb6a68e4727b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dd95d8e0-a044-4873-b81d-6b18b9be937c)(label(vals))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         347f46ae-8fe0-4d69-b86e-ce93f2c34d56)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         b1f34a4e-6481-4659-b43e-445691db1dfb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         29a76855-5a47-4343-ba3f-6b8ee6d327ac)(label(filter_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ddf8d525-e200-422c-bf6b-09d6c4fe32ce)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         75c9dbf7-34b8-4316-a4ea-512fa57100dc)(label(g))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5c5c5054-bc7c-4970-8e1c-924e9dd5ec2f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         943980d0-824f-4afb-b609-1d726f0824e5)(content(Whitespace\" \
+         \"))))(Tile((id d64d4717-2204-43bc-8d6b-387059c5a14f)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         07990d3c-65d7-42fd-babf-a5ebf1cceed6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         21ee11a6-ba2a-44ad-b45d-0e516b81ae9a)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a48f6977-ecc3-4ac1-a78d-5af97ac84c7a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         518a7ec2-3297-4628-930b-1a2d78e2ceb3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         181bdf8c-c908-4042-992c-729bc9652c93)(label(find_opt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4d95ed3c-f579-478c-a65e-95c1f787c8af)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         9d01f476-1db0-444e-ab9e-efe6634ac4bf)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cf20abf2-7cb5-4921-a22a-1951904ddfa0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         ffae4832-7113-4d8c-830d-96b9eedbc6b1)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         30278cb4-b0b9-4c52-93f6-d1420b0614fb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9709f2e4-7d98-48c6-8aed-38436b3807be)(content(Whitespace\" \
+         \"))))(Tile((id 876d6f31-d86e-4f14-98ef-b1332a823149)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         16879c52-7a16-4d41-87a4-f4f3418bb84a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9aaa984a-c0ca-4827-8fd5-e17226739c44)(label(e))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         d845c88c-e2ac-48d8-be00-f58c559426e4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3757467c-ff64-48b5-873a-19089806fd81)(content(Whitespace\" \
+         \"))))(Tile((id \
+         41846cdd-ba54-4de7-9685-e56813524f03)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         539cf90c-29ec-4cb0-bdc6-2943dcec4932)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         623c3285-0712-452b-b191-b07997da3a24)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         dc5e604a-7518-4966-a3b0-2a7b8b640f19)(content(Whitespace\" \
+         \"))))(Tile((id \
+         056e97b2-e48b-404c-af22-fee0367ad635)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         40c10b86-fa94-4e5c-9d57-56ee7d740a2f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         be682c2c-4647-498f-8a49-d8f2f23b3d6d)(label(source_col))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         8745d518-33e0-4622-88cd-de3f084d143a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0204ad7d-7972-4a41-be7c-7907b9487cd6)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4d0b0a05-e226-4f35-9afc-77c8b90d9129)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b5bf3fe3-3718-4ed2-934f-9a374584f46c)(label(option_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         730c5ffd-5a8d-4afd-a11a-32be1b397534)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         d2ab5d28-fd90-474d-886f-b5ad447faed2)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f7f87413-b72b-4af1-8abd-f7cd5ce75dba)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6bfb71e2-4251-4df5-ac48-693dd47f1705)(content(Whitespace\" \
+         \"))))(Tile((id 29e433b9-6b90-4111-b8b3-c0fa62b59931)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         c57c8896-1008-4f15-95e1-944fa1050a7e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c874c9db-058e-4ce5-a172-19d95b6f7f15)(label(e))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         8d7afb4e-22b1-4c3e-a126-bff81ce06b33)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         fea7b727-6d4d-4664-a002-7f444bff946f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bf632028-49ad-434d-9fcc-bb4ba56cb6d9)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         76574941-1f4a-474c-b814-854920b8a3bd)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         ffab3081-7ad4-4cf5-932a-df3f8d9d2979)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         891289e3-0c99-482a-84e7-0e4fde77bc4c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         85285bcd-0b9e-4569-9f76-ee69dc1204df)(content(Whitespace\"\\n\"))))(Tile((id \
+         329925f8-2e6f-434e-a008-f07191431b03)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         225ff045-0a9c-449a-969c-eaad32517c8f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8034737d-6651-4ad6-8f39-d9fac8aaf4a9)(label(reduced))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f53b8a4c-f346-4977-8ce6-d7635a1a2a98)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         94275c05-d20e-4411-b5ad-3735f70f6a68)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d6f27ba8-de88-40e7-b8e1-46fd41b5a7f4)(label(reduction))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         81e81632-8f21-4253-81f4-d8923feb98ba)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         8547715c-4e16-4470-b54b-f32eee8519c7)(label(vals))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         2c9b919f-babb-4662-98aa-da952f02c5c7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         db62fa53-f0cf-4d91-b87e-a754e08f23fd)(content(Whitespace\"\\n\"))))(Tile((id \
+         0a0a6815-97df-4177-b9b8-849ad90fe575)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         99d5bda4-8747-4729-a615-77d579f00edf)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8211f222-6576-4648-b262-4e80347fd0e8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4d4c89b9-d88b-4448-a187-afed5a0bd159)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         594eb830-8ea8-40f1-b638-e387cdfb1113)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0af97fc0-a2a9-4227-8e4b-ea990cc3ca43)(label(dest_col))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b120aedd-5398-49e6-a7f7-42b5ac52049c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4048f1a1-782f-4e5a-b5fb-820db9c0b7a5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         79121d23-0f74-4f11-8182-8d367c043843)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1227b524-c05b-4ac2-a0ed-bb8d3521cca4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e46c7264-c5fc-4572-b266-37a684a1b3a5)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3408b8ab-b378-4695-beb2-d9e9d09cbe04)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e9432bb7-3154-4be2-803a-05731acbf415)(label(reduced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         f502ba14-c313-47f4-afd1-d42d88b22830)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         dcb69a3d-8730-4c2c-a69e-3ece37cf06ce)(content(Whitespace\"\\n\"))))(Tile((id \
+         d1f254e0-a0fc-4c00-aa50-90ffd066d377)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         73c87b09-e290-481e-b872-f309df595e21)(content(Whitespace\" \
+         \"))))(Tile((id \
+         001c5ea0-e571-4e88-91c2-d4947300a560)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         5e08afae-6752-4089-a332-4c870ee2dccf)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         340954bd-082f-4816-a5f4-4fc09344dda9)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         a5a1905b-4a44-4263-93ff-addc48d4bb92)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5036a913-875d-4619-baf2-f3c9bcf59712)(content(Whitespace\"\\n\"))))(Tile((id \
+         4d15709d-5b4d-4775-8f6c-a0da5366349f)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         4b57b67a-a5ed-42eb-b1f2-34d1008bc12e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d6e2f0ac-bd72-4c9f-9f27-1aa02fe11b54)(label(average))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c43d939d-3f36-4613-878a-4b9a333bcb99)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         98f5f375-7c75-4625-9857-94a6b8861e3a)(content(Whitespace\" \
+         \"))))(Tile((id 50cf54c7-ef0c-4e9e-8de1-3f559ae73f12)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         3403e74e-6585-48ed-8c14-4c7714a68e1e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         21d7adcf-207e-4041-9661-4f97ae9d1c3f)(label(ns))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5c73726a-50e5-4d03-bc90-4458ee9a2451)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         bfd6c5bc-d703-4cd9-9d3f-00cf4ef64b22)(content(Whitespace\" \
+         \"))))(Tile((id \
+         250dc911-5b94-4bad-8c41-10b58fccc2e9)(label(fold_left))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ec0f6b8e-1ef7-47ad-a173-279a878fcb05)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         a326562e-63ec-4c48-8d8f-723d45e45897)(label(ns))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         44856105-3e23-4467-96a3-4268d7ae716d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         969ebd4e-88f7-4865-ae1f-7f67c5388328)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fceff804-b353-4470-92b6-b5f763e2a9b6)(label(int_plus))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         dbb44c6f-3315-4ae1-8e35-8c141bb62424)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c09bd84f-34f2-4e60-a3e8-63fd77f08f64)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dc801af0-4fa6-47ef-b311-9dda916bbff0)(label(0))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         777405ed-5d85-4aff-bc21-87d15daab997)(content(Whitespace\" \
+         \"))))(Tile((id \
+         433b2ec8-37f3-4a83-bee0-8a8cf1abcaa6)(label(/))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
+         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1727e10a-e3af-40f8-a40c-b50dff8a0ef5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d1c33b91-9398-4610-8661-88ed762b1607)(label(length))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         04d0c67b-5319-459c-9bb9-91fd8d6d6ef4)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         a11d82a1-ed41-4f8f-944c-2f145d5ed1ac)(label(ns))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         9cea5cd2-707d-4506-8583-c4de4a3a7927)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         647f959c-c857-4ea9-9377-61a351100564)(content(Whitespace\"\\n\"))))(Tile((id \
+         bd16cbd3-cae2-47b9-999b-46c6903eae2d)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         84fc8c68-ebab-46bb-95f4-879180a50652)(content(Whitespace\"\\n\"))))(Tile((id \
+         bea16027-a3e3-41a9-9192-e8ed0ec3d270)(label(pivot_table))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e2c32b1e-b290-4a73-8e9f-7aea205e68d4)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e7c5e7d9-b7e1-4fc8-8cfe-e5f7039dcd78)(label(students))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         83fd3e23-aa2f-4c29-9d10-e07077ece778)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         def69fb1-32ec-4141-a016-edf4f121f37a)(content(Whitespace\" \
+         \"))))(Tile((id bace113b-e04b-4aca-a894-f1a29a2282f9)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e0964bb4-7a06-4983-9703-ecb829ff3aa5)(label(\"\\\"favorite_color\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         1a5beace-3e64-4c1e-8c6a-3bb80cc66bfc)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ec616d1f-823d-4347-b3ca-6b1ca17e8950)(content(Whitespace\" \
+         \"))))(Tile((id f80b2630-5122-497a-86e7-91873a8a4169)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         652b3ca0-ed66-4374-867c-6a56546f912f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         fdf0136e-0496-47c8-b3ac-deb1ee6dbb7b)(label(\"\\\"age-average\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         85e5dd31-5176-4c88-9634-2022c205d4a8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f00d91c3-18fc-4ae5-af79-814b3d8dd75f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c3b8a63a-86dd-440d-a12b-32b4744fdb5f)(label(\"\\\"age\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         53a5e5f3-71f0-4deb-998d-841e39f4847a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         af8a390c-de6b-4daa-b46c-4acc5b418146)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0db6b1c0-89cc-4624-8a14-5cd16435467d)(label(average))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         7912a19d-ade7-46af-ada1-9f504fdda738)(content(Whitespace\"\\n\"))))(Tile((id \
+         962807a0-0b69-43b0-85cb-b35c8ef68c61)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b22418af-82e6-457e-b7fa-583426069c21)(content(Whitespace\" \
+         \"))))(Tile((id 683f7c9d-8721-4f44-98bd-facad3416f85)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         8fd035ac-dd40-4a68-b6bd-5c25f840bd6f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         faeed74e-1d4e-4883-8ce4-5d54e1d3fd85)(label(\"\\\"red\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a399130f-8a60-49fb-b21d-b12e2c61355f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5828e699-6632-4512-bb71-f914cc67050c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8f410567-8019-476f-9f40-12f7813e0cab)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         5fba5b01-9476-4312-b059-a9a2204809c9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8cf44755-e6eb-49c9-926b-12e6dcb60b7f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b71921ba-cf89-47ee-ac4d-cbaab4b55047)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         70a2cc69-58f8-4357-b3c4-a89e22c9b625)(label(\"\\\"green\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b459802c-5b01-4619-8322-61630fb57263)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9dd6db2d-1aac-4674-a0cd-0ba69042ea10)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ce7ad6cf-0f4e-40a2-a15d-d7831c8f8f8f)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         5623501d-6d58-4313-94d5-69ccb1719d37)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e4de8ca5-3b3b-4c21-9b57-3c4876387a04)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bf87e499-67bd-4ebc-996b-0ea157fe39fb)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a8d74cc4-4191-46cf-b06a-386b0a9bf7f5)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         584df5ba-d325-4d3f-8387-339b05af7bdc)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4fb5ae33-c919-44be-aa66-e1904d06c122)(content(Whitespace\" \
+         \"))))(Tile((id \
+         88244373-6a1c-4884-8413-e88e29114a93)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         3a7f3fc8-a3f3-4e2f-93de-84efc453f2af)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9946961a-0d17-48f3-81b0-f8c41912d42d)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9add8b87-68e0-440b-a0b8-c0e76d02ce6a)(content(Whitespace\" \
+         \"))))(Tile((id e24fdd23-9225-4919-90c6-06992387ae91)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         f01de6cb-49a4-4145-8ff9-5fdbf6f63f91)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         5e52d9ce-ddfd-401a-a521-feb818428797)(label(favorite_color))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a4c38d4e-7adb-4ebc-91d6-55e016076767)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1a28a567-5075-4692-a703-0e537b07b1cf)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8e6e612e-4142-49b2-941c-3fffd4e4d894)(content(Whitespace\" \
+         \"))))(Tile((id \
+         910a7493-97ed-4163-8181-dc30339181bc)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         08858cd7-c01f-4e3f-94f7-60368842582c)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6fbb2b6e-2032-4c7e-8962-cbee7bf90ecc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2dc5f1df-8c48-429d-aa2c-cf4bee03430e)(label(`age-average`))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         85b24ad9-e57f-4583-b562-f22cb3a2615a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b0d443bd-7f6a-4ea2-9be2-5c5c11e3829f)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fbc57844-13cf-4a67-a9fe-834adbcce9be)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eeb4f6cf-c515-4bd6-989f-69142be9dc6e)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         ad3bf7af-4ed2-48a5-a9ac-570e84745053)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ce13e288-cdab-432a-a232-ac0c28125cdb)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ef9d78e5-8c67-4e84-8429-5160fb2285ea)(content(Whitespace\"\\n\"))))(Tile((id \
+         79791b32-6a38-4331-b265-9907a3907ed3)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         c1c391fa-029f-4f8b-a7e3-dbcc71f24e08)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c7dd707b-8e51-424d-bd07-47228c254087)(label(group_by))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1bb48d66-e441-4a88-9c2c-77f935033327)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         63891ed8-cd4b-40c7-bdec-05c49790b668)(content(Whitespace\"\\n\"))))(Tile((id \
+         fa5144ee-3e23-4f96-9692-e0b2814d3a34)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         de966d61-6043-4eee-8e34-2432229591c2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         df6e3766-88e3-4844-9121-d07aec8be02b)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         2c5bbdbb-10cf-46c9-a2f8-86cd0cf7d1c5)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         83c88e99-542e-4ccb-86a2-c135fbcf76f3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b3d0cfca-bda0-471c-b3b3-d3983e12e929)(label([]))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         4de8ec92-2a27-440b-a4ca-7e9ce42a4a9e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d5ce5dd3-3a6c-49bd-b457-2d517409a47b)(content(Whitespace\"\\n\"))))(Tile((id \
+         ea499a85-2404-43fa-9d8a-f38b5fc3a5db)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         80c79374-24be-42c6-adb3-3be3ada10ede)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dc41d10e-1594-457d-bd66-0cfa3f524b1f)(label(_ensures))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         66d14e6a-02ab-41ca-90d5-d0eeeed6ce08)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         2c8e5f43-d100-4645-be6e-7039d74e28eb)(content(Whitespace\" \
+         \"))))(Tile((id e864106b-9c1f-4c43-9c71-ca65698d9987)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         b9321bf9-99fe-4098-983e-a383d73e8901)(content(Whitespace\"\\n\"))))(Tile((id \
+         e685aa4c-5d81-485e-b1bb-21e190360d92)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a143b1bb-8fcf-4ed8-8f1a-0fe02dd387fb)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         285a1143-fec9-40a5-b9b4-8848edb9e4a5)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         0179bb77-3aab-41df-afd4-bf648ab5bdff)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         1a259c3f-ea49-44bb-a9c1-5d356e01b3d0)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         8dd83ac2-409e-4a31-a82e-638aa542462e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         41c3dea5-fbca-4df0-b6b6-0289e6c77eec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5665e89e-e13a-409e-8b07-587df4fe8ee5)(label(\"\\\"schema(r1) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         0b97984a-f199-4f5c-8cdd-44cac5e14dc6)(label(,))(mold((out \
+         d67c2bee-fe22-466b-ac2c-4a4c57462419)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         26830c71-e2ef-40c7-9eef-646fd5f86410)(content(Whitespace\"\\n\"))))(Secondary((id \
-         12b175aa-7b87-4670-94a5-940e5d8f9a13)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6eb73507-ec10-49f7-85a1-d946c1b1bbec)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd4f2e56-4e4d-40cf-b099-17f38a97d8a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3d25455b-5ea9-4997-a3bf-8e34002e41f4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9edf0754-4eab-4034-aab0-048b9e382129)(label(\"(\"\")\"))(mold((out \
+         2b911d9b-ba56-447b-9e6b-1d5a80dcff6a)(content(Whitespace\"\\n\"))))(Tile((id \
+         ae00c433-3290-4436-a719-1aeb2c1ed026)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         226858f5-68c1-4fe9-9ad6-1e411d0d7b50)(label(enforced))(mold((out \
+         af9fa071-a267-4942-b790-3d11f6ea45c0)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         1ea9ac86-3399-477b-a04b-3bf7ca308337)(label(=))(mold((out \
+         ffa9e9bb-7e19-44bb-8a2e-8d723e3e3ff0)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         d2a830cf-a38a-48be-bf02-eb3706c6e186)(label(\"(\"\")\"))(mold((out \
+         5f6e2af8-de2a-43dc-862d-ab6afed7fc83)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         7fb5d38d-8cd6-4e39-8b5d-69ade694823a)(label(true))(mold((out \
+         ef52b446-589e-4182-a752-ef208ba42f0f)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         08efeae8-3959-4d83-8878-8b924abea20d)(label(,))(mold((out \
+         1b7af21a-1e6f-401e-a0fd-105105d842fa)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4e9eb20c-8704-4e07-885f-b7955128e85a)(content(Whitespace\" \
+         d843afdd-f909-4c97-9780-ba8d39f39391)(content(Whitespace\" \
          \"))))(Tile((id \
-         07e7a217-ec9d-42e6-9e79-60e783e54148)(label(\"\\\"schema(r2) is equal \
+         25bde831-66ba-44e2-b7bc-b541810e441e)(label(\"\\\"schema(r2) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7e6eefc2-c0d4-443c-9e91-1613e21dc67b)(label(,))(mold((out \
+         2b9446da-95a7-447a-8417-22c34d47a708)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8572c91c-2e2d-4638-a5e4-a6b6bff0bf48)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eb9fb9b9-517d-4181-9d8d-9d630de38232)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b06288f-f48a-4709-8dfa-d2000314cd07)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e685e3b-0ac3-4ab1-b87f-6ded9183dd55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e4e61390-7e66-435d-a606-d363c3f78f01)(content(Whitespace\" \
-         \"))))(Tile((id \
-         645b2b8e-3e39-4697-8d55-35329b5cae4e)(label(\"(\"\")\"))(mold((out \
+         3b6f3dfb-4329-440e-99e9-30fbaabf738e)(content(Whitespace\"\\n\"))))(Tile((id \
+         ab478f56-1b2d-4e01-ac95-9220616df835)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e2fd7f2d-996d-47a1-b6e9-cc0ca4d8cf42)(label(enforced))(mold((out \
+         69caa10d-de0a-49f9-803f-3eda6aba5e7f)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         09b5c3c0-3029-4ac4-be87-83e972fa4172)(label(=))(mold((out \
+         1813d5b4-1ad0-46d3-856d-3195910c51d1)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         07040d61-93ad-402e-944f-17b40776f678)(label(\"(\"\")\"))(mold((out \
+         7e374a98-6fbb-4504-99ac-7d4719ed26fa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         93744280-7acb-4444-bcb6-20983531c373)(label(true))(mold((out \
+         2344e4ef-6772-4c7f-a01f-f22d0d6c1406)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         64eb1ad5-459f-43d0-9bee-8aceefe1971c)(label(,))(mold((out \
+         05ae6920-23ac-49da-8fc9-170374ee08a3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ea9aadec-4854-4940-b41d-82226b9ac765)(content(Whitespace\" \
+         967b3963-1484-498c-b804-970242782273)(content(Whitespace\" \
          \"))))(Tile((id \
-         565d7776-c1ce-4f71-bcc2-bb571d0cf41d)(label(\"\\\"schema(t2) is equal \
+         701d6727-211e-47ee-a853-a0141f7daf8d)(label(\"\\\"schema(t2) is equal \
          to schema(r3)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8f21b099-c577-40a8-8f5f-bb65acc7e94f)(label(,))(mold((out \
+         00b5cc7d-ee9c-4ee4-86fc-e0242b2bec57)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a8ef2276-5f2f-4f51-9598-94c143573a9b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9cd55830-5b17-435d-8890-1b64c0fee44b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         782d7dba-60bf-496e-aa94-d5dd5a1ffa0d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2bc26113-2028-46cd-9d10-a7659ebef6cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6aa32f5e-59b9-4765-af70-b563d50d0074)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b64eeff6-2d21-43d5-a1c6-a507aa94f760)(label(\"(\"\")\"))(mold((out \
+         7b0dbc74-70ee-43fd-b63a-a6697e4d4b8a)(content(Whitespace\"\\n\"))))(Tile((id \
+         738c5da9-82c3-440a-9d72-d51481e0c614)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         23b4220f-42eb-4135-b4a1-0eb85c8427d9)(label(enforced))(mold((out \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         b36fd083-8a0d-418e-94a9-060adaae1e03)(content(Whitespace\"\\n\"))))(Tile((id \
+         e48b25bd-a48a-4ceb-ac46-384cc7791d9e)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c8b2b17f-4a9b-4103-a9c8-8b4a86c5192e)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         72924acf-9930-4b2c-a02f-7b15d4cf8812)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dce554d3-c97e-4c63-b5ba-c765828f7e0b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         124bfb3a-fa3c-4784-bd56-b574bc8a918c)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e9eb414a-de9e-41fd-b7b3-6765af6667d8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0427cc7d-4984-4918-a8ab-8ecdd4c5bce7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         418e7515-7cdf-4a1a-80b3-e4851138f3e6)(label(false))(mold((out \
+         9629f458-c1a1-4d7d-9d19-e47fa64839b3)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         961fd2ad-5543-49ac-9f72-3a4e861bf883)(label(,))(mold((out \
+         2ffefdcc-4629-4f2a-b9a6-49eacba868d5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5bd9b876-5a6a-48b2-8efc-000f92d5b629)(content(Whitespace\" \
-         \"))))(Tile((id \
-         208a98cb-bcb7-4b9d-a166-038a64693729)(label(\"\\\"nrows(t2) is equal \
+         7870db2f-0931-4a73-85f2-3d1785e7dc86)(content(Whitespace\"\\n\"))))(Tile((id \
+         63741906-ea48-4871-817f-4cd9c1e3540e)(label(\"\\\"nrows(t2) is equal \
          to length(removeDuplicates(ks)), where ks is the results of applying \
          key to each row of t1. ks can be defined with select and \
          getColumn.\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         307ee64c-3823-4487-bd9e-cbfc92e0daf5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         49215c1a-48d5-42ba-b910-c0373b6d18b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d51edb59-ec93-46ff-a564-bc8079000f5a)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d767de26-9d6d-4379-b8a9-d8cc9c3e686b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         56c7dcfa-50af-4d03-bba4-9c873383f3d2)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         0dfd5124-cd88-4fb5-9df1-c2db68a06eb3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ecabb8ba-a0bf-4008-8280-460ee6ec7163)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         48decb42-704d-48f6-bfea-d23badec3072)(content(Whitespace\"\\n\"))))(Secondary((id \
-         07777c30-c097-4ee0-a43d-8f8573a39ff1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b479cc5f-8df7-401a-ae16-50700d7ab7f5)(content(Whitespace\" \
-         \"))))(Tile((id 47d8784e-9e05-4f2c-83a1-d8817b4edb03)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e77b93e7-de45-4454-a324-0a1fa00e960c)(content(Whitespace\" \
+         eac0e99a-2f33-4e52-83b2-f8b79729360c)(content(Whitespace\"\\n\"))))(Tile((id \
+         a32ed5ab-93f6-437c-8ea5-5be92ecef12e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f82a7277-ed83-42af-847b-a467555114ad)(content(Whitespace\" \
          \"))))(Tile((id \
-         caa307af-2a27-4de1-b700-bcbc31681bee)(label(group_by))(mold((out \
+         31b5a642-1deb-4262-a8ab-3a1d1158e452)(label(group_by))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         33de824a-322d-4405-ab4d-94d16a8aa31a)(content(Whitespace\" \
+         59a264f1-2d3e-4ad3-8742-33a9d017ae9b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         99cd7964-807e-4953-8bc7-06102ce3fd1b)(content(Whitespace\" \
-         \"))))(Tile((id 2804cce5-a434-4906-b60c-d5aa92a437a7)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         1cb8aee1-468c-424d-82cb-ae453689b708)(content(Whitespace\" \
+         3f1ff98a-3a4d-4af8-9c03-1e952c1171c5)(content(Whitespace\"\\n\"))))(Tile((id \
+         d5d0aa34-5ecb-4872-9301-084f8be86ac7)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         53b1faaa-bf03-4923-b775-d596b5f9d4ed)(content(Whitespace\" \
          \"))))(Tile((id \
-         c7acaf8f-3bf9-4de9-8963-8e46b8617bc2)(label(r1))(mold((out \
+         f39cbf1a-7715-4ed1-b959-3406355a98e3)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         f5de6e77-3e09-498c-9409-49fc2429f8c5)(content(Whitespace\" \
+         f9fea5ff-98ac-4ec3-b9ac-14183d7ff902)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a52f4335-b951-4724-9599-624e05a206ca)(content(Whitespace\" \
-         \"))))(Tile((id a27927f7-81e2-45e1-8823-45f7de67f56a)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         b270e8a1-6477-429e-a321-6c9907955dd5)(content(Whitespace\" \
+         b05f1a28-d444-42dc-b3a0-0104e2e8a522)(content(Whitespace\"\\n\"))))(Tile((id \
+         801be42d-abc2-42ea-92a3-775cf5e93105)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         513b8a6a-7335-4dde-9bd5-6cc8bc3b1c96)(content(Whitespace\" \
          \"))))(Tile((id \
-         c2497d7f-529c-4fe4-b59a-88900a8ee535)(label(r3))(mold((out \
+         ad91a8a3-8781-4d82-aa0e-cb1f70f5bcc3)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         114c742f-e905-4680-838c-4f3832ea7566)(content(Whitespace\" \
+         8eb13648-93a5-4fc4-a153-81e18455cba0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9cf3dc28-b701-4099-a393-b58bcbc56e59)(content(Whitespace\" \
-         \"))))(Tile((id 9243b6d6-235b-4f5f-8e37-26934c7b7f80)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         c07f8376-65fe-4fee-9b0b-68404cf58197)(content(Whitespace\" \
+         da4303de-b86c-4ba5-beb2-fad9495ac543)(content(Whitespace\"\\n\"))))(Tile((id \
+         9ab3f22c-28a2-4adb-962f-1f10c7fcee79)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         747f5ac2-c309-42d0-9e36-32b54ec16b90)(content(Whitespace\" \
          \"))))(Tile((id \
-         2bae0697-13fa-4e34-af0f-cfc7373600a1)(label(K))(mold((out \
+         ba4cdd6b-0d3e-4496-a3a7-25f2f3633e78)(label(K))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         0279f6ef-9640-4438-8b3a-5dfc96a418bb)(content(Whitespace\" \
+         78bfe428-4f2e-4fe4-9319-3ed465c8d173)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d54f5b59-5818-4abf-a207-e9829f41d2a5)(content(Whitespace\" \
-         \"))))(Tile((id 3f31d7aa-4881-4e97-8f94-b17e543640fb)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         b3b53384-e770-4c82-bad5-f5b177a1868d)(content(Whitespace\" \
+         4427b28d-a18d-40e3-89a5-17999913898d)(content(Whitespace\"\\n\"))))(Tile((id \
+         b028f9bc-6c38-4178-994a-96cf56dd7a99)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         b0db0dbd-771a-41db-986b-e918112851bd)(content(Whitespace\" \
          \"))))(Tile((id \
-         59e8f280-bd1d-44b9-bc05-f4660db6a7ab)(label(V))(mold((out \
+         28df6644-37c2-4cf3-a05a-8399ba5cffb3)(label(V))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         eba94a02-3ae5-445c-ae7f-569b80f6abe5)(content(Whitespace\" \
+         c7a38616-08bf-4b12-9fb0-d324458c9bb1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4911bf03-5052-4cca-871f-a44a2cdefd3c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d2e3c8b4-2978-4d02-b13d-c9b50eac0eb6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dac196f4-28da-4cbb-bb56-1a0c77139da8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e34b24f7-bb2e-440b-816f-5a1a58f96993)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c60ea531-dd26-4492-8a53-13ca88267d41)(content(Whitespace\" \
-         \"))))(Tile((id b6c5fb65-9239-4905-878c-0b0805c2143a)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         c0bb67ad-3b11-4538-abac-67c6b7638523)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b563907a-9785-4a9c-a048-8dacf9d22c18)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         68b3b0d7-04e7-4374-89b6-e261a652c8a4)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d981ddbc-27b0-48d4-983a-fb8327860d7b)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         1fc04759-68c5-403a-be47-17007baab7cb)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         bb1382c2-1a3f-4d88-adfe-4311eb8f0c0b)(label(r1))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         9da1a9fd-bdef-425f-9d6c-5be1a777d2cf)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         722754ec-1909-4026-bdf8-dcecd3bd78fc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f253deaa-ef75-482a-a152-245e836ba2b6)(label(key))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         f695ca1b-a2f9-40f1-bac7-122532ef4ce7)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         9ac736cc-899c-4893-a0c0-5a114d68d4f0)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         531610a7-2dfb-422d-9535-4e730c24bfc0)(label(r1))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Secondary((id \
-         50cf0d9b-3cdb-4de1-8f1e-28bc68228ebc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4764821d-54a7-46dd-8b72-3709a91afad0)(label(->))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
-         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b0f372ee-4fbf-4e07-a7db-49baa0246f62)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fa65ad7c-803a-47be-9886-a4928177f886)(label(K))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         7092cfa8-b5f4-461b-84e3-8386a3e21f2b)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ece34473-8894-415f-a4c8-88a6c802fc71)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ac9225b4-561f-4343-a8e2-6a1aa1017ee9)(label(project))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         19290354-f5a9-4420-8c26-795c87849d43)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c874870a-dc73-40a9-9caa-855305b69e38)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         144de9ae-1f98-4474-b4b7-585004a103cd)(label(r1))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Secondary((id \
-         b864da36-80f3-4ee0-a98c-e5efe487259e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5be55cdc-8b3b-4c9c-bcd4-be20e6aaa0d4)(label(->))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
-         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         651c5006-4397-4951-9318-cfc02cc4e9f2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         65841db8-db17-4ec4-94f7-2c3e2e644683)(label(V))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         5ff6f6a9-eb00-4934-88a2-562688657479)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         25b8eb80-60be-4a9d-b833-4a35000bd90d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         48a100f7-1e8f-4388-8930-fc35aee6e0b1)(label(aggregate))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         69ad4af2-ae13-4a01-9e2c-bf48c8479995)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         cafb542a-421a-4362-8df5-cc0036d47b59)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         7c2302f7-fbbf-4a72-a619-5565c67894f7)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         e9b230b6-b6f1-4bf5-a4b5-396deede06d8)(label(K))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         be70eb63-9c63-4353-99d2-0aa62700d74f)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8d7f9bcb-b0b6-4f2e-94fd-def578908e30)(content(Whitespace\" \
-         \"))))(Tile((id f49b9bdb-9d3f-4a2b-8585-1b9659cf4ed7)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         520dc58a-aa72-4895-b512-1b9033fd8d5c)(label(V))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         8b6f420f-155b-487e-90bc-28f393131d0f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ecf56390-aeee-4b60-b250-4d0f4d5528ab)(label(->))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
-         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7f05aa40-8575-445f-bd60-0daa8280874d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e4ab25e2-3b7b-4175-94cd-ad660fd8d3f7)(label(r3))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         8f07f293-f19a-4c6c-8e6d-d3402b2264b4)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c1e51482-18b2-498e-ac43-24c96eb581f7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7c5babe5-d04f-42d2-9c62-1e30689b37f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c85b5ea-8785-49b9-ba80-dd69e8251d82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7212e648-958e-48aa-8ab7-72b55b1f7622)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bbe957cf-1d52-476f-9980-878d0df9ce2a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         215adebb-cf89-4de0-b953-a28e3ebbdb4d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         98ca99ee-ff7a-41af-bc47-aa60926e2b44)(content(Whitespace\" \
-         \"))))(Tile((id 86a7d6ad-51ac-4519-906b-803c13382b49)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         145fe2fb-7f05-4fb0-b8e7-2a018d7e8421)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e61bdebd-6d84-439d-86d8-042da3445d39)(label(grouped))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         f7b1186b-0150-455d-a749-56a043766331)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         1360446c-2c26-463a-a6f0-39b064237eee)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cbfc7fc9-01f6-4724-94f6-8a00ad73c7ab)(label(fold_left))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         eaf27d57-77fe-4506-a8d3-06e7677c5738)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         ec1ed745-df3e-498f-a2ab-b39bf2942b9b)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         464b6362-c59d-4021-808e-109267a585b9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c45bdc54-2a10-45d3-9004-8dcf3559bdd5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2e954059-96a4-4995-800c-81312bf90d1e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         60a4aae4-eacf-4b0e-9e21-1a4a554ccdc5)(label(fun ->))(mold((out \
+         7c40d81a-8bab-4807-b8c6-25356bcaa1f2)(content(Whitespace\"\\n\"))))(Tile((id \
+         e47c171a-60d3-448e-969d-05db8858a6ae)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ad369202-cdcc-4854-9d51-c9431e231941)(content(Whitespace\" \
+         812f7edd-a0c8-4303-97f5-8ef9b735eebc)(content(Whitespace\" \
          \"))))(Tile((id \
-         bbef16fc-8157-471d-83d9-f5c82e970ed4)(label(\"(\"\")\"))(mold((out \
+         ae6cbbce-9f24-44f5-bb4e-4f29d04ed386)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         c323fd43-9e58-4f62-b0e9-af3bf65c8e92)(label(groups))(mold((out \
+         7acaea58-ca7f-47ac-b684-326ad92da8db)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         df6ba851-2a5c-4659-a766-3816062eab58)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0e56587f-6c9a-4b79-97bb-ae4ae85e4b93)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1ea9d587-179f-45a8-ba12-631d96412f11)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2e0d9bf9-5313-498d-b969-c9947c082dc1)(label([ ]))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dacec886-7de2-4a95-9f46-7ba9388a1c14)(content(Whitespace\" \
+         \"))))(Tile((id d3099bc3-ea7b-4075-b273-e611d280500e)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         7ec79c2c-14a8-4bbe-a9ed-2499aacba025)(label(r1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         bf286ce1-f7b0-4c82-a66c-66e988574e71)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         f2609747-2c98-4640-b2ae-922d866aeae6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bfd53218-290e-4169-975d-842bc00bee09)(label(key))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4ccc035d-bf78-473b-b305-4a1f84a8f2d2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eeac1c2e-8a68-4803-bb63-5e7d688694a5)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1d5f9eaf-82ef-4733-94c6-f386859e2f08)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c84c1517-d599-49e9-8965-458aa90385ae)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         ef9b600b-1f5d-4e2a-93f9-c1826c0a11fc)(label(\"(\"\")\"))(mold((out \
+         d97d7f76-07b3-4a80-bfad-d2d25a177d07)(label(r1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3ead9982-646c-458c-925d-85b7a0ae27ed)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ccb880d0-531a-4d99-a83f-829a75ca808c)(label(->))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
+         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         422d97a3-8754-4e3c-88c2-8bc2e18043ac)(content(Whitespace\" \
+         \"))))(Tile((id \
+         509ad513-a90b-4a66-b90a-f9dfad15e191)(label(K))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         1d1e6bcb-3371-4c21-83f0-a47a2415dc2c)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         5b8112e9-7d23-486b-a51a-84361452a33c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f3827a6e-232d-4136-9db7-68b6b90e955f)(label(project))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f1abb9f1-f2cb-49e0-908d-f2d9ce152c64)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dc620cd8-a8b6-4cc6-9cf4-6a3b48d87f54)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e73841b2-f5bd-4acf-bb3c-313e3423df5c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         13659f9f-7d48-4ebb-8bfd-9ad064698ca8)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         41d117fd-b64e-41d9-a009-6bbe55fdd78e)(label(K))(mold((out \
+         b91d75ba-a4c0-4387-9c52-f37b00dc4cb3)(label(r1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         872e827e-c7ca-4cf5-875d-2b3bf29a7762)(content(Whitespace\" \
+         \"))))(Tile((id \
+         464f02fc-3677-4c2a-beae-50502e32a696)(label(->))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
+         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fc99b0c5-a543-4503-9bcd-cc339f097f78)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ce32b21e-84d2-4250-b544-070cff613766)(label(V))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         e7025867-2915-4a7b-8a97-7ba3026d14ac)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         132486fc-3881-4465-a01f-1b23eb4c441a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         565f924a-d91a-47af-8ed8-521a2ae9ffc1)(label(aggregate))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         371d7ff8-00b5-471c-a2a1-3044a6b0024f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c041b60d-5e51-49ed-8521-1dc1b00fa664)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5c647db9-45db-4ee4-b5a5-44eaa1de64d7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         48826039-24e8-41cc-9fcc-4461b62c34d0)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         9d7ad094-eae0-4e96-be63-4199fc828a27)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         4575be96-ff7d-44ff-9fc8-66715b7cd454)(label(K))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         1abb96e8-43fb-4ab5-bf57-360d7a665208)(label(,))(mold((out \
+         60fde0db-dedd-4de8-be07-c9ed37ccf618)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dc7a746a-f6a7-4c2f-97a9-c4083585e9ae)(content(Whitespace\" \
-         \"))))(Tile((id 15af9dcc-71e2-41eb-968b-9956858ea11b)(label([ \
+         24a78df5-68ae-45d0-bf9c-b187f79724f7)(content(Whitespace\" \
+         \"))))(Tile((id d4e3f52e-7474-46c2-b93e-d710930387bc)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         9b18140d-496f-4f56-9e45-f3e7b2931253)(label(r1))(mold((out \
+         7d802890-039f-4b2e-84a8-9c9e6433efc4)(label(V))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Tile((id \
-         97e68fc4-cc12-4d00-8e11-17895a9e51a7)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         de18904c-2002-4685-b44f-80f1ad188f7e)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         4cdbeb52-d502-4d87-a635-eed21942a553)(content(Whitespace\" \
          \"))))(Tile((id \
-         a28ef542-278c-4993-aebd-30e5240d327a)(label(row))(mold((out \
+         d47d5941-39a8-4171-9f20-625568d9b2ce)(label(->))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
+         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a8ede93c-bd75-481d-aad7-cf6f0282576c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7be85167-8b43-4da4-a2a7-27758c6fe9fe)(label(r3))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         f51014f7-a9ec-4b4d-8808-2b9b9ff8be7d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         16b75eba-f720-4ecf-80cb-d58e4857f578)(content(Whitespace\"\\n\"))))(Tile((id \
+         9a49e43d-715c-4dd1-91cb-a6381cb57c7b)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         eba8e0d2-9ae0-40f8-85b3-469365e5a95a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f3908407-b7d6-4165-b466-bb08eac15356)(label(grouped))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         01601b25-651a-454d-b28c-a348650b562c)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         4f9f4e5d-df5e-416e-80fb-15799f49ac42)(content(Whitespace\"\\n\"))))(Tile((id \
+         ebadfa86-0c57-4715-beda-5cb11ef2b623)(label(fold_left))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         86d318ec-49c7-4946-b187-2d706356a5bc)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         bbda05d4-b20d-48f1-82e1-169f4897963f)(content(Whitespace\"\\n\"))))(Tile((id \
+         aabbea3f-b024-46a2-ad9e-42a2706e739e)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cd09ebae-5162-4041-b3c0-b845aa1982a0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         23dd82fe-67a9-43ea-a2d3-2913d604b13b)(content(Whitespace\"\\n\"))))(Tile((id \
+         557babb6-c76e-47f2-9ed0-d8efcb1e7115)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         5e340c13-4768-4278-8a33-c2926569fbc1)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         db9ce7c7-7366-437d-979e-b6ce4bfc6e71)(content(Whitespace\" \
+         \"))))(Tile((id \
+         49e1f32b-6c36-48fe-8c62-c6741a34ec80)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         c1dd5769-18de-4f2a-92cb-cf7b643efee5)(label(groups))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         f97965af-2d3c-4fb7-839d-5e52d8c08aaa)(label(:))(mold((out \
+         0ca707f2-9084-4654-af9b-0644b62a34c8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         a631ae34-5e03-4c3b-a7e8-963b5586f7a1)(label(r1))(mold((out \
+         807fef95-3cc9-4fd7-b4c8-2a18ac06c08e)(label([ ]))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         31e0f7da-4446-4e15-863b-a2d39abde490)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         14ad0d3e-b48b-49d2-b2af-735bdb61f0b1)(label(K))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8596e294-923d-4fa8-8f77-6bc923002511)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         aceeb028-2864-4d12-925e-53466147e334)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fa057fc3-4ac6-4536-a736-4a68111f734e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1298bf54-844f-45d3-aef0-7a9778e65cbf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9f3255b7-a82e-45f2-9ce9-1a7dd1a674af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         92abe2fd-00c5-4d36-9061-cd1dada54a15)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         efa1478b-c1e1-4d57-bf1d-8783639ffefb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ed3cbf1-d608-4a6c-8e12-e3e68b4d6345)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a1c3ac88-49e3-4036-9c58-a346b8ddca4c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f24b91e-efce-4ed6-9b56-43522a29a583)(content(Whitespace\" \
-         \"))))(Tile((id 3ddb04d2-9cbd-4be7-ad3b-0412ce63f208)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         3294ee0d-0962-427a-a13a-883abfc422be)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b0074f61-3e43-41cc-8ab7-a69962b55faf)(label(k))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         1f7051ea-8eae-4503-8c56-ad711493286d)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         b54b17b4-91f7-4aac-88f0-3dd994bf9ba8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         423ba30f-52dd-4e34-96ed-c9d09fc4ac16)(label(key))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c84e5393-2eb8-4e5b-a2fb-456d76e1184f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         3896c1f5-780b-497d-8e6d-f7af40339b05)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fb6032a2-d438-411c-99d9-a7a853ce9455)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         2a304543-a1c2-4e77-930e-7a15e6497aa2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d7cfe85b-714e-427d-9da4-ef7201b90f75)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a47588f3-98e9-4b39-9f84-0dc9e83a57a7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b549fb7a-c49c-45f3-9f09-bd684bc753a7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dc98c2e5-4cee-4b9e-ba35-ea88a5d587a7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         89c3daea-7ab7-4a43-96b4-79b2236d163d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32e333aa-607a-4bb3-8692-831745b8fc02)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         15b2aa8c-6900-4a66-b862-1197cda7f32c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aa322ff8-e665-40d2-8b80-24387bfe5b47)(content(Whitespace\" \
-         \"))))(Tile((id d79dd173-bc78-450c-84b1-90b94e1b80bc)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         63533e63-d51b-471e-bad8-ceb050082e2a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b0b07a7a-a42e-4f34-8d29-b3563744f319)(label(find_opt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         43a3812d-b7bf-4430-8199-80d9edb4a98c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         3ad9983e-58ff-4cc9-ba40-c51ed34b0172)(label(groups))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fca9bc4d-2493-4b7e-a8a0-ca9e8d9004c8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         26ea16fb-25db-4718-8131-820fb17d4493)(content(Whitespace\" \
-         \"))))(Tile((id 897dc6b2-67ee-4c15-82ed-3514a3074ad0)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         10573c22-8376-45aa-97ed-472a5bb3d95b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e63a0c68-63eb-46d1-89d0-6deae20d9eaa)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         197a89f0-c79e-4d69-89c4-9a6f5ce18d41)(label(gk))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d0601eb4-2358-4682-a3f6-5482888c795f)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         e79a4ead-f79c-4b03-a505-e09d9aecf80e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         32d2c512-510f-46c0-8cad-edb1c8616632)(label(_))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         c4dd8c33-2b68-46e7-8848-25e5fa33dc34)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         aa610384-9a02-48c2-b95c-2d19aa993463)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e29abafc-e13b-43b3-9013-341eb0fbe13a)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         26d42889-4ecc-4e10-9ca9-e91dbe895b1e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9fd366a6-1dfe-4350-9afb-3bfed9ab82a9)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d7e1b926-9cbb-4c7c-bad3-33909b242d41)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3a8793ac-5265-4865-adc4-979d033211c8)(label(gk))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         80d8313c-fdd8-4486-8496-a0f1d64b327b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bf02671a-1d2e-4b0a-9d56-21bee1a2c5b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3bd4dc0f-bc6e-40c3-bcdc-4cd6358ca1b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3b7078a2-15cb-48ec-b645-bbb885c9da18)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c6f7885-28fb-49b4-889a-9ed8b081010d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         75a2d299-65f4-40c1-abdb-df6c64682d3b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d2682b3-8cba-450f-8784-0e1e446685f4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8ebf773-3d52-494c-9ee9-50816b1a14bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dd1f32fc-726b-4219-ab9d-9311ab625b15)(content(Whitespace\" \
-         \"))))(Tile((id 97a18b6a-342e-4690-a6cc-6e47d5baa162)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         e614c4af-de5f-48fa-8a26-e1f8d58fa609)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4c1aebfd-ec1f-4227-92eb-25eb7f1a2d89)(label(None))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         50a3cf8c-1cc4-4dc6-8d58-9c178a1e08b3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         7298a20e-28a4-4a4f-a5cb-0237aac28453)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4a396df9-c294-4b3e-8e6a-666904344636)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         0795d7aa-03a4-450f-8ab0-c472764c1aab)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1979c164-0a9b-4994-ade5-811305b205bb)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5448e8f1-3a48-4496-aaff-31bd950cca86)(content(Whitespace\" \
-         \"))))(Tile((id 0d55634b-3349-4d48-bc22-9fa9322acd92)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         310e9c44-6cf2-4ed6-ad78-2469d670a700)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         4dd68f70-b934-498f-aa8e-dd9f698c110e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1c41ebfb-1348-40ee-91c0-040cd58f345d)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         123d3203-d969-4e60-a784-4647377cd463)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2f6cfb56-7375-4f82-9b5b-270538f959fe)(label(groups))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         9ccc2118-b9c2-4b0d-b863-eb1fabb6cf65)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ae5d9838-685c-4420-bc77-ea41b363ba08)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ae6e422-36ee-4c00-8be5-7baa8a84ca45)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         401c0065-7d8e-44ba-a7e3-9356e833f394)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4eb04d49-822e-4f8b-ba95-7e2072cab357)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2cc5c8e0-e531-4cb4-b22f-be7cf84efef0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6da16c1c-dee0-48e8-beda-af456b5cb3bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         401e4019-fca6-4ce0-bd9c-c2a01fce56f4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         59e1b9a5-75cb-4acc-9d72-3393afac5838)(content(Whitespace\" \
-         \"))))(Tile((id 5b3362ec-1aba-4ff6-883a-d78a6718321c)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         e32224f8-717a-4bc0-afc4-c3e762531daf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         72abfc39-7332-4f7d-a972-02053912b17d)(label(Some))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         88516bc3-f177-43ba-9f38-688ce27502ce)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
-         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
-         4ca1a53c-d820-45c6-9519-8e91a0a1971e)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         daef0871-c449-4f24-bbd6-f4399b66d106)(label(key))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d29dd5de-3283-4c75-abdf-dd4c4ab88f60)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         1a627fce-a03e-4202-9030-eafaf46d4ff0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4ee8f2fa-3e46-45ee-b302-94559aace500)(label(rows))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
-         fc41ce62-c80f-4d58-86b3-568e0abd0df2)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         90d4fe37-eca0-48b7-837c-d853fd1c7370)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f042061e-adaf-4a1d-9ba0-1dcd3b63e630)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         fd6d7a0d-beef-4160-9181-95a22387902b)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a96d88e2-b431-439c-ae7b-f92e5f1d308a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb6f5a53-5d76-41ad-979c-30b7004dac11)(content(Whitespace\" \
-         \"))))(Tile((id \
-         373dee1d-ede0-4255-acfa-1c103a79f37d)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         d479a5c5-d7ee-42a1-b122-7b1adf14f5b8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a30e9f81-a2a0-4563-84f5-6ef0e67398da)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         85ab77c8-acfc-42ae-b477-982cd7f7a75e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         03bbfa45-36c6-4ef1-bc89-74ffa4be2951)(label(rows))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         403a7fc8-0f33-4b6c-9518-c5d77167b59c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         63779e56-6ae5-4e90-a7ec-cab7c9d4ac92)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4cf04bc4-614a-459c-9b5b-9f88e56ba25a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         20727d38-f530-493d-adca-fe25b1e5c3e1)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e65b2acf-75a7-4068-bcb9-ba61743d8b75)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2848c77a-030a-4541-980e-7e7584afab53)(label(groups))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         909f0caa-0c0d-4bd0-a0df-dd220f38b9ef)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         799db33e-86b6-46bc-86fc-c8cdcb4291f7)(content(Whitespace\" \
-         \"))))(Tile((id d741da62-539f-4544-ac27-73f370e00977)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         9d71ac20-aafc-4289-bbf0-6104ce9b3535)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dc81de88-007a-4f19-98ab-72a52b6a06c0)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         b9d91227-6603-4ddd-a047-66deab62b6c1)(label(gk))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         f56d29b1-2a7d-415e-ad27-38655c1cf0de)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         a48b373a-2ba5-426f-a595-b09c95fc6513)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c729e0ae-ac6a-4a40-99cf-48e1dd706a50)(label(_))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         47882aa6-6d38-438f-8067-8f040459246d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f2db8318-eab6-4732-a5f6-e22354443402)(content(Whitespace\" \
-         \"))))(Tile((id \
-         93250f19-ba74-48a3-930b-9e81f6730d05)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         000da051-98ac-417e-9b79-5f2aaf865d20)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2fd43338-e7c0-4f4a-a325-9cc1ce334990)(label(!=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d163e14d-a5e4-43f5-af73-6df0a9ba2e3f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b168a66c-38e1-4ca6-a786-8aa4e8cdb8ca)(label(gk))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3ee8f5df-9e96-4705-b865-bc0c16c1b120)(content(Whitespace\"\\n\"))))(Secondary((id \
-         32d1050e-5d0a-4618-8e78-b7d3bc743062)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b0ae787c-0789-4874-8964-7173a29f2592)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         48c0340b-7a50-4d81-85c4-f866f5cec8ee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         35be5854-ef2f-4f49-a410-ba0e37a60678)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c509987-95ac-4f6b-bb16-ed273f3e1f66)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         920e8ea8-eacb-4ba7-89cd-19c50352f8b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3bf29022-f29b-4aca-9eef-d84264eae65c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9265693-4108-44d7-acf7-9d90719c3623)(content(Whitespace\" \
-         \"))))))))))))))(Tile((id \
-         81ff9924-17ca-4db4-968d-6c57dced7da2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         88328bc7-11f0-48aa-a18a-de7f5bacfa92)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e4df79f0-810a-4a65-a98c-b320e4e2a3eb)(label([]))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         548c5ec8-1e9b-4506-960d-a3094c78cbcb)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         923c5bd6-0f70-4c4d-a6ef-cbe572ff14d9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ab406557-f7c3-458c-9903-ec1991bb7ab0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c2354e2d-3268-40b7-8193-95ae9f77668e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e4135d93-301e-4a5f-b6a2-1d0d83426940)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cd753230-c7bd-4b4a-8356-eb10203b6bd5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         793c1f55-573d-41ef-95de-d8d46aa5e7c3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e4acc396-f225-4e61-b83f-3b1e5fb7ee41)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bd56bd4f-d6e7-4318-ab3a-2229146ae335)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         53ea7eca-ed14-4662-b275-3f9935c04b9f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         314c3f84-61f1-4479-9207-c2d6cc58d845)(label(grouped))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e8b44c8d-3982-4129-be7e-8c5e5110afad)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a9d60924-0f23-4fbe-b4e2-d38fac3ceba8)(content(Whitespace\" \
-         \"))))(Tile((id 3ea0b323-8003-4664-852a-01b795c1ccb7)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         7a36d9ba-9559-4655-b590-0135709ba7d5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2340b227-5c2c-4dc2-8b7e-cd8311f2cd10)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         1db0a0de-3854-4bf9-b826-e5b98eef3c38)(label(k))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         54fab7b8-d7e7-42be-9dde-8fa2e3b06152)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         0d85f1d9-b17b-4886-be50-bcf53c09970e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c8290a1e-30ef-4f2a-a5b0-f4d80d9cf9a4)(label(g))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         51140b8f-2646-4707-86e3-603c6b7d7926)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         39081034-7c85-4c17-bc2f-f442ce76eb4f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         74431a3e-51b1-4b29-8646-d8f8059ef269)(label(aggregate))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         91f80e2d-d955-4c1f-b1aa-88bfbceffef6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4c211bef-5153-443c-a60a-9a6b5995bec0)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         754e4152-5df3-46af-a093-b742f57c2141)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2a623ce6-8d42-45bc-8a08-177ad21b1002)(content(Whitespace\" \
-         \"))))(Tile((id \
-         47b0d963-2a9d-46eb-96c7-9cfe812b77d0)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0ebaf9ac-11c8-4a9e-bbf2-6f45195baa2f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6ddff9dd-bcc8-4b94-b226-422e1fb9316d)(label(g))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4240a3e4-10a6-4df8-b1cf-13547e51240a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c676f2f7-9f56-4b2b-beb1-1f7d8c80d918)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ceeaff04-4686-4772-821c-02e1f0157337)(label(project))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         e8b82540-ef69-4e9f-9452-b47c0c59da44)(content(Whitespace\" \
-         \"))))(Tile((id \
-         eff243c5-f1e3-4c1a-ac85-7aa4497ba40f)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         835af954-7f4f-4b8f-8970-c968ac3745e9)(content(Whitespace\" \
-         \"))))(Tile((id ea277a67-9130-4741-bf06-1c2e3509aaf1)(label([ \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         313a1e17-140c-48d7-aebf-564d872dc0a3)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bc3062b2-7acf-48f0-9a04-5142717ef0f1)(content(Whitespace\" \
+         \"))))(Tile((id d84ee3ec-40a0-4708-a01c-9d955ae4f5df)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         f7f8fe31-8475-4b57-b64e-7f8ef11f4827)(label(r3))(mold((out \
+         83262287-0d15-426b-ab0b-54dbfaa34901)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         3c2954ae-0597-48a2-94e7-4ad9bcd9ccf1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c91eee73-397d-4963-9c74-c604973bb27f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c4442a24-6f59-4de5-bf0c-04bb5fc471b9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c66299f-d59b-4388-955e-9cf4b84d24f5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4dff637f-d7cb-44dd-86fa-4aedabe1b6fc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e2d9bb75-2927-4211-b913-683900068f87)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7b78b3b7-5d46-4b8b-ae55-0f448acea28c)(content(Whitespace\" \
-         \"))))(Tile((id 3e90ac7d-849c-4aaa-85a5-84494507b3a4)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         9482eef8-04f1-4ded-affa-f7107b900fd3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8819e1e8-1392-4b1d-ba1c-e6c56afb3489)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d3b1157a-208c-4c62-bd11-8485d6d9a035)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         01182779-a206-4366-9ff5-a06f126e2c71)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b152e549-6ba0-4bc4-bd4a-e28c4cc33a33)(content(Whitespace\" \
-         \"))))(Tile((id 5e783438-e08f-49da-8c39-909c5882e1ae)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c11426b6-5880-485a-9943-0cd3f566986b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a74249b7-f81c-43e7-a6cd-67c5a38459bd)(label(average))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         f332cf36-61c1-4a33-b847-7dd7528a937d)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         bdfdceed-3eae-4ddc-a438-d38029269d9f)(content(Whitespace\" \
-         \"))))(Tile((id ac2aaba3-8547-4b75-b98c-ea512d1fd09b)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ac2f435a-0a62-4144-a164-7009809be5f7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fcede8e8-d15e-4152-824f-03034c0620cf)(label(ns))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         c9e05172-d355-4f43-9eba-cf7a0e637f3d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         32d3f8c9-358e-4cc4-aa65-2e3d2da9ea0c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2befd8d1-1337-49a8-90d0-75bb8f84be25)(label(fold_left))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0415d9c2-0951-44d3-aa71-242a324d3495)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b6df8a01-7aaa-4ea8-aabc-a5d879d97daa)(label(ns))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         20f4f9f3-edb0-4c8f-ab32-8ce13a2632d6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         085664fc-21d7-4d42-99fb-a41e7204aab5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5fb0a830-1332-4a85-9297-906183a51b4f)(label(int_plus))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a1d346aa-3d4e-4fe2-98cf-cf03c200b547)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         62af365b-d354-47ac-8af9-b3da65fa15e5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         38c2d504-470c-49b4-b1ad-a45f0469d068)(label(0))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8d832292-8331-4aca-89fc-5f3dacab8346)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e096f600-6f0e-47d0-b6e5-c77229b5e4ed)(label(/))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
-         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         415856ee-d716-4a2b-b22b-57b331cf5c5d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         93432a97-2c36-49d5-b995-d81bec76e060)(label(length))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e60f2f41-e49e-4e0c-87bb-c68fcedb0209)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         fa6bce92-22e3-43c4-851c-90a77fd734ae)(label(ns))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         12981e68-d724-4416-98c6-9226deb3cd47)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         ba0f02bc-281e-40bd-819f-c9b23ec11022)(content(Whitespace\"\\n\"))))(Secondary((id \
-         45a15e67-2fd1-422d-8c52-29ae89f24436)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         589e008c-797d-416c-8e2f-6ee7bcdad53a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d22e836f-0a3e-417e-bd1c-2c5275807740)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         03732e23-40fd-41a8-a6c9-37180e262e34)(content(Whitespace\" \
-         \"))))(Tile((id c580a721-a873-49cb-a292-81e8bbf0108b)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         4055756f-e8b9-4e3e-a385-18f72999148a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3501e99c-95b0-4859-8fda-276eb30195ac)(label(abstract_age))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         910c5479-b9fe-4e38-85fd-56305cc496e9)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         0d045152-052d-4709-9851-5a103130331f)(content(Whitespace\" \
-         \"))))(Tile((id 341ddc61-f8df-4cff-bb64-bf75e4650544)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         81a33706-bc25-4eb2-ac91-38950f609030)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6f9edbff-1fa8-41c9-a419-f7f704e353f6)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         a29b1e18-9a0b-4872-8243-a94f218d99ec)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         738b85cf-564c-4525-9d90-1328651cc3e3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6315df94-e598-4b35-94ca-cfde210e357e)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ef4c6f32-2703-4ad7-8343-2ad53b9a6008)(content(Whitespace\" \
-         \"))))(Tile((id \
-         adef8da4-696b-4f4d-96e2-70a009ae3b7d)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7118aa60-a37b-4854-8e12-2c8ab57aed98)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         abbf98f2-09d7-4d33-b7ce-2939b2c8d295)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ebc981a4-3f2f-4196-b259-baf81ea4d35e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e5a7e40-6d77-41dc-9b55-3fa2fc72f08b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4635fa41-fa20-4cc7-93b9-611bb9c79f3b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c046e255-cc57-4a2f-b010-3f81e1d8dba7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         63995ac7-5aac-46b4-a83d-3f524ded4653)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         02b0822d-0a96-4fc6-a54d-bbf08bb2ef9c)(content(Whitespace\" \
-         \"))))(Tile((id a8682a47-1f20-4c22-9db6-3948717f4ccb)(label(if then \
-         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d27cb898-c74e-4264-bc66-1cac058c973c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         78010b1c-8c07-4e68-bed1-b206427cc98f)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7ca51dcb-7898-4a61-8ad5-db80099abe85)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         2ed0c4b0-459d-4c5b-9eb8-51304ebd1e89)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         04bbb43e-7333-4bdc-b3ca-9151ea8a35f2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         188bca2e-109c-42be-89ab-4d85c021cb93)(label(<=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fdcaec8f-b129-47b8-bfdc-e39f0b47d76d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f5edc806-6753-44c8-94af-942a8e1048b0)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         2965cd53-64b5-4f93-817d-8b79d2d071ac)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         831cde86-385b-40e6-8d83-99ec626169fa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         43906e03-bf60-48c8-999a-26262196cf37)(label(\"\\\"kid\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         ce225ee2-9434-48c8-8d32-4df2f90f9322)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4b463598-8e7b-46b8-923c-16c0926009b5)(content(Whitespace\" \
-         \"))))(Tile((id 43b26716-dd93-482c-a853-9f191e13b549)(label(if then \
-         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         449ff1c8-4a8f-47f6-a822-3c3908d42856)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8caf0240-fd9f-4fbf-8ac3-9bb9978dd946)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bde96df6-1d80-4c1c-b73c-475dc3a1053c)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9be214ae-5b6b-4429-b918-b8ad839e941e)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         ef25a24e-9309-48d5-b283-b748e8a882f3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         236856a6-f21c-48e0-84c7-9964be140673)(label(<=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1b5df57a-6e71-4e34-bcd8-d7d997f97a29)(content(Whitespace\" \
-         \"))))(Tile((id \
-         98d23b56-460c-470e-a2fd-6a03bfe53a98)(label(18))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         075c2776-66ce-4200-9aae-163f982d4048)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         b0db5a75-5ead-4bec-b4f4-a91f2f5170a8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ed171237-3289-4615-955e-9242d3a5d9fc)(label(\"\\\"teenager\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         9e8f9d71-8338-4445-8861-cb584f475087)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4afeb720-0167-4a5d-add1-22c4a3c074b4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6a3f549e-2412-40a8-b056-d29076c10787)(label(\"\\\"adult\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         7c37a97b-b5cf-474c-a87b-230ec738c000)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         41027cbc-4404-426b-ad53-2e42eca3fac3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fb215524-a7ec-417e-99d9-f2e49219a936)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7d3558c6-8ff2-4080-bae0-5363678c7d08)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a5b055ef-1606-48df-bbdc-7fe29447c422)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         798e54ac-76a1-45ef-bd77-ad3a44b78e29)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0fd4dcd9-15c1-4d4c-9c65-b3e9f9e75e1a)(label(group_by))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         dcb7e08c-a807-494d-a1d5-7377ff9e16aa)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b7eaacb0-14cc-45ec-81d5-3039fa17edf0)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         5ade386c-c1db-46cb-8d9a-9bec7565e94d)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         71ee759e-3d9f-49c9-9ca9-51d537599264)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         13727802-ff73-42d5-bebc-495d507cdd17)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b7509d3a-a1ee-4671-ae69-568e04aa8ad4)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         277f2608-1884-44f0-812a-74e4e70d195f)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         66bbbb0c-0438-4642-bd02-1244fae8b811)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         c7d636db-a4e1-44a4-9993-75b9ce1fee05)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         5e4f8de3-75cb-40e1-987e-0759d08a0ab5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7811976b-ec49-4d20-a332-856d70d492f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1b10016-862c-4df1-bc86-b13227805607)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a63e2490-2ed6-459b-a59c-a52f1a767581)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a387223b-1e9d-40ea-86c5-c4bb046f90ad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f6d6e89-dd12-4b31-9747-9611a02c1d80)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         19909eb0-a1fc-4fb2-ae58-5abea8e8a32a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         863fb0de-221d-4c64-87d8-173a33468358)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f839df75-7492-4414-811d-f27682d4d899)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8763b464-0b9b-4557-8623-2236609eddf3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         668f49d9-1042-43b3-98c6-e20340008dad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         44d21f94-3a00-4f19-871a-26705395a4e1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7a175744-eb33-47f8-91e2-575383499f70)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b6a7f27-c386-4f0d-85e5-17a4494fb973)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3854c9ff-4c6a-4704-9124-34c49694866f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         128c163c-5128-4d0b-bc5b-1952ead8184b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ebf2c8e4-02b8-4630-951c-974b95566da2)(label(abstract_age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a7e8f30c-e66e-4d0c-b893-cfe7dea7f431)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cdb06f6b-50a5-42b4-bce6-dd1b906584be)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ecb8ab94-9f90-4099-b61b-ab223efcc864)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2e494fe5-43f7-4602-8a40-b64ad0b6b9d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6b14a556-f966-426b-aa86-946f6264e5a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b076fe5-ee55-474d-8eaa-d287712bbadf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         281b8f28-882c-4764-a42c-dfab6ab53d5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32f500b7-c058-4521-8b02-fda43e30f132)(content(Whitespace\" \
-         \"))))(Tile((id 958bac77-1fd0-450c-b544-8e4524cb0529)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         05eeed76-10f7-4f70-a234-66fbc39f0876)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4ea2ff97-76ec-42d9-a7ff-90346e15f747)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         abe56d47-6c3c-43fe-8516-a14ea6a9544a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f3564dc7-8b02-47e0-9011-2f81f6135cc7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         558f095c-7d32-42ab-9b85-121ded9d0ecd)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4c8fb84f-aeb4-4ec5-b678-50287b680e99)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         aa6ac808-5ea2-469a-9431-a22db12169a5)(label(final))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         62c365e9-4889-4c43-a564-a0940bd6c712)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         97617344-aa43-4aee-8e3c-fcfbfc79ea88)(content(Whitespace\"\\n\"))))(Secondary((id \
-         dfac29a4-c7d7-49cd-948c-1c8386951c8b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         03ebad65-0a7a-4a7a-b0a4-eb4135c666b6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         64d19a5a-57ee-426d-a7f9-ea5adcbd1f58)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd009357-355b-40ce-8e64-71edc38f5bda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2ead315-bd16-4639-b85d-92cbf081440a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c856dc3d-cbb3-48d6-9a86-13801f611f4d)(content(Whitespace\" \
-         \"))))(Tile((id 0f5117c6-fd43-4579-98d8-53b76e10417e)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Tile((id \
-         cddfdc94-f010-464e-a12b-40d5bf6ef7d0)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         6bcf1d0c-486b-4fd8-aeb7-bdc24d8a6862)(label(k))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         0dc92f14-734a-4983-9f6f-670b9c99e754)(label(,))(mold((out \
+         Typ))))))(shards(0))(children()))))))))))))))))))(Tile((id \
+         91d17b71-0a27-42aa-ba14-82cde83203e9)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         5c6d93db-5d8a-4edb-90b0-915fd2085aac)(content(Whitespace\" \
+         54115c9a-3029-4d7f-8f0c-264f2afb54c4)(content(Whitespace\" \
          \"))))(Tile((id \
-         87d9677d-1641-4647-b92b-be01403e6a71)(label(vs))(mold((out \
+         224deaac-1e44-4b56-a252-481e30379eb4)(label(row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         f665dfe3-defe-498c-bb8c-9d8f0dacf6ce)(content(Whitespace\" \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         68045aef-5588-4ab7-b041-cd5717666e71)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         0b77b4a7-484c-446b-8648-f0d452a7ffbc)(label(r1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         a24c2236-5c1b-4df4-a00d-8f6e867f2635)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e4e19d90-70c3-4569-af62-159e9bf442e5)(content(Whitespace\" \
+         ef5d3d19-c305-4b88-8e57-904eceac46f3)(content(Whitespace\"\\n\"))))(Secondary((id \
+         b510ff49-5d5c-4b70-84da-da979146f6bf)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         111936b2-cac7-42f4-b0b5-02142cac158f)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         447d91ab-a3f4-4eb5-b0b4-b385d0c9417b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         342d1aa9-c1db-4652-9afb-6979d9329ee7)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ead323de-2bdc-45a0-aab4-9fa9994bbb06)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         f11f51d7-9535-4cf2-88d9-c585ebdafef0)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         d3be9b7f-e807-4405-8218-066683523bac)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         92b036d4-2fc6-4534-b693-c2abe3019e67)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         910a985d-f0c4-4e37-a3f9-f1f607295b9c)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         0d15bf30-ee5e-4bc3-bd57-e9b8901b4248)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         3593dfcd-cd3b-40a0-b307-2dcfb7cfc96c)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         8ed9b1a6-6078-4b88-bd02-977e32df4e28)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         aa681d8c-c621-4bc2-bb7e-51a10585ff93)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         2ad3fae9-2be9-4399-a841-4a5b25d677c4)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c270d0ae-3e03-4431-8954-3929d34ac553)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         0f3908e6-1a9f-45b6-91d5-aa7e968faf1b)(content(Whitespace\" \
+         \"))))(Tile((id 459c7860-bd68-465f-982c-104398da0f54)(label(let = \
+         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         9d37b692-bd4d-4752-9760-f57a7aaa0845)(content(Whitespace\" \
          \"))))(Tile((id \
-         17c36913-f804-48c6-9893-a5e45c2a49de)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ef001058-b069-4167-a5dd-ddd6e1536383)(label(key))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cec9a2e7-16cf-4aae-9f3e-35ed895a2505)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         795154b4-94d3-4a47-b155-21a0d99d074c)(label(k))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ba541629-ec8e-4908-bcbe-d4362a0266ee)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         744871e0-7a2c-437b-ace3-a8513cd3cc4a)(content(Whitespace\" \
+         70540c92-57e3-44cd-a72d-cd24f4821f1e)(label(k))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         538f2ee4-c60c-4bdf-8aa2-fa996875bd19)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         3fa76204-9d16-491b-86b3-4886c2e05a11)(content(Whitespace\" \
          \"))))(Tile((id \
-         a49c3d97-8e4a-4835-b858-f417d009562d)(label(average))(mold((out \
+         e4af3dfd-58b3-4929-9a1b-8c4756613cc8)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5e1810c3-c1d6-45b1-b4ea-cfc3e3ed1424)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         b76ebae3-536c-45b6-8fd6-9b5129477a27)(label(average))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9e7a8ab9-02fd-4e63-8d43-ce95f5c12b5f)(label(\"(\"\")\"))(mold((out \
+         b228f56a-87a4-46f6-897a-e1c6866bca1a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8721b19a-fafd-4db9-87f9-69729c2e8566)(label(vs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e35ad4a8-2151-4cc1-8131-ea04211b3fc5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a4fec851-4e05-4163-bf59-6f31d15d4cdb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         429c901a-74fd-42be-ad1c-e4084dd057b6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         66be4be2-aa02-4ce9-baab-4b4c4b1f7605)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6f28ca52-6749-43bd-aec0-998b48d15257)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         7f4d6819-d77f-4cfd-94b4-92951b3bf7a6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5f2f8205-bd07-4140-954e-f75adfca80d2)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f639a9ad-91cc-4d3f-a121-d1add31cbeac)(content(Whitespace\" \
-         \"))))(Tile((id 5985ce7f-27f7-4604-89a2-6d8033e0ad57)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f91fa4dd-c57e-45e5-a4cd-42483057e22b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         133f37b4-1268-4e2c-b5e4-fa5bece46b4f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9b2a47e-6d09-4882-b102-60184dcb388d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d86e02da-b918-4f07-b1f6-abfdcdf088ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a7dfdba2-28c8-407e-90e7-dba0af46ac4f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d3519546-3393-4478-bb50-aadc1967b359)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5fbad335-d1b4-4183-9e2d-376ca450fdb1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d645275c-1812-4e5c-bbfc-9fef6bebc229)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         01360118-cdee-4f6d-9078-81a9def68a9b)(label(key))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         02b8c6bc-2236-413a-b48a-2b27ccae2f91)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c35c7d2d-b739-4930-94b9-c2c5b6bc7df6)(label(\"\\\"teenager\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bfc15a2f-ce4c-4277-b837-372e8e913a55)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3ac93eb7-ffc5-4def-811f-c83824e4f9d3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6d401b96-e51d-424e-90a4-e2841b7c5f23)(label(average))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b5b64ed8-e069-4443-b2a4-e0fb698f3f10)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         d8a264fb-6c55-493a-9cdb-9846621d1df8)(label(81))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         41dc1f25-f428-463b-99b2-db7c9c4bea4e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6ce9e68f-8b49-4802-9551-7e3e844ea3f0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         991c64cc-6402-4022-bfe2-b81dc272d401)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         41a5b66c-af49-4462-9c12-5bb9b426752a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ffcd92ea-8ec3-4f11-aab4-23eba9406b76)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5f09d4d3-cc14-4821-86b2-f4033da3541f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33bb65d3-751c-4d98-b0ac-7b935de6d8e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c22dc4be-a408-4c79-89bc-787d87d822f1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         02b5b8f2-fbc8-4cfe-aaa7-6edc4e877cd6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         0bdaf933-1332-42f5-9643-a2e5a90a292d)(label(key))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6cb94846-e624-4996-be00-52aa8d015f62)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         5873b034-436a-42ae-920e-4ae21bb8e979)(label(\"\\\"kid\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8aa2f834-72a4-4832-80ff-dab2c748c28a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2dd7cee5-66aa-47c9-81a9-5394dcccc1d1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         03d3ab5d-ad8c-44fa-b9ba-3a94d46d31b4)(label(average))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ee1a6216-c2b5-44f2-84d3-d56060ab85f1)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         fc4c26b6-5d04-4183-843f-efd5e1f5351d)(label(87))(mold((out \
+         041ba51f-8c86-44f7-a75e-c22bb4fbcb52)(label(row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         42ce56a0-8fac-494e-8ed1-217fa930ca8e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6a97fa81-98a3-49fc-bcfc-186feb000ba3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         94cfae77-eebd-4d64-9319-1ba8a0ef0c73)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc458de6-1e09-4c41-9e9b-f6bd7c0654ce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d12d778c-78ca-4478-87b5-e2e30fcb4fad)(content(Whitespace\" \
+         8d7ce355-b473-43bd-adc3-32f8f135c62d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6cfa87f3-ab4e-48e8-b37b-a964c5f043db)(content(Whitespace\" \
+         2f3d8169-95fe-4ac4-8b58-5ab3ae10a6b1)(content(Whitespace\"\\n\"))))(Secondary((id \
+         dbda58bc-c489-485b-bec1-5c2602de92bd)(content(Whitespace\" \
          \"))))(Secondary((id \
-         a9c1e64f-2869-4dc1-a661-3a59be1658f2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         083e1db0-b88b-4e42-94ff-52673184b80b)(content(Whitespace\" \
+         e8f70949-b7b2-4f19-ab97-0562423bc2e0)(content(Whitespace\" \
          \"))))(Secondary((id \
-         02f53611-d37e-4bcf-9856-22358446d79b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9cb0adaf-bc93-45ac-b597-c2e7e4adde8f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         2e942a85-10cb-48c0-af8b-909f6f30ce5f)(content(Whitespace\" \
+         36bb4b9b-5640-4b93-aa4c-eadfa9a9744c)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         711c3d58-ac9c-468e-91cb-386c2d0efa9e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         2ed8fba6-27f9-4b6e-bd8c-a211dd63bccd)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         f1d23571-23da-4679-a1c1-90e0e5f2c4b3)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         5c12cf7a-6df6-4a86-9fe7-6530d5a6b3ca)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         bae034a4-4df8-4c8c-aa0a-8b12f0985ac8)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         2e1a2079-a5d1-41c4-a1fb-5455b7a2bff1)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         33be3751-3985-4a60-98b2-6a657b9106ef)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         90770d42-85d2-424d-9486-98279e17aeb3)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         cd7ba01b-67d8-492a-9668-17f0289da99d)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         d357500d-857f-466e-ac4c-2f2e7cbbc008)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a4ca285b-a5f6-4511-b127-760adaa4afff)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         dde31f96-809e-40b4-a941-3a7672bf3bf1)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         d3c7c9ca-750a-472d-adcb-05ef3cfaa2a1)(content(Whitespace\" \
+         \"))))(Tile((id c262bfe5-9916-4ebd-a641-afbfccb73d9b)(label(case \
+         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         6bb0534b-b47b-484f-be42-7bc57b54d959)(content(Whitespace\" \
          \"))))(Tile((id \
-         36ff7baf-d5f9-4f06-a548-0fb54237aa7f)(label(?))(mold((out \
+         6a18e276-ac62-49c0-bf63-f3dafa2597cd)(label(find_opt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         db27c472-c7d6-4528-9b5f-0d6c4ea84c43)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         2d2d7299-4ec3-4561-a3ad-38ad6e09f3b6)(label(groups))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b541b17a-6a0c-4748-91f6-241c824f6367)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a0dd1a0f-ff37-4b74-8744-184958cb04b5)(content(Whitespace\" \
+         \"))))(Tile((id cdbb2c41-e6f0-4ca6-926d-bfc1a5f33111)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         fd30885a-0900-4717-95cd-e137a9be0e83)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9ffce7ee-d4a1-4b0a-aa99-a30404832f87)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         0289facc-7f16-4247-917b-872ef051681b)(label(gk))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         84df7b69-3f01-4d24-bd83-722ce12151a5)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         b5c0b76c-5bdb-4467-af09-c7ef3152e863)(content(Whitespace\" \
+         \"))))(Tile((id \
+         283b3d26-2f36-4f76-807f-2da33ee27412)(label(_))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         2ffc478b-f410-4939-82ee-f33c0da7681b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d054717c-91b7-44b3-88f8-399d8c4f2caf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c9f466e7-7293-4660-8e89-d121448d169a)(label(k))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         adc3b44f-d913-4866-b3c0-1ac2ed42e400)(content(Whitespace\"\\n\")))))";
+         3e095d66-5e2f-4418-8b64-bcdae04b5432)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e6ff0d90-d152-49ae-a0d9-118db4adb3d3)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e0e8fbaa-6d54-4ce0-b5dd-bafe5843eaed)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2f2b1920-fb94-44fd-bf58-9c43443d7abc)(label(gk))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         f28a6720-feb9-4bb2-9b67-8431f0e4e685)(content(Whitespace\"\\n\"))))(Secondary((id \
+         211aae70-b50d-40fe-9170-bef0ecb24cca)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         86fc2d28-a284-443c-834e-d17df98a8aee)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         578c6080-c3e4-4a2a-8490-fe29f182520b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         e4351de5-03f2-4002-b71e-b5a365224831)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ee656ab7-886a-45c7-9207-0f905eccba0b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         797fc0ad-93d9-4bab-98cb-772b07400986)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         fe59d151-26da-4762-9a5d-32cb4f890efd)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         28a117a2-def5-4c18-a3f2-100ab1bd713b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         71dd81c0-217f-474d-81c2-73f26585c763)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         0c2f3d80-7dd9-4c54-bcf7-48dd99cba960)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         54bd16c9-5bee-4d76-bdc9-e6a64a17a884)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         adab6600-ec4f-45bf-98bd-8c57d426f9c0)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a5aa32d5-271a-46c2-98b0-84d181399627)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         9c730eef-1ae0-4484-ada4-58dd56ed844a)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ff2183c3-85f1-4970-b5c9-bb3b25407e99)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         17075d29-4977-4f2d-b574-a6c526ff41ae)(content(Whitespace\" \
+         \"))))(Tile((id e9798819-07bc-44b7-98f6-074663ad139c)(label(| \
+         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
+         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         11430378-76cf-4f29-9b8e-f849caea8450)(content(Whitespace\" \
+         \"))))(Tile((id \
+         64056f6a-9614-4305-9076-276d764ce305)(label(None))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         da811a8e-9fae-4622-b9ec-fd3d1cd0f91c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         4f192409-8272-4759-8047-ab4e3355ccfe)(content(Whitespace\" \
+         \"))))(Tile((id \
+         42ab7683-ff04-409c-a0a4-3e6d4779a29b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         b4aa8b13-8dd3-430c-b2d3-d30c2f0f9f37)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         00182ee8-dbe4-480a-ba26-5f534e0ca36c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d5745441-5777-40aa-832d-ba5df13e01a6)(content(Whitespace\" \
+         \"))))(Tile((id 4651d166-85e9-40ef-97bc-f513e591071c)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         b01df78f-d52b-47ed-a2c5-1a61406a22a1)(label(row))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         c4b78818-5be7-4080-8658-06c24b41eb09)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ad84604f-d070-4023-9e53-66b66bbcac0e)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         518dae46-136a-43e8-8822-8009c08c7b1c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5524b61b-5115-4582-b74d-514d06bb712f)(label(groups))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         36db7986-0083-47a1-996a-cdb4a138aa76)(content(Whitespace\"\\n\"))))(Secondary((id \
+         45d39bc7-d929-45ba-9610-612725523282)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         4aa0ca1f-3d65-4881-9108-7510e975d0f6)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         312922d6-8e60-469e-8909-99a6a90fd92e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         cfb0b727-2bd0-4724-97f9-bd556ce2f77f)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         fd19f00b-ad2a-4bd6-b1c4-8fb5b1f0b2e5)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         1df86ff8-0001-4525-8002-2f7131148e50)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c8815b5e-f8ab-49a2-b112-2cd8405f0501)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         d099c7a2-cb41-4569-9a0a-a84bdf5bab90)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         eb028fbf-b004-402a-8e0c-1b6c0e517322)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ba58ac1e-d769-4e6c-a42a-d7a9fbbc5fad)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         65cad5ee-63c7-43a3-a0af-013f2246c346)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         25c3929f-793b-4f05-bcd1-7c93fd1e372d)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         428f8a6b-dd9f-4fa8-ba12-30c0f1d2ce61)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         4c513d9a-7411-4433-bc9a-69baeedb33e3)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         db78b1d8-526c-4083-aefe-80d55af3a213)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         da135f22-5210-4f92-95a3-8c7eceddd070)(content(Whitespace\" \
+         \"))))(Tile((id 27779042-b547-4089-8748-a3c1b5b80a02)(label(| \
+         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
+         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         9ed039c6-cfa5-4134-b407-ab20165c496d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         40b2527a-b8b3-4654-8e8e-68abec6c998f)(label(Some))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         92c5114f-cb1c-4844-aaad-edb1142c1750)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
+         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
+         f08bc586-8453-4ecc-8484-50c0f27a6c1f)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         32e93da8-f7e6-4ee5-95bf-5cea4d3c489a)(label(_key))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         d55bf9c3-8f86-4e72-a84b-8c48de8e619d)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         bb12683f-9bde-464a-a1ee-be454417de27)(content(Whitespace\" \
+         \"))))(Tile((id \
+         03f66924-9fba-42e1-bf5b-205cb0bcf689)(label(rows))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
+         53086123-6529-4349-a321-b7c2eb0f39c8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         98def422-6272-49a3-a5cb-1e47c4a05c97)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bfa98e98-63e9-4092-9cd1-f0e301c88a1d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         cf32016b-8813-4b71-8f2d-29b561d2d2fa)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ba90a89d-69cc-4cd2-8eba-1bfec9e19a13)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a1722c82-fc95-4629-89eb-09de8d202159)(content(Whitespace\" \
+         \"))))(Tile((id \
+         624de969-b0d6-4642-a0de-17c8a27a4ba1)(label(row))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f3558781-1ec1-4631-868d-21b6fc9ba874)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f80b94f8-f696-4884-9e13-d144e31a49fd)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5140cb72-9c15-43b2-bdf5-6290f958d853)(content(Whitespace\" \
+         \"))))(Tile((id \
+         504a3cc1-1396-4277-991b-6abab41181cc)(label(rows))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         ebf795e4-2841-4fd2-b0fc-a02312deee92)(content(Whitespace\" \
+         \"))))(Tile((id \
+         67b1f5c2-b40f-4d32-8e2f-7029572feedf)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         832d3540-30b5-4862-be01-a6188249295d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e93a542f-76e8-4593-9932-4cd61682c314)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         74f84539-fd6c-40bc-86d6-cc0e87791b25)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         b9b58633-a38d-419d-a3b9-54e526abf4f1)(label(groups))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4c42d07a-16c4-47bb-90c5-178ef65d847c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         759a81fc-de65-4fd1-b6e8-d840d4d84fa2)(content(Whitespace\" \
+         \"))))(Tile((id 2e8adaa0-b8a3-4fd0-b1a4-28ebe49ddfc8)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         962e936c-ebfe-466b-ab39-55bb07a5052b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1ef01cc6-807e-4947-9509-38be1fb7207b)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         750ec8ec-0c21-493e-9477-d5c35013c1e7)(label(gk))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         b14bbb82-ba36-4974-9867-377d08e1d036)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         bb948dc8-5cbc-4a2f-bedb-3e6682deb970)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2e848a85-6f5f-4a9d-8795-d4f7503d051a)(label(_))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         b169c191-88d0-45f9-b315-f99c331dba59)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d8919a5c-d2b0-4096-be46-b0a13570a0be)(content(Whitespace\" \
+         \"))))(Tile((id \
+         587b72b6-4688-48b5-a4ed-6bb0f4630ecc)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a9297334-8a9a-4b4e-bf07-b1bde1295ad0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         56b58130-18d3-4024-bc7e-6d9f16ec3cde)(label(!=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f69748c1-a4fc-48c5-bac1-e1d669fa7d5a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7c40a76d-b260-4156-b547-93edbcdf58c7)(label(gk))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         86199e6e-87bf-4b9c-84c2-96a891522139)(content(Whitespace\"\\n\"))))(Secondary((id \
+         b3482f2e-8a25-4756-b8ff-8478fc9bd540)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ee58c2ea-fe7a-44bd-8086-66c909a067aa)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c47bb616-10a7-47ec-a4d8-52031b2ce6dd)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         1bfd521a-525e-4b8d-a89a-0be88e0e8be2)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b9e3d2e7-b595-4b4b-8260-7b61c160a12e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         aa9adcdd-4aba-4807-b3cc-b558a0f95c4b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a35bad1b-39e1-43dd-bb02-1053796941f9)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         f1b09e05-6824-46f4-b044-53c1d9c0d98e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c5506538-cfcf-40a2-af0e-0a799c814622)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a173cc46-3233-4e4a-961a-afc58e8e99c1)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         4ff46f95-6d99-401c-8a05-2f33c6e49340)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c96235cc-b17c-4827-9083-698eeffa6df1)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         fae82d30-7ff6-4ab8-b9ab-2752633c32eb)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c2b45875-c3ce-4ec3-a2ba-7d4e27fe8efb)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         bb7d288f-dc6e-4462-8b52-2379548fea5b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         fa2d714b-a612-4875-a408-5b3f883699f8)(content(Whitespace\" \
+         \"))))))))))))))(Tile((id \
+         bea257f0-6a99-423d-bb26-799ab1d16558)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         508d1bb4-84c5-4d60-8e75-3ca54f03d492)(content(Whitespace\"\\n\"))))(Tile((id \
+         e834a85c-08b0-406a-8528-f2d10e94d11f)(label([]))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6277260a-a27c-469a-928d-dac82da433cb)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         f2e7783d-8130-4b03-9a05-5b38c8e343e0)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2af5e216-7874-4311-b022-a7819ddf193b)(content(Whitespace\"\\n\"))))(Tile((id \
+         d1e677dd-9a46-477b-8454-3c0dd96df17d)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0360a078-1fd6-4db7-9856-36963bceb7ed)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         2d3830d6-72d0-4002-9395-a859d79c568c)(label(grouped))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         465a3662-bedc-481d-aee1-1d99158f36c5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         413f7127-7d51-429d-b3ad-866734fa98a1)(content(Whitespace\" \
+         \"))))(Tile((id 726eaa40-71c6-4fb3-af5d-1ce07ec3a903)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         14093a17-0e65-4451-8a52-8c1e52a48aa6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         14400b8b-d454-4871-8d5b-ebd43dc5ace1)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         8a8a8daf-2c6d-46f2-acd0-dfa96adfc5fe)(label(k))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         1800d083-fe3b-41bb-9be3-5280e190c9c3)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         862883b2-f4af-422e-ac08-40f8a2345eef)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dc29bd3b-cf4a-424a-a537-9349b5c0fc85)(label(g))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         184018ae-97fa-4e77-aec5-9cb3fbc17473)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         feddad9d-62d9-4d1d-9074-207c35c4ac8c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         03a6156d-9f8f-47f3-a897-c3d080974f8e)(label(aggregate))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f8463192-71f6-4ee5-a225-23a307282d4b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4df65cce-ab11-4abf-9359-20f0041781e9)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c9805909-8d90-45f7-8365-2897e6be5665)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9f8139e8-4c31-45af-b2b2-7c6e097016cb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0a3b59fc-d87a-4505-aa8d-94c8d8ce23bd)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c8901ae0-6e8c-4767-9fa7-7a468b399af3)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         1bcf5cc4-1516-42e7-a8b8-b669d8984037)(label(g))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e9d4bfbb-09fe-491d-ada2-dfdf47628f51)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         23759b30-f0fc-4d57-9e38-06e83f5d6176)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e35a250e-d3d8-4d53-acdb-ffad5b6ee4a4)(label(project))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         1ef44803-d33e-4cbb-b0af-c122def60dfb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5b8ee56f-fb87-4897-a759-6339bab2e2c5)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         889cd638-e49c-4ead-bab7-2ba9283f2477)(content(Whitespace\" \
+         \"))))(Tile((id b3713353-98f6-4388-b692-ed27ade941ef)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         093ca34b-e4a7-44c2-b2b2-329f7dd73f4e)(label(r3))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         3f2ca5a1-9680-40d3-b598-4067ac32dfdb)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2fb44c99-7597-4092-91c9-0e1020a1476d)(content(Whitespace\"\\n\"))))(Tile((id \
+         f6f23922-e606-4783-a323-d0da9afa628c)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         33766745-bd36-477e-b15f-211fd5c48df1)(content(Whitespace\"\\n\"))))(Tile((id \
+         c38f54a1-260e-432a-b2cf-2c2b3c4de2ef)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         594db0bc-937d-4e9a-aa2b-fde487fd0481)(content(Whitespace\" \
+         \"))))(Tile((id \
+         569d978c-5d0d-44f1-b968-a86a6f9f9dcf)(label(average))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f054bf6c-99d6-47ae-bc04-327495458c0b)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         a073d03a-5c5f-475a-8144-e40f51e05150)(content(Whitespace\" \
+         \"))))(Tile((id 298c92af-cde7-4dcc-8575-129b3596f684)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         a4c3f7e4-1ed4-4713-a4d2-9a32918a4157)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2b4ca76d-8aa5-4938-bce3-eeed076ccab2)(label(ns))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a9bbb78d-94e8-4945-8541-304055ac9440)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2b495798-4569-484c-8c10-45b933ce24a8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c171f169-ac29-4a61-aff0-103555e2dd25)(label(fold_left))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9fd92b22-ca09-4a7b-8130-6c67d90f0ad8)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         566a0f59-87bf-4e22-a6e3-f6f8b489743c)(label(ns))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0a9601a0-6f3a-46c6-95df-a6a686cb04b4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2931485d-f60f-48ab-894f-97ef84054020)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9cf5283b-7bcb-4a7a-98ad-af88ecc882cb)(label(int_plus))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e1764209-ff8d-40a8-9128-451840dc99f3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         149ff0aa-56cc-4ee7-bdb0-10761e9b0042)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4264927a-6b22-41bc-8b41-ecd73ae082aa)(label(0))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         cfa1e76e-9bb7-4f7a-88a0-28c9e961f4e2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fe64830f-3807-4c34-b875-2a9d602b4902)(label(/))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
+         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         40c78656-15bb-4740-a649-22a71189a6dd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6299abd6-6238-46c1-bd4d-0e0cfc8a6cf5)(label(length))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         708a214e-a6ff-4ef6-975a-a6bcf49fe62e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0c3ecb72-7d35-4930-b6f5-bef6ac7afb88)(label(ns))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         09c3b2d4-fd39-49ee-918a-f378c02dacf9)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         1afa4154-c02d-4592-a00c-89f9456e2b0d)(content(Whitespace\"\\n\"))))(Tile((id \
+         b60c629a-09ce-4124-aa84-1f61eb302c5e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         99c86c89-f06e-48c4-b2df-2fa3a41745e0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         91da9552-dee1-453e-9293-09036e185a4e)(label(abstract_age))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5a9d7270-c393-43d3-82ec-628949c61a6e)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         a9f2fdfa-46af-48d5-a97d-3aa44112e212)(content(Whitespace\" \
+         \"))))(Tile((id 45eab4c9-ad15-4d0e-af39-bad0e3dcff42)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         69b5ab1b-a792-4e4d-8ffe-fecdb4991189)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e0b00dc4-dd70-4fbb-aba1-265328acd309)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         039a0c1a-920c-427a-84e5-7bed8c0e3396)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0b28480e-19ba-47d7-820a-1984ab2b5709)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9fcbe0a5-d81b-4a0e-9a2a-98e0f8b9de1a)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3a9d7f18-465e-470f-be02-8b48f5603214)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e5b79351-9360-4e9f-8f59-76e7529c95a3)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         04a6652b-1a37-47ea-98a2-ed4a48409ff3)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3c05f4a2-4806-46ad-9f2e-174b1efe0ded)(content(Whitespace\" \
+         \"))))(Tile((id ad0806cd-4d38-40f9-a3c5-e00dbe837cd2)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         9a9d8198-cc5b-42f2-9ae0-3ef956ad61ac)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3943a9ad-6423-43da-94d9-4e8d73b65cc4)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         620b96d0-3954-4559-b28a-a29b7dde5ddd)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         ad2e0335-8025-48a6-897e-f8d380e93732)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9cea2a27-e1df-4f3d-99a3-a6876a813ef3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e2405611-fe4f-4d94-b61d-84be81a7ad7c)(label(<=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e9342b28-e912-47b0-9470-2687356eb32b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e0802519-d3d2-4d2f-b619-116b97b00af4)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1ef327ec-14dd-4c7e-8d62-8fae2fd40df1)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         78fb4c72-3e4d-4632-ad8e-c4b21099b571)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8b3b3996-21af-43a8-a5d1-7f46fbbb0e7d)(label(\"\\\"kid\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         4bc14d6d-9108-4d2a-a70d-d13b48872d59)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d226c5b4-f880-41f3-a603-e7f3920cbb08)(content(Whitespace\" \
+         \"))))(Tile((id c0858d54-2e25-4605-b946-2b5d1b82614d)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         a6ea420e-8162-46d0-8086-4c9691d354cc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b1fd86f6-96b5-4340-835d-cdfae28f5817)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e1ea3732-fe6f-4fe6-bdf4-ab2034909bcb)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         5473e17b-40fa-43fe-858c-9b4205929eff)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f9cf4689-a70e-4c3f-9bc2-e8007bbd7570)(content(Whitespace\" \
+         \"))))(Tile((id \
+         53655d21-6d3b-4d55-acf9-98e4c0559ae6)(label(<=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5f0fc01c-cb5c-46bb-9782-e1d15719f94c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cb9d3858-e737-48d5-9e28-d0d378a76994)(label(18))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a7c861d6-9c5c-40a6-b382-fe80b23a3663)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         ac489691-ba3d-4f70-8bb9-07dd9b4ea147)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c94b79fd-7994-45d8-a2ac-0204cd2710f3)(label(\"\\\"teenager\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a5d56d86-80e4-44c2-96b6-ebbcc3e79884)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3df557df-e1ac-4881-aea4-28f2b58cabc4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bccd13ad-2dfa-42bb-a221-ddb82b5cda7f)(label(\"\\\"adult\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         4bdd5f21-e05f-4822-ac90-f9072d47cd25)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         df69a08a-2c81-4a0b-aa21-2345d187d0a2)(content(Whitespace\"\\n\"))))(Tile((id \
+         8a11be2b-f50f-4438-b527-5f40e9e6cce0)(label(group_by))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d1ae62a9-1c2a-4957-9633-e793c0811f80)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e60df484-8df0-432e-9ff9-08739480f913)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         8f5c1a08-97af-43ef-a5c7-17c9812d1871)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         f6f52525-8683-4006-a0a8-7254e6f7cec3)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         6da65992-e725-47ea-9600-54eb8789ec26)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         6dd920e4-f8db-4a14-8a67-71b4b6861c9a)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         18e6ed0e-ff92-4481-87c1-5811257bc179)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         24d21663-84bb-41ee-b1f8-5bc6e1ff82a5)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         d2b5c31c-df81-46f9-b060-e0c08f08a52a)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         dba5ab74-4ca8-4f98-8f07-ba54253a7167)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5a515b9e-86e2-47b6-b4a1-bcaada8e95dd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ecce35fe-be16-4b04-b04a-59b0f6bd569a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0a5d70ce-67cd-44ce-ba32-7cba587c2454)(label(abstract_age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7ea684d1-4e3d-4521-9c39-b5968a24c846)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ea7c3d2b-7cd9-476d-ab1e-e1a60e09ad9e)(content(Whitespace\" \
+         \"))))(Tile((id a2543e12-81c7-4a68-901e-2185ddac273e)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         34a933a9-d8f8-4985-9302-17d3a21f83e7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dc3119d4-d0c0-4150-affb-aed7c002b69d)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6429a0f0-3839-4194-a97c-a4f3355d5060)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         1a103400-a202-4220-b56c-6900ee484cbf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e36440de-57ea-44bb-a7ed-0f0438f05b6c)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         201bca7e-36af-407e-8acb-9d3ff369f763)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         0660f81d-87e7-4f53-a670-a91286fbb165)(label(final))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c3d98112-4973-4577-8c97-4b7c90e87166)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e85312e3-7b85-4681-b42c-de78e4fd2961)(content(Whitespace\" \
+         \"))))(Tile((id 17e16142-7bcb-4356-939e-6420e6748658)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         c2f064e9-e3ea-416c-8ef3-4e603d98b2e1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5f7cfb60-ea4d-46ca-ac4e-24f288987d4e)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         1b250b2f-702e-4811-8b26-421cc95d2406)(label(k))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         a99956ff-d1f1-4c46-8929-4f824959eba9)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         430d4db0-2b82-4ca2-bff3-e0bc9ddbd5dd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         677477a8-4e5f-4c28-959a-38424197cd87)(label(vs))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         214d106e-5071-41aa-9047-a67dfbca4e60)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3f315876-4aac-48e2-8f84-145c45601955)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f09ce46c-1ef6-4ccd-98b2-ca6c08cfa21b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         3734b284-40ad-4b26-91f9-bd6fff56d279)(label(key))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1b27a1aa-1a27-4dda-bf3b-e9de0b419db1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1b53d10b-0be6-410c-a1e9-307ca4d4a000)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1c8a3280-9d74-454c-af31-881521c9710e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         afdd2cb8-b1c8-468c-a175-fc4803cf747d)(label(k))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c4f21cad-d5c7-4f15-b5c4-090043b99a03)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0a53ae05-0f04-4727-b77d-b513fbe2eae2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0cf737ea-6f21-4ef2-9e41-0efd4b3f262e)(label(average))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7f7c2a5c-9c34-42cd-99b8-101b452e3e2e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cb5ecef9-33b6-4f4d-998b-e7856df23a57)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6bc3964f-5a53-4c1c-95d7-13ce7558d0c8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0efaed12-70d6-4c0b-aef1-39f2ae7edb8c)(label(average))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         eed5f634-1bc9-4ec3-919b-5dabfd0f79f4)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         2cd53fc2-a68e-4500-85d3-6dcdb3a852be)(label(vs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         3e7aa351-0961-413d-819a-595c5554c72d)(content(Whitespace\"\\n\"))))(Tile((id \
+         234dd1cb-87f8-4360-9b98-85d860ff8c2f)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         26449e54-b07f-420d-9c8e-5817211ab71c)(content(Whitespace\" \
+         \"))))(Tile((id 71b7b8ad-7427-421a-8ab3-5fa81fa26d6a)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         6cd66133-28db-4837-955d-c67b6739f106)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         1d4338e2-1d8f-43cd-ad0e-ece21b624c41)(label(key))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8f4be9c9-bca4-4dd8-8a38-b16c708dc0d1)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         8d422060-6ddb-4bdf-a7d0-bb45d8c2b306)(label(\"\\\"teenager\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a3cd837c-d9fa-4598-998a-608a6f6fded4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         debec431-1a27-4a40-9530-4fa2afc09f1b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         619bdb08-7721-4940-8311-a23053b23a05)(label(average))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         95883dee-3c5c-404f-8b33-e7a722f62510)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         9a8705b2-7ff3-451b-a5bb-31007c2b1065)(label(81))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         64e805ac-39f3-4232-b645-b12c0f459704)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c9fa5552-6137-4c8b-9826-9dca4cc31461)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2481e96c-4ddc-4ab9-a07c-d10952c960e3)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         68801549-c059-4a9a-aca3-dcfd14b2d8ee)(label(key))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1df124c9-51da-4e38-bd7a-9ff95c3da4bf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2ec72185-48d0-4125-af34-1f673578bff9)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         182d24ac-24f4-4f0f-ae40-91b2b15f3bc4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1a9159d9-6a18-4c27-8e26-3e39025700dc)(label(\"\\\"kid\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ea569943-1bd3-4dda-ad03-81d64790f6b1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fa937100-ee0a-480e-b759-260135d359a5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e22cebc2-500a-4da2-b3e4-50b365fa5a7d)(label(average))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         be0507e9-0b41-4361-8cbc-b99f7953a105)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fe5c2c17-1f00-4a88-9815-bc6da0bf9e0f)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         63f4f2a6-b6dc-4a30-ae38-b0ff13598c62)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8c73c65e-e673-461d-af77-a3c38f6275ac)(label(87))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         e319ff40-f13c-424b-b1fa-fc6f2161a86b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         0b82015d-d723-4f73-a506-e4d13d0ef95a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7b065948-9a5c-45a3-b7d3-0513aa361df9)(content(Whitespace\"\\n\"))))(Tile((id \
+         99eb2706-3b78-4672-b7f5-63dd9c0fe79d)(label(?))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
-         let students : [Student] = ([\n\
-        \  (\"Bob\", 12, \"blue\"),\n\
-        \  (\"Alice\", 17, \"green\"),\n\
-        \  (\"Eve\", 13, \"red\")\n\
-         ]) in\n\
-         type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
-         let gradebook : [GradebookEntry] = ([\n\
-        \  (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
-        \  (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-        \  (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
-         ]) in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = ([(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")]) in\n\
+         type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
+         let gradebook : [GradebookEntry] = (\n\
+         [(\"Bob\",   12, 8, 9, 77, 7, 9, 87), (\"Alice\", 17, 6, 8, 88, 8, 7, \
+         85), (\"Eve\", 13, 7, 9, 84, 8, 8, 77)]\n\
+         ) in\n\
          let count =\n\
-        \  # V1: This version is more idiomatic and uses a higher order \
-         function to project out the value. #\n\
-        \  let v1 =\n\
-        \    let requires=[\n\
-        \      (enforced=(true), \"c is in header(t1)\"),\n\
-        \      (enforced=(false), \"schema(t1)[c] is a categorical sort\")\n\
-        \    ] in\n\
-        \    let ensures=[\n\
-        \      (enforced=(true), \"header(t2) is equal to ['value', 'count']\"),\n\
-        \      (enforced=(true), \"schema(t2)['value'] is equal to \
-         schema(t1)[c]\"),\n\
-        \      (enforced=(true), \"schema(t2)['count'] is equal to Number\"),\n\
-        \      (enforced=(false), \"nrows(t2) is equal to \
-         length(removeDuplicates(getColumn(t1, c))) \226\128\148 Note: if \
-         there are missing values in the input, this constraint requires one \
-         row for missing values in the output.\")\n\
-        \    ] in\n\
-        \    # This utilizes the primitive_pivot operation to group the \
+         # V1: This version is more idiomatic and uses a higher order function \
+         to project out the value. #\n\
+         let v1 =\n\
+         let _requires = [(enforced=(true), \"c is in header(t1)\"), (enforced \
+         = (false), \"schema(t1)[c] is a categorical sort\")] in\n\
+         let _ensures = [\n\
+         (enforced=(true), \"header(t2) is equal to ['value', 'count']\"),\n\
+         (enforced=(true), \"schema(t2)['value'] is equal to schema(t1)[c]\"),\n\
+         (enforced=(true), \"schema(t2)['count'] is equal to Number\"),\n\
+         (\n\
+         enforced = (false),\n\
+         \"nrows(t2) is equal to length(removeDuplicates(getColumn(t1, c))) \
+         \226\128\148 Note: if there are missing values in the input, this \
+         constraint requires one row for missing values in the output.\"\n\
+         )\n\
+         ] in\n\
+         # This utilizes the primitive_pivot operation to group the \
          categorical variables. To work on numbers another method would need \
          to be used. #\n\
-        \    let count = typfun row -> typfun key -> fun (t1:[row], c: (row -> \
-         key)) -> \n\
-        \      case t1\n\
-        \      | [] => []\n\
-        \      | (r :: tl) =>\n\
-        \        let k = c(r) in\n\
-        \        let counts = count@<row>@<key>(tl, c) in\n\
-        \        \n\
-        \        case find_opt(counts, fun entry -> k == entry.value)\n\
-        \        |None => (value=k, count=1) :: counts\n\
-        \        |Some((value=key,count=c)) =>(value=key, count=c+1) :: \
-         filter(counts, fun entry -> k != entry.value) \n\
-        \        end\n\
-        \      end\n\
-        \      : [(value=key, count=Int)] \n\
-        \    in\n\
-        \    test\n\
-        \      count@<Student>@<String>(students, fun r -> r.favorite_color) == \n\
-        \      [(\"blue\", 1),\n\
-        \        (\"green\", 1),\n\
-        \        (\"red\", 1)] : [(value=String, count=Int)]\n\
-        \    end\n\
-        \  in \n\
-        \  # V2: This version more closely matches the TableAPI and takes a \
+         let count =\n\
+         typfun row ->\n\
+         typfun key ->\n\
+         fun (t1 : [row], c : (row -> key)) ->\n\
+         case t1\n\
+         | [] => []\n\
+         | (r :: tl) =>\n\
+         let k = c(r) in\n\
+         let counts = count@<row>@<key>(tl, c) in\n\
+         case find_opt(counts, fun entry -> k == entry.value)\n\
+         |None => (value = k, count = 1) :: counts\n\
+         |Some((value=key,count=c)) => (value = key, count = c + 1) :: \
+         filter(counts, fun entry -> k != entry.value)\n\
+         end\n\
+         end\n\
+         : [(value = key, count = Int)] in\n\
+         test\n\
+         count@<Student>@<String>(students, fun r -> r.favorite_color) == \
+         [(\"blue\", 1), (\"green\", 1), (\"red\", 1)] : [(value = String, \
+         count = Int)] end in\n\
+         # V2: This version more closely matches the TableAPI and takes a \
          string column. Given the lack of row polymorphism and first class \
-         labels no constraints are ensured #  \n\
-        \  let v2 =\n\
-        \    let requires=[\n\
-        \      (enforced=(true), \"c is in header(t1)\"),\n\
-        \      (enforced=(false), \"schema(t1)[c] is a categorical sort\")\n\
-        \    ] in\n\
-        \    let ensures=[\n\
-        \      (enforced=(true), \"header(t2) is equal to ['value', 'count']\"),\n\
-        \      (enforced=(false), \"schema(t2)['value'] is equal to \
-         schema(t1)[c]\"),\n\
-        \      (enforced=(true), \"schema(t2)['count'] is equal to Number\"),\n\
-        \      (enforced=(false), \"nrows(t2) is equal to \
-         length(removeDuplicates(getColumn(t1, c))) \226\128\148 Note: if \
-         there are missing values in the input, this constraint requires one \
-         row for missing values in the output.\")\n\
-        \    ] in\n\
-        \    # This utilizes the primitive_pivot operation to group the \
+         labels no constraints are ensured #\n\
+         let v2 =\n\
+         let _requires = [(enforced=(true), \"c is in header(t1)\"), (enforced \
+         = (false), \"schema(t1)[c] is a categorical sort\")] in\n\
+         let _ensures = [\n\
+         (enforced=(true), \"header(t2) is equal to ['value', 'count']\"),\n\
+         (enforced=(false), \"schema(t2)['value'] is equal to schema(t1)[c]\"),\n\
+         (enforced=(true), \"schema(t2)['count'] is equal to Number\"),\n\
+         (\n\
+         enforced = (false),\n\
+         \"nrows(t2) is equal to length(removeDuplicates(getColumn(t1, c))) \
+         \226\128\148 Note: if there are missing values in the input, this \
+         constraint requires one row for missing values in the output.\"\n\
+         )\n\
+         ] in\n\
+         # This utilizes the primitive_pivot operation to group the \
          categorical variables. To work on numbers another method would need \
          to be used. #\n\
-        \    let count = fun (t1:[?], c:String) ->\n\
-        \      (flat_map(t1, to_lvs)\n\
-        \      |> filter(_, fun e -> string_eq(e.label, c))\n\
-        \      |> group_by_label(_, `value`)\n\
-        \      |> to_lvs\n\
-        \      |> map(_, fun e -> (value=e.label) ... \
-         (count=length(e.value)))) : [(value=String, count=Int)] in\n\
-        \    \n\
-        \    test count(students, \"favorite_color\") == [\n\
-        \      (\"blue\", 1),\n\
-        \      (\"green\", 1),\n\
-        \      (\"red\", 1)\n\
-        \    ] : [(value=String, count=Int)] end\n\
-        \  in ?\n\
-         in \n\
+         let count =\n\
+         fun (t1 : [?], c : String) ->\n\
+         (\n\
+         flat_map(t1, to_lvs)\n\
+         |> filter(_, fun e -> (e.label == c))\n\
+         |> group_by_label(_, `value`)\n\
+         |> to_lvs\n\
+         |> map(_, fun e -> (value = e.label) ... (count = length(e.value)))\n\
+         )\n\
+         : [(value = String, count = Int)] in\n\
+         test\n\
+         count(students, \"favorite_color\") == [(\"blue\", 1), (\"green\", \
+         1), (\"red\", 1)] : [(value = String, count = Int)] end in\n\
+         ? in\n\
          let bin =\n\
-        \  # This version takes a string column name and can't guarantee the \
+         # This version takes a string column name and can't guarantee the \
          column is a number #\n\
-        \  let v1 = \n\
-        \    let requires=[\n\
-        \      (enforced=(false), \"c is in header(t1)\"),\n\
-        \      (enforced=(false), \"schema(t1)[c] is Number\")\n\
-        \    ] in\n\
-        \    let ensures=[\n\
-        \      (enforced=(true), \"header(t2) is equal to ['group', 'count']\"),\n\
-        \      (enforced=(true), \"schema(t2)['group'] is String\"),\n\
-        \      (enforced=(true), \"schema(t2)['count'] is Number\")\n\
-        \    ] in\n\
-        \    let bin_int = fun (is:[Int], bin_size:Int) ->\n\
-        \      let floored = map(is, fun i -> i / bin_size * bin_size) in\n\
-        \      let grouped = fold_left(floored, fun (acc, i) ->\n\
-        \        case find_opt(acc, fun (i', count) -> i == i')\n\
-        \        | None => (i, 1) :: acc\n\
-        \        | Some((i, cnt)) => (i, cnt + 1) :: filter(acc, fun (i', \
-         count) -> i != i')\n\
-        \        end, []) in\n\
-        \      map(grouped, fun (i, cnt) -> (group=(i, i + bin_size), \
-         count=cnt)) in\n\
-        \    \n\
-        \    let bin = fun (t1:[?], c:String, n:Int) ->\n\
-        \      let entries = flat_map(t1, to_lvs) |> filter(_, fun e -> \
-         string_eq(e.label, c)) in\n\
-        \      let vals = entries.value in\n\
-        \      let bins = bin_int(vals, n) in\n\
-        \      map(bins, fun e -> e ...(group=let (group=(min, max), _) = e in \
-         string_of_int(min) ++ \" <= \" ++ c ++ \" < \" ++ \
-         string_of_int(max))) : [(group=String, count=Int)] in\n\
-        \    \n\
-        \    test bin(gradebook, \"final\", 2) == [\n\
-        \      (group=\"76 <= final < 78\", count=1),\n\
-        \      (group=\"84 <= final < 86\", count=1),\n\
-        \      (group=\"86 <= final < 88\", count=1)\n\
-        \    ] : [(group=String, count=Int)] end\n\
-        \  in\n\
-        \  # This version takes an explicit projection to gurantee the \
-         requires constraints#\n\
-        \  let v2 =\n\
-        \    let requires=[\n\
-        \      (enforced=(true), \"c is in header(t1)\"),\n\
-        \      (enforced=(true), \"schema(t1)[c] is Number\")\n\
-        \    ] in\n\
-        \    let ensures=[\n\
-        \      (enforced=(true), \"header(t2) is equal to ['group', 'count']\"),\n\
-        \      (enforced=(true), \"schema(t2)['group'] is String\"),\n\
-        \      (enforced=(true), \"schema(t2)['count'] is Number\")\n\
-        \    ] in\n\
-        \    let bin_int = fun (is:[Int], bin_size:Int) ->\n\
-        \      let floored = map(is, fun i -> i / bin_size * bin_size) in\n\
-        \      let grouped = fold_left(floored, fun (acc, i) ->\n\
-        \        case find_opt(acc, fun (i', count) -> i == i')\n\
-        \        | None => (i, 1) :: acc\n\
-        \        | Some((i, cnt)) => (i, cnt + 1) :: filter(acc, fun (i', \
-         count) -> i != i')\n\
-        \        end, []) in\n\
-        \      map(grouped, fun (i, cnt) -> (group=(i, i + bin_size), \
-         count=cnt)) in\n\
-        \    \n\
-        \    let bin = typfun row ->fun (t1:[row], c:String, c_project:(row -> \
-         Int), n:Int) ->\n\
-        \      let vals = map(t1, c_project) in\n\
-        \      let bins = bin_int(vals, n) in\n\
-        \      map(bins, fun e -> e ...(group=let (group=(min, max), _) = e in \
-         string_of_int(min) ++ \" <= \" ++ c ++ \" < \" ++ \
-         string_of_int(max))) : [(group=String, count=Int)] in\n\
-        \    \n\
-        \    test bin@<GradebookEntry>(gradebook, \"final\", fun r ->r.final, \
-         2) == [\n\
-        \      (group=\"76 <= final < 78\", count=1),\n\
-        \      (group=\"84 <= final < 86\", count=1),\n\
-        \      (group=\"86 <= final < 88\", count=1)\n\
-        \    ] : [(group=String, count=Int)] end\n\
-        \  in ?\n\
-         in\n\
+         let v1 =\n\
+         let _requires = [(enforced=(false), \"c is in header(t1)\"), \
+         (enforced = (false), \"schema(t1)[c] is Number\")] in\n\
+         let _ensures = [\n\
+         (enforced=(true), \"header(t2) is equal to ['group', 'count']\"),\n\
+         (enforced=(true), \"schema(t2)['group'] is String\"),\n\
+         (enforced = (true), \"schema(t2)['count'] is Number\")\n\
+         ] in\n\
+         let bin_int =\n\
+         fun (is : [Int], bin_size : Int) ->\n\
+         let floored = map(is, fun i -> i / bin_size * bin_size) in\n\
+         let grouped =\n\
+         fold_left(\n\
+         floored,\n\
+         fun (\n\
+         acc,\n\
+         i\n\
+         ) ->\n\
+         case find_opt(acc, fun (i', _count) -> i == i')\n\
+         | None => (i, 1) :: acc\n\
+         | Some((i, cnt)) => (i, cnt + 1) :: filter(acc, fun (i', _count) -> i \
+         != i')\n\
+         end,\n\
+         []\n\
+         ) in\n\
+         map(grouped, fun (i, cnt) -> (group = (i, i + bin_size), count = \
+         cnt)) in\n\
+         let bin =\n\
+         fun (t1 : [?], c : String, n : Int) ->\n\
+         let entries = flat_map(t1, to_lvs) |> filter(_, fun e -> (e.label == \
+         c)) in\n\
+         let vals = entries.value in\n\
+         let bins = bin_int(vals, n) in\n\
+         map(\n\
+         bins,\n\
+         fun e ->\n\
+         e\n\
+         ... (\n\
+         group =\n\
+         let (group = (min, max), _) = e in\n\
+         string_of_int(min) ++ \" <= \" ++ c ++ \" < \" ++ string_of_int(max)\n\
+         )\n\
+         )\n\
+         : [(group = String, count = Int)] in\n\
+         test\n\
+         bin(gradebook, \"final\", 2)\n\
+         == [(group=\"76 <= final < 78\", count=1), (group=\"84 <= final < \
+         86\", count=1), (group = \"86 <= final < 88\", count = 1)]\n\
+         : [(group = String, count = Int)] end in\n\
+         # This version takes an explicit projection to gurantee the requires \
+         constraints#\n\
+         let v2 =\n\
+         let _requires = [(enforced=(true), \"c is in header(t1)\"), (enforced \
+         = (true), \"schema(t1)[c] is Number\")] in\n\
+         let _ensures = [\n\
+         (enforced=(true), \"header(t2) is equal to ['group', 'count']\"),\n\
+         (enforced=(true), \"schema(t2)['group'] is String\"),\n\
+         (enforced = (true), \"schema(t2)['count'] is Number\")\n\
+         ] in\n\
+         let bin_int =\n\
+         fun (is : [Int], bin_size : Int) ->\n\
+         let floored = map(is, fun i -> i / bin_size * bin_size) in\n\
+         let grouped =\n\
+         fold_left(\n\
+         floored,\n\
+         fun (\n\
+         acc,\n\
+         i\n\
+         ) ->\n\
+         case find_opt(acc, fun (i', _count) -> i == i')\n\
+         | None => (i, 1) :: acc\n\
+         | Some((i, cnt)) => (i, cnt + 1) :: filter(acc, fun (i', _count) -> i \
+         != i')\n\
+         end,\n\
+         []\n\
+         ) in\n\
+         map(grouped, fun (i, cnt) -> (group = (i, i + bin_size), count = \
+         cnt)) in\n\
+         let bin =\n\
+         typfun row ->\n\
+         fun (t1 : [row], c : String, c_project : (row -> Int), n : Int) ->\n\
+         let vals = map(t1, c_project) in\n\
+         let bins = bin_int(vals, n) in\n\
+         map(\n\
+         bins,\n\
+         fun e ->\n\
+         e\n\
+         ... (\n\
+         group =\n\
+         let (group = (min, max), _) = e in\n\
+         string_of_int(min) ++ \" <= \" ++ c ++ \" < \" ++ string_of_int(max)\n\
+         )\n\
+         )\n\
+         : [(group = String, count = Int)] in\n\
+         test\n\
+         bin@<GradebookEntry>(gradebook, \"final\", fun r -> r.final, 2)\n\
+         == [(group=\"76 <= final < 78\", count=1), (group=\"84 <= final < \
+         86\", count=1), (group = \"86 <= final < 88\", count = 1)]\n\
+         : [(group = String, count = Int)] end in\n\
+         ? in\n\
          let pivot_table =\n\
-        \  let requires=[\n\
-        \    (enforced=(false), \"for all c in cs, c is in header(t1)\"),\n\
-        \    (enforced=(false), \"for all c in cs, schema(t1)[c] is a \
-         categorical sort\"),\n\
-        \    (enforced=(false), \"ci2 is in header(t1)\"),\n\
-        \    (enforced=(false), \"concat(cs, [c11, ... , cn1]) has no \
+         let _requires = [\n\
+         (enforced=(false), \"for all c in cs, c is in header(t1)\"),\n\
+         (enforced=(false), \"for all c in cs, schema(t1)[c] is a categorical \
+         sort\"),\n\
+         (enforced=(false), \"ci2 is in header(t1)\"),\n\
+         (enforced = (false), \"concat(cs, [c11, ... , cn1]) has no \
          duplicates\")\n\
-        \  ] in\n\
-        \  let ensures=[\n\
-        \    (enforced=(false), \"fi consumes Seq<schema(t1)[ci2]>\"),\n\
-        \    (enforced=(false), \"header(t2) is equal to concat(cs, [c11, ... \
-         , cn1])\"),\n\
-        \    (enforced=(false), \"for all c in cs, schema(t2)[c] is equal to \
+         ] in\n\
+         let _ensures = [\n\
+         (enforced=(false), \"fi consumes Seq<schema(t1)[ci2]>\"),\n\
+         (enforced=(false), \"header(t2) is equal to concat(cs, [c11, ... , \
+         cn1])\"),\n\
+         (enforced=(false), \"for all c in cs, schema(t2)[c] is equal to \
          schema(t1)[c]\"),\n\
-        \    (enforced=(false), \"schema(t2)[ci1] is equal to the sort of \
+         (enforced = (false), \"schema(t2)[ci1] is equal to the sort of \
          outputs of fi for all i\")\n\
-        \  ] in\n\
-        \  let pivot_table = fun (t1:[?], cs:[String], aggs:[(String, String, \
-         ? -> ?)]) ->\n\
-        \    let groups = fold_left(t1, (fun (groups, row) ->\n\
-        \      let k = filter(to_lvs(row), fun e -> mem(cs, e.label)) |> \
+         ] in\n\
+         let pivot_table =\n\
+         fun (t1 : [?], cs : [String], aggs : [(String, String, ? -> ?)]) ->\n\
+         let groups =\n\
+         fold_left(\n\
+         t1,\n\
+         (fun (groups, row) ->\n\
+        \            let k = filter(to_lvs(row), fun e -> mem(cs, e.label)) |> \
          from_lvs in\n\
-        \      let group_tup = from_lvs(k) in\n\
-        \      case find_opt(groups, fun (gk, _) -> k == gk)\n\
-        \      | None => (k, [row]) :: groups\n\
-        \      | Some((key, rows)) => (k, row :: rows) :: filter(groups, fun \
-         (gk, _) -> k != gk)\n\
-        \      end), []) in\n\
-        \    map(groups, fun (k, g) ->\n\
-        \      k ...(map(aggs, fun (dest_col, source_col, reduction) ->\n\
-        \        let vals = filter_map(g, fun r -> find_opt(to_lvs(r), fun e \
-         -> e.label == source_col) |> option_map(_, fun e -> e.value)) in\n\
-        \        let reduced = reduction(vals) in\n\
-        \        (label=dest_col, value=reduced)\n\
-        \      ) |> from_lvs)) in\n\
-        \  let average = fun ns -> fold_left(ns, int_plus, 0) / length(ns) in\n\
-        \  test pivot_table(students,  [\"favorite_color\"], \
-         [(\"age-average\", \"age\", average)])\n\
-        \  == [\n\
-        \    (\"red\", 13),\n\
-        \    (\"green\", 17),\n\
-        \    (\"blue\", 12)\n\
-        \  ] : [(favorite_color=String, `age-average`=Int)] end\n\
-         in\n\
+        \            let _group_tup = from_lvs(k) in\n\
+        \            case find_opt(groups, fun (gk, _) -> k == gk)\n\
+        \            | None => (k, [row]) :: groups\n\
+        \            | Some((_key, rows)) => (k, row :: rows) :: \
+         filter(groups, fun (gk, _) -> k != gk)\n\
+        \            end),\n\
+         []\n\
+         ) in\n\
+         map(\n\
+         groups,\n\
+         fun (k, g) ->\n\
+         k\n\
+         ... (\n\
+         map(\n\
+         aggs,\n\
+         fun (dest_col, source_col, reduction) ->\n\
+         let vals = filter_map(g, fun r -> find_opt(to_lvs(r), fun e -> \
+         e.label == source_col) |> option_map(_, fun e -> e.value)) in\n\
+         let reduced = reduction(vals) in\n\
+         (label = dest_col, value = reduced)\n\
+         )\n\
+         |> from_lvs\n\
+         )\n\
+         ) in\n\
+         let average = fun ns -> fold_left(ns, int_plus, 0) / length(ns) in\n\
+         test\n\
+         pivot_table(students, [\"favorite_color\"], [(\"age-average\", \
+         \"age\", average)])\n\
+         == [(\"red\", 13), (\"green\", 17), (\"blue\", 12)] : \
+         [(favorite_color = String, `age-average` = Int)] end in\n\
          let group_by =\n\
-        \  let requires=[] in\n\
-        \  let ensures=[\n\
-        \    (enforced=(true), \"schema(r1) is equal to schema(t1)\"),\n\
-        \    (enforced=(true), \"schema(r2) is equal to schema(t1)\"),\n\
-        \    (enforced=(true), \"schema(t2) is equal to schema(r3)\"),\n\
-        \    (enforced=(false), \"nrows(t2) is equal to \
-         length(removeDuplicates(ks)), where ks is the results of applying key \
-         to each row of t1. ks can be defined with select and getColumn.\")\n\
-        \  ] in\n\
-        \  let group_by = typfun r1 -> typfun r3 -> typfun K -> typfun V ->\n\
-        \    fun (t1:[r1], key:(r1 -> K), project:(r1 -> V), aggregate:((K, \
-         [V]) -> r3)) ->\n\
-        \      let grouped = fold_left(t1, (fun (groups:[(K, [r1])], row:r1) ->\n\
-        \        let k = key(row) in\n\
-        \        case find_opt(groups, fun (gk, _) -> k == gk)\n\
-        \        | None => (k, [row]) :: groups\n\
-        \        | Some((key, rows)) => (k, row :: rows) :: filter(groups, fun \
-         (gk, _) -> k != gk)\n\
-        \        end), []) in\n\
-        \      map(grouped, fun (k, g) -> aggregate(k, map(g, project))) : \
-         [r3] in\n\
-        \  \n\
-        \  test\n\
-        \    let average = fun ns -> fold_left(ns, int_plus, 0) / length(ns) in\n\
-        \    let abstract_age = fun (r : GradebookEntry) ->\n\
-        \      if r.age <= 12 then \"kid\" else if r.age <= 18 then \
-         \"teenager\" else \"adult\" in\n\
-        \    group_by@<GradebookEntry>@<?>@<String>@<Int>(\n\
-        \      gradebook,\n\
-        \      abstract_age,\n\
-        \      fun r -> r.final,\n\
-        \      fun(k, vs) -> (key=k, average=average(vs))\n\
-        \    ) == [\n\
-        \      (key=\"teenager\", average=81),\n\
-        \      (key=\"kid\", average=87)\n\
-        \    ] \n\
-        \  end\n\
-         in ?\n";
+         let _requires = [] in\n\
+         let _ensures = [\n\
+         (enforced=(true), \"schema(r1) is equal to schema(t1)\"),\n\
+         (enforced=(true), \"schema(r2) is equal to schema(t1)\"),\n\
+         (enforced=(true), \"schema(t2) is equal to schema(r3)\"),\n\
+         (\n\
+         enforced = (false),\n\
+         \"nrows(t2) is equal to length(removeDuplicates(ks)), where ks is the \
+         results of applying key to each row of t1. ks can be defined with \
+         select and getColumn.\"\n\
+         )\n\
+         ] in\n\
+         let group_by =\n\
+         typfun r1 ->\n\
+         typfun r3 ->\n\
+         typfun K ->\n\
+         typfun V ->\n\
+         fun (t1 : [r1], key : (r1 -> K), project : (r1 -> V), aggregate : \
+         ((K, [V]) -> r3)) ->\n\
+         let grouped =\n\
+         fold_left(\n\
+         t1,\n\
+         (fun (groups:[(K, [r1])], row:r1) ->\n\
+        \                let k = key(row) in\n\
+        \                case find_opt(groups, fun (gk, _) -> k == gk)\n\
+        \                | None => (k, [row]) :: groups\n\
+        \                | Some((_key, rows)) => (k, row :: rows) :: \
+         filter(groups, fun (gk, _) -> k != gk)\n\
+        \                end),\n\
+         []\n\
+         ) in\n\
+         map(grouped, fun (k, g) -> aggregate(k, map(g, project))) : [r3] in\n\
+         test\n\
+         let average = fun ns -> fold_left(ns, int_plus, 0) / length(ns) in\n\
+         let abstract_age = fun (r : GradebookEntry) -> if r.age <= 12 then \
+         \"kid\" else if r.age <= 18 then \"teenager\" else \"adult\" in\n\
+         group_by@<GradebookEntry>@<?>@<String>@<Int>(gradebook, abstract_age, \
+         fun r -> r.final, fun (k, vs) -> (key = k, average = average(vs)))\n\
+         == [(key=\"teenager\", average=81), (key = \"kid\", average = 87)] \
+         end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIConstructorsaddColumn.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIConstructorsaddColumn.ml
@@ -6,89 +6,96 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         b5345007-6722-43e8-b512-f85cd5322902)(content(Whitespace\" \
+         2957f4a8-931d-4c6a-ba3e-84bad4e9eca8)(content(Whitespace\" \
          \"))))(Tile((id \
          14e4cfbe-3660-4810-a8f8-6cd33121fea1)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         bf6701c7-eb2b-4c73-94a2-a2a566fb3f9a)(content(Whitespace\" \
+         02d9fc91-fbc7-43ab-9092-bc79c9fe46b5)(content(Whitespace\" \
          \")))))((Secondary((id \
-         cfaaf2f1-9a15-43aa-ba85-9be02f732e1e)(content(Whitespace\" \
+         7193ba1b-b7fb-453f-aa3d-bfa822a00b9f)(content(Whitespace\" \
          \"))))(Tile((id \
          1d351d31-0027-491d-b420-532b957d8ce4)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          2e381eb6-73ec-4e10-8748-5a123b4da33f)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         955abb69-15e2-4772-9c63-0f7ec1c6e09c)(content(Whitespace\" \
+         \"))))(Tile((id \
          4975bc58-aa20-4e34-aba7-d890ea80862c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1219531b-5a82-427e-afca-e0d166254251)(content(Whitespace\" \
+         \"))))(Tile((id \
          63a04cf6-64ad-4148-9109-b9296d995352)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          585917a1-d17a-4bfc-a3cd-9a3a3f54125d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b1833046-5a14-4d02-ba47-56f31a439779)(content(Whitespace\" \
+         19955d11-b2dd-4f8b-b529-b4d5764afedd)(content(Whitespace\" \
          \"))))(Tile((id \
          5cc3159a-b108-439a-9567-f310da2b3e03)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5e3bb31b-607d-40c7-902b-01e394dbd6b3)(content(Whitespace\" \
+         \"))))(Tile((id \
          54d4ce58-66af-413a-abd6-a7f08a3e9467)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dcbfb5a1-a666-4ff1-bf40-15f4c4952290)(content(Whitespace\" \
+         \"))))(Tile((id \
          d7ca8245-8285-4e85-a713-3738543437f9)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          366bafee-0729-4085-8e82-64a6ae52672d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         afd726e5-5c36-4f6e-96f5-4176d658280e)(content(Whitespace\" \
+         0671f51c-97ad-47c7-9972-3ede981e1c21)(content(Whitespace\" \
          \"))))(Tile((id \
          1b5e77e1-ab6b-473f-85ff-40957679ba38)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7cb1eec5-4a86-4f9f-8218-f2e4a675f5ce)(content(Whitespace\" \
+         \"))))(Tile((id \
          f8cd2307-ee26-476c-a657-39e36dc476dd)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         32504701-ccb4-4b62-a149-060eb41d9d42)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a8e67d9-42fa-4d23-a62a-52ee7b6b29be)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         434df16c-0030-4045-a7d3-27b8a6593723)(content(Whitespace\" \
+         678fd56c-a5ab-4e15-8af6-6ec2772646b6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         05bb1a6e-cee9-4a32-b5de-f4a285e9156a)(content(Whitespace\"\\n\"))))(Tile((id \
+         e0c384b5-5c4a-451d-b1f1-2c123c5a2162)(content(Whitespace\"\\n\"))))(Tile((id \
          e283615c-2ef6-4a7d-8780-acfb8d042f01)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         ebce6e80-4771-4d48-a488-ad63ffa62f59)(content(Whitespace\" \
+         063d25e2-ebe9-4892-a0cb-2608c67de599)(content(Whitespace\" \
          \"))))(Tile((id \
          3b95d56a-c432-453d-927a-3cd1d656b726)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1d64acf0-732e-47fc-94ec-12d7e573592b)(content(Whitespace\" \
+         9a687b9c-40cd-4695-a097-748a18ab297d)(content(Whitespace\" \
          \"))))(Tile((id \
          c3bad592-1438-403b-a1a1-2c7e830f16c7)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         392f6d07-2d68-4e27-a9d3-c122401caa04)(content(Whitespace\" \
+         693b13ba-a37e-4e49-92b9-497764bfffe7)(content(Whitespace\" \
          \"))))(Tile((id 75187488-3d1f-4110-a7a5-a8bf40da0f29)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          8750e1ff-a383-47bb-9fbc-1a663ef667d0)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         790bf084-fedd-4afa-887e-748a736389ac)(content(Whitespace\" \
+         e9c62475-ece4-4edd-81d0-ceebc075d764)(content(Whitespace\" \
          \")))))((Secondary((id \
-         68c54cd4-a26e-4e4b-a5ce-0070399063f2)(content(Whitespace\" \
+         8c51d7cc-ec87-40b2-8536-4f99f2d50cc4)(content(Whitespace\" \
          \"))))(Tile((id 15ba059d-df0f-4404-9fd7-f107258c6f3b)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         7f290159-152d-4dca-aab7-123b8f5e873c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         795b441c-a12a-448e-b962-b37dde570b52)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         108ef784-b0a7-4a96-961c-cb669d3267d0)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          af0242a2-6e59-495a-a50e-614fb70ad65a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -114,10 +121,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          891f7aec-05fb-4e1b-b304-c9a16f4a56a1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9404f6b5-450a-4ace-bba3-a046127a650b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         19d56cfa-5c19-42ef-b839-30da23a0a26f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7083754-e2d5-47d7-aa07-33d36a607e19)(content(Whitespace\" \
+         c87c8385-1645-4820-adb8-eb5f0c0096c2)(content(Whitespace\" \
          \"))))(Tile((id \
          8c5725a4-6b66-49eb-b1d2-cdcbdf5a507f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -144,10 +148,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b1350300-74c9-416b-8dd9-b8806bd84d23)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3745ed4b-a430-446f-b871-1ab41b16fffa)(content(Whitespace\"\\n\"))))(Secondary((id \
-         336338cf-b64e-4adc-8ad3-d57368f8b022)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3f7b69e8-f53a-46cd-aab8-b1cb0456f08d)(content(Whitespace\" \
+         14444137-7464-40df-ace9-130bfd6e0689)(content(Whitespace\" \
          \"))))(Tile((id \
          08a2ce37-24af-49d5-ad1b-d67c9c191ce7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -158,7 +159,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aef48d3b-13c0-4cca-9bb2-57ed6360bb39)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         539fad2a-7ecb-400e-96a9-41ca746719dd)(content(Whitespace\" \
+         18833326-10d0-4187-9dd9-f14088d388d9)(content(Whitespace\" \
          \"))))(Tile((id \
          a67c3bdb-4c6c-4b1e-bf0b-3b5b22ff77fa)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -166,60 +167,44 @@ let out : string * Haz3lcore.PersistentSegment.t =
          25786668-9321-4b5c-82ef-288c130bca1d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         89c669df-8ca3-4bef-9615-ea840b7a0cbe)(content(Whitespace\" \
+         f0b15122-6bb8-4002-b28e-a4e3d8ea2593)(content(Whitespace\" \
          \"))))(Tile((id \
          5c4e4235-b488-44d4-b4f6-17ac19a251fe)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         68ad01cd-9ede-4093-bb05-51b1574048c3)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         b8a74add-48cd-406b-9b59-f88dacd30a8a)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         eff4fe2c-0962-4a39-afd1-b2972a5d52ac)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d3c8b56f-5306-4c3a-9493-ff80f96d2a13)(content(Whitespace\"\\n\"))))(Secondary((id \
+         380c3ec7-e949-4de8-a45b-098f947280f7)(content(Whitespace\"\\n\"))))(Secondary((id \
          b0bfab33-07fa-49dc-892b-969412eaa92b)(content(Comment\"# V1: This \
          version is more idiomatic but requires the caller to pass a function \
          combining the rows explicitly thereby getting more type safety. \
          #\"))))(Secondary((id \
-         c6b36256-9051-474f-bb5d-1f21458cfb78)(content(Whitespace\"\\n\"))))(Tile((id \
+         a7956594-cbf8-4c8f-b726-4e01031005d4)(content(Whitespace\"\\n\"))))(Tile((id \
          3b8a8c56-a9d3-418f-87d9-eb939d8ece53)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         14fe03e9-cb07-49eb-b677-7af47efeb035)(content(Whitespace\" \
+         343f367e-2f24-444c-b624-dab6ddb2f0b7)(content(Whitespace\" \
          \"))))(Tile((id \
          035c3b20-3aa8-4003-952a-1c2b685e130f)(label(v1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2e9ec572-5312-4eb3-90a0-7a7c3d5f2e2f)(content(Whitespace\" \
+         cc877667-b70d-4856-a0ef-a71561373d08)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9e48afe4-9cb1-4276-9510-7f1c7324902e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9f7bed84-d231-45f6-a81b-b023883ed2e4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c88b4f4d-34cf-4752-bf13-21fce4e92118)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5284c4d4-9b94-43a7-9734-91a64c3f0e9b)(content(Whitespace\" \
-         \"))))(Tile((id 3fdc4de1-97d5-42e5-8a55-14150b042c78)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         46fde66a-b1ca-4935-b2a5-da7f1a0d8041)(content(Whitespace\" \
+         dc2ace7a-0a84-47de-8c7e-5257f64c1ac0)(content(Whitespace\"\\n\"))))(Tile((id \
+         3fdc4de1-97d5-42e5-8a55-14150b042c78)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         85f0a6aa-1b80-480b-b0d8-f1487cefb969)(content(Whitespace\" \
          \"))))(Tile((id \
-         a7d8af1d-96ee-4039-a6b7-0b6a7175ad20)(label(requires))(mold((out \
+         a7d8af1d-96ee-4039-a6b7-0b6a7175ad20)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         657e14ce-b063-4589-b7b4-c4280cb8e75f)(content(Whitespace\" \
+         85d98c5a-5e29-4232-8f4a-0e8409b88401)(content(Whitespace\" \
          \")))))((Secondary((id \
-         de09dbe4-67a2-4483-9990-e764e2d76124)(content(Whitespace\" \
+         a9a0cf9b-02e8-408a-a81a-9a8a0f96c1ca)(content(Whitespace\" \
          \"))))(Tile((id 93edef59-5d41-4de9-b324-dbc58ef79218)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ea26b00e-d3e4-4244-ae7a-ed8d0a8acbd1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7093b916-b2cb-4bf3-88c3-200e0af3fd16)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         09e2df1e-ec2d-42f2-bf36-12516746e25a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8b0eba71-dc73-464c-9b9a-3688821c99af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         802683da-9eb2-4bb3-8e07-bea657352547)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          7098e5fe-459a-441a-888f-23c3418aab75)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -247,25 +232,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          db9e605d-8b74-4b5f-b1a1-223123fad129)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e716c476-751f-4cf5-804f-1e41cd441241)(content(Whitespace\"\\n\"))))(Secondary((id \
-         42769330-3c8b-46fe-b71d-2bad1e0e742e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         48482cdf-b524-4597-860e-a47edcef77a9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b68072e7-016f-4fb0-82d9-ead3df33461a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cba5137a-1006-4e54-9e9b-0fc559170efe)(content(Whitespace\" \
+         0d64d5c6-c79a-4ba4-b7b1-bd030cfbc8b4)(content(Whitespace\" \
          \"))))(Tile((id \
          0a720176-d33d-44c2-8fe0-d4aa866efb94)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          57cfc260-f2ec-4ad9-a237-d234636d086e)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         59ea98fc-871e-47aa-875f-16989fca0802)(content(Whitespace\" \
+         \"))))(Tile((id \
          ba035293-3077-487b-b3ef-8776f111c900)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         ce487fed-fcf8-4807-9a91-88ac871af661)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         108e9660-29f4-466d-b160-73f38dc30bbc)(content(Whitespace\" \
+         \"))))(Projector((id ce487fed-fcf8-4807-9a91-88ac871af661)(kind \
+         Checkbox)(syntax(Tile((id \
          767f6b99-5b23-4397-8c7b-7f17c8b259a1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -275,47 +257,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1b9829d5-7042-4efd-aedb-f4632aaf0ba4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4c88cb3d-b5db-48fb-a1b0-82da33629392)(content(Whitespace\" \
+         f562cf00-6837-4c70-bc3e-52aa2787212c)(content(Whitespace\" \
          \"))))(Tile((id \
          5861a85d-18c6-4d5d-8faf-4a5a8584bc04)(label(\"\\\"length(vs) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         725ae256-0900-40f6-857f-bc69a84a7b0c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         61e13bb7-e95f-43be-97d6-b1325a000f47)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b05c43b0-291e-4a85-b31b-10778684100a)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         ec9c024f-bdfd-49ad-91db-716205dd6d6c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3dc4672b-67f4-4706-9360-70d18d5b6448)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         175a66ea-eaf1-4974-8ff9-563dd8b98161)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5c09313f-ce5b-4321-8038-edaa28328cef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46ff5486-aeac-47a1-aaf0-2f9c01b4a660)(content(Whitespace\" \
-         \"))))(Tile((id 6dbba814-8f87-477d-a4d2-9aca5e72ee12)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         a07fdbb3-1d18-41b8-af77-6ea72d0f532c)(content(Whitespace\" \
+         0dd3b92e-bd55-42dc-b385-9eef2bdb241f)(content(Whitespace\"\\n\"))))(Tile((id \
+         6dbba814-8f87-477d-a4d2-9aca5e72ee12)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         991c7637-6723-4fdd-8293-40e4671dd3fb)(content(Whitespace\" \
          \"))))(Tile((id \
-         2267c045-25aa-4063-a245-549911ed12e6)(label(ensures))(mold((out \
+         2267c045-25aa-4063-a245-549911ed12e6)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c553bf7c-d6eb-47c4-8205-dcb5ed859b70)(content(Whitespace\" \
+         7c854193-0be5-4719-bf58-a17ba77a69a6)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7bb8bd9d-22b2-43f0-a384-016cb5347eb4)(content(Whitespace\" \
+         3e87185d-4463-4dfe-bb0d-22fedd356616)(content(Whitespace\" \
          \"))))(Tile((id 2a8988b3-1820-44f3-8cd7-0d2049469461)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         3d0d8d6b-016e-44cd-a6bc-abaa5307b960)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0afef688-489e-4049-9ba4-30d61a68b80b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e99e5e55-0216-44fe-a8c7-a6a5df778ed1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a29eb892-60ee-42e4-8722-e642e970ac60)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         076b68df-56f3-4488-ad40-22107bb6443e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         db943edd-e926-4f68-87b9-9ea3e1e251eb)(content(Whitespace\"\\n\"))))(Tile((id \
          72217fa0-d3c4-441f-9958-2283a429583f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -344,20 +309,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          638cce8b-3df0-486c-829f-199e7af6fd39)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         01ddb51f-6f15-4d70-91ee-1a699d55693f)(content(Whitespace\" \
+         4b362b26-e156-4aed-9413-80873ef72529)(content(Whitespace\" \
          \"))))(Secondary((id \
          f7f793a5-7f60-4964-9d69-10692aebdac8)(content(Comment\"# Assuming the \
          higher order function provided is extension with the new column \
          #\"))))(Secondary((id \
-         5e5f1b77-aa2e-4ca1-813f-bdd8ae3296cf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d5f23831-7ff2-4b50-be54-b046aea8279a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58f366c5-2369-4968-ac4c-3e013e7ff193)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6749de94-23d2-4091-9766-c27e86ec0839)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2df294d5-230e-4973-9403-79a3654be066)(content(Whitespace\" \
-         \"))))(Tile((id \
+         fca13f38-1050-45cf-b3f1-657dc814ee11)(content(Whitespace\"\\n\"))))(Tile((id \
          2b8cdb2d-bd60-480c-8156-e66d7122a483)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -386,22 +343,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          754733d2-81ab-4c00-ac75-66b7c89be493)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a231d258-bf30-43a2-91ad-35888eaf707a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9bf89d57-94b3-42e1-8068-1e761669c4bd)(content(Whitespace\" \
+         1648d77f-ff09-4b30-a522-ae4ef7bdab96)(content(Whitespace\" \
          \"))))(Secondary((id \
          08efff8f-043e-48a6-980f-8ca358410cad)(content(Comment\"# Assuming the \
          higher order function provided is extension with the new column \
          #\"))))(Secondary((id \
-         43fd387b-2002-4c3d-beda-8797d8a99a8d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         946034e7-958f-43cf-b9c9-a935ba765202)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c48a3c2a-50f7-4e28-84cf-0e0f26e1feb9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e482dde9-c3c6-458f-9343-28104131470a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b846ea6-040b-4cce-b53b-3109fdbe540d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         491d5c6f-4e6f-4069-ab4d-969dcc69a285)(content(Whitespace\"\\n\"))))(Tile((id \
          ee39a7a5-bbd7-4ad6-b645-02884250139f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -430,32 +377,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          246e6b23-ef9f-40ef-abdd-3f02b4343bc8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         31bd5edb-b5d7-4686-b199-0b0e1f6d772b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         03fa2a50-6a26-41c7-adce-4134f6833de0)(content(Whitespace\" \
+         629a79e9-8a75-4e9c-aeb3-73a711c0aff7)(content(Whitespace\" \
          \"))))(Secondary((id \
          de59a23f-c80e-45a2-b4fe-9a758a14ef07)(content(Comment\"# Assuming the \
          higher order function provided is extension with the new column \
          #\"))))(Secondary((id \
-         e6084c68-705b-4940-ae7c-3df8591935b9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ee6bc2fd-62db-4dff-a25b-8d3a83daf9a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e6e177c-5eb6-4d7b-b36d-a5e1c391723b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         feb0edcf-fc3e-4a19-9891-220c37d88d16)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         733e39af-e0e6-40c7-9417-c65a60bbae5d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5718c06d-397e-4c85-8d37-1d8887c83dab)(content(Whitespace\"\\n\"))))(Tile((id \
          7801c68a-abeb-4d03-99e2-03b96e0669a1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          d9557759-0372-41db-af44-4ca76fa1d4a2)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e8a00264-1e15-4677-83e3-8059895bc521)(content(Whitespace\" \
+         \"))))(Tile((id \
          bc6decc4-8475-4444-8679-6ac1d7879bf9)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         6d102d3e-6e23-4304-b773-cf0b842894fc)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4d0735c9-ab11-4f1e-a3ff-3da2fad08e65)(content(Whitespace\" \
+         \"))))(Projector((id 6d102d3e-6e23-4304-b773-cf0b842894fc)(kind \
+         Checkbox)(syntax(Tile((id \
          0d0bb346-24f6-4fc4-8e84-e0f6ebbc068e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -465,76 +406,68 @@ let out : string * Haz3lcore.PersistentSegment.t =
          36d12467-3ae8-4999-ae5b-3b94423ba2eb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         383bd7ba-b8c5-4d13-b7ce-86778d9ceff3)(content(Whitespace\" \
+         81f3b0d3-6f1b-4236-a653-676fec32be22)(content(Whitespace\" \
          \"))))(Tile((id \
          901896e2-b803-452a-b160-f39f8c982f87)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         051cab13-bf7a-4df5-aa18-e15b94402f07)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5c9a22f3-7709-46e8-8842-a09b8bd6d4f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aea77470-ac5e-4e26-962e-f7c0ab475bdb)(content(Whitespace\" \
+         47d9a392-1b30-4462-850e-14fc39354593)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         729fb89c-fa39-4b40-8725-8776da72d91e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f616a71d-b211-4d19-81a7-207d8d2f59eb)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d4767221-fafd-43a5-a647-6ff33b34262d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bbc6fb3e-95e0-4751-9930-46c889d17cd3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8fc67d28-3d23-4b03-9afc-ce61a27bc0dd)(content(Whitespace\" \
-         \"))))(Tile((id 1ba5b6a0-c73a-4c88-b93e-03a2dbefb920)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         152d666a-24e2-49be-9f5d-393deb8afe39)(content(Whitespace\" \
+         2337f091-1f37-4b1d-bf5e-47b1a35b7599)(content(Whitespace\"\\n\"))))(Tile((id \
+         1ba5b6a0-c73a-4c88-b93e-03a2dbefb920)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0080f7b6-3700-4d49-bb27-640ace6345f4)(content(Whitespace\" \
          \"))))(Tile((id \
          821b4ceb-2c42-46bd-9290-437ac3ef1f71)(label(add_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         36b2243e-f9b2-4d5b-8a03-9e43aad96a11)(content(Whitespace\" \
+         5276743e-10be-4b88-8c9f-4a3d61f8a2b7)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ce050441-343d-4349-9b68-828984e3024e)(content(Whitespace\" \
+         806bde14-ee96-4363-8c38-d47fb8541b48)(content(Whitespace\" \
          \"))))(Tile((id 6804a282-0d78-4366-970a-80fa2208599e)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         5b2f8397-39a2-4d9c-b36a-fa98d290a769)(content(Whitespace\" \
+         56d9c320-9209-4bae-afd4-a1abf913e2a8)(content(Whitespace\" \
          \"))))(Tile((id \
          32c5a2ee-7bd9-4416-b281-2145a33663fb)(label(r))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         b30d0e11-d385-4ab6-985f-c4ad05bcbd9d)(content(Whitespace\" \
+         e2f38a4a-fa51-4801-afcd-8c4d4315ab54)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         13d04c92-4e28-41f3-99a7-9d3816685fe0)(content(Whitespace\" \
+         61c9769b-df55-47b6-98d1-52cb7254ea7b)(content(Whitespace\" \
          \"))))(Tile((id 536f02cb-5a9c-4e6a-8405-396b44534c7d)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         04fd6123-b241-4071-bbd2-1660d558fd5a)(content(Whitespace\" \
+         632a5be5-92e8-4e1b-8890-fa2d94004256)(content(Whitespace\" \
          \"))))(Tile((id \
          14e89aad-1313-43b5-9bdc-af4d4afb502d)(label(v))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         8122196f-527a-48c8-abd4-82d5ba36282d)(content(Whitespace\" \
+         3fa8244c-999e-418b-ac4b-5951cfc30671)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         165583d4-f910-47f5-9b19-b68ffd058258)(content(Whitespace\" \
+         dce4f0f3-7f22-4d5f-a1eb-bf85c927c541)(content(Whitespace\" \
          \"))))(Tile((id 7cd2940a-e3ff-4dbd-94cf-e9007c47e13a)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         42ef72bf-c62a-4e97-a57a-4dbd5a7bd642)(content(Whitespace\" \
+         7f4b52ba-a849-4255-990f-49f5a3d5dd17)(content(Whitespace\" \
          \"))))(Tile((id \
          1428be38-cbc6-4e77-9bcc-b33d001dc725)(label(r'))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         96a54c32-ae0e-4bb0-85d7-357ec232bf2b)(content(Whitespace\" \
+         f20fe821-12b5-4777-959e-f58eff73dcae)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         165fc591-7c2c-47c6-9247-3ba9459e1834)(content(Whitespace\" \
+         348e00c2-de21-4ce6-95f3-35624010b9b9)(content(Whitespace\" \
          \"))))(Tile((id 160466fe-8833-4fd4-ad76-893effee0c2d)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         b44a32da-fb1d-4ec5-a46f-034c1ab3481e)(content(Whitespace\" \
+         084a441d-478a-4837-a473-5648914011e3)(content(Whitespace\" \
          \"))))(Tile((id \
          0f940d7b-e051-4020-bfb6-48baf45de694)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -542,12 +475,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6cf3de9b-9d28-4fdc-a262-56494ffb3efb)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b252a5f0-4df9-4f4f-9fa1-0e2548310925)(content(Whitespace\" \
+         4f4a6aa7-e3ce-4ca4-88ac-d06955f5bb9e)(content(Whitespace\" \
          \"))))(Tile((id \
          a992bfa7-d633-4431-9875-eb211c2056a2)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         87d502b0-ffa9-4031-8348-58d368f71dd3)(content(Whitespace\" \
+         e7ec5634-fcca-48c6-8f6a-a35ce497ac69)(content(Whitespace\" \
          \"))))(Tile((id 89d253c4-528b-4df9-af24-a13799895e54)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -557,17 +490,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5ea21c54-dcff-47d6-ba41-9f0878ff5035)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         6d5b5857-80af-4641-a2aa-12a2b814506f)(content(Whitespace\" \
+         ae6bbea9-d131-44f4-8dad-cf0ca9773a3a)(content(Whitespace\" \
          \"))))(Tile((id \
          a5c794b0-bdb0-4f3c-90bf-0d53cec93796)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         94618814-5529-494c-8abe-7eb966900c8d)(content(Whitespace\" \
+         2c85667f-84bb-4b89-ba03-cb136497e6b7)(content(Whitespace\" \
          \"))))(Tile((id \
          88c21e3d-92ca-4dbc-bdd1-799bb56e6929)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7d25db18-4614-4d8f-ae6f-2e0b7d9220bb)(content(Whitespace\" \
+         fc47b4d3-b85c-49a1-af3e-2f34a81229a2)(content(Whitespace\" \
          \"))))(Tile((id \
          baa7140b-0569-4ced-94cf-299dc40186f8)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -581,17 +514,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          af1061a6-a4c1-448a-bed4-8ea147b9e3aa)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6ddf1767-5254-408f-b207-950afe76bbc0)(content(Whitespace\" \
+         b0902e0e-0621-45f7-a9e4-a1bd95717046)(content(Whitespace\" \
          \"))))(Tile((id \
          1dc0c6d1-a4c3-4262-941c-e92ec6aae140)(label(v))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a10336ff-0c66-4a40-bb8a-86bacaf137de)(content(Whitespace\" \
+         f9771a77-0dbd-458a-9ed0-f4f9240a7da6)(content(Whitespace\" \
          \"))))(Tile((id \
          cf49b7d3-6f52-404c-ad4b-bcab7cc80833)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8c86dd17-ba31-40b7-8c8c-42322b9289a0)(content(Whitespace\" \
+         3448a9ff-f3f0-4cbb-83b4-c1bf940e485b)(content(Whitespace\" \
          \"))))(Tile((id \
          71f5701d-ed02-428a-9730-f9a99151c795)(label(r'))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -599,31 +532,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d8644d01-5a30-4e8b-8ac4-9ee5e468ded2)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         7b3c42e5-76ec-465a-9a40-d2f0a93fe946)(content(Whitespace\" \
+         b4418e60-e8fc-474a-a8c7-9d0304e8888a)(content(Whitespace\" \
          \"))))(Tile((id \
          9cf2a753-7f8a-4d23-83b3-e0eb4cae1345)(label(vs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         dc234cf8-8e03-46d3-8ab0-9c520f0af789)(content(Whitespace\" \
+         \"))))(Tile((id \
          6dd05cb9-2f93-430f-b66c-354144d4a9e2)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b5b9e73f-3df4-4fb2-90c6-eb30880aa946)(content(Whitespace\" \
+         4d7bbc65-1acd-47c2-b0f8-33f8f253e3d7)(content(Whitespace\" \
          \"))))(Tile((id 57c09492-d7ec-4b9f-87af-2749f2feb1c4)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          914c9c12-281a-487f-98bf-424cecc9d30e)(label(v))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d6838bc6-23fe-446c-951b-07a7bd5e63ff)(content(Whitespace\" \
+         0ad11fa6-6cc6-4828-8acd-f34f5a3922cd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4de5e5f4-1a2c-45a3-b7b1-4948ec2cf305)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8762367a-7ae6-4976-a859-bcac4f79d27b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b17c0a85-a115-46e8-a64a-2433126ee281)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7bf94892-ceb1-4f9b-a467-84b976b5477a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         15caa034-191e-4835-b97c-7425c6639d2a)(content(Whitespace\" \
+         a29896a4-61fa-43c1-b7b2-338eeaaa472b)(content(Whitespace\" \
          \"))))(Tile((id \
          aae6ca13-983e-4ed8-817f-837461891231)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -640,24 +568,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5288ef41-ba47-4440-b6ed-b65af2a21e51)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f7256bd6-34d1-4dc2-9922-38e5c62b2194)(content(Whitespace\" \
+         63425e1e-f287-406a-bdd6-f5ab9ab51124)(content(Whitespace\" \
          \"))))(Tile((id \
          85249abb-5fe5-46fe-a998-de1ad6c1d1a1)(label(vs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         68b74e08-db10-4c09-985c-3a0e39fc0ba9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3d5b28f8-b83f-4029-acd1-ae03322077a5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b947df6b-cd96-4e57-993c-843a79ec0233)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8023adfa-69be-44a6-ae19-e021225d03b9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         344ea411-e4a0-4540-9dc1-5144281be40e)(content(Whitespace\" \
+         9dd79d4a-4913-407a-9498-3fc80fea6ecc)(content(Whitespace\" \
          \"))))(Tile((id \
          28962af9-68ed-49c6-9470-b374330cdc13)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c5703bd4-b778-4916-97b8-6ca1eb150ecf)(content(Whitespace\" \
+         b4856d5c-1df0-4bef-b380-bdd156567f62)(content(Whitespace\" \
          \"))))(Tile((id \
          3396f99c-05f6-4b65-b564-ff280d8d86cc)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -671,61 +592,41 @@ let out : string * Haz3lcore.PersistentSegment.t =
          54f5dc06-2797-41a7-9313-336aa3d48327)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb6f97ce-2bde-4201-8806-7e80b1d62941)(content(Whitespace\" \
+         5f9bde04-4b13-4822-ae16-d1b765c2dec6)(content(Whitespace\" \
          \"))))(Tile((id \
          868616ca-ff8f-4b69-812e-1b1e33b7360b)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         2f5f1253-2754-4c05-9ad0-b2bddef86816)(content(Whitespace\" \
+         d3c89a77-fb0f-41de-a9d5-ca0a3c8c0ed5)(content(Whitespace\" \
          \"))))(Tile((id \
          937867d8-f3cd-4f2c-aa3d-9df27334379c)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b10c6e10-f925-4f18-ab20-d8160396341d)(content(Whitespace\" \
+         bb1f2c29-7066-4c81-abdb-acbdb4f273e8)(content(Whitespace\" \
          \"))))(Tile((id b2bee8e7-649d-4b31-a741-9ad1d4aed415)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          54d8e274-e328-43d4-bddd-dd7e8f4d3135)(label(r'))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         fde9e8f2-b08b-47a3-b523-86c4377ab40f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fe154668-7e7d-4e5c-9a9c-12aeb6050206)(content(Whitespace\" \
+         36c73b66-6b70-4e34-95e4-f2f30f623a96)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         dcb14758-fa9f-449d-9a51-36b1591b7025)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c4f093b1-ca77-4c70-865f-64e60cc25a05)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b42d4f05-8da8-41b8-b926-d79b9fc7ee5c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         058f80cf-04b3-497b-ac53-ce577683f429)(content(Whitespace\"\\n\"))))(Secondary((id \
-         528cfb17-0f79-4fd6-be3c-080ab74c6a80)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         496fee72-77f6-4294-90ed-08b9e3b0294b)(content(Whitespace\" \
-         \"))))(Tile((id 2c91754f-78fe-413b-a385-ed578afdb467)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         4a179cbc-6ad2-40b9-9ccf-1e49e776e8ee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         226e1af9-386d-4121-a9ac-768f0ce021d8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2dc47575-6f20-4490-ae9b-87789dc01581)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7281ca04-bcb7-4c59-9301-2e7ff8d88ad9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ec867fe8-9c25-4bbb-a3a2-433e1ce664e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         62045134-3d35-4ba5-88d7-e346c1a223a0)(content(Whitespace\" \
-         \"))))(Tile((id 7a2a7edb-0ac7-4285-9e74-9d27cb838594)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         5d10cc25-795e-4837-a53a-0fbb825f85f2)(content(Whitespace\" \
+         6b1873e2-ae7c-404e-88a7-1d37d3c246c1)(content(Whitespace\"\\n\"))))(Tile((id \
+         2c91754f-78fe-413b-a385-ed578afdb467)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         825cd8f2-1ccc-47fa-acc0-0adebd994f1c)(content(Whitespace\"\\n\"))))(Tile((id \
+         7a2a7edb-0ac7-4285-9e74-9d27cb838594)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         51c6c112-bcfb-4fba-a5bc-818ab3397e57)(content(Whitespace\" \
          \"))))(Tile((id \
          62478bf8-5963-4710-90f4-92a9a3a39176)(label(hair_color))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8be79da9-698c-4182-a18b-c8778739f0ba)(content(Whitespace\" \
+         69811a5b-75de-4920-a514-2a10b03e894d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5c3d890f-4a9d-4474-acc3-3596f7664551)(content(Whitespace\" \
+         7e8baf66-8d9c-4f5f-8660-7583d8d07d34)(content(Whitespace\" \
          \"))))(Tile((id 26825d21-bdce-4f28-b367-b58b3aa7c4e3)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -735,7 +636,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          76a2a461-7cca-4df6-a3f7-793b2b4bdbd2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f8fc3fbe-1e19-4c1f-b682-1be29cfbe284)(content(Whitespace\" \
+         633a8dff-aa82-49ea-a9d6-948f23c87275)(content(Whitespace\" \
          \"))))(Tile((id \
          da5a6a40-0106-4423-984c-b88bd3b8ed21)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -743,111 +644,99 @@ let out : string * Haz3lcore.PersistentSegment.t =
          22fdeb4f-7fe5-4072-a9f7-c82dcae656d5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         382db1c6-1fe0-4ce1-822b-cb392e742733)(content(Whitespace\" \
+         4ad4a0d0-cc5e-46f2-85f8-b4831fdfe43c)(content(Whitespace\" \
          \"))))(Tile((id \
          040577fb-c441-4f25-978a-cbf01124634b)(label(\"\\\"blonde\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9f09c6f3-e077-4cf5-a5fd-b87bbdb6f69b)(content(Whitespace\" \
+         7b9705b1-1ed5-4762-8e92-91f38243c8ed)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4c5fb8a4-25b5-48f6-b72c-63832a1b59ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         079dca9a-8b16-4197-a893-c10ee0e4ce5d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b0a34325-cd5e-4cec-b826-21eaf2496c5f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8dc41e2-da4a-4bf7-9120-89fd35cca654)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d4aff962-ec5f-4953-a42e-444b86c89606)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82064116-61b5-4f6d-9174-6fddb3ab3ffb)(content(Whitespace\" \
-         \"))))(Tile((id \
+         bfa987a0-6f87-49b8-998c-8fe9d5a1e10e)(content(Whitespace\"\\n\"))))(Tile((id \
          73244dd9-4cda-49a1-9f35-fec5eec1dc0f)(label(add_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         8bc9db06-b9e4-4625-930b-69fbe84e46de)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5f0213c7-59e0-4b43-b30f-502606f3f00e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b26c1bda-6879-4903-b1bf-0bbb5a79f691)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61cb8d3d-7809-4839-9546-0cd0d68869de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eaa48b35-0927-46d9-a75b-ee4192c05073)(content(Whitespace\" \
-         \"))))(Tile((id 9ad0e234-93b2-4270-b841-21fa5c138c47)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9ad0e234-93b2-4270-b841-21fa5c138c47)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          11346f8c-650f-4f73-9a94-dec0f4a52610)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         05a7b6f3-34db-4b6c-b442-efe773832e12)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1053f207-cf71-45e3-a9da-aff094837302)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         904354d3-9e9a-4755-a3e4-c1777d433690)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea455579-5857-4267-ab7b-b6d85bd3f8cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e7324537-29ad-42cb-8565-b3c49d786943)(content(Whitespace\" \
-         \"))))(Tile((id 76d02cd4-3ba2-4fe3-865a-4cb69048b7a5)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         76d02cd4-3ba2-4fe3-865a-4cb69048b7a5)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          ef6f2b98-c626-46d6-973b-1d7ef8ea754f)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8b56972a-8fe1-4b80-a5d7-d088047ac8de)(content(Whitespace\"\\n\"))))(Secondary((id \
-         87e1e4ee-70d8-43b9-9eb2-590fec249ed3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2dedafc2-0dd6-412c-83dc-2030d3922dbb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ee2648f1-dbb3-44e6-b43f-742998b14d48)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7b9af5ba-b81d-45e4-9b91-d008eaff1d0e)(content(Whitespace\" \
-         \"))))(Tile((id c751c474-3a20-406a-8923-cb080a43c0c9)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         c751c474-3a20-406a-8923-cb080a43c0c9)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          710b5944-f6ee-4c15-b42b-d74defde2b07)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          19584d36-071c-4677-8270-ef54bd165efd)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1f871d48-fe21-486f-8dff-a64f022678ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          8de124df-e083-4a5f-aa4f-444cc3d7d207)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         99977d0f-bc7f-4d53-833c-4db91979a7da)(content(Whitespace\" \
+         \"))))(Tile((id \
          cea63db5-2db6-4bbf-a4bf-bf4366a84f8c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          33f9d32d-690c-446e-b70b-d3e67830767d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         368cf21e-4c95-4950-ae3e-f86b87ac22fc)(content(Whitespace\" \
+         \"))))(Tile((id \
          ee7baf7a-d04f-480f-9608-e5488228b364)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e7176ef7-5df0-486e-90c5-d05e5fb27099)(content(Whitespace\" \
+         \"))))(Tile((id \
          a2ecf36a-3e2d-4413-8b71-063c78e436fb)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a7dc34a6-ea34-4958-bb85-e5068af0b246)(content(Whitespace\" \
+         \"))))(Tile((id \
          ba6b066b-6596-4de1-a7b5-684e6b67e7d5)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9f44fd11-f4df-4e0a-9682-9722a2ad97b7)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         04d0f3eb-a8a3-4a37-b8b1-520199934720)(content(Whitespace\" \
+         \"))))(Tile((id \
          7d1521e4-9f43-4ddc-b6ed-8a53910962d0)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ace4a543-8a44-4c61-a7e8-d66fcc1b27d5)(content(Whitespace\" \
+         \"))))(Tile((id \
          18079d17-8810-43ba-a556-0fbb687ae54c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         71c2c0de-4b9c-404d-9aa0-74d66d526cd3)(content(Whitespace\" \
+         \"))))(Tile((id \
          037492ad-4247-467b-bfc3-ecba2ddb60e7)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          682d94d9-a69c-44f6-9e5a-886eab20f793)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         68264254-3c45-415e-ac7a-a1367f5b8a82)(content(Whitespace\" \
+         \"))))(Tile((id \
          c8322e6b-be93-48b5-9e27-70cf8f805f5d)(label(`hair-color`))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a69c2814-55fc-4b3d-ba24-6afda65a4a23)(content(Whitespace\" \
+         \"))))(Tile((id \
          aee7c9ad-fecf-4357-9a6f-be16eaad0b8e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0aba372c-d8c4-475a-ba77-621bd36d42b1)(content(Whitespace\" \
+         \"))))(Tile((id \
          ddde7d54-b60c-477a-b1b2-623884b1f4e5)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
@@ -860,12 +749,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          21c19453-37ba-46e0-86d2-efd020bb8c63)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a5f55041-8dd0-4907-88e3-eedd4b51dd8d)(content(Whitespace\" \
+         0cc9cca5-a035-46f5-8e61-3cee2f04bdfc)(content(Whitespace\" \
          \"))))(Tile((id 48122eab-3f4b-4b19-ac3b-c60a646001d8)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         1afe1420-ee9a-4083-8f6b-66290dd45b1a)(content(Whitespace\" \
+         1a43096b-1c13-4685-94e6-1cd3880759c1)(content(Whitespace\" \
          \"))))(Tile((id \
          9eea7322-a29d-4d0a-bc5a-4aadbda96c69)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -876,85 +765,62 @@ let out : string * Haz3lcore.PersistentSegment.t =
          30a28cc0-97f0-40d6-b708-5c2a2337ef13)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         224e223c-c137-4641-9396-ca32db45cf21)(content(Whitespace\" \
+         103c1f1a-5239-4e63-859c-3ccbe42ab4d6)(content(Whitespace\" \
          \"))))(Tile((id \
          29531518-69ad-4eb6-a680-f2c5dce494c6)(label(v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         3539e039-1480-4a20-a281-37a6e7ea2536)(content(Whitespace\" \
+         df77759b-b52d-4347-893e-ae23af4bbaf6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d6c9b63e-b35f-42f8-b034-9337116b738c)(content(Whitespace\" \
+         ee5b0629-56b5-4343-b1fb-5c527fdb457c)(content(Whitespace\" \
          \"))))(Tile((id \
          0d2d93de-4804-4bdf-8760-ea4ac679ff23)(label(s))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         07c82482-5f12-4824-9570-a3faaa60305e)(content(Whitespace\" \
+         ae9564fd-81e9-484f-a432-f2fc8ff4a341)(content(Whitespace\" \
          \"))))(Tile((id \
          aa1ebd32-15aa-499e-a82a-34621f984d2e)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1d00ae6c-d88e-4cad-99d1-6c7e5d152831)(content(Whitespace\" \
+         daaf489c-0dd8-458a-97f5-8c50f315e2ce)(content(Whitespace\" \
          \"))))(Tile((id \
          870ef53b-8fde-4050-92fc-963cdf77d3bf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          4685e1d0-f2c7-4301-938c-05d6a98bcb73)(label(`hair-color`))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         750a475b-712a-4133-9c95-bcb369e6e016)(content(Whitespace\" \
+         \"))))(Tile((id \
          053cf735-2bd8-4f23-9424-c711449b762b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a98e2512-cbb6-4ce7-9982-c56fd7961f05)(content(Whitespace\" \
+         \"))))(Tile((id \
          964452ec-9c43-4f8a-a9a4-997cff48d0c3)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          bd6bfc83-1579-4a09-930f-84d31f1aa313)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         890a9e50-b178-4d0b-ac07-ff4f46d2c726)(content(Whitespace\" \
+         610edde6-80c3-430a-9e2c-5e1036604b5e)(content(Whitespace\" \
          \"))))(Tile((id \
          9845aa65-81f7-47d1-859b-77af83b3b79e)(label(hair_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3cc6ad98-77ea-4e25-8707-1ff0c26c2e11)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b18276e0-d955-4859-af12-783591ddfd01)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9de799a7-2305-4e20-9cea-ab4a671c4e6a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf97e128-0b1c-4d78-94e8-d8bc4f63efd8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61f1e576-fa78-45e1-bedc-0d39a3b6df19)(content(Whitespace\" \
-         \"))))(Tile((id \
+         fe827d87-3b62-470c-bd80-157cb2bbd616)(content(Whitespace\"\\n\"))))(Tile((id \
          73c4c523-000a-43ef-a5e8-f5d68e70bef5)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3f179983-7048-493a-b178-a919f606365e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ed3165db-47a3-4e79-8b59-15536d69aacc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8557d371-af6a-4a01-8151-5de6485951d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f66f189b-7254-4273-9d8a-8276a3a1c767)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8be4a2a-5943-4d47-b536-314dbe2b1479)(content(Whitespace\" \
+         a5f48346-8ee0-49ad-b17a-c5c7ded353e7)(content(Whitespace\" \
          \"))))(Tile((id \
          4e0e339f-5782-4d86-a780-4ce4a18308f3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         80d67d78-cdaf-448d-a540-d2ed03336fa7)(content(Whitespace\"\\n\"))))(Tile((id \
          97af944e-a8cf-4acf-afff-00c8b9e1f6f9)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         667906d7-63b1-410d-abbc-3c31dd6eba67)(content(Whitespace\"\\n\"))))(Secondary((id \
-         64ad21a7-2f68-4533-a229-89618d134b9c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         421d7885-73e2-40ed-9a00-ee2a5745ca82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         89de012d-9e23-4235-90bc-d8642336cc9b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c19f0708-3b8d-4137-94c8-4cb9506f7330)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fa61df00-867a-41f7-97dc-e570de6597d9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         624aa296-e8f4-4590-b169-9484d39bb23a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          3703e4e6-7844-469d-882d-6600236fabab)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -988,18 +854,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          421e82cc-dbf0-4b63-9746-19506cbc6505)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5b93e002-0dc8-49f3-9e92-87245ecfefc3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f122f279-2fa9-4918-bd44-3826b3877177)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1f9b50e0-f466-423d-8e99-d57e8db171b7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b360826a-9944-4fff-b8bc-00c7958023f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e77eca60-ec23-494d-a397-4737a9fd4950)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7091db0d-5f54-4c51-9c8b-dd638cecbe7b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4c25c160-5627-4cd9-b195-15f64b9697e8)(content(Whitespace\" \
+         35051a6c-290c-40ec-b1e8-e3d62b358b41)(content(Whitespace\" \
          \"))))(Tile((id \
          390ab02f-d0c1-48f6-b8bf-65dd2700446c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1034,18 +889,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3caf449a-9f2e-4b80-9484-c2d4e3e5f53a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5a53ccb6-c385-4cc7-a790-6c6493d868e2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         02a4d70d-885a-462d-85ac-bcda8f1e9546)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46d3da18-2125-45db-ad5f-c926c20e43ae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c52dc776-0d05-4e36-9c34-62e4b570db9c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         833a101d-cbbd-4973-9a37-df2d104f8fac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a5c14172-f66e-419e-b6d8-52872a7a38dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fda25127-f17b-44cc-b0a2-71dd35f10166)(content(Whitespace\" \
+         f01bf068-c25d-4bc0-b203-c899ff8b6f7a)(content(Whitespace\" \
          \"))))(Tile((id \
          e186f069-1325-409c-9e05-11ad7e30bf85)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1056,7 +900,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          54298ec4-05ac-4bcc-8da3-c058bfd3cd3d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c66c874b-f76a-47f7-81bc-fdc238044ad1)(content(Whitespace\" \
+         8b110b69-03eb-4bec-9fea-65cd29bbb36e)(content(Whitespace\" \
          \"))))(Tile((id \
          2055f0c4-04fd-4f8d-9ddf-535735b6cf1a)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1064,7 +908,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aa4397bc-0044-45d9-a8f9-7fb86c5b7bf8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4689fa40-3e81-4106-b89c-7fa81d78a40d)(content(Whitespace\" \
+         4764e928-9d2f-41c2-8169-cbe5ccb44796)(content(Whitespace\" \
          \"))))(Tile((id \
          f9d43774-d254-41af-85d2-2273136b5861)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1072,26 +916,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a0693f22-7052-464e-8840-7ee8be3f4713)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8a23b65a-27b5-443f-912d-2be1cf254f13)(content(Whitespace\" \
+         c9f69ac5-b8ac-4b39-b13d-03c0c3fceb35)(content(Whitespace\" \
          \"))))(Tile((id \
          a05cd7c5-b8a7-401d-99fe-0a3584b82701)(label(\"\\\"blonde\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d8756db2-a024-4a62-bf5f-98565be9492f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1c9d80d5-ddb3-466d-b606-2873bc187166)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         163cff0a-483c-4865-becd-89b2a5a63edc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e01c75b9-20bd-41b4-ba57-d127f23c3ef1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b6ae850e-7e57-42c1-a7cf-19d95e15079a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         387e0fb7-061b-4d8b-8626-52f5afb9b0a5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         7fb9098b-242a-4d93-b9d5-45a7650d9a51)(content(Whitespace\"\\n\"))))(Tile((id \
          296597ef-c490-4e39-9545-139728036785)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ade6be82-d2cf-41cf-8056-3c2731eef2fa)(content(Whitespace\" \
+         fc95efaa-4968-4f31-8b04-960bb8af1551)(content(Whitespace\" \
          \"))))(Tile((id e2500bbb-0d6a-4fde-991b-d352b57cd238)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1100,104 +934,107 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          ae1429e8-5600-492a-bd5c-42f902b6706a)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c43c0591-af35-499b-b50a-7ab7485882cf)(content(Whitespace\" \
+         \"))))(Tile((id \
          98af917e-c1a4-45bf-900f-4f43babae5b5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         aaeea7fc-0bbe-406e-8ec3-aae4a6094975)(content(Whitespace\" \
+         \"))))(Tile((id \
          34c0e650-7ce5-45b8-96e9-a23d193d3441)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          68857f59-7cae-4704-9e2b-490030bbf33c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9454cf03-9d74-41eb-8f2a-c3a25e408eec)(content(Whitespace\" \
+         212dd740-64c1-473b-83b9-995d7abac154)(content(Whitespace\" \
          \"))))(Tile((id \
          a74c6bb1-d98c-4193-87ec-69edf58457c5)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c7775145-5aea-4074-bdb2-70d5177a81e3)(content(Whitespace\" \
+         \"))))(Tile((id \
          006c6fde-27f7-44fd-acba-d6e6bb6ff754)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c5f05a39-0898-4778-a522-60f2f39f5985)(content(Whitespace\" \
+         \"))))(Tile((id \
          dced006e-a159-4095-8d2a-db7e1b47e2dc)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          dd806adc-aa82-4bdf-a3b1-9d2e7f43e0d0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c62e9f27-92ff-44da-8e2c-03905d93b95a)(content(Whitespace\" \
+         b488c70f-81de-4827-b5db-117aef063249)(content(Whitespace\" \
          \"))))(Tile((id \
          4e29cf1e-3d53-4b90-a3a0-edec99d4733c)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7478fff5-c3c1-4947-be9c-ffc79d88004a)(content(Whitespace\" \
+         \"))))(Tile((id \
          db28baab-3609-4e5c-bdae-8c80a1e88b2e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4ed01277-8af5-4915-97fc-d5cb219c1e11)(content(Whitespace\" \
+         \"))))(Tile((id \
          b9fd1bda-a264-497b-9b1a-96432bc76fdf)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e7da82b9-52e0-442e-8883-f5a12df56b97)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9def3c08-a50a-4e0b-8e44-e604dbbc827d)(content(Whitespace\" \
+         e83cb09e-aebf-4b2d-9b8c-c9c8fc49fda9)(content(Whitespace\" \
          \"))))(Tile((id \
          268190b8-00ba-467e-acdc-a40cf59619c5)(label(`hair-color`))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         23f9b112-3ef0-43bc-b8dc-76dfc78b27ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          2415203b-09ff-4aa0-aa37-19b76a39e960)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5fc7f322-a1c9-4650-b9c8-e5fe5929792d)(content(Whitespace\" \
+         \"))))(Tile((id \
          6833ddfd-61d3-47a5-86e9-b72a9bfb56d2)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         51983d99-4885-4028-a3f1-c296b70d4ff0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         48fdf825-c853-4622-bdbb-d059b754c39b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3adb2eef-2a7b-43be-badc-ca795b6dfca3)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         17bc9fd1-62ed-464f-81ad-2c1af7991e06)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         8debae22-750e-4471-9c90-c1d4423604eb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         80964157-502f-49fa-9c74-30120eac6a0b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         c96d237f-9a54-4810-9f5d-29f166446c39)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d33a73e5-3012-413f-bf82-8cad4a31a4e8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         b9d3383c-9243-4628-877e-461493ad0d6d)(content(Whitespace\"\\n\"))))(Secondary((id \
          b4722d09-6217-413e-a808-d8d236f9e2b9)(content(Comment\"# V2: This \
          version more closely matches the TableAPI and takes a string column. \
          Given the lack of row polymorphism no constraints are ensured \
          #\"))))(Secondary((id \
-         1ee23ddd-fa44-4f0e-9ef6-c7be1df1c6a5)(content(Whitespace\"\\n\"))))(Tile((id \
+         f0d458ea-a07e-4145-97f4-5fb59a310e1f)(content(Whitespace\"\\n\"))))(Tile((id \
          0bca4f4c-f1af-486d-86a0-16a5e9cfeaa4)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         0584da58-4f9a-424b-8648-9b4d64e14890)(content(Whitespace\" \
+         49843cff-cf90-4792-a01f-082aed5872c0)(content(Whitespace\" \
          \"))))(Tile((id \
          030f1a9a-2083-4db6-946b-3a18a5e63c54)(label(v2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8ac36690-f532-4c47-ae07-0d061b22f2b6)(content(Whitespace\" \
+         bc47e206-f1a1-4f33-9311-241ec024e1b4)(content(Whitespace\" \
          \")))))((Secondary((id \
-         95b381b3-798b-4377-9f2a-7a5632481f80)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ba91449-ccb3-4b79-b004-824b9262bdff)(content(Whitespace\"\\n\"))))(Secondary((id \
-         da6dee3b-fdd1-4323-914f-8456b88dee08)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ff83225e-bce0-4b81-bec0-ff1fb5b83c25)(content(Whitespace\" \
-         \"))))(Tile((id cd3ed81d-dd8a-4660-935b-91ec2dc6b846)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         8cd30564-0777-436e-85e1-0d937517e9d2)(content(Whitespace\" \
+         7ead55c1-4734-4e41-a120-4ac890df6385)(content(Whitespace\"\\n\"))))(Tile((id \
+         cd3ed81d-dd8a-4660-935b-91ec2dc6b846)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         93874829-2232-4b03-9589-183ca097a1ae)(content(Whitespace\" \
          \"))))(Tile((id \
          14d67bf4-192a-42a2-8d22-02148e54527b)(label(requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         3190d1c5-6090-444f-9dd6-ec6649c0128f)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         0e3f9ebd-f624-40c1-8090-b8c1cf257bb8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5edeef69-3d6f-4575-9752-32cf81a5b646)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         90cc2331-bb97-45f4-ac01-936210fb5115)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fc4e2058-7733-4a3f-a97f-df3d8f5cf443)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         745d74da-f88d-4a13-9b3d-df9da9d8d68a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         969e73c4-e86b-4d22-aa59-50f7a378dfa4)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         51213930-e909-4642-a884-7e8d86c396fb)(content(Whitespace\" \
+         \"))))(Tile((id 3190d1c5-6090-444f-9dd6-ec6649c0128f)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          25d4941f-23e6-4135-aa3d-868697f75d9f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1225,25 +1062,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1fd91bf3-24fb-4e19-a217-70f8a71ca20a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e45b4b13-328a-4515-a81f-2c6db2a8478c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d14aaa4a-221a-4c2e-ad80-c4d2d5c91f83)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         602755ec-54fb-49da-9eeb-ff4b9b719cb7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e47bc18-f0b2-4e6e-8bad-e721046032d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a56d3caf-4cbe-4b5f-8ac2-f221523b49dc)(content(Whitespace\" \
+         70f9065e-2bcc-479e-ace8-4d938ca7ce00)(content(Whitespace\" \
          \"))))(Tile((id \
          029ef5e5-f1ac-48ba-81dc-e234a090ba70)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          3b3d5293-c86d-4325-8935-0d4558de2b66)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         bf26558d-fa94-480b-a80f-aae0a684f668)(content(Whitespace\" \
+         \"))))(Tile((id \
          c5b649d6-4e02-414d-81ae-15cfa62f459c)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         f1cb81dc-6d37-43bd-80ab-32c87b9869b6)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cc7d53d0-36b5-4f0e-824c-d0e13c35b66d)(content(Whitespace\" \
+         \"))))(Projector((id f1cb81dc-6d37-43bd-80ab-32c87b9869b6)(kind \
+         Checkbox)(syntax(Tile((id \
          6c85b1f0-eef9-4cd0-b7b8-345a112ca035)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1253,44 +1087,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5bfd07b8-a7aa-4f5a-a0a8-e766c8ba2753)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         19a7da57-04bf-405b-a751-8f3bbe7cfc65)(content(Whitespace\" \
+         a14cc46e-636d-4706-83d3-ab32d8e38b1b)(content(Whitespace\" \
          \"))))(Tile((id \
          ae6fcc13-6b27-40d6-b3f8-7e5c6b58494d)(label(\"\\\"length(vs) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9b31cd82-d805-459e-9247-bbddba57045d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         dbac8fb5-0bcd-443c-9380-ff3ffd2085d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a7ac35f4-2ffd-4733-abff-4c883da145d9)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         fa9b5685-f63a-40c8-88a4-1182f8663ae1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         bfaeac3a-8a94-427e-a7c3-3aa621355d23)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8b8184ab-ca79-4253-b044-eb4d9885e887)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b6c890b9-0801-4092-b888-3b37303b6b32)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e0f073b6-0ac0-4dd7-a8fc-27611d7556a1)(content(Whitespace\" \
-         \"))))(Tile((id f3fbdb44-4b37-4904-8746-b122e3ac2741)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         56a782a5-9e11-4947-ba1f-28b4d1493532)(content(Whitespace\" \
+         4fc513e2-8b0a-4f3d-b664-7cbf4ebf8d24)(content(Whitespace\"\\n\"))))(Tile((id \
+         f3fbdb44-4b37-4904-8746-b122e3ac2741)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0191062d-abc6-4c9d-9624-77e1e3aa775b)(content(Whitespace\" \
          \"))))(Tile((id \
          14e9db7a-8117-4ecd-b4db-4027d5510816)(label(ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         8ee3c438-a9e8-4a46-8a06-3dc6570acb1a)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         09882ddd-4b4b-4199-b5e3-0c40f01d3b9d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7d9c7228-0014-4ace-935f-188a1ca18b62)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2d1e827a-ead7-497f-9de2-c1847728cd7d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b1a06bc5-e744-4488-8a28-4cab0c41bc91)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba8a9f15-c355-43bb-8448-b2d1d8843f69)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         9892e0ac-ba5d-442a-8b56-1be988991618)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         1c248fad-f48e-4c03-b50e-275f54f5b3da)(content(Whitespace\" \
+         \"))))(Tile((id 8ee3c438-a9e8-4a46-8a06-3dc6570acb1a)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         301d70bf-32ec-478b-bf6f-71a96edea626)(content(Whitespace\"\\n\"))))(Tile((id \
          67ac7009-1eb4-4e22-930e-1ea6caf5b884)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1319,17 +1139,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7e9c23c2-8361-4deb-a499-aa0d183d5f90)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6ddc4948-2a23-42a7-ae45-4a7c04b59b59)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c5a77a2c-c736-4ce1-93fb-c8a604daa779)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ed533b3a-ac35-49c1-a759-5ae846b2b6cc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c3378483-8dc4-4380-b5d0-5b38dc36563b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d5ccb0f-2f97-4624-a94e-27455985fdcf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd13b4ee-a241-47d8-b766-34628508e08e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c92e8173-ebbf-4594-852a-4028442e147e)(content(Whitespace\"\\n\"))))(Tile((id \
          ad4b33ae-1272-4478-ab2b-66d1bf1afb06)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1358,17 +1168,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b404ace1-fb3c-42d2-aad6-e907dfbb0ab7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         26dd5e55-b1db-4a6f-bae2-9c6c7cf9e141)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82cfb4e6-84bd-418e-8fa2-fa341c951d6e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         18991c84-422d-4898-9a8c-2f4e37807887)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eeebabaf-8d82-4cd5-beed-dd7b285d5b39)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f89ab390-26bd-4f0b-b6d5-a77071762b6f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5f8761bd-a1f4-4de7-86d2-f947567d9605)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0e71dc30-097e-4c7c-b6a2-5eb69dca826e)(content(Whitespace\"\\n\"))))(Tile((id \
          c91ca4e9-0f33-42d2-82e5-d3590d005951)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1397,27 +1197,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0d554c4f-2f7f-4900-ba11-d638a1dbc9b2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b3d52670-4aee-4cb9-bc3f-42094bac87b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a80ae4fa-3f0d-422d-a7a1-4af358dc827c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c3ec9194-3780-4b74-a62c-ca60ffa04fdf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         92cc8253-4241-4508-a936-6e5a9ce17118)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a158702a-8083-4ef7-9b7a-57431439cedb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1f7e1c70-20cd-4655-b437-c492c729dc44)(content(Whitespace\" \
-         \"))))(Tile((id \
+         33437644-ae3e-46c4-aa6b-db51b9f551e7)(content(Whitespace\"\\n\"))))(Tile((id \
          16898fc6-055d-4fb7-937c-e590b2a40ea7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          75facde2-8d08-4b7b-b87e-add402e32f44)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         15030dae-3129-4c64-8493-70c9c7e9689a)(content(Whitespace\" \
+         \"))))(Tile((id \
          14ece1b8-6471-4fbd-b7d9-7d6efd92d7f6)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         82477415-28a7-492e-91f3-a8a5e0f799e5)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         16d06085-b7fa-41a1-abde-ffd059bac59a)(content(Whitespace\" \
+         \"))))(Projector((id 82477415-28a7-492e-91f3-a8a5e0f799e5)(kind \
+         Checkbox)(syntax(Tile((id \
          2213815f-bd43-41ec-9cc0-b163f99a8a05)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1427,40 +1221,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2963de29-ac83-4f2b-b5d6-59d40f9f4290)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b8568975-35d1-4627-8ad3-2657e5590cfa)(content(Whitespace\" \
+         1de9b159-8796-42e8-bc85-3d50af5fddf1)(content(Whitespace\" \
          \"))))(Tile((id \
          89eeaf53-6659-47ee-8f53-08a870ac807d)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         2cc46f72-fb8b-4352-b5d0-5617f7fb7aac)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d23cebf6-e855-4700-92b1-3282a5e0b23e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         12c51cbf-f71a-4102-8d4a-f88d60661719)(content(Whitespace\" \
+         461ec299-efae-42ca-a375-a8330d8313a0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         e36ea49c-e880-4604-aa35-0dbdb1e18daa)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3ae7c88e-4906-412e-9cbb-7385dcf51b6c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         157faf56-1c47-466c-88e1-9223c7c45805)(content(Whitespace\"\\n\"))))(Secondary((id \
-         757abe00-7f73-41e5-be76-b70b9e4493e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2d27b60-9db7-4654-afe0-ee85cf51133b)(content(Whitespace\" \
-         \"))))(Tile((id 89c9f625-76d2-4b8f-9b03-d738d4895814)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b6244149-dfe1-44e0-a739-78486473d73f)(content(Whitespace\" \
+         c690255d-1a6e-49eb-a8e1-d1c5d427bb81)(content(Whitespace\"\\n\"))))(Tile((id \
+         89c9f625-76d2-4b8f-9b03-d738d4895814)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         6f1a759a-d994-4fe6-a364-bae765b32d22)(content(Whitespace\" \
          \"))))(Tile((id \
          fe2eded8-dd93-47b8-9e66-75b8854ed7a3)(label(add_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         199d8ef8-f05b-41c4-b1cd-2843f8d4b08e)(content(Whitespace\" \
+         d5a0ab64-d268-43ab-ad25-9df2f67a4b81)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7a76daf8-89df-419d-9d3b-ea835935fcae)(content(Whitespace\" \
+         95c742b5-6465-4f89-8f58-cf1623a8b0b0)(content(Whitespace\" \
          \"))))(Tile((id 59d06fce-294c-40fc-a9a1-c26b09c2085d)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         37c6c0a5-17bb-4d8c-93d6-3410d1cd42c8)(content(Whitespace\" \
+         9f9232f0-2db0-407e-b42b-9a951b84d132)(content(Whitespace\" \
          \"))))(Tile((id \
          d2b425d2-e85f-4869-8fce-791db2f5f796)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1468,12 +1254,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          58367221-2978-4d13-9caf-d3c7586ae31c)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         84a81f22-dd89-43d5-a6a9-cd5b5d79638e)(content(Whitespace\" \
+         e9fb543b-de30-4b87-a23e-ca74753d0b46)(content(Whitespace\" \
          \"))))(Tile((id \
          fffc853d-fb8e-416d-8058-68027474b3e1)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9086c5dd-5015-47fe-9422-b151593dc097)(content(Whitespace\" \
+         f52dbd26-f51d-4b68-9a4d-2b990b549178)(content(Whitespace\" \
          \"))))(Tile((id 9ac796c4-2f9c-4949-bf49-4ff0a6d921fd)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1483,17 +1269,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1c5bc1f7-802a-4ba6-ad7c-6c1c3a794d53)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f0616300-8a72-4e4e-b04c-f3aec8e143a2)(content(Whitespace\" \
+         964b109e-73ea-4754-8732-e111fa58baf5)(content(Whitespace\" \
          \"))))(Tile((id \
          ba1c776c-5aee-41d4-b292-c0709ad66d39)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         dd6d4ca4-93f4-4e95-99fa-f12995f45b0f)(content(Whitespace\" \
+         09cb3d68-10da-4852-8ec3-e5557c70334e)(content(Whitespace\" \
          \"))))(Tile((id \
          5c0daf48-cdac-469a-98fd-54df480ae127)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         435292d3-006a-4c17-9594-0784727796bf)(content(Whitespace\" \
+         9da255c7-d5f8-4172-922a-d589777bbcdc)(content(Whitespace\" \
          \"))))(Tile((id \
          730c3d92-0da0-4308-af7d-57d48b568387)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -1501,31 +1287,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          41cfa25d-4d2e-453c-9c1b-6af6c4629e0c)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         a6212fd7-53bc-4664-90d3-9260f032c7d5)(content(Whitespace\" \
+         07d1f4a2-4a51-4583-87a0-cfb3c8d17660)(content(Whitespace\" \
          \"))))(Tile((id \
          0ca2cc8a-1e84-4bc9-82fd-8c3aa5cc4778)(label(vs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         31dacd82-ef22-48c8-b7fe-581142d81c29)(content(Whitespace\" \
+         \"))))(Tile((id \
          873d1556-fb47-4528-9d08-2f572fddbb55)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dc668e8c-a41a-4164-9f38-69abbe76fb1d)(content(Whitespace\" \
+         e71d28b3-6bad-4dac-bb27-5fa91fa6ac3f)(content(Whitespace\" \
          \"))))(Tile((id 11af88fd-0cf4-49b9-a0eb-58e54e03606e)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          ceb0cfc1-c5b0-4f40-90c4-05dd67882e05)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         6b857d47-50d6-43da-9f5a-54ec7e02cb9f)(content(Whitespace\" \
+         0d7c39f5-7d3d-41d4-8df1-9270f9d45360)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c81e0724-6582-450b-ac3b-0b2ecbbaea2b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         81aa539d-1a88-44d7-aed2-e4b8fd816a6e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         99d5d14d-a654-446d-995b-588faf7be588)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ed62afa-7eb1-4e54-a09b-d13b47da40e1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         09844a50-dcff-45de-8ca7-2a8382a1c9cf)(content(Whitespace\" \
+         0ed4d462-a8e3-49e4-bd27-a0612f1fa2d3)(content(Whitespace\" \
          \"))))(Tile((id \
          b822721c-abf8-4692-a9af-28c3713a121e)(label(zip))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1539,24 +1320,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          18d13896-018d-4c68-be87-68cdbae6d308)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3e7e72cb-2c33-42c4-aab1-ce79d67cd27f)(content(Whitespace\" \
+         55abb52c-8589-410f-891f-38814fb5aff0)(content(Whitespace\" \
          \"))))(Tile((id \
          a7904b41-4626-4012-8844-7e21a2d6c368)(label(vs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d52ac402-81ce-4ebc-ab00-debbb0fe25b2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0c8ef7b4-4013-46bc-83be-f826485c0ac2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         411ada19-5662-4f1a-aaa4-1a76f510d9de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8fc3dc09-bc32-4cc2-8f96-4a89fe0e958c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3852b255-c4c6-4504-9d5c-b97ee1dcab86)(content(Whitespace\" \
+         28fb93ed-6454-48d0-9485-b2c20464a9e9)(content(Whitespace\" \
          \"))))(Tile((id \
          be247204-8505-4c42-b661-bbd2dca2eeea)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         14243767-0c0a-4b30-a5c7-8379955f668f)(content(Whitespace\" \
+         a2c46aa7-536c-428a-a260-fd3f711a5b3e)(content(Whitespace\" \
          \"))))(Tile((id \
          c19d69cd-061f-43ef-9c69-6887de57ce0b)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1570,12 +1344,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bd42bbf9-332e-4bd6-902b-9f77e49be330)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3dde5e8c-7864-42ac-8db0-c4280c8ec555)(content(Whitespace\" \
+         6d5e38de-9010-4efd-94a8-8611342e4c88)(content(Whitespace\" \
          \"))))(Tile((id d0652f4f-c877-4490-ac27-0dd90549bdd7)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         bf221dcb-b523-4b5d-ae37-ac70750c4000)(content(Whitespace\" \
+         34e797df-82e7-4908-93e4-3553976de811)(content(Whitespace\" \
          \"))))(Tile((id \
          d78794c9-2094-4723-8c53-5950535b4252)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1586,14 +1360,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          75dc67c9-7ac8-43e9-84c3-e1a47e777eab)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         0ae89042-dabe-4ddd-ba56-ec3fc37e96ea)(content(Whitespace\" \
+         d229afaa-93e4-42bb-9fdf-69f56a6ea670)(content(Whitespace\" \
          \"))))(Tile((id \
          c4a786a1-44a5-4988-8090-cf57a23e3501)(label(v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         1021469d-4c02-4e08-9e49-e37d98257628)(content(Whitespace\" \
+         217bb717-371f-4fd8-9f85-e8db19c8766d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         50362e38-dd86-4b41-980e-6b2e612ee01e)(content(Whitespace\" \
+         93c0425f-f166-4e8c-a5a4-2a8e72eba682)(content(Whitespace\" \
          \"))))(Tile((id \
          9990afff-a7e4-4c02-bfeb-5f93c70fcc99)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1610,12 +1384,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e6d74fe1-3c95-45ae-80aa-d8c5ff47ab42)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         35e6bf2d-f3ae-4eb4-8d89-acf36dc2f956)(content(Whitespace\" \
+         11224979-0288-4d7b-b8ad-08beb8b45e16)(content(Whitespace\" \
          \"))))(Tile((id \
          952eb132-074d-4ad6-a479-5337cc931e57)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e06b5005-ae3c-4f93-aaef-b5718710f235)(content(Whitespace\" \
+         c881ae15-312f-4dd1-850a-69fc352d01c0)(content(Whitespace\" \
          \"))))(Tile((id 33232ac9-8f33-4924-b5b6-37ce2b0dced6)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1628,42 +1402,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          11b55948-444c-4895-85b0-5a4996abcc34)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         62ff16d1-9842-47db-a042-a19524ebb41a)(content(Whitespace\" \
+         89e1b83e-89fb-48f1-8476-f60b5392736f)(content(Whitespace\" \
          \"))))(Tile((id \
          6d1e9687-f383-42bb-9998-890779c6f04d)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         ac7717b2-8501-4af0-afde-95807e44733d)(content(Whitespace\" \
+         861e4791-af06-49a1-ba4b-ab41147751e2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9d598026-8a9e-454e-a63f-896a670d9261)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6370fef3-6420-4a76-b5a7-daf4b56c9051)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ff2ff9c-60eb-4e4f-bcda-25aff9cd8985)(content(Whitespace\" \
-         \"))))(Tile((id 61728508-cb96-4fc2-b0e6-85f0277864c9)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         cfd262bc-60a3-4589-80f1-077d15e44b89)(content(Whitespace\" \
+         958af9ba-5fbf-469b-b50a-adf3fd43f102)(content(Whitespace\"\\n\"))))(Tile((id \
+         61728508-cb96-4fc2-b0e6-85f0277864c9)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         3b0fe950-c17f-481f-b894-5c0aa9f6cd70)(content(Whitespace\" \
          \"))))(Tile((id \
-         0263d349-c176-486c-9120-bc314c0c21a9)(label(notes))(mold((out \
+         0263d349-c176-486c-9120-bc314c0c21a9)(label(_notes))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         38a08f92-781e-485b-9c36-de1538e93fc9)(content(Whitespace\" \
+         357324d3-b6c0-42b9-93c6-e7631a64b9c4)(content(Whitespace\" \
          \")))))((Secondary((id \
-         72894705-2d6c-486d-8c4a-d1b5a663babc)(content(Whitespace\" \
+         88649b09-b20c-421d-914b-df2720f5f8ca)(content(Whitespace\" \
          \"))))(Tile((id 1dca1acb-70db-4711-a715-7f4d0a71aefb)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         135746a4-f755-420d-b425-19e92d23b170)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1fe09d6b-01f2-480a-b32c-b844d1e9cc0e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aa0baa81-a7bb-4144-85e4-1d6f59e474a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7a0ad16a-3911-4246-a71b-e93952135f95)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eae54cab-ca4d-418f-b55d-2651b2b7b4d1)(content(Whitespace\" \
-         \"))))(Projector((id a16eb9c2-5628-4a69-8360-e3484aef5e47)(kind \
-         TextArea)(syntax(Tile((id \
+         dde2334c-22d9-4b42-b3a2-6d051c3f5296)(content(Whitespace\"\\n\"))))(Projector((id \
+         a16eb9c2-5628-4a69-8360-e3484aef5e47)(kind TextArea)(syntax(Tile((id \
          ffe1cb60-bac3-484c-a4ac-8b400bb393f5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1674,16 +1436,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          520f5f34-1d25-4e6d-963b-ba4ae3505b0a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         74441516-c809-4090-8c3d-48a0b16eded8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d9c8b90c-37ba-4b60-be0d-c68ddeb05f5b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c3acfa22-505d-47d8-a9a8-1673bdf8c99c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6506f99e-7c14-43cd-adf1-41e14fa0f4b9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6100dedd-6dbd-4433-ab06-10fcb526b0a6)(content(Whitespace\" \
-         \"))))(Projector((id 709ea06c-bd3c-47ad-b216-e7439e9b7eef)(kind \
-         TextArea)(syntax(Tile((id \
+         fde2b1da-8bbf-4039-b0a4-2d7e941ccd11)(content(Whitespace\"\\n\"))))(Projector((id \
+         709ea06c-bd3c-47ad-b216-e7439e9b7eef)(kind TextArea)(syntax(Tile((id \
          8c2f69a5-bd42-449c-be6f-cbdee317518f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1694,51 +1448,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
          8a9ab2cc-abd6-4f33-8606-f17da6256f61)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
-         35))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6c9af49f-7a75-465f-a8ec-4bdef0ddec66)(content(Whitespace\"\\n\"))))(Tile((id \
          2b158496-42d6-4262-9024-a57155db1605)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         e6cc119c-06ea-4513-bc93-1153c1c98435)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dd12b302-218e-49e9-a457-a5aaf21659ee)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4b1c6afc-cc8d-4cb6-9017-a1ee53576758)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         18d6ea86-b606-4217-9236-0560ac4de7d5)(content(Whitespace\" \
+         0109ab50-d54d-486a-8c0b-5df37bdc4c5c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         bd561e9b-b4fe-413b-bdf5-8f1667f870da)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         21ee9ab8-e2da-44a7-a002-9cde9d2529fc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b9c4f001-813a-4faa-af14-f57aed7cf97e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         14c09d6e-588d-4148-9555-4ae684809c81)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         05ef69a9-e83c-401e-a27e-4a8b5b5cf01d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eff62b73-6d42-4241-8d70-83e255cd2e92)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e136847-09a5-44e1-93c9-a7d3315de1d5)(content(Whitespace\" \
-         \"))))(Tile((id ca699559-598e-4bc9-b8c5-7ab43fdf0f07)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2e3b3025-fc99-4539-b2c9-83e365daef25)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fc5925dc-67ce-4594-84fe-ea839e19ab9d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3ea5fec5-d485-4bf9-b61e-6093f8f91f90)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6c113569-3b27-46e5-a634-1dbbc9080d37)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2e8559f7-a9e7-4e5a-8935-bd92a9f30c34)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         660ec827-2217-4a18-b01d-86ccd9c8f654)(content(Whitespace\" \
-         \"))))(Tile((id 27775bf0-b137-449a-b1f5-34bc736315d3)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b8e4e2bf-ea8c-47b8-855a-55863077214d)(content(Whitespace\" \
+         5e59856d-b117-4399-a49f-581e6f18eb64)(content(Whitespace\"\\n\"))))(Tile((id \
+         ca699559-598e-4bc9-b8c5-7ab43fdf0f07)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         875aa549-dc03-4ebe-b996-e8bb18a4e12e)(content(Whitespace\"\\n\"))))(Tile((id \
+         27775bf0-b137-449a-b1f5-34bc736315d3)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         be7419aa-fe72-4865-a005-23d8b372b20b)(content(Whitespace\" \
          \"))))(Tile((id \
          ebf9e72d-8a06-4f30-87a5-208400cd9ab7)(label(hair_color))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6a467aad-a511-4cc9-ae72-375cf342b50f)(content(Whitespace\" \
+         6aaf7e96-6aab-40ba-a1ea-471990b2fda5)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5d2d7211-bf13-40f3-bd13-6f7fe2193618)(content(Whitespace\" \
+         c1d31bf1-51a3-4f21-9492-6cfdcf93f711)(content(Whitespace\" \
          \"))))(Tile((id 2af42994-93a2-43d5-b76e-0f2477476679)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1748,7 +1481,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1237b649-296c-4f98-b527-52f417bf89eb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         35a746c3-046f-4884-980d-3ddf81c668cf)(content(Whitespace\" \
+         87b34580-931d-43cf-99aa-77c8814ce091)(content(Whitespace\" \
          \"))))(Tile((id \
          32a21127-ab1a-4009-8f46-bcbb7a3b80ec)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1756,24 +1489,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2f450718-6802-4d86-a2eb-409b25707146)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4fff372c-9106-4963-b159-a384f338179c)(content(Whitespace\" \
+         a9fc7fc0-8449-4e5e-9719-b916e9c16722)(content(Whitespace\" \
          \"))))(Tile((id \
          ce4327d2-9dab-4d09-9bed-1af0566a2910)(label(\"\\\"blonde\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b55fb056-f8ed-4d29-84e9-15b8f8f35714)(content(Whitespace\" \
+         cfb24ca9-1dc5-4810-be60-aebbd31e0ea0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8ea90b89-4b9d-49f7-9aee-762f75717bdb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9684dab2-7dee-427f-b9eb-5e6193cf9862)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0f0dc939-7ae6-48a5-8a07-047fd09d636e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c9782f93-2f03-4e3b-b050-c5f6348e8027)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b3ed484f-1859-487f-ba25-87572ff04e2f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ce74707-f812-4862-affc-003063b97e28)(content(Whitespace\" \
-         \"))))(Tile((id \
+         648338a5-ae55-44bc-9426-a9dda341cab2)(content(Whitespace\"\\n\"))))(Tile((id \
          7d6162cd-1749-45b0-8922-6a48bd9a1eee)(label(add_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1786,7 +1509,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aca0b045-d335-424c-a6be-a0292b624b4b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         515ea3f8-bfd6-4d5c-adcb-8a9d83c4fffa)(content(Whitespace\" \
+         356cdc2b-050a-4ef6-b6ba-5f34dd30dc93)(content(Whitespace\" \
          \"))))(Tile((id \
          96c400ba-ad99-4694-a381-37da341f9d24)(label(\"\\\"hair-color\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1794,51 +1517,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          461e8538-0301-41a6-9456-fd290a9f4b6f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         655a3d9f-c6d8-4fb8-8b3f-478115ddcbd9)(content(Whitespace\" \
+         12f30ddb-cb3c-42b7-8234-65d919b18519)(content(Whitespace\" \
          \"))))(Tile((id \
          a07bd7c8-058f-464e-8e6a-02fbb1110158)(label(hair_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9363ff75-a0d9-4c09-a0cb-bd43d0a37686)(content(Whitespace\"\\n\"))))(Secondary((id \
-         aa9aa9b9-4d58-40d8-9a1a-f961521d7d66)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         64854e81-345b-47df-aa28-9ecd9586f078)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ebba9e9-b28f-49e9-9224-b190aa21b90e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c28ff61a-db0b-4c73-9a63-1549175ac7c4)(content(Whitespace\" \
-         \"))))(Tile((id \
+         19c7d9e5-4b64-460c-856d-7326ba9813f2)(content(Whitespace\"\\n\"))))(Tile((id \
          ed5c0301-e8c6-4929-b7bc-5d8c5ce30b58)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6e9c3f09-3bfa-42ae-a871-51736ec868dc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         67dae072-2257-462f-8688-1141393abba2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d995934f-2894-4796-8aeb-40ebd7b769ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fbbab750-12f5-4f8d-bf8b-ae077d5f4e7e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         11a0c682-2bc4-447f-8c23-45c2c8961b1d)(content(Whitespace\" \
+         061052c1-6dda-4102-9faa-ded282a854bc)(content(Whitespace\" \
          \"))))(Tile((id \
          df4996a7-f82d-4643-822c-53bbc14b8eb0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         54c4a82e-15c1-4a8d-9d2d-5b36a1720106)(content(Whitespace\"\\n\"))))(Tile((id \
          a7371c41-cce3-4db3-9e9c-656839ee0b6d)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         9aec903a-1f4e-4111-b0f3-85810981e526)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b0c4141d-d1e5-4977-b945-32b0fd617245)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eb7c9fc4-ddc9-4a85-adaa-96c4b4d55c42)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fa102167-e480-4b13-b9f0-2c7ef56b8739)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b005f5ee-f0ce-47e3-8494-8d8b74c19c9d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         12f65514-44e8-4eca-8d41-f8285fddb36e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eba26e0d-b714-40c8-a61b-6d1444e065c7)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          6a38a44b-d2ea-4b0f-9ec6-0e2cf4355bbc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1872,18 +1568,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b536eb02-1822-4cc8-af11-ff84694317b1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3443f749-0d30-490c-9303-e941e0afa4f9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2e4d8ce4-f3a2-4d73-8b35-327484c7828c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f06e7ea7-7fb0-4dff-9c90-ebf00961be21)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0123ff38-57ed-48e7-91ca-255b77508e1e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a550e2c0-a989-408e-8ec8-f80b3fbe204b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         34e0622b-bbd7-41c1-8e91-f41551dbfcc7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f66ebf5-c671-4e4f-bc37-8924b6eb5908)(content(Whitespace\" \
+         35dfcb75-547e-4f49-a17d-7de46b33fbb8)(content(Whitespace\" \
          \"))))(Tile((id \
          ba896a18-cd6b-4d07-8cae-c84878af93f7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1918,18 +1603,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          09fa2186-98b3-4d97-b984-9ab0a6323f73)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1ebdc54a-5eee-4b80-8171-b6129826294b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         93c387ca-8e83-45c5-876c-401639b9863e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5655a0e2-4f2f-459c-9f0a-2a254f4e069c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0cd59540-7ecd-4d65-bbaf-f4a48f11039f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab00e4fc-2715-4d64-b002-c8767e33266e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3d6febbe-50af-4dc9-8fd4-360fddebf890)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         81709abe-a4b2-40ba-ab69-2186fee9f2da)(content(Whitespace\" \
+         bbb75ea5-6e60-4d28-a08e-f374000e1058)(content(Whitespace\" \
          \"))))(Tile((id \
          3bb40188-26de-4964-b4d0-798a9139a51e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1940,7 +1614,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          186ed4ee-f284-42c5-bcf2-a1e87ebe38a1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         758b140e-34e3-47b8-9a62-c839bd7a5f73)(content(Whitespace\" \
+         91356602-10f6-4e19-b001-3580f56b2695)(content(Whitespace\" \
          \"))))(Tile((id \
          0bccdca6-b3ba-4fd9-8bec-4ad014f79ac9)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1948,7 +1622,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f8dc6e1e-2cba-4004-9e83-aff6ff51a144)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         28d79600-4aa9-43b1-ac4f-df074f4706b3)(content(Whitespace\" \
+         e5a02ad3-cb70-43a9-a624-1f6d0b702520)(content(Whitespace\" \
          \"))))(Tile((id \
          9a25b240-2bc0-4941-b5a5-3b7714370140)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1956,26 +1630,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0e293962-19de-453f-91a3-4e96fed7e423)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0c057781-35cb-49bf-8cb4-9dd30e56feeb)(content(Whitespace\" \
+         f5b59d84-f68a-47be-892d-911485dbd5a8)(content(Whitespace\" \
          \"))))(Tile((id \
          68a496ce-5980-4ed3-90b2-ef17a1230ec9)(label(\"\\\"blonde\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f1596d7d-e33e-4109-ad0f-66854bb41ecc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3ef57bb1-60de-47db-abde-f41e5df9a5ea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3da7ee76-f723-4df8-b2e3-5a9989791fb0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e07ebbcd-12d2-4e81-9121-9f89265d4ede)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3d51d8cd-df80-43f1-8d06-ace132f0ece2)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9a08bee3-bf54-42b6-a30b-bdd09cf2a739)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         402d84c5-acfb-404f-91f1-903e122670a7)(content(Whitespace\"\\n\"))))(Tile((id \
          9e60e6cf-5c05-414a-aa57-1d6a2b96bc4c)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         080a75f5-49d7-4dca-a8bc-85009ef8dc65)(content(Whitespace\" \
+         631ab4dc-4aa1-4de3-b29e-7f10d373daca)(content(Whitespace\" \
          \"))))(Tile((id 334e2197-85b5-4cce-ba48-f9d5773d19e2)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1984,161 +1648,150 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          4493db76-549e-4e1c-bf3c-a1c56cba76ed)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0479d99a-307b-45b2-aa14-333d316412a7)(content(Whitespace\" \
+         \"))))(Tile((id \
          abca761d-d692-4e47-b470-435cdf3e5479)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         db9446ee-2e03-46c7-a371-659c6b5204ba)(content(Whitespace\" \
+         \"))))(Tile((id \
          5a658ca8-d745-4202-9c19-2695bf0aff73)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          220d2b36-1273-407e-a80a-4ff16c23c1ac)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ab6efb6e-b8ad-4f1f-a722-9d2a28d10cb8)(content(Whitespace\" \
+         d0cb3bae-c235-4b70-a537-f9e54a9c47c6)(content(Whitespace\" \
          \"))))(Tile((id \
          e60015a5-4b0e-4420-b5c6-9d7c6125a677)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         678f344a-201c-4e08-aab2-c8d4bd3a016f)(content(Whitespace\" \
+         \"))))(Tile((id \
          fec145b0-8144-435a-a156-40b112cd2c3e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d32edda6-1b7c-42ee-82e3-a6246d6f77c6)(content(Whitespace\" \
+         \"))))(Tile((id \
          21119200-99b0-4da2-b340-e7a5e42ec35b)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          90fbae76-276f-4878-9a87-f1a9442f50a0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1d9c102c-b27e-425f-9bd0-31bc7b431e1f)(content(Whitespace\" \
+         4b19bac8-2a55-4040-bd2f-42c997be0fb6)(content(Whitespace\" \
          \"))))(Tile((id \
          2d88a5b7-7318-4bf8-9b02-81e8f1da8096)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         27d87f1a-d01a-42bd-bafc-9e2d13a98ee6)(content(Whitespace\" \
+         \"))))(Tile((id \
          b917f22e-b8f9-4c49-a8c0-e10016bfd52f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e86be9ce-636f-49ce-9bab-c082503db147)(content(Whitespace\" \
+         \"))))(Tile((id \
          db06c879-dd4e-4788-82e0-1f35ff681654)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4bd385d5-29a4-4da0-b147-0f8ffe062d47)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3f15058b-baea-4a00-9f43-95c0b1a4d90f)(content(Whitespace\" \
+         51a57683-0b45-41bd-82d7-0f96ddc227ae)(content(Whitespace\" \
          \"))))(Tile((id \
          e1940190-349a-4a0d-8ea1-5d39ec83a371)(label(`hair-color`))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0f0bbc69-8af4-4dee-80ca-026ee61a0b29)(content(Whitespace\" \
+         \"))))(Tile((id \
          7860d0a6-6c98-4d37-9fa3-79f55c737994)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bc9146ac-fe98-4e18-a571-ca02e3ae7c89)(content(Whitespace\" \
+         \"))))(Tile((id \
          b3192501-7cf3-426e-8520-1c546e88a35d)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         836f0105-2254-42ed-8c5a-442f922a5ddb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         af672c1b-80ff-4c5e-b0b8-dee7435e3b2c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a75148d7-74dc-4e18-b96e-980b2df96bec)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         009b7da6-e0b4-4892-abc8-07785ca4b116)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         b3ab2bde-0307-4444-ac4b-8453beab9939)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ae7fba64-7474-4574-ba3a-e30c2bfde378)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4aa6f684-f690-4ae4-9d6a-cd97bcd346b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         805d43d1-463c-46da-a1cf-4f1b3dbbd75a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33658181-1907-4bfa-a757-6148aed913c3)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a588e21f-bfae-4a19-9929-6a92e541e589)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ced62a3e-835a-4e15-bf59-eb45d4a2a435)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f683c297-a98c-421c-8b9d-e25f583aab49)(content(Whitespace\"\\n\"))))(Tile((id \
          8f2ca4e6-4c92-4a6b-8aed-7a54c3e94ad1)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         3e815c9d-c4bc-4cd6-8362-56b1b79e384c)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
-         let students : [Student] = [\n\
-        \  (\"Bob\", 12, \"blue\"),\n\
-        \  (\"Alice\", 17, \"green\"),\n\
-        \  (\"Eve\", 13, \"red\")\n\
-         ] in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = [(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")] in\n\
          # V1: This version is more idiomatic but requires the caller to pass \
          a function combining the rows explicitly thereby getting more type \
          safety. #\n\
-         let v1 = \n\
-        \  let requires = [\n\
-        \    (enforced=^^check(false), \"c is not in header(t1)\"),\n\
-        \    (enforced=^^check(false), \"length(vs) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  let ensures = [\n\
-        \    (enforced=^^check(true), \"header(t2) is equal to \
-         concat(header(t1), [c])\"), # Assuming the higher order function \
-         provided is extension with the new column #\n\
-        \    (enforced=^^check(true), \"for all c' in header(t1), \
-         schema(t2)[c'] is equal to schema(t1)[c']\"),  # Assuming the higher \
-         order function provided is extension with the new column #\n\
-        \    (enforced=^^check(true), \"schema(t2)[c] is the sort of elements \
-         of vs\"),  # Assuming the higher order function provided is extension \
+         let v1 =\n\
+         let _requires = [(enforced=^^check(false), \"c is not in \
+         header(t1)\"), (enforced = ^^check(false), \"length(vs) is equal to \
+         nrows(t1)\")] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(true), \"header(t2) is equal to concat(header(t1), \
+         [c])\"), # Assuming the higher order function provided is extension \
          with the new column #\n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  let add_column = typfun r -> typfun v -> typfun r' -> fun (t : [r], \
-         c : ((r, v) -> r'), vs: [v]) ->\n\
-        \    (zip(t, vs)\n\
-        \    |> map(_, c)) : [r']  in\n\
-        \  \n\
-        \  test \n\
-        \    let hair_color = [\"brown\", \"red\", \"blonde\"] in \n\
-        \    add_column\n\
-        \    @<Student>\n\
-        \    @<String>\n\
-        \    \
-         @<(name=String,age=Int,favorite_color=String,`hair-color`=String)>(students, \
-         fun (s, v) -> s ... (`hair-color`=v), hair_color)\n\
-        \    ==\n\
-        \    ([\n\
-        \      (\"Bob\", 12, \"blue\", \"brown\"),\n\
-        \      (\"Alice\", 17, \"green\", \"red\"),\n\
-        \      (\"Eve\", 13, \"red\", \"blonde\")\n\
-        \    ] : [(name=String, age=Int, favorite_color=String, \
-         `hair-color`=String)])\n\
-        \  end\n\
-         in\n\
+         (enforced=^^check(true), \"for all c' in header(t1), schema(t2)[c'] \
+         is equal to schema(t1)[c']\"), # Assuming the higher order function \
+         provided is extension with the new column #\n\
+         (enforced=^^check(true), \"schema(t2)[c] is the sort of elements of \
+         vs\"), # Assuming the higher order function provided is extension \
+         with the new column #\n\
+         (enforced = ^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
+         ] in\n\
+         let add_column = typfun r -> typfun v -> typfun r' -> fun (t : [r], c \
+         : ((r, v) -> r'), vs : [v]) -> (zip(t, vs) |> map(_, c)) : [r'] in\n\
+         test\n\
+         let hair_color = [\"brown\", \"red\", \"blonde\"] in\n\
+         add_column@<Student>@<String>@<(name = String, age = Int, \
+         favorite_color = String, `hair-color` = String)>(students, fun (s, v) \
+         -> s ... (`hair-color` = v), hair_color)\n\
+         == (\n\
+         [(\"Bob\", 12, \"blue\", \"brown\"), (\"Alice\", 17, \"green\", \
+         \"red\"), (\"Eve\", 13, \"red\", \"blonde\")]\n\
+         : [(name = String, age = Int, favorite_color = String, `hair-color` = \
+         String)]\n\
+         ) end in\n\
          # V2: This version more closely matches the TableAPI and takes a \
          string column. Given the lack of row polymorphism no constraints are \
          ensured #\n\
-         let v2 = \n\
-        \  let requires=[\n\
-        \    (enforced=^^check(false), \"c is not in header(t1)\"),\n\
-        \    (enforced=^^check(false), \"length(vs) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  let ensures=[\n\
-        \    (enforced=^^check(false), \"header(t2) is equal to \
-         concat(header(t1), [c])\"), \n\
-        \    (enforced=^^check(false), \"for all c' in header(t1), \
-         schema(t2)[c'] is equal to schema(t1)[c']\"), \n\
-        \    (enforced=^^check(false), \"schema(t2)[c] is the sort of elements \
-         of vs\"), \n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  let add_column = fun (t : [?], c : String, vs: [?]) ->\n\
-        \    zip(t, vs)\n\
-        \    |> map(_, fun (r, v) -> from_lvs(to_lvs(r) @ [(c, v)])) in\n\
-        \  let notes = [\n\
-        \    ^^text(\"Polymorphic type limitation stops most ensured \
-         constraints\"),\n\
-        \    ^^text(\"Lack of first class labels requires writing this with \
+         let v2 =\n\
+         let requires = [(enforced=^^check(false), \"c is not in \
+         header(t1)\"), (enforced = ^^check(false), \"length(vs) is equal to \
+         nrows(t1)\")] in\n\
+         let ensures = [\n\
+         (enforced=^^check(false), \"header(t2) is equal to concat(header(t1), \
+         [c])\"),\n\
+         (enforced=^^check(false), \"for all c' in header(t1), schema(t2)[c'] \
+         is equal to schema(t1)[c']\"),\n\
+         (enforced=^^check(false), \"schema(t2)[c] is the sort of elements of \
+         vs\"),\n\
+         (enforced = ^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
+         ] in\n\
+         let add_column = fun (t : [?], c : String, vs : [?]) -> zip(t, vs) |> \
+         map(_, fun (r, v) -> from_lvs(to_lvs(r) @ [(c, v)])) in\n\
+         let _notes = [\n\
+         ^^text(\"Polymorphic type limitation stops most ensured constraints\"),\n\
+         ^^text(\"Lack of first class labels requires writing this with \
          from_lvs.\\nIf doing this with concrete data you can do a \
-         transformation like v1\");? \n\
-        \  ]\n\
-        \  in\n\
-        \  test \n\
-        \    let hair_color = [\"brown\", \"red\", \"blonde\"] in \n\
-        \    add_column(students, \"hair-color\", hair_color)\n\
-        \    ==\n\
-        \    ([\n\
-        \      (\"Bob\", 12, \"blue\", \"brown\"),\n\
-        \      (\"Alice\", 17, \"green\", \"red\"),\n\
-        \      (\"Eve\", 13, \"red\", \"blonde\")\n\
-        \    ] : [(name=String, age=Int, favorite_color=String, \
-         `hair-color`=String)])\n\
-        \  end\n\
-        \  \n\
-         in ?\n";
+         transformation like v1\");\n\
+         ?\n\
+         ] in\n\
+         test\n\
+         let hair_color = [\"brown\", \"red\", \"blonde\"] in\n\
+         add_column(students, \"hair-color\", hair_color)\n\
+         == (\n\
+         [(\"Bob\", 12, \"blue\", \"brown\"), (\"Alice\", 17, \"green\", \
+         \"red\"), (\"Eve\", 13, \"red\", \"blonde\")]\n\
+         : [(name = String, age = Int, favorite_color = String, `hair-color` = \
+         String)]\n\
+         ) end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIConstructorsaddRows.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIConstructorsaddRows.ml
@@ -1,18 +1,19 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Constructors / addRows",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id ffaefca0-eab9-425c-a9c1-da13aa1c7f78)(label(let = \
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         7c558656-2e0b-463e-9040-c3b307e443b8)(content(Whitespace\" \
+         77c8737c-a667-43fd-9cfb-2ee625f6d90f)(content(Whitespace\" \
          \"))))(Tile((id \
-         226af35a-5339-421d-a89c-72cea22e478c)(label(requires))(mold((out \
+         226af35a-5339-421d-a89c-72cea22e478c)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Secondary((id \
-         b39b064a-93d7-4374-96fa-91cac3885cb2)(content(Whitespace\" \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         98208576-7107-496f-a4c5-0fba98675663)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         644eb0fa-c7ff-4fe3-a8d6-49e41e47ec60)(content(Whitespace\" \
          \"))))(Tile((id 1d03717e-6824-4ef7-b8d8-5a04c668553f)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -21,11 +22,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          14761e35-579c-4208-8f22-f79cce1b63ee)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7e931f02-e5dd-45bd-b79d-f63c0ac4b864)(content(Whitespace\" \
+         \"))))(Tile((id \
          3d15b4fb-12cb-4e9c-b1cc-17db6859ad65)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         570fc0db-4b9c-440c-8305-a9fe8003cfd6)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6feb674b-bd9c-4e8f-89a0-ba3b95bb8680)(content(Whitespace\" \
+         \"))))(Projector((id 570fc0db-4b9c-440c-8305-a9fe8003cfd6)(kind \
+         Checkbox)(syntax(Tile((id \
          5cb80f0e-c34d-439c-935c-c454fb0b170e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -35,29 +40,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a8534017-a9e1-4ef1-b961-53bdc49264d3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         89f0812d-e1b8-4c2e-9455-82ae2ad4c2f7)(content(Whitespace\" \
+         6c1436f1-5497-4a10-a637-e1c90b6da1e6)(content(Whitespace\" \
          \"))))(Tile((id 007c0d16-1616-4851-b79c-40bb02ccae58)(label(\"\\\"for \
          all r in rs, schema(r) is equal to schema(t1)\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         abfda762-9507-48c4-8d0d-299ae5826963)(content(Whitespace\" \
+         946f73e8-742b-444b-9fcf-3668f3489efd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d2fb4d21-3fae-45a9-8f4a-bd826d6cf353)(content(Whitespace\"\\n\"))))(Tile((id \
+         0bbc390c-0f1f-440d-9196-46d785132c9e)(content(Whitespace\"\\n\"))))(Tile((id \
          d1bf9872-b34f-482c-ae02-e8a879586ec7)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1e90be74-d3b3-4f81-8ab6-97ac66fdacbc)(content(Whitespace\" \
+         83060077-55f8-41fb-8da6-2469cf61b75f)(content(Whitespace\" \
          \"))))(Tile((id \
-         6b26801b-05ef-48d9-a09a-811667cf52f1)(label(ensures))(mold((out \
+         6b26801b-05ef-48d9-a09a-811667cf52f1)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1bdf358b-a940-49d0-b7e0-b4fb062636cb)(content(Whitespace\" \
+         c81832c4-8296-4c11-a945-e9cf9fa6c564)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ed608b11-47e9-42fb-ba0c-efc11224ab83)(content(Whitespace\" \
+         e3fc6c76-345f-483e-aec9-929df97734a9)(content(Whitespace\" \
          \"))))(Tile((id f7644480-f3ae-4162-a69b-956d4ff847b4)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         428934e7-d888-48a0-9056-4fcf1431015d)(content(Whitespace\"\\n\"))))(Tile((id \
+         d6bc2af6-6d2b-47e8-8134-fae3e68a4f49)(content(Whitespace\"\\n\"))))(Tile((id \
          e69ad744-9e1b-4c51-b3fd-dcace4528788)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -86,17 +91,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6c696ac8-51d7-460f-bc3d-a00143cfa0ce)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9196183a-9491-4c85-906d-bdfc6686b0fb)(content(Whitespace\"\\n\"))))(Tile((id \
+         f6ffda94-d159-44d8-bbe9-c884f5a85286)(content(Whitespace\"\\n\"))))(Tile((id \
          5ca59999-73bc-49ed-b8d7-c877bc92bdb3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          a74c4cce-2ea5-4f85-869d-2761f51b1c0e)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ead767a6-6651-4544-afb3-be2500da989d)(content(Whitespace\" \
+         \"))))(Tile((id \
          e15d65ff-556d-4bd5-bc39-647186af49ba)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         e121a7af-57c7-4fde-afa0-68f9f9ce4684)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7ec2a74d-020b-440a-9795-26229d463a55)(content(Whitespace\" \
+         \"))))(Projector((id e121a7af-57c7-4fde-afa0-68f9f9ce4684)(kind \
+         Checkbox)(syntax(Tile((id \
          a33c85a0-9823-4212-b7d8-16f4d9bbdd41)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -106,48 +115,48 @@ let out : string * Haz3lcore.PersistentSegment.t =
          073f376d-725b-4ba5-b91d-78cded07efb9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         84fbb18e-a445-4162-99aa-8c4193a8ba6c)(content(Whitespace\" \
+         5cc7de9d-51b8-48af-a4aa-b6ffdd7299dd)(content(Whitespace\" \
          \"))))(Tile((id \
          c59ad567-78b7-4758-b7a3-3f576530367b)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1) + length(rs)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         090c2eda-53a7-4367-9837-3beca5fa6ff1)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         23b8e07b-e013-4135-a1f1-84728d932387)(content(Whitespace\" \
+         2a00aaf1-a76d-4219-9049-3355892e8f0f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         f90e5fc0-6b0b-489e-8327-99b9af812126)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f992e154-ed13-4427-b321-c9be9f42a5aa)(content(Whitespace\"\\n\"))))(Secondary((id \
+         b2cdcf96-1956-4b3d-8e36-59a0b482287a)(content(Whitespace\"\\n\"))))(Secondary((id \
          c115e823-bd82-4d67-a60c-c4facbcf7ee4)(content(Comment\"#Hazel tables \
          are lists; so add_rows is just list \
          concatenation#\"))))(Secondary((id \
-         85721d3d-c7d3-413c-8947-330c25e10851)(content(Whitespace\"\\n\"))))(Tile((id \
+         09681b57-1435-409c-93ba-65697d267e0f)(content(Whitespace\"\\n\"))))(Tile((id \
          13fd9425-7b2a-4840-98db-4c215a8d89d6)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         db62cb76-96a1-4011-9eab-5abf4265effc)(content(Whitespace\" \
+         9dc75aae-2233-4539-bbbf-b34027c788e7)(content(Whitespace\" \
          \"))))(Tile((id \
          d7bcd0a2-9baf-4a2b-965c-21e13f60be18)(label(add_rows))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cdf90c13-f845-4461-9ca2-e200f44b0d42)(content(Whitespace\" \
+         5131e03e-4b40-422b-80d1-384fcf1514dd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9d9da642-d447-491f-b026-005ade419f45)(content(Whitespace\" \
+         c88366ad-c5e1-4a26-a538-d4aa9c68c0d4)(content(Whitespace\" \
          \"))))(Tile((id b00f4852-801d-426d-9965-602eb358bdd1)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         238820f7-9739-44ed-b21b-28f9cad81092)(content(Whitespace\" \
+         58b492cb-0d37-4d85-877b-9826cdb928ff)(content(Whitespace\" \
          \"))))(Tile((id \
          f60b403b-dad0-43c5-aea8-3c592c21196d)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         fc0dd5af-2061-495f-84b1-2f8545a25b55)(content(Whitespace\" \
+         da898502-c37e-4129-b980-f7c80a19d0f9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         31ea6208-7265-4a8b-b173-69a05cfd8386)(content(Whitespace\" \
+         00838389-b332-4e6f-8832-ca7d1b58972d)(content(Whitespace\" \
          \"))))(Tile((id 8710400a-8aeb-4c72-929c-8c857cd379f1)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         d7f05ee5-75ae-4ee5-930b-16f2a0c85a15)(content(Whitespace\" \
+         35c70907-4b90-4ea7-ab03-ca2c8cd48c78)(content(Whitespace\" \
          \"))))(Tile((id \
          e86f9a8c-aaa2-4204-88e5-42429ee25670)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -155,12 +164,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cc73d794-a5db-4229-8e7c-c43842213fbb)(label(rs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e85f5c48-1bf6-414f-9a7d-9fb835319cec)(content(Whitespace\" \
+         625111b7-906f-4bd3-a896-6afd2a5b0890)(content(Whitespace\" \
          \"))))(Tile((id \
          b45e9d5f-6cc8-49c1-af33-7fb3c0e6e866)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dc202e75-708b-40b9-a482-7fc5ef59c6a7)(content(Whitespace\" \
+         aaccf426-86f1-48a7-af8e-6d9b5936e851)(content(Whitespace\" \
          \"))))(Tile((id 4034e113-c5bd-4055-8669-e9920ae76fe9)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -170,193 +179,227 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4e7ccc83-c444-472b-ab75-fdd1edfbe67b)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ce583a50-fd0e-49c0-acf9-227b51ef346a)(content(Whitespace\" \
+         ae9dcead-9bd7-4e73-a1f5-a5ab12773d59)(content(Whitespace\" \
          \"))))(Tile((id \
          10655ac1-d832-4824-8d97-2ae7a10c5ba4)(label(rs'))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9e2979e9-45ac-4e62-939c-5704f2015439)(content(Whitespace\" \
+         958468ea-5fcb-4199-b886-e34b4f5c3e9f)(content(Whitespace\" \
          \"))))(Tile((id \
          30219cfe-c6de-4d0f-9494-de5af65b1e21)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9a6799c4-b9b3-4db3-acff-6a46b8300d76)(content(Whitespace\" \
+         eefaba59-f6d9-41f7-a4db-05634c37d65d)(content(Whitespace\" \
          \"))))(Tile((id 6ea358f4-4fa8-4bd7-a0a4-8774202cf666)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          65ba2f3b-813f-408a-82f5-d88f194495bb)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         6590778c-b794-4e57-bc9e-03c6b1863179)(content(Whitespace\" \
+         b0935ba6-5bdc-49d8-b371-a90079855835)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1de5970e-e7bf-4476-8bf1-063274b1ab6d)(content(Whitespace\" \
+         f18a016d-33f5-4bcc-b50f-9127dd1d5555)(content(Whitespace\" \
          \"))))(Tile((id \
          5962437f-52c1-46d7-af97-2bdeea9e754a)(label(rs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         6a1ad756-0390-46b8-9d1d-459bc24f68fb)(content(Whitespace\" \
+         30a8c5eb-4db5-4781-ad3b-3acd4a201c41)(content(Whitespace\" \
          \"))))(Tile((id \
          5ec9aabc-37b3-4303-8920-7ac75d67cbb3)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1b3ce1f2-2729-44b7-b6c2-c4a254b6f5ff)(content(Whitespace\" \
+         fee52c6d-5182-4700-8bc1-e666b1ea98d1)(content(Whitespace\" \
          \"))))(Tile((id \
          17998707-c364-4279-bb26-c8990ce2cce2)(label(rs'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         5bfa1166-0c85-4632-8806-808f6cc124ae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f682670-8c3a-4699-bd9c-17c809d6fe1b)(content(Whitespace\" \
+         668dd757-3714-4090-841d-54ee2b6cadc0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         990ecda5-137e-4c35-83e6-eeea7e64bd43)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c3a0b3a6-874e-497a-8c63-1d86d0f07750)(content(Whitespace\"\\n\"))))(Secondary((id \
+         29bf6b90-d16b-4e7c-bc29-d44cd83a281d)(content(Whitespace\"\\n\"))))(Secondary((id \
+         914daaca-4dbd-4135-bd7d-c25dbacbec0d)(content(Whitespace\"\\n\"))))(Secondary((id \
          6046083d-3f85-4b99-afd0-c3fdaccf5b57)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         2282625f-591d-4a8a-87ef-80fd35b3c8d2)(content(Whitespace\"\\n\"))))(Tile((id \
+         3256a609-8f74-45fc-a136-2b015e10b9cc)(content(Whitespace\"\\n\"))))(Tile((id \
          c4020d05-afe1-426c-9907-f9f93597f41c)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         632b90fc-c9ed-4da3-b7cb-a4df6b0cec31)(content(Whitespace\" \
+         1c1fe3ce-03e9-4c55-80ab-3452e0c290d1)(content(Whitespace\" \
          \"))))(Tile((id \
          45657d73-9dc0-4dcd-9c0a-1bf020446a29)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children()))))((Secondary((id \
-         8fe061ac-2061-4f37-af4f-6f4fa963047d)(content(Whitespace\" \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         a926dc3a-cb61-497f-aa7b-ffabaf1908e7)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         31c6d0dc-b82c-43d3-aecd-b2897983ccdd)(content(Whitespace\" \
          \"))))(Tile((id \
          fe6ec8d7-f31f-4cc4-bb79-8ec5520c7e8e)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          6ae0f912-8cb9-4d13-be97-4b81f3e98ee4)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         74a6146e-f4e2-494c-b533-88751ab58c9e)(content(Whitespace\" \
+         \"))))(Tile((id \
          67982480-961f-45c9-a66b-2e732ca34675)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ef02ef3c-2400-4fe4-aac9-cac35f85b666)(content(Whitespace\" \
+         \"))))(Tile((id \
          a951ce2a-1387-4b5b-8ebb-0c0bc6d1fa0e)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ba8cf955-8fb9-4271-948c-dece83af75d6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c1637fd5-68eb-4e8a-abf8-595842a2e24a)(content(Whitespace\" \
+         72b08dce-5fbc-4977-b67b-93d8b330dd7f)(content(Whitespace\" \
          \"))))(Tile((id \
          c739ddaf-45c4-47f9-8aeb-84accdaf6941)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         945c9ce4-42d8-4db8-8500-913e5b875243)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a5095e7-f62c-478b-9aa9-fcab5b855b8c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         78e05092-0be5-4755-baab-18aa11ef6d5c)(content(Whitespace\" \
+         \"))))(Tile((id \
          e53b8656-e9d7-402b-80f4-282db6fffbe7)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          643d687e-4667-4417-a11b-4cca47d7bf22)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e854ceee-6e79-4baf-a1d5-eab04531c486)(content(Whitespace\" \
+         9e06c53e-98da-4129-9662-a3a9fef2b8f8)(content(Whitespace\" \
          \"))))(Tile((id \
          0ec59367-81ec-44c1-b427-5ef24110fe98)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         48335dd8-f8d8-4276-b6c8-111011b6fb4b)(content(Whitespace\" \
+         \"))))(Tile((id \
          a0c9dc56-219e-4ff6-9bd2-3641a7816be4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         502226c0-6a6c-4361-aa4d-5f9d83ed21b6)(content(Whitespace\" \
+         \"))))(Tile((id \
          83a0c092-6bc9-4389-92a3-2738c80d32e0)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          eb5d2ee7-e6fa-4c42-ab60-98d6f1326386)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         26fdd393-2dff-44d4-acd0-4ace1c128e37)(content(Whitespace\" \
+         4ce0e385-3a93-4ccc-a514-048249830dd4)(content(Whitespace\" \
          \"))))(Tile((id \
          c702366b-0143-4877-91df-9c62b900f2db)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         fecd4d09-c465-4316-8b0c-190fe2be923d)(content(Whitespace\" \
+         \"))))(Tile((id \
          e2aad05e-9cfa-4dc0-a2fe-e60397e756b6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e363a6ff-f094-41c7-9b0f-7b80a01416af)(content(Whitespace\" \
+         \"))))(Tile((id \
          606e435d-bc0d-40c4-8622-965320d51d81)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d085da86-c6ef-403e-883b-bee6f4c01017)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4fde1c40-4547-427b-b463-98cd5cdd2cb6)(content(Whitespace\" \
+         5d53d730-2589-4061-a2fb-5b8fd87be6b5)(content(Whitespace\" \
          \"))))(Tile((id \
          8905fd27-4dd9-4aac-a7e0-bc4470f1dec6)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         531e5e81-8287-4e28-9b53-1ae9d60020ce)(content(Whitespace\" \
+         \"))))(Tile((id \
          d03fe7c6-e47e-4ae4-b6aa-b77cde87cf52)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ef34699d-f766-4ad6-b1ab-2a3926c79083)(content(Whitespace\" \
+         \"))))(Tile((id \
          ba4c33ae-b3da-46fb-8ad6-53834823d4e3)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bd965b1b-e4e1-425f-912d-1fb1d8cab8a1)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4b8eb806-4ebe-44df-9f45-5e6b10dd65d3)(content(Whitespace\" \
+         60917761-2f00-45e9-ae2b-f53200dc81e2)(content(Whitespace\" \
          \"))))(Tile((id \
          169ce5e2-0aab-41e6-85b9-2d3101b1aae5)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f1fd2848-0744-4f49-9d34-f7ef7853debb)(content(Whitespace\" \
+         \"))))(Tile((id \
          abad3ee5-1cc4-437c-876b-c13a53e4afe9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9ced132c-b40d-4b8d-b117-61633c392ce7)(content(Whitespace\" \
+         \"))))(Tile((id \
          a9ad6cc9-f7f7-46d0-b009-2cb61c6df970)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e225f006-66a5-44db-963a-a47aabff9cd3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c5070526-b448-4b66-99fe-e1ae08bf05f7)(content(Whitespace\" \
+         0c93a3a8-9696-406f-9d3f-f0b113f87c6f)(content(Whitespace\" \
          \"))))(Tile((id \
          eb7632a7-56c0-4e0c-9d96-0cd3e2c61175)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bd3864cf-8302-41f8-9774-337c69b192b6)(content(Whitespace\" \
+         \"))))(Tile((id \
          381c8a04-d902-433a-889a-151eb09a9527)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c6125656-e9e9-4f6d-980f-209e8b6f5a79)(content(Whitespace\" \
+         \"))))(Tile((id \
          6851627c-6f40-4c2c-ad87-ff4033de3070)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6843af37-d985-4aab-bf30-663b2e3ad930)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         993f60f0-9d06-481b-bde8-fdaea5405bca)(content(Whitespace\" \
+         abf7b05a-01b4-478f-aba8-768b28702799)(content(Whitespace\" \
          \"))))(Tile((id \
          c429c94e-d496-454e-bddb-96450ddb8eb3)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2ba5e23f-8681-472b-8906-fcf7383e8dd1)(content(Whitespace\" \
+         \"))))(Tile((id \
          410229a8-a65a-4120-9c36-b1008a2013c9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         243f2a8b-2164-485b-9542-7d63822a9fb8)(content(Whitespace\" \
+         \"))))(Tile((id \
          2cf30022-535d-4564-a68b-85d553e66a72)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0631e879-be9a-4be4-aad7-30d067bd14b7)(content(Whitespace\" \
+         8cc66df7-aee1-4b17-a892-cabd269bbd2f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4e12bf2a-f3f9-477f-ac95-2c76ca5c6985)(content(Whitespace\"\\n\"))))(Tile((id \
+         d2708e06-26fc-4e53-9c77-ecf2fdc2a1c8)(content(Whitespace\"\\n\"))))(Tile((id \
          d76e3950-3d49-48dd-a1dd-e6be55ee8dda)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c8ae37e2-c541-4883-95f8-45a61df46f4e)(content(Whitespace\" \
+         ec8804b3-7771-4c47-974d-bca85731bd5c)(content(Whitespace\" \
          \"))))(Tile((id \
          dbeebe80-f05f-4923-8fa0-eda4c97a0f09)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ef4cdd89-a72d-4c3b-926a-07496377e968)(content(Whitespace\" \
+         \"))))(Tile((id \
          f00c0aca-b3c1-447c-9e4b-ba03e6177524)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         24be1792-01b0-48b1-944e-4e5a2ec36d56)(content(Whitespace\" \
+         bcab6119-27e3-4d0e-b5fe-c90626a29c62)(content(Whitespace\" \
          \"))))(Tile((id 5de6a9ca-8ce5-4c41-b541-7093b336500e)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          d6d92884-1f13-4bfe-a695-66591a3e40be)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         ec484817-0dbb-47fa-8a48-4cb4edbd5564)(content(Whitespace\" \
+         2f8f9a80-a530-4d45-89b7-554bcecd6960)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5b418fb2-2541-4414-bbbf-e9683f9ce067)(content(Whitespace\" \
+         47b5a38e-b454-4dfb-afad-10a70046c766)(content(Whitespace\" \
          \"))))(Projector((id 933c5a88-28e3-4a39-aa98-543629021946)(kind \
          Fold)(syntax(Tile((id \
          444a87d0-d432-4b90-9c24-b8f74e6f4de7)(label(\"(\"\")\"))(mold((out \
@@ -570,18 +613,13 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          2531cb86-66cf-4c4d-acd8-6278a473c5b8)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         3be52aaa-2e2f-4309-9da1-dd3ccac6a6a9)(content(Whitespace\" \
+         be194d82-beaf-4eea-a927-49365627047a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7867a84b-74e8-4325-bd9f-51ceaabd4bfc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         542c6d70-bc58-4ee3-b4a0-6472359c4cff)(content(Whitespace\"\\n\"))))(Tile((id \
+         64d345d1-cfcd-4bd9-88af-e117cb04e1ca)(content(Whitespace\"\\n\"))))(Tile((id \
          6c1b4a29-77fc-4347-85ab-e60023c0e94e)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         b91a1fd4-c4e5-42c2-98f9-f7cf5ebf01cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e6f9195-0fac-4e7b-9207-333605790a80)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3c1c0a38-1f23-447b-93cd-c2ad7130dbec)(content(Whitespace\"\\n\"))))(Tile((id \
          c9053836-ebb7-4b94-9ecb-759d9de691b2)(label(add_rows))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -600,43 +638,43 @@ let out : string * Haz3lcore.PersistentSegment.t =
          78a14e7c-6ec3-433d-a43e-7fd2b525f3e6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         37911dd9-217d-4099-885c-4ba8e08ab516)(content(Whitespace\" \
+         f6087e85-99c3-4bf5-942d-46daeb3a8cf4)(content(Whitespace\" \
          \"))))(Tile((id \
          8ff789e9-4cf3-45d6-80bb-921c90304824)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         20baeca3-bb8e-433b-8711-94cf545089aa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ad8f28b9-47ed-4875-b4ab-ee88a0fad501)(content(Whitespace\" \
+         f321c0ea-9aa7-4037-9bea-676915334237)(content(Whitespace\" \
          \"))))(Tile((id \
          cd49a982-3ee9-45d0-b98e-2d67a1eff4da)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2f85f425-cc41-47ef-acb4-c71cb93aaa93)(content(Whitespace\" \
+         252f864a-c859-4903-9da3-d9867dd1835a)(content(Whitespace\" \
          \"))))(Tile((id \
          954ac427-b2eb-47ce-82be-b4b372f1c616)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         81cf0395-3a23-4a04-bc67-0b72b3ce57a2)(content(Whitespace\" \
+         c49a4cf6-b3b1-49db-93cb-b1a0ef077ed6)(content(Whitespace\" \
          \"))))))))))";
       backup_text =
-        "let requires= [(enforced=^^check(true), \"for all r in rs, schema(r) \
-         is equal to schema(t1)\")] in\n\
-         let ensures = [\n\
+        "let _requires = [(enforced = ^^check(true), \"for all r in rs, \
+         schema(r) is equal to schema(t1)\")] in\n\
+         let _ensures = [\n\
          (enforced=^^check(true), \"schema(t2) is equal to schema(t1)\"),\n\
-         (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1) + \
+         (enforced = ^^check(false), \"nrows(t2) is equal to nrows(t1) + \
          length(rs)\")\n\
          ] in\n\
          #Hazel tables are lists; so add_rows is just list concatenation#\n\
          let add_rows = typfun row -> fun (rs : [row], rs' : [row]) -> rs @ \
-         rs'  in\n\n\
+         rs' in\n\n\
          # Examples #\n\
-         type GradebookEntry= (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
-         let gradebook: [GradebookEntry] = ^^fold([\n\
+         type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
+         let gradebook : [GradebookEntry] = ^^fold([\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
          (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
-         ]) in \n\
-         test  add_rows@<GradebookEntry>(gradebook, [])  == gradebook end";
+         ]) in\n\
+         test\n\
+         add_rows@<GradebookEntry>(gradebook, []) == gradebook end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIConstructorsbuildColumn.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIConstructorsbuildColumn.ml
@@ -6,89 +6,96 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         d62b28aa-f855-4c36-8a7c-ada189a3a97e)(content(Whitespace\" \
+         310951b1-9408-4655-b4da-9504e83264a2)(content(Whitespace\" \
          \"))))(Tile((id \
          62c60fcf-8298-45b8-8cbf-48b328054420)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         0f349b7f-e990-4f14-a089-67a95818270e)(content(Whitespace\" \
+         f9f7dba3-1e62-4422-80ec-0e5cb546f87e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4503d08e-8de3-4062-bd3c-79d5c8f43ff5)(content(Whitespace\" \
+         aac378db-54d3-405f-a67e-8dd9c7369dee)(content(Whitespace\" \
          \"))))(Tile((id \
          d660be55-773d-4980-b08a-54dabf174138)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          5f3244d2-5282-49cf-a2f0-9e6908a1b991)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dc25686b-e4f3-471e-b6e3-b0e80f4e93fa)(content(Whitespace\" \
+         \"))))(Tile((id \
          e7e36666-930e-4147-9aa6-6ea01252d8b3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6db7237e-c8eb-44eb-8ebb-4b8956e848c0)(content(Whitespace\" \
+         \"))))(Tile((id \
          2062c46e-54cc-496b-9ae5-b419e2c1849c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6c84983d-8b2b-4247-9e59-68e5aca17590)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         823438c6-d5cd-44b2-93db-4fb9ba27bce5)(content(Whitespace\" \
+         32a54797-3848-413c-993a-a9553fe480b4)(content(Whitespace\" \
          \"))))(Tile((id \
          9d8e7f47-706b-4ecd-9812-8062d880066c)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c2109125-2d70-4642-8476-ebc5d1a5b196)(content(Whitespace\" \
+         \"))))(Tile((id \
          1ff858f8-4faa-410f-94c3-dc044777d960)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ec4029e3-9ff0-4248-a67a-7a3102cdb284)(content(Whitespace\" \
+         \"))))(Tile((id \
          3218225c-619d-47e0-bdb6-7da48e3a4521)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          36ded3f3-d1f4-4bc8-bdbb-6e4614f35759)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         92651726-89cb-4927-8c1b-9216ab92efb5)(content(Whitespace\" \
+         97e73bd6-4cdf-4a21-9e8c-516519a34fdd)(content(Whitespace\" \
          \"))))(Tile((id \
          23f1cc4c-ab56-420b-ac6d-840783a75353)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         80225371-517f-415b-bdf6-c3bf68a9cf4d)(content(Whitespace\" \
+         \"))))(Tile((id \
          682f3261-f96c-4ec1-9690-f86600ec1564)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dca3e9da-9b20-4e10-ad13-ff7ee588be0b)(content(Whitespace\" \
+         \"))))(Tile((id \
          1fdf22ce-8ba1-4969-91ff-f0c0f5c440d3)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         897f65fb-6158-478b-887d-99bb2952eb3e)(content(Whitespace\" \
+         65f59643-c651-4658-8ff5-64f2002d9dad)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         911de730-8f27-4160-b371-808def801160)(content(Whitespace\"\\n\"))))(Tile((id \
+         0f00f682-5356-4cc4-8adb-7c3c36ac52c8)(content(Whitespace\"\\n\"))))(Tile((id \
          c54a5143-380b-4cba-a48a-bb3b14029593)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         76cc1072-5fb1-4300-b38b-93f96a669a69)(content(Whitespace\" \
+         8d01fc80-6ebf-4213-863a-7bf01e2ad7d3)(content(Whitespace\" \
          \"))))(Tile((id \
          8417cc2d-966c-4b4f-97b9-cec4517450d1)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         21ea51fc-815a-4249-8c24-bb00b1367e13)(content(Whitespace\" \
+         577b5e68-f993-418e-8245-0c0837c56cbd)(content(Whitespace\" \
          \"))))(Tile((id \
          a4f02bff-8bc9-4a32-be3c-6100178da271)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b52379b9-8839-418e-8320-fec049990790)(content(Whitespace\" \
+         e0b17295-3706-439b-abd7-c369cf170aa7)(content(Whitespace\" \
          \"))))(Tile((id 3da02f6a-cc83-4dea-a24e-5151ec3b7f81)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          7acfb1e1-eee3-4b74-9a2e-258b05708dfd)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         2e524093-7560-4b34-bfcc-065ee609b331)(content(Whitespace\" \
+         12e9e16f-ee3e-4778-b283-7ca3f58ea790)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8199f666-b330-45e5-8724-1ccd622652d6)(content(Whitespace\" \
+         124a049f-36e3-4e47-853e-baa8f4318f48)(content(Whitespace\" \
          \"))))(Tile((id 3e1e7561-9b73-49db-8994-4cafdb3ba91a)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a36fd509-8ce7-48b2-a0a1-16056d6bd26f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f8dde553-b5a9-4259-8569-553a35472d36)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         823845a0-d2cb-42e5-b4eb-af6c371636b7)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          ec99f066-0f02-4960-8b98-db59b6a7885c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -114,10 +121,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          de2080a2-9d43-4d10-977a-8c51b706ef93)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f12b954c-994b-495b-98b0-dd71dbf5bd52)(content(Whitespace\"\\n\"))))(Secondary((id \
-         128c80a2-5379-4522-a2a2-2fa1256c32ee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d0579e90-a9d4-457f-822e-30d231240702)(content(Whitespace\" \
+         688dced6-6ca6-48bb-ad09-1e08fdd4631f)(content(Whitespace\" \
          \"))))(Tile((id \
          964ff4ec-fa93-4365-a671-ccb297e7f538)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -144,10 +148,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          028978e9-7dd8-4120-b851-dbbf1a4596c5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c279cc7b-6490-49d5-8281-3ace1c091039)(content(Whitespace\"\\n\"))))(Secondary((id \
-         98263c57-09bc-4064-98c6-252b0c272486)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         889e1e80-ec70-4a3f-924b-ee7c23d7151b)(content(Whitespace\" \
+         9d1f6070-4614-480c-9c3d-2a3348a28123)(content(Whitespace\" \
          \"))))(Tile((id \
          2bfa59ee-67f7-487c-aca4-eff77022c162)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -158,7 +159,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e0310660-fac9-49e0-b64e-537d1f9892e6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         40650685-498e-4541-ad6f-01c1aebf7fe6)(content(Whitespace\" \
+         1f016220-5ce8-457a-a400-562f7ca0b94b)(content(Whitespace\" \
          \"))))(Tile((id \
          33932b86-c6aa-4960-ae2f-8f59518288b5)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -166,47 +167,42 @@ let out : string * Haz3lcore.PersistentSegment.t =
          01414d33-8870-413e-8673-346b4b3f5638)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         56891b2d-5ae1-4d10-a531-af60ef833616)(content(Whitespace\" \
+         39fc3e35-7e27-47cf-9e08-2557043b5f51)(content(Whitespace\" \
          \"))))(Tile((id \
          995e5572-7fd5-48ec-b054-7be71db58cde)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b2eba123-bfa5-4738-a022-a012a0056f25)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         db014f55-bf2f-49f7-8053-e92e9076d012)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         24eaa8e9-0d66-4215-bf6a-e6fdfcc3e559)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9c5a286c-66c8-47d4-958d-f3001c2ad95a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0c0ca4e2-7812-4856-9dd2-76129a6919a3)(content(Whitespace\"\\n\"))))(Secondary((id \
+         39806e86-8d1c-40ef-93cf-393529d603bd)(content(Whitespace\"\\n\"))))(Secondary((id \
+         3e328bb1-3d6a-43b6-98ce-3b5c264238d1)(content(Whitespace\"\\n\"))))(Secondary((id \
          3933dfc9-d893-4320-b599-432e3c4a85da)(content(Comment\"# V1: This \
          version is a higher order function that takes a function for \
          constructing the resulting row offering more type safety \
          #\"))))(Secondary((id \
-         75d83b06-6796-4608-a865-361be3e058cd)(content(Whitespace\"\\n\"))))(Tile((id \
+         a4bc65d7-759c-4dc1-ba2c-ed0c4d93cab7)(content(Whitespace\"\\n\"))))(Tile((id \
          0091a9ea-7b1d-43a4-b99d-6252a6bbaeff)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c7c27854-75ca-41f7-b7b5-b6a575ead985)(content(Whitespace\" \
+         b03488dc-394a-45c2-bbc5-d86d0a97010c)(content(Whitespace\" \
          \"))))(Tile((id \
          5944aaec-5df0-4c5b-9dad-40b14899157b)(label(v1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         60bee878-7575-4fbc-9f9e-c1fc277d092b)(content(Whitespace\" \
+         7a37ae2f-c761-449a-8024-9f9ef71ee0e2)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d18bf7e0-89a5-4742-ba6c-2aa40988d80c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1d695af9-5b7a-4074-a530-e806c5a11fd1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6f1f3a23-f1e9-41de-aa76-4114a8610d0f)(content(Whitespace\" \
-         \"))))(Tile((id a4abd723-6304-4874-bb34-7e408eca4726)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         4f0b90a1-aa55-4f09-8219-34285c5c0c76)(content(Whitespace\" \
+         ca7183b0-ee68-430c-b7d6-ed3bb6660247)(content(Whitespace\"\\n\"))))(Tile((id \
+         a4abd723-6304-4874-bb34-7e408eca4726)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         19408900-d16a-46ce-90bd-150bfdecf804)(content(Whitespace\" \
          \"))))(Tile((id \
-         a3f82ea6-6d55-41c0-819c-3219e45acba3)(label(requires))(mold((out \
+         a3f82ea6-6d55-41c0-819c-3219e45acba3)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         60b0bb51-8ed2-41ad-94b4-4a7f4f7605fc)(content(Whitespace\" \
+         5045fd95-df88-42f2-9c90-1f9320fa1630)(content(Whitespace\" \
          \")))))((Secondary((id \
-         47ff26cb-e397-4949-ba83-b35092b7ebcb)(content(Whitespace\" \
+         6a15a623-f922-4039-84e3-bfc894c5c645)(content(Whitespace\" \
          \"))))(Tile((id 31a5012e-33b5-4a6f-b645-c913bc7a8102)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -215,11 +211,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          92ec4026-ae41-4a11-a1eb-746c8692d4e9)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b45f8838-6c69-471a-938f-3720aa2e2388)(content(Whitespace\" \
+         \"))))(Tile((id \
          1cfc1f9e-2882-44e2-af08-76e5bfebf876)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         02939f41-44c8-4bb4-8127-6843f644331b)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         839d138f-2c75-46cd-8d2e-a7b56e58b347)(content(Whitespace\" \
+         \"))))(Projector((id 02939f41-44c8-4bb4-8127-6843f644331b)(kind \
+         Checkbox)(syntax(Tile((id \
          52b4fdfe-f315-49f0-a338-4f85213efc43)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -229,39 +229,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a9685485-7dd8-42b6-b8b3-a51dae3a1a98)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cc52d021-f684-4960-a8b0-d98cba864151)(content(Whitespace\" \
+         4527e65c-e5fd-4e4c-9063-92a2a820503c)(content(Whitespace\" \
          \"))))(Tile((id 1c2b2fa4-b023-4e27-bd1b-48edb7029d44)(label(\"\\\"c \
          is not in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         44537ab7-9df1-46ed-8784-4da408a21cd2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         49519acc-f891-4d10-a6f4-c454ce35c8fe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         309996fd-8fee-4871-b675-bbc076e75a14)(content(Whitespace\" \
-         \"))))(Tile((id 138cd38d-b1e8-468f-8179-56c8cc8ccafd)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         6b1348b3-6fbd-4232-ba24-3fe978bb5adf)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         6d8964ec-f6f9-426f-8047-dcf3ad9344ed)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         a5b7134e-09e5-4677-aec0-3fa9752f5b6d)(content(Whitespace\"\\n\"))))(Tile((id \
+         138cd38d-b1e8-468f-8179-56c8cc8ccafd)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         65014a22-9a3f-4513-bcdf-cf49559645f0)(content(Whitespace\" \
          \"))))(Tile((id \
-         9b4c983a-fdb1-470d-9485-2c419b581f39)(label(ensures))(mold((out \
+         9b4c983a-fdb1-470d-9485-2c419b581f39)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         47620c34-7906-4a1b-8059-9ff247c0fca2)(content(Whitespace\" \
+         4bf18c1c-2015-4aee-b27b-1101de95159b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9dc8b19c-8cfc-48b0-970f-d092c7e8d227)(content(Whitespace\" \
+         de3beeb1-ff70-4038-a2a9-8e7e8fa797e3)(content(Whitespace\" \
          \"))))(Tile((id aabf0cbf-cf81-4596-a253-9f9f73f5b3d3)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         85396bbe-cc01-44f7-b2c8-c2292b9d4207)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3afef8ca-a6fa-4ab4-8475-9832aa8081ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9e24c21-ccbd-4cbb-a850-e404d595beff)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d7d34d16-b778-4012-928c-788299cc433a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a79a5d0e-0905-452e-a517-55bbf82d191c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e8dc101a-c384-4d98-9851-5ebc7e815933)(content(Whitespace\"\\n\"))))(Tile((id \
          2cd68f53-b619-4e92-a7cb-eb5735ac8530)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -290,15 +280,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          304682de-0cd1-4e8d-a722-1fea93896944)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         01711bd5-1c72-42ef-983f-1e207e5e1885)(content(Whitespace\"\\n\"))))(Secondary((id \
-         93618499-4454-4491-88fb-768ddf9efb8c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         74c90564-aa71-440b-b5b3-9d1fd0592e13)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9207ae50-e39e-4d05-bfe3-f3652972182e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac1bc1c7-1c16-407b-8c08-f303a36190ed)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f3d926ca-971c-40af-8780-e491501190e3)(content(Whitespace\"\\n\"))))(Tile((id \
          3d9da1fb-496b-432c-ac5e-107a80c29e43)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -327,19 +309,11 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e5f4b9ac-cc1e-444b-aec1-3a1b869cfab0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a3b8afca-e4b9-4305-8de6-ac91fffc807b)(content(Whitespace\" \
+         aa47a7f9-ef89-46f9-890f-1c4b95d948d6)(content(Whitespace\" \
          \"))))(Secondary((id \
          2c2eb25a-1699-463a-b595-7c251ccd81e3)(content(Comment\"# Assuming \
          user passes tuple extension #\"))))(Secondary((id \
-         9fd0b12d-c34c-4b67-b873-ac5b2b0ea838)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1ce044c5-581d-48e3-bc45-60162c1fe018)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3173c15d-fadc-4df6-aebe-b4d547857b6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7d1639a4-2867-44a7-a372-f6b1cb09e357)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         da1ad0a9-1b86-41fb-a671-d41fb7e52409)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b361a453-e852-45ba-b716-b2c1793151b2)(content(Whitespace\"\\n\"))))(Tile((id \
          a4a47c81-811e-439a-b546-c4162197c480)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -368,19 +342,11 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0e9b271e-8a3f-4994-9b0a-ac48104f621a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         77dc50b4-85e0-4ff9-8e15-52d4174a99d9)(content(Whitespace\" \
+         7ffbe05f-4fc4-40f3-880b-73459e2c1af0)(content(Whitespace\" \
          \"))))(Secondary((id \
          fd57ff7d-177d-4f57-a496-2baef805b24a)(content(Comment\"# Assuming \
          user passes tuple extension #\"))))(Secondary((id \
-         4539a87b-5152-4503-9bc5-c73195afe0f4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         621c929e-b02c-40ad-b7a5-11a78230a1fc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bf03305d-f0ef-4cdb-b37b-375abd1f8a09)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0a976b8e-e8a6-44d9-8439-e991706d466b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f4737cd7-c009-4dd4-93b7-9270505993ce)(content(Whitespace\" \
-         \"))))(Tile((id \
+         1fd1e53a-e6e9-40be-9a4b-12f85f8b0bde)(content(Whitespace\"\\n\"))))(Tile((id \
          1fbf1225-dc04-461a-8d8a-26f773720994)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -409,29 +375,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          90272874-bd83-42fd-8874-cf0391085432)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0bb4ee5c-b857-46bf-bac4-2957286720cc)(content(Whitespace\" \
+         077a8f50-804a-434e-a47b-a263e13d3d30)(content(Whitespace\" \
          \"))))(Secondary((id \
          dc58214a-f96f-45c1-a822-79cdc696a3cb)(content(Comment\"# Assuming \
          user passes tuple extension #\"))))(Secondary((id \
-         0ef1391d-b351-45d4-afe9-97bc63029b79)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8af908b0-53d2-4d7b-b522-9d93be0e1543)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c4c7e7da-41a1-4a1a-83b1-15324ec5c9a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6cdb2b31-ebf7-4161-b1fa-05bc74a7bc17)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         88ae71a8-6674-415c-a1ae-1d42336e25f2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         046f2677-2132-4961-940e-515b71f95096)(content(Whitespace\"\\n\"))))(Tile((id \
          3cf4065b-4ea0-47f6-9567-f1bfc61449f9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          f8201ca0-7630-41a8-a33c-807ee79ad5b2)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c7fa0d61-40e2-4779-84fc-c337ee2c9575)(content(Whitespace\" \
+         \"))))(Tile((id \
          9d6eee93-2b62-4a32-849f-207dbe884f98)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         48c46d35-1a9d-48b2-8cf7-46cf7cecac1e)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         44f08102-468e-4b35-9ce4-56a16efcbab4)(content(Whitespace\" \
+         \"))))(Projector((id 48c46d35-1a9d-48b2-8cf7-46cf7cecac1e)(kind \
+         Checkbox)(syntax(Tile((id \
          0df30a7a-b071-4b6c-bd34-ba9db3cfd8e3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -441,81 +403,67 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e0208a75-6854-46bd-80e6-50e2505afc33)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         097002b7-8b1e-4fff-a4df-3973bcaf54f9)(content(Whitespace\" \
+         5524c5a8-0429-4643-84c5-72d51bdd802b)(content(Whitespace\" \
          \"))))(Tile((id \
          cef3ced1-3c35-4651-a9e4-58f9d89255ae)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5baf1451-6473-423a-8d36-d58f78f3731e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b7703962-26f8-4492-8b32-d51c78935f2f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8d47a08-3966-4cb8-aed3-855eaad483fb)(content(Whitespace\" \
+         0f2e2fac-8a87-4171-9af5-f6326dd9f6b2)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         76dbb817-08ff-469f-9926-5910a4a68ea0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1c473b33-4616-4579-9e55-acbfed289b78)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         369bfd02-750c-4b9c-8a91-c7def1f8af9d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ee727c2d-27cd-4a75-b555-2a26d595c5bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         74ea20b7-4745-4899-9a5d-4fcdf07806b0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8a738c5e-d0c1-437b-a9a2-bc0b0c957698)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4e89ebbe-8ed5-403f-8146-d5e9e9096961)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e501f2e7-6899-45a4-856b-4ab03d7f5ed5)(content(Whitespace\" \
-         \"))))(Tile((id 82b5843b-6b71-4826-9d4c-309408ef01ad)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c5f1c120-83b8-4378-90dd-61435a296082)(content(Whitespace\" \
+         69b040a8-653f-4a36-967d-21b850975ccf)(content(Whitespace\"\\n\"))))(Tile((id \
+         82b5843b-6b71-4826-9d4c-309408ef01ad)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         fd279007-aff9-417a-a408-8fd45af41c1a)(content(Whitespace\" \
          \"))))(Tile((id \
          d3784c11-53d3-4b84-b994-23bb7b7e75b9)(label(build_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         344a61e8-65f3-4be5-842f-5e54e764351e)(content(Whitespace\" \
+         1f9c0dfc-8653-487c-bf4f-d6891fdb92f7)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b15da1be-43f9-42d6-88e5-ea0a79ca54ca)(content(Whitespace\" \
-         \"))))(Tile((id 20320799-38a6-4489-8e31-2a3d56fe8c90)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         c96c02a9-9d55-4e7a-9898-2979e8fa38e8)(content(Whitespace\" \
+         d3261a0c-c3d5-4cd8-83a0-0e19328debae)(content(Whitespace\"\\n\"))))(Tile((id \
+         20320799-38a6-4489-8e31-2a3d56fe8c90)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a35e49ac-49d5-4bc3-bfb6-b6c6fe1e0707)(content(Whitespace\" \
          \"))))(Tile((id \
          69a8963d-b969-4a8f-a5b4-9fc97d56c235)(label(r))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         79393653-cea6-44b8-9139-82ea0fe54b81)(content(Whitespace\" \
+         2da94cad-5d2c-4809-9894-28f07e13df80)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         de2ac542-2148-4c2a-86c0-72d63314afd9)(content(Whitespace\" \
+         4ac35d20-65e4-4de7-8482-4bd63657369e)(content(Whitespace\" \
          \"))))(Tile((id 333e79d4-0d83-4437-8a13-8be03826b022)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         8f827ff0-df53-41fd-810e-cfc1cb573824)(content(Whitespace\" \
+         da59f49d-f644-42a5-b021-14fc8944b658)(content(Whitespace\" \
          \"))))(Tile((id \
          d8057c65-6a65-4362-9b03-3db7bd7315b9)(label(v))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         d6eb7d68-db35-4016-ae26-36bf298fb0d4)(content(Whitespace\" \
+         9e5d361e-b116-4c33-aece-a65b9d943fdf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d9cd33a4-45eb-4193-a396-dad9e5ef9493)(content(Whitespace\" \
+         b5660c80-5fa0-46d5-b299-08fd654ee2a0)(content(Whitespace\" \
          \"))))(Tile((id 734ee947-96ef-4561-b4f6-79993bac8277)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a6b8d95e-7280-4d17-a6c3-d4ff1202e03d)(content(Whitespace\" \
+         1218065d-6e6a-4e4c-b43d-1c4a6b8bc4a3)(content(Whitespace\" \
          \"))))(Tile((id \
          f04d14e2-35dd-4169-a768-f4a275f0d600)(label(r'))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         a1df3a0a-afb4-475a-8b2c-c5d08e5b28ca)(content(Whitespace\" \
+         f7b9f1e8-b4a0-4988-93ee-c0a24b05cbff)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1b7f04a9-a892-46b1-8421-098fe00efdb5)(content(Whitespace\" \
+         7776a0b3-8222-428b-a329-40339dfb5fd6)(content(Whitespace\" \
          \"))))(Tile((id cb60a49f-f615-4626-b9ab-433c6aa65337)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         951e2685-fa03-49ef-9742-446e73417200)(content(Whitespace\" \
+         1fcaccfd-3726-4bd6-b880-21d09f3589e2)(content(Whitespace\" \
          \"))))(Tile((id \
          4b0180ae-5e5e-4b6c-a459-2cdb66121599)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -523,12 +471,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c225a400-98c0-45e2-9ed1-2fd7cc7bec9b)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c03df5a5-2737-4c05-8ab6-7ad7c7f88250)(content(Whitespace\" \
+         071c2baf-e88c-4091-80d5-1d65c1a242d6)(content(Whitespace\" \
          \"))))(Tile((id \
          5846a89e-d9ce-44f3-b041-bc2a1b62fa63)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2e7443b9-8921-4835-bd2e-d8aebf129dcc)(content(Whitespace\" \
+         62b939fc-7453-45b2-b7c3-c7341d6ce2d8)(content(Whitespace\" \
          \"))))(Tile((id 78738858-651f-4f5e-8495-7f28628d8e60)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -538,17 +486,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6e74140e-f921-4e20-ace7-677521d119e5)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         a508ec6b-cfce-4b52-b8d4-534102e58275)(content(Whitespace\" \
+         c14c5bd6-bdfe-4d86-82a2-5e159091652e)(content(Whitespace\" \
          \"))))(Tile((id \
          f39b1565-858d-4e15-b987-b4a1d0636238)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2b3695df-ab42-4138-aebe-538733491d08)(content(Whitespace\" \
+         301b0c8e-0d2b-4e3e-95ad-cb16ee4ef3e5)(content(Whitespace\" \
          \"))))(Tile((id \
          9fb4fefc-ea3f-441e-8b7a-c41302eb528d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8908ea60-fe1e-45df-ac09-21525019456f)(content(Whitespace\" \
+         c3914866-f12b-4109-93f2-23a96f9f8fe5)(content(Whitespace\" \
          \"))))(Tile((id \
          ac5c0347-11d0-4be1-9eb3-6adeda736f4a)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -562,17 +510,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4f3fd9c7-b3f4-4b9b-90ba-e9ea3418edbf)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         60c09fa7-4345-45fb-824a-a0f58310bc36)(content(Whitespace\" \
+         2516e399-030d-45e8-8989-3c877cac3ade)(content(Whitespace\" \
          \"))))(Tile((id \
          4bedfae1-6a79-4962-ac99-40650a699506)(label(v))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         5ec306cf-2d12-4cb1-bfc2-a6ca3bd6510b)(content(Whitespace\" \
+         831e01b6-d75b-4e32-ae97-ca1457c0dace)(content(Whitespace\" \
          \"))))(Tile((id \
          a3924bfc-66ce-4832-bf3b-7c152354d8ec)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f296d97f-4874-42ec-bd1b-d8009a2c850d)(content(Whitespace\" \
+         184ab5b9-867a-4fc9-a0d4-72ccd51f9726)(content(Whitespace\" \
          \"))))(Tile((id \
          16a90083-3cd6-45a9-90dc-822e4f19597e)(label(r'))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -580,15 +528,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ffb8fe98-df61-4c73-90ac-f02d6aac9caa)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f31c721d-a1e5-4263-8c22-18a9aeefc148)(content(Whitespace\" \
+         36e74cf5-675c-4626-920d-29cad3ab6ee1)(content(Whitespace\" \
          \"))))(Tile((id \
          0571e2c5-4817-4d3a-a2b9-7ad563b80555)(label(f))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         222bca66-16a7-45bc-a0ef-deee3ac1cb69)(content(Whitespace\" \
+         \"))))(Tile((id \
          b70af8b7-c5f7-46ce-83d0-4b779fbf8ae5)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         53bb97a9-212b-4900-826e-12d585e13656)(content(Whitespace\" \
+         e9ce304f-7ec5-4c7f-931f-95dcdc400482)(content(Whitespace\" \
          \"))))(Tile((id \
          941ec5ec-b548-412e-85aa-0ee8e2a241f5)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -596,26 +546,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          89f5e74c-1d15-47af-a638-e8a53102f30f)(label(r))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         09f1533d-5e20-4f57-b0ee-8208cbfb23f6)(content(Whitespace\" \
+         3858045c-7030-4940-95e9-284f2aef234d)(content(Whitespace\" \
          \"))))(Tile((id \
          5b88faf3-8875-4e3b-90f2-579f18d298aa)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b420e167-cde7-416b-b204-99247bef4aa4)(content(Whitespace\" \
+         29945695-c479-4583-85fb-48ea4289ec94)(content(Whitespace\" \
          \"))))(Tile((id \
          8956a427-82c0-4193-81bc-366c98afb1bc)(label(v))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         31f4aee8-791d-44f3-ab17-0506f6d92963)(content(Whitespace\" \
+         6ddb31c9-bc5a-4cb8-9c34-6ddd6ab6a1dc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3d2334c8-7a05-4165-99ae-f1916390bac6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         756c1620-878d-45ac-be7e-921cbbf4cd75)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         124f0867-e4f3-4630-b8c7-e3e790ba20fb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         679016b9-9fd1-40f7-9dbb-bd3c7da9a1a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         079c4631-0d87-44df-8d00-7d121d4dfa83)(content(Whitespace\" \
+         9e5a9a46-d284-43c1-bf07-7395059ffd52)(content(Whitespace\" \
          \"))))(Tile((id \
          eefb5f2a-bc5a-4b5e-b01c-f07ba32cfdeb)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -629,19 +572,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          69988785-3da7-45d7-8596-d88fb787b16a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3d067ccc-a94f-4ca4-a099-6f469c7934b7)(content(Whitespace\" \
+         33188188-8bad-44a0-afc7-f27d0c679ac3)(content(Whitespace\" \
          \"))))(Tile((id 60881db1-dbce-485a-ada4-273c8ba099bd)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         5058745a-2220-4efc-bb67-16212b6f154a)(content(Whitespace\" \
+         a64fdda7-4506-4dd2-842d-d57fbb6d58d5)(content(Whitespace\" \
          \"))))(Tile((id \
          e3c53d71-6657-4d4a-8651-f0bdfd58890a)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2edf2550-14a7-42f3-b733-072ea42ea331)(content(Whitespace\" \
+         787a9ed6-6fd9-4bc0-b05f-bafdde16e565)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b094b6ce-53a1-4402-9d65-f29a99d463ee)(content(Whitespace\" \
+         ac707b33-5a16-4a16-8fa0-173fd4aee554)(content(Whitespace\" \
          \"))))(Tile((id \
          0d79d9cd-116d-4ac2-85b6-51b55f676c33)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -655,7 +598,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c05217ca-b9fe-43a2-90e7-f66e14113c72)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3b75764f-8ae4-4ffc-9763-8e1121b2a7f4)(content(Whitespace\" \
+         40bc81ff-dec4-4323-a413-98bc030dc317)(content(Whitespace\" \
          \"))))(Tile((id \
          55215881-7d47-45ea-8b02-a84371cdfd85)(label(f))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -666,152 +609,116 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4962dbaf-83c7-455e-af56-5f914d1fa211)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         97376a62-0747-4c5a-a0f9-eb3b3e783704)(content(Whitespace\" \
+         a2463b60-ed99-424e-a23b-537aedd076c7)(content(Whitespace\" \
          \"))))(Tile((id \
          b9c545b4-7e61-4550-9bcf-530d93eadab1)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         23292fce-5d1e-40c1-a7ba-da944a1ccf41)(content(Whitespace\" \
+         8246e351-4a65-47bb-affc-2ef34f06f6bf)(content(Whitespace\" \
          \"))))(Tile((id 465711e3-5a89-4e69-997e-48ca6956e280)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          6a2fe9cd-8c83-4be6-a9c0-43b4f0e79dd2)(label(r'))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         66a1abfa-0ce7-4b58-b358-af7a3061c715)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fd7d773f-d7af-4a49-b164-5cda06798afe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e83e75ec-f2f8-44bc-a25f-3dd13900c768)(content(Whitespace\" \
+         4c8cc4bd-b391-439e-9945-987cb5afa744)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9a91d8f3-9b20-4f22-9ec3-33c411427e15)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9f28cce9-94eb-4b88-839d-69552bd78e7a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1901669b-3c38-4915-95ff-05b8b6c2d92d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3fe8a1c1-54f7-44ed-92c4-2d525e898a47)(content(Whitespace\"\\n\"))))(Secondary((id \
-         93154f62-0ee8-43ec-8950-d94eccc27bcd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9e8eaf44-e1ee-4082-9df6-6b45e4e991d3)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         6c358960-b3d7-456e-b3a9-3eeeec46e967)(content(Whitespace\"\\n\"))))(Secondary((id \
          05369f11-2a95-4313-87dd-6085b54a7e66)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         c2998c67-57e6-435c-9237-1f3cf8107bdc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         024cfab9-f7b4-4162-959d-7b7307f6d74c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         038fefdf-bb5f-42e6-8e94-d878304c0adc)(content(Whitespace\" \
-         \"))))(Tile((id f00230ae-da0b-412d-a6f3-36d9744897a2)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         41f2f35d-4ad1-4f21-ab3d-60633b939058)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         faa2b3e1-0265-4126-8669-b07d3c737a1f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3fe291ad-1f56-4f51-9b4d-3e59c7e0be5c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4c2343e1-c3f2-402f-89f7-a9896307fb10)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cd654455-ba09-4540-b147-40be7915e986)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e45237af-4146-4e48-a9a5-9d3111e377c1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9745e1b7-e73b-400e-b6c0-4edc4b1afa9f)(content(Whitespace\"\\n\"))))(Tile((id \
+         f00230ae-da0b-412d-a6f3-36d9744897a2)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         e37884ce-d52a-4590-be36-7793a743d9e5)(content(Whitespace\"\\n\"))))(Tile((id \
          087ecfbe-e1cc-4c73-808f-33c8e43b4eb1)(label(build_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         1813c165-6dab-46f9-b6ff-16bbd8e2c8ed)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3b9a8345-d16c-4553-86cb-1a3fc3c38d0a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1720e3f8-13ca-4e84-94b2-76abd96588c2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         71225c01-9f48-4e67-a77f-e3102da719dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8f19112b-6c87-49f7-a0a4-bb8609bb2226)(content(Whitespace\" \
-         \"))))(Tile((id c0ae755f-4dbe-4dc9-8b2d-d21993eead7d)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c0ae755f-4dbe-4dc9-8b2d-d21993eead7d)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          c425a429-dcd5-45c8-945b-aa16cc0c5987)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         4390bb0c-851f-4a99-9ead-ccf3e5624d1b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d9a4128d-42d2-4044-986d-adf451c418e3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         14de8670-647d-4be6-9dc9-77f8e2a5646f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cdb14edf-5a00-46ba-b55d-31b4319d2c11)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         93ef5003-97ca-4a94-b5c0-b229e8bcb48c)(content(Whitespace\" \
-         \"))))(Tile((id a2c1d71b-d374-40b0-976b-b037b0336dfe)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         a2c1d71b-d374-40b0-976b-b037b0336dfe)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          72b8a894-7ce8-4f96-a017-aa8d3b5fb4f3)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         60b4717a-7c6d-402f-8442-9decce860389)(content(Whitespace\"\\n\"))))(Secondary((id \
-         11c9d560-65d7-48c1-8fa4-366ca124c68d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e3ef2e61-70d8-44bb-94b2-82522264a4f4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ce399ee-45d6-4663-83fe-0d2fb5567895)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6ab6250e-1594-4285-b968-9da3c2c56b48)(content(Whitespace\" \
-         \"))))(Tile((id 811207a8-f0ca-4fc3-99a0-f4d734671b69)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         811207a8-f0ca-4fc3-99a0-f4d734671b69)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          3a5a68f5-997a-46c5-95db-eba05ac557cd)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          0dea8d57-8b68-4b3b-b5b4-eb95c7926622)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         39705df5-9843-4c6e-b7a6-e1ca035a12f9)(content(Whitespace\" \
+         \"))))(Tile((id \
          b1a4dc1d-0cbd-4eb6-b0f0-ccc99aea202a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         81740df9-e1d0-4a27-b122-a5ad45e5bdb1)(content(Whitespace\" \
+         \"))))(Tile((id \
          a5c5f4e8-fded-4765-a6c9-fd02726be72a)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          964adf7a-0c3e-4e87-975b-bbd68417575b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e76741a2-7ba5-4deb-99a6-b9bcb08c007f)(content(Whitespace\" \
+         \"))))(Tile((id \
          9f68d398-9acc-4e29-b7d9-ff3ea2ff24f7)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         be1b37f1-2009-464b-8c44-31f946f28ec9)(content(Whitespace\" \
+         \"))))(Tile((id \
          ac45ecd3-b799-4244-b107-aef479fc8088)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4ef00f9b-8777-4954-9e01-faf4f7724717)(content(Whitespace\" \
+         \"))))(Tile((id \
          dc74c162-b53e-4409-804e-482989da23d6)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f9954b49-e8f7-4e6e-be2b-3ee2cab07499)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         722f2d58-9a09-43bd-8c89-89985a538734)(content(Whitespace\" \
+         \"))))(Tile((id \
          09d24419-3b00-49af-b7a0-1d2f26200171)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e4a6f7bf-8043-486d-9115-6f1b3925cfd8)(content(Whitespace\" \
+         \"))))(Tile((id \
          2d505a34-35ef-44c9-8ddc-dac15a6a0c99)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dbe16e34-c0f1-4239-9e20-f3097eb2f4d1)(content(Whitespace\" \
+         \"))))(Tile((id \
          f0a199e6-9986-47d0-8c47-e0f22385465e)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          1661fb83-9b3f-4aae-939d-8003e018a676)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b27938dd-9985-4591-ae9c-391634ec3633)(content(Whitespace\" \
+         \"))))(Tile((id \
          45e9a4cb-c8d9-4caa-8b8e-e3915b160747)(label(`is-teenager`))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0f310dff-cb49-4a10-ad88-c25b2a95d46a)(content(Whitespace\" \
+         \"))))(Tile((id \
          8c2eba31-44c7-4810-83cc-067ab4db985c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         872c9713-50fd-47f2-b015-fa78a1930cdb)(content(Whitespace\" \
+         \"))))(Tile((id \
          5832acba-4ae6-4172-8058-dd1c81aeb151)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         468e0e8f-a013-4b85-b76e-95c84c30abf9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         875fb71c-f76e-4fb8-97d8-a86f1da86d24)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a4556dbe-9a5a-47ad-b169-5375cee2950e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         93c17a4a-275b-4611-a91e-00140be22070)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e5baebc1-20cd-431b-9e3d-0192502227ad)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Typ))))))(shards(0))(children())))))))))))))(Tile((id \
          68651d28-bab3-496e-a61c-982dbe80669e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -821,12 +728,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c47fd6e4-c7e7-4396-86d3-e7639876d700)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         443b15b3-26cf-43c6-b5b1-634b42b51630)(content(Whitespace\" \
+         63e92a5d-6331-4311-b978-ee53274b0ae8)(content(Whitespace\" \
          \"))))(Tile((id 7af53e4b-97ba-4539-9393-ee989c8f9b51)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         fc74bc94-6501-416b-bb79-2ab2410a167a)(content(Whitespace\" \
+         b1e4910f-a1ae-4fe9-995f-f597a6b1cf93)(content(Whitespace\" \
          \"))))(Tile((id \
          d3b52a07-ac0b-4056-b6ee-d252ad45cdd2)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -837,51 +744,57 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0b19234d-2eac-44f3-aeff-49a8d368ad52)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         0f14f678-b229-4c64-b84a-6211fad3b965)(content(Whitespace\" \
+         30a6536d-0a30-40c7-9ec6-ba038c03c08a)(content(Whitespace\" \
          \"))))(Tile((id \
          5e1227d0-7194-45ad-a2a8-fed2be59b75d)(label(b))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         8cd72b04-e400-4ef8-a692-ab865fb3bc7f)(content(Whitespace\" \
+         d3efbc54-803a-49ca-8c0a-0141f5cfab9f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         45bc23da-12d7-4a5a-a7aa-0455ca7f258b)(content(Whitespace\" \
+         5e385da2-76a4-4fc9-8977-74f5e7e67408)(content(Whitespace\" \
          \"))))(Tile((id \
          755f4f31-0e14-44c6-b9c0-2ae018a49c45)(label(s))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d8a95306-a07d-4a36-93be-67f899de6bc9)(content(Whitespace\" \
+         0ec7c59d-356f-46e0-bd1c-7936bd65599b)(content(Whitespace\" \
          \"))))(Tile((id \
          61b08dc3-6154-4b17-8bc2-6fbf0c32a1c2)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         636cbc39-02dc-4d3d-8594-ba3d1e76734e)(content(Whitespace\" \
+         \"))))(Tile((id \
          f5c07d05-64ef-45db-9570-b707a0eb5fce)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          de0a18a8-84b8-4ad9-95c8-29e28a3f337d)(label(`is-teenager`))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8ed6d4f9-2883-4496-9a22-5f5e65163b41)(content(Whitespace\" \
+         \"))))(Tile((id \
          51e3e599-8ccc-4b99-9877-4f990bbe437d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ea6e59bb-f38b-48ef-9d25-5ea7377a7eff)(content(Whitespace\" \
+         \"))))(Tile((id \
          10d30ece-84c0-4315-9d8c-b2b7e4d17265)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
          8dcade7f-e7cf-4d22-8926-77358e2652f3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4ccbbc86-cbcc-433c-8714-dbdde13d8fc3)(content(Whitespace\" \
+         e77773cd-1979-4665-91fe-a28f35c205e9)(content(Whitespace\" \
          \"))))(Tile((id 02d5d8b2-017d-45cc-82fd-5eb2fc38b02a)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         5d46b84a-119a-4843-95af-a514ab912789)(content(Whitespace\" \
+         7ea0803e-48ff-49aa-b683-0bf083b4d812)(content(Whitespace\" \
          \"))))(Tile((id \
          8c832e1c-8329-42db-9ff3-07e843d6e0e3)(label(student))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6e9292c3-544e-421f-a5a8-916aca264f38)(content(Whitespace\" \
+         cfeb0070-1c67-4bfe-9a1f-883e142ef145)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3d074187-5021-4e27-9f53-12be9d4899ac)(content(Whitespace\" \
+         53b2c509-4239-4205-8fe7-04fae3eaa9ba)(content(Whitespace\" \
          \"))))(Tile((id \
          c76c4139-c8d1-4ea3-99da-6eb95020e2b1)(label(student))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -892,22 +805,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d881a02d-03bb-4b19-8f2e-dfb6f3d498c1)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         3fa917fc-0be1-4966-9801-9cec082ea667)(content(Whitespace\" \
+         7169f078-f241-439f-91f0-e1378fa47ff0)(content(Whitespace\" \
          \"))))(Tile((id \
          f306205a-584c-4cd8-9285-ea56149e6211)(label(>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         76828d0f-4027-48c5-89d6-cfd8d30d9134)(content(Whitespace\" \
+         9918b821-6683-442e-8a7a-06daca4ea959)(content(Whitespace\" \
          \"))))(Tile((id \
          34c6efc6-fea6-4d7e-8609-12355ef799dc)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         cb6d6790-6f30-4f3d-8527-b4e8c85ab228)(content(Whitespace\" \
+         6a47f239-4ece-43c6-b485-6a6c7406769b)(content(Whitespace\" \
          \"))))(Tile((id \
          3e8785b2-e1c8-4cde-81d2-44f16896ecb7)(label(&&))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 32))(sort Exp))((shape(Concave \
          32))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c2bba0b5-a815-4333-bce7-25a7ee5adbc2)(content(Whitespace\" \
+         42cd7661-5d58-450f-a688-045d0d243f96)(content(Whitespace\" \
          \"))))(Tile((id \
          6765c24b-2310-42aa-9100-9bb988c6713f)(label(student))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -918,51 +831,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e4f59c0c-4223-4621-979b-aff558d3c446)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c60a2dc9-6ae3-4a82-a1c2-cac6235e2b24)(content(Whitespace\" \
+         5b2dae4a-9796-4f36-a1ac-7ed0a2aeaa86)(content(Whitespace\" \
          \"))))(Tile((id \
          58974e81-e5a2-4da8-bb61-b2082feba322)(label(<))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1ac7f710-da56-47a9-aad9-c2bea43af6f6)(content(Whitespace\" \
+         d3fb806d-c1b7-4647-9b6d-c6f629b9b146)(content(Whitespace\" \
          \"))))(Tile((id \
          ff8d33db-53f7-46b0-990a-9c399e1defa5)(label(20))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1a1f74e2-9bb1-4d5a-b82a-c35a007f45cd)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ea1dce70-e95a-4f78-b8cf-14719be14a09)(content(Whitespace\"\\n\"))))(Tile((id \
          e2e53d0c-24dc-49d9-b61d-1a0c3746d54d)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         98c0d02d-3d6f-467c-b891-3c730179dc32)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bbf86227-f8e3-4558-8526-ab1f157cd2bb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ec06619c-a0f4-44e2-a17a-2291311b2b95)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6b0c066c-76c2-43cd-92e9-83758c326c5e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a345ecfb-9c49-4f7c-ad31-7788586903d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eb3f8b1b-708e-43d7-9bb9-3642479d8edf)(content(Whitespace\" \
+         6f46082b-3aab-4f29-bfd0-7317ca172c60)(content(Whitespace\" \
          \"))))(Tile((id \
          165f6f3e-53cb-4f2c-aa74-310671dab70a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         3f5d521a-53d1-4f28-be9f-fb76f49c37c1)(content(Whitespace\"\\n\"))))(Tile((id \
          4aa651c3-96d4-4ac5-a6c4-f57e1258adcd)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         bdc61499-2a72-449d-a998-de055032b2be)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4e8d8433-0e9c-420b-89ba-47b2fbc8b0dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab421395-2e2c-449d-abfa-5aea5c52f764)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         20c59a4f-12dc-4496-99c0-6cdc8fc2b734)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ea25d5a-8b6a-4d1f-ac67-a02bce995ea9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e75e969-cc5a-461c-bc2a-64a93c92a708)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dd5090e5-d2aa-4746-982d-c6ce0d309b2e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          c86cccfb-5716-4793-b749-229c0f9ec8cf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -996,18 +887,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          af8fa224-59d6-401f-86c1-38ebad3ffe41)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         deb1d583-1bbd-4725-bec7-c0dc8f4abf20)(content(Whitespace\"\\n\"))))(Secondary((id \
-         010745ac-9209-49d1-a201-f2f2fff36cb8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7aac2ae9-41f4-418a-b76c-13d5654bfeb0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33f7dc9c-f7a2-4daf-93a2-b6436b58eff5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1fd24266-a4d4-4a9b-80fd-3b548f532172)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0478c1b4-b578-4c6f-a791-df2a61fe1081)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d83fb658-70ee-462f-8fc0-8e5e30a5560e)(content(Whitespace\" \
+         19ea18ce-b805-42ec-8b59-d750ff37e88d)(content(Whitespace\" \
          \"))))(Tile((id \
          783dfc26-dc6b-4006-a5a5-e0be0f1b507e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1042,18 +922,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6d12e158-57b9-468e-91fd-235ab59b309f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d9a68f63-91e4-4774-9372-2559bf42725b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fb05548c-861e-4f29-836c-801c7b063b52)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d4b962e-2692-4bcc-8935-c9a88752e695)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         02bf1eff-fee2-492d-8600-0f94e00e20a5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c9261e5e-d67f-460a-92e5-fe69867a875b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         129054a3-c331-4e9d-accc-37eb2660e831)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         26363234-fdcb-472c-8ed5-8a2afc4d21d6)(content(Whitespace\" \
+         736c208e-1357-4f84-8922-0e410b654ee9)(content(Whitespace\" \
          \"))))(Tile((id \
          a291f851-b2a6-416f-adf6-c2935db0c56d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1064,7 +933,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9b1341f5-b783-4ee9-9f00-7aaeeff03e78)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         90742622-9e98-4111-b04f-14a4f08b758b)(content(Whitespace\" \
+         1b2a0d74-1fac-4be7-840d-2529627fe0db)(content(Whitespace\" \
          \"))))(Tile((id \
          779e2cb6-86b4-43d1-94c0-e5b108b8ee7a)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1072,7 +941,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a1484fb3-1ac7-4bc6-bc1c-fbf4c42def5a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10e6e10f-5994-4ae3-8e06-9e873515172a)(content(Whitespace\" \
+         80449bbb-a71a-4fd3-b2eb-fba3a2f38798)(content(Whitespace\" \
          \"))))(Tile((id \
          608553fa-3dee-4b3b-9094-fdde1d117069)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1080,26 +949,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6d62c34c-c4d2-4262-b551-e6dfb256cea0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0241016b-d1ac-4039-930d-e244904647e4)(content(Whitespace\" \
+         9d5d67e5-3f37-4562-ae5d-1076291fafe4)(content(Whitespace\" \
          \"))))(Tile((id \
          ca70c289-c589-4995-95a8-2dbd17514997)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         cd401e82-767b-472c-acef-7be99571149a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         654c2bf8-2782-48ed-ada5-1944b0a7556a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b0f2e0bc-bb11-4b1c-a6d7-040f1b68bbb6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         66c4cbda-1920-4fc1-bf2d-ddcdc186f657)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b0d8169b-eb05-4d57-86a2-69157c29300a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         eced4281-b62c-40cc-875a-6d55d331a311)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         8544270e-03b5-4711-b9b7-0e8a029331ad)(content(Whitespace\"\\n\"))))(Tile((id \
          9bdc255e-8950-46f3-9869-7aca73a319a1)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c612609a-7bf5-451d-aacb-dc061d1d37f5)(content(Whitespace\" \
+         660e20ac-daad-4dbb-a82e-9ecd249391f4)(content(Whitespace\" \
          \"))))(Tile((id 3ee7e871-063e-46b4-a3b4-7960a9c7b2c7)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1108,94 +967,105 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          0f1d27a0-b552-4cc8-aeca-6ada6d17f020)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3edfa3c5-7c7d-4be0-9741-5774aceaf23f)(content(Whitespace\" \
+         \"))))(Tile((id \
          85982c63-3562-437c-b145-4ab0b6e00f5e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2f38bd42-0512-41c5-b28e-27afa3092080)(content(Whitespace\" \
+         \"))))(Tile((id \
          355e875d-9773-41fa-b0a4-5118c6140826)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          1bf2f67d-5283-4552-a0d7-00ad7501caaa)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d1dead34-f385-4bdd-9fb7-fe51eb08238f)(content(Whitespace\" \
+         b21acb72-9c99-4343-8632-123d20c90ac8)(content(Whitespace\" \
          \"))))(Tile((id \
          de2d311a-3745-4639-8cda-a2ca99e4c011)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5f315f3b-9ebe-4366-a6d4-4cfb087c7e94)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a7baaf3-89e4-4e9b-9953-caa7210242ed)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         403d6447-7a34-4e5f-be40-f3aa6e9e0b9a)(content(Whitespace\" \
+         \"))))(Tile((id \
          60f191ca-67a5-4373-83ae-8a6781b710c6)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6d4d7bd1-b103-4fa2-81a5-a665a012e0af)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9e62cf0f-2e76-496c-95ff-5abda1be7600)(content(Whitespace\" \
+         4a2a4ec6-74a3-47a9-9797-2f44edbca5c8)(content(Whitespace\" \
          \"))))(Tile((id \
          f83913f9-0a4f-4425-b8e5-b6ca0ec8d8f3)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         67b8a6cf-9700-484e-a0d7-1b656cdb9c95)(content(Whitespace\" \
+         \"))))(Tile((id \
          ad9b90a8-b844-43a6-ae5e-013ea8b30e5c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1b8bb6d4-3fd1-49c7-a4c2-16b50815288e)(content(Whitespace\" \
+         \"))))(Tile((id \
          e6705139-65cb-45f8-9fc8-b575a7df1fd7)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7074f8e0-c615-4ff2-9702-140142198745)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bc604fe9-a81d-4f5b-99fc-bdc79ad1fd4e)(content(Whitespace\" \
+         1edd0b22-7d13-4d7f-8e4f-1e130376d527)(content(Whitespace\" \
          \"))))(Tile((id \
          7275d9a3-afcb-4fbb-ada0-18ad021c3bb4)(label(`is-teenager`))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         072a7cfe-8eaf-4bed-83de-921bb38fda05)(content(Whitespace\" \
+         \"))))(Tile((id \
          11b3c0a0-fae1-418f-802d-44390913c056)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a03c6252-a7f2-44f4-a38f-49bee2f3355b)(content(Whitespace\" \
+         \"))))(Tile((id \
          499f55f9-d808-4d3f-91fe-23ae418e653d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         f79f95aa-4e2b-44b2-9b1e-b0aa28b93d7b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d270e0f1-36e5-4eca-8e23-c82dd1f0dbb9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         798b3f0c-1466-4967-be26-a67fd0863ef5)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         c768159f-fcd1-4649-9a4c-7feefa8de164)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         d2f56ecd-507e-463e-94da-74d0364a04df)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e8935a17-b78a-4cd9-ac71-10c046b5d9c2)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         b0e8fd81-228c-4b4c-a1d2-ae889c0a7fe3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e2a7b14d-38b4-44b0-b8d7-d4a20df991a5)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d4e5616f-2843-4730-8344-60dccf64bfd8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f5e160a6-9bd9-460d-a98e-ef3541cd5c7b)(content(Whitespace\"\\n\"))))(Secondary((id \
+         90332067-5646-4241-be2b-297cdbb968ca)(content(Whitespace\"\\n\"))))(Secondary((id \
          193e4aed-e5a2-423d-a475-ad446c8d978b)(content(Comment\"# V2: This \
          version more closely matches the TableAPI and takes a string column. \
          Given the lack of row polymorphism no constraints are ensured \
          #\"))))(Secondary((id \
-         592e8e48-c9aa-436e-a596-951317b25fab)(content(Whitespace\"\\n\"))))(Tile((id \
+         ec26c33d-23a8-446c-b52e-d7298727d0fd)(content(Whitespace\"\\n\"))))(Tile((id \
          0489bff0-4e17-4eca-8197-c5fd67d1e84a)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         69eebc88-5cc8-48ca-873a-ea3222c5042e)(content(Whitespace\" \
+         25c1aae8-57ba-4c76-a3d8-7bbe41262ed5)(content(Whitespace\" \
          \"))))(Tile((id \
          8d43b257-2a9e-49a1-b105-870e248ea10a)(label(v2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7e4dba64-4959-4f19-9da7-1e581e370878)(content(Whitespace\" \
+         4ac64225-1ca0-48e8-8fde-903bb18a7c60)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4c88e5a1-1a35-4a47-877f-604ecf16dd20)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bdd56f13-5a64-4411-972a-7351b2407dcf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c108cd15-b1ab-4a34-b909-6d1bc36d9a7c)(content(Whitespace\" \
-         \"))))(Tile((id 83e64191-a134-4548-95de-5425f45e6435)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         6b22fc16-2809-462b-9b74-dab5c8073695)(content(Whitespace\" \
+         8a2292ce-fea4-4420-962d-730ac26683f2)(content(Whitespace\"\\n\"))))(Tile((id \
+         83e64191-a134-4548-95de-5425f45e6435)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         74c3a4f9-596e-4f8b-9d7a-c4834179f485)(content(Whitespace\" \
          \"))))(Tile((id \
-         fd40dabf-42a9-4662-9a04-e842591a3e6b)(label(requires))(mold((out \
+         fd40dabf-42a9-4662-9a04-e842591a3e6b)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7ee370a9-9127-4f0d-bae7-659ab1aed4a9)(content(Whitespace\" \
+         33d029bc-ae3f-4d8f-959f-2ef5cd924838)(content(Whitespace\" \
          \")))))((Secondary((id \
-         52c38ced-82e8-45ab-b594-f3269f95c573)(content(Whitespace\" \
+         0b881499-bfc9-4f92-8d0c-d7d47572cd27)(content(Whitespace\" \
          \"))))(Tile((id 1c2d8382-f63e-4743-94cd-dfbc6a8d528e)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1204,11 +1074,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          85a7cba8-0380-4715-91cb-493b4d212be9)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9e524517-d127-4db6-a680-2c321e5d470a)(content(Whitespace\" \
+         \"))))(Tile((id \
          3492fcb5-a5aa-4864-86dc-332db27f1350)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         51fb472b-affd-4889-b1e3-d508049e319b)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7e4653b4-5ee9-422e-9d00-46942c87fb8b)(content(Whitespace\" \
+         \"))))(Projector((id 51fb472b-affd-4889-b1e3-d508049e319b)(kind \
+         Checkbox)(syntax(Tile((id \
          888a762f-209d-44aa-8841-a9e843d2de36)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1218,39 +1092,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d2e10440-6dd7-4ef1-b5eb-6491b481d620)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6a6b4363-fcd6-4356-b2c4-e575e643b69a)(content(Whitespace\" \
+         5364d084-806d-423a-a596-f61de7c872f7)(content(Whitespace\" \
          \"))))(Tile((id 3d4e5517-0d60-41fe-a59a-d301e80a10d4)(label(\"\\\"c \
          is not in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         78abee3a-02aa-4dd0-ac62-bba3e138f9b9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         54597d67-c8b0-4874-89f0-a5c3597ce713)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fb949867-6f08-4923-aa74-ad8468cfb9e2)(content(Whitespace\" \
-         \"))))(Tile((id 33065cb1-1203-474e-9b18-3ddef0842ff4)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         009766ae-738b-4c70-90d1-5d4e96ee5c59)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         e8934ca8-6a14-4156-b17d-3604b28c58d1)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         fea44c96-f893-4cd5-a762-21860c62ccdc)(content(Whitespace\"\\n\"))))(Tile((id \
+         33065cb1-1203-474e-9b18-3ddef0842ff4)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e26c961e-3510-4553-bdb7-bd57d21e5313)(content(Whitespace\" \
          \"))))(Tile((id \
-         86614656-4cbf-4f07-a767-3bfb3e993bae)(label(ensures))(mold((out \
+         86614656-4cbf-4f07-a767-3bfb3e993bae)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d1871d0a-3eb5-4395-bd85-8f61849852e7)(content(Whitespace\" \
+         8d24e5ec-d5ee-4ce5-a8b8-d085466cc82b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         bee752b6-fab1-47be-b14f-cf347d65955f)(content(Whitespace\" \
+         46e8cbc2-73c2-46ca-bb86-ebd7ef3dd1fe)(content(Whitespace\" \
          \"))))(Tile((id 50495046-7e58-4fe8-a73d-7b7a66f39cc1)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         1b0b9593-494d-42a9-9b5a-b37a079ec3bd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4534ce6a-09a0-421a-90d6-93dc73e6096f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a986639b-8978-472f-b5c6-eaaa4fc1817e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         786d3b56-8662-4d75-b9a1-0f2f39a252f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b096aef7-86f4-48d4-808f-e4ae5f27231f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         75f1d99f-afec-4f92-b3f7-9c00de71be8c)(content(Whitespace\"\\n\"))))(Tile((id \
          7ac34663-e561-46ac-b22e-a449081bc585)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1279,15 +1143,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          36acb3d8-2c17-40a0-b953-dc9965ca6c09)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         01f0f32a-00c9-4251-8cf5-c07862771b1d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         78f6f39a-db5b-43d6-9739-19c865c7eb60)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d97f6158-4fd6-41ac-be81-4b8e5d21399c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1460bae2-e60b-4c0f-b616-a3f46cc77610)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9e6a379f-a744-4c3f-aca4-e0c0f2855089)(content(Whitespace\" \
-         \"))))(Tile((id \
+         10b77cee-ec49-4d6c-b383-d8d377ad1978)(content(Whitespace\"\\n\"))))(Tile((id \
          463bea6f-2f7e-4365-b5af-d7bc6e2c4d8b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1316,15 +1172,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5abd9311-a396-4697-aec8-8e47b8bfb624)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0b17ef28-96c6-4ed4-a472-21fecb146b37)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b6db0e6e-80cb-4760-ad83-16c06d2814c0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         00c96d2b-4948-4613-92e8-a7569e58c95a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         be64c6aa-d9e4-477c-9e80-947cb71c3bc8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         084c2508-d4cb-43c3-b1e3-ae8165e95575)(content(Whitespace\" \
-         \"))))(Tile((id \
+         90d16ad6-124a-4396-8df7-147375248217)(content(Whitespace\"\\n\"))))(Tile((id \
          6a866f50-a2c5-4c09-9c26-dd7b50cb7b7e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1353,15 +1201,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d3d577c4-a716-436d-8c42-073414b3ff81)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7e70ae69-40e2-49ec-bd57-c25386f3bdb2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cd5bd212-78e0-44d5-ac59-2eb129f145e3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3acf0b1a-a647-43b4-9743-e65bd116fd25)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8a3c86d9-064a-4356-8e0b-51677d48ac59)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f8aea104-9091-4e4a-8c7d-240706cc9f8a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d2ba27d2-80e8-4714-85f0-3ad90f1cd7d2)(content(Whitespace\"\\n\"))))(Tile((id \
          e7302834-feeb-493c-ba83-270fa667f13a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1390,25 +1230,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a082fa6b-4fa0-4182-9c3e-e147e8799f3e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         81af98cd-91f5-4d97-ad7c-ea0473ef5ae6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         db2fdf27-12a0-498e-8d8c-490dd41f1264)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea1859c1-5c7a-414a-b48a-3986cfdaced5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f55569e3-cb97-43ca-a460-b2b6a4a6002f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4003f94e-acd7-4e91-af48-7f3d98093de3)(content(Whitespace\" \
-         \"))))(Tile((id \
+         24eca0bb-802f-4a16-a4cd-f13108f2717e)(content(Whitespace\"\\n\"))))(Tile((id \
          72e6c408-997c-4e25-b798-448cafcc22d8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          6ab052c4-31b6-438c-a93d-1b0758ffdec6)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         5765213a-b68e-448e-aeb1-ca1aeda2210d)(content(Whitespace\" \
+         \"))))(Tile((id \
          50325bff-4f05-4309-8f2a-9a8ba5bb55fe)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         a2e45ec5-c663-44c1-a6c3-b9ff8132b234)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9d2f2333-02aa-4e46-8914-75ad7f1e0012)(content(Whitespace\" \
+         \"))))(Projector((id a2e45ec5-c663-44c1-a6c3-b9ff8132b234)(kind \
+         Checkbox)(syntax(Tile((id \
          665a4cf0-6350-46a4-81ca-b5bb5e3fc717)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1418,48 +1254,36 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cb563918-60b6-4b6c-a683-23caad0c428e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c0d48cc0-2744-4d2c-a743-1e7c552541ec)(content(Whitespace\" \
+         d03d45e8-23aa-4f3b-9656-6ef01de1f891)(content(Whitespace\" \
          \"))))(Tile((id \
          1652e1a2-e1ae-458e-acfa-dc3f8b379444)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fdbfb8b7-875b-4c95-a4c9-d5ebd936c0e2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         43663035-5aac-4167-95df-f65477c83b3d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bed35aac-96fa-4cb3-aac5-894cba4ea679)(content(Whitespace\" \
+         4342be61-c478-46d3-b6b4-d5a998523f24)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         cd00e912-7137-4907-b3a8-63e24f3ba49e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         52a8dce3-c416-4317-b22b-80316086ad92)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         349273db-1799-42d6-9b7a-c4b18b726b84)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8b8cb0ef-754d-4d37-9ec3-8c914a7d02e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a7e3c460-4ce1-43cc-b06b-b750c3c02d24)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         f32a6806-da1f-48af-9bed-68b5902a4a2e)(content(Whitespace\"\\n\"))))(Secondary((id \
          6da6f2c1-302a-4d43-9aea-a5c79703a9cf)(content(Comment\"#Lack of first \
          class labels requires writing this with from_lvs and to_lvs. With a \
          known column v1 should be used#\"))))(Secondary((id \
-         ba1b5e49-8788-48a5-aca8-8d1dfe955180)(content(Whitespace\"\\n\"))))(Secondary((id \
-         13e6996b-2c09-4db8-b79f-0c76bc501e0f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4cb60eae-33ff-4014-ac0e-1513596d4c2e)(content(Whitespace\" \
-         \"))))(Tile((id e485e11e-eaca-45bc-8969-735613922314)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ef190165-d163-4b01-a947-727d8f433ed7)(content(Whitespace\" \
+         7b4af96c-dc9e-481c-9ee1-db192715ce82)(content(Whitespace\"\\n\"))))(Tile((id \
+         e485e11e-eaca-45bc-8969-735613922314)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f7eb4983-fa0c-4153-9438-e13f1fc76a34)(content(Whitespace\" \
          \"))))(Tile((id \
          c7b55988-47c7-4fe0-995d-f776c6d55f9d)(label(build_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6a6a2d09-e9da-4e7d-9ed8-bb449da86a29)(content(Whitespace\" \
+         6be81eeb-dca5-4e77-83a7-636af6e16c23)(content(Whitespace\" \
          \")))))((Secondary((id \
-         950d7fdd-b21b-486d-aef3-af52eefbe395)(content(Whitespace\" \
+         33f42d10-cecd-49b7-abd1-40c308e7d735)(content(Whitespace\" \
          \"))))(Tile((id f21354ad-f103-481e-b7dd-651c22dc33da)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         151adf4b-0524-4c99-a638-33344f556773)(content(Whitespace\" \
+         2bf33038-5968-4e92-86e1-634c1cc77816)(content(Whitespace\" \
          \"))))(Tile((id \
          a3d384cf-164f-4846-88e1-e124911fd5a2)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1467,71 +1291,67 @@ let out : string * Haz3lcore.PersistentSegment.t =
          41709df6-8ae8-4d86-a54c-7797f7f25099)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         dff96547-aedb-468f-97a7-b7c6e7bf8bb4)(content(Whitespace\" \
+         22d3f4b7-6b9e-4c20-a8c9-27cd5112b00c)(content(Whitespace\" \
          \"))))(Tile((id \
          be0ac8b8-f2a7-4ebe-b3eb-261850ba04b2)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         73ae7c6c-7a87-499c-aee3-382f4998e123)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         91485252-547b-445c-a217-a553104e54ff)(content(Whitespace\" \
+         \"))))(Tile((id 73ae7c6c-7a87-499c-aee3-382f4998e123)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          0ea57182-ee89-4c0d-a4f2-aa136823334b)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          c6764925-57c0-4721-b60a-ec9da94c9436)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         c5e1fa22-fd6c-4f3b-a197-5f1ee20abf43)(content(Whitespace\" \
+         d4067494-d4d9-4693-8098-887f76a103a6)(content(Whitespace\" \
          \"))))(Tile((id \
          a7135a70-1c56-4cb1-8377-2a672434deae)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c2d20298-40f1-493b-bb49-dbee089f3a1f)(content(Whitespace\" \
+         71024520-182a-47cf-a0a6-006391b8c44b)(content(Whitespace\" \
          \"))))(Tile((id \
          554d1420-53c3-4d22-bac7-2bf54317b34d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         691461b9-9fb8-412c-963c-3231776a4ee2)(content(Whitespace\" \
+         \"))))(Tile((id \
          bee233b8-41a8-4081-9079-921d33e36b7a)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          89e982a8-56fe-41f0-8442-12f42ad4104b)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         9d6023fb-3d81-4f84-ac52-42f7644a1903)(content(Whitespace\" \
+         12323c90-e391-4fc2-846d-b2374bcee2b8)(content(Whitespace\" \
          \"))))(Tile((id \
          05254681-a1e9-46ab-8aa5-02539250dcfc)(label(f))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6d3b24b0-221c-439f-a44f-eb2a4ea38181)(content(Whitespace\" \
+         1ddeaf6d-d5e9-48c2-ac5d-39bacf63f38d)(content(Whitespace\" \
          \"))))(Tile((id \
          a62f98ca-e7d8-4c00-b9e0-ca6bb0a83559)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         295ab0e0-6496-40de-a361-53c140baa800)(content(Whitespace\" \
+         a8d1e9ac-ed31-4a5e-8968-d2325f5a00aa)(content(Whitespace\" \
          \"))))(Tile((id \
          9cb4e6a0-9261-42f9-b44f-34bf49bff2c9)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         0c66a243-1325-4c35-8dea-0274f11f8be8)(content(Whitespace\" \
+         b41455b9-d88a-440b-b63b-1a33ce5cf729)(content(Whitespace\" \
          \"))))(Tile((id \
          8f3018fd-c928-4e8d-9fa8-fd2370172426)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b42a8f0b-8819-4b45-b9fe-6df791eeb36a)(content(Whitespace\" \
+         e58882d5-3093-4ba8-9ed3-577619d2f995)(content(Whitespace\" \
          \"))))(Tile((id \
          b9464385-c242-465c-8f1c-438302b16ba4)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a0ea222f-f6c9-4b7a-a4f3-552fe8b7a1f6)(content(Whitespace\" \
+         54692b11-ef53-48ad-a1bc-dde1c9789da6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8165153e-8831-4f8d-8a91-3e585f6a7e7e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         02d05c11-4c75-4ca9-8300-948608c1fe70)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         792d627f-162c-4606-b83c-16d32e2afb7f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc59d538-3f82-4c2c-a465-3bd88bc7f089)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cfa60813-f2fa-4ad2-8251-e58b6ea08311)(content(Whitespace\" \
+         aa5fa1e6-760e-48b3-9a30-96a469ef0f19)(content(Whitespace\" \
          \"))))(Tile((id \
          e0b4bf20-33eb-4d83-be64-e3d64639acbc)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1544,11 +1364,13 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          117ec82e-82ce-4641-a29f-a56c65a05b46)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         94ff25c7-d3fb-4161-893d-7c1250b053c7)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         444b21e8-c5fb-4566-9420-838ef01c6753)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         13b31e24-e775-47cc-ba41-0049879f71f7)(content(Whitespace\" \
+         \"))))(Tile((id 94ff25c7-d3fb-4161-893d-7c1250b053c7)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         adb68a86-2ba3-443d-9c24-2a9001125e02)(content(Whitespace\" \
          \"))))(Tile((id \
          258d7454-5c48-4aef-8ca5-62227d867e64)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1556,8 +1378,10 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ee715358-5e85-4cb8-aef4-1d8f3af93e6e)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         000f46aa-322a-4554-9e83-03e2f43bc638)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         b9bdd3b2-11c3-4163-bbde-aef5609c4332)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d83aac32-82f8-4c49-b0fc-e09b3b20ec22)(content(Whitespace\" \
+         \"))))(Tile((id \
          9881be81-e9c3-44c9-a802-305d24d5dc97)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1573,14 +1397,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3307eaaa-d69a-437b-89d3-acbd80b7b03c)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1994be2d-70b1-4766-88dc-4328ac5b536b)(content(Whitespace\" \
+         3b171738-d76a-4a58-9b13-228da2e1f408)(content(Whitespace\" \
          \"))))(Tile((id \
          8aa23dbd-e65b-4ada-9dbb-c08f10abfe30)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         d4398f1b-abe3-4328-9cca-83e038da8949)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cc0e6fbf-aea4-4d22-ba63-7ad0b1de905d)(content(Whitespace\" \
+         \"))))(Tile((id d4398f1b-abe3-4328-9cca-83e038da8949)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          f916a611-140a-4617-8d71-8e923aa7797f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1589,7 +1414,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          4376eaca-12ed-4d27-86fb-0f3acc7167a3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e531c2e2-d3f9-4413-8705-3b731b7eb2e0)(content(Whitespace\" \
+         \"))))(Tile((id \
          d3f1063e-0a94-4746-b9dd-0942f881d25e)(label(f))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1599,29 +1426,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7772ffb6-c61c-4e57-87f6-dbc93b338f66)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))))))))))))(Secondary((id \
-         9ef6b9e3-2346-4a22-b5bd-7236a65ea7c6)(content(Whitespace\" \
+         8b37fb05-58c3-4978-9cc3-9448461e2ce2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         094ba75e-f6a2-43de-8f20-c6d27f9c8995)(content(Whitespace\"\\n\"))))(Secondary((id \
-         02fac2c5-cd01-4729-999c-ca1cf493d3f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         84aa6e85-f6f7-451a-99af-1b4c8441c70c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5356ca60-8b7e-4b31-994c-3d5273c6ae41)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fbfa69e0-36da-4740-b1df-54de10c02e41)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2585011-cb72-4438-928d-ae72be2e5405)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         58979cd9-5db9-424f-8c58-097638b0f881)(content(Whitespace\"\\n\"))))(Secondary((id \
          414381df-8a2f-4833-bb4a-9a35853c8307)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         8e2d2467-ee98-499d-96dd-c6ca8617f55c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5d981a6a-c768-4e93-b16e-37f9ca470e27)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c85890c6-f5c3-4814-8011-41fcdb8ec866)(content(Whitespace\" \
-         \"))))(Tile((id 46ea739d-40a0-4f91-977b-e18590840c28)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         8cfeaad0-51d3-4d92-a3d4-de0223052295)(content(Whitespace\" \
-         \"))))(Tile((id \
+         bd4aa0ca-997a-444f-beb8-540955a17886)(content(Whitespace\"\\n\"))))(Tile((id \
+         46ea739d-40a0-4f91-977b-e18590840c28)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         7b5ffd15-e3aa-4ab0-970d-bbc38dd53d26)(content(Whitespace\"\\n\"))))(Tile((id \
          ca18950d-50f3-4ca5-b7d1-af5836b106ec)(label(build_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1634,7 +1448,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b64de8a0-c5a4-4a4a-b0a3-65f7d001f596)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5b9086d8-b4fe-4e50-9cd6-ac475377c238)(content(Whitespace\" \
+         7bb27d5f-da2b-4099-8503-1c619e7985cf)(content(Whitespace\" \
          \"))))(Tile((id \
          9a09dc2f-11d3-4c45-930b-c15128ed19b4)(label(\"\\\"is-teenager\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1642,19 +1456,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c002e46c-cb44-4a53-81dd-9d0e4a1d83ab)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7df881e3-1909-44d7-a704-619c87efd1a4)(content(Whitespace\" \
+         8574bd5c-ff6e-4272-abc2-17ccbc4a4411)(content(Whitespace\" \
          \"))))(Tile((id 93532098-2f9b-4966-9a38-e9bece82533c)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         5583c001-c8ab-4645-8e4d-d2d25036f07e)(content(Whitespace\" \
+         2e08ad0e-f344-4dee-b2e2-7d84e8ad94c4)(content(Whitespace\" \
          \"))))(Tile((id \
          00215539-2cba-4994-bfe7-53e083bc65e6)(label(student))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         af2ff639-3c39-4768-848d-8abb0b8ffde5)(content(Whitespace\" \
+         97f99cfc-d3ee-4684-b64b-251e6b0c0051)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4bf73a56-8543-4899-91bc-eb972000258a)(content(Whitespace\" \
+         d3b69b2f-6aa8-401e-8de9-2e0442d2cb41)(content(Whitespace\" \
          \"))))(Tile((id \
          1452cd0d-7675-44d1-bbfb-f3b58b34ed1c)(label(student))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1665,22 +1479,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0e1b3edf-ea17-4eb8-93ae-2a24d4b0d7c3)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         7d0ca236-f357-455a-a32d-0aaada288cf4)(content(Whitespace\" \
+         f4fc658b-7587-4cc8-adf5-59927ab5ca43)(content(Whitespace\" \
          \"))))(Tile((id \
          7420a67b-c834-4c83-b117-dd0fff7d0a57)(label(>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2cd58799-ddc7-4a49-bdb7-b2916ab1992b)(content(Whitespace\" \
+         d2ff08e2-aa3d-4228-9c6a-5f6d4bc3a9d1)(content(Whitespace\" \
          \"))))(Tile((id \
          21c12f1e-294a-4ad4-97c5-0c535985b673)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         03a830ea-dad1-4347-a8c9-347d50078c73)(content(Whitespace\" \
+         eb8cb5df-e6f9-4bd2-b306-a50f7befb883)(content(Whitespace\" \
          \"))))(Tile((id \
          1225e4ad-e289-4469-93ac-e0514fd0de0f)(label(&&))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 32))(sort Exp))((shape(Concave \
          32))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3af57978-0971-4f23-9506-074bdc89fc6f)(content(Whitespace\" \
+         3da4dc33-6f51-4384-a8ee-c9458b1dc78c)(content(Whitespace\" \
          \"))))(Tile((id \
          25903ec6-4e83-4763-9319-d6532421c105)(label(student))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1691,38 +1505,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          72c9c628-6bae-41ee-871c-d40dbf87c049)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         3d4e3668-8185-4cdd-b3aa-e14fee275361)(content(Whitespace\" \
+         b6de6b6c-85c6-4da6-b0c6-24188c967e42)(content(Whitespace\" \
          \"))))(Tile((id \
          58b34e02-7721-485d-9ea8-1e5b7f14f3b8)(label(<))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         64a39cf9-1400-414e-847b-64ce1de2555c)(content(Whitespace\" \
+         57c39fd8-564d-4a0b-8ac3-f941c481b73b)(content(Whitespace\" \
          \"))))(Tile((id \
          97ea0d23-77c2-4c80-9ac1-f8b0c5c8c5ad)(label(20))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4b85f7ba-5c6a-4040-bad9-4c88fdab0cc5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9e42c62b-9325-4043-a1fa-eb3a2ce20982)(content(Whitespace\"\\n\"))))(Tile((id \
          1551a234-010f-4bc9-a3db-097471c68ce7)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         972a68df-377a-405b-9ee7-1e03b94f5b2c)(content(Whitespace\" \
+         4c5e29ef-02e3-4897-a536-61aa427bb393)(content(Whitespace\" \
          \"))))(Tile((id \
          3c1490b1-b041-4dea-9ec7-0fda843a9e9a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         fcca8487-8237-483e-b888-af6ed6882a6d)(content(Whitespace\"\\n\"))))(Tile((id \
          4bb5cb52-2415-4764-afac-fc2ffa21685b)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         5d03c250-cc39-4de9-a8d7-14362134c55b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a1563554-382d-463e-90bb-b64b09fdb7d7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb4e73db-92cc-44df-90ac-a88949dc5489)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7fa6f6fb-710b-464d-b19b-3b099511c814)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f6797f37-e0c4-45fd-af10-025346905e9c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          34e36ef7-aafb-4208-a0bc-bc41020c72bb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1756,14 +1561,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          06bc69cf-8bf0-428b-9db8-b83da7a67e8c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2768f0b6-e281-4652-b316-125b73b93c16)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a42af377-132f-4411-9c58-2e7cf7d96d6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6361fe2d-425e-4039-87f5-2dcba937b638)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bd508d00-6236-4561-9982-1ef22e8c20c1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         00d85eb8-7037-4f14-9fec-ab1f166cb5be)(content(Whitespace\" \
+         4bb9f6cd-9ada-4745-b575-df338d63cb92)(content(Whitespace\" \
          \"))))(Tile((id \
          8f5eafc5-60be-4aff-8564-e1c8e96fe888)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1798,14 +1596,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4406a1ee-8f74-4422-bbad-1432c07366ec)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10b46cde-6538-43b2-a7d7-b2b971d375de)(content(Whitespace\"\\n\"))))(Secondary((id \
-         88feb3ff-78fd-48ca-badd-e88668913629)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bbf4aabf-e801-4e0a-9474-a3bb248b82f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1f46d7b2-4e29-477a-a42d-60f097aaf939)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8c25ab8a-ddaa-4490-9094-c9ad4ced9242)(content(Whitespace\" \
+         a3945d31-6ba9-4d95-acb2-dced8a90f2f7)(content(Whitespace\" \
          \"))))(Tile((id \
          d278dc99-2065-4c39-b138-dfcf02ecff59)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1816,7 +1607,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b4c3c43b-7ac7-403e-b863-c833d726bbd1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8e55cc40-079a-468c-b885-b313904476fe)(content(Whitespace\" \
+         3da3354f-5c20-459a-9e73-a462e040fa04)(content(Whitespace\" \
          \"))))(Tile((id \
          f87b487c-214e-41c0-aec4-5d4ad7d3bac7)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1824,7 +1615,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b9863adb-ce0e-4b01-91c9-b0801a07ab95)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         74b2c6e0-9a3e-42c3-ab9d-c701b763e14f)(content(Whitespace\" \
+         6dbbdd87-8ce9-44f3-b55a-386524a90b72)(content(Whitespace\" \
          \"))))(Tile((id \
          20d5e1f2-79df-4d82-b7d9-5fff6aa61ad3)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1832,22 +1623,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c9c129f0-e8ba-4eae-a829-1472c1ed6e21)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e8f69f67-1df8-430c-b872-3bee45d6aa01)(content(Whitespace\" \
+         c8df88df-acf5-4489-b71d-83c2dfe68bc7)(content(Whitespace\" \
          \"))))(Tile((id \
          5825344b-12c4-4728-be1f-c755d3a7ddcc)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d2ef4f01-ef51-4f94-8151-e41999b00ae3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f5004e54-89ea-46f4-bbcd-f7d8714d6d02)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         165e28b5-ed25-40ef-a580-46d9abbcdff9)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d38bd8ea-c3af-4143-aecb-054e162d4e34)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         54f66420-645d-40d3-9bc3-a4eddcf663e5)(content(Whitespace\"\\n\"))))(Tile((id \
          ecf64724-d3eb-4fb6-a9fc-da90c1e1d6fb)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ff7bb4d8-80b4-43fe-a6a1-dfab10a2e80a)(content(Whitespace\" \
+         17683075-2b9b-40c8-93db-c49eeb069dc3)(content(Whitespace\" \
          \"))))(Tile((id 3733b4d4-d3e6-4a13-96ba-de4e08fe7318)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1856,136 +1641,144 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          f1a8b18d-a819-47ab-afcf-560a892a7463)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e26e1a66-f62b-4c3b-8f66-7ca9dc4030dd)(content(Whitespace\" \
+         \"))))(Tile((id \
          4b5f773b-c056-4332-a9c7-17cc8f59fa13)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cae7406f-5226-49b8-9db8-02ae584bfe47)(content(Whitespace\" \
+         \"))))(Tile((id \
          2854af77-f4e5-4d9a-8dcc-16a114231190)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0141d213-a9e6-4cce-b2f0-d41080810f78)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2ed9ed89-c093-4dab-a971-3b26e191c5a5)(content(Whitespace\" \
+         557ed4ee-7f4f-4754-98db-7b89e15a7884)(content(Whitespace\" \
          \"))))(Tile((id \
          dc14e3f4-53f7-43e7-bb46-7efab8903662)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         47547573-3506-4a80-928a-24e8134330c5)(content(Whitespace\" \
+         \"))))(Tile((id \
          2267743b-19e2-4f19-be6f-5d8afe590492)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8419d249-f8d5-4fc5-be8e-d8ec132b70c6)(content(Whitespace\" \
+         \"))))(Tile((id \
          dc57d3e8-bc62-4d9a-850a-29ba835c0101)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          363e29d7-b589-4ab0-9fc6-935949104762)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         41f488c1-e78f-44b0-81ed-574c58fc183c)(content(Whitespace\" \
+         e2ce2208-5501-4b8e-87e1-2aa57cf80ef9)(content(Whitespace\" \
          \"))))(Tile((id \
          4b84e312-58f9-4213-98e1-55d86692d500)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cb3d99e9-6643-4a02-a50d-1e20d5bb02bc)(content(Whitespace\" \
+         \"))))(Tile((id \
          b3d1d9ea-b14a-49c1-8b79-4c7858d81b64)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         58046392-4d25-4505-98c1-0a3d682aea3a)(content(Whitespace\" \
+         \"))))(Tile((id \
          a71ad80f-9a91-483c-a0d0-67bc067b2092)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d06e1f0a-4c69-4c01-bb5a-cb722b484b4d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a2096c1f-000b-42ba-b605-e8136d95c016)(content(Whitespace\" \
+         aa832982-1f5e-48bc-b2b4-c3e53a9892b3)(content(Whitespace\" \
          \"))))(Tile((id \
          021b9397-ba4e-42cb-a115-02d0198e61e2)(label(`is-teenager`))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bae184a5-e5a2-46ad-adbc-96b4428efacd)(content(Whitespace\" \
+         \"))))(Tile((id \
          2b4b1583-9418-4c32-b063-c73eb8840e8a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         91fcca2e-896f-4ce7-8762-f5a8e7545b40)(content(Whitespace\" \
+         \"))))(Tile((id \
          92b2191e-bc8e-4c51-bedf-07e9cedf1814)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         40ee3abe-a1e8-4b18-a460-7d37edc14254)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         01f98a29-7f5d-4727-8248-c5b082341ead)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         8ee485b6-f0c4-42d0-9423-c5fc12218d58)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         3b34f946-95ca-41b6-a26f-f222606a5a12)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         db238bd3-bfdd-4e77-b412-dee4389531a6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         69697727-27df-4d87-86fc-90b3d1a11118)(content(Whitespace\"\\n\"))))(Tile((id \
          f7494667-8ecd-4b63-ace7-dbf0bc2342f8)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         0f570ec0-3485-45e9-af66-fc21d9bc4413)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
-         let students : [Student] = [\n\
-        \  (\"Bob\", 12, \"blue\"),\n\
-        \  (\"Alice\", 17, \"green\"),\n\
-        \  (\"Eve\", 13, \"red\")\n\
-         ] in\n\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = [(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")] in\n\n\
          # V1: This version is a higher order function that takes a function \
          for constructing the resulting row offering more type safety #\n\
          let v1 =\n\
-        \  let requires = [(enforced=^^check(false), \"c is not in \
-         header(t1)\")]in\n\
-        \  let ensures = [\n\
-        \    (enforced=^^check(true), \"schema(r) is equal to schema(t1)\"),\n\
-        \    (enforced=^^check(true), \"header(t2) is equal to \
-         concat(header(t1), [c])\"), # Assuming user passes tuple extension #\n\
-        \    (enforced=^^check(true), \"for all c' in header(t1), \
-         schema(t2)[c'] is equal to schema(t1)[c']\"), # Assuming user passes \
-         tuple extension #\n\
-        \    (enforced=^^check(true), \"schema(t2)[c] is equal to the sort of \
+         let _requires = [(enforced = ^^check(false), \"c is not in \
+         header(t1)\")] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(true), \"schema(r) is equal to schema(t1)\"),\n\
+         (enforced=^^check(true), \"header(t2) is equal to concat(header(t1), \
+         [c])\"), # Assuming user passes tuple extension #\n\
+         (enforced=^^check(true), \"for all c' in header(t1), schema(t2)[c'] \
+         is equal to schema(t1)[c']\"), # Assuming user passes tuple extension \
+         #\n\
+         (enforced=^^check(true), \"schema(t2)[c] is equal to the sort of \
          v\"), # Assuming user passes tuple extension #\n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  \n\
-        \  let build_column = typfun r -> typfun v -> typfun r' -> fun (t : \
-         [r], c : ((r, v) -> r'), f: (r -> v)) ->\n\
-        \    map(t, fun r -> c(r, f(r))) : [r']\n\
-        \  in\n\
-        \  \n\
-        \  # Examples #\n\
-        \  test \n\
-        \    build_column\n\
-        \    @<Student>\n\
-        \    @<Bool>\n\
-        \    @<(name=String,age=Int,favorite_color=String,`is-teenager`=Bool)>\n\
-        \    (students, fun (s, b) -> s ...(`is-teenager`=b), fun student -> \
-         student.age > 12 && student.age < 20) == \n\
-        \    ([\n\
-        \      (\"Bob\", 12, \"blue\", false),\n\
-        \      (\"Alice\", 17, \"green\", true),\n\
-        \      (\"Eve\", 13, \"red\", true)\n\
-        \    ] : [(name=String, age=Int, favorite_color=String, \
-         `is-teenager`=Bool)])\n\
-        \  end\n\
-         in\n\n\
+         (enforced = ^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
+         ] in\n\
+         let build_column =\n\
+         typfun r -> typfun v -> typfun r' -> fun (t : [r], c : ((r, v) -> \
+         r'), f : (r -> v)) -> map(t, fun r -> c(r, f(r))) : [r'] in\n\
+         # Examples #\n\
+         test\n\
+         build_column@<Student>@<Bool>@<(name = String, age = Int, \
+         favorite_color = String, `is-teenager` = Bool)>(students, fun (s, b) \
+         -> s ... (`is-teenager` = b), fun student -> student.age > 12 && \
+         student.age < 20)\n\
+         == (\n\
+         [(\"Bob\", 12, \"blue\", false), (\"Alice\", 17, \"green\", true), \
+         (\"Eve\", 13, \"red\", true)]\n\
+         : [(name = String, age = Int, favorite_color = String, `is-teenager` \
+         = Bool)]\n\
+         ) end in\n\n\
          # V2: This version more closely matches the TableAPI and takes a \
          string column. Given the lack of row polymorphism no constraints are \
          ensured #\n\
          let v2 =\n\
-        \  let requires = [(enforced=^^check(false), \"c is not in \
-         header(t1)\")]in\n\
-        \  let ensures = [\n\
-        \    (enforced=^^check(false), \"schema(r) is equal to schema(t1)\"),\n\
-        \    (enforced=^^check(false), \"header(t2) is equal to \
-         concat(header(t1), [c])\"),\n\
-        \    (enforced=^^check(false), \"for all c' in header(t1), \
-         schema(t2)[c'] is equal to schema(t1)[c']\"),\n\
-        \    (enforced=^^check(false), \"schema(t2)[c] is equal to the sort of \
-         v\"),\n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  #Lack of first class labels requires writing this with from_lvs and \
+         let _requires = [(enforced = ^^check(false), \"c is not in \
+         header(t1)\")] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(false), \"schema(r) is equal to schema(t1)\"),\n\
+         (enforced=^^check(false), \"header(t2) is equal to concat(header(t1), \
+         [c])\"),\n\
+         (enforced=^^check(false), \"for all c' in header(t1), schema(t2)[c'] \
+         is equal to schema(t1)[c']\"),\n\
+         (enforced=^^check(false), \"schema(t2)[c] is equal to the sort of v\"),\n\
+         (enforced = ^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
+         ] in\n\
+         #Lack of first class labels requires writing this with from_lvs and \
          to_lvs. With a known column v1 should be used#\n\
-        \  let build_column = fun (t :[?], c :String, f : ? -> ?) ->\n\
-        \    map(t,fun (r) ->from_lvs(to_lvs(r) @[(c,f(r))])) in\n\
-        \  \n\
-        \  # Examples #\n\
-        \  test build_column(students, \"is-teenager\", fun student -> \
-         student.age > 12 && student.age < 20) == ([\n\
-        \    (\"Bob\", 12, \"blue\", false),\n\
-        \    (\"Alice\", 17, \"green\", true),\n\
-        \    (\"Eve\", 13, \"red\", true)\n\
-        \  ] : [(name=String, age=Int, favorite_color=String, \
-         `is-teenager`=Bool)])end\n\
-         in ?\n";
+         let build_column = fun (t : [?], c : String, f : ? -> ?) -> map(t, \
+         fun (r) -> from_lvs(to_lvs(r) @ [(c, f(r))])) in\n\
+         # Examples #\n\
+         test\n\
+         build_column(students, \"is-teenager\", fun student -> student.age > \
+         12 && student.age < 20)\n\
+         == (\n\
+         [(\"Bob\", 12, \"blue\", false), (\"Alice\", 17, \"green\", true), \
+         (\"Eve\", 13, \"red\", true)]\n\
+         : [(name = String, age = Int, favorite_color = String, `is-teenager` \
+         = Bool)]\n\
+         ) end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIConstructorscrossJoin.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIConstructorscrossJoin.ml
@@ -6,91 +6,96 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         1e3cd3ac-405f-4e4f-9801-f6849dbec4f0)(content(Whitespace\" \
+         2c130674-7003-4200-a019-36ea2602470c)(content(Whitespace\" \
          \"))))(Tile((id \
          328522cf-0a2d-48a1-b20e-12abc647357f)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         7b6cf85f-cdac-41a7-8f82-864f3aa23bde)(content(Whitespace\" \
+         802d4ef1-6ff6-4d65-ac43-879b820affa9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c2533ea9-27d3-4958-aab0-8762cb09a9d7)(content(Whitespace\" \
+         43a67c1f-76ae-4bdc-bcec-52f5b2fa9924)(content(Whitespace\" \
          \"))))(Tile((id \
          0010ae12-2d26-4eb8-9b7b-04ac981d4e12)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          22d7c70b-a454-44b6-9d71-2758e8881735)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         381fff08-6276-465d-a150-034ded0fffa3)(content(Whitespace\" \
+         \"))))(Tile((id \
          13108468-f7f0-4565-b4c8-0c33204d195e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6223659d-a0c2-469f-949b-130022422bb5)(content(Whitespace\" \
+         \"))))(Tile((id \
          64b33844-9072-45a3-aa22-5ba6dec015ff)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          033f8aab-fd71-4d7c-8dfe-ed2082ef11a8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         261875c4-9ccb-4c5a-894b-b30464156ab2)(content(Whitespace\" \
+         5bf8e259-ee19-49fb-afab-626c9272cead)(content(Whitespace\" \
          \"))))(Tile((id \
          9beeeeec-f00b-4224-a6de-c67702b78975)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         806912db-fc8a-458c-b432-5fd22729b569)(content(Whitespace\" \
+         \"))))(Tile((id \
          55151a7d-9cf1-4d81-8d43-25aee7f6409b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7da5269a-f450-4e8b-86ae-b6959be20547)(content(Whitespace\" \
+         \"))))(Tile((id \
          82641340-8f3f-411c-9a03-157ee689cf55)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          3ad4eca0-09a9-4ded-bd1e-49262dbf5bf2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4433405f-e58c-477e-9a2c-fb101e5918f3)(content(Whitespace\" \
+         1a95d1e3-4082-4d5c-b304-5b584b4c15ee)(content(Whitespace\" \
          \"))))(Tile((id \
          98f91bbf-5689-49e1-91f8-d3b170898ac8)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3d011d08-957e-42b3-8a1e-95e741740719)(content(Whitespace\" \
+         \"))))(Tile((id \
          6baf6215-23cd-420c-819d-a5ad6c01c2ec)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e46e66bd-052e-4e98-b79d-bd412daef82a)(content(Whitespace\" \
+         \"))))(Tile((id \
          964c5021-5802-455a-b833-f29d74c3e908)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1dac3b67-ca2b-4670-9fe7-96774b1cb07d)(content(Whitespace\" \
+         1e16dd19-4d83-4c03-89cd-8b4140210ad8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         dc4c6840-7e51-4002-ad0d-3fcf7f78b827)(content(Whitespace\"\\n\"))))(Tile((id \
+         34577c0f-4cd1-47e7-88cc-c5d8169c5c56)(content(Whitespace\"\\n\"))))(Tile((id \
          43aeb31e-c10a-48aa-8979-746211170b36)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         08736d34-ee90-46bd-8825-45dd25266684)(content(Whitespace\" \
+         ed4c80db-2c20-414b-95ac-e0030c3a431b)(content(Whitespace\" \
          \"))))(Tile((id \
          184122f0-ef5e-4697-aca3-a98549246bd5)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         62e78837-0fa9-473a-8f27-45b463311d32)(content(Whitespace\" \
+         e9f01566-7ac9-4775-b3c2-29097027110b)(content(Whitespace\" \
          \"))))(Tile((id \
          06a41b28-2f7d-4967-bd01-e7c3fa336b61)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c147e3ad-6b8a-46af-88a1-9837acf8aba2)(content(Whitespace\" \
+         e86bc586-343c-4acb-9d4d-14e93e80145a)(content(Whitespace\" \
          \"))))(Tile((id 0fe92be2-f1ff-48f0-93de-8098f26d06a2)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          59cf2d03-6b85-41a6-b50b-71e3e16d3c38)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f74bb418-3cab-49ee-92f0-2e594cf5f01c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9f2829e-d283-4e7f-a029-675ec23e2ab6)(content(Whitespace\" \
+         9fbaa7b3-f7e8-4149-a02c-70b36e33ce18)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4147980a-ee1e-4273-8713-88559665d16e)(content(Whitespace\" \
+         dd483d86-4093-4623-979a-5c72fd8da00a)(content(Whitespace\" \
          \"))))(Tile((id 0509e722-af2e-4ce6-9138-1d82456b9bd5)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         86a81fbe-3c19-4e56-86f1-d5f9dc25c213)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d488ee79-f432-4e02-a663-b2c8f78bfa33)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1afd84b5-387a-49ec-99f4-a8cf74e78a85)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          ed6142b9-cfc9-4d16-a954-8ce8d5c8f127)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -116,10 +121,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8ab1e538-f163-4846-bf78-fb416f24eb75)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ee94a157-6690-4152-9cf7-d1df16a64048)(content(Whitespace\"\\n\"))))(Secondary((id \
-         42423511-72f6-4582-8e4a-2563d5742ef8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc86324f-a209-4326-aa00-b482ef6a53f7)(content(Whitespace\" \
+         bef4e5bc-18e0-4bbb-8f8c-a58a98580341)(content(Whitespace\" \
          \"))))(Tile((id \
          22e69438-4233-4f60-8b7c-f70728a4ee12)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -146,10 +148,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c011c86d-c059-4dae-bbf5-bc1a3e81818a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9e25621b-7373-42a1-9883-d5206b2bd6cf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         849bc3bb-bff1-4586-b5dd-d9c67aa6822a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4cc96e18-3c58-49d2-8b54-be45664ad36a)(content(Whitespace\" \
+         11ca3315-794a-4735-907b-e63c060cf3ed)(content(Whitespace\" \
          \"))))(Tile((id \
          117b0c6c-d1e0-4b50-9f8e-c7373db07910)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -160,7 +159,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f8641b17-a304-46b9-a940-5f16f0aee3d0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         faef3365-97ce-49c1-980a-12a1b9413d33)(content(Whitespace\" \
+         714e9f0b-66d1-4a49-8f78-ff0dcbac5d9c)(content(Whitespace\" \
          \"))))(Tile((id \
          37f6b2cc-cdb4-4911-b386-ec8700ca440a)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -168,93 +167,104 @@ let out : string * Haz3lcore.PersistentSegment.t =
          62560364-8955-45e3-ac5e-b3ddfd5c0985)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f2e9a732-81bf-4848-8557-6e9e16cbd0bf)(content(Whitespace\" \
+         61a4d49f-be37-45ad-8b2a-f8ad82873b7c)(content(Whitespace\" \
          \"))))(Tile((id \
          9f66c47a-6bf7-4d55-bfe6-e78e212da83c)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         0153ca06-b94f-4ee0-a32f-b1d038bf7605)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a4f09fbc-5c78-40eb-9754-4e78e629a12b)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         3550652f-c6b9-4583-bf58-fa227a8f0cca)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6028441b-a568-4015-b96c-1ac5be0e8758)(content(Whitespace\"\\n\"))))(Tile((id \
+         826d5263-cc60-463d-9aa6-43fe43c13b3f)(content(Whitespace\"\\n\"))))(Tile((id \
          f292951a-b170-4106-a6ab-42da8eaf1f0f)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         98f6ea71-4e54-4dfa-930f-3e372f392da5)(content(Whitespace\" \
+         4bcfded2-622f-4b59-96aa-9bd3611202f5)(content(Whitespace\" \
          \"))))(Tile((id \
          c9c59dc1-31db-4c20-9745-2d32a195f6cb)(label(Jelly))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         7efdfa29-cd16-45ab-ab96-d47ff082d9a8)(content(Whitespace\" \
+         38dd2cc8-dafc-4a5a-9d59-87dd1b915b66)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3e507da4-3236-4e3f-a60e-89d233647e82)(content(Whitespace\" \
+         d1639a3d-a6bb-47ff-af89-430683b1a03d)(content(Whitespace\" \
          \"))))(Tile((id \
          d3975000-4c83-47c0-82f3-def3bd73987e)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          c7e1a3cb-db7e-43d6-8b7b-f9f734024481)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         97c3b6f8-a803-4d0c-9f78-db86fa5290dc)(content(Whitespace\" \
+         \"))))(Tile((id \
          360765b3-ce78-4263-af39-94301db5f792)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         09b36e3a-e1be-4075-8d8c-dc5a8dcd0210)(content(Whitespace\" \
+         \"))))(Tile((id \
          4575cccb-c190-4809-903b-bfdbbd8a30ab)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7e927daa-caf3-4b63-9437-0b2e89bf09f2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         790e3c35-92d9-4844-9244-a15098706828)(content(Whitespace\" \
+         2a42b457-866c-4d65-be52-0366af40779a)(content(Whitespace\" \
          \"))))(Tile((id \
          530b7dec-9188-452d-af37-5ca23617cf07)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ebaef431-a73e-4ac7-be0e-9953bbe2c13a)(content(Whitespace\" \
+         \"))))(Tile((id \
          6b2a1ff0-496b-42b6-bdb9-01b3e360ba79)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9eabad4c-63e1-492c-a26f-e34d702f7c6a)(content(Whitespace\" \
+         \"))))(Tile((id \
          aeac050c-9bc1-4502-8d98-e0879b8a47b6)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5f48c2ae-d3e2-4d4b-b293-383fb5fc6855)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8e796038-5457-4e95-86e6-e6c3a7f61a70)(content(Whitespace\" \
+         fe01252b-3df1-4d9f-9321-1572eecaecaa)(content(Whitespace\" \
          \"))))(Tile((id \
          8e2ab47d-3ad9-46a0-9310-53d415f43f85)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bcafa2c0-d98c-4c01-b6a1-6c3abcddade2)(content(Whitespace\" \
+         \"))))(Tile((id \
          c207279e-1b36-48a6-a2e2-0b3252e19a5b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         897a0394-a4fe-4eeb-ba27-e07b87201d9b)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a780536-8317-4e0c-a0c3-81e358cff721)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7a180ec9-dea6-45aa-90cd-9e56d7aa3219)(content(Whitespace\" \
+         69c3462e-07f7-44e1-96fc-c4ae6053fcd9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a627f5b9-6282-48b2-a249-ca436da95d59)(content(Whitespace\"\\n\"))))(Tile((id \
+         f7043a92-fbe8-493f-a2e3-d356be071dad)(content(Whitespace\"\\n\"))))(Tile((id \
          44743a4d-12b4-4368-ac97-8ba5bcc9c9c5)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         d13a69da-1ad6-49ed-829f-c06c0c7cb73e)(content(Whitespace\" \
+         dc8a0b83-d92c-48c6-a3a4-9d2d6e93a435)(content(Whitespace\" \
          \"))))(Tile((id \
          f21b2a90-e7b4-4137-9392-41b6ba3b32ac)(label(petiteJelly))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3ba49ae4-066c-4348-881f-45d1db2379fe)(content(Whitespace\" \
+         e7ebe0cc-f957-4cea-9bc0-bf4f2f050b37)(content(Whitespace\" \
          \"))))(Tile((id \
          e869118f-098a-4df3-ae8e-362a2065260c)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         34ac99fa-031f-4f0f-9d46-5ecd599589d2)(content(Whitespace\" \
+         b9dc3dba-ccf9-42c4-a271-48a43fd772ae)(content(Whitespace\" \
          \"))))(Tile((id 25f0a477-18ae-486f-9692-eb1367e616fe)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          4e92c446-2ec2-4c07-b2bc-07acd54098ac)(label(Jelly))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         2dc55ed5-7688-409b-837c-bb17d18859a5)(content(Whitespace\" \
+         b6637f1c-8f78-4f30-a31d-444a3bacb3a2)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f233a2b8-66aa-4878-89de-c3835bc7a854)(content(Whitespace\" \
+         2de0074e-9d41-4f83-a3ff-9d9dc602bf09)(content(Whitespace\" \
          \"))))(Tile((id f4e2ec5f-f739-4013-83c6-6d62e4b2bd25)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -283,7 +293,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f12a4751-9509-4ace-a3b4-8bebaab15386)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         197c44eb-9ebb-44df-87d9-a3caafda4cf8)(content(Whitespace\" \
+         3470b46f-f817-4c8d-baf5-f3c7a52ee56f)(content(Whitespace\" \
          \"))))(Tile((id \
          fc4fa735-495f-4789-bc54-9943456aa4a2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -294,7 +304,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          03c3fb5a-e686-4cbd-9ed7-c015de671fad)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0933a3f9-0ac3-42eb-8d09-0bddca02f9ae)(content(Whitespace\" \
+         438dfd15-f4b9-45ca-9603-2b83deb5349f)(content(Whitespace\" \
          \"))))(Tile((id \
          e5ab3dfc-895b-402a-bd94-a0ad350ea569)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -302,69 +312,59 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f5e6b3a8-98c0-4266-9b4b-79cdcbd4d1b7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         98491df3-9510-4a8c-adf5-5ac86da34d6c)(content(Whitespace\" \
+         1e7b80ed-9a51-4b21-93b0-9097f4eeb959)(content(Whitespace\" \
          \"))))(Tile((id \
          ab7bae35-b929-424f-8e65-18379a1e9d24)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b1a09a6e-f70d-407e-b2bb-f592ee6df839)(content(Whitespace\" \
+         ab0c27e8-3894-404c-9038-f94e34537c85)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6d693044-deaa-4518-9c4e-e53998e4a794)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c650de6a-d46d-475b-afd8-0cc2bfce286b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         979e1bce-2b62-40c8-b00c-ec433f1b1483)(content(Whitespace\"\\n\"))))(Secondary((id \
+         5fc22f16-f4f5-4006-bac8-b3f3a99be4b5)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d842e909-e085-47a0-94d7-f9ca0106ad13)(content(Whitespace\"\\n\"))))(Secondary((id \
          fa8084a2-1476-46a3-92de-f1f87da37c28)(content(Comment\"# V1: This \
          version is more idiomatic and requires the caller to provide tuple \
          extension via a higher order function. Therefore more constraints are \
          ensured #\"))))(Secondary((id \
-         3f5fff94-6af3-4fa1-b8e7-ec3bfd3c521b)(content(Whitespace\"\\n\"))))(Tile((id \
+         4b517c6d-9cb6-4bd5-a428-2aaacf967f3a)(content(Whitespace\"\\n\"))))(Tile((id \
          71bb8b67-91c8-4978-8f5e-443c39c79f8b)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         0ad3a00b-810e-4f79-b038-8c6d38f34447)(content(Whitespace\" \
+         dbc1fd31-17eb-4cc1-81e6-a3a390dfb496)(content(Whitespace\" \
          \"))))(Tile((id \
          d94e8602-9fd1-4819-80ad-c990f6652ac2)(label(v1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3e2fdab1-a2e2-4b72-a9fb-ab082b1b1549)(content(Whitespace\" \
+         327edd4f-1f25-4312-8e5a-4dced289c966)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2be0464e-429e-440d-918f-676fb0dceffb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f883a5b2-b670-4b19-b3b9-d141a6a9a0aa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e8da8e86-fa97-4723-8163-7e576414651e)(content(Whitespace\" \
-         \"))))(Tile((id c596b1d7-7905-418e-a686-7d4b22317582)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ccddb0bb-b5a4-4deb-afd0-46eba19448db)(content(Whitespace\" \
+         acf477bf-8454-4755-8a74-50aaf07a14bf)(content(Whitespace\"\\n\"))))(Tile((id \
+         c596b1d7-7905-418e-a686-7d4b22317582)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         017a837d-60c9-4652-8982-dbc870597787)(content(Whitespace\" \
          \"))))(Tile((id \
-         d4863a82-80f6-41c7-9478-73872e746f70)(label(requires))(mold((out \
+         d4863a82-80f6-41c7-9478-73872e746f70)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         65db23a9-15d7-44b5-911a-7d9efde8e874)(content(Whitespace\" \
+         df6e0ed6-6670-4e6e-84a1-96b2f8c226a1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         34c106f8-6b6b-4168-99de-8aa4e03fd5bc)(content(Whitespace\" \
+         53545d35-449c-4500-ae03-3774b7e25b15)(content(Whitespace\" \
          \"))))(Tile((id f328d026-1399-4d88-b290-ae2211083c06)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f874555e-18bf-4584-9d03-e9e28e3ba8d6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3e03d0c8-04f2-4308-8bcd-b00e1e790615)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aa3b403d-389d-4dbc-afdd-1e0c3525d8f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ca516761-d386-46d1-8554-9b14e22549a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b76207b-40ce-49a7-a557-c8c8691814a7)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          34ca85c4-2d36-44b4-8b53-f30336833c0e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          c373de90-41f2-42a6-99c3-e323b66d25ec)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         495bd22d-fc47-43f3-b851-94e01bd92839)(content(Whitespace\" \
+         \"))))(Tile((id \
          5fab9f22-b025-47b1-88c9-0b41c673315a)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         992d91ec-15b8-4b7f-822f-7c27ce3df884)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e6077daa-4a46-4d4f-a0b7-d0a099f6348a)(content(Whitespace\" \
+         \"))))(Projector((id 992d91ec-15b8-4b7f-822f-7c27ce3df884)(kind \
+         Checkbox)(syntax(Tile((id \
          f1571847-e99b-4c31-93e6-9ae2d0b3991e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -374,47 +374,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bc7cb541-9843-434c-985e-6fe8a43bd2bd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         698f0775-5dca-4a9f-b279-2f138c2b7721)(content(Whitespace\" \
+         9a4f71a6-b980-4881-90e3-8a6d14828d1f)(content(Whitespace\" \
          \"))))(Tile((id \
          28d0c2e8-205d-4baf-966d-81248300e726)(label(\"\\\"concat(header(t1), \
          header(t2)) has no duplicates\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5740af55-d541-47bf-b1ce-a4c8c6afb697)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f932e13c-9af9-4f17-b0ec-d7fd80806973)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         475061e2-cfa8-4f42-bff5-067dbe29db8f)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         98d49f1e-158f-4ecd-ac9e-d4faebf1e64f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c6c7660b-e62b-4206-a94c-f56eb027d7f6)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0d0bc4ee-fafb-410b-b1aa-4e93a0488d66)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f52c5c8d-7f71-440d-b9b9-76a3e3ba6402)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0ad4f871-269b-483e-a7af-087cf9710637)(content(Whitespace\" \
-         \"))))(Tile((id f0314dd0-3f22-4994-89f7-62847455c5eb)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         da4d3f05-1645-40cf-8ec4-fdefa21cf9e4)(content(Whitespace\" \
+         c782343f-b663-49da-8049-86627be69c26)(content(Whitespace\"\\n\"))))(Tile((id \
+         f0314dd0-3f22-4994-89f7-62847455c5eb)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         57beba7f-bd18-4cae-986f-8b375b8521e3)(content(Whitespace\" \
          \"))))(Tile((id \
-         4904582d-811e-478d-9764-a0390500cb65)(label(ensures))(mold((out \
+         4904582d-811e-478d-9764-a0390500cb65)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         08d0ca89-6b2a-4889-920c-97e98a5a6a10)(content(Whitespace\" \
+         425546ad-6e34-4bb7-a050-ce065a8798f1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         23af933e-3a25-4e20-99c8-8da9580b1209)(content(Whitespace\" \
+         44103edd-6993-4229-88d2-a17721000d30)(content(Whitespace\" \
          \"))))(Tile((id f3c4cbe4-4d6e-4322-a71f-887ea455d3aa)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         4cc16165-4ab5-403e-9a1c-e13ce68243e2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9082e34c-240f-425d-b98c-0316c569554d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d87a224-f98c-4ca8-967d-d3f3f2df5975)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         37b68def-1c6c-49ca-a767-02c994e7d180)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bf69329a-ccea-45f4-8b50-ad09dfc9e917)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f1fff58f-f18e-4c57-a8bc-93f773c384aa)(content(Whitespace\"\\n\"))))(Tile((id \
          d7234ec2-914a-43bb-a71e-5fd101e9f81f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -443,30 +426,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9adac2c8-5e0f-4db3-bb63-07d141b327fa)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         647fee61-3a6d-41de-9c29-90cf03b1b9b5)(content(Whitespace\" \
+         b455f1b3-4fcf-4c9d-9a74-68d2e7642940)(content(Whitespace\" \
          \"))))(Secondary((id \
          8c5a2deb-42e6-4c88-9a4a-9db8da8a3299)(content(Comment\"# Assuming the \
          higher order function provided is tuple extension \
          #\"))))(Secondary((id \
-         c8bd5622-9048-469b-ac82-a4ebfad8f231)(content(Whitespace\"\\n\"))))(Secondary((id \
-         08b6da9a-a8ec-417c-ab80-3b2fd5743fcd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f32eb1ef-00dd-413a-90e9-8d64245b3b56)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1abd699e-b120-4224-843a-b7a57e0fbaf6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         43f7a60c-82bd-4159-ba42-f4549a98b5ea)(content(Whitespace\" \
-         \"))))(Tile((id \
+         4e01878d-1f81-4e50-bcd3-dc5eff868185)(content(Whitespace\"\\n\"))))(Tile((id \
          d0d5f68e-64e6-4525-96ed-888c43fb400a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          15e27d4a-0976-49dc-b3e8-7d7eadb90ca7)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         66cc66b4-61e3-4504-ab31-4c1b65d7e85e)(content(Whitespace\" \
+         \"))))(Tile((id \
          7a3abada-6687-422d-9d4d-603232930288)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         27f461b5-8181-4f01-bdc5-99b75898ee75)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7493d4b8-3a0c-4ae7-bfaf-22244099438b)(content(Whitespace\" \
+         \"))))(Projector((id 27f461b5-8181-4f01-bdc5-99b75898ee75)(kind \
+         Checkbox)(syntax(Tile((id \
          be8b5452-db38-43d0-833f-cae793e3dd31)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -476,85 +455,65 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7c73faa8-1790-4f4c-8da1-c4adf0d6c3a8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         329baecc-a36e-43a5-b924-d05a81573485)(content(Whitespace\" \
+         47cc6cd3-3377-46e1-835a-c29d9c0d344d)(content(Whitespace\" \
          \"))))(Tile((id \
          f904fdb1-133a-4edd-b12f-808b603d84f6)(label(\"\\\"nrows(t3) is equal \
          to nrows(t1) * nrows(t2)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         10cbd97d-b82a-4fdb-8538-ae949ef19276)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2c2f8f25-acbf-496b-81d7-0f91a3eca3fc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3629343d-ac72-441a-8621-02767b3ab82f)(content(Whitespace\" \
+         0477a6c9-fbc7-4042-9d7b-bc83789a3992)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         3e294e33-5f16-4576-9158-a41910b25882)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b193ba7f-9b37-437d-b42c-cbf7a374f4ba)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         22172c3f-22e7-4cf9-a5a9-081c2aeca45d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         38ac07ae-a810-459f-a9de-1b7cafdb15be)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f4b60e9c-0c1f-4de0-99ed-6ad62ef80d59)(content(Whitespace\" \
-         \"))))(Tile((id e2486281-3fa5-4e5c-93a2-7f4099f0290c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d596aa02-ff6a-47ad-952e-279a1bb99c41)(content(Whitespace\" \
+         5b32c5f6-8460-4dce-9c30-0d651719dc9a)(content(Whitespace\"\\n\"))))(Tile((id \
+         e2486281-3fa5-4e5c-93a2-7f4099f0290c)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         c626700a-dbb6-49dc-be87-8e65344ad8d2)(content(Whitespace\" \
          \"))))(Tile((id \
          6ff0873e-7a67-47cd-9869-4ce92ae5fd38)(label(cross_join))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         52d6acea-b5bc-413d-ad54-f97f1a811d86)(content(Whitespace\" \
+         19de3cd0-c710-4dc9-a153-f89c191f17e2)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0a7fb326-66df-4d94-971e-d22e082e1be4)(content(Whitespace\" \
-         \"))))(Tile((id aaeb29f8-4b19-48c4-ba06-ca6f4b92d1fe)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         d99bef1a-c251-491c-9e1c-a83952a5dc8f)(content(Whitespace\" \
+         1beda580-724a-4c16-89c0-749cea0c338a)(content(Whitespace\"\\n\"))))(Tile((id \
+         aaeb29f8-4b19-48c4-ba06-ca6f4b92d1fe)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         df47aaa1-ec5a-472a-8aee-8f158f02997c)(content(Whitespace\" \
          \"))))(Tile((id \
          89969da1-3164-4394-95f0-a7286ad42bea)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         aacb2e09-9b7e-4b31-8dd3-0f212dfaa4f4)(content(Whitespace\" \
+         f0204c74-dcd6-401d-a7e5-51d706487b8c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         20346f39-08ef-41e7-a25f-89ccf992ac10)(content(Whitespace\" \
-         \"))))(Tile((id 2ae89242-86c1-4919-864a-187eea46fd5e)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         80595fc1-e989-4c85-b6a7-3dbc7fc3eb0a)(content(Whitespace\" \
+         e1061cc6-0b68-483e-b733-1da9c9882b21)(content(Whitespace\"\\n\"))))(Tile((id \
+         2ae89242-86c1-4919-864a-187eea46fd5e)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         24459374-040b-40d7-88d2-a2260b6cd04d)(content(Whitespace\" \
          \"))))(Tile((id \
          25215bda-d688-4b55-8353-9a2643a9c829)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         11adad81-bfe0-4f45-9f9d-eb58ca388a0c)(content(Whitespace\" \
+         7dfe2dbf-aad4-4f58-99b3-ee3d54bb3f3d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ddc437f6-73e3-4903-87c8-c1bb50bb8dc3)(content(Whitespace\" \
-         \"))))(Tile((id 16413ee4-7a5e-4003-bf9a-93e2653c0cb8)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         3a05baa5-ede9-4033-8296-8f46d8d10398)(content(Whitespace\" \
+         dd1afe7a-a9dc-4a71-8c8a-d7fb0f6a74f6)(content(Whitespace\"\\n\"))))(Tile((id \
+         16413ee4-7a5e-4003-bf9a-93e2653c0cb8)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         22f6cd7f-cb15-4364-b405-3ae4016ed403)(content(Whitespace\" \
          \"))))(Tile((id \
          0a28edc1-6a65-4feb-992f-ac719f5a10a4)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         4a641446-ca90-4280-ad80-6305f965bf44)(content(Whitespace\" \
+         36bd9d71-c22b-4da1-b247-11f8dc9afe83)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         db240bd2-b787-4cf5-b35c-a5b2f7a2ae27)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bd4d961a-8464-4fbf-b7f3-c163eaa5d91f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f7a8899f-91bd-4650-ba18-f4dd6a15e36b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6c54b762-0fa9-48ab-9546-99885a272531)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3765ada6-108e-4584-a25c-9ae17098b85a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b05d5099-293d-4058-8f44-26f2e46c8af5)(content(Whitespace\" \
+         9d76bc6e-0bcb-43fa-9f79-58d052bb3c13)(content(Whitespace\" \
          \"))))(Tile((id d9c85037-5691-4791-98f5-11152ba4d25f)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f1fc986f-623f-4f05-9d5d-c3e79cd11a1e)(content(Whitespace\" \
+         50da6920-941e-4e9e-8ab8-aff95c22d02d)(content(Whitespace\" \
          \"))))(Tile((id \
          6be07a60-e0a2-480f-a308-ee0339012bdf)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -562,12 +521,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0114da1f-b976-4a3e-ba3d-c209f4bb162a)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         34b51330-5d9a-41f7-89b7-5b146d2b5ca7)(content(Whitespace\" \
+         f7b1102c-5b91-4598-b8f6-22008d4a25cb)(content(Whitespace\" \
          \"))))(Tile((id \
          1f440eca-ea53-4d6a-839f-6dc5d6373a53)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9b8cd4da-e25f-433b-8c30-f3d94fb70fe0)(content(Whitespace\" \
+         aba3874e-bff2-4014-8b61-9ccb9f07f55a)(content(Whitespace\" \
          \"))))(Tile((id 57fb2ab9-4b9e-4ea5-a980-2404f269e415)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -577,17 +536,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          59b30ffa-3c40-4c6a-9605-3271371c47ec)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         588f69e9-8c47-4309-b097-9cd67397f562)(content(Whitespace\" \
+         647d440e-aa27-4d40-bd17-0f946ce22dd6)(content(Whitespace\" \
          \"))))(Tile((id \
          98980f8d-8021-4c0d-8fed-6b2013c9981e)(label(t2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         33d2e413-3842-4d52-9a3c-83edd59bd5cc)(content(Whitespace\" \
+         590b4cd5-c1d4-486a-9294-282d1c31e58c)(content(Whitespace\" \
          \"))))(Tile((id \
          68913211-f2a2-4b71-a4d1-8ccaab1ede39)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         05b1e056-b560-4544-bded-64447885ac1b)(content(Whitespace\" \
+         76cddc25-fd13-482b-acd7-3919ec670357)(content(Whitespace\" \
          \"))))(Tile((id 4ca40436-02db-4381-a2cc-ec2ee9e4672f)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -597,15 +556,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e64d5a3a-a4f3-44bf-8cf1-aedfe746d5b5)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         017d0c77-c867-49d1-8c09-b77bc33cc240)(content(Whitespace\" \
+         f06eb002-2bcf-4168-8399-b57b1a8abfdc)(content(Whitespace\" \
          \"))))(Tile((id \
          6d18a955-1490-40d3-af31-cc23cb3bf93b)(label(combine))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0d239af0-b439-4d92-b81f-17d8eeea4c09)(content(Whitespace\" \
+         \"))))(Tile((id \
          6b01c4a3-4aa8-4d4b-b05e-10d6fdcc2c41)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0169a4e8-6b0f-43a4-9fe8-09dae90f9d7d)(content(Whitespace\" \
+         b0f98fd8-900e-4d63-9bfc-2b37150474ff)(content(Whitespace\" \
          \"))))(Tile((id \
          108512a5-7b99-46de-97b4-0f29a320761c)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -618,34 +579,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          0950fca3-d6c8-4e19-9214-93229eb96029)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8bae43ef-4751-4588-9f03-870657b0a956)(content(Whitespace\" \
+         \"))))(Tile((id \
          b5391c44-baf1-4677-8f55-75f58648b8d3)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f5f6a3bb-89c5-4f36-8c56-7a3d87ff0ccb)(content(Whitespace\" \
+         84d85ab2-bd51-4ebc-a605-5399da7d86e6)(content(Whitespace\" \
          \"))))(Tile((id \
          7b1c4fad-0841-4ec0-8e85-fa72040def8c)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8965ae86-29b3-4622-a1d8-9eb19daca31c)(content(Whitespace\" \
+         a3a6189c-1ec0-4efd-8ede-009fd128f5e4)(content(Whitespace\" \
          \"))))(Tile((id \
          e4e814c2-5020-469a-a584-2acc2edb3445)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         f0249983-1d32-4132-9b9d-b9cc96e60a54)(content(Whitespace\" \
+         4c54e3c8-bd9a-4f85-9c6c-34577e82a5a2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5e378465-d14d-4e13-be35-002404b3aa59)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9e90ae62-76cb-4234-a9f5-edaf051365ce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61043415-0bcd-422e-a951-1de366c1327f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d6345ced-de06-4f0a-b6f2-10e7700c6250)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f5bd7f62-e196-48c1-8373-5b774d4e9bb6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5de9eb95-1e26-4a66-b27a-5b547ebed415)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         31083801-0170-4d34-a7c5-a3846c104d5a)(content(Whitespace\" \
+         e47bd8a1-72f9-4214-8f24-3740684e52f6)(content(Whitespace\" \
          \"))))(Tile((id \
          ee1533c2-3289-49da-b24c-5ed1a80ef576)(label(flat_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -659,19 +611,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5246d324-6a4a-4610-927d-d94a610908cf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         28369371-c5d1-4740-b710-5bd022ffd2c3)(content(Whitespace\" \
+         9a1b5a3c-4534-4d78-b912-f05380f13681)(content(Whitespace\" \
          \"))))(Tile((id 03fbcead-2814-4f41-b7bd-508814d05b37)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         735a3750-f364-49b0-a0a7-ba13d1e243c9)(content(Whitespace\" \
+         261172ca-1a28-4567-918d-7ccfdbb64b92)(content(Whitespace\" \
          \"))))(Tile((id \
          87132e16-1b71-4945-a076-7f0c690a8e73)(label(r1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         59c75cbe-8fb9-4ed7-9bd4-6d89133be17e)(content(Whitespace\" \
+         159bd19b-c5d2-4b29-bccb-783c32f895e2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         754ad7e0-47f1-4261-a5e3-f69045dc6cbe)(content(Whitespace\" \
+         b36d9434-d492-4244-9587-ee651a3a8d86)(content(Whitespace\" \
          \"))))(Tile((id \
          6f285537-c783-4b90-adf4-6a34466da839)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -685,19 +637,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6a2e4dba-6f84-4e68-bf28-eda7184c7f3d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0e44832b-7ce1-41a7-a539-1910ccea6c6b)(content(Whitespace\" \
+         2415a2e4-b3df-4187-ae79-a65662baaaaa)(content(Whitespace\" \
          \"))))(Tile((id ab140251-6ca6-4825-ac4d-b3e3992ed705)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a48cea93-90ce-4cf2-a15f-3bdf151057e8)(content(Whitespace\" \
+         c6a18a6a-be03-4812-bd4f-cd7a8261024d)(content(Whitespace\" \
          \"))))(Tile((id \
          7c786282-73b5-4d72-b3af-cc9cc845bbad)(label(r2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         95d0c3d5-4a01-49f7-9bb6-ca71204f4efb)(content(Whitespace\" \
+         854371a3-5dc4-4f2e-b546-87a21e0f9ff2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         22102caf-98fa-4ccf-9a8b-e7f7cba1d041)(content(Whitespace\" \
+         d5111cdc-3efb-444a-9360-c7e269f12c20)(content(Whitespace\" \
          \"))))(Tile((id \
          7892a6ee-5278-4cf0-85f9-aa3e3c50327e)(label(combine))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -711,190 +663,157 @@ let out : string * Haz3lcore.PersistentSegment.t =
          880c3bc0-b3de-4978-8af3-4f518aa65c56)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1ac35194-be62-4695-9e77-c1cd2d8881e9)(content(Whitespace\" \
+         65caf1da-dace-4356-ae87-5c90fd9426ff)(content(Whitespace\" \
          \"))))(Tile((id \
          2b9776d3-e0fb-4059-8d69-149fbe683061)(label(r2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         5b7d5418-b728-476f-b8a1-e663cead55b0)(content(Whitespace\" \
+         0455730d-b8f5-4dd0-9c07-0339c772ea5f)(content(Whitespace\" \
          \"))))(Tile((id \
          07646c5f-ae7b-4ba5-b76a-a2bc09fc1c77)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fb294aeb-5e40-4407-aa62-68fb51db1e8f)(content(Whitespace\" \
+         c3ad3223-ea61-45af-ade5-98f592c1485a)(content(Whitespace\" \
          \"))))(Tile((id 2eba7dd0-52fe-4f09-9c82-e81354fd1bfe)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          9da59f9f-0154-4520-ad6a-8f13ed4ddfb0)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         736325cd-4df9-4fe6-bce3-e2f7d688a89e)(content(Whitespace\" \
+         bb2a5520-41f0-4f92-be06-219e255e3b72)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         219c6319-c33f-420d-838a-0b0561ba76ec)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         931d743b-0d26-4a7e-83b3-d86e2bfd4f47)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b46b754e-6bda-4ce4-830d-9c0c004b61ef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         21f50e4c-8e08-43a9-b42a-debfe0f9ea85)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a09fc4c-8678-4eb8-9923-14777a3f0154)(content(Whitespace\"\\n\"))))(Secondary((id \
-         19ed8021-671e-43ec-9afd-3bea731649dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d21e9922-7eef-4f8c-b4fe-67ddc77c7993)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         934c3912-e926-408b-8d80-0977ba6351e5)(content(Whitespace\"\\n\"))))(Secondary((id \
          f5e9259b-2aff-494f-b36c-f12443eea0fe)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         7e7c2b02-d262-4b9a-a54c-75cfe450015a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e47bb46e-c3d4-49b3-9a66-0b2b0e71f067)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         be27d157-4830-43c4-a3c2-e900aee32365)(content(Whitespace\" \
-         \"))))(Tile((id ad57b0b1-14b6-4b4e-b5f4-4b99aa565c5f)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         52a97f1d-a4f4-4ca2-acb9-434690c400c4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         07d702a1-931e-4d65-ad46-a8febb48222a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6d63098b-6e7d-49cb-afad-8ee3288a8947)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         78fdf5bf-a006-400b-8fd6-82433df6b8bb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2217f1e-0fa3-4887-9f0e-1d414a336f09)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8e43826b-ef02-4974-b91a-72f484faa03c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         97a2bee2-7013-4478-8dfc-126565bead22)(content(Whitespace\"\\n\"))))(Tile((id \
+         ad57b0b1-14b6-4b4e-b5f4-4b99aa565c5f)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         e6733bd8-5da2-4a83-bded-2a8e73af9de7)(content(Whitespace\"\\n\"))))(Tile((id \
          f2cd0e12-d5d8-48de-a19f-2e887e353808)(label(cross_join))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         07d78124-ad13-45df-a189-391bd2abc7c8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8016de78-b15c-4768-b90b-7af6dd8f300b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4becd752-2b81-4ffe-840a-15fedde92b6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8cc6a76-c58c-4780-bdab-ac8176874de8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2d04832-6582-451d-93e9-d9a53b5c84a7)(content(Whitespace\" \
-         \"))))(Tile((id fe923caa-3783-4541-a7ca-8ca412d9c12f)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fe923caa-3783-4541-a7ca-8ca412d9c12f)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          8ae686a6-b22b-430d-a96d-8ad2df89bf30)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0222fae9-cacf-48a8-839e-2176c29a32ed)(content(Whitespace\"\\n\"))))(Secondary((id \
-         42d928ba-a1cd-47da-a0a8-bda3e658b95a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a7461827-0839-470f-a9ff-520cb5d69f10)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         41573c1b-62a6-482c-8159-b67029238639)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         45a5d250-6847-4e92-a46b-988b3a2e5fe0)(content(Whitespace\" \
-         \"))))(Tile((id 1a3ac401-b567-4bbf-b7ec-02acfd4475fc)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         1a3ac401-b567-4bbf-b7ec-02acfd4475fc)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          2bce67b7-4bcf-4e35-bca8-ed62ebfc2cbc)(label(Jelly))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7f670311-f46a-4527-b237-bc5f75712f8e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         64c24c2a-fbd3-4b66-8c06-8658a187fc04)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8dd7ffe0-9cf3-4691-8997-c7146b3438f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         56095321-fc37-4c78-aa0d-52c9c41ca70a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0a6513f8-120d-428c-876f-87ab510af940)(content(Whitespace\" \
-         \"))))(Tile((id 7d45b000-eef6-41b2-aad3-c559225bfd92)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         7d45b000-eef6-41b2-aad3-c559225bfd92)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          9496b251-68a0-43da-be26-f1079427bc15)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          17c512f8-4c69-4d4c-afed-da883e980520)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         723c0573-eef9-4f78-8431-6b780f0d3309)(content(Whitespace\" \
+         \"))))(Tile((id \
          5cd9ae30-57ec-49c7-983f-c1679cfda6f9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a891ac76-2d1b-4a49-bd91-1de2792b6180)(content(Whitespace\" \
+         \"))))(Tile((id \
          21a550a0-d1be-4f73-babb-e69ef76217fc)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c606e909-458d-4110-8ff8-a3fbd295df1c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7e0b6227-dad5-4adc-855c-d0e4da19cd02)(content(Whitespace\" \
+         ce134b21-df4c-468d-97c5-777fa1571eaf)(content(Whitespace\" \
          \"))))(Tile((id \
          6711cbbd-d1c0-4f81-9b3f-229e80a96237)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         368763d0-b2e9-4083-901f-494d0ff763ad)(content(Whitespace\" \
+         \"))))(Tile((id \
          d87adc7b-0acd-4402-8b80-4dfc41f52044)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4d4ea53d-33c1-4dfb-806b-adc10f1589e5)(content(Whitespace\" \
+         \"))))(Tile((id \
          1a1216e2-09b0-4562-8016-9128f8c1a339)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7a37ed59-5495-41ca-94d9-c8eec03226e5)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d94702d9-531f-469c-84eb-1f6799f53c45)(content(Whitespace\" \
+         181279bd-8047-4fbb-a4bb-89a70bad90f6)(content(Whitespace\" \
          \"))))(Tile((id \
          2a9429e1-576e-471e-b122-597570e7a95e)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3ce1efd8-0299-4100-b7e5-0efd835b34cd)(content(Whitespace\" \
+         \"))))(Tile((id \
          275976d9-4fda-4522-87de-1e49f7cd92ff)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0a5e4672-7e8c-4aa3-ac8d-f3da6b665ee7)(content(Whitespace\" \
+         \"))))(Tile((id \
          1a4ce316-9a83-4562-930f-efec34a3dd87)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          61faedf8-ca05-4c48-863b-121e04d3888b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         46bb4f27-7357-47c7-b436-ca62c93e72a0)(content(Whitespace\" \
+         cc254d1a-cdb7-486b-906e-48d1e91f6cbc)(content(Whitespace\" \
          \"))))(Tile((id \
          36618673-7f1b-4acc-9388-b2b7a3a0bfe1)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dc6d9e43-b2fd-4767-96a2-0bc561db1142)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce0b3450-2fa5-434a-b7ce-e91a9c064c34)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a9be9695-c19a-425c-9561-43ad8e02e579)(content(Whitespace\" \
+         \"))))(Tile((id \
          261ab3a0-2e42-43ef-bee9-ecd6bf13c69c)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d5f3b53d-f191-48ef-83cd-8e3f9422c0e3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8b505e2e-2ab2-4363-8dab-5540d73e45a7)(content(Whitespace\" \
+         178204a4-cefb-45ca-add4-72cd63b5e6bc)(content(Whitespace\" \
          \"))))(Tile((id \
          32a3b876-bfb4-49fb-8161-88450d5e32d0)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d91d3d32-fd1d-4bf3-985b-9d7bdd3440d7)(content(Whitespace\" \
+         \"))))(Tile((id \
          ccac073a-2aae-4638-bffc-8fb368256a92)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3297166b-98cc-4ee9-9e17-52f49cedc3a7)(content(Whitespace\" \
+         \"))))(Tile((id \
          98d4beb5-9161-47c3-aabb-9daf8c479ccf)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          da78d40d-0945-4407-987f-6da80b87cd4d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b4879183-f0e7-43cb-bfc8-cdfdf2980dc4)(content(Whitespace\" \
+         6c7c9f17-c5a7-489b-b46c-517ba27d2778)(content(Whitespace\" \
          \"))))(Tile((id \
          ee7206cd-5031-462c-afeb-8608a34c35ff)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         582a2773-2f4c-4055-84db-1783b167fae4)(content(Whitespace\" \
+         \"))))(Tile((id \
          762e57d9-1ca3-4eb7-bc5a-0107df6b3ab7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b30cd239-39ad-420c-b8f0-09001d38e081)(content(Whitespace\" \
+         \"))))(Tile((id \
          c719979c-bdd3-4a3c-af9d-28733c63213f)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         ce99bc3a-d41a-4431-82bd-ade41f260e67)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4cf02a45-bf7d-48e0-b1db-61bc8c4e7c38)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3ac1e8fd-45bb-42c5-b44e-fbec1fbf156c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2d5e7f73-a44b-43cd-9b37-3306585ac2e9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b15d51b0-6188-4025-bbf8-635dd767e45c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Typ))))))(shards(0))(children())))))))))))))(Tile((id \
          d4b70a7d-26db-4e4d-b97f-83f826458934)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -904,7 +823,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3dd0bb9e-4e95-4f37-a5c0-442f97991166)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b96c5903-a1b5-4aa6-876b-84cf4f375f8f)(content(Whitespace\" \
+         2cd3ab1c-0b9d-4e94-959b-f78906aa2f0f)(content(Whitespace\" \
          \"))))(Tile((id \
          b1a5f819-10d3-45a8-a949-d1a378765034)(label(petiteJelly))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -912,12 +831,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          812202f9-2bf4-4c74-96f6-acf0dfa47996)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7ea8c7f3-a14b-431d-9fa0-72520d918346)(content(Whitespace\" \
+         4ae24728-7ce6-42c3-867e-cb174012416e)(content(Whitespace\" \
          \"))))(Tile((id cdb38c9f-6c21-4eee-af02-ff0000d827cb)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f12217be-c4ca-4625-b413-debc857defdb)(content(Whitespace\" \
+         1223812c-ec04-4bd3-9fce-a9f638c3bfea)(content(Whitespace\" \
          \"))))(Tile((id \
          37b4aae9-7ffb-4a97-aa30-bef6e3bbabd5)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -928,61 +847,42 @@ let out : string * Haz3lcore.PersistentSegment.t =
          af3c58b0-5533-435e-864d-d4a4c9615928)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         75d7e353-a635-487d-851b-7d9e54e5a026)(content(Whitespace\" \
+         cece451b-d4fe-44d0-9762-9346eea05d0a)(content(Whitespace\" \
          \"))))(Tile((id \
          660f017a-63d9-4380-ae5e-c232978afa83)(label(j))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         09f04452-8361-4aab-8f59-803698271977)(content(Whitespace\" \
+         519ade13-111a-413d-af91-33f159b5568f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7270975b-7d50-4020-8ed6-8d13ae780f97)(content(Whitespace\" \
+         a315854a-3378-4d36-96d9-62a9c0007d43)(content(Whitespace\" \
          \"))))(Tile((id \
          e9d2ed92-c1b8-4669-9fda-fceb4aab1fec)(label(s))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         cc532caa-da13-4d7a-9bbd-fa9158b1bfd9)(content(Whitespace\" \
+         53f04bdd-4528-43bf-b13a-cfcbc434035b)(content(Whitespace\" \
          \"))))(Tile((id \
          1b4bdc36-a61a-4df7-b031-0bdbf88bf037)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c431aef5-5682-4071-be7c-e2d555b82104)(content(Whitespace\" \
+         53e7291a-8021-4b51-8ef8-e23a48488740)(content(Whitespace\" \
          \"))))(Tile((id \
          884d035e-7260-4ecc-9e68-9ef4ba2e77b2)(label(j))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7a7d7a34-e239-403c-906d-bf54536edaec)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5dce2b22-0645-4aef-90e3-7eb7d284d8ec)(content(Whitespace\"\\n\"))))(Tile((id \
          240707d1-7574-405f-9c3c-ab6bc2d0a974)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7ed170f1-6f8f-43e9-9977-c4feed5187fa)(content(Whitespace\"\\n\"))))(Secondary((id \
-         61298ef5-02b9-4d16-aed6-156df6725822)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7d750d8e-0ab8-44b7-9eb2-4890ca9ba2f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c0002c56-939f-471b-bbef-6dcb40e195d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         38201c40-180a-443b-a91a-66125d5b4933)(content(Whitespace\" \
+         204ced12-f8da-4b57-9544-7d94491a06e5)(content(Whitespace\" \
          \"))))(Tile((id \
          e2cdf6b8-6dd4-47a1-9d67-9c5ddcf50860)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         4684fdd4-81a1-4180-b6f7-952848d7c304)(content(Whitespace\"\\n\"))))(Tile((id \
          dadaa0ff-946c-44ab-94b9-9f0cdea27c69)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         22486c47-2191-480d-a192-67a2ba3d7068)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c9d80f4c-1d2f-40eb-8ad2-8707b00bc9fb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6f10762a-4e08-4262-ba0e-6bc8e52e4035)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ce20e012-9591-4bc8-b673-a897bf52f134)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5022f783-2680-45fd-8625-0f54643ef17d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac105b19-5137-441a-b833-587027fe4d68)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d17d51d-fd75-4a98-9a59-f3452e379884)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d5696910-4d20-4081-8740-91d99679bdf9)(content(Whitespace\"\\n\"))))(Tile((id \
          00ba3570-8797-4fdb-b14d-6c48e46da044)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1032,19 +932,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e5b3e569-4912-48a6-a000-4eda272a8fb7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9c234015-9995-45d1-8e11-be95af619625)(content(Whitespace\"\\n\"))))(Secondary((id \
-         25ab3586-1807-4da4-8f05-ce6a583eaa0c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         29134b5e-1927-4166-b6f3-b6c3a1b06709)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd36367e-1a12-4aaf-a3d6-e7c6e29223d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7b7ba6a6-f433-4224-9876-02baf651a72f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         843d193f-5896-4414-9006-330ba61153a8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd8866b0-bc8b-4e94-9a21-4544c7a62409)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e4ca29b3-e041-40f0-9d60-7b35ebf11d15)(content(Whitespace\"\\n\"))))(Tile((id \
          d7102be3-63a2-4571-a3f6-02ac984fe187)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1094,19 +982,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e9be1774-1a98-455a-a423-d947946b3ca4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         46a6596d-37bc-4429-b7bf-2c158327fb8b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1c853fa1-fbae-4079-918f-eaebb09e3870)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         02ec5008-ef29-4c2e-a190-fb41b61ab414)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4098799d-09e9-4caf-9ca5-036f8bc7c28e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4a1bbfe8-e2c9-43e7-a6ac-2b967e490b2d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         92a6517b-745b-4186-91aa-c3b0517edba0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9153654f-8fed-4a33-ad03-9815feb0de69)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0d872939-1c99-410d-8f19-408d8dc4a275)(content(Whitespace\"\\n\"))))(Tile((id \
          7b277a70-916c-4bd8-8ee1-08099b130346)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1156,19 +1032,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          49006aa9-b711-473f-bd21-9e1dadb85e46)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bedcd792-e69b-475f-8edb-cc60054277dd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0544061e-0fef-48f9-bbe2-8dde8d2a14a9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         01ff12cf-c17e-4c87-90e0-a8f2618ea480)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58f800b5-5697-44f2-afe3-7ce3519be7e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c22be456-970d-4761-a54e-3f8484f8e39e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         105b023f-1f89-4b30-93e7-8b137c58acc8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6d216d10-b665-4880-a95f-e7afa6a378f8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e897198f-b55f-4fe7-b9ef-d31c80efa76b)(content(Whitespace\"\\n\"))))(Tile((id \
          434af0bc-8787-4c3b-b1e2-1d487c387766)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1218,19 +1082,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f5ea7204-63aa-49af-936a-28201468b647)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7d7f50af-edd2-401e-9e21-a348beb63929)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6308448c-b5cc-4bfe-a205-b9e961499536)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         69a00485-679b-4313-930f-25bc5ff8edad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6383e737-ae25-4d61-bd54-b615fcc3e6cc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3bc3fe60-3b28-4a54-a05e-87e9d4b83d32)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1cf22af-32ce-4d6d-9e04-636bd93bd22c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b8a01b29-22cf-4a12-bdfc-ee99470415a4)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ca5c7918-a971-400a-a8c9-3713c00e235c)(content(Whitespace\"\\n\"))))(Tile((id \
          015c88fa-13c3-4803-9468-ef6463f2023f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1280,19 +1132,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          26f4ed46-084e-466e-8119-69896e7ce603)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d1924baf-a478-4d30-bad1-8dfdd99ab7cd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         df8bbb1e-4d65-4196-a3fe-278d0fa001a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         443036c6-be5b-4b8f-b1a7-95820be72de4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         757b24a7-8259-4ad5-b421-9aa95fe8788d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4cb5cdc0-b00e-4f66-bf0b-5d20333afe97)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9d56f34e-deb5-4122-b21e-b0980bba032c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cbe1081b-3d05-4845-8dd1-9ea7612a2b12)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d123d1c1-ee6b-4e6b-a40c-85b763fc9e85)(content(Whitespace\"\\n\"))))(Tile((id \
          f87b98af-da95-4ff9-a2f3-6244e766a3d5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1302,7 +1142,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2e024c64-26cf-4011-940c-cc825ae5b113)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         666dd766-9288-4ef7-8c68-cae080afe457)(content(Whitespace\" \
+         3f5d4958-4545-4f4e-b619-dee4aba7d95e)(content(Whitespace\" \
          \"))))(Tile((id \
          f60b0e35-5632-4961-92cf-f41121b09bd9)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1310,7 +1150,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c25c34f6-939d-44ea-a574-938774a24c8f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d2f31106-8c15-4533-8cb4-cf200caff660)(content(Whitespace\" \
+         0480efd9-6e10-4881-9574-8c83dac2a418)(content(Whitespace\" \
          \"))))(Tile((id \
          7253c7c3-d044-4bd1-8057-5bc8eaab91b4)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1318,7 +1158,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          df2f7655-6d28-4e12-bc92-18b7e59cf116)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         05c0cb35-db4d-46c6-842d-b24a56f5b125)(content(Whitespace\" \
+         42e35a6f-3304-403c-89f7-eda5a9786024)(content(Whitespace\" \
          \"))))(Tile((id \
          644a4c4d-c5f9-4df2-bd2d-da8d45fc1ecf)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1326,7 +1166,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          598b7f80-cb1f-4f24-aacf-536d6dc5fc3e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8213b8c1-fdba-4bac-bc32-b30ee509d245)(content(Whitespace\" \
+         95db63fa-c10d-4087-a26c-75b15ed7d4dd)(content(Whitespace\" \
          \"))))(Tile((id \
          b09f65e7-8986-45d0-be98-9c06a8aa0933)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1334,26 +1174,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          23b17f5f-c7e3-4aa8-894b-7a63538db437)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         be9414c0-3ad8-4a0f-8c0a-b1d5b143a513)(content(Whitespace\" \
+         1acace7a-9bbf-419c-936c-fb9c568d641e)(content(Whitespace\" \
          \"))))(Tile((id \
          680710c8-82ef-4066-9b14-4b092b36cb04)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         22757935-1bc7-40a8-8935-0904d899d156)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d095e879-facf-473f-b94f-033dea315a89)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         276aeaf0-bf46-4de8-b50d-1d50fa1e65d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8d63f4f1-0e70-400c-82d4-6eabbb3c06a4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         72bd4081-8ea1-4216-88dd-f2baafe46e74)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d6e6b4cf-dc79-482d-8106-d3065199cd41)(content(Whitespace\" \
-         \"))))(Tile((id \
+         6928243c-c0c1-496c-84cf-8b57480e6eaa)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         ac216fdd-23c7-4911-acb7-fcb91ebb4884)(content(Whitespace\"\\n\"))))(Tile((id \
          d05852a3-964f-41e9-bd63-c9b00beece41)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         434792ce-cc2f-485a-b96d-597c85bc1a58)(content(Whitespace\" \
+         76b7f774-7614-4953-b43d-4ab9995f3e0c)(content(Whitespace\" \
          \"))))(Tile((id 48b5c1a3-0c25-4919-bb1a-f2197759b795)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1362,142 +1193,156 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          a215d75d-e744-4c57-9016-ffeaf9a39f71)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         39f07bf4-c524-4870-a2ed-f0c3455ba5a6)(content(Whitespace\" \
+         \"))))(Tile((id \
          090227b3-2836-43b9-a60b-1a407360b043)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         da85603e-c595-4bc2-bd53-cea78bc51500)(content(Whitespace\" \
+         \"))))(Tile((id \
          3b6f1c31-52a2-45f3-a170-bb5811e91aa3)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          949ed4c1-b4c1-4af8-b5b7-159799b9c306)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         37483fc6-f164-47a5-84a0-868bcaf3e829)(content(Whitespace\" \
+         7fc5c587-fc36-46df-a5d6-48a70ac79cde)(content(Whitespace\" \
          \"))))(Tile((id \
          8096c0e0-b36d-4a0e-8aea-b951f74d2b86)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2f466e1c-522e-49f1-a741-82c1b26735c8)(content(Whitespace\" \
+         \"))))(Tile((id \
          1436766a-0488-421f-8bd4-c7dd52780782)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d07b40d4-d0f4-4642-aea7-1fac4733be8f)(content(Whitespace\" \
+         \"))))(Tile((id \
          4009fe03-2afb-46da-94d4-dff3fefcad1b)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d8518a7b-bbe6-4ab4-9e47-d52e6ac5f2e9)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5781b268-2c66-4044-84f0-09607944a824)(content(Whitespace\" \
+         2e629c54-ed86-4cda-ad62-5b71283533b5)(content(Whitespace\" \
          \"))))(Tile((id \
          c63beca7-069c-444f-b220-ca60390ff89f)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e42b9f81-f473-4f96-bbf0-bcb1cb6a590f)(content(Whitespace\" \
+         \"))))(Tile((id \
          addb621a-e462-4d69-8ea2-90b7b6c124d6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c6301d46-53ae-4983-ba79-bbbe500c854f)(content(Whitespace\" \
+         \"))))(Tile((id \
          b986eb26-14b0-4101-be8f-f20f49db11fc)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e24bd5c0-d485-4dcd-be38-f093809902d6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3ce3d0e4-81e6-4130-90c9-1afa0b06bb4b)(content(Whitespace\" \
+         0e23c701-3650-4a23-857d-fb497328a6c0)(content(Whitespace\" \
          \"))))(Tile((id \
          6c825ba3-51f9-4ccc-8aeb-d1e2f709b823)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f1a27f79-ff99-4396-8c44-1e6f0b482137)(content(Whitespace\" \
+         \"))))(Tile((id \
          0b462fbb-b49a-442d-84c7-195d03358f00)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         33491299-62fa-4866-b309-3529a613a7de)(content(Whitespace\" \
+         \"))))(Tile((id \
          0e90c513-92b5-4c61-8a23-78987c9b2d82)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bfb3e5fb-bada-4ff9-a11f-59941df7280e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dade8486-ebfd-4f7e-8915-1ad36fcf944b)(content(Whitespace\" \
+         2f6b8ee0-8bea-47c5-93c0-5bc5b6242ad4)(content(Whitespace\" \
          \"))))(Tile((id \
          7d20d5d9-5145-4842-be4c-03015fa5594d)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b9b06997-7d7b-4f79-8c4d-60d45471e20f)(content(Whitespace\" \
+         \"))))(Tile((id \
          ba914628-e99c-41b1-8da2-74e104d31842)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         360b6324-8438-40a4-9cb8-5c9277258888)(content(Whitespace\" \
+         \"))))(Tile((id \
          265dbfb5-6d24-408a-a042-85e1a45aff15)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b23489b1-5598-423c-b327-b9e9db466370)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         64a97962-7360-4b30-9573-e52c0e96be19)(content(Whitespace\" \
+         4c34d292-4f9e-46ba-800d-17af43f52306)(content(Whitespace\" \
          \"))))(Tile((id \
          60fcdacb-30b8-4007-a5be-e7ec7d79c5d1)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         413528a1-bfca-4fba-8e46-4d4413748d72)(content(Whitespace\" \
+         \"))))(Tile((id \
          f3ab69be-90d4-4ac6-b9ca-fcf42ee958f7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e7364626-2ef7-4164-9e2e-bd0cac169c5f)(content(Whitespace\" \
+         \"))))(Tile((id \
          00392f46-1d47-445c-9049-cb6c3556e16d)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         59920221-4a98-48c8-b444-d21c37534ad2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ac0e6757-42cd-405e-aff4-bf3cd7c279d8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dc41c8c1-948d-4565-9b38-8dc40d1478fc)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         4afa2393-8127-4fbe-84c9-17e7b3c32798)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         ba289e55-8bfd-4cf4-a57e-5af9c1fa2909)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         54f60fc7-8a3c-4ade-8ee5-d1376ebfa133)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         79fde24b-6c40-4dcf-b455-390611ce5b8d)(content(Whitespace\"\\n\"))))(Secondary((id \
+         2ae22f0c-6106-4420-b5e7-22de07124512)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9a644006-47ea-4b95-8603-ab7add18c9da)(content(Whitespace\"\\n\"))))(Secondary((id \
          cd2624ae-a525-4148-b045-32dc145e8e14)(content(Comment\"# V2: This \
          version more closely matches the TableAPI. Given the lack of row \
          polymorphism no constraints are ensured #\"))))(Secondary((id \
-         f833802b-8307-4f05-97dc-826012c1af83)(content(Whitespace\"\\n\"))))(Tile((id \
+         b0ce0a48-977c-4a55-84db-dbb0eefcef2f)(content(Whitespace\"\\n\"))))(Tile((id \
          cbbbc756-b76c-4d57-9cdf-7618ba20cf85)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         dd8c1519-418f-4061-904b-35bfde8f0060)(content(Whitespace\" \
+         498e366f-0868-4150-8220-a8b852a71473)(content(Whitespace\" \
          \"))))(Tile((id \
          7872eef1-bf3b-4883-83c4-7e0f09565af2)(label(v2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5885fd4e-2fb4-4e96-a214-dd2f6617e5e1)(content(Whitespace\" \
+         475bdc63-d506-44bf-becb-dfd6efe46748)(content(Whitespace\" \
          \")))))((Secondary((id \
-         def84193-c4a7-401d-95fe-138e6ce044ec)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ff5f50d3-1464-4cb7-82be-5115a61ad8f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         443f0473-179f-4f74-a40f-82c7e4d9c240)(content(Whitespace\" \
-         \"))))(Tile((id 43faf0f8-ab6c-4336-978e-cdac06299984)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         dcce5ef2-b816-4653-b8b0-488b8a953d5b)(content(Whitespace\" \
+         4fd9e2f2-5ebc-4f11-a891-4e32ea491a7b)(content(Whitespace\"\\n\"))))(Tile((id \
+         43faf0f8-ab6c-4336-978e-cdac06299984)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         51ab2238-e481-44c4-86af-67d32c7007eb)(content(Whitespace\" \
          \"))))(Tile((id \
-         753ebd19-f07b-47da-aff3-e518336ceb97)(label(requires))(mold((out \
+         753ebd19-f07b-47da-aff3-e518336ceb97)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         99ffab63-9feb-473f-8370-52bfbaa9d9a2)(content(Whitespace\" \
+         2229c971-a477-4983-b271-70ddceda7843)(content(Whitespace\" \
          \")))))((Secondary((id \
-         990389f7-da55-4b85-8e49-00f16156d4ad)(content(Whitespace\" \
+         709d6dfd-def8-4dee-995b-e7c0c68fd99d)(content(Whitespace\" \
          \"))))(Tile((id 9801f829-6a55-4b6f-b912-d7a8759c377c)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         09199dcb-44c0-4ce0-bce6-4deb66cf32d5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1c91c97c-be0e-4f91-bf95-0bf90bab71c1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         22602de1-1df5-4b92-bb2a-7abcf35ee4b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e788953e-ab98-40ad-b433-5bf9017f4132)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c8e409d-67a7-44b0-8f86-c125a331fc70)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          eda0d46d-a655-4d97-9286-016b7c7acd4b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          da39c4e9-c7e0-4fab-982d-d90e3e949a75)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         84fb9486-99dc-4b86-8f48-d727d87df763)(content(Whitespace\" \
+         \"))))(Tile((id \
          9919a3da-97cc-41b3-9748-915d5fe1f313)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         a5012281-b59d-4506-80b7-033a13939d6b)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7266d9f8-6b41-4d9d-bfcd-418f861c020d)(content(Whitespace\" \
+         \"))))(Projector((id a5012281-b59d-4506-80b7-033a13939d6b)(kind \
+         Checkbox)(syntax(Tile((id \
          0dea594e-2cb9-4fab-9996-8399da8ac085)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1507,47 +1352,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4ebc32d5-eacd-4e3e-b66b-1cf51b803182)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         541a5fed-f2ca-4fae-b92a-f3cec78d1015)(content(Whitespace\" \
+         c73bf999-1dbc-4db6-ae34-c2bcc22b2d0d)(content(Whitespace\" \
          \"))))(Tile((id \
          1c9e7fd3-cea7-4ebd-b6f8-a1a59bc26b51)(label(\"\\\"concat(header(t1), \
          header(t2)) has no duplicates\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         403c0df1-cbae-4215-b212-db0707bea388)(content(Whitespace\"\\n\"))))(Secondary((id \
-         db7b2d81-5488-42ed-b11e-cadc1679d568)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5eec9dda-410f-4c46-a10b-fcfbc66ab62a)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         8e62c0c6-5c12-44b6-a161-20d41f16c29d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0bd34589-6fa7-4cc8-b029-198e45c61e08)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f5a4d37e-e8e5-4e04-a824-0106d06b7e56)(content(Whitespace\"\\n\"))))(Secondary((id \
-         717cab29-93ec-4340-9b58-aa129a7bab66)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c2278322-1e2b-4a88-8660-d82b7f264a72)(content(Whitespace\" \
-         \"))))(Tile((id 7a1570ec-9c6a-4f80-816e-8907b7542dce)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d465db29-af9b-4061-920c-8216b126843c)(content(Whitespace\" \
+         ea43f49e-b55e-40a7-84c8-df310f2e55df)(content(Whitespace\"\\n\"))))(Tile((id \
+         7a1570ec-9c6a-4f80-816e-8907b7542dce)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         d031c893-37b1-455c-994a-ea97f0566d67)(content(Whitespace\" \
          \"))))(Tile((id \
-         f5877294-3a73-4f17-93e0-e1b098229036)(label(ensures))(mold((out \
+         f5877294-3a73-4f17-93e0-e1b098229036)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         dc9ded8b-a881-4ffb-9b93-2163dbab0226)(content(Whitespace\" \
+         2a0c2467-5771-444f-919f-12c59a3f6911)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d6ef3bf3-ae01-41c0-a728-287a842b819a)(content(Whitespace\" \
+         0ec8a959-1072-4c28-bfd2-ec05fc699306)(content(Whitespace\" \
          \"))))(Tile((id ffd7cb49-8e08-4ec6-bccd-9cf83d5352d2)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         19fab8af-cffc-482b-906d-dc28bb546018)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6fe8ecc1-e7de-4f34-b7e1-5cd045a9ee22)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0935e0e4-b64a-4de8-90dd-fa31704c4063)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a914e5d8-7ae2-4615-ac23-02e2882d1df5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         adebc136-1695-4ef7-80bf-e9c92fa4affb)(content(Whitespace\" \
-         \"))))(Tile((id \
+         33f851a2-46df-4fcb-8447-a1d6ee7f71a3)(content(Whitespace\"\\n\"))))(Tile((id \
          87f7db74-ad7f-4ac1-a537-821a8f956508)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1576,25 +1404,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b2cb67bf-e396-4e33-a38f-155328cbf448)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         61959f6a-6f2e-4bc4-9da5-3197036b42f3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         22cc542f-9943-4c06-8646-032b0954f6fc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e343c5a6-e245-47b7-9fae-b3ff63ddf314)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6a994992-f893-49ab-9274-77ff0ddef164)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9c521d98-cd2e-4afc-93e0-ccbd1d8063ee)(content(Whitespace\" \
-         \"))))(Tile((id \
+         7857b4b8-6d80-4473-b74d-ef8c4af98a2f)(content(Whitespace\"\\n\"))))(Tile((id \
          06b7e996-fd4c-4e97-819b-f1bad0bc683f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          6fa436cc-7b5c-424e-a6ed-b5186fb4c3b7)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         cfc96759-faef-47d1-a3e7-9e0735f984c0)(content(Whitespace\" \
+         \"))))(Tile((id \
          47a593b7-5e18-4540-84ee-5a8a3d7cc40c)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         ba9ef8c2-8764-4b88-8557-f90880dfd12f)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b6efbfb8-a052-476e-a048-a52d83e90404)(content(Whitespace\" \
+         \"))))(Projector((id ba9ef8c2-8764-4b88-8557-f90880dfd12f)(kind \
+         Checkbox)(syntax(Tile((id \
          0601f25d-cc76-4f0c-9936-57ef31772d2d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1604,56 +1428,35 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f641fef8-aa33-4dc5-ae25-46952842acc4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fbba3a98-8563-40a6-aa32-6153966196dd)(content(Whitespace\" \
+         af521f53-0811-4245-814b-2e82d8d6f07b)(content(Whitespace\" \
          \"))))(Tile((id \
          de76d661-22e1-48ab-8b5e-b6ad02a8cca0)(label(\"\\\"nrows(t3) is equal \
          to nrows(t1) * nrows(t2)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         16057b86-91f4-48cc-80ef-50661e46cafe)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cc33aa7c-3ae6-4967-b4a3-d84bdb182fde)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4ee57d48-2d27-4026-a8df-2c6106899ec7)(content(Whitespace\" \
+         e64a8193-d8b9-4074-8db8-caeb90a9e390)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         941b7499-1f4d-4678-817d-ea4dca810951)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fa8468f5-9499-4566-b42b-aa9c94779f44)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e183b8d1-5462-45a4-881d-a8970aaabc65)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4c989604-94be-4876-a23b-0899c3e699cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         143909e1-6c88-4de5-a48a-ffca8ecc684d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1754d4bd-26bf-4fab-a982-e901e6f5934b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d5fccc03-99f6-4d0e-82be-37e3e2e387bb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7afe1d7d-49c8-448d-b78f-71069bc4bf97)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         63e0d27d-879c-4ee6-b33b-c4af5596f34b)(content(Whitespace\"\\n\"))))(Secondary((id \
          86ea2af2-38b1-431a-94be-504ad7a47cb8)(content(Comment\"# V1 is the \
          more idiomatic version #\"))))(Secondary((id \
-         bf0cf5b3-a322-49d1-b699-c84a215a645d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8926062-c44d-46b7-8306-950aa41776d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36242273-ee68-4291-a24c-40cebc80cd9a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1de4198c-b59f-469f-bd58-d745baa41bcc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         89a1c063-13c7-4750-9765-d07037051315)(content(Whitespace\" \
-         \"))))(Tile((id a485dab4-6584-48b5-aa86-3bd2311bd5ff)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         6a7bcf08-fe1e-440a-bc34-e9dbd2013a0a)(content(Whitespace\" \
+         a5728479-0124-4a19-8e73-01f080551fcf)(content(Whitespace\"\\n\"))))(Tile((id \
+         a485dab4-6584-48b5-aa86-3bd2311bd5ff)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         1234e201-6483-49ef-91ee-25a2ccc5ca6f)(content(Whitespace\" \
          \"))))(Tile((id \
          c0ca6e60-eb57-4a52-aa67-152df0850648)(label(cross_join))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         94c09d7e-ff6a-4b23-a648-cfbecd956908)(content(Whitespace\" \
+         445ff9fd-2093-47a7-98d1-95849eade9cd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0b471ab5-aabb-416b-8c49-f9c965acb120)(content(Whitespace\" \
+         a98c4861-bfcf-4bef-8975-3b2975641a79)(content(Whitespace\" \
          \"))))(Tile((id 507901b1-9bfc-4b87-a9e6-f8643202d3d1)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         51f9c864-5c0f-433b-87da-9b4dfc601ba5)(content(Whitespace\" \
+         58d1b0a0-5112-41cf-8361-db438eb592d2)(content(Whitespace\" \
          \"))))(Tile((id \
          f93b862f-dbf2-4a5b-8688-ceab89feb8be)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1661,12 +1464,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5649e5f3-8889-4dd5-a3cb-c309e4044933)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3df85e71-b224-4cee-a0db-7e70be42b6fc)(content(Whitespace\" \
+         ef383a8e-4ffe-4617-8c92-37cc44c0437e)(content(Whitespace\" \
          \"))))(Tile((id \
          657456f5-9a78-40f5-a242-3b174593ab9b)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8146501a-1f76-4d08-9ca0-2e84d4f7c449)(content(Whitespace\" \
+         7a207b43-5ca6-49f3-9059-86abd717f73a)(content(Whitespace\" \
          \"))))(Tile((id fe17ef32-a146-4385-8de2-0abb0a01df54)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1676,33 +1479,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ad1a1fa3-2381-4807-b3be-17e0d89618e7)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ab8d8424-06c1-41f1-9cbb-531d3c6052e1)(content(Whitespace\" \
+         e3c2a83f-0917-4775-804a-b98f53131dcc)(content(Whitespace\" \
          \"))))(Tile((id \
          0f2c762a-b3fe-4600-97c1-96110011ae3b)(label(t2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         639b0db2-6376-40d3-a5e7-a349d15fb7ae)(content(Whitespace\" \
+         60f25181-2f14-41c3-b655-270f50a4a686)(content(Whitespace\" \
          \"))))(Tile((id \
          84610356-1bdc-4463-9147-af738aac8c89)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3790655a-dca8-4bd3-a17f-73e81d47a311)(content(Whitespace\" \
+         3654813f-9d05-4eab-b7e0-75df3c2d3d81)(content(Whitespace\" \
          \"))))(Tile((id e9879bfd-3cba-4deb-ad05-c4691fbd5a8c)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          8e511492-965b-43a0-9f1e-8c26277cd027)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         0e3feed3-cc65-4e02-8765-1f036d0bc552)(content(Whitespace\" \
+         4f90521c-5d77-4bca-b908-af288094c861)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e6a49989-fd27-4db9-a8bf-6a2b0967260c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2a5aaf74-0827-418c-b442-abff2116f128)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         42304d5d-61c4-45d3-917f-09d7ab120e0d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         90afc015-02e5-4438-ac37-dfd06ca794b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ec326399-cf1b-421b-8a29-89ba1fc3d443)(content(Whitespace\" \
+         c66938e1-a8d3-4aee-a921-0e59d101bb1b)(content(Whitespace\" \
          \"))))(Tile((id \
          85cab564-c25c-4f91-9cc4-999206bc2a74)(label(flat_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1716,19 +1512,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e9d95205-1fa1-45ce-a11a-57eba0a7c98d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         32656e25-0403-4e6c-89ea-0b99cf4c5874)(content(Whitespace\" \
+         08b57b9f-7cff-4ac2-ace3-3915484dbf3b)(content(Whitespace\" \
          \"))))(Tile((id 3b160c00-e17c-4b5c-a799-e7fa51bb709d)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a874aabe-eb75-4ef6-90e2-c720292b63ac)(content(Whitespace\" \
+         a8d7393a-cd11-4648-ba5f-eb99f54ca6d6)(content(Whitespace\" \
          \"))))(Tile((id \
          a3adabd5-d758-4c16-933b-5b5169a847f6)(label(r1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         00158601-c51a-4ed3-9c2a-324663e315c4)(content(Whitespace\" \
+         9e5684aa-be5e-4345-98e3-ed502f92fe10)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9cbd6b7d-8b71-4453-a43c-e90840d560ed)(content(Whitespace\" \
+         0ac3fedb-6b35-493c-a939-a541c9058775)(content(Whitespace\" \
          \"))))(Tile((id \
          5164a4cb-1dd2-4324-8b04-206d1a5230df)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1742,82 +1538,46 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e0fa0fc9-9718-4500-b048-aaed97724c7d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         563a792e-2e29-4a25-a9e4-62702add51ad)(content(Whitespace\" \
+         3944572c-0f08-4650-8811-b95f5fbccb1f)(content(Whitespace\" \
          \"))))(Tile((id 4a6a9a7a-64a6-4a11-8b3f-e7a82c6aa68e)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f5bfc891-685e-475f-8b56-38c8ae16e734)(content(Whitespace\" \
+         1c8e225d-1678-49ff-9d2f-9fed0178124b)(content(Whitespace\" \
          \"))))(Tile((id \
          524d5e20-d951-4252-9fa2-3cd23764c782)(label(r2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a0242f52-d352-493b-b6d8-81b0a8a3efe5)(content(Whitespace\" \
+         673c01c6-1b5c-4919-941f-b7e1d9e543b9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fa302b05-3536-4573-be9a-fd7fe718e496)(content(Whitespace\" \
+         7a5adc12-350a-48f4-974c-b92e7ef78a65)(content(Whitespace\" \
          \"))))(Tile((id \
          cf6851c3-8fd0-4174-a23c-8e60f09b0b4d)(label(r1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         6c1b2b0f-c731-490b-a2d6-49e66f6ed5e8)(content(Whitespace\" \
+         9f65399d-3dc9-4dda-ac7a-5cc1fc7e23b5)(content(Whitespace\" \
          \"))))(Tile((id \
          3d4f2494-b603-466c-9209-188bdbde33c5)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2fc454d1-2ed0-4a69-ab2f-dc17bf9112b0)(content(Whitespace\" \
+         cb5d03c4-d7b5-4031-91ff-c5c938c1685f)(content(Whitespace\" \
          \"))))(Tile((id \
          42f7c656-3018-4bb2-ad74-707d4858f87b)(label(r2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         8c5b61a6-822e-4fed-9ebc-d419e3263fc1)(content(Whitespace\" \
+         d73ed8f3-d039-413c-a8ce-4637e611e2dd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b7c1e0e9-a0cd-473e-900a-21630da5f0a8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e6c4fd29-62a6-48dd-acca-6807bbc81d95)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e03b4bc1-1352-4594-bf90-741703214639)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         53952cfb-706b-45d8-b697-6594b7fd84f6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         086c5604-e048-4fd1-834f-24d94c0a9c91)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         981abb16-5d43-472e-bdd5-5ba48cfbde3e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         969dbf23-8f49-466a-a0a3-01c69b70352c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c1e63df5-b176-4644-a3c0-8c120946e641)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5123d371-d9b5-43fb-a6e5-b3a96d32e92c)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         019bc8d8-c75a-42d6-9f16-1cfcadfc3b71)(content(Whitespace\"\\n\"))))(Secondary((id \
          1675d2a3-3c4f-4215-a033-c56414a197c8)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         cc874d79-b91c-4989-b192-4150934fc97c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f727f7d5-9f31-4e89-9843-233d198e530b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d2819c4-a77d-40f2-93f4-0b532d50caf1)(content(Whitespace\" \
-         \"))))(Tile((id 542dfcf1-a80f-4457-91da-0a7eaa9d7c46)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         92828375-7072-4e20-93fb-06c95c7a5bdb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         df7cb7b8-19c9-42f5-9034-d56e614fa44b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7a4d5d47-a6c3-435e-a6f1-d6760ba36196)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a11a4201-ae9b-4a95-9ed9-7d3b94351bb6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         06683230-35e1-4f15-aed1-d720a0161500)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         231c5f1c-938c-4ed5-9e6c-54add204698c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         bfcaf564-35ee-4610-a739-0a84136537df)(content(Whitespace\"\\n\"))))(Tile((id \
+         542dfcf1-a80f-4457-91da-0a7eaa9d7c46)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         36874eed-811d-410d-b67a-4141fd6546cf)(content(Whitespace\"\\n\"))))(Tile((id \
          d82d9f22-41b0-469f-ae60-9c95817fbdfb)(label(cross_join))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         1d7c9c85-e65a-407d-a7e8-249fd0fd5f3f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2d51fe40-feeb-4191-8ee8-330e9444c19f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8632a775-5608-4166-8d0f-30346d2f8f35)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4de38169-14e0-43bf-bd30-93dd3989f253)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         885e392e-961e-47ef-a1c7-21f5de6a3017)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
          e768f07a-21eb-4d3f-9aa6-49411898e1f9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1827,44 +1587,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f8a587df-ec8b-4440-9d45-36e164f7e504)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ba2ae109-17e2-4a97-b329-4b5f4f24f062)(content(Whitespace\" \
+         e9a9ea70-4ef6-4a09-b005-128316506250)(content(Whitespace\" \
          \"))))(Tile((id \
          9bb99cd2-06d1-4e61-803b-4b44279b5e82)(label(petiteJelly))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7cfc0d33-b8d1-49fb-9885-a8a5b7992fff)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0295ac79-b9c3-4e99-a2de-6cd789759895)(content(Whitespace\"\\n\"))))(Tile((id \
          685c139f-2214-46fb-b571-b6a5440aad1e)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9c660c54-a51b-43b0-882c-5c6dcbf37134)(content(Whitespace\"\\n\"))))(Secondary((id \
-         45f71eec-3c21-454b-a77f-24e4adc75e9c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d588c26-fbc4-47e0-bb15-1ff12263689c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dde074c4-8355-49be-bc14-2b9143622479)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7eef6cea-1097-4178-9f6f-63016e36986f)(content(Whitespace\" \
+         aec15d51-d2db-445d-9cf4-9936fb13ad63)(content(Whitespace\" \
          \"))))(Tile((id \
          f226178b-d8d3-423f-826f-422d204f8891)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         87c1698a-9935-4a69-b5f5-ecb275a38de6)(content(Whitespace\"\\n\"))))(Tile((id \
          3ccfaf4a-4e0f-4671-9e45-da4937d23bb8)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         63332618-f50b-49fc-a7c2-b86a0544c3a8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3eefc787-252a-450d-a0d6-4c32a756e48a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc53811a-7fa6-4111-bb99-ac46b90ccb8b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         555eae86-85c5-45ae-9b2a-f7e58d9d617d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1e7ce5c2-e21f-4db6-ac78-ddd2ed475aa0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         694d2034-99b3-4678-8772-2b088507f1ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dfc138dd-0d1d-484c-b697-aaecb28bc338)(content(Whitespace\" \
-         \"))))(Tile((id \
+         059bbabc-2cf4-4db3-923a-22ada4050032)(content(Whitespace\"\\n\"))))(Tile((id \
          ddfd260a-e16e-4a4d-8811-5416383b8fcb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1914,19 +1655,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8b6f436c-04f2-4d31-8522-5140e4f12fbb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6666087e-9322-43e1-873c-3d709b2cd6d1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         119fc2d5-15ce-48fd-8f02-41706a6dee4c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6bf9cb03-9a27-40cb-ba4b-11288930fa7a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         78a48217-7945-4d54-9044-2870083102d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58c1e32e-7567-4baa-8eaf-19a951d754fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         70a65199-3f11-4914-bd3e-74c534cfd9de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab5dafdc-fd5a-414a-ab98-bf033b1f364d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         30ce9336-4bf6-48d5-9cbf-363b0d1b3469)(content(Whitespace\"\\n\"))))(Tile((id \
          b439a709-824a-4fa6-916b-eaad12c0edb7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1976,19 +1705,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0fc70fc7-9c51-47aa-b837-96f6ebf2c83b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e0b7119f-fbaf-4009-b563-7bd0c34149c4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c26d2b73-a3fe-4c11-aff7-db7a38ccc95f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d916bb7e-8b75-4eba-8610-1ffeb160f5ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6dc65dd9-b345-41ca-8351-042945f61d14)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0ee068f3-e873-4a7e-b75c-3bf7d9c6f8c9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba4840f3-ccc8-40a7-93a0-8bed7b0dfff8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea5734fb-65c5-4586-8177-db6058271b9d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         671da013-4884-4259-b410-9c2a2192a9b6)(content(Whitespace\"\\n\"))))(Tile((id \
          fa464fc2-906d-483a-8659-c2663295fd74)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2038,19 +1755,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          141b6a6d-3132-4729-89b5-4237dc9c0da9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1e191b92-fe79-472c-b781-a61f64f998d2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b1d80bdb-95b0-4004-99d4-b91b9f578232)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         591ea0fe-fabc-4b31-a3f3-33e950c2304d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cac20b1f-8940-4ca1-ba82-b84f884d8f71)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         94d69040-aa76-49ba-bf3e-91ad5ef9d3dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1f5c07e8-ebad-4bdb-bb92-d1136496a425)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c132fa7e-b63f-4dc5-bb52-79ab387cf025)(content(Whitespace\" \
-         \"))))(Tile((id \
+         965299e4-a18a-405b-9d2c-9ee1e95e286c)(content(Whitespace\"\\n\"))))(Tile((id \
          f69ce5fe-50c4-4892-90af-e9ace81ce461)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2100,19 +1805,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8f2cde3c-0d41-4f35-ad3e-2d92b316ec97)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         39be2d2b-29eb-49ac-b2e4-efb0eedb30af)(content(Whitespace\"\\n\"))))(Secondary((id \
-         351a0037-9d91-482b-8a00-527ca4c68ffb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         35e89116-8f52-47f3-bc9a-0ecdb75fb40c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9d32a78d-3ca0-4efb-b302-39f1074acc59)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c99fb31-a0ea-4310-ae02-d783b158e280)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6ba59ad3-af16-4d36-b786-99f842fa5d26)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e417e01-f9f2-4bfd-9256-72d734baacbb)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5095faee-7294-49b7-9c18-8a68e7fa858f)(content(Whitespace\"\\n\"))))(Tile((id \
          93e6058f-6a4c-4546-ab44-0616eeb0db77)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2162,19 +1855,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c9f2d6dd-c5cc-43ad-8bf4-e51b059df05e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         14ff31bc-4949-45e6-8da7-6c41dffc0cfe)(content(Whitespace\"\\n\"))))(Secondary((id \
-         194ec866-52c3-418e-98e5-60df5b2b44be)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ee18753-09f9-4a06-9b38-96200407338b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2eafd1af-cf33-4765-a665-ee2b179f33d8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         94320428-f218-44b5-9805-bca805d10c68)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a2854365-2555-4d5e-b14e-21a9b3575846)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7c5769d-8da9-484a-9d21-56f902f2938d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8544bbfa-5be6-46a6-b157-d6d194bbed22)(content(Whitespace\"\\n\"))))(Tile((id \
          92e22e5f-26c1-4f74-b931-6800156f8179)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2184,7 +1865,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b4207f37-dfdb-45be-b258-b18814d08f5a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a64088d0-ff4e-405b-bbda-6768e1245345)(content(Whitespace\" \
+         7124ec13-e44c-4b4d-b174-aaf805f12029)(content(Whitespace\" \
          \"))))(Tile((id \
          4ba17f7f-5c5d-401a-a9ef-baf1c51c4da4)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2192,7 +1873,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          89889cdf-9ae6-4209-99dc-c22fa4bc3644)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aba73cf9-316b-4908-b8ad-23cea374f7fd)(content(Whitespace\" \
+         291358b4-b6fa-4b2b-82ad-15fa4256d23f)(content(Whitespace\" \
          \"))))(Tile((id \
          67fe110d-67f6-4e88-9411-83cfda8a0b50)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2200,7 +1881,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9fc82e7f-9871-4266-84d1-3cb1d17cb05d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6154c663-ec47-4520-9cd3-5357ad96ff7e)(content(Whitespace\" \
+         6d844605-57ee-48dc-b2ec-915cd6cec276)(content(Whitespace\" \
          \"))))(Tile((id \
          79a20352-6184-4975-89a7-37574c5206e6)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2208,7 +1889,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          52180142-043b-4ae2-853e-dbc15a6c412b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f2fd2faa-0df5-4cd3-b886-07241366230d)(content(Whitespace\" \
+         e2130539-0130-4281-bb26-ff6a74bd4e28)(content(Whitespace\" \
          \"))))(Tile((id \
          f3b182a3-0752-4fbd-a46b-c87e07fd40da)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2216,26 +1897,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ee077e2b-d1db-47d9-9380-7c89f97f894c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d85ec5d1-fd12-456a-8f0c-69839d7708ab)(content(Whitespace\" \
+         aa43ad1f-0e5e-4907-a0d3-639b1a6e3457)(content(Whitespace\" \
          \"))))(Tile((id \
          be203f8a-7d7f-4fda-8447-e241ccec66f4)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         48f415df-4e24-4d5a-9a53-adc42dd0f05d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1ad4a66a-e13b-48f9-b4d8-5a84707c2f73)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5b3fd7be-9d28-4770-961e-973f9bf69d87)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f0024a53-eabd-42e4-986d-f2bc6e1b000f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a62e4344-05d6-4b43-97fe-dc95a380dad7)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         02c8d44f-6397-42bf-8b94-53af8962b3fa)(content(Whitespace\" \
-         \"))))(Tile((id \
+         de76cfb4-b3f1-4b02-b9bb-fd263af61558)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         990e7a6f-99a7-440d-87e7-387a3e68d77c)(content(Whitespace\"\\n\"))))(Tile((id \
          d767151c-e123-44e9-96db-3f841b4ac6c0)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f637559b-f003-447a-a0f8-88d7858c28bc)(content(Whitespace\" \
+         1768b1f1-463e-41a6-a199-60536d934563)(content(Whitespace\" \
          \"))))(Tile((id e76f8b9e-6d9d-4700-a6b8-7a748463d984)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -2244,183 +1916,188 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          68579357-ed86-48a3-8ca4-04985da4cc86)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a870183d-c362-450e-8d56-a80c13891ecc)(content(Whitespace\" \
+         \"))))(Tile((id \
          a528c29d-116e-4f22-bcd2-e8528336bcdf)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         22785c5a-6a01-474c-ba7a-e6f9ed257ae0)(content(Whitespace\" \
+         \"))))(Tile((id \
          7ca61124-c995-48bd-8388-53c99484282c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9cfd370f-d094-4f01-83cf-be73c38c5bc7)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b2d29ab9-8236-4fac-93f2-3a8ecec12f12)(content(Whitespace\" \
+         b28c2df4-e7fd-4bf2-af2e-b8e185afd557)(content(Whitespace\" \
          \"))))(Tile((id \
          953aff6a-a60d-40fd-a764-972a42eb9c38)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         04f5e2b3-8ec6-4dcb-a1c5-b62bcb817a33)(content(Whitespace\" \
+         \"))))(Tile((id \
          19ccc1a8-fb9b-408d-8cc2-25f70e2ed9cc)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         54065d78-0663-43ac-ab45-1569c9fefadc)(content(Whitespace\" \
+         \"))))(Tile((id \
          89eb9344-9da3-4794-a8cb-730cd09a0288)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          700fe374-1036-45ca-9ab3-58e75881f4c6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dd8f5235-d538-400b-a7ba-1f422d302b25)(content(Whitespace\" \
+         077dda68-7101-4c9e-89fc-b7b386fba209)(content(Whitespace\" \
          \"))))(Tile((id \
          4d7a626c-e445-4431-b8fe-92b94eaf3f35)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bc415264-3f3a-490f-879d-062eb35f7495)(content(Whitespace\" \
+         \"))))(Tile((id \
          504459eb-39e4-4de8-9928-8ef285ccb81a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dbd2c182-da79-4037-8f52-8629b756ad9b)(content(Whitespace\" \
+         \"))))(Tile((id \
          a1d0bc9e-020a-4616-812c-c6e6e3479631)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9f3892b5-9550-42a5-9aaf-b773f29a23e2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9632ee36-de57-45bf-9712-0c533e9253f7)(content(Whitespace\" \
+         85aedeec-2e0b-4e40-a14e-fece49e143a5)(content(Whitespace\" \
          \"))))(Tile((id \
          a195b1f2-8481-4a58-9194-5780980ba926)(label(get_acne))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4171f1fe-7c70-4296-b540-beb6732e85af)(content(Whitespace\" \
+         \"))))(Tile((id \
          23866efe-0f7e-4eec-bc78-c319ba4ea650)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3d5fabc6-5c87-4cbe-8f43-dfd0ccfe0f08)(content(Whitespace\" \
+         \"))))(Tile((id \
          3d466973-d5e0-4043-900d-ec26482a12fb)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          48190bc4-ef36-42a7-980f-68df493f5266)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d966472d-f629-4989-ac21-85a556f3e8f9)(content(Whitespace\" \
+         55d2a5e5-2464-4d72-8c10-0a3260f81c46)(content(Whitespace\" \
          \"))))(Tile((id \
          04dd8f8b-942a-417b-858f-65470ed57f80)(label(red))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         34880cf5-9371-473f-aa2b-153bb5dd8ba4)(content(Whitespace\" \
+         \"))))(Tile((id \
          e1558846-b586-4155-80c8-506ebdcc5714)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         674725a6-f836-4403-97d9-20c415ad03ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          52b58478-2243-4e3a-9878-8eec784024f4)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          eb3eecaf-9eca-4ee1-bcb5-293976193554)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4abfd8e6-0e8d-47c2-a7da-d97eb79af4c6)(content(Whitespace\" \
+         867cf19e-458a-4e6c-841f-fff3c84ec92c)(content(Whitespace\" \
          \"))))(Tile((id \
          2439272a-30db-49d8-9dd2-e08a379d13c7)(label(black))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c7b814d0-e0e8-4a9f-8646-6f2ae3e8c30a)(content(Whitespace\" \
+         \"))))(Tile((id \
          291f062e-10dc-4481-a5e2-fc8cdf53d09d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0aece139-2634-4ffd-9152-d74a6a5905a8)(content(Whitespace\" \
+         \"))))(Tile((id \
          11dcbbd7-9d5d-4ff1-8a5e-c361a57fc5f4)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         8d1a0476-a4a8-45c1-8ffb-7afa26ea8847)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9922c346-fc8e-499a-8720-4fadcbd43f0a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eea315a6-7c3f-4aa6-8874-f1cb59eee55c)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         c56e8f48-92bc-45a2-bc11-5466c96b4cd5)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         3348b90a-63cc-4f36-b4d0-ee01a7887760)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5187409c-a930-4b38-bcb3-6e3929b64d6e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5f493e48-7241-4a07-a956-28f5d34236b6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8cd2d8ae-1baa-48f4-bd1d-703f24547800)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ed67123-aa3a-4ef6-a3a4-37a5df9548a7)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         f5f35aca-90a7-4a45-b0fb-8f90595f01de)(content(Whitespace\" \
-         \"))))(Tile((id \
+         657dcf2e-29ec-49bd-a758-a901a44c1530)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         05146bc7-3eb7-457b-addf-fadca44c8665)(content(Whitespace\"\\n\"))))(Tile((id \
          0a0201a8-2701-4aa3-8927-317a1ccdbae4)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         b28e8b79-638d-4406-99f0-d81307ed6e4d)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
-         let students : [Student]  = [\n\
-        \  (\"Bob\", 12, \"blue\"),\n\
-        \  (\"Alice\", 17, \"green\"),\n\
-        \  (\"Eve\", 13, \"red\")\n\
-         ] in\n\
-         type Jelly = (get_acne=Bool, red=Bool, black=Bool) in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = [(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")] in\n\
+         type Jelly = (get_acne = Bool, red = Bool, black = Bool) in\n\
          let petiteJelly : [Jelly] = [(true, false, false), (true, false, \
-         true)] in\n\n\n\
+         true)] in\n\n\
          # V1: This version is more idiomatic and requires the caller to \
          provide tuple extension via a higher order function. Therefore more \
          constraints are ensured #\n\
          let v1 =\n\
-        \  let requires = [\n\
-        \    (enforced=^^check(false), \"concat(header(t1), header(t2)) has no \
-         duplicates\")\n\
-        \  ] in\n\
-        \  let ensures = [\n\
-        \    (enforced=^^check(true), \"schema(t3) is equal to \
-         concat(schema(t1), schema(t2))\"), # Assuming the higher order \
-         function provided is tuple extension #\n\
-        \    (enforced=^^check(false), \"nrows(t3) is equal to nrows(t1) * \
+         let _requires = [(enforced = ^^check(false), \"concat(header(t1), \
+         header(t2)) has no duplicates\")] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(true), \"schema(t3) is equal to concat(schema(t1), \
+         schema(t2))\"), # Assuming the higher order function provided is \
+         tuple extension #\n\
+         (enforced = ^^check(false), \"nrows(t3) is equal to nrows(t1) * \
          nrows(t2)\")\n\
-        \  ] in\n\
-        \  let cross_join = typfun r1 -> typfun r2 -> typfun r3 -> \n\
-        \    fun (t1 : [r1], t2 : [r2], combine: ((r1,r2) -> r3)) ->\n\
-        \      flat_map(t1, fun r1 -> map(t2, fun r2 -> combine(r1, r2))) : \
-         [r3] in \n\
-        \  \n\
-        \  # Examples #\n\
-        \  test \n\
-        \    cross_join\n\
-        \    @<Student>\n\
-        \    @<Jelly>\n\
-        \    @<(name=String, age=Int, favorite_color=String, get_acne=Bool, \
-         red=Bool, black=Bool)>\n\
-        \    (students, petiteJelly, fun (s, j) -> s ... j) ==\n\
-        \    ([\n\
-        \      (\"Bob\", 12, \"blue\", true, false, false),\n\
-        \      (\"Bob\", 12, \"blue\", true, false, true),\n\
-        \      (\"Alice\", 17, \"green\", true, false, false),\n\
-        \      (\"Alice\", 17, \"green\", true, false, true),\n\
-        \      (\"Eve\", 13, \"red\", true, false, false),\n\
-        \      (\"Eve\", 13, \"red\", true, false, true)\n\
-        \    ] : [(name=String, age=Int, favorite_color=String, get_acne=Bool, \
-         red=Bool, black=Bool)])\n\
-        \  end\n\
+         ] in\n\
+         let cross_join =\n\
+         typfun r1 ->\n\
+         typfun r2 ->\n\
+         typfun r3 -> fun (t1 : [r1], t2 : [r2], combine : ((r1, r2) -> r3)) \
+         -> flat_map(t1, fun r1 -> map(t2, fun r2 -> combine(r1, r2))) : [r3] \
          in\n\
+         # Examples #\n\
+         test\n\
+         cross_join@<Student>@<Jelly>@<(name = String, age = Int, \
+         favorite_color = String, get_acne = Bool, red = Bool, black = \
+         Bool)>(students, petiteJelly, fun (s, j) -> s ... j)\n\
+         == (\n\
+         [\n\
+         (\"Bob\", 12, \"blue\", true, false, false),\n\
+         (\"Bob\", 12, \"blue\", true, false, true),\n\
+         (\"Alice\", 17, \"green\", true, false, false),\n\
+         (\"Alice\", 17, \"green\", true, false, true),\n\
+         (\"Eve\", 13, \"red\", true, false, false),\n\
+         (\"Eve\", 13, \"red\", true, false, true)\n\
+         ]\n\
+         : [(name = String, age = Int, favorite_color = String, get_acne = \
+         Bool, red = Bool, black = Bool)]\n\
+         ) end in\n\
          # V2: This version more closely matches the TableAPI. Given the lack \
          of row polymorphism no constraints are ensured #\n\
          let v2 =\n\
-        \  let requires = [\n\
-        \    (enforced=^^check(false), \"concat(header(t1), header(t2)) has no \
-         duplicates\")\n\
-        \  ] in\n\
-        \  let ensures = [\n\
-        \    (enforced=^^check(false), \"schema(t3) is equal to \
-         concat(schema(t1), schema(t2))\"),\n\
-        \    (enforced=^^check(false), \"nrows(t3) is equal to nrows(t1) * \
+         let _requires = [(enforced = ^^check(false), \"concat(header(t1), \
+         header(t2)) has no duplicates\")] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(false), \"schema(t3) is equal to concat(schema(t1), \
+         schema(t2))\"),\n\
+         (enforced = ^^check(false), \"nrows(t3) is equal to nrows(t1) * \
          nrows(t2)\")\n\
-        \  ] in\n\
-        \  \n\
-        \  # V1 is the more idiomatic version #  \n\
-        \  let cross_join = fun (t1 : [?], t2 : [?]) ->\n\
-        \    flat_map(t1, fun r1 -> map(t2, fun r2 -> r1 ... r2)) in\n\
-        \  \n\
-        \  \n\
-        \  # Examples #\n\
-        \  test \n\
-        \    cross_join\n\
-        \    (students, petiteJelly) ==\n\
-        \    ([\n\
-        \      (\"Bob\", 12, \"blue\", true, false, false),\n\
-        \      (\"Bob\", 12, \"blue\", true, false, true),\n\
-        \      (\"Alice\", 17, \"green\", true, false, false),\n\
-        \      (\"Alice\", 17, \"green\", true, false, true),\n\
-        \      (\"Eve\", 13, \"red\", true, false, false),\n\
-        \      (\"Eve\", 13, \"red\", true, false, true)\n\
-        \    ] : [(name=String, age=Int, favorite_color=String, get_acne=Bool, \
-         red=Bool, black=Bool)])\n\
-        \  end\n\
-        \  \n\
-         in ?\n";
+         ] in\n\
+         # V1 is the more idiomatic version #\n\
+         let cross_join = fun (t1 : [?], t2 : [?]) -> flat_map(t1, fun r1 -> \
+         map(t2, fun r2 -> r1 ... r2)) in\n\
+         # Examples #\n\
+         test\n\
+         cross_join(students, petiteJelly)\n\
+         == (\n\
+         [\n\
+         (\"Bob\", 12, \"blue\", true, false, false),\n\
+         (\"Bob\", 12, \"blue\", true, false, true),\n\
+         (\"Alice\", 17, \"green\", true, false, false),\n\
+         (\"Alice\", 17, \"green\", true, false, true),\n\
+         (\"Eve\", 13, \"red\", true, false, false),\n\
+         (\"Eve\", 13, \"red\", true, false, true)\n\
+         ]\n\
+         : [(name = String, age = Int, favorite_color = String, get_acne = \
+         Bool, red = Bool, black = Bool)]\n\
+         ) end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIConstructorsemptyTable.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIConstructorsemptyTable.ml
@@ -1,42 +1,40 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Constructors / emptyTable",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id ae87bbc5-a815-4105-afe6-792aade0d1d0)(label(let = \
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         3db95b9a-4e85-4c8a-a312-868904518514)(content(Whitespace\" \
+         afc0e056-b995-49a8-9275-ec8813bf7fae)(content(Whitespace\" \
          \"))))(Tile((id \
-         4234a5dc-d8eb-47a5-af39-88ebc085e244)(label(requires))(mold((out \
+         4234a5dc-d8eb-47a5-af39-88ebc085e244)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         844198bb-869f-49aa-a271-611cadaa910b)(content(Whitespace\" \
+         98cf91b9-c0ab-459e-ab30-d0cb31faad95)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8f4ef603-02eb-437f-9963-33bca59ef987)(content(Whitespace\" \
+         06e6d377-1e31-4103-8f8e-3056144971e4)(content(Whitespace\" \
          \"))))(Tile((id \
          8d894cba-b269-45d6-b66c-3a51f05c1261)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         272636ce-6224-4aca-a2ba-3f9fa660a67d)(content(Whitespace\" \
+         72fecbdd-3772-497e-b4fa-d9786ef59cb2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4524a219-3601-44e1-b4b5-40593cfe7166)(content(Whitespace\"\\n\"))))(Tile((id \
+         7894a73f-f66a-4aad-8879-4529ff40c50e)(content(Whitespace\"\\n\"))))(Tile((id \
          5e060146-46f3-40ef-8f81-1da37f78f493)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3140d701-8fea-4b68-b7f5-f4fbea7977b4)(content(Whitespace\" \
+         c36962db-55fc-40a9-8c56-c1403c514958)(content(Whitespace\" \
          \"))))(Tile((id \
-         32ac9d0a-38ab-429a-abdd-40b44235dff7)(label(ensures))(mold((out \
+         32ac9d0a-38ab-429a-abdd-40b44235dff7)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         56899b06-6a2f-4e05-a10c-e5e7b9b60b62)(content(Whitespace\" \
+         9fbd511d-1e84-44b6-bf99-a02982b9621b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b8b8dcba-07b2-4c8b-8b99-06d84f8d16e1)(content(Whitespace\" \
+         23338048-fa10-4ebe-959b-a5f2043402ac)(content(Whitespace\" \
          \"))))(Tile((id 17336541-c416-4ae9-bfb7-27d10dfbcd85)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         fe080057-3482-4f1d-846c-09298f81e9c9)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          a9755439-898b-4c5d-b775-ab8dcdbca058)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -65,17 +63,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          837350ce-acfd-4a87-b8d4-f1824d33b5a1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0a5d35b5-57f8-4374-89e5-0495b0bbc60e)(content(Whitespace\"\\n\"))))(Tile((id \
+         6eeb8ce0-5b99-47f0-9e1b-927efc30633e)(content(Whitespace\" \
+         \"))))(Tile((id \
          91417092-6751-4ada-9f24-087f38f1b28f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          54fc292d-4f11-480e-969e-9cfbd47b3db6)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ef1ee712-f81c-4ba4-958f-29da614c923b)(content(Whitespace\" \
+         \"))))(Tile((id \
          14839640-8318-44a4-afc0-3a3684ea4c70)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         d61c2c85-f3c7-4dc8-bbe3-face83a47af6)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         139d4af0-a46f-419b-8c5d-14c604a75e43)(content(Whitespace\" \
+         \"))))(Projector((id d61c2c85-f3c7-4dc8-bbe3-face83a47af6)(kind \
+         Checkbox)(syntax(Tile((id \
          85fc4a68-34e3-4bae-99b1-1481a24d93b0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -85,82 +88,77 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7d6e289e-58f0-4393-8271-76da06310686)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dc4c50fd-b4fa-4f67-a1ac-360e2c597e04)(content(Whitespace\" \
+         3abe0f20-5966-4597-94c9-fe6a72c8e053)(content(Whitespace\" \
          \"))))(Tile((id \
          13c1e4bc-58fc-403f-8b7f-3d3ca9472217)(label(\"\\\"nrows(t) is equal \
          to 0\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         45bc5ad6-8708-43e2-9d79-bfdfaddb5c71)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         674b2107-f7b4-4bd3-aa90-4972d9954263)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         a94c9410-2b1c-4421-a0f6-9bf4f6bdb4a0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         03d79ea0-e401-4e6b-ab2e-3357541ff5b8)(content(Whitespace\"\\n\"))))(Secondary((id \
+         8444894e-5dc5-4a97-bc8e-517fdd349e9d)(content(Whitespace\"\\n\"))))(Secondary((id \
          cc4fb141-643c-4a57-9a47-f35918d814d1)(content(Comment\"# Hazel tables \
          are lists; the empty table is the empty list of unit rows \
          #\"))))(Secondary((id \
-         60d58ccc-38b3-4075-a3e8-c219bf7e4896)(content(Whitespace\"\\n\"))))(Tile((id \
+         9076006a-2e7f-4322-a846-c64cf02e4d8b)(content(Whitespace\"\\n\"))))(Tile((id \
          44660fdc-7ee6-40bb-877e-0ef480b2c1ac)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         18b0964b-8133-47f4-aa0b-8677f6f326d9)(content(Whitespace\" \
+         6889bb79-239d-46a3-85db-bc8b7d9224e9)(content(Whitespace\" \
          \"))))(Tile((id \
          7f4b6103-5059-448b-ad9f-8cf43a0f8e88)(label(empty_table))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9cad9cc8-750b-4e91-bdd8-2318890c4e18)(content(Whitespace\" \
+         0c67a87b-5ecc-4a60-81ce-663986ea8c0e)(content(Whitespace\" \
          \"))))(Tile((id \
          8794311c-d061-4332-bde1-ce09dcd0e4cd)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ec48a01f-1b28-439a-843c-5ea1cb5cb1f7)(content(Whitespace\" \
+         338acc96-8684-4b37-8d78-83741c2151c2)(content(Whitespace\" \
          \"))))(Tile((id 2deb617a-8680-4c07-99db-7be2451f6ace)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          8bb09eba-ef2f-4ee9-8566-dceaed269c24)(label(\"()\"))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         aa62cb70-7a02-4c1b-934d-7bb49dbcb600)(content(Whitespace\" \
+         1970ec0f-dfa5-4d3c-9739-808199cdd2a0)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ea4e2bc2-4e0c-48bb-8ab0-f1f589d68cb0)(content(Whitespace\" \
+         c6147310-1249-49f5-8029-696e8e70cfa0)(content(Whitespace\" \
          \"))))(Tile((id \
          68ca5bd9-c55b-4de2-af0e-9b74e319a835)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d6faeebe-2ac2-4d1c-9536-765330e80b96)(content(Whitespace\" \
+         44309272-6e49-4121-ad5d-f8313494c596)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         099d49bc-de67-42ff-90ba-1111b260cf54)(content(Whitespace\"\\n\"))))(Secondary((id \
-         931e870a-e71b-4de3-8e09-45b41bfb0942)(content(Whitespace\"\\n\"))))(Tile((id \
+         c14d4e75-3d7f-4a5d-9465-a20ee632fa17)(content(Whitespace\"\\n\"))))(Secondary((id \
+         b3381317-d861-45ce-8511-854245a271a3)(content(Whitespace\"\\n\"))))(Tile((id \
          18cf871b-8744-4a03-9bd6-43b3c084c1d0)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         5b0c73a2-92a7-4835-ad74-defd9749e78c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9fa1ab03-d321-43db-936c-8cba0c888145)(content(Whitespace\"\\n\"))))(Tile((id \
          cb1823b1-d7f2-4f00-953c-58e6c7f92b88)(label(empty_table))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         de0c5206-5717-46c9-8393-f64a00493cab)(content(Whitespace\" \
+         bfbc0eea-a6db-4c19-945c-55ff9be03de2)(content(Whitespace\" \
          \"))))(Tile((id \
          98334a56-3b2b-4fab-b5f2-e690fd94f04b)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a3d30078-8373-4c0c-8293-c4ccc6bb78b9)(content(Whitespace\" \
+         dcfab6bf-d2e1-4a1a-9958-525bfd6cb9b4)(content(Whitespace\" \
          \"))))(Tile((id \
          89992808-4df9-42be-9d19-36d9dbb8a4f1)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         7dd3ff64-f591-44c1-8f81-6342992abf12)(content(Whitespace\" \
+         2131be20-7ec8-454b-9eb1-6c4bf4e46b12)(content(Whitespace\" \
          \")))))))))(Tile((id \
          da82abf0-50e9-4ffb-a56b-1f8e63ff50a5)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8fd7935e-2997-4589-96c5-492db996aa72)(content(Whitespace\"\\n\"))))(Tile((id \
+         bf6b5c0b-aced-4dc8-8273-730f6c25af7d)(content(Whitespace\"\\n\"))))(Tile((id \
          f3a97f64-e1d2-4223-a98f-f89dde6a1a4b)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         874a1c93-cc64-488f-a5c2-afb03ad6cfe9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fe4a5f6b-c5be-4264-ad3e-b52359a79dfd)(content(Whitespace\" \
-         \"))))(Tile((id \
+         372975f0-0b11-4c01-a752-777ecca9833d)(content(Whitespace\"\\n\"))))(Tile((id \
          a43278e8-ce6d-4108-aa9f-2619e22e347b)(label(length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -170,27 +168,28 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1b0c385e-5e95-4a08-9b18-b7c0224e160b)(label(empty_table))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c95d99f3-f106-44d2-9b64-1c08fc86aaa4)(content(Whitespace\" \
+         4b8a5e18-5e70-44bc-9bd4-ecc44c6759f7)(content(Whitespace\" \
          \"))))(Tile((id \
          ae60a776-e484-4299-8bd8-1e66ebc3acf6)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4c822887-2c8c-4804-a5c3-71e193684b44)(content(Whitespace\" \
+         fe4e3c7a-a050-4d41-b36f-7ef60b4473fe)(content(Whitespace\" \
          \"))))(Tile((id \
          f070be1b-c89c-4712-8fee-13163d0d5bbc)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         7ea6dc6a-8aa9-4051-a2f7-c2fa3c73c8f3)(content(Whitespace\" \
+         772300f9-35ea-493b-8445-95e8bf5fcb15)(content(Whitespace\" \
          \"))))))))))";
       backup_text =
-        "let requires = [] in\n\
-         let ensures = [\n\
-         (enforced=^^check(true), \"schema(t) is equal to []\"),\n\
-         (enforced=^^check(false), \"nrows(t) is equal to 0\")\n\
-         ] in\n\
+        "let _requires = [] in\n\
+         let _ensures = [(enforced=^^check(true), \"schema(t) is equal to \
+         []\"), (enforced = ^^check(false), \"nrows(t) is equal to 0\")] in\n\
          # Hazel tables are lists; the empty table is the empty list of unit \
          rows #\n\
          let empty_table : [()] = [] in\n\n\
-         test empty_table == [] end;\n\
-         test  length(empty_table) == 0 end";
+         test\n\
+         empty_table == [] end;\n\
+         test\n\
+         length(empty_table) == 0 end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIConstructorshcat.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIConstructorshcat.ml
@@ -6,89 +6,96 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         c64e6664-c9aa-4a0e-a426-dba520a7dfe3)(content(Whitespace\" \
+         9106f26a-a1da-44e1-887a-2d9a234e92da)(content(Whitespace\" \
          \"))))(Tile((id \
          f4771ff9-fc6c-42b1-bdf5-e16a8c3058fc)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         ea64dec7-bc62-4c64-90ce-6c7d12ee41e6)(content(Whitespace\" \
+         9144f8f7-5863-42f3-bf6e-00055cdd4789)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d8e53ac7-d1a4-4e83-b93d-87bcf6d40a04)(content(Whitespace\" \
+         24a7b9ea-7fd4-4f6c-9a79-67e71166d70c)(content(Whitespace\" \
          \"))))(Tile((id \
          8262ecb6-b4c1-44bc-b2ce-b026d44b0157)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          64999aef-6ed6-426f-9dfc-b531964cb504)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cd045261-ff5b-4543-9a36-5a01902947b8)(content(Whitespace\" \
+         \"))))(Tile((id \
          4f18680a-0b52-497c-97a1-2219f200fd09)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         07f54318-f8d1-491c-b737-5c06b9ddbf6b)(content(Whitespace\" \
+         \"))))(Tile((id \
          787f0cce-7e8e-4233-a981-a67dfb07df2e)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          685931b7-ee70-4d9a-9e62-8f4be5dcf384)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         439e5455-acca-491c-b64f-669a6b71ac90)(content(Whitespace\" \
+         e7226b3c-7bf4-4df3-b377-420ebb496ca3)(content(Whitespace\" \
          \"))))(Tile((id \
          596d29af-72d8-4a03-b322-ab4dbfae08bb)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         108e8039-5634-4f8e-9979-e5a38e9f535f)(content(Whitespace\" \
+         \"))))(Tile((id \
          a998287a-20bf-4665-ab12-adddff7f1a91)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3ca5d632-ec84-4a9c-81c6-0277824f422b)(content(Whitespace\" \
+         \"))))(Tile((id \
          57038754-6598-4b36-b490-69274172d1ad)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          470e0029-e996-4da8-897c-24adb1508396)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         351bdcae-74e9-4e9e-8885-0ee3ea94f3a0)(content(Whitespace\" \
+         680eeddf-f173-4331-b5dc-c4c343316708)(content(Whitespace\" \
          \"))))(Tile((id \
          f8154a26-64be-4f81-a0fa-c230f2849d38)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e40ce805-0dba-4719-aa38-24243988c0d1)(content(Whitespace\" \
+         \"))))(Tile((id \
          ea42adee-080a-4155-a93b-628f93da2e6b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a7961476-e144-4bfb-912f-d3636e02e626)(content(Whitespace\" \
+         \"))))(Tile((id \
          d4615c3e-51b7-4c09-97a7-575f282081dd)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         6c72d486-f388-44af-ba58-23ccf73f1cbb)(content(Whitespace\" \
+         4fc83501-0dd2-42fe-9227-d266280f48ec)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         bf0080a5-67bb-4f3b-bc1f-a10d5f30c5ef)(content(Whitespace\"\\n\"))))(Tile((id \
+         b1006b84-b225-4198-b17d-cce0bd6588b8)(content(Whitespace\"\\n\"))))(Tile((id \
          b74f7d4e-080f-465b-b680-665c903fe3fb)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         0c863e44-d2b4-459c-a058-799d1d950382)(content(Whitespace\" \
+         91caec37-6ecd-4a23-9596-5c811669f31c)(content(Whitespace\" \
          \"))))(Tile((id \
          85af2b24-ad14-44bc-a6cc-8ee8cbe4a445)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         688db9f6-0645-4fc2-946d-81c7b92a33e0)(content(Whitespace\" \
+         6d19376a-986f-472b-a720-e5ed44b29a70)(content(Whitespace\" \
          \"))))(Tile((id \
          583bb5e5-f063-4ebc-b268-4ae5081ceef5)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         425df4f0-1ad0-4f30-87e0-d2655144ecf2)(content(Whitespace\" \
+         a1cf0769-faab-4489-9058-4d156b004d02)(content(Whitespace\" \
          \"))))(Tile((id 6e492314-c6c5-4d33-9d3b-e4f56d7cd16b)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          740db495-abc4-490a-b143-e2f30353e13d)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         ac30a6c5-f630-4804-8da9-7877c374d8b1)(content(Whitespace\" \
+         2f9aaf30-a64c-4157-870a-844fb0d021f2)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4b789aee-641a-4872-828e-29d547fdaf75)(content(Whitespace\" \
+         a3fb088e-155f-4655-8b9e-8673b7a96825)(content(Whitespace\" \
          \"))))(Tile((id 5354b7b1-a2ab-4ccb-ba33-69ce49e5b850)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a43e7690-0dc6-4faf-af37-96e6b11ac525)(content(Whitespace\"\\n\"))))(Secondary((id \
-         29b85f42-8249-4b65-a75a-fbe0d06de45e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         78799e1a-b3c1-4210-be3e-73d5d143d4af)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          ead19e19-4f4a-4991-8569-d55909071f77)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -114,10 +121,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          627561b0-1b7a-4145-8c9e-52c50634ca0d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f6d30426-3db1-4872-afd2-d9756bc5ea96)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2abda590-d631-4ba0-81b6-8002142e0892)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9a80bba7-819e-46b6-9032-b1a44e5f1856)(content(Whitespace\" \
+         bf1056e8-dbd3-4779-aeb5-4e081595adeb)(content(Whitespace\" \
          \"))))(Tile((id \
          3d3934f0-be4a-43b0-9b2a-779fc25cacb9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -144,10 +148,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b226d317-790a-42d8-b416-cdbe2842f1f3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         815fca04-2ad2-4cb2-aa71-c63ac9600025)(content(Whitespace\"\\n\"))))(Secondary((id \
-         528a6c8e-c05f-442c-a235-8b2450d17908)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c69c6b34-1b6f-48d8-b7ff-7fc5ea1d7566)(content(Whitespace\" \
+         ae3eb574-cac6-4ca2-ae2e-10a10df41957)(content(Whitespace\" \
          \"))))(Tile((id \
          fc44f1de-2255-4bdb-91f5-7fd41439d4f4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -158,7 +159,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1340aced-9b03-4925-92cb-dd51c1ab4117)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         489e3d4a-a7a3-4deb-afa4-0cb57b161557)(content(Whitespace\" \
+         c8735a7c-76cb-4c88-8c06-ca1510a8ea39)(content(Whitespace\" \
          \"))))(Tile((id \
          b875078d-0372-43b6-8dff-5e77b53e8466)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -166,171 +167,198 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cbef5ebe-f917-43ec-9fb1-f846aac5ac5b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         84063e18-daa6-43fc-9fc8-b3e14ca7edd9)(content(Whitespace\" \
+         a523bdc9-f4fc-4da0-9a9e-c7271db9b080)(content(Whitespace\" \
          \"))))(Tile((id \
          4304dcbb-667d-4790-a242-c94bb0623da7)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7b0ac0e1-d332-4a3c-b793-b775448278bc)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         f1d64f37-aea6-4a80-82a3-d45d45a1dce2)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         1415b935-487e-457b-9985-7dfffd9c8d7e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1c5a2451-2470-4b6d-ab39-ea9ded713e49)(content(Whitespace\"\\n\"))))(Tile((id \
+         66f89362-2094-4948-aa0e-a4d3ece8e15b)(content(Whitespace\"\\n\"))))(Tile((id \
          afd7884f-d8a9-4356-b2f1-625a024b9973)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         50c8fa57-2f20-490a-aa4d-66dd8473c440)(content(Whitespace\" \
+         d01faf99-930a-4a3a-ad01-0bfefa6abf34)(content(Whitespace\" \
          \"))))(Tile((id \
          e792e1ae-6947-4a5a-9061-d5e48e7d4c24)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         26ca7509-06a4-4aef-bcd8-94fc6281f552)(content(Whitespace\" \
+         63a4e891-cf96-46b0-9530-d0dbee3a050a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         df1a93e9-ad0f-417b-ae93-439ed3ccd4b3)(content(Whitespace\" \
+         d17e2af8-d685-45e5-b772-8046a8af3fb3)(content(Whitespace\" \
          \"))))(Tile((id \
          f421785d-5d80-48ff-b600-92f6d86b7cfa)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          4d7c7803-a3cb-41f2-821e-cc3f1befd5b1)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         fd188cb5-32e2-4560-b195-58b67e6f206b)(content(Whitespace\" \
+         \"))))(Tile((id \
          85c0d8a6-6127-41d9-9051-92f6e74afe81)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         50ca19f3-a8d0-4a13-b166-079e2487514e)(content(Whitespace\" \
+         \"))))(Tile((id \
          849ab779-2e3c-489d-a53a-508beb024e9c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9820885c-a5f2-4bea-a728-69834d48b5cb)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8081a62c-d82e-44d5-94e9-150b2a169b62)(content(Whitespace\" \
+         59f850d4-d883-4e2f-9bff-a1767a8371d3)(content(Whitespace\" \
          \"))))(Tile((id \
          7316ee7f-abb9-45b1-bfce-68833c0b732b)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         166a9a17-8290-4593-b722-75235fee5330)(content(Whitespace\" \
+         \"))))(Tile((id \
          c028ca6c-28b3-405c-8fc3-364910fff0f9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         74cbefe6-0691-4d0e-9704-3e86d8ca6b29)(content(Whitespace\" \
+         \"))))(Tile((id \
          ddc86247-cdda-44f4-8c51-d85f1f290178)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          809b0a02-9d32-476d-b84d-cfbea04f19f0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d2ca9b55-b80b-4726-8aa3-fe9a9a2d18d4)(content(Whitespace\" \
+         275d4fde-d5c4-49e8-9f6f-2af14f95c5cb)(content(Whitespace\" \
          \"))))(Tile((id \
          ddb27f35-9238-447d-94dd-6ce82361eb67)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e7b479ef-b080-4c70-b47c-2bea3dd461f0)(content(Whitespace\" \
+         \"))))(Tile((id \
          67da692a-4e9d-42ba-b271-5d93096c891c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b4274f4c-d46d-4f89-b301-ff625d71c411)(content(Whitespace\" \
+         \"))))(Tile((id \
          e7f4a564-ca64-4689-9f37-c94fbbf577b0)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c20402d8-e7fd-40e9-a308-059ea0111fda)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0a214b1f-649a-448a-a6e7-d932bcf177f3)(content(Whitespace\" \
+         3c86704d-45a8-485e-bcaf-9498a3b47751)(content(Whitespace\" \
          \"))))(Tile((id \
          b55fe75e-0542-4dc5-ae38-f3f55d2ec470)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         038c746d-4cc9-425a-80de-8120b1a6ee62)(content(Whitespace\" \
+         \"))))(Tile((id \
          d911ed6f-1f7a-4110-a9b4-44bb325c142b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c33cf1f1-813c-4530-863b-5777f05badc5)(content(Whitespace\" \
+         \"))))(Tile((id \
          6ed3078b-6b14-4e87-a637-23ae603eb049)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a86c56af-e465-42c4-b554-1254dc2971a0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0f9f1ee2-9c99-46a5-a644-25639c9c1905)(content(Whitespace\" \
+         7080e2a9-adf7-4250-b622-9bfccd00c1f6)(content(Whitespace\" \
          \"))))(Tile((id \
          b5012f13-d2fd-438f-8562-4ff7b8b44d9e)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8aeacacd-7752-4902-b52f-440389fb028a)(content(Whitespace\" \
+         \"))))(Tile((id \
          934b4727-36ed-4a3e-8664-d458e2403eea)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5283bd44-a6e6-48a9-9107-a4ed7920e6e4)(content(Whitespace\" \
+         \"))))(Tile((id \
          d192a9bf-a5ea-4f98-bdad-914c669f09a6)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          81108972-f9be-4e64-9941-91d4ad209f45)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0b291639-cd4a-4bd4-8e97-6ee23453d3ca)(content(Whitespace\" \
+         c434c37e-aa8d-4067-8ed4-0c46ba49364d)(content(Whitespace\" \
          \"))))(Tile((id \
          3421c635-47f9-4564-86ce-848cad901883)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f2fae0a8-4362-4c42-af87-a517b68b47c1)(content(Whitespace\" \
+         \"))))(Tile((id \
          7569452e-2517-4121-911d-56cf1e9d1e67)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         86e8ce58-3e9c-4905-a6c5-3f6441201197)(content(Whitespace\" \
+         \"))))(Tile((id \
          6eb2395a-66b1-45fb-a183-e739a861a5e7)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a3a7e155-f34e-4afb-91b7-595e9b037fdd)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ebc3e7d2-bf84-4abc-9b6f-18e25bd6057f)(content(Whitespace\" \
+         6ecfe73e-6cb6-4ed6-8e14-99ab705a1337)(content(Whitespace\" \
          \"))))(Tile((id \
          ae6f70f6-eb8f-4a1a-b923-001e9798ffd5)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         11fdf3e6-c3d4-43b7-a83d-bd0ed56b85ef)(content(Whitespace\" \
+         \"))))(Tile((id \
          900c70dc-249d-4b51-ad4c-e4398a1f1b2e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         691b2e9c-9f45-4f4a-9579-739397408a68)(content(Whitespace\" \
+         \"))))(Tile((id \
          ae931ed2-e3e9-4e20-a9e2-3f2096847de5)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5965cfdb-47d7-46a1-9cee-be645d192555)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1c992dec-9046-414f-8ed9-39e7363b04e1)(content(Whitespace\" \
+         2c865e26-51bf-48a6-94bb-768a558c90ea)(content(Whitespace\" \
          \"))))(Tile((id \
          2d7cabe4-9238-473a-8449-d999f2097eb3)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         368c646b-82f5-4a0d-98e8-c304d9ccbeff)(content(Whitespace\" \
+         \"))))(Tile((id \
          71e4c0ac-8c60-4b07-96f6-94537f6f4b38)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         58051e7b-a10a-4254-af7b-337a4454da11)(content(Whitespace\" \
+         \"))))(Tile((id \
          05bb7fae-dab4-4957-910e-3cb5a697e41c)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c4dfeeb4-628c-404a-83a4-40c471c0a003)(content(Whitespace\" \
+         ca02d1dc-830a-4750-b77d-562684df1bff)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         edfdc2d9-936c-4b6c-a1fe-74de4aecf91b)(content(Whitespace\"\\n\"))))(Tile((id \
+         8d0863e8-6063-4be9-bc57-af5abfecfc90)(content(Whitespace\"\\n\"))))(Tile((id \
          c5a307db-8dca-4ee2-b490-97551e4dfe3f)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         6447e39e-0524-4d3b-82f9-4969db89f0d8)(content(Whitespace\" \
+         d767645f-89d5-4256-b481-b78454c0cb80)(content(Whitespace\" \
          \"))))(Tile((id \
          2d0af9cc-e1ce-4848-9ea6-2c528dd2e8c9)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0802efa7-4455-4f2a-81c9-3e913a8be10e)(content(Whitespace\" \
+         db752d54-a8fe-4ec3-bb4b-f6000731cfe8)(content(Whitespace\" \
          \"))))(Tile((id \
          e6512145-628c-4f1f-8192-a25c287c3d2a)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d281a4dd-8cde-48a1-baad-dc13c874863d)(content(Whitespace\" \
+         e1575bad-95d4-476c-8f69-fc421779a001)(content(Whitespace\" \
          \"))))(Tile((id ceb06e34-d5bf-47a3-a934-b1174966798a)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          2060f284-d6d8-48b9-b909-cd7e3c24baaa)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a196e091-37f5-4271-bde4-bdf3bb27bb15)(content(Whitespace\" \
+         74a3a47b-f016-4bf3-bd3c-b747dec52d46)(content(Whitespace\" \
          \")))))((Secondary((id \
-         916eb19f-ab24-4af3-9cba-be7521e8376d)(content(Whitespace\" \
+         ba0eff49-53c1-4171-a8e9-328d28de4a3c)(content(Whitespace\" \
          \"))))(Tile((id bde5f93c-f31f-4a53-93f2-2046190a5dfc)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         843d48c9-bc53-4191-a162-f4bd50274351)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b1580023-12fb-4330-bfe5-103a25425cea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3459a892-9ee5-4d2b-aa51-92f080c5c4c0)(content(Whitespace\" \
-         \"))))(Tile((id \
+         46b66b34-6cde-4b6c-b506-239058dcdc59)(content(Whitespace\"\\n\"))))(Tile((id \
          438aade9-f3fe-4929-ba20-d4c3049bcdb9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -400,11 +428,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d725d808-101d-42a9-afac-bcc3697058f2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0654a027-12bf-4e7c-835a-ddbc6f25ca49)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e68bcc50-3c19-45e1-b4aa-684ed3362a44)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eae67ff5-2ae6-4c99-aedc-8171b7231189)(content(Whitespace\" \
-         \"))))(Tile((id \
+         250514cf-fb92-4db3-8f2e-edff1d55581b)(content(Whitespace\"\\n\"))))(Tile((id \
          95dc85f3-127b-47a7-9d2e-fe169939eb2a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -470,11 +494,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0226936d-48c0-4ffd-9615-ee1d1a58c35e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1ac2a3aa-afe9-496d-8b6f-5b2bda2cee5c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a19e86e4-41c7-4600-a5f6-d7f53c577407)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc11a2b5-adfe-49ff-8a79-572ea0fc0f5a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8e301945-9b0d-4036-b59b-daa08fbf02bd)(content(Whitespace\"\\n\"))))(Tile((id \
          4bb317df-5773-46a2-9e61-2c0d95aa0448)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -484,11 +504,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          50c640ce-4c2c-47bb-b0f3-c3b75c66da9e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         01f3ae7f-a6fb-4c44-8698-bee2f6c6be91)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c46b2b32-6014-4e7c-8e7b-9cc9427243af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         88d90237-20e2-4db9-9787-bd3b82888c55)(content(Whitespace\" \
+         cfe3391b-0467-4b4a-8f72-91e30bc0ac88)(content(Whitespace\" \
          \"))))(Tile((id \
          7986d807-6a5c-48ff-bfcb-bfa4119198f6)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -496,7 +512,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          54059d3f-7101-4f63-becd-3fb921740df2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e2963aa3-ce0e-4588-9f33-ab82bb1430e5)(content(Whitespace\" \
+         ecdb1c12-f536-40d5-8ab0-09072323ee83)(content(Whitespace\" \
          \"))))(Tile((id \
          bdba140d-7f37-4dc9-94d5-de8db1e9c084)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -504,7 +520,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1d290555-d1b0-4763-b5a3-a916482cea3f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         522e2de3-dd8e-4fcf-89f8-8335514de0fd)(content(Whitespace\" \
+         70d02ddd-7503-495b-b284-409481bbeb0b)(content(Whitespace\" \
          \"))))(Tile((id \
          20433387-2a44-44b0-a0e6-c61f80da8189)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -512,7 +528,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e71ef86c-c6b1-4a0e-aa7d-b1cd84b6d646)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ab994dba-22e1-4658-99a1-0094dbea32b5)(content(Whitespace\" \
+         99817356-e3c1-452a-a439-c15d1f221b6c)(content(Whitespace\" \
          \"))))(Tile((id \
          829c6b57-a83a-4d81-90c7-acf2af58bd86)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -520,7 +536,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0e8ba7c2-56ba-4d7f-a746-59975af5c0c6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         03a3c4e5-e069-4673-a30b-b59626a5d228)(content(Whitespace\" \
+         fdef1dee-579b-4ec1-bd8b-d17ab993a410)(content(Whitespace\" \
          \"))))(Tile((id \
          1db4a7e1-2b3f-415b-b84e-dca368887098)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -528,7 +544,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f3f4d139-7118-40e7-a163-7998240e5b8e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         838d808c-74d1-43bd-adce-03a7238b7006)(content(Whitespace\" \
+         8b266f24-f308-4edc-974e-00c2d9f1777e)(content(Whitespace\" \
          \"))))(Tile((id \
          a5d7a890-361a-40b9-9652-4a7024ceefd2)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -536,57 +552,46 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c81f3327-31df-4a0d-99b8-7cd743753ddb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         36e9b19f-bfd9-445e-9fdd-a161c6ca8dd1)(content(Whitespace\" \
+         a2d766fb-6652-46d3-9d2a-7a8d40918504)(content(Whitespace\" \
          \"))))(Tile((id \
          934aa048-c3c5-403f-aec6-5573eedcd72c)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         738baa37-88f8-4f5b-a39c-e1ae634692c5)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e0ed5fbd-a054-4b03-8b32-7c6953f8a229)(content(Whitespace\" \
+         3406b226-a6e8-440c-8616-e9e8c6d1404d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         f6526d48-64b5-428e-a418-a5efd178d677)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         aca05157-87be-444c-8f69-369a1d552a8f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d26df0eb-8b6e-4c15-a5b4-c2fbb942e8d9)(content(Whitespace\"\\n\"))))(Secondary((id \
          60871723-f783-44a4-b880-7b15b8bc0273)(content(Comment\"# V1: This \
          version is more idiomatic but requires the caller to pass a function \
          combining the rows explicitly thereby getting more type safety. \
          #\"))))(Secondary((id \
-         7518934e-ee49-4e74-a013-37befb93066a)(content(Whitespace\"\\n\"))))(Tile((id \
+         912fe910-dfc7-457e-8fb5-61701c306fc8)(content(Whitespace\"\\n\"))))(Tile((id \
          c98f0bcf-6b13-495f-a231-4ad8eb4ae32a)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         25961c99-1f2f-435a-82f8-88bac8a2b375)(content(Whitespace\" \
+         4e37dbd7-b844-4cea-8972-67e5d1e70552)(content(Whitespace\" \
          \"))))(Tile((id \
          2122387a-99fa-4e04-ae41-b962b43d050b)(label(v1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         68b62f3f-6070-4343-a697-d5d2f00fe12e)(content(Whitespace\" \
+         190d06a4-9c5a-43d7-a33d-e92de1cb1f8c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d1aab87f-6635-4498-955c-64a501dbb32b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9c9e2e3e-d7ee-4263-94ca-5a3ff807ebf1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         21036d62-a79f-4f91-8899-82762a1f6583)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         af467a62-2b95-4512-b081-6940c987fc9a)(content(Whitespace\" \
-         \"))))(Tile((id 94d9cfd6-92f4-4b71-9042-fcb7e2ab6bb8)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         fadaf4a8-1a9b-4cc7-9abb-30b2d1a1ea59)(content(Whitespace\" \
+         21bfdf5d-3baf-4b71-8b3c-158c74d78255)(content(Whitespace\"\\n\"))))(Tile((id \
+         94d9cfd6-92f4-4b71-9042-fcb7e2ab6bb8)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ad49b2e1-7912-438b-b616-bba4d4744d51)(content(Whitespace\" \
          \"))))(Tile((id \
-         7858784e-de07-43de-96de-3e82f9868a0c)(label(requires))(mold((out \
+         7858784e-de07-43de-96de-3e82f9868a0c)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         b794350f-f11b-49a0-92d4-2dc14f90d6d6)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         fc8e0b5a-4f58-41b8-8f7d-8d481fcc1a21)(content(Whitespace\"\\n\"))))(Secondary((id \
-         483934c4-dd53-4b7b-b2f5-40b079952235)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab26b6ef-e7e5-40b0-842d-3affd3085acd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3d661aa3-96c2-4bac-8f92-eb3ef0b32193)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f4f296f0-cd07-47bc-8901-cac22bbe2bbd)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         d91288c1-d483-42ce-ab81-7591287c8879)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         1b968f7b-3bce-42c4-94b1-b8de571b83f6)(content(Whitespace\" \
+         \"))))(Tile((id b794350f-f11b-49a0-92d4-2dc14f90d6d6)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         242c6bd3-fa6c-45bd-b876-6b5033b2cb6b)(content(Whitespace\"\\n\"))))(Tile((id \
          de203255-f554-4154-956e-8ad648a30151)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -615,25 +620,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          780c756f-b4cf-474f-9ded-1e236ea5cbb9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3e912f18-6e91-4b42-9799-91a7fb77a517)(content(Whitespace\"\\n\"))))(Secondary((id \
-         23482d1e-a342-4018-8cb1-c89d94c44869)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bda79b6a-29dc-4171-8d91-b629281bda13)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         49a54a28-e378-47df-aa7d-5a07bdbdb6f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb15adb1-cf45-4c4c-bf97-77fbc877a0a4)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f0320f30-6ff1-401e-b059-51542fd05a65)(content(Whitespace\"\\n\"))))(Tile((id \
          8877ce10-f452-42c0-bb0d-334fd7786dd9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          1517dbfc-7585-456f-945d-0cc825233b39)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c98128bf-b721-49ff-93a0-1a81177f670f)(content(Whitespace\" \
+         \"))))(Tile((id \
          5efa422f-2ffc-4e5c-bd35-3de89fd0aaec)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         64552734-2b0d-4e76-bfee-be34cde27d5d)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a030008d-96ad-4496-801c-78ff1a9862f0)(content(Whitespace\" \
+         \"))))(Projector((id 64552734-2b0d-4e76-bfee-be34cde27d5d)(kind \
+         Checkbox)(syntax(Tile((id \
          b66dd31e-5d7c-4634-bbfb-2cf4b9ef37e1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -643,44 +644,31 @@ let out : string * Haz3lcore.PersistentSegment.t =
          59aed6e1-51b6-4281-a49a-6a4a4c2e79a9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e5a92f75-3cef-4ad8-a34d-4a05429eb6a3)(content(Whitespace\" \
+         692baa2c-c0bf-4c4c-9631-76029690e191)(content(Whitespace\" \
          \"))))(Tile((id \
          b70d1d44-4099-407c-849e-f8ad835bbf7c)(label(\"\\\"nrows(t1) is equal \
          to nrows(t2)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e7db3f87-801d-44e8-8bb9-ecc70222e6cb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         54ce9946-2e5b-4c21-ae1e-0d80a29e1388)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7df7a39d-36de-4b50-b786-7123e7f25e6a)(content(Whitespace\" \
+         58c4efe0-cf2c-4268-92ee-c8438ea876ea)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         8d5780f8-2e72-4097-98f2-4a731c34f0a3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2aa71a2d-9676-4517-b70b-3dc61b7f48ff)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         73b7c910-4ac0-45be-99e6-7f53fa7fe44d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e7aff0d6-0931-42a3-8b26-38bac1138374)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1467eb0-96ec-46f9-b0bb-60e9702f0cd3)(content(Whitespace\" \
-         \"))))(Tile((id 98c69fe6-c296-4756-90e8-d4571dc1fe25)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         10c85597-ece7-4cf3-a1f1-3bc60da33731)(content(Whitespace\" \
+         ceaf9d99-995e-44c5-88df-8ff334a715dc)(content(Whitespace\"\\n\"))))(Tile((id \
+         98c69fe6-c296-4756-90e8-d4571dc1fe25)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         1d30c3a7-b88a-423d-a22d-8696cf295b46)(content(Whitespace\" \
          \"))))(Tile((id \
-         bef11464-7f9e-4ffa-bf82-a227bd5602ad)(label(ensures))(mold((out \
+         bef11464-7f9e-4ffa-bf82-a227bd5602ad)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         01446f41-15da-496f-9fd2-95e39908214e)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         5e06e06f-340d-493a-8955-a74ff5d6fb40)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8cc71421-46ed-4811-9557-58b1dfb6ac74)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e9127bdc-e8eb-44b3-8e95-86b0e1c1df41)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d15e79b8-0f0e-4463-9406-2b8dfe238b97)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ebb84fe4-753b-4c02-9223-6cd3463775aa)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1c794ce5-f85d-46d5-8431-ed561aa28450)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         2f9e224b-4099-478c-a0a1-1aaa395b566c)(content(Whitespace\" \
+         \"))))(Tile((id 01446f41-15da-496f-9fd2-95e39908214e)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         0a6c15c2-d013-4e8b-a9c5-9d8ce2b72460)(content(Whitespace\"\\n\"))))(Tile((id \
          dfdcc611-af22-484f-af9e-aa13ac409ad7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -709,30 +697,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a476d070-d13f-47f0-a24c-15b0ec849edd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         84123350-031c-44dc-b426-505d9b67ed13)(content(Whitespace\" \
+         e2a3c214-5803-4ad3-aa43-c3c2b6b01fd1)(content(Whitespace\" \
          \"))))(Secondary((id \
          3d274d43-3382-42df-92e2-7296fc2aa2b3)(content(Comment\"# Assuming the \
          higher order function provided is tuple extension \
          #\"))))(Secondary((id \
-         d1263f97-4ccf-4cfa-a39e-8b1ff392d483)(content(Whitespace\"\\n\"))))(Secondary((id \
-         83bb8901-e441-48c4-848f-debd4c432414)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d350587f-a899-4911-b9ec-454255c9dde4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab34324c-85c2-48b9-b5db-9afa0b6f90b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c24b2885-a0e2-419c-95e6-6277122e70a2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8bf25edb-b51c-48b8-b7e7-f045af62d7b2)(content(Whitespace\"\\n\"))))(Tile((id \
          330ad824-f618-4af4-897a-d31c6d2deb74)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          470d6735-ebc0-48d0-9fa3-7a92660fc8d2)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         bc051a6f-959f-46f1-a358-8c39fd549a70)(content(Whitespace\" \
+         \"))))(Tile((id \
          7b686350-0702-49b2-91ef-2cafada71cfe)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         abf7044d-1bf9-47f3-b3ed-2c75d5b5e4dd)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ba37ccd2-2c97-4ecd-b859-b719df4123f0)(content(Whitespace\" \
+         \"))))(Projector((id abf7044d-1bf9-47f3-b3ed-2c75d5b5e4dd)(kind \
+         Checkbox)(syntax(Tile((id \
          9971d2fd-0d78-4679-9def-f26a584526ae)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -742,128 +726,123 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3697b784-840a-4cfa-9f25-0196193c4194)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4ef7f78b-bafe-4204-b275-ba85553dbefb)(content(Whitespace\" \
+         a24b752c-e3bb-4efe-bb57-df242f88a62c)(content(Whitespace\" \
          \"))))(Tile((id \
          5214de4a-98f4-4767-b40f-60f9cd718c09)(label(\"\\\"nrows(t3) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f2bf6207-8193-48e6-a771-8ec698b157bd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6f687a3f-b2a5-4e7d-b66e-a02add78650a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         93714765-0b4c-4ebb-ab3d-a496671b4d12)(content(Whitespace\" \
+         6436f4ca-a0e6-4174-90e2-9adcfe1880b0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         f7e803f2-1927-4bf3-a614-2f77f1ab2ad7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2fe28f3e-dd5f-4a27-b0eb-9700a20c984e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         899df2fd-e674-46de-9ce9-aaff3f0184f6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b0786642-29ea-4b14-b8fa-8c1901a10290)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         18e61f2c-1dae-4dd4-9653-945ef18a82d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         7d8b206f-e2d5-4aa2-98d5-96a1b47ff633)(content(Whitespace\"\\n\"))))(Secondary((id \
          7fc0c5ff-931c-4730-934f-a47f5117f634)(content(Comment\"# V1 is the \
          more idiomatic version #\"))))(Secondary((id \
-         7a880f79-ed13-4ce8-8103-8b2bed3aed78)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eea3e020-034d-4b6d-95a2-442334850b8b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         adc56f07-2e53-499a-94ef-311b13bcbbe4)(content(Whitespace\" \
-         \"))))(Tile((id 7b2a86bd-65d9-4a1e-b878-5a0d863f1f99)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         24d334b1-21d2-418f-b5e7-0a3f1853c7db)(content(Whitespace\" \
+         bdea71a6-b420-4d6f-b589-cdf9f64bf0b1)(content(Whitespace\"\\n\"))))(Tile((id \
+         7b2a86bd-65d9-4a1e-b878-5a0d863f1f99)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0dbfaa47-7fe5-4e21-81a6-3c57680a37a9)(content(Whitespace\" \
          \"))))(Tile((id \
          173dab2b-fcd4-473e-910d-218ae6a3ceb1)(label(hcat))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7ea8dece-a5a9-4f1e-a248-085155b5c6e5)(content(Whitespace\" \
+         0a1623be-bf8d-452b-89e8-1b26dc5203ef)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e9445838-97c5-4f18-9ecf-f65f40bbfb34)(content(Whitespace\" \
-         \"))))(Tile((id fd8e23dc-1ed5-42c1-b06c-4ee5332cbc15)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         68f187fd-5004-4b24-a84a-69e2133067ed)(content(Whitespace\" \
+         1b604f79-28c5-44f3-845c-8c981cab5cd8)(content(Whitespace\"\\n\"))))(Tile((id \
+         fd8e23dc-1ed5-42c1-b06c-4ee5332cbc15)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         96696269-32a4-41d4-b00e-31fb14606b19)(content(Whitespace\" \
          \"))))(Tile((id \
          4ae5cac6-b924-42b0-b8b7-ae1f18bc55d9)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         ec24f9a2-01a1-4dd2-926e-61133b3c9ad8)(content(Whitespace\" \
+         be6a4d30-ba36-4022-abe3-e5fcb9a513c2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         939be504-9a61-405f-bd16-1afd37a5cfd2)(content(Whitespace\" \
+         f73592cf-2309-4aca-94a7-0f3455efbd3c)(content(Whitespace\" \
          \"))))(Tile((id 659b9259-257b-4179-b885-2fd091bf31bd)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         7b8ae476-a054-4413-875b-d5657756b12b)(content(Whitespace\" \
+         e6d693d1-deb2-4a21-aad5-dc1285ebd91b)(content(Whitespace\" \
          \"))))(Tile((id \
          3df66e54-ac13-458d-8667-02a43c8ace81)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         3325798b-65d1-423c-b1d3-31802bd5b1cd)(content(Whitespace\" \
+         6a7b9c1b-e438-4030-8950-24e68c4e9645)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f103a1b2-9dcf-48d0-8125-354d59f8b43f)(content(Whitespace\" \
+         92c54533-782a-4ed6-af10-e175bbfc3ccc)(content(Whitespace\" \
          \"))))(Tile((id d8188750-0ffa-4105-86e7-51506adc14ff)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         fe73acf0-1e64-4c8d-b4e8-45b0ed99200c)(content(Whitespace\" \
+         7890c52d-e092-4517-8dbf-7d7cdbf06e60)(content(Whitespace\" \
          \"))))(Tile((id \
          c9f2a611-ae4b-47d0-969e-39fe2f7a4d01)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         23322dca-fda2-45c4-934f-9afac1f69ab4)(content(Whitespace\" \
+         9d1cb374-ffce-404f-bd44-3c178c4b30e5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         df7ab567-f38d-4226-bece-acf428569d01)(content(Whitespace\" \
+         33d400e3-eeb3-475b-a1d0-9b7fe5fec577)(content(Whitespace\" \
          \"))))(Tile((id 3acea0a0-9231-4e7c-bc32-4c7f1a2fc69f)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f19500d1-fbf4-4865-9b90-fdf30d54d79f)(content(Whitespace\" \
+         8e81bf2b-25ca-4c73-82df-491a16e9b2fa)(content(Whitespace\" \
          \"))))(Tile((id \
          a802fa82-8449-4efc-9867-1220fa855466)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          0693e011-b769-4450-9ee2-f36cb5d0033b)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         10643da6-96eb-46aa-9acb-6df8bb76aeb4)(content(Whitespace\" \
+         \"))))(Tile((id \
          1a78ad6c-e817-4daa-bdd1-1d69d0585757)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         437c43b8-c4d3-4a6b-9a56-52c4f6dfc927)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         160ef3b2-fc44-4bd3-82a6-d0f786b08847)(content(Whitespace\" \
+         \"))))(Tile((id 437c43b8-c4d3-4a6b-9a56-52c4f6dfc927)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          c304f754-9df0-4142-83fa-2c17ee8e7e78)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          e65f660c-421f-42c7-ab65-92d4ddfb3087)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ebf24999-3b3f-44a8-8493-d01302d5e32a)(content(Whitespace\" \
+         7026c1e4-c36c-48ba-aaff-dafbdbee5cfc)(content(Whitespace\" \
          \"))))(Tile((id \
          c6846c5b-63ad-4560-af1f-ad0e59e9bc28)(label(t2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c8853c8b-eeb0-40c6-8e79-eb8ad0fdbec8)(content(Whitespace\" \
+         \"))))(Tile((id \
          09496727-f65a-4b34-8b2b-62bf8c420fe7)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d2faa61e-ecd7-4cb1-82f0-fab1de340773)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b07d3a0b-7516-4f1b-a6c9-4ecdca23dd4f)(content(Whitespace\" \
+         \"))))(Tile((id d2faa61e-ecd7-4cb1-82f0-fab1de340773)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          cb6ada86-f21e-44d1-aff4-05f92fb780f6)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          eb85352b-24ec-43a4-9631-ed3c37a2787e)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         2f495ee4-e3ba-4e3d-89ed-aecea95e0263)(content(Whitespace\" \
+         690df8fa-4775-444a-bffc-5d553488a7d7)(content(Whitespace\" \
          \"))))(Tile((id \
          0e047d63-d021-448a-8978-1da638236606)(label(combine))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         652c9b99-fcfe-4890-b08c-336c398f7484)(content(Whitespace\" \
+         \"))))(Tile((id \
          8e8604e7-454e-4ee4-9489-d45897bbb576)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         67050354-2208-4d7e-8c8a-a79d81b85710)(content(Whitespace\" \
+         e3d6f5b8-df9c-4a8f-b14b-4ddc0a12fbd1)(content(Whitespace\" \
          \"))))(Tile((id \
          3e218f5c-973a-4fba-8fb1-a4a095f9ecd4)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -874,31 +853,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4d74b39d-9e57-428e-8fda-b922267586c8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         426bb771-eb1b-4d79-b8a6-3f390057010a)(content(Whitespace\" \
+         aa0b6323-71ab-4fb2-97c2-2fa733e0599b)(content(Whitespace\" \
          \"))))(Tile((id \
          7b4ec06e-f94a-4ec5-be13-05db0a4b806a)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         68963db4-f766-4266-9224-31443ba3ddca)(content(Whitespace\" \
+         f67c2834-5490-467f-bcd5-462247d3ab0e)(content(Whitespace\" \
          \"))))(Tile((id \
          f5cb5c19-301c-4e57-b71c-b6e5b8b1c49c)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2aabd366-a722-44b2-8fb1-8b3bd36f2cc3)(content(Whitespace\" \
+         b7d25d3c-48a6-451d-985a-44faf0964857)(content(Whitespace\" \
          \"))))(Tile((id \
          304906e2-33cb-4359-9f22-c7e36f09cda6)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         99e9fcce-e255-4bc8-8c21-df94e5ff01e8)(content(Whitespace\" \
+         ecd26cbd-3b6a-4634-8ce4-f0e57c206228)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         307501e9-12ae-48c7-a5ea-639dbb26882f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         60df54f1-19b8-4bc6-bc2e-35af1ea6593a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c294f5a6-dead-4d2f-89cc-d732e5a47689)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aec5f6eb-092e-441c-9b03-6bfb9700348a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         97782c3d-a082-47c9-aa05-17f2bb2d8f21)(content(Whitespace\" \
+         e30d8205-38e8-4dcb-8715-43d5f103654a)(content(Whitespace\" \
          \"))))(Tile((id \
          e07fe13a-6374-418e-8fec-85acaab50e0a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -915,24 +887,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6a1cc2fa-a387-4404-ab13-cc641eb558c2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d18861ce-3a2e-43a3-a07a-444dc590af14)(content(Whitespace\" \
+         7f3a686e-83d0-41a0-a85a-6e2f5bf21563)(content(Whitespace\" \
          \"))))(Tile((id \
          b6f0ba8c-7b97-4142-afa2-a86b25d98997)(label(t2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8c7167f5-7a0f-459c-bd8c-4e5d120203ab)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9df1cef5-84b6-42b2-85fe-4864d44de3d9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0e2fced1-51d2-4cbd-97c2-46bc108b07ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         920b7441-703a-417d-b15a-8ed467642adc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         83ff80c5-e054-4791-8204-a15b14e9715e)(content(Whitespace\" \
+         3963932e-16d2-42e5-ae1b-876ea82af915)(content(Whitespace\" \
          \"))))(Tile((id \
          c9802a43-22d7-431e-99fa-bc0f6fd45851)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7bd4e340-4b38-4123-8d13-b43c2d5e42a9)(content(Whitespace\" \
+         bdae37ec-589d-4c63-89c4-2c3139ca7177)(content(Whitespace\" \
          \"))))(Tile((id \
          dd409cec-65b7-4abc-9fe5-aa66689c171d)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -946,46 +911,33 @@ let out : string * Haz3lcore.PersistentSegment.t =
          abe28cf0-5acf-4575-9e8c-371535a69490)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e75caf7e-5ad2-4eba-8405-89def77ba2fa)(content(Whitespace\" \
+         d0cf48ae-3a75-468a-b260-07699df46b37)(content(Whitespace\" \
          \"))))(Tile((id \
          23436a70-e251-4d7e-a3e3-d235926322f5)(label(combine))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b8ab061c-bf82-4e20-84b5-e83275379242)(content(Whitespace\" \
+         76a63875-92f3-478f-ace3-944fba167fd7)(content(Whitespace\" \
          \"))))(Tile((id \
          405a767f-edba-434f-a96a-6c062b7fe7a2)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         00a36a81-6241-4aae-8fd4-b4490f436f4b)(content(Whitespace\" \
+         a3f9927c-b404-413c-9d86-5eec4945734a)(content(Whitespace\" \
          \"))))(Tile((id 482484b6-7c3e-456b-b65e-4e97c21774a2)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          12079d61-8019-4d0b-84c1-04c247e169f3)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d081847d-5d46-41a5-bc62-a0e4514bad2f)(content(Whitespace\" \
+         6f49f3ef-c906-4675-ad7f-e210a7ffde37)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7f4a28df-f0ea-4aa2-a0c2-2dd5b2f03b85)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3114a981-5784-4a40-8613-459e5d62a3b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         65a9a9f7-29ff-435d-b02a-8980ae33104c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d23b1cf-d545-4bb0-90f9-a3a70b505ff1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c837299e-3763-443e-8f03-c459ba1a728c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         690fb1a7-bf8e-4349-ab7a-34d08d630b18)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         31dc6223-a4a9-49b4-b454-6c147be5beb8)(content(Whitespace\"\\n\"))))(Secondary((id \
          12b251f0-ea4a-4d2b-a66d-d8507a21de42)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         1a371e3d-737b-4559-9d24-8cdf47059e9c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         db81b9f5-a91d-4f51-93d7-7d8070ade448)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f643141a-eb98-4767-a4d1-41e833c56af1)(content(Whitespace\" \
-         \"))))(Tile((id aa897a41-0bb2-417d-a69e-849ce2320228)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         521a8bd6-712a-4939-aae7-e776cea40da1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ad6ccd28-43d3-47c0-999a-e53e41344a5f)(content(Whitespace\"\\n\"))))(Tile((id \
+         aa897a41-0bb2-417d-a69e-849ce2320228)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         958abc8f-200b-436e-9fa3-7bc0fbbe2e21)(content(Whitespace\"\\n\"))))(Tile((id \
          c207feae-4324-4a5d-b071-8d70f0444582)(label(hcat))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -994,153 +946,176 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          6f4030c4-3ff1-4cb4-9126-9dc4d3440829)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         55e0d221-fedf-4e2c-b683-cad1648bd068)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ecca0248-c465-4609-9df3-552d099f1ad7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4fe058d5-2a88-49d7-8513-6ef150bdbedf)(content(Whitespace\" \
-         \"))))(Tile((id 38147f9b-2880-4e39-8e9d-0eccb36b07fe)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         38147f9b-2880-4e39-8e9d-0eccb36b07fe)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          008be3b0-1fa8-4ca8-b78a-119496940f80)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         52255adf-11bb-402c-92a3-30b4afcafc70)(content(Whitespace\"\\n\"))))(Secondary((id \
-         10be3e8c-cd20-4d56-bb53-1f60e6fe2ac9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4ea0974d-abcc-44ac-9395-b99050383bf5)(content(Whitespace\" \
-         \"))))(Tile((id fd3dcfb4-eb4b-4225-84fa-b56946c96ed1)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         fd3dcfb4-eb4b-4225-84fa-b56946c96ed1)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          80b72888-dc35-48b9-8101-be7748ab6a57)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          ef7f198b-b583-427a-9cb3-4922923f3689)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ae723ab0-e006-4d3d-a946-3f4e5df81977)(content(Whitespace\" \
+         \"))))(Tile((id \
          521e315f-3d36-4e39-b68d-2dcefecf4240)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         95465153-c6a5-47b0-ba54-030cb48c771f)(content(Whitespace\" \
+         \"))))(Tile((id \
          8d01d81b-9e9b-426a-bebf-912dd9b99767)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ad8ac781-6149-4dff-982c-85574fcfccf5)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         15001961-2a84-4520-846d-8b4ec5b4d66e)(content(Whitespace\" \
+         fbe496b0-6eb7-4844-a7d3-40f7fd880b1a)(content(Whitespace\" \
          \"))))(Tile((id \
          0923e742-8f7d-4c04-b550-dc2ab02e8f6f)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b1258454-5c14-4716-bc66-d8c9da637b0a)(content(Whitespace\" \
+         \"))))(Tile((id \
          72bf4b45-f914-4ad7-a033-d22571c276a8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e8d9a469-f0c0-4151-952b-11cacf1176c1)(content(Whitespace\" \
+         \"))))(Tile((id \
          4392ce71-cc7f-43d2-a8d5-e7f2adca41e0)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0c372987-3a60-4af9-8160-d6880b48cbad)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4ba36427-b8e7-4349-a712-f2924ec015e1)(content(Whitespace\" \
+         22efba78-b914-4d45-8460-723b0bba112c)(content(Whitespace\" \
          \"))))(Tile((id \
          b815bf4f-f185-404d-b1a3-07cf2a322637)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cef5d914-0a7d-4517-9bef-59024f8f9535)(content(Whitespace\" \
+         \"))))(Tile((id \
          89f220c6-2785-4e64-9c52-33fecf25cd1b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e995cbf5-9e89-46e3-a712-afff04e80b05)(content(Whitespace\" \
+         \"))))(Tile((id \
          76031e31-7ed3-4c85-b5e7-4ed28215df90)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          743b5a4c-3fa2-4186-8ea3-594467a98979)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         71042de8-9700-45cd-98f5-aaad5d270fd8)(content(Whitespace\" \
+         6f09998d-fc51-43b3-91a8-3604911cb573)(content(Whitespace\" \
          \"))))(Tile((id \
          29e26b8c-0054-4811-ac87-d88ec7fa31e5)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ef397384-1a58-4646-8479-5da1229aa599)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a69ddc6-1a7c-40e2-91f3-e3ec0aa2475d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         db23f23b-5a39-466c-952d-0fd3e18fc78f)(content(Whitespace\" \
+         \"))))(Tile((id \
          5c4c8948-c441-4cc7-8bb1-62eb75f8cca7)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          579e5a60-8489-442a-9f22-43adbb1183bc)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ea191f75-3ac1-4875-aca4-30c02ff6522d)(content(Whitespace\" \
+         ab6549df-eea0-4cd1-af83-1a33dd487e0e)(content(Whitespace\" \
          \"))))(Tile((id \
          e505efd9-5a95-4fa7-a2f9-8b6b0d3b93e4)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b9ba6f6d-ae89-4644-a493-c5cb8141e522)(content(Whitespace\" \
+         \"))))(Tile((id \
          517a79c5-38c5-4e38-bae8-fc153de33d59)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a56d94c9-a509-40e0-97a7-5d21d58055e7)(content(Whitespace\" \
+         \"))))(Tile((id \
          e8088b38-d8a9-4833-9545-6f62b0d08e35)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e1ef42c8-254d-45b7-b1f1-ef86838a75f0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         65304cde-de5c-417a-994e-3fa3a22c58e3)(content(Whitespace\" \
+         63cd2183-5b81-457d-8f02-8a61f8e8f420)(content(Whitespace\" \
          \"))))(Tile((id \
          2feda102-01ee-46de-8a6a-f30919f18420)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d747c268-294e-408c-b7f8-518f81dea318)(content(Whitespace\" \
+         \"))))(Tile((id \
          fc4bb30f-a349-452a-a64c-fa7d17aa860e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7905629a-5769-4803-adb0-54c9153585dc)(content(Whitespace\" \
+         \"))))(Tile((id \
          a04830d7-4e29-400f-9664-e79b27d2a3e5)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7df8916c-dd17-4b09-b2b7-54abaef0ce94)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9715510f-23bd-4db4-9e30-c48881537fd5)(content(Whitespace\" \
+         42a1d66e-1ddd-4988-84b9-00915a3af21f)(content(Whitespace\" \
          \"))))(Tile((id \
          f119982b-9e68-4a5a-98ff-63b7f90357cf)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0acc2aa1-160a-459a-a82a-5647094e4a2d)(content(Whitespace\" \
+         \"))))(Tile((id \
          6a368739-b1a4-4c0c-b481-9df673f1fec7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         94fa093c-334e-4e0e-b4bc-a80657801284)(content(Whitespace\" \
+         \"))))(Tile((id \
          6792442f-ed48-4bd0-b322-92a419347378)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          25aa2c10-8523-43f3-a606-1a757144ea11)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         290d8df5-50e9-4949-a10d-773138168b66)(content(Whitespace\" \
+         a1f80170-ec5d-4554-8f38-f99e6e7ae25f)(content(Whitespace\" \
          \"))))(Tile((id \
          c03b9379-2adb-44e8-8baf-b8feaf611ed1)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         77851527-07db-43af-bd1c-0a9340d2589e)(content(Whitespace\" \
+         \"))))(Tile((id \
          4e4f79a9-3d62-4fe1-a0a8-6ab925832ce8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8236114f-58db-4440-9cb0-89c82c4fdc7d)(content(Whitespace\" \
+         \"))))(Tile((id \
          1d2185b4-2744-474f-a426-b65fe835f4bf)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          2aea611c-a89b-4831-a031-7139485d0ab8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2e9d5eeb-9204-48f4-89db-301cde60fcc6)(content(Whitespace\" \
+         cbcf11a1-ef5e-49a5-906a-bdb698f671e8)(content(Whitespace\" \
          \"))))(Tile((id \
          947917c6-c109-4c4f-985f-980f1a1bfbeb)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         42808320-e9b3-4f8a-a8b2-4bf0d26635d1)(content(Whitespace\" \
+         \"))))(Tile((id \
          f4074d7f-81a0-4480-aafe-156d8c17fb0b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         81c217ec-a251-4360-9f49-6a7cf9e4e033)(content(Whitespace\" \
+         \"))))(Tile((id \
          d62362a4-da0d-4a3c-9622-9378ed5d2a22)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         ea1ebfda-f860-42fc-95dc-fa8b0a3ab3e5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         027b70c9-3c3c-4035-9199-fb947ce8029c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc01f9eb-197e-4bda-81e7-44205e74e123)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Typ))))))(shards(0))(children())))))))))))))(Tile((id \
          9bce3d26-8bf1-418a-8c29-8ad692e0f9f7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1150,7 +1125,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7070a370-66cb-43fd-acd5-66f68ac13c19)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         25a47bdf-1074-4931-a95f-804294b58d31)(content(Whitespace\" \
+         3ae7f049-d598-415a-ba3e-025b5ae9f615)(content(Whitespace\" \
          \"))))(Tile((id \
          ed3c1d28-9f02-410d-ab4e-44a221e71a3c)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1158,12 +1133,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0d44517e-d571-4ffd-ad0a-07daeced556e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cd284943-cea8-4209-8d8a-d95d2b27cf4c)(content(Whitespace\" \
+         234c7c86-8941-4d76-ac37-80271ffcc9b2)(content(Whitespace\" \
          \"))))(Tile((id e8ba8514-0d7f-4dbd-ba0e-b36b20d8a1cf)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         7e6e33dd-3edf-40b7-8458-d6b8dc3ff08c)(content(Whitespace\" \
+         19e03ede-8e8a-4de6-8400-65bf2b716e48)(content(Whitespace\" \
          \"))))(Tile((id \
          0e43ceb0-8f38-4302-b210-a95fabf5f538)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1174,55 +1149,41 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2e89cd53-936f-4b05-9b3d-527a62b0ec34)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         8b9e0404-8536-4fee-9402-0705820abb54)(content(Whitespace\" \
+         9ca6e5d2-e1db-4659-8609-1b5bfcbe5466)(content(Whitespace\" \
          \"))))(Tile((id \
          7ea3b4c7-b723-4042-a6a3-b0aea35bc926)(label(g))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         0c32a6ec-412f-4cef-a312-78a333af784e)(content(Whitespace\" \
+         d090c7b0-f6d0-4601-839a-b3a3e03e1317)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ba88e955-9bb2-47d3-8e17-eac8a7b64c2e)(content(Whitespace\" \
+         f3c8807a-ca7f-4e9f-8e34-8654d9f0b4ae)(content(Whitespace\" \
          \"))))(Tile((id \
          4fe56e3c-ba67-4797-b751-b63eb91c1b96)(label(s))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         a625824a-6d04-4323-ab6f-96aa5e064af9)(content(Whitespace\" \
+         fc638e1c-e010-44b5-9041-0d07766ee166)(content(Whitespace\" \
          \"))))(Tile((id \
          3d08e098-b112-4402-a4ba-c4063422cedc)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         54264605-02da-4dd3-846b-7c03b7b428bc)(content(Whitespace\" \
+         34040a36-9d1b-4525-a20b-ae0058c95d72)(content(Whitespace\" \
          \"))))(Tile((id \
          4c9edab8-8ca1-45b9-a285-34770dadb59e)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f794b0eb-cd92-452e-9bcf-03ae1f172f36)(content(Whitespace\" \
-         \"))))(Tile((id \
+         4f18531c-bbe6-4bca-9803-d45eec3bb21f)(content(Whitespace\"\\n\"))))(Tile((id \
          8390be8f-cadb-47f7-bd69-8ba63fee006d)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2401a91a-52c2-49b0-8026-da4f6c60f743)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e03d4b6-5b28-43ab-a7ee-e27fa6e48072)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ca757892-947e-4f9f-a8db-6320052ad6cf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         39c6b00b-9140-4977-863d-90c9acdba59b)(content(Whitespace\" \
+         b7edeacf-42d7-436f-ae3b-4ed1e361e119)(content(Whitespace\" \
          \"))))(Tile((id \
          035f611d-efd5-4686-820b-f60a9545c8c9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         23ac8ee5-dfdd-4d17-8d31-ea934676c3ed)(content(Whitespace\"\\n\"))))(Tile((id \
          b407783c-1637-4033-afc6-78b04a41ca44)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         d7834cc3-0167-40c1-ba68-2d4bad6a99de)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d346aff3-18ef-4f7b-b4c3-a3451caa55a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9781652-ec0b-48cd-9790-9a4ab6ed4b9c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7b9106c7-c65a-4d5d-9d67-cc1186a6b346)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e5972c4-2214-4cb5-be78-2bf1e3a53fa2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          de6044f5-5ea2-4da3-91c5-f09f6bd40352)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1296,14 +1257,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          38b9a35b-4478-4bf3-ad6d-007d12fbb5aa)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fceece50-4a9c-4a15-af1f-c89207f899c6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         626b44a8-d208-4b24-bebf-4b80dbdfbe79)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4ddbb642-f4d7-4f46-84c4-fb7161890ee2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         67ec49db-1839-42fe-be9e-a342494247b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b1704090-2854-4903-8859-507a2acbe7b9)(content(Whitespace\" \
+         057b1829-6ad8-4ff8-9312-201c53cf8655)(content(Whitespace\" \
          \"))))(Tile((id \
          87685cbe-21e2-48e2-b74e-e7335a32d7bc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1378,14 +1332,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2291ccc2-3e94-4558-b6b6-76cad35f8869)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         67e42072-517c-4917-ac4c-9fa15b59d8eb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e9edf65e-450b-428a-9409-a84d5cf7f839)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf060a17-f9eb-41da-bc9c-32b502dd3b3d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         296b3d4a-1da1-4d2f-8a7d-82e617a5ee1b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3bd89cfe-401a-4986-90df-3f700db6a461)(content(Whitespace\" \
+         421b2875-b2df-41cf-98cb-8a42d9c11a72)(content(Whitespace\" \
          \"))))(Tile((id \
          1742c357-7397-4bd6-bbbb-e7dc32fdb1f2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1396,7 +1343,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cf07e7e9-96c0-4291-a041-44ef2dc0efa7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         11de7f7a-e349-494f-ac42-f921dc60f18e)(content(Whitespace\" \
+         84ae8ffb-79fa-443b-82ea-1674ce080dda)(content(Whitespace\" \
          \"))))(Tile((id \
          e0b87bd5-9621-4e71-becd-759a4564b038)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1404,7 +1351,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f98a7e10-0224-41a0-b2ee-d4b6a615d2f1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8b61d16c-b7d5-45a4-9d07-3ae9e3986822)(content(Whitespace\" \
+         c1cc2a66-eefd-488d-9f95-1dce7f921207)(content(Whitespace\" \
          \"))))(Tile((id \
          c7595b2b-4182-4718-a4af-c1f91b97105f)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1412,7 +1359,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          348a3bab-055d-4c91-9912-add61ea08219)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         36276a1f-3ddf-4bd8-b480-c1bb9875301d)(content(Whitespace\" \
+         51a3c973-4248-46d5-996d-818c768d6f93)(content(Whitespace\" \
          \"))))(Tile((id \
          1aeb0e39-dcf4-41d0-bb47-b25c1ef943ce)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1420,7 +1367,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cbfd63c7-2d0c-4b1b-a35a-f8add4943953)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ee5f4434-92c9-44be-9250-fddf4f8386bb)(content(Whitespace\" \
+         328c6949-6138-4b05-a748-2ac4a5bcbc72)(content(Whitespace\" \
          \"))))(Tile((id \
          1fbd5c87-4bd6-4dba-b4d7-16cca865158d)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1428,7 +1375,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f0eb354c-a956-40f4-8977-92c85a0929ad)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fdf91d06-fe17-484f-900d-7f696ed6356f)(content(Whitespace\" \
+         561435eb-2505-4c3a-819c-f09197b64644)(content(Whitespace\" \
          \"))))(Tile((id \
          c5be9fed-d7aa-40a7-89f4-65aa2b786eae)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1436,7 +1383,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5785005c-4734-4927-bd18-b38f2bc6314d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3c6655b3-7388-4186-9d95-cefa9eec84ad)(content(Whitespace\" \
+         d664a3e4-16a0-4b3b-916d-1da18c612420)(content(Whitespace\" \
          \"))))(Tile((id \
          0e6c4e8c-7c3c-4d76-a227-9bcb1ec2e91a)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1444,7 +1391,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          999950c5-a633-43b8-8503-4b26c9ddabce)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ed514d25-8723-46ca-bd3c-7851a09a49cb)(content(Whitespace\" \
+         fb51933e-ab6f-4ab2-866e-96e440c261fd)(content(Whitespace\" \
          \"))))(Tile((id \
          9b6af065-ef65-412d-9adc-b02d0aae3fc4)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1452,22 +1399,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          06d07bd0-66db-417c-8421-89a332373bf0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ad23ee11-0c3e-474a-acbe-eedd7732d02a)(content(Whitespace\" \
+         6d1c9ce4-4131-4982-86cc-1cc3c22cf6aa)(content(Whitespace\" \
          \"))))(Tile((id \
          922c5f5b-4a2e-47f3-b043-b433fda98745)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         594ef1ad-1486-46a5-98fb-66935450dd6f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9dac77ed-4a00-416c-ac9b-2d50dc8a05a8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         96f7499f-436f-4142-8227-e25c55e9655f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         66d965be-4a4f-441d-9857-1d0d6882e5f3)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         200c1600-81f3-41a7-8a68-1e241d7d1c3a)(content(Whitespace\"\\n\"))))(Tile((id \
          81a7cd94-6171-4bc7-baa1-4e042315ffb8)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         90d3ce2e-4257-41e3-8183-1e7529f52c6f)(content(Whitespace\" \
+         2238f4f4-420a-4c17-8eb1-d5d6ea9b8317)(content(Whitespace\" \
          \"))))(Tile((id 7a65caf2-0203-4ad9-9f75-833d4a418478)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1476,184 +1417,199 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          b5539840-2a30-40e5-a0a2-e392d6848303)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         99186a63-f4eb-4037-b476-babb65e4a1a8)(content(Whitespace\" \
+         \"))))(Tile((id \
          159a0745-8b43-4709-8668-ab21049e7254)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         80808b3e-0d8e-4773-a65c-9609c9c7ee66)(content(Whitespace\" \
+         \"))))(Tile((id \
          51b335e4-5974-42e5-9bb0-f40d0ee9ce1e)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6168e39a-c7d8-499c-be5c-2f3c714e6262)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c5b68f58-98cc-47e6-8d3d-11c9bafd3fd4)(content(Whitespace\" \
+         b14175ef-35a9-4d9c-aa6a-20c34f993464)(content(Whitespace\" \
          \"))))(Tile((id \
          20d788b3-545d-458a-ba71-e0c947a6d999)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         858143ba-1df7-4ea0-9d09-347e0a328396)(content(Whitespace\" \
+         \"))))(Tile((id \
          e452f7ce-8fec-4962-83e0-bb5acfbf046a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f85768ac-1fd3-4c2b-a8c8-9527d02956d3)(content(Whitespace\" \
+         \"))))(Tile((id \
          d8c8e9bc-b4fb-4626-ab25-dbd892204be6)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ac261874-2adc-45fa-bf71-a2a2022dc543)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0af0223b-7a60-4ddd-ae84-14da0639cf23)(content(Whitespace\" \
+         e3a1c73a-2fc2-47ca-831e-40678fb39ec3)(content(Whitespace\" \
          \"))))(Tile((id \
          0465f004-dc6c-4c26-a4a1-357476ee9087)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         32fcc2a9-7ac0-44d5-a4da-e054e5c0c3ba)(content(Whitespace\" \
+         \"))))(Tile((id \
          6be8a158-fbe6-4929-bd97-9df6ecafa628)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         47bdc1ce-7a14-41b4-a25d-46f4dac7d681)(content(Whitespace\" \
+         \"))))(Tile((id \
          74296deb-07b8-4a39-97ca-d3c1ff887d9b)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          582358b6-7384-436d-82bd-13f6c76d9148)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         38c52655-5fe7-40dd-b325-fca84bacb86e)(content(Whitespace\" \
+         2c8a0e7c-6960-40c2-80f2-2970126411e4)(content(Whitespace\" \
          \"))))(Tile((id \
          0b0f94b9-0544-4b10-9e28-f5d76e618dde)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         76b9c924-fa6c-447e-a539-b8d71511ee29)(content(Whitespace\" \
+         \"))))(Tile((id \
          ef679303-cf36-44cd-b6bc-d9caff55ce77)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9874c335-de6f-4227-9e59-34de9a3bfec6)(content(Whitespace\" \
+         \"))))(Tile((id \
          5f959d47-05ca-4c67-91c2-4e4600427cd6)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          639b167a-c9bb-441f-91af-cf114676cbd7)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         244aa46e-851d-4871-8a66-7f2986101b47)(content(Whitespace\" \
+         f45cbf4b-4791-4320-8101-2330cec63fd2)(content(Whitespace\" \
          \"))))(Tile((id \
          9697b61b-08de-43fa-8659-da6d47d9ddd4)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         568a76ee-f4af-4799-aa30-9372ca226b26)(content(Whitespace\" \
+         \"))))(Tile((id \
          56725bc8-c839-4239-b8a0-e11b2bcde080)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c810b85b-0fbe-401e-a758-6e5bfbcb138e)(content(Whitespace\" \
+         \"))))(Tile((id \
          0434b50b-c853-426e-96ca-f952b028bace)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c2c34b01-f42b-494f-b163-da7ebcad858a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9b90cb62-1594-49b7-8fa5-8154ff586f79)(content(Whitespace\" \
+         5d81858d-6cb2-4636-8811-82184345540b)(content(Whitespace\" \
          \"))))(Tile((id \
          394fdaac-dba6-43a6-9065-4411fa96fbc4)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         44586c5f-4fe0-424f-b056-e09a448d7d02)(content(Whitespace\" \
+         \"))))(Tile((id \
          2c1c84d7-c261-4fca-963d-941676ea1702)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0072e7bd-0a86-4fe0-b39d-e3e9aaf6c171)(content(Whitespace\" \
+         \"))))(Tile((id \
          2a09dbcb-cb40-49d8-8352-bec96343e5fc)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          3e64b843-3f9c-4eff-9a95-d34ee950d7a0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c8b06d2d-2869-4913-b721-b0fba9bcd2f4)(content(Whitespace\" \
+         b0d8f0f4-4eee-4195-ac8d-209647ccbfb5)(content(Whitespace\" \
          \"))))(Tile((id \
          4f491654-ace4-40c9-9f63-831a1a37b1ca)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9d81b742-be8a-499b-8b5b-d5b676093f85)(content(Whitespace\" \
+         \"))))(Tile((id \
          06ae1a65-7fa1-449e-8045-a145167cb34d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         236799cf-a5ed-4aa9-a457-32f772afb65b)(content(Whitespace\" \
+         \"))))(Tile((id \
          9dc97191-5eb5-4c77-915a-b457c78fa48f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          67ad2f93-e2ea-4ba7-a5e6-9b44d115c214)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6721cfc6-aefc-424b-b6f1-3fb86ac3164c)(content(Whitespace\" \
+         ff4a783d-ccd1-4556-a599-7c13730efb92)(content(Whitespace\" \
          \"))))(Tile((id \
          8abfea9f-02fc-4f78-a18b-39734363ecd2)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         253e6da1-6012-4f58-9caf-04a88f400797)(content(Whitespace\" \
+         \"))))(Tile((id \
          d35430c4-2710-488d-b489-2dbf803c9444)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2e6a4146-6f20-416a-a2e3-17ad47225085)(content(Whitespace\" \
+         \"))))(Tile((id \
          4ad567b8-ab20-4d81-bbd9-a534f37052b3)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          777c25bc-acc4-4172-aecd-dc82d2812cfc)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c8d5273e-c332-41de-bf04-e17f6d018c99)(content(Whitespace\" \
+         a30487dd-2033-4d1a-ab92-3ceffa754803)(content(Whitespace\" \
          \"))))(Tile((id \
          ddc6631f-118e-4477-83fc-c3273195b0ce)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c101749d-792c-470b-87ee-1779669b5fc3)(content(Whitespace\" \
+         \"))))(Tile((id \
          75af841c-6f5b-47a1-babc-91d92473336f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         de74cbe1-663a-4a5c-8df5-f500f37d2786)(content(Whitespace\" \
+         \"))))(Tile((id \
          2f3b52f2-ce0b-41f8-9d48-064010d0c0f3)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         91c9a653-e003-49e8-8e45-437bd4f52974)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d88210a9-7357-4cbb-92dd-491a48de2e9c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7bbc43af-0d47-4804-9359-425c8548a798)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         77daf0f7-5ab1-4d0e-bfa2-edb2f8ff990d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         31aa954d-fd26-4404-94ce-771ed0a4a4b5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         74251a4e-15c5-45f6-ba98-5d4306aedf67)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         f34d28b4-8185-49ac-8207-821a754109db)(content(Whitespace\"\\n\"))))(Secondary((id \
-         af920352-4825-41cb-941f-ff871e6218f6)(content(Whitespace\"\\n\"))))(Secondary((id \
+         87f75258-d39f-46da-bf14-0acd47c08f24)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e951f5d7-a293-44a4-b20d-6b88494a35ce)(content(Whitespace\"\\n\"))))(Secondary((id \
+         00705ee2-8a58-48fa-966d-ce5ac155e92f)(content(Whitespace\"\\n\"))))(Secondary((id \
          def38e9b-4821-42c8-94be-ccd54b3ede41)(content(Comment\"# V2: This \
          version more closely matches the TableAPI and takes a string column. \
          Given the lack of row polymorphism no constraints are ensured \
          #\"))))(Secondary((id \
-         72d5d09e-082d-4cd5-8336-a4b92d5f256a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a1fc6aec-32b4-4089-848d-67379b24631f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f6418091-aa31-4e2f-bb7c-b53e5679cc2a)(content(Whitespace\"\\n\"))))(Tile((id \
+         706181dc-8b14-4aff-b78e-6e90244f2b73)(content(Whitespace\"\\n\"))))(Tile((id \
          fc82392e-7d0c-4bba-8091-c0229de3b542)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         34466117-ed57-4b28-a7f3-dbb27d4bd172)(content(Whitespace\" \
+         c5e90c43-35ff-4f13-befe-6a37971023fc)(content(Whitespace\" \
          \"))))(Tile((id \
          bddc10ea-f10d-4962-85c9-f508cd4f167d)(label(v2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         65943aed-1365-44f5-8600-b0008bb5effd)(content(Whitespace\" \
+         c1f176e9-a279-42ce-968a-cdf2495ae41c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ea51a96e-5926-470e-9237-59682574476e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5897f1db-53d9-4b65-94c5-2f9420bea8bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0374ec5b-a6b0-4dd7-8fe2-495aa2e1a818)(content(Whitespace\"\\n\"))))(Secondary((id \
-         62f44011-0239-420a-8590-9772ef59938f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         281f0bc5-0452-4017-b4f3-3f0d27e83eb3)(content(Whitespace\" \
-         \"))))(Tile((id 9f8a560d-0b0f-441a-b502-a1b8fdb8ecde)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c36f18e5-f8ae-4041-a3e9-00662c53a538)(content(Whitespace\" \
+         07c672fb-c789-4a0c-8203-e239068ea009)(content(Whitespace\"\\n\"))))(Tile((id \
+         9f8a560d-0b0f-441a-b502-a1b8fdb8ecde)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         de8195b3-21b8-4fbf-a616-1267377867c4)(content(Whitespace\" \
          \"))))(Tile((id \
-         1a5e9e8c-5e0f-4768-8bdd-1a27891cf62c)(label(requires))(mold((out \
+         1a5e9e8c-5e0f-4768-8bdd-1a27891cf62c)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         4af368d1-9e91-4a12-84e2-5228a12b6f3a)(content(Whitespace\" \
+         afb5d25f-525c-49e4-b983-1ae758d1079f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         de74e415-04e4-47d7-a866-ece8935b0804)(content(Whitespace\" \
+         bfe37bbc-64b5-42e7-97a4-76e1cc7663c8)(content(Whitespace\" \
          \"))))(Tile((id bc6984be-6cc7-43c3-ba6e-9f22213a96dd)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         c2639c91-a1b9-4e38-beef-961235aa5665)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7bd1175c-ba33-4fac-946e-f6388f4dbbb0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8efda80-1832-4e8c-b94c-107a6dc21822)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         839b2c33-5260-4bdc-badc-8881d581466b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1f776c5d-0470-42f2-bd0f-c1b9c33716eb)(content(Whitespace\" \
-         \"))))(Tile((id \
+         81d34b0f-a8bd-41ee-b439-d21d52fd4811)(content(Whitespace\"\\n\"))))(Tile((id \
          a305fed7-519a-4ec0-97bd-59927dc1118c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1682,25 +1638,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          77234021-c303-4dee-b74a-593e96df1443)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5fed8342-bf83-4a37-a1e0-3cb1005b2a7f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bcd8e718-a507-49ef-8734-047ac13b6cb4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         50809e19-e0b4-4a87-b36d-a0bdd11017b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c3ecdb5-074a-4374-b579-03dadfd7d62f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         11b27b07-3190-426e-b688-e6ac5106f1c4)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e122138e-a6b5-4574-83c6-016d788fd209)(content(Whitespace\"\\n\"))))(Tile((id \
          f3f31f07-0479-47ac-b9aa-671de8a19a85)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          6d004667-844a-4cb5-bd06-4632e13ffbcb)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         530d726e-e0bd-49a6-8bb8-ac249d369b80)(content(Whitespace\" \
+         \"))))(Tile((id \
          528b4e8e-7fb6-4b9d-a8db-90f98f2a85b3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         2dd7c1bd-e462-4211-8715-801326af6e15)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ea9a2aa0-5538-45fd-8c7a-3c130e2859f3)(content(Whitespace\" \
+         \"))))(Projector((id 2dd7c1bd-e462-4211-8715-801326af6e15)(kind \
+         Checkbox)(syntax(Tile((id \
          08f388f9-2230-400c-b4dd-07a30d8f7c10)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1710,47 +1662,31 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bfeaefd6-a40d-428d-922d-af9a10253aec)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d2b7a1b8-8380-43ef-972a-9c8167ac1244)(content(Whitespace\" \
+         d3c67c17-b750-467c-8a86-2d114b3997c9)(content(Whitespace\" \
          \"))))(Tile((id \
          6de4d10c-613a-4ede-b247-e3c8b8936320)(label(\"\\\"nrows(t1) is equal \
          to nrows(t2)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         28ee1523-3101-4d5c-805b-6954ab96da8c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fb11957d-bbfc-4452-92c8-ef57f329ed91)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4eda6ce8-c6da-47f5-9382-168e06077042)(content(Whitespace\" \
+         4b6d18a5-aca4-4743-b841-2ebb377fac18)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         5831231d-edc3-4a1b-aa7a-d3690ca557a2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d27e5694-0ec6-4da9-8b60-2fa3e383099b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         7681c01c-e5e4-41b3-b1aa-fda7d0f7aa46)(content(Whitespace\"\\n\"))))(Secondary((id \
-         83bb693b-aed7-4b57-9a5f-d52278f9615e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0a74a45b-342b-43ef-aace-36c563177deb)(content(Whitespace\" \
-         \"))))(Tile((id 73d09db2-8c22-4e39-92b7-ec62f1e2c915)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b4a70687-242a-4d6e-8a18-c471defd13f0)(content(Whitespace\" \
+         36a41a51-7da8-45e4-b84e-868d80907537)(content(Whitespace\"\\n\"))))(Tile((id \
+         73d09db2-8c22-4e39-92b7-ec62f1e2c915)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a862aa93-51e1-4955-a790-60eb1c03c8fb)(content(Whitespace\" \
          \"))))(Tile((id \
-         e527b93c-934d-4bd0-ab57-ce4e4e4dbabe)(label(ensures))(mold((out \
+         e527b93c-934d-4bd0-ab57-ce4e4e4dbabe)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6ebfad49-3e33-467d-8d28-cdc1c2d62367)(content(Whitespace\" \
+         aa06cee9-5c39-4e94-b43f-5ae158184540)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c30d35a9-04b0-4638-b41e-b8d81027e319)(content(Whitespace\" \
+         014da99b-61a3-4a1c-95ef-40de25c895cb)(content(Whitespace\" \
          \"))))(Tile((id f7bf29a6-030d-46e0-b2f6-de1408a2468c)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         575d28d6-01cf-4232-9615-54630ad8d8b0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3f6fecc7-2dcc-4dd8-b169-5ae13d647463)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e0ec05f2-407d-4fe3-9a76-b549bb01cac1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         30df5744-68c3-460b-a18d-47c18fbd51fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         60a97cba-b29e-4ce5-9942-6aa3d3b2a407)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f13c758b-f45f-481d-944d-eb86e695c271)(content(Whitespace\"\\n\"))))(Tile((id \
          8d3d3332-c98b-49b7-a9bd-8c4face506d4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1779,25 +1715,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b4c81c94-37d6-43fd-8825-f1cece505a64)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b6f642e2-2f55-4dc4-8261-3d36a3ef75ae)(content(Whitespace\"\\n\"))))(Secondary((id \
-         714a3f65-94cd-453b-9f5c-5fd8044f1671)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4390ae7e-4a83-4cec-b912-3673ad1b42d4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         91e03a5b-0723-4c8c-829b-9cfe6c17cd87)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dbeada98-6a44-4544-99b9-12cc93be8a2b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         db2d3f49-5ebb-406f-aaa5-32bb059131d6)(content(Whitespace\"\\n\"))))(Tile((id \
          cfd5da82-6fc8-47dd-a224-ccb45ef2ecf5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          7d4c04c3-39be-4684-a868-f4846993a44c)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1bb1642a-242b-4c6f-a005-69fadf06fbfe)(content(Whitespace\" \
+         \"))))(Tile((id \
          ba8b46a2-8711-4c21-8f5a-e99d10369d14)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         27013c2e-2e2f-4df7-8cab-16e7d1dd92aa)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7104ce22-0be6-4fe0-8be6-c5ceeffa8e74)(content(Whitespace\" \
+         \"))))(Projector((id 27013c2e-2e2f-4df7-8cab-16e7d1dd92aa)(kind \
+         Checkbox)(syntax(Tile((id \
          f36e4c62-76ac-494c-ac6d-9dd8e3882453)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1807,90 +1739,77 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6d788ef4-0f37-487a-88e2-ce9a7e31d110)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5dfba3c6-989e-4be8-88cf-b180b6575d27)(content(Whitespace\" \
+         87792fd6-297d-4034-abf6-1596b75bfeec)(content(Whitespace\" \
          \"))))(Tile((id \
          2ead443e-5434-40d0-ad91-c2ffeafb59f5)(label(\"\\\"nrows(t3) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9f7eaefc-d7f2-4cc9-a901-04ce5d891922)(content(Whitespace\"\\n\"))))(Secondary((id \
-         53f15177-9315-4a58-ae7d-65391cb8af2f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b702a910-285b-43b9-8882-aad57caa8beb)(content(Whitespace\" \
+         c3d1d2b0-4798-4522-a6ac-5616a0640cac)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         b11adab7-1b69-45bd-aaea-a43053fbb1aa)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8cf39dce-a1fe-48ab-9eb2-573bd95729ab)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         ff6e0b69-0eb3-4b48-ae87-be026e36a2dd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9fff65db-498a-4721-a548-c7716bd2f8b0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f16b3ca-413a-4c91-a7f2-0698a134c785)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         bd4c088c-a505-4273-b1b6-06744aaed835)(content(Whitespace\"\\n\"))))(Secondary((id \
          d7c27aa6-8d93-4279-a4ff-93ae4aa89dea)(content(Comment\"# V1 is the \
          more idiomatic version #\"))))(Secondary((id \
-         31f43037-e5d8-4638-8f0c-8bfdb8c95f10)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f97a3453-23fc-4eb4-9abe-5ebec2bc33b0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e86c776e-c7da-4392-9b1f-acdbf36cfdbe)(content(Whitespace\" \
-         \"))))(Tile((id 1a8bcefb-e61c-4e76-b950-9a781f6a817c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         2336949f-b24c-493d-a1f8-1546cb6cc9c9)(content(Whitespace\" \
+         065c2efd-0fc9-4fc4-81b8-9bfb4ac70c0c)(content(Whitespace\"\\n\"))))(Tile((id \
+         1a8bcefb-e61c-4e76-b950-9a781f6a817c)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         4179f307-dac0-4651-ad81-946b29036257)(content(Whitespace\" \
          \"))))(Tile((id \
          98025c01-95de-4c32-9edf-7431fa51ec62)(label(hcat))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         392c8f83-6460-4885-812f-d8a8d3284259)(content(Whitespace\" \
+         32a8930e-f891-4fbf-b25d-4b775b06885c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3853bdab-4b56-4d81-8a6c-fc4be3a10e5b)(content(Whitespace\" \
+         d3e38ec7-3a28-4006-b8f3-75648d00989f)(content(Whitespace\" \
          \"))))(Tile((id 536e8416-dadd-4443-a9b4-7124adc29847)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         455c66e5-c412-4ea8-95d2-64fdb158e6aa)(content(Whitespace\" \
+         269be9a4-b817-4bc3-b26b-40c932ce7622)(content(Whitespace\" \
          \"))))(Tile((id \
          5c23f885-2f70-4e3a-ba02-02f5222bd32e)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          6780b1fc-b520-48ea-b0b5-61d90e8b4a8b)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         9db9741e-5386-42f7-a77e-05e17c038361)(content(Whitespace\" \
+         \"))))(Tile((id \
          b390d8eb-1ae9-4976-958c-8f6b8ff8f55f)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         48e5decf-cc1d-48cd-ba9e-3e44a5f7190a)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         32c61bd7-2eef-4b6b-844a-cc1964f9142e)(content(Whitespace\" \
+         \"))))(Tile((id 48e5decf-cc1d-48cd-ba9e-3e44a5f7190a)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          53834818-7f44-438d-a6fe-6f6d0fd31bec)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          bac204e2-7794-45f8-8dfd-b46016312816)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         7d51bfdb-4491-4b65-865e-c430c1fe8d04)(content(Whitespace\" \
+         3c9bdcfa-2146-42e1-8b5d-d3441e8c512c)(content(Whitespace\" \
          \"))))(Tile((id \
          ff98328d-ce91-4507-821d-770e2da1c983)(label(t2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c30e9753-fdd3-409a-9dd7-3b033f47ee62)(content(Whitespace\" \
+         \"))))(Tile((id \
          119fd794-5bee-4329-904c-1e72b7e2db77)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         063a6854-c071-4f75-abed-008959492256)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a4c30024-b26c-4d4c-abef-3c6bcb639145)(content(Whitespace\" \
+         \"))))(Tile((id 063a6854-c071-4f75-abed-008959492256)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          3b093592-e61a-464c-ae2f-060b86720d13)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         c866e137-2c1a-44ce-aed9-fcbf55996f15)(content(Whitespace\" \
+         ab2beb43-46cb-4e47-b8bc-183faa7fdf5c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         18701f22-f5f9-4124-b538-d430f0200684)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ffc7521a-2027-4d4f-9419-e8581570d368)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         14f0afe7-ec0f-42bc-8699-fcb4a9ed09fd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f5a1c26-8b0c-4a7c-af48-f9a57c0370fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3bf9ec15-43ed-40c6-95b0-54c4eb28844e)(content(Whitespace\" \
+         c1fe603b-877d-4708-bb9a-1e7f3788bfea)(content(Whitespace\" \
          \"))))(Tile((id \
          6707fcce-b3db-4356-b9ef-47dd94d22b88)(label(zip))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1904,24 +1823,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e0047248-3810-44b0-bd70-c937ec8e55b5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0271db78-b0a3-48ff-81ea-4fae1da037d4)(content(Whitespace\" \
+         3800c4af-3188-45d5-b3d3-d73d67ce1623)(content(Whitespace\" \
          \"))))(Tile((id \
          8d35a706-6c67-4755-bd6b-2f2040b029a5)(label(t2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c44e4045-766d-49b5-84f6-f2327f053808)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0ca6177d-579b-4398-b63a-17a45b2483ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc9d2fad-5ec5-44a1-8185-fcbd30393923)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5cdae9f-7c83-49c8-9d03-c551353a9d8f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c9af5d68-5a93-4c17-8ac9-f20df2cba0d9)(content(Whitespace\" \
+         c9dc3ed0-667a-4772-9e35-d3f5a6d75ae4)(content(Whitespace\" \
          \"))))(Tile((id \
          bf2e3fdc-48f7-4b75-9ae7-56e647b17486)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         606cb77c-3690-46af-92b5-ac1edc14ae2e)(content(Whitespace\" \
+         a4a83b67-cef8-4959-8379-0b20a3301635)(content(Whitespace\" \
          \"))))(Tile((id \
          866dbc5f-f573-4a30-95ad-f46a8841e718)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1935,12 +1847,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ed6c0b48-561f-4ae6-8ec3-e2ea90569de9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bc10611b-5c54-4bd9-8efa-a63eb3d3ba9a)(content(Whitespace\" \
+         3eabdd42-d67b-410a-824e-2e2540a58fe9)(content(Whitespace\" \
          \"))))(Tile((id 98149767-b865-423d-99e9-54ec24b5da11)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         89fd5e54-3c9e-40a9-b097-6144732130ce)(content(Whitespace\" \
+         b2a94611-a141-4ece-8497-6f44b76e3e90)(content(Whitespace\" \
          \"))))(Tile((id \
          62abf084-db09-4f02-8c67-5de24ee0fc1a)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1951,60 +1863,38 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e3ebd4d4-47be-46ff-8c3f-86ff774fdefb)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         6a0dfe53-1ffa-4e03-894e-6be9b1362e04)(content(Whitespace\" \
+         59980a57-b3ad-45f4-ac88-a7bd1d12b2b5)(content(Whitespace\" \
          \"))))(Tile((id \
          bd248840-4528-4515-b527-4005149766bf)(label(r2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         415e4e9a-b8fb-4047-b439-59ee5999ddcc)(content(Whitespace\" \
+         db4b8d84-5acf-40cd-9845-e283b7bce7de)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         edb44740-051a-4ffa-abef-c69053bddf20)(content(Whitespace\" \
+         4074162e-1ac1-476d-be8d-7a09c7b01b05)(content(Whitespace\" \
          \"))))(Tile((id \
          cc054694-e7a6-4cc5-8641-7d77a755ad24)(label(r1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         1fb4e9c3-6ca2-436e-b6d6-9703e5dd13ef)(content(Whitespace\" \
+         c87d5210-16c3-4c91-9141-f45c14280495)(content(Whitespace\" \
          \"))))(Tile((id \
          bc2f854c-dc85-4626-80d9-94e54f282dc2)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c06fa920-61e5-467e-8b1b-7c20932fdcef)(content(Whitespace\" \
+         e5655065-9f46-4681-9111-47f25bbd0aef)(content(Whitespace\" \
          \"))))(Tile((id \
          a95d1f82-98fc-4fb3-a82c-69c7f0096824)(label(r2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         815a2144-1da9-4e7d-9684-e966ed409536)(content(Whitespace\" \
+         1a5a32ef-1480-4da0-83e7-6e5e59a94be3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         84216510-3405-428b-9d23-8c1f605071a9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         10d5d4aa-0c98-457b-b70f-5551f44e6b4f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e59d3ac-9065-4da1-8383-7f14f0a79ef2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0287e448-4eeb-4063-93e1-e394bf0a76f7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d2515340-d3eb-46e1-8e8a-c05eeff29c9a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         89e1325f-7373-45d9-ace1-bea7d0a7f419)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         7b6304ed-92eb-49bd-a821-ef375d46d91d)(content(Whitespace\"\\n\"))))(Secondary((id \
          f196a1fa-501c-46f2-9d86-e7861b02c449)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         34dce37f-1281-4fce-9cf7-71455447d003)(content(Whitespace\"\\n\"))))(Secondary((id \
-         99bdc5a6-422e-4a45-ab97-67f8c0e6005a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         74302eb7-aa8b-412b-a1ad-f602de3422f8)(content(Whitespace\" \
-         \"))))(Tile((id d417c3a2-b16c-4521-9e89-27648a7b5597)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         acc2273f-278e-4443-8d2b-ad40c7f570cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae58a794-fc15-4b1c-9d3f-8c082278e4f0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b2eceeca-9732-4036-bdcb-90a4a92dacf8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         26bfe952-dcb5-40f6-a753-8fc59a8b037c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eea8782c-8cda-48b0-b300-e1e3142837c5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ef41e90a-34c4-42dd-be4c-185aef6bdc7b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         acf4ec9c-d9f9-4361-a4cd-d7196ebe30bd)(content(Whitespace\"\\n\"))))(Tile((id \
+         d417c3a2-b16c-4521-9e89-27648a7b5597)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         76f399af-4435-4fd8-81ad-8884ce72d97b)(content(Whitespace\"\\n\"))))(Tile((id \
          76e6019c-a496-429b-83f1-2643aae4f772)(label(hcat))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2017,37 +1907,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ebddca8d-7695-4b31-8349-e79f5ff54ab5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c8a3a988-98b6-4ed2-8b47-30fcd5fca4ec)(content(Whitespace\" \
+         7977b4fc-0395-4dcc-b5c9-d8d959f75473)(content(Whitespace\" \
          \"))))(Tile((id \
          c2a247c5-8a05-4607-bd10-29ab5869c00f)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fbb3be5d-2159-4123-925b-0c3509a49cd7)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3a466884-e006-4094-a631-d540e582aac7)(content(Whitespace\"\\n\"))))(Tile((id \
          d09ff3ff-4bde-41dc-a677-3fd09110dff4)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c1db91bf-de53-4ae3-b2c3-8e72637b1019)(content(Whitespace\" \
+         7cd2ba1a-5fb0-4173-b791-3c9d1823e126)(content(Whitespace\" \
          \"))))(Tile((id \
          2621a44b-1fe4-4ec6-99be-cd22f909b522)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         3975f3e2-97e2-48f1-9df7-6696aeea09c7)(content(Whitespace\"\\n\"))))(Tile((id \
          6f3081b7-729e-492b-9ae2-30069e31d1ca)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         4bc233f8-aa32-4f8b-a4dd-9349f98451de)(content(Whitespace\"\\n\"))))(Secondary((id \
-         79d434d3-6384-4b12-9232-9ebdefbbaf49)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8638446a-6cd7-470d-8eaf-94ea5a4d1284)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9b4af5a1-15e6-4cdb-a077-794ca0d03b57)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c5aa2d4-47d9-470d-adea-02f943cdf3ca)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eb3dbb32-2768-47cf-bb7c-d939ebecff47)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         21aef80c-082b-44e3-b303-8caca3dd1bc1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          c323236a-3105-4058-8a0f-1674d4d0b5c6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2121,18 +1998,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f1fbb549-07cd-4e4c-89e3-166b92aee12d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0331e8e6-8784-4007-a09f-eb11c5e4df3c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8fc44b3a-07b2-4330-8f96-cd8d1b35e6df)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8e9a51e8-0c34-4a0f-8532-888b30e4c3ee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7e2b83c-1fd3-4749-9890-100b6ff2c8b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4b0fb0a1-be3e-4cd9-a8f1-33c92fd7d252)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de2fc9c8-4da7-472d-ab2f-4818ae181be9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         63d30aa2-e450-49ae-862b-a11da272b77b)(content(Whitespace\" \
+         13d5620d-1d6b-422a-ac5f-902be0e0022f)(content(Whitespace\" \
          \"))))(Tile((id \
          e7ca1ea3-6281-4718-923c-e080071451ba)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2207,18 +2073,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          27297dcf-3396-4c2c-b97a-23cf41f7b0bb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7002203b-d7ba-4308-9ceb-ed5fc97958e7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         54db2fd7-e20a-4b65-96fd-7eeb98929aec)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c531c80-ffd4-4c76-90a3-0660f5c9d356)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e3abaa1-2587-4ef8-a96d-0d43effa09b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8a1ce83-e895-4d4e-a4d5-b7392012dbee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bff753e8-3b9a-478e-adf4-3077b68ddd3f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57576d2e-a927-4f61-9a12-a01c1a18bec1)(content(Whitespace\" \
+         7879d502-5ab6-4a90-a145-783e065d927b)(content(Whitespace\" \
          \"))))(Tile((id \
          4791c26a-ba0d-4a22-a9ff-41804db62e58)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2229,7 +2084,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0f7d97ac-5950-43c8-abad-2c94c650a8da)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ede22ced-3031-40bf-96d1-a4522bf26f1c)(content(Whitespace\" \
+         78198744-c79a-421c-b335-982d9b288652)(content(Whitespace\" \
          \"))))(Tile((id \
          1126a081-cfae-4940-a834-447f707c3071)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2237,7 +2092,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a319d0aa-36d9-4d76-a7f3-5b7a6f598425)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e18f8fa4-7840-4d2c-bf7e-6ff2c505047a)(content(Whitespace\" \
+         a2ae9cad-1cda-404d-baf4-45ff3f7e695a)(content(Whitespace\" \
          \"))))(Tile((id \
          e6451724-d9b2-46f9-afcd-18ddc93f78e9)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2245,7 +2100,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f115c77d-2316-49ef-a1a4-1710d84b138c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         43929f1f-e3d1-4636-87af-6df476cdef74)(content(Whitespace\" \
+         4b427d17-403b-4b3d-aea3-45201509ec38)(content(Whitespace\" \
          \"))))(Tile((id \
          c034b5b6-6784-4edd-b3df-26e8fe016c58)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2253,7 +2108,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a27d9baf-3ee3-4b2c-9bea-a88f526172b3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c5432896-1f33-46e0-8976-f84f559bebcf)(content(Whitespace\" \
+         383bfd82-3fc4-4523-9071-08607efd62e4)(content(Whitespace\" \
          \"))))(Tile((id \
          83aeac6b-2a77-4b12-bfc9-4e03af800d38)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2261,7 +2116,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          63a82bfa-e5ab-4a1b-a4b7-564ebd4a2dd7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b9280974-91e6-4e2b-9162-31f2d322995f)(content(Whitespace\" \
+         bbc37681-50b1-482e-a88b-08a329e9862b)(content(Whitespace\" \
          \"))))(Tile((id \
          c697997b-bc9f-4b51-9104-2c6d03473e34)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2269,7 +2124,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3792cca5-83fd-4896-b1fb-c52515d05e0b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         faa85344-39d3-4f09-9601-ae1481e6bfbb)(content(Whitespace\" \
+         5d30cbeb-bdca-4b2e-b541-ee61be4f5ce9)(content(Whitespace\" \
          \"))))(Tile((id \
          88779bf3-04b8-4cfd-8712-d43964bd8676)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2277,7 +2132,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          54b7b9df-1b3a-4287-96e9-d2241f1c3682)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         36236b88-f1ed-4790-b2fe-958f21e03159)(content(Whitespace\" \
+         39656a06-fac3-4092-9f06-8232eb69ea37)(content(Whitespace\" \
          \"))))(Tile((id \
          e6c1b6d0-4af2-485a-a986-a88f95e19e96)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2285,26 +2140,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8b4262ca-db01-462a-9d99-bd0d749a053e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5083f03b-c2da-442d-9165-54cf73d33881)(content(Whitespace\" \
+         0df85a67-f476-4de9-8784-705ba8770c3a)(content(Whitespace\" \
          \"))))(Tile((id \
          ab24a4c3-e948-4e7a-8eac-c72c8e17120c)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         584d75b1-aa49-4c0f-927c-a2e7a7c80a13)(content(Whitespace\"\\n\"))))(Secondary((id \
-         221416ed-06ee-410d-b6e5-94227ca94280)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2bc9416f-3ca5-45b6-bc93-16a8b198a15e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e668abd5-b261-4fd8-b325-c1e2d87fa256)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         76c5951b-340a-4806-8b36-cf4bd4f99129)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c467da62-91c6-4466-9e09-13cbb64c90fa)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         ff57c604-5bd7-4d09-a477-76d84e80bcb1)(content(Whitespace\"\\n\"))))(Tile((id \
          f54ae0e0-b2e7-4df6-9675-a6a7e30a2ba4)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1872bff2-415d-41eb-ace9-5be75c9a807e)(content(Whitespace\" \
+         6d5305f6-e5bd-47ba-b943-d58386ace454)(content(Whitespace\" \
          \"))))(Tile((id 7142b7e5-9dc4-4773-8792-20f24ce3e22d)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -2313,216 +2158,241 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          ca0a0899-c13b-43e8-99ef-05f8d5c09815)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         16fe763b-f1a4-4b11-aa62-fce6dd5e3b4c)(content(Whitespace\" \
+         \"))))(Tile((id \
          bafe6d96-12a0-44aa-89dc-51758d5b2778)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3cd13950-094d-4b45-abb2-3f1b88188481)(content(Whitespace\" \
+         \"))))(Tile((id \
          f09e6450-1310-4dc0-9f0b-39c62c81767e)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f8161841-4152-4d64-bbfa-04cf7b5fe85b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         217e45cb-068b-4c2e-80dd-315d0e6c04bb)(content(Whitespace\" \
+         fa1f8a77-744a-4e21-8a45-4098011f7935)(content(Whitespace\" \
          \"))))(Tile((id \
          83c4f4f8-1cec-4cfe-8421-f0df56fa80da)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0ac8bd0b-ba23-44e8-8fa2-5f1281126a0f)(content(Whitespace\" \
+         \"))))(Tile((id \
          056eb252-981f-4019-ab5f-47a594333159)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         036bf0cc-5b60-4ffc-a1a9-dd67ee3c0918)(content(Whitespace\" \
+         \"))))(Tile((id \
          d272a37e-8832-4726-8825-9a545f3d0922)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          66d93a05-008f-4f4e-ac7f-b1eb12d8a1b6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d5b05218-4651-45ec-8e2b-1427c4aedc68)(content(Whitespace\" \
+         feb14321-0230-434c-a7f4-75b94e71158c)(content(Whitespace\" \
          \"))))(Tile((id \
          1307b614-d0d3-4394-8fa4-4f0d1b3d9ff7)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7776aabf-d340-4093-9f28-6b20168fb230)(content(Whitespace\" \
+         \"))))(Tile((id \
          af2d3923-876d-4e07-88ce-e5e1159896aa)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         003dabdb-1070-4d16-87df-f86d9e0ea70b)(content(Whitespace\" \
+         \"))))(Tile((id \
          f4845fa9-ffd8-4ea4-9b72-de7ec9e18898)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ba35ac2b-32f4-4236-add2-e27d10d10048)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         79e9b3ef-723d-433c-bde7-a9ff4d85e0a3)(content(Whitespace\" \
+         9e7f3482-edec-49b3-b7f4-6992cebf9686)(content(Whitespace\" \
          \"))))(Tile((id \
          97a9cb01-9329-407e-8136-3b1a8c76f6b8)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9c6871a6-3b65-4444-ae7b-f27d455fc6c5)(content(Whitespace\" \
+         \"))))(Tile((id \
          4f852833-5838-486b-9c97-0793445190aa)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e4443045-036a-4535-aea7-022127963c9f)(content(Whitespace\" \
+         \"))))(Tile((id \
          56dac03f-c78f-4120-9c59-6fd0e2512aed)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          1cc5cb0d-9110-44a0-a87b-cde0099253fc)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ccb018bb-9cf4-4ca5-9bad-3cbf78978956)(content(Whitespace\" \
+         b2c47bc8-03ac-4f4f-af16-7329afef7f71)(content(Whitespace\" \
          \"))))(Tile((id \
          7559cbe0-f02b-4090-823e-d76042dcd84b)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3af5cafd-8809-4f70-a3f9-dfe6ad6281e8)(content(Whitespace\" \
+         \"))))(Tile((id \
          1b1298d8-59d8-4c43-a842-fb04c2250ef9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4717397a-0cd4-4316-9379-4de679132832)(content(Whitespace\" \
+         \"))))(Tile((id \
          251bc492-46a3-4455-81de-411e874f2090)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          40a6b05a-8b35-4117-bcc1-6ab1a71720ac)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b367d186-a9e8-4b7e-9cc5-afe5cd6c5e4d)(content(Whitespace\" \
+         1c0e69e7-15a7-45f0-aa7f-b1745a25c499)(content(Whitespace\" \
          \"))))(Tile((id \
          c845b9fb-c643-4682-9b4c-dc3e6a951d4a)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9189bed7-6132-4ad1-95f3-8a4b2b34eb3c)(content(Whitespace\" \
+         \"))))(Tile((id \
          2422a532-8807-435b-a50a-6ad827a14ed3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cfef0fa5-9a8c-4eed-95e2-7e1f7b6ab708)(content(Whitespace\" \
+         \"))))(Tile((id \
          2bb838d4-2565-4008-800f-645a0577d554)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          8d73dd2d-feda-4487-b809-39a4ce89e4bc)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8e180f9e-67c1-49bd-8609-44a7c070d093)(content(Whitespace\" \
+         6efd24ca-3fd2-4fba-9173-7dfe35a1f9e0)(content(Whitespace\" \
          \"))))(Tile((id \
          5955fb69-6a3c-4898-b123-e7c559ecdd56)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3f724fb4-c7f8-454b-946e-0700f37f58fc)(content(Whitespace\" \
+         \"))))(Tile((id \
          3b299ea0-0546-4701-913c-d301751e6fe8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         961f0b11-880d-49d9-ade5-cd6bd1b15f2a)(content(Whitespace\" \
+         \"))))(Tile((id \
          e886f7b5-a0b1-432a-8363-862d7ceb056f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9a1a3f1d-b201-447a-bdca-f29de59d7f4a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8f8594ca-3b3f-421a-b351-c9b937d7a7ac)(content(Whitespace\" \
+         dec7678f-3475-4233-84e4-6893352da495)(content(Whitespace\" \
          \"))))(Tile((id \
          e3087ea8-c1bc-49c4-a40b-21e55c5616a3)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2910984d-4ac1-458a-a921-ca21c231ba74)(content(Whitespace\" \
+         \"))))(Tile((id \
          b3757cb0-1378-40ba-aa51-f51646b5c763)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fff1edde-dd9d-44d7-9408-49c0e18c2528)(content(Whitespace\" \
+         \"))))(Tile((id \
          6a754209-1da3-4822-bc1c-b6e107bc0b97)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          1ff63a2a-84c3-4c14-b37a-dc3f38a38070)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         08cf2611-295f-4939-8e87-8d538dcfa8ac)(content(Whitespace\" \
+         e1296bf9-78d7-47c1-a350-ef79b9e18f3b)(content(Whitespace\" \
          \"))))(Tile((id \
          348da331-ad0c-4f14-89e5-dcc9e9e1b005)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3f764955-9414-4a08-a822-ac9bce708353)(content(Whitespace\" \
+         \"))))(Tile((id \
          cfea3aae-e410-4d6e-90a3-2a2d5f12d080)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b748d202-82a1-45fc-a790-2c2e3b3276c2)(content(Whitespace\" \
+         \"))))(Tile((id \
          4fad38d3-6413-47ac-b55c-8bc4394a7811)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         ed34a300-4880-4e7b-95b2-558cb7be6c21)(content(Whitespace\"\\n\"))))(Secondary((id \
-         69e0345f-b669-46b8-92a5-1a63381da166)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a0528859-142b-4386-9394-7eef2c73afb4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e70a5343-a01e-416d-8c2b-d536d77dd991)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         2cda0058-ce0c-4c0d-8536-42cce92ab6ae)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         e6b566ef-fff9-4ae7-988f-6e6482baa6da)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6aae4dd5-0aec-4af1-a209-303ac2bd64c0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         187c497f-457d-4c3f-bf70-94ad49211968)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5c529abe-506b-4b48-b72d-74691391ae53)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         68508fe8-e2c9-429e-8766-7a4dbb5d1198)(content(Whitespace\"\\n\"))))(Tile((id \
          1c79690d-611f-4ac1-851b-5403bb950555)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         afa5f9f6-a73b-4083-a3f5-6486f27d12b9)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
-         let students : [Student] = [\n\
-        \  (\"Bob\", 12, \"blue\"),\n\
-        \  (\"Alice\", 17, \"green\"),\n\
-        \  (\"Eve\", 13, \"red\")\n\
-         ] in\n\
-         type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = [(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")] in\n\
+         type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = [\n\
-        \  (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
-        \  (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-        \  (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
+         (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
+         (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
+         (\"Eve\", 13, 7, 9, 84, 8, 8, 77)\n\
          ] in\n\
          # V1: This version is more idiomatic but requires the caller to pass \
          a function combining the rows explicitly thereby getting more type \
          safety. #\n\
-         let v1 = \n\
-        \  let requires=[\n\
-        \    (enforced=^^check(false), \"concat(header(t1), header(t2)) has no \
+         let v1 =\n\
+         let _requires = [\n\
+         (enforced=^^check(false), \"concat(header(t1), header(t2)) has no \
          duplicates\"),\n\
-        \    (enforced=^^check(false), \"nrows(t1) is equal to nrows(t2)\")\n\
-        \  ] in\n\
-        \  let ensures=[\n\
-        \    (enforced=^^check(true), \"schema(t3) is equal to \
-         concat(schema(t1), schema(t2))\"), # Assuming the higher order \
-         function provided is tuple extension #\n\
-        \    (enforced=^^check(false), \"nrows(t3) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  # V1 is the more idiomatic version #\n\
-        \  let hcat = typfun r1 -> typfun r2 -> typfun r3 -> fun (t1:[r1], \
-         t2:[r2], combine: (r1, r2) -> r3) ->\n\
-        \    (zip(t1, t2)\n\
-        \    |> map(_, combine)) : [r3] in\n\
-        \  \n\
-        \  # Examples #\n\
-        \  test hcat@<Student>\n\
-        \  @<GradebookEntry>\n\
-        \  @<(name=String, age=Int, favorite_color=String, quiz1=Int, \
-         quiz2=Int, midterm=Int, quiz3=Int, quiz4=Int, final=Int)>\n\
-        \  (students, gradebook, fun (s, g) -> s ... g) == \n\
-        \  ([\n\
-        \    (\"Bob\", 12, \"blue\", 8, 9, 77, 7, 9, 87),\n\
-        \    (\"Alice\", 17, \"green\", 6, 8, 88, 8, 7, 85),\n\
-        \    (\"Eve\", 13, \"red\", 7, 9, 84, 8, 8, 77)\n\
-        \  ] : [(name=String, age=Int, favorite_color=String, quiz1=Int, \
-         quiz2=Int, midterm=Int, quiz3=Int, quiz4=Int, final=Int)])\n\
-        \  end\n\
-         in\n\n\
+         (enforced = ^^check(false), \"nrows(t1) is equal to nrows(t2)\")\n\
+         ] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(true), \"schema(t3) is equal to concat(schema(t1), \
+         schema(t2))\"), # Assuming the higher order function provided is \
+         tuple extension #\n\
+         (enforced = ^^check(false), \"nrows(t3) is equal to nrows(t1)\")\n\
+         ] in\n\
+         # V1 is the more idiomatic version #\n\
+         let hcat =\n\
+         typfun r1 -> typfun r2 -> typfun r3 -> fun (t1 : [r1], t2 : [r2], \
+         combine : (r1, r2) -> r3) -> (zip(t1, t2) |> map(_, combine)) : [r3] \
+         in\n\
+         # Examples #\n\
+         test\n\
+         hcat@<Student>@<GradebookEntry>@<(name = String, age = Int, \
+         favorite_color = String, quiz1 = Int, quiz2 = Int, midterm = Int, \
+         quiz3 = Int, quiz4 = Int, final = Int)>(students, gradebook, fun (s, \
+         g) -> s ... g)\n\
+         == (\n\
+         [(\"Bob\", 12, \"blue\", 8, 9, 77, 7, 9, 87), (\"Alice\", 17, \
+         \"green\", 6, 8, 88, 8, 7, 85), (\"Eve\", 13, \"red\", 7, 9, 84, 8, \
+         8, 77)]\n\
+         : [(name = String, age = Int, favorite_color = String, quiz1 = Int, \
+         quiz2 = Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int)]\n\
+         ) end in\n\n\
          # V2: This version more closely matches the TableAPI and takes a \
          string column. Given the lack of row polymorphism no constraints are \
-         ensured #  \n\
-         let v2 =  \n\
-        \  let requires = [\n\
-        \    (enforced=^^check(false), \"concat(header(t1), header(t2)) has no \
+         ensured #\n\
+         let v2 =\n\
+         let _requires = [\n\
+         (enforced=^^check(false), \"concat(header(t1), header(t2)) has no \
          duplicates\"),\n\
-        \    (enforced=^^check(false), \"nrows(t1) is equal to nrows(t2)\")\n\
-        \  ] in\n\
-        \  let ensures = [\n\
-        \    (enforced=^^check(false), \"schema(t3) is equal to \
-         concat(schema(t1), schema(t2))\"),\n\
-        \    (enforced=^^check(false), \"nrows(t3) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  # V1 is the more idiomatic version #\n\
-        \  let hcat = fun (t1:[?], t2:[?]) ->\n\
-        \    zip(t1, t2)\n\
-        \    |> map(_, fun (r1, r2) -> r1 ... r2) in\n\
-        \  \n\
-        \  # Examples #\n\
-        \  test \n\
-        \    hcat(students, gradebook) == ([\n\
-        \      (\"Bob\", 12, \"blue\", 8, 9, 77, 7, 9, 87),\n\
-        \      (\"Alice\", 17, \"green\", 6, 8, 88, 8, 7, 85),\n\
-        \      (\"Eve\", 13, \"red\", 7, 9, 84, 8, 8, 77)\n\
-        \    ] : [(name=String, age=Int, favorite_color=String, quiz1=Int, \
-         quiz2=Int, midterm=Int, quiz3=Int, quiz4=Int, final=Int)])\n\
-        \   end\n\
-         in ?\n";
+         (enforced = ^^check(false), \"nrows(t1) is equal to nrows(t2)\")\n\
+         ] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(false), \"schema(t3) is equal to concat(schema(t1), \
+         schema(t2))\"),\n\
+         (enforced = ^^check(false), \"nrows(t3) is equal to nrows(t1)\")\n\
+         ] in\n\
+         # V1 is the more idiomatic version #\n\
+         let hcat = fun (t1 : [?], t2 : [?]) -> zip(t1, t2) |> map(_, fun (r1, \
+         r2) -> r1 ... r2) in\n\
+         # Examples #\n\
+         test\n\
+         hcat(students, gradebook)\n\
+         == (\n\
+         [(\"Bob\", 12, \"blue\", 8, 9, 77, 7, 9, 87), (\"Alice\", 17, \
+         \"green\", 6, 8, 88, 8, 7, 85), (\"Eve\", 13, \"red\", 7, 9, 84, 8, \
+         8, 77)]\n\
+         : [(name = String, age = Int, favorite_color = String, quiz1 = Int, \
+         quiz2 = Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int)]\n\
+         ) end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIConstructorsleftJoin.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIConstructorsleftJoin.ml
@@ -6,89 +6,96 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         b7f55100-d334-43da-a264-b7f58dfa417a)(content(Whitespace\" \
+         796c4eab-3982-4cbf-a108-4621dcac3e39)(content(Whitespace\" \
          \"))))(Tile((id \
          a4c6b36c-4c46-4045-91cc-93e9922f1dac)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         e03df292-a04f-4b1b-a0f9-29e2f4db62d8)(content(Whitespace\" \
+         b61bceab-f4df-4e41-be20-ea1784671497)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e37fd512-e9a6-462d-93a8-04c9119d3729)(content(Whitespace\" \
+         f30a8e3e-9c4c-4dc1-9c4e-4bf44beeda51)(content(Whitespace\" \
          \"))))(Tile((id \
          42d37ff2-3cc7-44f3-9977-03766e1924e5)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          677ccab1-607e-4e01-8578-272a0469f6a8)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e81c647d-0795-451f-a4b3-655b5eb365c0)(content(Whitespace\" \
+         \"))))(Tile((id \
          62e13d72-9bbb-4cee-8e58-7b2caaafd4c4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dd121a55-b5f9-47dd-accc-0f4eef7850eb)(content(Whitespace\" \
+         \"))))(Tile((id \
          655cb476-6861-4066-9e81-170a0beba1cb)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9b5e95a2-2f17-4595-88fa-f2e29600113c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c38e5d01-4ac9-402d-bf30-e2b198888847)(content(Whitespace\" \
+         c0a287e2-b2e0-46ef-8013-b1ef55583fa9)(content(Whitespace\" \
          \"))))(Tile((id \
          ff4daf6e-4feb-4f9c-99aa-7d43f3686d6f)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c5fb4994-fcbe-42d5-962c-bf741a5c5a82)(content(Whitespace\" \
+         \"))))(Tile((id \
          6cb5cf3a-4c91-48f4-8ff6-239c64372aaa)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         389d7890-a112-4a13-8f1d-8f706906662d)(content(Whitespace\" \
+         \"))))(Tile((id \
          762c37b9-8824-4594-af16-b6b43dc34a75)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          782c0ef6-6714-494a-a861-0c4a551024b8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         015aba33-4b51-4a3c-a1ae-a3bd07c3b426)(content(Whitespace\" \
+         cd2756a6-d2b0-4f52-adfe-2f572c9e7ed4)(content(Whitespace\" \
          \"))))(Tile((id \
          e5db3223-59f9-4ed4-a810-c5dda24f21a7)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ce88e1ec-1722-45c4-8918-12843959795c)(content(Whitespace\" \
+         \"))))(Tile((id \
          34eb7dc7-a44f-40c6-bb58-91bcc9e40413)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         efd53501-4263-4a45-ab39-58b862fd603d)(content(Whitespace\" \
+         \"))))(Tile((id \
          d0b6eced-9001-4832-a22a-84aa34c689f3)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         ffe11efb-1131-4557-9b6c-01e6a813d584)(content(Whitespace\" \
+         9c3f9e75-2482-4d03-8610-8b3696f20b53)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ae058c71-ee9f-4f22-b485-a421d3c09668)(content(Whitespace\"\\n\"))))(Tile((id \
+         2bf6fed9-1ee7-40e2-ae74-704b6f4fa9fe)(content(Whitespace\"\\n\"))))(Tile((id \
          c5ee4596-3cf5-4e05-a2f3-620054f5afd6)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8d0c80e1-ab4f-456b-a314-fd7b38fb9845)(content(Whitespace\" \
+         54b0ca31-c7fc-4a08-a75c-f1987e5ffed5)(content(Whitespace\" \
          \"))))(Tile((id \
          117b145e-a403-49bb-97b1-03562aadbbe4)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2eefcfe2-c002-4b2b-9837-22746d844be0)(content(Whitespace\" \
+         1121f83d-3ea9-4f7c-b16c-b96a6a4cd27e)(content(Whitespace\" \
          \"))))(Tile((id \
          3090d000-5cbf-4143-bd68-46772eb7bff0)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         98d5b47b-ae11-4fe6-9f53-e838df05f8f2)(content(Whitespace\" \
+         1f759b1d-617c-49f4-a9c9-d28897f45c4e)(content(Whitespace\" \
          \"))))(Tile((id 40b239b2-2f91-4839-84a7-133654a67b3e)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          48a54ddc-a2ca-4101-ada7-e443d1843ba1)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         af52ec8e-3df6-479d-aa85-ef4a485968a1)(content(Whitespace\" \
+         4506cc51-aa3e-4f4b-86b9-0be4d3198dd8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5980d7a1-44dd-4907-88fe-a203deaa2e51)(content(Whitespace\" \
+         22da9881-d648-4508-b9ca-f6120824ed2c)(content(Whitespace\" \
          \"))))(Tile((id 3b13eacc-9568-4f55-b5c7-32e711e43ea1)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         6c51576c-33fe-418a-9723-6110d13fb712)(content(Whitespace\"\\n\"))))(Secondary((id \
-         06917f7b-a64e-4f20-aedc-ce3710004ecb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dc9e0278-94d6-4e52-bbc9-57504471efdf)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          d608294d-e897-4d87-9554-a6d9282bd192)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -114,10 +121,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          108a485c-58e9-4ed6-ac94-443f96ec9e94)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b86f15e1-8399-4892-b1e9-72e705295851)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1f6a52cf-ae2d-4944-87ac-7002d55381ff)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a9557320-4653-4ffd-bb8a-537e5e310ae9)(content(Whitespace\" \
+         635e759e-7074-472b-99f5-d018600ccfaa)(content(Whitespace\" \
          \"))))(Tile((id \
          cfe3a6b5-8f67-42ef-bb05-e8b21c2425e3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -144,10 +148,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ae91bc15-6101-48c4-ae0d-ec91ce67bd36)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         88c3d5d0-bd0d-449e-9f94-c0f36441128b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         400b3531-6e2e-4d71-a76e-9ad4e905d555)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e6ef517-e606-4d50-91b9-17e561ccaebb)(content(Whitespace\" \
+         07d2ba1e-1949-41b3-b189-087a493940b0)(content(Whitespace\" \
          \"))))(Tile((id \
          561d00d3-5606-400d-9c91-1f9b97a2fa62)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -158,7 +159,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f6fe2d88-b969-4fcd-91df-6242883e288c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         db6f1ea3-0662-4957-b590-45b91cc8d6d7)(content(Whitespace\" \
+         b482c6e3-8b76-41a3-80d1-5d37cca0d0b4)(content(Whitespace\" \
          \"))))(Tile((id \
          bdf5d253-6e28-4d3c-ab1e-26e575aa44dc)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -166,171 +167,198 @@ let out : string * Haz3lcore.PersistentSegment.t =
          794870d3-0d8c-43ad-8bc0-b309f29c1e44)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f9620401-27c7-40f7-9b6f-df5a8d618507)(content(Whitespace\" \
+         7341dd3b-d768-4cc4-9953-5153eabb03ce)(content(Whitespace\" \
          \"))))(Tile((id \
          9e616918-06c9-4c60-b356-a97fedec75a3)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1a806a3f-344e-4e9b-af29-77595c703bc4)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         be316594-8b21-4d01-a338-88d700e075fc)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         0b585ce7-7aa3-431c-a2cf-88b6a61e4e31)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         74ffc122-aae2-4680-ab96-c90115c2e39d)(content(Whitespace\"\\n\"))))(Tile((id \
+         e57ac107-5e9a-465f-a97b-034cdeb4eea2)(content(Whitespace\"\\n\"))))(Tile((id \
          0afb202c-83a3-43d6-80f8-e3198df7b2b2)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         38db3ef8-5a84-49a0-afcc-f067b6f20524)(content(Whitespace\" \
+         92ea0de9-2187-4f95-84df-24cea7ad8c99)(content(Whitespace\" \
          \"))))(Tile((id \
          7f0a36f0-42b2-450b-b1cc-6fa85b2a71e8)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         cfcf9a89-5f5a-40aa-9f89-0493610d89ef)(content(Whitespace\" \
+         17733ebd-e73e-4ed2-975c-f85f14184bfd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         952e4f31-3d7d-4493-873c-52f159ec18a6)(content(Whitespace\" \
+         42578119-28bc-4490-9eba-3a97a779bff9)(content(Whitespace\" \
          \"))))(Tile((id \
          31f9b17b-ecc5-47e0-84ee-36cd4f83608d)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          06c7b267-a80f-452c-a415-c60dbec35fe5)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5163c609-bbf4-4b60-894b-f54d689eddb0)(content(Whitespace\" \
+         \"))))(Tile((id \
          443db672-7064-4c47-ac8d-1e1419e072a7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ee532569-40a4-45be-b64c-acd579eeded2)(content(Whitespace\" \
+         \"))))(Tile((id \
          b910ccea-0e12-45d5-839d-c97c6bb08300)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          8b84e081-9e3a-400a-a7f2-c8340963b3b3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bbc9f758-09cf-480a-90a2-8520a22299e8)(content(Whitespace\" \
+         b44ab9c1-691e-46f6-9958-9e11afe92806)(content(Whitespace\" \
          \"))))(Tile((id \
          21a00cc6-426d-4dd6-a96b-9d62080feb7e)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e708f17a-69f2-4afc-8f45-eb0f64e00e5c)(content(Whitespace\" \
+         \"))))(Tile((id \
          0134cfd2-e065-4b89-917f-01e5b7ce8af5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d6fe2411-2f5f-4783-955c-0ace07c51462)(content(Whitespace\" \
+         \"))))(Tile((id \
          4bf2e128-8e3b-4448-a2eb-88219e30da6e)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          1a74ffb1-01bc-440f-97b1-d63647aca812)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c7cfca51-ba6c-4f49-9b89-68a1d3b3a27a)(content(Whitespace\" \
+         b0c11325-a791-43a7-b405-58909d323e87)(content(Whitespace\" \
          \"))))(Tile((id \
          6a8ddbeb-83d1-468b-b2c2-7e74ea2f6188)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         68758510-7e9c-4fb1-b027-95504019b7a8)(content(Whitespace\" \
+         \"))))(Tile((id \
          553cee16-d5aa-4e0e-a234-89a6087c1fe4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dbb71abe-d824-470f-87a5-f2069358bef0)(content(Whitespace\" \
+         \"))))(Tile((id \
          a4d1e1bc-d797-414f-ae91-c1e004b53c93)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          cd20b303-de01-4b5d-8b1c-a7df48a6b680)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9394a53e-5224-4d10-b62d-b4af76a6f602)(content(Whitespace\" \
+         31dc55c8-ff07-4167-a07a-6eabcb97dce6)(content(Whitespace\" \
          \"))))(Tile((id \
          d1a60256-1019-46ef-830c-02b8c29d64f0)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dcd2e925-e661-4f15-a578-a4580d07134f)(content(Whitespace\" \
+         \"))))(Tile((id \
          234e6203-feed-4ca5-ae16-d05189d8c552)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         26d498da-bcf6-4190-ac71-4adc0d6673cc)(content(Whitespace\" \
+         \"))))(Tile((id \
          4cbcfe63-621b-44b2-a3b9-316693d5fe41)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bca129c7-1931-42ab-aaa7-c90281220c5c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4c758789-3407-4e56-a2a3-dc216bc1dcad)(content(Whitespace\" \
+         50415226-1178-4eca-a198-ac5031d006c0)(content(Whitespace\" \
          \"))))(Tile((id \
          fe8d4e33-19b1-4027-9968-962a9b9a20e3)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c3ef76dc-832e-4501-8d2f-55488fdc2b05)(content(Whitespace\" \
+         \"))))(Tile((id \
          8cfbc797-c79f-4e07-b3ca-0c4bc354e0cf)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6d090772-1cdb-4f07-aaa6-897afd7d1ef8)(content(Whitespace\" \
+         \"))))(Tile((id \
          f5cf595b-4ee6-4646-aaad-1b567854b9fe)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          cd598332-4c09-4236-923b-17e57e358ced)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a816a49a-bf7b-4ff0-b685-2fcac3d410cd)(content(Whitespace\" \
+         fc8816ed-e435-4bf9-ae92-033adebc5602)(content(Whitespace\" \
          \"))))(Tile((id \
          d558de71-d0ea-4522-9dca-d49ef9e94ddb)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bd752942-baa4-4b07-9d57-0f75fd444317)(content(Whitespace\" \
+         \"))))(Tile((id \
          aac1858b-d01c-48b1-b2a1-fba6ea66d543)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b843232a-cbdc-434f-b242-a05f96269937)(content(Whitespace\" \
+         \"))))(Tile((id \
          61dbb363-cd2f-48e0-aa14-88ad7adacf2a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bb019a6d-2111-49d5-a89b-bf84aaa3265d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         894c7c95-687b-442c-a12b-3842851ee735)(content(Whitespace\" \
+         ad18c2cb-25c9-4784-9883-60dad0657280)(content(Whitespace\" \
          \"))))(Tile((id \
          8447e9c8-507d-4fbb-a51f-f929dd3776c3)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         40fb8d1b-fb76-4981-aab6-35ff607ddd79)(content(Whitespace\" \
+         \"))))(Tile((id \
          f3a441f2-4628-489d-a362-db0a45d0c69b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ababfb25-cc56-46f0-afff-566346c6583d)(content(Whitespace\" \
+         \"))))(Tile((id \
          e580f505-ffd8-4b91-88f7-a358ef585815)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c4f68f55-0dfb-484e-8ce3-309cb01ab2a9)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         79fd4c4d-8de2-40a3-9315-55a6dcbd96f7)(content(Whitespace\" \
+         c1db4078-2981-4908-be1f-ee592e83f9e9)(content(Whitespace\" \
          \"))))(Tile((id \
          61b2e80b-8032-4fe3-a5e1-cfaf48b21aa3)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0bc00e50-6b1b-4b84-b323-8b9f55db7f79)(content(Whitespace\" \
+         \"))))(Tile((id \
          98cd13ed-f9da-420e-9f3d-8b1ae419ffec)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         be746d02-2d50-4599-ae33-f99dff50bb39)(content(Whitespace\" \
+         \"))))(Tile((id \
          0c5cce2c-ac4d-4a8e-b0a5-cb9d16cf82b9)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         43b67038-ebfb-4bb7-ba3e-8975d5faf32f)(content(Whitespace\" \
+         535378f2-5695-45bb-b3ea-4aca12b83a4e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f5978bdb-bb50-4638-a9e5-d14b923df36e)(content(Whitespace\"\\n\"))))(Tile((id \
+         8d4019b2-e033-4024-97aa-414b6e72e6ba)(content(Whitespace\"\\n\"))))(Tile((id \
          3d01fbee-c41c-487f-ae30-55624778eef4)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         cc3cd715-a38f-43f9-915a-21275e2cf3ed)(content(Whitespace\" \
+         ae958794-6a83-4a0b-b119-f81f5d43768b)(content(Whitespace\" \
          \"))))(Tile((id \
          638e9126-cc36-4a2a-8e42-37ec19cdf283)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a7f5517c-059d-4412-a60b-59445bcc2504)(content(Whitespace\" \
+         181a55e2-ba09-46f6-9e53-fa9e595abf47)(content(Whitespace\" \
          \"))))(Tile((id \
          01b7ecc9-46cb-42e6-ae9b-8de646fbdf3a)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         19937b59-1ec5-46e0-88d9-925477d075db)(content(Whitespace\" \
+         542640a1-b01b-409b-bbfa-d882033320db)(content(Whitespace\" \
          \"))))(Tile((id 24a897a0-8794-41bf-9ba4-b06f1b13d485)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          6f6193af-51f8-49b9-999f-e9f5e5337fd5)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e7541d49-35ce-4f84-8570-494d96847421)(content(Whitespace\" \
+         8ed4dc0f-9e83-4e37-ad64-fc19566e7d1d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d2b6bb79-3962-4efb-84e1-3ce61e535d7b)(content(Whitespace\" \
+         967ab11b-e99f-47a3-b65f-a7c12767377b)(content(Whitespace\" \
          \"))))(Tile((id 804c58c5-beff-4040-9c11-36aa3766c9a9)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         e9a1cb2e-02aa-4fac-ab00-b198753f7b8d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4d3ed652-63a4-453e-85ab-37e657d8ccb7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57a8b193-ff00-4bdd-bf4a-2bba4eebe9eb)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ad865f10-c26b-4b87-adbf-c1b689e478e4)(content(Whitespace\"\\n\"))))(Tile((id \
          186be1fc-66bd-41ad-aadd-eb888f7a6f5f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -400,11 +428,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          de8396c9-3052-4583-be3d-d2e34edf8cd7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6c43b4b5-b54b-477e-8960-95782d00bdb6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         79f5db01-4f92-43c0-bb8b-b924b4b56e7f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c69befc-79db-42ba-a864-d55fff2b4768)(content(Whitespace\" \
-         \"))))(Tile((id \
+         2cbf85d1-9273-4ae9-b3d8-d7c2e5f39699)(content(Whitespace\"\\n\"))))(Tile((id \
          59c331d2-b5b2-4609-b67e-5e1cc803a3e8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -470,11 +494,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          458040e6-54c1-4d65-a10d-d2ca5bfc52f7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         eaece5ee-55cc-4981-a877-991b93427bff)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bf19afb6-42f2-4598-b2a1-2187364d5fd8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea9b290e-c404-4b20-961c-e7666ab112db)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9468ea64-bea6-44a6-b196-b0d471deec93)(content(Whitespace\"\\n\"))))(Tile((id \
          bcf29380-30b6-45a1-8dcf-5f3cb008b7b9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -484,11 +504,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          27b80d83-165e-45be-83f9-25fa62a89081)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         16eea519-9298-4cdc-9c4e-ee2b2100beaf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         53417d31-5283-4948-a77c-a7d1015b3022)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8324d82c-6d6a-4131-8d45-408d8633c55d)(content(Whitespace\" \
+         b1f7c4c5-304b-4cdf-830f-7eb34cb12484)(content(Whitespace\" \
          \"))))(Tile((id \
          f2b2f241-6a25-4276-b952-df9646384a88)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -496,7 +512,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          89103d08-04cb-4e56-b774-59ad0c682edc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6038b12e-3d2f-45f6-89ed-1c7bcd8d2ce8)(content(Whitespace\" \
+         cb387c0b-9ff9-4609-8316-bbc4ddacf48f)(content(Whitespace\" \
          \"))))(Tile((id \
          7f85cd7e-ab00-4c68-8e32-b1f35eccae2e)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -504,7 +520,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6d75e6d1-2fc5-487c-b037-763bf850392a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6bb5048b-a4d6-474c-9e44-deb0f629121c)(content(Whitespace\" \
+         b49da3ba-25d1-453e-ad0e-e4bfb6522c01)(content(Whitespace\" \
          \"))))(Tile((id \
          548caefe-5f48-485c-9ceb-a7b0e1d54303)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -512,7 +528,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fab027b5-c25c-42f8-811b-321f39667ae6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         78c9bbe0-57c2-46d9-9839-723069055a7d)(content(Whitespace\" \
+         f6431faa-218c-48f6-9b51-4f16c8eb54c3)(content(Whitespace\" \
          \"))))(Tile((id \
          ac6c5655-277b-41ba-bdaa-24315d7d95ce)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -520,7 +536,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          95fa3250-c3e0-42b2-a2d6-0a37aa214402)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6b9e7f2d-0145-47f3-9ef9-e87a80fc7995)(content(Whitespace\" \
+         80e620de-c845-46ba-887f-a46672639307)(content(Whitespace\" \
          \"))))(Tile((id \
          936a809f-f6a3-4369-bf7e-afeb03dbed0d)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -528,7 +544,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5f9757a5-a747-4e66-9c46-f5fb8d42d905)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb485345-89ae-4fae-81b8-2d2950588693)(content(Whitespace\" \
+         424c4627-c6c7-4d47-92e0-8bbd6c8a3182)(content(Whitespace\" \
          \"))))(Tile((id \
          3a5454ce-e996-453a-984e-7428a036319b)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -536,72 +552,53 @@ let out : string * Haz3lcore.PersistentSegment.t =
          94bd5b74-56c2-44b1-a7e6-7bbfc8fc0aae)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cf6927b6-119e-4d1f-9445-8fc962122071)(content(Whitespace\" \
+         16c6fbbc-30f3-4402-9fbf-cbc5e9690e51)(content(Whitespace\" \
          \"))))(Tile((id \
          d54c8df8-424a-4819-8640-60d1f1791c45)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3d0efb87-8013-4200-99fe-6b83ec2df240)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ce7148f8-cc9d-4351-b76b-955fdbd06fbb)(content(Whitespace\" \
+         a465707b-8de2-46e9-9653-20cca83aef31)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         5d89cf90-0ec7-4bd6-838e-1f12158b2d68)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e5315edf-34b5-4b5f-820a-59468915983e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3bad56bf-c4e4-4648-9887-05930d1f450e)(content(Whitespace\"\\n\"))))(Secondary((id \
+         0475b401-b8b3-40a4-85ef-81e4ef543b35)(content(Whitespace\"\\n\"))))(Secondary((id \
+         844295fd-57b6-4d35-949e-5fd8655a9c94)(content(Whitespace\"\\n\"))))(Secondary((id \
          cd5663c7-5b16-48d2-8dac-abecd6639a13)(content(Comment\"# V1: This \
          version is idiomatic but is a higher order function requiring the \
          caller to construct the resulting schema by passing in a function. \
          #\"))))(Secondary((id \
-         03b97e23-ad18-40c8-84a8-e47a1d7e3917)(content(Whitespace\"\\n\"))))(Secondary((id \
+         c40f0d16-ae7e-4b56-a0f2-2eb824aaa7ff)(content(Whitespace\"\\n\"))))(Secondary((id \
          d1e81e91-e08f-4bbd-93e4-bbdb90eec30c)(content(Comment\"# In addition \
          the right side of the table is wrapped in a single option type \
          marking the whole row as present or absent. A future operation could \
          turn a optional tuple into a tuple of optional values \
          #\"))))(Secondary((id \
-         ce93b896-a381-4b7a-b51e-1391bd87f7ef)(content(Whitespace\"\\n\"))))(Tile((id \
+         88e9e8dc-fcd3-49ae-9773-1d0e6f277386)(content(Whitespace\"\\n\"))))(Tile((id \
          0cad66e2-a2b0-4cf3-b4d4-85c99e870bb2)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         826a4f35-40bc-491b-ade4-99fb94224f77)(content(Whitespace\" \
+         d8eb6e65-0a7c-4269-8aac-fc52e1e1b723)(content(Whitespace\" \
          \"))))(Tile((id \
          e2ee9284-c234-49f0-b636-c045c766535e)(label(v1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6111eb90-38a6-4b60-bb18-110e2cbb4978)(content(Whitespace\" \
+         0699028d-22d5-4ea0-b5e2-052a8cadf9da)(content(Whitespace\" \
          \")))))((Secondary((id \
-         72bec735-a17e-4b3f-aeba-5ac307aae1f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         72620ea4-2d92-40af-ba03-82b273f123d3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f1b4ea61-f2c9-4b69-b34f-d3dbc7d554a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         60fac229-178e-4f24-85ba-8c06eb56928d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27b72aee-ce1e-4ec6-8e3d-997cf77c9a32)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         588ab1e7-2a42-452d-a021-3a3bdd8ff820)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c816e223-a145-49fd-be2c-a95fc6b6937e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd085803-83b5-4f64-a285-364089ea638e)(content(Whitespace\" \
-         \"))))(Tile((id 5a2518a4-4ff1-4b8a-9f72-2bad2e0131a9)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         3addec8a-78fb-461c-9429-4768c44e1547)(content(Whitespace\" \
+         941ef2ee-079e-4daf-a14e-2c7037a10692)(content(Whitespace\"\\n\"))))(Tile((id \
+         5a2518a4-4ff1-4b8a-9f72-2bad2e0131a9)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         982b6f39-0d9b-464b-9a42-a5a4b71ac761)(content(Whitespace\" \
          \"))))(Tile((id \
-         0e6efe2b-1982-4fa8-b437-c15331f2b799)(label(requires))(mold((out \
+         0e6efe2b-1982-4fa8-b437-c15331f2b799)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         f98d281f-7800-4191-a06c-9c0e058ebec6)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         6c9b00a4-1bf7-497c-a275-4ed5b4bfe14e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a59424f0-071f-4eef-bf85-6768a8604d4b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f57754b0-6c6e-47eb-bb22-f44afa82460e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e43e5818-8bab-4f82-81c8-db40c3cd3f65)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b69f281-e7c0-43f3-8aac-7d0075db28aa)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c943c159-bdde-44f2-95dc-62b3b1858ce6)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         69347395-3800-43ac-af63-685a86f12e36)(content(Whitespace\" \
+         \"))))(Tile((id f98d281f-7800-4191-a06c-9c0e058ebec6)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         9cf4732f-c84f-4ffa-a2b7-b24807dd43a1)(content(Whitespace\"\\n\"))))(Tile((id \
          65934b11-efd2-4477-bbcb-7d77e692d8b6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -629,19 +626,11 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e108fa72-1aa2-4542-a38f-3a463ff9b242)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f27054d3-48b8-4e34-a10c-10bb9b01a690)(content(Whitespace\" \
+         c0968ca1-5f7a-4351-b290-96305afaba14)(content(Whitespace\" \
          \"))))(Secondary((id \
          88727000-12ea-40f9-91eb-f29d95bf903a)(content(Comment\"# Ensured by \
          projection function #\"))))(Secondary((id \
-         70b29a53-a7c5-48ce-9fb7-c7565ef07127)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a0177b25-8370-4afd-9783-55c9a6698023)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d6b9fab6-3f92-45f5-a1cc-494d239aca03)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         99f1def5-b528-43d4-93d2-75d688fb3d5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         335c5d5f-f7ff-4040-bbf8-fa4491414ff6)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0a1fc947-f7c1-42e1-9d85-9eccff41b7ed)(content(Whitespace\"\\n\"))))(Tile((id \
          ff46b429-a85e-40d2-938b-82574c55b7f0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -669,21 +658,11 @@ let out : string * Haz3lcore.PersistentSegment.t =
          afba11f2-c07b-460a-b8ac-240abe2d8b51)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69ea55d2-906b-4fad-a103-132d81ca4dd6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         44f5c286-8548-4014-ac9b-2f97c0426e57)(content(Whitespace\" \
+         b696e4c4-d3f1-4129-8869-39327a427536)(content(Whitespace\" \
          \"))))(Secondary((id \
          e746f783-e1a0-42da-870a-9a7db533be0a)(content(Comment\"# Ensured by \
          projection function #\"))))(Secondary((id \
-         4bdb083f-a216-48e6-b5a9-4bf0c921fa98)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6b2fd021-dd1f-4310-af49-39e8d9717923)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         05e25ccb-6e95-49c8-81f6-7b5a5c810585)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e5e73855-0dfd-42f1-afa4-f03f5f678612)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f306cc26-3a7c-48a9-8250-8c93990c871f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c3bfb33f-0cea-4dcc-b852-02ee6f6eb354)(content(Whitespace\"\\n\"))))(Tile((id \
          0eab25f9-6ed0-4add-9941-155e5c001180)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -711,21 +690,11 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b9edd264-55aa-4725-a0c0-d0c838fe5847)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a978c9cd-5ae8-4d35-bb30-2c9a29802584)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5d870d0b-2bc7-4d13-888a-0d095e0e1738)(content(Whitespace\" \
+         2074641a-7019-4726-bf09-9ea6b93a9603)(content(Whitespace\" \
          \"))))(Secondary((id \
          af75ebc4-b6b4-4a6a-bea8-d9ae1fef3445)(content(Comment\"# Ensured by \
          projection function #\"))))(Secondary((id \
-         9d9aa191-90c7-4f60-8b47-dd1f902172c0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         65f2d0f4-bef5-4b6e-842c-aa24ef35a5a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0c7d130b-fdf2-44f5-b43c-ad55011ac6c4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c4d16b1a-e921-492f-9f59-5bfef2291ee9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ff7c6821-a07d-492c-a5be-7e8d902ec867)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b8710852-9821-4c2c-810a-a51c64cdeec8)(content(Whitespace\"\\n\"))))(Tile((id \
          76ca3c75-8189-4ed9-a70d-f029a42b3cf9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -754,31 +723,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          29874998-85ed-4e2a-b557-4f10d8c6f412)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9fe99881-351b-470b-a12e-0de3c17ae05f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1e214d28-97a0-4586-908a-acb71e930a7d)(content(Whitespace\" \
+         6a2caa52-a8c7-4657-93b9-cfb24b73a1a2)(content(Whitespace\" \
          \"))))(Secondary((id \
          c7604b59-0899-494d-a29e-56feb1ae4d1c)(content(Comment\"# Ensured by \
          projection function #\"))))(Secondary((id \
-         4d87749c-b48d-4f1f-a2d8-c9beac69d06d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         629d7b44-a711-4bcb-8947-117865e4a64f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eedf7a50-ef16-467c-b512-d6ca687e5c65)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         145f57ea-fa7f-46ef-bf2c-d4247d756e05)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         29d469f4-01ed-47c5-a836-e31410ea147b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c8bf7f29-e393-4398-ab84-e177762615a5)(content(Whitespace\"\\n\"))))(Tile((id \
          6b08ad0e-a211-4986-a145-b76062a4af99)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          b0e2c5d6-5008-4b01-9120-8f3e3c9393c2)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         32506dcf-5398-4044-8aa2-b5b330e8ec23)(content(Whitespace\" \
+         \"))))(Tile((id \
          9015f33f-2e93-4c9a-be97-6cf7584ddd97)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         deed361b-03dc-444c-b539-0344bda58766)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         17fb705a-f4e7-419f-9b91-393cd9ab7481)(content(Whitespace\" \
+         \"))))(Projector((id deed361b-03dc-444c-b539-0344bda58766)(kind \
+         Checkbox)(syntax(Tile((id \
          4dfeb246-29c9-45d2-8a95-9661c8c17a0f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -788,46 +751,31 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1df55739-a25e-4477-96dd-782238ea98ea)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         992c514d-dd8e-44f9-b1da-2d2302cee2aa)(content(Whitespace\" \
+         ca5052c7-6c09-4f32-be05-49c18b59be5d)(content(Whitespace\" \
          \"))))(Tile((id \
          1ef38bca-ee24-4015-a86e-dee7b0e964a5)(label(\"\\\"concat(header(t1), \
          removeAll(header(t2), cs)) has no duplicates\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4818c07e-a97f-4eba-b79c-23caa1e35cfc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         523ae04d-6e03-40fd-acd3-803169f0952c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46a9cb3d-636c-4b3d-95de-b9a78ce9cf9b)(content(Whitespace\" \
+         0480029b-054f-4cda-a2d2-98b53cf1b00b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         d30e10ac-bbdb-4806-bb99-fa766a475487)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9c530f06-90bd-4170-aaab-004aae03156c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8c123dfd-593c-4c4f-8368-5d055d37d7af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e0469bed-da92-49b5-a99d-8dd1ea4ede62)(content(Whitespace\"\\n\"))))(Secondary((id \
-         45ec0f6f-c9eb-44bd-99e5-64d82e0a1661)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         270962cf-e83e-457f-b2e0-64f5ffd7b4bf)(content(Whitespace\" \
-         \"))))(Tile((id 1f49128c-575b-42e9-9632-1c6af1ae2b7e)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         3d00e288-1d19-4dbc-9b2a-616a9c5ab8ba)(content(Whitespace\" \
+         f87685cb-925c-40cf-9b89-d81165bc5d2c)(content(Whitespace\"\\n\"))))(Tile((id \
+         1f49128c-575b-42e9-9632-1c6af1ae2b7e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         653149fe-3de0-40b8-9ac5-96185c447047)(content(Whitespace\" \
          \"))))(Tile((id \
-         61924c97-8463-4775-8815-b13676c0ce4c)(label(ensures))(mold((out \
+         61924c97-8463-4775-8815-b13676c0ce4c)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         20ad9a7e-0212-4c22-b11f-8e1ab95de2c8)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         ed37851a-549a-49bf-98c6-c0ac8e82eba7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c496d15e-b0d8-432f-999a-0584f17dbaec)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58bac390-d7d0-4bdc-8b43-6d14f34a18f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         103037e9-4dde-411a-a8fb-6afe3d2b9c41)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b0620217-4c7d-4f43-a23a-dd84d2263426)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         7cc45dff-2524-476e-b98b-82aef94381c9)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         676db3a2-79d3-4067-9dfb-0fde8dda7aae)(content(Whitespace\" \
+         \"))))(Tile((id 20ad9a7e-0212-4c22-b11f-8e1ab95de2c8)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         512aa33a-4fc2-4c5f-9c58-98ca027f21c8)(content(Whitespace\"\\n\"))))(Tile((id \
          75dc69c0-4366-4557-b2e8-ecc86ff0601f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -856,15 +804,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          822c7195-f7cb-4c1e-b387-98ddd5fe218d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ceb9dacc-f8c5-476e-bdbd-679fa26b9cca)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7e62c66a-ed04-49a8-b888-22a900f5338d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         da62a8b5-f479-49e7-86e9-79ed775af194)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         998a8b45-e190-4a90-a639-17d1c6a2a9d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dc816a80-e889-4378-97c7-9e32e9a7f330)(content(Whitespace\" \
-         \"))))(Tile((id \
+         867e19de-ead9-4f36-aa19-ee112c79693d)(content(Whitespace\"\\n\"))))(Tile((id \
          c561021f-5478-4871-aa87-4f71c3b7e806)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -893,21 +833,11 @@ let out : string * Haz3lcore.PersistentSegment.t =
          751db467-03a0-4317-9d4d-9072e0d22b1c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7f8cf5c3-5e40-4bc0-b3d6-bac0a053cd51)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         882f143a-964f-4aa5-9dac-cefb3ae59d88)(content(Whitespace\" \
+         c86435ee-2383-4da3-96d2-71f1754643a0)(content(Whitespace\" \
          \"))))(Secondary((id \
          af215f72-10fd-4886-b247-8e9e2f980f45)(content(Comment\"# If combine \
          function is just adding new column#\"))))(Secondary((id \
-         ae4acc92-7da3-413e-ad46-70baf220bb0a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9505ef46-f090-4c7b-a093-b95c4cd48c6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         79d5f581-94d0-46c9-9bc5-e8d2f1babb2e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f3586802-84dd-4375-823f-30eedd985b83)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f8e3ad8-f574-48b4-ab05-88591776d5ee)(content(Whitespace\" \
-         \"))))(Tile((id \
+         4defe5dc-7d11-452b-93b9-6101489e3613)(content(Whitespace\"\\n\"))))(Tile((id \
          a5675f5d-5014-4388-92bf-8412222ee9a6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -936,25 +866,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f848eb66-c810-4c17-927b-8419115dfb8a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dbbecff4-c85f-498b-b2b4-75599c80c842)(content(Whitespace\"\\n\"))))(Secondary((id \
-         be664c63-2cef-42d3-ae05-56b9c00ec4fd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         05ea8513-9e8b-4ccd-9145-6d201a7d55fb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a6752010-e001-4a92-8271-153e716b2575)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e33ca00c-8743-46c1-99ec-d5e2b16fa053)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8df178db-ee4d-4138-8058-43b50c611703)(content(Whitespace\"\\n\"))))(Tile((id \
          cf514ff6-b39f-4140-a972-9ed1ab7befe2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         f374f634-812b-44e5-88e8-a25f8fcf1c71)(content(Whitespace\"\\n\"))))(Tile((id \
          ccf69667-6a88-490f-8688-263f31050893)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e88c33af-c531-4d74-928b-d47076e5604a)(content(Whitespace\" \
+         \"))))(Tile((id \
          6c52f708-a916-4262-9325-9fdd3d1362d3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         f1ae4833-9e6a-4744-82ed-dc4b2e144eb3)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         301dd72e-2601-42b0-bd68-c892775e5315)(content(Whitespace\" \
+         \"))))(Projector((id f1ae4833-9e6a-4744-82ed-dc4b2e144eb3)(kind \
+         Checkbox)(syntax(Tile((id \
          3f9d8e12-3216-4899-9523-521ad0452440)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -964,119 +891,86 @@ let out : string * Haz3lcore.PersistentSegment.t =
          52b624d7-af40-4698-9be5-006c5c5a67b2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b2e8f3b8-ee95-41fb-aba4-d4dbb4f948c6)(content(Whitespace\" \
-         \"))))(Tile((id \
+         14c8a151-3237-45ea-9f4a-9fd0fb931d48)(content(Whitespace\"\\n\"))))(Tile((id \
          e80238aa-944a-4f79-8eca-f261eadc13a2)(label(\"\\\"nrows(t3) is equal \
          to nrows(t1) if distinct(selectColumns(t2, cs)) is equal to \
          selectColumns(t2, cs), otherwise each row of t1 may have several \
          matches\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         099912ff-ed7f-40fb-a0de-a0ad7154016b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         002c6478-655a-4d1c-9a8f-cb36b2aa7b5e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         035e1ed1-d1b1-4329-932f-54f4f735922a)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3582c10d-19b4-4e23-9951-0cdcfe2639ee)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         cf9a3c50-794a-4043-9c8d-57104d7387a1)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         5de6cd30-bdfc-4d8e-b3d7-d9cf6564d0e3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6f4435d9-e081-49d1-980d-1fcb3a27038c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9959651f-56c6-487a-8981-be0673edeea9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b63b8c80-f1cb-4de3-b572-d41f22c03bda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e33490ea-efa2-455d-8129-3943c2057faa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6715582f-f5ca-4eca-aa68-5dcf160bedf7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2bb3f21c-2ad1-46f9-a778-75384e70df15)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d3d6601-3623-4e98-82d9-6b7474b6921e)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         abb5e58d-091e-4bf7-ab93-7cfc12c811de)(content(Whitespace\"\\n\"))))(Secondary((id \
          0d22108c-138d-4463-acd1-c31b13ce623a)(content(Comment\"# We just \
          require the caller to combine the resulting rows. The closest to \
          leftJoin would be to just wrap the right row in a new column. \
          #\"))))(Secondary((id \
-         785cd78f-75a0-457b-9e28-afbd3263b111)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e77c074b-cd29-4175-83c9-5b034886703f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         979ef18a-a095-4afb-9f18-be47cde3828f)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         704eb00f-4beb-4d7f-a36f-9da26c29199d)(content(Whitespace\"\\n\"))))(Secondary((id \
          0ba847f6-df7c-4fed-a9ca-591e0493177a)(content(Comment\"# The caller \
          could also decide to flatten the option type into individual optional \
          columns #\"))))(Secondary((id \
-         2a9a33c6-25a3-4431-9bb4-e197e102dea6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e5dcac2d-c1b0-43ca-9bac-41c08dcb53c0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2fb661ba-8d6c-47e5-9078-4edbbd8e569d)(content(Whitespace\" \
-         \"))))(Tile((id 428ae573-5f16-4f96-b8bd-37c3f9ac2c8f)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e986d86d-0a6e-403d-bb61-a6a6e5b2533b)(content(Whitespace\" \
+         075899b5-36f5-468e-9744-2bc16f4fbb35)(content(Whitespace\"\\n\"))))(Tile((id \
+         428ae573-5f16-4f96-b8bd-37c3f9ac2c8f)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9f0178b0-7f89-411a-9bb6-a6eff7f7f56e)(content(Whitespace\" \
          \"))))(Tile((id \
          b5f3ca38-6973-4397-bdc6-cfef31b655de)(label(left_join))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         29696a96-3d0a-41dd-a85b-189d6e7b0282)(content(Whitespace\" \
+         b33d041e-d347-4650-aa5d-9b3c6360c757)(content(Whitespace\" \
          \")))))((Secondary((id \
-         1bb100b3-eaf4-403a-ba55-972ee19fe4d9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         33f502b4-970a-4a77-b884-46b969b76806)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5a6fd25b-89c5-4db6-a899-f536353ddb74)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4a7f5401-f3ef-455d-90bf-d7261506d2a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b17dc0d-c7c1-41d1-af4b-c08a0030b79f)(content(Whitespace\" \
-         \"))))(Tile((id 1fab297f-cfe1-42d4-aade-ba41b183a4d2)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         f10eeff6-68a7-4606-9fe3-d09ec95c2251)(content(Whitespace\" \
+         319f5007-6e30-4b0b-b181-e0a8c89d0815)(content(Whitespace\"\\n\"))))(Tile((id \
+         1fab297f-cfe1-42d4-aade-ba41b183a4d2)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         f49bec0f-4b50-4952-8e1c-f8a92c14b1e8)(content(Whitespace\" \
          \"))))(Tile((id \
          48452f86-a1c6-4815-9b61-13c45480318d)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         900c01a5-68a8-4611-938e-7df57249edb1)(content(Whitespace\" \
+         ec95e4c4-714d-47e2-96c9-f4e08218bfd2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ee7d46cc-e066-432f-9188-173294bcc59c)(content(Whitespace\" \
-         \"))))(Tile((id b324f0d9-80e6-46b0-ad7d-6a6dfac0696e)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ce7b380d-24ac-4080-9fcd-9cc376d1343f)(content(Whitespace\" \
+         2cde689c-c124-4e45-8759-5e32b3dfc205)(content(Whitespace\"\\n\"))))(Tile((id \
+         b324f0d9-80e6-46b0-ad7d-6a6dfac0696e)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ab27369e-97ac-4a5b-8859-7d31a0d074c8)(content(Whitespace\" \
          \"))))(Tile((id \
          bc37a33b-84c6-4ada-a02c-69162a7b9271)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         d1c35a84-820a-495d-95ac-59df8f3abdde)(content(Whitespace\" \
+         e8fe06c8-6c6e-47e7-be88-290b9236ec3d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b662f803-5371-49a5-a9b3-920f559981e0)(content(Whitespace\" \
-         \"))))(Tile((id f0d9ac81-64b9-41fb-915c-239ba7d13eb7)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         acdd1aaa-5f61-4c54-88fb-109d3e62d0e4)(content(Whitespace\" \
+         6403d0d6-dc7f-4701-903b-b959fbf8c644)(content(Whitespace\"\\n\"))))(Tile((id \
+         f0d9ac81-64b9-41fb-915c-239ba7d13eb7)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         9fe01ed9-ecdb-415f-9f36-117f58d2f237)(content(Whitespace\" \
          \"))))(Tile((id \
          20c281d5-ab56-4bca-b797-a0497eb9b7b8)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         0677cf78-e1fc-4d74-951e-ace1d2b89c30)(content(Whitespace\" \
+         4c909093-835f-4b9f-a91f-3676a11842ad)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f79ec86c-fb14-4b60-895d-8ab144bddb0a)(content(Whitespace\" \
-         \"))))(Tile((id ec4ddffe-2b7b-4d6c-8cc7-9cc55b8e6370)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         14fe2ff0-9d15-45fb-8fd5-9ed5eb2a89ae)(content(Whitespace\" \
+         c6d753ce-cf9b-48f2-9711-4ab79bce8a6e)(content(Whitespace\"\\n\"))))(Tile((id \
+         ec4ddffe-2b7b-4d6c-8cc7-9cc55b8e6370)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         d1c57f3e-a30d-41a3-a2ba-b71fbc6d784c)(content(Whitespace\" \
          \"))))(Tile((id \
          a236c7a3-c473-422c-b9ad-2c53bf2fdf47)(label(k))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         54b4f6c0-1b52-4e89-bf73-278838b35df7)(content(Whitespace\" \
+         4bb24eaf-a2cd-407e-a712-fb60fdd00eff)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e1c7f836-d89a-40c1-b9b5-d3de6976e066)(content(Whitespace\" \
-         \"))))(Tile((id b38b7159-3daa-404b-9110-e0d90f26d3a5)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         85dc370d-cc27-48f2-9ae8-78d20aaf70fa)(content(Whitespace\" \
+         27270318-7e95-4424-bdb9-e3bb67094283)(content(Whitespace\"\\n\"))))(Tile((id \
+         b38b7159-3daa-404b-9110-e0d90f26d3a5)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e7a2ee00-685f-4b0b-9d54-c46f27cb30a0)(content(Whitespace\" \
          \"))))(Tile((id \
          b6949094-5b79-4eb3-8b18-752101ae3e9a)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1084,12 +978,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          010242ed-a633-43be-8f7a-5a77d301a76b)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         73c64722-8cfd-4472-bc95-d8a21deaa222)(content(Whitespace\" \
+         885dc6aa-00a9-4f77-a720-864028defe8b)(content(Whitespace\" \
          \"))))(Tile((id \
          7a6fad93-0e77-46b0-a74d-b7ad9ca4817c)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3bac4a17-bc18-4b8f-b62c-57f23b750e9c)(content(Whitespace\" \
+         d8fada3e-2bfe-41ea-8622-1c4f2e144d68)(content(Whitespace\" \
          \"))))(Tile((id b0cd00c0-83fc-4854-a65d-4b884bce2d78)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1099,15 +993,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a6e3f668-d5e6-42c7-a9af-5a3da8d08b95)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         6fad6e73-4ec0-4ea6-ab02-4402edcb798c)(content(Whitespace\" \
+         90d98267-5c71-44de-8655-9d616f43f1dd)(content(Whitespace\" \
          \"))))(Tile((id \
          f83b6805-549a-4d38-82e0-489eeaf00c6b)(label(t2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f44e6b92-1453-4cdb-9a02-9b3a92ee3967)(content(Whitespace\" \
+         \"))))(Tile((id \
          eb433b1d-c118-4cdd-8429-6ac1c44d2d41)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0a2a0ebb-b891-4bd3-9961-aa59618e1165)(content(Whitespace\" \
+         784cfcc4-bd40-4e80-b396-822f5cbc5196)(content(Whitespace\" \
          \"))))(Tile((id 0e00a1e4-2982-4410-9c19-331a2de88837)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1117,27 +1013,27 @@ let out : string * Haz3lcore.PersistentSegment.t =
          56ea0416-12b4-4dae-b661-ae20281ff754)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f8c0b52b-aea7-42b6-924b-6b554611b054)(content(Whitespace\" \
+         89eeddc0-3fa2-4ce2-99c5-238af65b11c4)(content(Whitespace\" \
          \"))))(Tile((id \
          3bdc0578-dfed-4aae-8366-add355c9dfc1)(label(proj1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d2cba363-4488-497d-b18d-2bd4a927b602)(content(Whitespace\" \
+         202991ef-55a7-4509-92de-01bafb3cdbf4)(content(Whitespace\" \
          \"))))(Tile((id \
          27747c2d-0a48-440d-b294-e14fe7513108)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         23daf1ba-8104-44bf-9cd3-b339fa45daa6)(content(Whitespace\" \
+         1bc58bcf-988b-4e9d-a417-b52ebbb4346b)(content(Whitespace\" \
          \"))))(Tile((id \
          8b075dbf-a93c-4e7c-ba52-ada3dd14ffd8)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         fb01b573-5363-4555-b992-cc2596bf66bf)(content(Whitespace\" \
+         64deb169-82f5-4c6c-9b29-dbe2eb271ccf)(content(Whitespace\" \
          \"))))(Tile((id \
          60002923-06c3-4151-adad-d50a7e7bb662)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         024eee74-288c-4f82-8ce6-2d82d16e98ae)(content(Whitespace\" \
+         ba65edd0-4425-4bf7-ac7c-cf5416de6ec9)(content(Whitespace\" \
          \"))))(Tile((id \
          e8e7cd77-1cbf-4112-a086-769c119ecae2)(label(k))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -1145,27 +1041,27 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bb8b25ec-8d14-4eb2-a57c-e7cacfc4c264)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f9fb3352-2143-441c-bf75-60a2b6aa33d7)(content(Whitespace\" \
+         febd3241-6fe7-4325-9ff7-0cceb5797f6b)(content(Whitespace\" \
          \"))))(Tile((id \
          272e8b1c-0132-4140-b25d-d83cae73520f)(label(proj2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7600184b-db93-42ca-906b-cdfe35a881f6)(content(Whitespace\" \
+         83f17978-c720-460d-af76-d76d6fe03abb)(content(Whitespace\" \
          \"))))(Tile((id \
          e54483c8-d520-4868-936b-601681b1218d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8f968c88-bf4f-4474-a558-357582e203e0)(content(Whitespace\" \
+         d1ccd496-14f6-4e98-9c7e-f99db38a59c4)(content(Whitespace\" \
          \"))))(Tile((id \
          eaffc0f7-5b40-40cc-9a12-4b3b2e211176)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         126d6f39-56a3-418f-8cf7-b14c688c29c6)(content(Whitespace\" \
+         b765d416-bf76-4d06-acfc-d6eb0d0b6568)(content(Whitespace\" \
          \"))))(Tile((id \
          3f1f684b-1dff-4ae3-a1a2-09ef22695ac9)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         48d9b1c5-3179-42e3-9901-c2685f80c206)(content(Whitespace\" \
+         8076481b-1cb9-4ac0-a373-41c9b3871f8a)(content(Whitespace\" \
          \"))))(Tile((id \
          817a2c54-1920-44fc-a261-97214d665812)(label(k))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -1173,15 +1069,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bb42ea60-5ecb-4c7d-923a-58484d905694)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f98a9ea6-e3c9-4e41-8041-03d3bc60026b)(content(Whitespace\" \
+         4d636460-7a00-4485-b2b4-cfd629517681)(content(Whitespace\" \
          \"))))(Tile((id \
          8bc6d0b7-0c9d-4e2c-a5d0-12c6a363e676)(label(combine))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         00064564-aac4-42f4-824a-fe8f10055296)(content(Whitespace\" \
+         \"))))(Tile((id \
          0720be18-73d6-4275-9cae-ac472f63fb60)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ecd2262d-33d9-459d-b30d-9ef09d300fb7)(content(Whitespace\" \
+         093da7a3-43b2-4f6c-ab9b-23afdc496bb9)(content(Whitespace\" \
          \"))))(Tile((id \
          815458ee-ea4e-423e-9cda-ad834e12f69c)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -1192,22 +1090,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0498b41b-27a2-4aab-b522-34c0028c8b9a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         56a55ef7-aa92-492a-8e46-573b001fee71)(content(Whitespace\" \
+         95d43cc3-fea9-40c6-a5d2-3fe12577a3e4)(content(Whitespace\" \
          \"))))(Tile((id \
          fd4e3c88-5fb3-4548-9a33-3f0cb109d404)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          5ce4c43e-7823-4fab-95dc-424cd7bf7dc9)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         42764c3d-1970-4551-8812-200fc8e66398)(content(Whitespace\" \
+         \"))))(Tile((id \
          309900dd-33f5-45ac-97ed-72d8c66552a1)(label(None))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         741b053f-dd4c-4594-a95c-0962ba2826e2)(content(Whitespace\" \
+         a9139f59-856c-4bd9-96b2-108bdb5cad83)(content(Whitespace\" \
          \"))))(Tile((id \
          0ca5f9a8-564b-4892-a04b-c82c07ed4958)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
-         12))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         12))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         401b1eb7-39e4-4450-9d97-908f4aa15f91)(content(Whitespace\" \
+         \"))))(Tile((id \
          b3e85495-5ce1-458d-81a4-ff81fdb2bd4f)(label(Some))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
@@ -1217,49 +1119,37 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2954b41b-5b5b-4b60-b23c-4f2552e081ae)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         5b9b8297-4957-4138-9bcf-13da9a2f340f)(content(Whitespace\" \
+         79d5fbe2-bb5e-4f05-80ef-4e654d147b0f)(content(Whitespace\" \
          \"))))(Tile((id \
          5b3b3db7-5640-4a7b-b4c3-811fbe80e10a)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         176fc40d-bf3b-45f8-b7ba-03459c163a1b)(content(Whitespace\" \
+         04f7379e-81b1-4bf6-b5ed-3b973feee4e5)(content(Whitespace\" \
          \"))))(Tile((id \
          0eb1dba8-791a-4df4-94c0-2d80c9102763)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         bd7a44d6-3fc4-499f-9fea-21e01b7ece66)(content(Whitespace\" \
+         6c5950f0-8ed0-44df-978d-6b1c9f5f15e9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         163ab3b4-3167-4d1f-899e-4ff22805ec28)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7c76e392-99b9-4bee-8796-15aa90d04612)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c8b21bd-030f-4653-8c7b-c4c06e37eab6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         929250c0-b04f-48e1-8608-ed94861b9c4f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         38d8aefc-2bbc-49af-ac49-ab8d7c22dc86)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a49d38d4-ce03-4d6a-9e49-d4f9f99f842b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         06fe5b5d-e6cf-4d98-a02f-617a08e6c119)(content(Whitespace\" \
-         \"))))(Tile((id \
+         cb97b1d7-211a-40bd-b2dd-577baa9d26b1)(content(Whitespace\"\\n\"))))(Tile((id \
          74625a88-76e6-47d8-b43c-8d96236862e0)(label(flat_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          ddde3a7c-b605-47a8-a769-dfb996a0b6c9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         2efbfe83-83b3-45de-adbd-c18f8b9a6020)(content(Whitespace\"\\n\"))))(Tile((id \
          cb01e133-176a-42ee-a7af-42619cad8437)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          b6d65c2b-1082-4d71-9b89-fc08962700c0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         81b00867-f960-42ff-b41a-35e09dc39362)(content(Whitespace\" \
-         \"))))(Tile((id cca23cde-ca91-4789-8c55-d1c25bbf316e)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         c5dbac53-15ac-4619-99ae-88b91acb0011)(content(Whitespace\" \
+         52e5ce7b-194a-493c-a35c-5541cc39e000)(content(Whitespace\"\\n\"))))(Tile((id \
+         cca23cde-ca91-4789-8c55-d1c25bbf316e)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         bdb13967-aa12-40b5-9fbd-235c5ff6c8cf)(content(Whitespace\" \
          \"))))(Tile((id \
          f387bbf5-5822-4fb3-b17e-bb99507ed0fd)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1267,46 +1157,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f3569906-084f-485b-8d34-117aa76aa053)(label(r1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0a8d898a-38da-474b-9c01-4618b97d4405)(content(Whitespace\" \
+         0e75aed4-6eba-4ce1-8539-3338f44f7cc1)(content(Whitespace\" \
          \"))))(Tile((id \
          2fdce252-afce-4cf8-bad8-cde836234283)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1792259b-5be8-4356-bf52-05c68251e7b0)(content(Whitespace\" \
+         e1c90f82-8c67-4480-9491-3cb860c093b8)(content(Whitespace\" \
          \"))))(Tile((id \
          17b5b03c-4037-458d-a9f5-89b48eb55af0)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         cfa45a7e-9a93-4c32-bdbf-21a652936a9b)(content(Whitespace\" \
+         e7a85c1c-4662-4b87-bb1c-bee5994d5db6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         aa4b23be-2853-4b03-83ff-e7fe32f316b8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0f51f506-6c60-4b3a-8413-e8328b11f307)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         347d10b2-0b8b-4cb2-b911-2e388d6817ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         25b9c0ea-5c1f-4238-abfc-a038439365d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e00bd4e7-457b-402d-ba3e-95ef85d4d775)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8763583-b83a-4bf9-b8f0-1f1bd0bf2ef3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bfceff88-9966-4256-91bb-d86012f29a87)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8fae8786-c811-4126-8c0b-df75c80cbc6f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         912f57b8-d3d7-44d0-bfc9-4fd87dfdee8f)(content(Whitespace\" \
-         \"))))(Tile((id 62b8da17-f86d-4a2c-976c-836348cdf0d0)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         6ebebe45-d780-4923-b871-5dd68439be2e)(content(Whitespace\" \
+         92aaf554-234a-4f1c-9655-d9693dbdeadb)(content(Whitespace\"\\n\"))))(Tile((id \
+         62b8da17-f86d-4a2c-976c-836348cdf0d0)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         fe729ea0-ef91-4f19-a1d4-16fea37a9787)(content(Whitespace\" \
          \"))))(Tile((id \
          a106236e-0f34-4f14-86cd-960736a50e2a)(label(t2'))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         03319c54-f778-4def-ab80-d8aeea6cb3e5)(content(Whitespace\" \
+         885d09db-7c24-4243-8bf6-d0dbba5f085b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c579a37c-33f1-45ae-9991-e1fc067ae82f)(content(Whitespace\" \
+         c449b490-9d89-4f2c-a171-60b8a5c54944)(content(Whitespace\" \
          \"))))(Tile((id \
          cbe169ca-91e7-4b36-bec5-4fcc453bc0d3)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1320,12 +1194,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3419bdf7-d96a-4384-8459-99b37dcdc503)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a9fc745b-08ab-4843-a924-b9b1dc92d3b8)(content(Whitespace\" \
+         8ccf8ce1-d7fe-4cbc-b914-2eb609ba72f4)(content(Whitespace\" \
          \"))))(Tile((id f726486e-3dfd-4f98-a7c6-119cce05c55a)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         c14d05ca-c56e-4942-85f1-0b9cfaad6a7e)(content(Whitespace\" \
+         f48c58c4-f444-4dcf-88e6-3eca78d3e581)(content(Whitespace\" \
          \"))))(Tile((id \
          61785518-98f9-46ce-8de1-ae208e9a23b6)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1333,40 +1207,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bb99876d-9b84-4ea1-880c-d230889d39bf)(label(r2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         937be819-30cb-4f4d-b067-a2dea5b9a597)(content(Whitespace\" \
+         59746d0b-def4-4439-a006-95aa02e66ad8)(content(Whitespace\" \
          \"))))(Tile((id \
          cb9bf4a4-6978-4445-be67-dc8ff0439be0)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f85b3b9d-edca-41c8-955e-64fb60644822)(content(Whitespace\" \
+         5f369a69-4083-4de9-9c08-c2c8db9428c4)(content(Whitespace\" \
          \"))))(Tile((id \
          c964a526-bb9a-4609-8ae7-b07419f33095)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0e66eee1-ebb1-42b9-b5d1-72f018cce13f)(content(Whitespace\" \
+         e5140877-993b-457e-b9d6-34b6f56a408a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         50c8692a-a4e6-485d-8baa-60fe2861fc35)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f0b148cc-318c-46bb-89c6-afa4705a6566)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6f6f0698-4f48-4550-a4b3-2c933f68936f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e4e6bf1c-5dd0-4efb-b3e0-2a411ab11707)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         51600523-82ba-4b48-8f5b-1c114915096a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e14a18d8-dcac-4d16-9439-5654e3488b61)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aff154b7-9ee9-4915-a208-a8eae10f2ed0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c765a6d-71be-40b1-b32d-36afe8d7a68c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5387779f-f5e6-4998-87b3-1f3af7531cde)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e51192c0-3bc2-4b96-91c0-f991fb44a27e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         90acea31-d8b6-46bf-9481-356445df3199)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         24de366a-cf8a-4fb5-ae13-187381542e2f)(content(Whitespace\" \
+         cdc17ccb-15ec-4dc4-8214-20eb95ed852b)(content(Whitespace\" \
          \"))))(Tile((id \
          5bb960c8-cc06-4881-ba7a-87fff6db5d68)(label(proj1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1377,12 +1230,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4f652e31-ae19-4a15-a792-c0f9840c2d55)(label(r1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8f4ea4bb-adb4-4952-a42a-55470c549b2b)(content(Whitespace\" \
+         c2ddd066-e964-49e9-b319-283b15d1d764)(content(Whitespace\" \
          \"))))(Tile((id \
          f3656290-985a-42bb-9e55-45946fe02031)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a8b57db6-b497-40ea-ba95-8d765f3a7b65)(content(Whitespace\" \
+         d71e4cb8-1ad0-43c3-a0c6-5dacb20967f3)(content(Whitespace\" \
          \"))))(Tile((id \
          b9b06266-1f9c-45f8-9a4a-af7ed6a8ba4c)(label(proj2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1393,52 +1246,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bac11993-6225-4fd7-8539-82d6a151b706)(label(r2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d197d64e-4ee9-4718-a88e-ab27258992d6)(content(Whitespace\" \
+         5d695d62-35f5-42d7-bb4a-d48505170c5e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         10dd02cb-6862-46d3-8975-11586a1360bf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         709a1e35-75fd-4a75-8de0-52401dc0a676)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c52e2bc-0eff-47b7-83a9-5c7509352b97)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cdc6dc65-deea-4ade-9709-e2a92329bfa2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f09464f-74a0-4593-b01f-cea608696411)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a1a74faf-1ac6-4d63-b14b-536876ead368)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f97ab678-2edf-4bb9-ad27-9708eb0fa7c6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         610edb4e-391f-4bc3-99ae-d881e202536a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f416d73-7f71-4d1e-86af-bcb55d7b49bb)(content(Whitespace\" \
-         \"))))(Tile((id a163b0a7-ce70-4422-b831-4833b1eeb57b)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         56246366-c19a-44ed-8771-d2e0ebc511d0)(content(Whitespace\" \
+         7d971d2a-619f-49a4-8612-206000315a72)(content(Whitespace\"\\n\"))))(Tile((id \
+         a163b0a7-ce70-4422-b831-4833b1eeb57b)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         d4e3bf37-eaf0-4158-adfd-9ecb9dfaa42d)(content(Whitespace\" \
          \"))))(Tile((id \
          1888191b-a44b-489d-b083-08df6dacc853)(label(t2'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         5d105cb8-051f-4bda-a8eb-6d31184ab6ae)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8b817540-0862-40cc-abbc-effef4bf83c4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         35b9f41f-f504-40eb-acdc-401c8723db5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         79f94a0d-1efe-401f-8832-eec081641651)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         322fdaad-9095-47f7-8c48-ca1c2ab3956d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f91edc5-460a-4bbd-bb83-5b4e15f64319)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1f022157-966e-4ddc-b4cd-bd075a46ccda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27b08270-3dbf-4d89-a0b2-82b74b7e95a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         899128da-f84b-4c86-a69f-98d4f84576b7)(content(Whitespace\" \
-         \"))))(Tile((id 3ef051bd-0e86-4a38-a5d1-cdbefb6fb31b)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         78a83b20-9d80-4de9-b2cf-41b1982a7faa)(content(Whitespace\"\\n\"))))(Tile((id \
+         3ef051bd-0e86-4a38-a5d1-cdbefb6fb31b)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          6b06ca4b-bc26-4a86-bc3b-716f20568334)(content(Whitespace\" \
          \"))))(Tile((id \
          76df7349-115c-4151-aed2-12c7ee697a22)(label([]))(mold((out \
@@ -1446,7 +1268,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          34f6d26d-4dd7-4a08-bab4-8e8ba21a8fbd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         00c78add-56b0-4f12-b82c-55e84b1e8873)(content(Whitespace\" \
+         96f466b3-fb05-4f2d-af71-e73e1a4d79a6)(content(Whitespace\" \
          \"))))(Tile((id f48f478e-080a-49d1-bce3-7f318e1290ef)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1462,31 +1284,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          23630a8b-86be-4368-95fd-20b4b8c59f6a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4cceda18-5a00-4b3b-b24b-790054a390b9)(content(Whitespace\" \
+         bd59bf83-0832-4f2b-9333-2c5997b2be7f)(content(Whitespace\" \
          \"))))(Tile((id \
          2df698fc-3e0f-4ca2-bbe2-be00028bcbc1)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e452c16e-c4b9-453f-85a8-fb7b333b4d74)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1be3b67e-570d-42e8-a8c1-d1db4da4d4dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         522c3dbc-6357-4b11-aba2-7578174d45d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b59a3085-17e9-4d0a-821e-1a25981c8f2b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de1b8e29-4533-4c33-b3d5-c89a80686150)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f267e46c-456c-4452-901b-51e72971d659)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         02d324fd-b00f-460b-a1f2-3529a3f7567f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b6d0e95a-0970-44a9-bc7b-cd496fea5419)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2d3d14d-b398-4aa8-bd7c-71c904729a8e)(content(Whitespace\" \
-         \"))))(Tile((id b7c1381d-b307-4cfb-aed1-e2268fbe353d)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         f4d1b9d1-f1e0-4cbb-a574-c5a355affc2e)(content(Whitespace\"\\n\"))))(Tile((id \
+         b7c1381d-b307-4cfb-aed1-e2268fbe353d)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          0232b500-e639-41cd-ba34-4803261beced)(content(Whitespace\" \
          \"))))(Tile((id \
          940401d0-3f67-468d-bc36-b60126040cbc)(label(_))(mold((out \
@@ -1494,7 +1300,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          f606e144-abce-40cd-b475-47f1c26a38cb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         985513c6-4296-4b42-abac-b645ebb7604a)(content(Whitespace\" \
+         37bf1040-4cec-451f-8d08-da7708be5712)(content(Whitespace\" \
          \"))))(Tile((id \
          c5a2f189-c420-4a44-b435-b0359bd2bd62)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1508,12 +1314,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e978fe85-4e2e-447b-93e5-62a3a5d00af5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1435b49e-fb7e-4b00-b8e5-742badbbfbe6)(content(Whitespace\" \
+         9614eece-d06e-4241-8f9a-905875aed41b)(content(Whitespace\" \
          \"))))(Tile((id ae41192f-2a63-4eae-a1a0-cf89d8d19e5b)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a8e2c858-8c98-4bd9-85bb-58f4f801d769)(content(Whitespace\" \
+         045fb744-52f1-4267-b1ec-c7380a15d245)(content(Whitespace\" \
          \"))))(Tile((id \
          daf4f71d-39b7-431c-a1a2-07c922170727)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1521,19 +1327,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ae8ccaf4-d8c2-4095-ba39-0a606cd0c6a5)(label(r2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6e62a86c-ff5a-45ac-bcd2-25bf730a7f7c)(content(Whitespace\" \
+         7f7481df-9f3c-40ef-ae35-7fb282f81376)(content(Whitespace\" \
          \"))))(Tile((id \
          684b9fce-b9a7-44c4-91d6-dcb6385cbe42)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5161cef5-b083-4e22-a699-9cb36450d3b9)(content(Whitespace\" \
+         c14bbca7-2b80-442b-9803-2c9d3cc1ed33)(content(Whitespace\" \
          \"))))(Tile((id \
          b73a22ba-ff95-40a7-b156-292c525017cd)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         57f1f7c4-52c8-4409-b2d4-c9831703372e)(content(Whitespace\" \
+         06d3c027-6294-423e-bbbc-b03aaf602284)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e9745983-5152-4a27-ab02-4171705d3e4d)(content(Whitespace\" \
+         c448eee8-d009-4024-9d17-8e38e6b182f2)(content(Whitespace\" \
          \"))))(Tile((id \
          cbf2f7fb-1351-46f4-8d29-fb64dd22e448)(label(combine))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1547,7 +1353,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b2bf731d-dc2b-4ec7-8f37-b0f5fce6f752)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2e38ff42-9651-4ddc-bff5-f83b07ea3c0d)(content(Whitespace\" \
+         a22ed5d6-24ca-4f79-a3fc-6be906c67489)(content(Whitespace\" \
          \"))))(Tile((id \
          54a19a84-ca13-4c6a-a98b-9198cb12e6e9)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1558,202 +1364,132 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0245d896-b11a-4423-bd13-6fd0f01beab9)(label(r2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         05235e38-1df6-4b59-9047-388dc029ff26)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0caa0c71-2dc0-47bf-a232-a2f3f5ba038d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         73754c2c-49b8-4480-94bd-7f73539df97d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a58343c7-2591-46e8-a104-e50c23e1e09a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         93c60c1e-17a6-4ed0-bf7c-7506eba081b0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e24f560-b656-4bc7-9a00-17ea90a75d57)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc32449c-6f7b-4c9b-b62a-a9b3a03653a8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7dc9ee2-b328-4d2c-aa28-e06935cf5c2c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b07374ec-edd0-49c7-b33f-d025ad413707)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c904c30b-004b-4d04-b1c4-76d006a398ed)(content(Whitespace\"\\n\"))))(Secondary((id \
-         397560b3-993d-44f6-a6cd-75d470680ee0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d83615c9-828e-498b-b5a7-5d7e7a8d07d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c7d6feb2-4c16-44cd-be46-f693eed4c760)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         451e2ed6-c265-4387-8bad-e63c503c1ff9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d6df7016-f237-4341-8992-fa8ea66abc02)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ad189fd-3a4e-45ad-96f8-a5ece8c9cba7)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         eec0b635-9636-4db4-9811-03d28b67a8d2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3bf1a76a-6c15-465f-9c66-a9362934916d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         90c5a040-7495-44b8-8155-5475bc0bba0b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         787ce704-dd88-4bb4-a95d-c7182fa6b26b)(content(Whitespace\"\\n\"))))(Tile((id \
          11784c27-a2bf-4d04-ad67-236b9f9be076)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         49c8411c-e638-4908-a434-432281da8409)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d15ef7b4-9178-4791-9830-839a05288381)(content(Whitespace\" \
+         \"))))(Tile((id 49c8411c-e638-4908-a434-432281da8409)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          ad397ba9-58a0-4b8e-9545-6edf8572b347)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         ae760f03-49bc-44bd-84c4-0d03b7c6c86a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         984d9f8c-c2f8-4e7b-9702-65fb84769636)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ff15c144-206f-4e20-841f-5a63bf685639)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82ea7ec7-d49f-405e-82bc-7fdbac5543ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         69cdfb70-2fe8-4625-823f-3f242ce0f88e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8ef532f6-4c14-4a35-8c10-cc775b9449e7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8eabc51d-e034-4a2e-bd28-5c57deb13c9b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         471d3c1b-0187-4500-b2db-13176b79c452)(content(Whitespace\"\\n\"))))(Secondary((id \
-         75f9dbf6-c41a-4fef-b775-c7b19c8a7a63)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         771ca0f3-7547-4b0a-83b5-48a6800bf373)(content(Whitespace\" \
+         4f7ad9e8-f687-4ad9-9c37-d156d20094eb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cff10038-a0fa-40c8-9d50-978997f18937)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27c804a7-f358-434d-ad78-36d1ff00b7bc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ef35edd3-ded9-4777-98b4-3f86da1ea0c8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         64bcdd8e-73af-401b-8128-04ea10def2ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         200fe2ee-1d54-47de-ab11-0757f5194c4b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ab508d67-a3f8-4c70-b8c2-be4ffb14d8a9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ab757a8-2c59-41b8-9ea3-fbab3e85251a)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         5d56fa6d-3457-4448-a648-52e67ed2761b)(content(Whitespace\"\\n\"))))(Secondary((id \
          2f3cda62-d182-4d45-af6d-97c1bb8c5eb4)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         95ceed5b-2dd6-4310-b56b-839338301f21)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b8e5e73d-2331-420b-9070-0f2bc3d8a006)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         babdc2b9-a0e8-4def-bfaa-c93d20678adc)(content(Whitespace\" \
-         \"))))(Tile((id a11a6aa5-328f-4f69-bac7-f385a4d204f9)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         5b746cdc-5f6d-49ac-b7f3-23f53a82ebb6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         06354fe1-987d-4f6c-b3b4-718804155801)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aa67c5c0-dd64-4672-8ec3-ff8e8749aa27)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a9940bec-f984-4712-8829-73131c707c6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2880a111-a31e-4cc2-a8b1-b407f20b2755)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d24c2e45-5ac7-4739-a987-007748d73e57)(content(Whitespace\"\\n\"))))(Tile((id \
+         a11a6aa5-328f-4f69-bac7-f385a4d204f9)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         9f2cde56-f8c6-480f-9ec6-3cabc3b8475c)(content(Whitespace\"\\n\"))))(Tile((id \
          39d9a2da-956a-449c-a735-1a91460e895c)(label(left_join))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         1a848338-830e-445a-b6cf-fcac3a3e15ee)(content(Whitespace\"\\n\"))))(Secondary((id \
-         377d9b60-331b-478a-b629-5b6ea3ad27e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4b1a3b31-669c-4437-80f1-ea5916920484)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e366511-8e5a-4d31-8f56-6a1b98bb6911)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0452aeab-3d1b-4378-9c38-d333c9f21c67)(content(Whitespace\" \
-         \"))))(Tile((id 954ea688-52a2-4c33-9c40-b0c7171bb36a)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         954ea688-52a2-4c33-9c40-b0c7171bb36a)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          f2c260a6-1b06-454d-90d2-a41f5e2fd1cc)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         9332668b-e4e6-4038-81e9-ec03a174bdc0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         68dad42d-fc3c-4715-b031-ccdfce76c418)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ef03f8c2-4b74-4c8d-87f0-885c749292fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         98a79c54-55aa-4cd6-ad0f-e43137083bdb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fb4365ec-ae45-4ec9-b932-aa3f90533adc)(content(Whitespace\" \
-         \"))))(Tile((id 76084c85-33ef-42ec-9c6e-1be3785e0f91)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         76084c85-33ef-42ec-9c6e-1be3785e0f91)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          df6510c5-6947-4251-b93e-1f33da115a4e)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         6653fc9a-e624-47c9-b168-5a2b363b3562)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cc166bda-b03e-436f-987f-44938a5c90d5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         99a8fb73-7638-41e3-83b0-5281201ecb0e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         15bc8dd5-df39-4e2d-8ba7-564ed59a4667)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e85eeb74-567e-4aad-9d3a-e7eb4fe0f072)(content(Whitespace\" \
-         \"))))(Tile((id 23dabd39-292f-4d4e-a4ed-96dedc60053b)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         23dabd39-292f-4d4e-a4ed-96dedc60053b)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          cc272103-5333-49bd-b378-d979e41470a3)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          47a67f46-6ebd-4fc1-9b34-cbd6d2edcc1e)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         423f14b1-345f-4e61-b682-44e4afe898a4)(content(Whitespace\" \
+         \"))))(Tile((id \
          7e0eacd8-54a7-461a-afc6-f04d03893b8b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b7b3b39e-c46e-485b-9608-b49920a61f22)(content(Whitespace\" \
+         \"))))(Tile((id \
          0675f913-4aac-4285-8afd-68ed1a13b777)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          8bc77439-4cca-4ed7-a475-2e278ce4e14a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         97c1cf75-8341-4933-abd6-95f44a9c47a7)(content(Whitespace\" \
+         33aeeb88-cd8b-4ad8-8169-bb8286b0a2b2)(content(Whitespace\" \
          \"))))(Tile((id \
          68fb0d4d-5fc1-465f-99f2-8731a4c4300c)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3d4e8208-87cc-4aac-be66-19fa6764f1fa)(content(Whitespace\" \
+         \"))))(Tile((id \
          1561f60d-2e92-4743-854c-038ac521ae0c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         83e0b1aa-26e2-437a-b886-da0f25e27db4)(content(Whitespace\" \
+         \"))))(Tile((id \
          63053169-423f-4ca1-9c99-cf6266982187)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          3966ef57-7685-4cfb-93a8-5545198af49c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         82256741-344a-4797-b64e-7e1eb9cd9489)(content(Whitespace\" \
+         17896e35-7856-419d-9c30-48a035330887)(content(Whitespace\" \
          \"))))(Tile((id \
          d4083079-9b00-41ab-83db-460a0b77db05)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         36f28673-ecf7-4d1a-80ba-778d8e1c1feb)(content(Whitespace\" \
+         \"))))(Tile((id \
          83f45c57-cb85-4627-bb0c-fe211b3ef17e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         15273077-fd07-4188-88d4-303364357a7d)(content(Whitespace\" \
+         \"))))(Tile((id \
          4d5e33ef-d5a7-450f-a740-0cd6ca6960dc)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          60193799-a38a-4ea5-9f2f-8bdfba1407c3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3a2e7421-ae43-4733-9bb0-a0c0e068ca32)(content(Whitespace\" \
+         b8f5e158-bcb4-4291-bc74-ebdb810dc5c6)(content(Whitespace\" \
          \"))))(Tile((id \
          1791d594-dab7-46ed-975d-0779c78a1e45)(label(gradebook))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a5edc7cd-15d8-454c-8aa9-980ede07398b)(content(Whitespace\" \
+         \"))))(Tile((id \
          c6c707a8-01c4-42cb-96ef-16fbc34ac005)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b779af80-cf10-4a5f-9e8a-bdb280976802)(content(Whitespace\" \
+         \"))))(Tile((id \
          50d39e6a-b640-4615-8614-3ed64538f106)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          a13cbc05-05ce-4db3-a39e-e36d3c02cd70)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e3a992f5-78af-4a9d-bbbc-f24ea58113fb)(content(Whitespace\" \
+         \"))))(Tile((id \
          55635658-adfa-4def-98ea-39739fb1e46e)(label(None))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         a84f270c-eb74-4239-adb0-9aa6967f2163)(content(Whitespace\" \
+         efee87e9-01cf-4955-b5dc-22755bd41d27)(content(Whitespace\" \
          \"))))(Tile((id \
          2b98777f-4a97-4d56-a6f4-cd5678d37c2c)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
-         12))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         12))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         71965fc8-5830-46ea-88fd-c007c4ceed6a)(content(Whitespace\" \
+         \"))))(Tile((id \
          09eff21e-0ee5-4cd8-83bd-76f3c1c7fc20)(label(Some))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
@@ -1762,30 +1498,13 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          fc68d7ed-b00b-4024-ad32-0cabc05b620e)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         8a5ae42f-3ab0-4d0f-9805-2c07144ede76)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3cb7d20e-814c-42b7-8829-c2afda2dc32d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b58fa8a-3e1c-4a3d-85dd-376d249b43a7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5eb9878d-df10-45ff-b162-42c94c7bac30)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea72e7d5-b0bf-447b-aa65-016d773a04d8)(content(Whitespace\" \
-         \"))))(Tile((id 28b32854-8aff-4eba-9e53-c1846c9c133f)(label(@< \
-         >))(mold((out Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0))(children())))))))))))))))))))))))(Tile((id \
+         28b32854-8aff-4eba-9e53-c1846c9c133f)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          dc1f2b3c-4589-4de6-b983-d5c90713a8d7)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c555eef2-8d1b-495e-8035-58be335c5357)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fc5091d6-7a2f-4634-a949-69db9fd49f6f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         60ac94d6-7f9d-4fae-b887-532dfae26987)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ebb1d2ff-ac3c-414a-8886-9aa13f8c3846)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6fe6bd7e-f7d2-4398-ab5d-cbf2c7788727)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
          18406aee-5a43-4ca1-bedf-0fac2759f2fa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1795,7 +1514,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9edc4387-8929-440a-b071-078533ac1d6c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8addda5d-5cbe-429d-b1b1-c4d096aa4cea)(content(Whitespace\" \
+         f6cd45e0-8175-4b08-89a7-b6e9e34554e2)(content(Whitespace\" \
          \"))))(Tile((id \
          c1711101-59d3-47b7-9628-8c5e81d8c79a)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1803,12 +1522,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c8ceef67-e330-456b-ab7e-9a119eeb0f4e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c108dcf1-e23d-464d-b620-77b97fcdfb9a)(content(Whitespace\" \
+         36da7176-511d-4731-aa14-4975ec737937)(content(Whitespace\" \
          \"))))(Tile((id 6155b5fe-1a8d-4a19-a7bd-478215cdaad1)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f40b54de-153d-437a-b5d8-df6c408e404b)(content(Whitespace\" \
+         087a8923-a01a-47e1-8dc5-2371df7fb534)(content(Whitespace\" \
          \"))))(Tile((id \
          82f72d51-d536-45f6-a754-a845d271ab8a)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1816,19 +1535,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          62a6ed33-50f6-4cf7-8717-4058dd8c124e)(label(s))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5c33cbdb-befb-4f9e-9f92-c5771e4e4b41)(content(Whitespace\" \
+         d6fd77a4-fe8d-40e5-8990-e04e2b0614e6)(content(Whitespace\" \
          \"))))(Tile((id \
          8d9e9a01-e53c-4c4c-b0e7-92b2ae65aab6)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2e822408-dabb-4121-a39a-59423cf6c961)(content(Whitespace\" \
+         7bcd655c-b49d-4207-9829-2553ed61fff6)(content(Whitespace\" \
          \"))))(Tile((id \
          a4b3dd9c-585f-4ea0-8a43-bd7b29012758)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d6c802ba-df6e-44a7-8e55-d4c65ca19e6e)(content(Whitespace\" \
+         c6c6a147-38da-4953-823e-d1e123667e7e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         863a56e2-982d-48cc-b730-3f74f2335591)(content(Whitespace\" \
+         09d258c6-566e-4971-b743-9852b5acc743)(content(Whitespace\" \
          \"))))(Tile((id \
          a9477a8d-8218-47e4-9bda-1aa6791276ca)(label(s))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1842,12 +1561,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2ae6e6a2-c2ac-4b0f-8d2b-728f02e9fdcc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a929dc2c-0f13-4e4b-8885-67400cb5911a)(content(Whitespace\" \
+         509d9356-adba-4e25-a5a7-fe75d82ef4fa)(content(Whitespace\" \
          \"))))(Tile((id 2e82e5aa-ccd4-4021-875a-ca83aa16071a)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         383e1d9e-9818-47fe-8fd2-6d3c84c08eae)(content(Whitespace\" \
+         33ff7d79-b2b5-467e-a20d-af427734df59)(content(Whitespace\" \
          \"))))(Tile((id \
          19cab581-70c0-4d30-a49c-ac95402b470f)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1855,19 +1574,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          eb548dbc-96a7-48b3-866a-095445c9611d)(label(g))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cde2f49c-af5c-4279-94bb-0849695ad8e6)(content(Whitespace\" \
+         cd83abad-8110-4c2f-a950-06e3dbd72461)(content(Whitespace\" \
          \"))))(Tile((id \
          a902fb3c-7f3f-4b25-ab0e-80a34b2c02ea)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         27ed1c08-36a5-4b6d-96b6-3ac5cd00963c)(content(Whitespace\" \
+         0e0cbadb-cbe4-4e54-b037-07cf4ebcf26c)(content(Whitespace\" \
          \"))))(Tile((id \
          b5b2573d-d911-4454-a162-7c5dd9db0464)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         5de1295c-425b-4b31-a465-628b6014e83f)(content(Whitespace\" \
+         d3747906-f4bb-4eba-bba1-080d7860165e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8d084c54-b8c9-4cb3-92bb-912f3b23328e)(content(Whitespace\" \
+         703f2ce1-5305-4539-8ec1-87ebeab819eb)(content(Whitespace\" \
          \"))))(Tile((id \
          45529968-ea05-4540-9f0b-330f61991422)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1881,12 +1600,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3ed2c97b-43d1-48aa-b36d-2620d5ddc9d7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8c872283-2e8a-44fb-874d-4f10bc3c3d15)(content(Whitespace\" \
+         83808287-336c-44dd-8e7e-1804b45ffb11)(content(Whitespace\" \
          \"))))(Tile((id d1865c3f-5647-4fba-9491-7b9a8d811434)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         8a34cc62-1e31-44a9-a614-7a9231f1a53d)(content(Whitespace\" \
+         9100cded-c7b1-424b-a28e-b700b39b882f)(content(Whitespace\" \
          \"))))(Tile((id \
          1bb580ad-cf49-42bc-a9d6-6bd763694871)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1897,70 +1616,55 @@ let out : string * Haz3lcore.PersistentSegment.t =
          54c9cccd-707a-4b16-9d09-761d2a803b50)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         a3167ad7-974a-4bb6-9d19-984c31939c73)(content(Whitespace\" \
+         dd52a23f-1cd4-4f16-969a-0d1338c5e9bb)(content(Whitespace\" \
          \"))))(Tile((id \
          88469231-a123-4c4b-980c-31ceb6aa6999)(label(g))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         5e1c5de8-98f1-4aa4-a510-68fd504db952)(content(Whitespace\" \
+         d356a5bd-8e67-4cfe-a086-5c1b4c06386c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         074909f1-d1ed-4666-9a61-f2601450b6e2)(content(Whitespace\" \
+         411ae846-c74f-4dd5-8071-adbc7e8e20b0)(content(Whitespace\" \
          \"))))(Tile((id \
          7a4974b0-8682-433e-8daf-722f93afa2b3)(label(s))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f9df975d-767b-4280-8120-87faa649111d)(content(Whitespace\" \
+         83a2a62b-64d5-48a3-9201-83aa0854155e)(content(Whitespace\" \
          \"))))(Tile((id \
          fe80003d-a31c-4387-abda-c1bdf78fd7f3)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7d251af4-6e99-4418-a4b4-a3dc96928c0d)(content(Whitespace\" \
+         bdf9a888-e4e9-41f5-8643-251cca247467)(content(Whitespace\" \
          \"))))(Tile((id \
          d5fac4d8-9154-43f5-8438-5f7543d70a42)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          31293152-5bb8-4af8-b183-ce7f76905654)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ddb79899-9f54-4524-aa9d-22b25fdb5c81)(content(Whitespace\" \
+         \"))))(Tile((id \
          5c39bbc8-558c-452b-8e18-95b43fb4a7f9)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         063c38c1-610e-4ccf-ba16-0310717511eb)(content(Whitespace\" \
+         \"))))(Tile((id \
          8eda9bdd-de9d-497c-91f3-2375557c1ca3)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b0584605-587d-4af0-b0ba-6b6160345965)(content(Whitespace\" \
-         \"))))(Tile((id \
+         cf8df8d4-62c9-4117-93ba-cc1ed23ae0d1)(content(Whitespace\"\\n\"))))(Tile((id \
          156c6d20-5d6e-462d-b443-73097f32f6b4)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         389c07c1-eebc-43b4-a50f-059aeec3d104)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2a99fb3c-376d-4cb9-a4b9-57ec5008547e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8d7e157-03e9-49e6-a9fd-1d5b214de04e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         914345b5-944c-4da9-8cb3-6715bb511f51)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27bba037-9c89-4c49-9097-89cda9903ed7)(content(Whitespace\" \
+         d4e92bef-3622-4cc0-8eab-8ecc4a3f730d)(content(Whitespace\" \
          \"))))(Tile((id \
          0258b5f2-fae4-4263-86c9-09a1128c23a6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         ec009144-80c2-42c7-8780-ba6801a75323)(content(Whitespace\"\\n\"))))(Tile((id \
          208555f8-cd63-41f1-a155-310f5daa96df)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         d4e2185b-b8ac-4349-b531-49d8ad11f9ac)(content(Whitespace\"\\n\"))))(Secondary((id \
-         de74f32c-b211-4b7b-af9f-46e560366cd1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         22be3c18-1e8d-4648-873e-68c0efadb8ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         02c665c2-6776-48f7-a0cf-9ed7f7953367)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         37d82cc7-bd2c-4cec-9c92-f7885694742b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         277e764f-e6fb-40e8-9a5e-15c60ddf6b4b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f502f40b-667c-4beb-b0da-70545b5d11f8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         cd6ce7a3-7a81-49d0-96b0-0f10c00447f0)(content(Whitespace\"\\n\"))))(Tile((id \
          6ca8884b-dcef-41bf-9161-ea8251aedaae)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2056,19 +1760,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          76c7ee9a-a155-4c10-ba1e-28efe9f8a55c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f20eb416-237e-4fde-be67-b88029d89c92)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6bdc6f77-964e-4004-affc-2128971c2f2e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         776290e2-f160-4780-8279-ad374b92906e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7d49f01-8add-4da8-b8ce-b8bd7bebcbda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         432dc1fc-b988-4573-85f2-9b893ca77bbf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04582132-91b3-4c18-8567-63b9bf95712b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c574f7fd-faf1-4872-bf3e-97a95bfdcd73)(content(Whitespace\" \
-         \"))))(Tile((id \
+         87b2bce8-3757-42a2-87a0-eda4ce1a4f96)(content(Whitespace\"\\n\"))))(Tile((id \
          c47d8b95-d96b-49f0-8446-5ee86f0b323b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2164,19 +1856,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4e0c50f2-09e5-4004-88ca-9b3362d52c65)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         adf65ae6-b648-4183-8785-f983b353ccec)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8aea6e2e-935d-47ba-8ca0-d73db71420f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         86bdc8f2-225a-4ae3-a11b-8df04c27e1ef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         da4658a3-c1f9-4819-8e87-9de4775fa77e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fcd82c26-3372-4be8-9645-f4bb3ee76404)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eaaa66a4-7405-4c19-a65a-8e04f3054934)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         da5852f1-3caf-4c2f-a765-b82883060666)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f85669ca-ff75-4dc4-ba5e-79165a8bf2df)(content(Whitespace\"\\n\"))))(Tile((id \
          539ed626-cb9b-4063-bceb-e8fa8a266877)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2186,7 +1866,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dfc3d7fd-f770-48a9-a2f5-b29307186961)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0a0252bc-aaa4-4e31-9fda-fdaf57fd59ee)(content(Whitespace\" \
+         4c0d7aaa-cb0c-4e25-99bb-d57ece5ec8a8)(content(Whitespace\" \
          \"))))(Tile((id \
          dfa3b1fc-9344-45cb-b60a-6eae53712802)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2194,7 +1874,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          610cf1f9-f9f9-475d-94be-61d09492cf9a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         464ce144-d631-4f58-9e72-804cc139d9fd)(content(Whitespace\" \
+         3f5efdcf-7746-409e-be75-05b3ddd9d0cc)(content(Whitespace\" \
          \"))))(Tile((id \
          ac1685fc-864d-4ff1-adef-9f2205f96cdc)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2202,7 +1882,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cb65f714-ee72-4062-a10e-9f72f311c111)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         74f79e1a-c9c6-4b56-856e-1537c11133fc)(content(Whitespace\" \
+         fc757e77-f2f1-4794-8b8c-019a85fc3ce4)(content(Whitespace\" \
          \"))))(Tile((id \
          f0cdd170-8748-4232-b3fb-025f05f4f6b5)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2215,14 +1895,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          b64ba589-65a5-4b54-ad7e-cd5fa096dd7b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         03a40882-4ff8-4ce9-b851-6c3534d33429)(content(Whitespace\" \
+         \"))))(Tile((id \
          efc6a0cf-0b7e-4c5a-affe-edc2c96679e4)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          8d4fce77-0237-4fa3-8bc5-90ed09569bfd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         891c1242-c266-4bb4-a258-f795b705f14f)(content(Whitespace\" \
+         8aa16a7a-d759-40d8-b797-89ba0be0e09f)(content(Whitespace\" \
          \"))))(Tile((id \
          7dff51bb-27d7-4bfe-bdba-682d63393396)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2230,7 +1912,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          327a2508-dc39-40c2-939c-f69b698b23a2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         680976b7-76f7-4582-b3b8-95f9ade9ba80)(content(Whitespace\" \
+         f06d3eb8-77ea-4e44-9845-5d36272b62b4)(content(Whitespace\" \
          \"))))(Tile((id \
          500b0f0e-2009-4530-bf44-726d822f8f4b)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2238,7 +1920,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b772e704-b9fc-47a8-8aac-08ce14b355b3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         db94baaf-e3c9-4539-912f-bfdf25fda582)(content(Whitespace\" \
+         5154e9f0-af99-44fb-89c6-8e2b85f678d1)(content(Whitespace\" \
          \"))))(Tile((id \
          6511cb1d-d338-4e13-8147-4c108dfde450)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2246,7 +1928,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          39c92d0a-ab2e-4434-a073-311c513cad3f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         45a939ed-a590-428e-8791-bc5a2d441972)(content(Whitespace\" \
+         c33f4351-3da7-4fae-9278-e2b1ca38e232)(content(Whitespace\" \
          \"))))(Tile((id \
          f2562163-0f2d-4f51-af92-f17dc85d6fde)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2254,7 +1936,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ca78b7e5-fd89-4f30-ae1f-5c716351f4ff)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5eb05d46-bb18-4f9d-b6c7-140129acdd88)(content(Whitespace\" \
+         ca75dd5f-78fb-414e-8e44-c2eb6d0deb0a)(content(Whitespace\" \
          \"))))(Tile((id \
          db6af9a6-e609-4600-b856-ec1096e95725)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2262,26 +1944,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e820cbea-067d-456d-84e2-0c00879a4699)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8d167183-e323-4b28-8ff6-0778c332da52)(content(Whitespace\" \
+         0513e43b-47b9-4b21-9f68-b120e8425bb6)(content(Whitespace\" \
          \"))))(Tile((id \
          fd522bfa-c6ed-48c5-a29e-1708681cc249)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         9373e753-a22b-48fb-8238-96599d462518)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8e377f17-8e27-4b6e-bcdb-3531501a1447)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0bf42414-c138-4bd2-ade9-a05475d4aa08)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         22b14db1-a0a4-4905-b27b-f8b868a59f87)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         28f992aa-7f52-4d90-a16d-1b0aff96f3e9)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         45df1528-ba3c-477d-b1fa-dd2a51610884)(content(Whitespace\" \
-         \"))))(Tile((id \
+         77cde17f-4a5a-4d4b-b2cd-a43f7f972e06)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         06a5bbf4-485d-4f61-883f-cdd6c4de1833)(content(Whitespace\"\\n\"))))(Tile((id \
          665e659b-cc6d-4ba5-9387-770c24be39db)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8618c9ad-116f-4b27-9b5b-03e9905d4e38)(content(Whitespace\" \
+         0c760616-c9f1-46ea-8e32-d5a35b192b5d)(content(Whitespace\" \
          \"))))(Tile((id 55d55d44-0380-4ec2-97ba-a437143f5ad0)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -2290,66 +1963,86 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          37e104f3-3bca-43a5-97ae-a5d2971eff03)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e7b1c854-456b-49c9-819f-3309e1597e8c)(content(Whitespace\" \
+         \"))))(Tile((id \
          dbd23b7e-b42a-49d3-94b5-98426bf4da0a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         971f81c9-7f70-44e2-960e-a5216b0ad00f)(content(Whitespace\" \
+         \"))))(Tile((id \
          355739bb-6cbf-4473-b920-aada3a7f8c47)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9ca9ecc6-e47f-4f64-abfc-6a62abf79bf1)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fe3f2045-9a24-479c-a9c1-17929f7baf15)(content(Whitespace\" \
+         af2dde61-57eb-481c-955b-e3cbb3320cd2)(content(Whitespace\" \
          \"))))(Tile((id \
          4582a701-6636-47cf-a9b4-e7381bf1f9f9)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b5ddd2dc-428a-4434-98b9-018c71a6c441)(content(Whitespace\" \
+         \"))))(Tile((id \
          fd3eeab4-eb95-4279-8cda-f140226e2864)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         01ef4c54-2b5f-4db9-a094-824f746de524)(content(Whitespace\" \
+         \"))))(Tile((id \
          fd7ce901-e928-4c90-a675-2e2e2091b2ff)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c2bad9a2-b38c-4629-acc2-721afe86f4f2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9341f0f9-61a3-4104-9ea6-e39443425912)(content(Whitespace\" \
+         b888fa45-16ef-4d18-9c14-e8d3994fbf64)(content(Whitespace\" \
          \"))))(Tile((id \
          14ecdfa5-02c5-4a50-ab89-32932e09f8ef)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3aa9900a-e285-4f36-b868-9fe3dd303628)(content(Whitespace\" \
+         \"))))(Tile((id \
          7d6023ce-d3dd-4341-a18c-f1c93913c9a3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         80cd3595-df34-4e66-a2b5-a3f4f2739167)(content(Whitespace\" \
+         \"))))(Tile((id \
          d62f8c32-9099-4cae-a469-ccac7e282f43)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          75c082e3-6f68-4ae6-80d3-2a67c61c3b9a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b464a239-b302-4c15-9dcb-e89210f55b85)(content(Whitespace\" \
+         3a5a54be-f6ba-4b6d-b153-71c4897b3d3a)(content(Whitespace\" \
          \"))))(Tile((id \
          1ade70f0-b68d-4a69-adfe-f20aa6c4a09a)(label(gradebook))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0402580c-6731-48e6-a8c4-af170c0d015c)(content(Whitespace\" \
+         \"))))(Tile((id \
          9dfec2de-0847-4f53-af47-e04bd9534513)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         158f23c0-67c7-4a2a-984d-80646f916a75)(content(Whitespace\" \
+         \"))))(Tile((id \
          87097013-ac2d-41e5-a870-8431dc52f5a1)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          3091fcf1-6f7c-46ff-b297-10a21dc91d5a)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         585ba3a9-494e-4dd1-afda-27dde8ec5502)(content(Whitespace\" \
+         \"))))(Tile((id \
          710275fa-b0e5-4d20-b384-3db997f7f70d)(label(None))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         2c1837c7-56bc-4c9e-8e34-47acb63d0e6c)(content(Whitespace\" \
+         b1d49c36-5bbd-4d8e-b7bf-100c9988a11c)(content(Whitespace\" \
          \"))))(Tile((id \
          d4819a33-679f-413c-9e12-34d2d0eeed42)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
-         12))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         12))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4285d393-ec43-45b8-9074-848599c2a7bf)(content(Whitespace\" \
+         \"))))(Tile((id \
          79d170bf-1ed6-4e75-a77e-6cc3954d7e1b)(label(Some))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
@@ -2358,57 +2051,45 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          f0ca7f7c-b403-4575-a893-f3a56b50d8af)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))))))))))))(Secondary((id \
-         a5c57b8f-ebea-4b9f-823d-10f9de89bb53)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c2c0d9b2-2813-4183-856c-2d6d108f370a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9302cb08-313f-46c8-a27c-620480048e30)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
+         09b50610-2668-4f0c-9ab9-7c09bf5765c3)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         5aa5c9fd-c606-4638-b20e-0322b01fead2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cf34ca57-7f9f-430e-b357-59ba1db5248c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         61afc9c9-a732-460f-bc4a-66957c6356be)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         73d6c1bc-09a1-4c14-a6a0-e27a29c7d710)(content(Whitespace\"\\n\"))))(Secondary((id \
-         226c767f-3a56-4905-bfdc-2067da5b28f1)(content(Whitespace\"\\n\"))))(Secondary((id \
+         1b9b336f-3b83-4881-8d2b-dfe020112601)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         eddf5344-f8b1-4f98-84e6-7a7511155fdf)(content(Whitespace\"\\n\"))))(Secondary((id \
+         4a8e7f9c-33ff-4c6a-a6bb-033085d7c6ed)(content(Whitespace\"\\n\"))))(Secondary((id \
          55fbdec9-7469-4d56-832e-f645568614a0)(content(Comment\"# V2: This \
          version works by dynamically building the schema from the first row \
          of each table. It closely matches the Table API but does not gurantee \
          many constraints. #\"))))(Secondary((id \
-         dfe9f7e8-96e5-43bd-8438-50a0a54adc10)(content(Whitespace\"\\n\"))))(Tile((id \
+         b0ed556d-b307-40f1-9b1c-794f9f3a13fb)(content(Whitespace\"\\n\"))))(Tile((id \
          09f1ca9e-0a40-496a-a37f-2163a4c0167e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         cefcb281-5a9c-4d12-b0cb-c1547d475248)(content(Whitespace\" \
+         c3ab4071-5707-4d32-8b9c-a150cf5da2f9)(content(Whitespace\" \
          \"))))(Tile((id \
          c05275cd-0581-41d5-a38d-57d79a45dae9)(label(v2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7d5e5235-1181-4a3f-a8e5-e6258ed80268)(content(Whitespace\" \
+         37c610a5-fe6c-47b1-a13a-10eca3c4a883)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8bcb24de-2d0c-45bc-b97d-a958143f89a1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         074f6766-b3a0-4ced-8c7c-b8ed93c79c6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         add9fecd-89bb-4357-99df-43a5c0615103)(content(Whitespace\" \
-         \"))))(Tile((id fe1e74d2-c34e-4cd3-95be-da99ab848960)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         1d6005a7-a60e-4c7c-ab36-f603b0fc3f6c)(content(Whitespace\" \
+         5150f613-e377-4c35-adaa-3e02b7af3634)(content(Whitespace\"\\n\"))))(Tile((id \
+         fe1e74d2-c34e-4cd3-95be-da99ab848960)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0da4d2f5-9210-4b3e-b435-072109783779)(content(Whitespace\" \
          \"))))(Tile((id \
-         f050e0ad-1f61-486b-9ac9-403796811556)(label(requires))(mold((out \
+         f050e0ad-1f61-486b-9ac9-403796811556)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         27164b39-e718-4638-bcfa-09f40ee98c62)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         acb63209-cf25-4851-8d6b-4138663ba7d9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         01dafca4-edcb-430f-9861-16f965a07ab3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd476785-cd85-4a32-8377-128c54818dbc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27d67665-6e73-4337-aa92-6d4fa56e60a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c12aab9e-c2b0-4097-90b7-b69abdb61442)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3f40cd2b-929c-4249-aeb2-b0957d98f867)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         369537c3-1de6-4396-a129-51676b0974db)(content(Whitespace\" \
+         \"))))(Tile((id 27164b39-e718-4638-bcfa-09f40ee98c62)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         8b29ae15-9e64-447a-b9cb-daac2f6256a3)(content(Whitespace\"\\n\"))))(Tile((id \
          93fb7326-4c1d-4182-987b-7e842e1178a5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2436,15 +2117,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6daa19f4-7a78-405b-8b4b-2f84f90dd100)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         af42484b-0bf9-4638-a133-265a546c82fb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2683cf05-a2ca-40f7-9606-5bcdb3543916)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         47fa46cb-6949-43ec-b2c6-d91acc92077e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2a31685d-c443-47d0-8fda-dea3e4dfc2d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         17c5b678-e8f4-4c36-878e-c0326ea0e819)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8978a48a-da54-42e9-88aa-e052c83f502a)(content(Whitespace\"\\n\"))))(Tile((id \
          b710a497-af3f-4a63-af23-33cd5c68e8cb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2472,15 +2145,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          68a353ad-9012-4358-bf37-92c171ccdebf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0f456a26-3fc9-4d3a-b47d-1c3d51e9b529)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3fba4ea8-ebfb-45b2-b9ea-4aa36345165d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         50738756-27be-454d-8651-4eaa51ad3dfc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9fd81431-12ab-4620-92f5-66b1487990cc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2d29e276-155a-4a93-b047-66ac3da60d88)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9b9abb2e-a7cc-4c88-9eba-6baa3573cebc)(content(Whitespace\"\\n\"))))(Tile((id \
          caabf48e-02dd-4f8c-beaf-ed6287a5cc9e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2508,15 +2173,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2af5d69f-db85-46eb-b418-9fcf7349cd26)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         667e75dc-f784-4e47-a56a-ea3c431515d3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2e07dabe-24c4-4f9a-abb6-e5d8549ad9f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e26329a9-d710-4440-86e5-437de2a45ccd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         213bd634-5e5c-491b-9adc-f16d5a2786fb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bd46938c-761d-4c24-9c37-d4aab087bfd1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         01dcbe48-5b09-429d-a1e5-b035fa1c92bb)(content(Whitespace\"\\n\"))))(Tile((id \
          385b5f1c-53cc-434b-8bff-070761f96595)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2545,25 +2202,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          858c7243-519b-4246-a554-75a0ba29b84d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a95a4db7-24d4-436b-968f-34ea1e2a29f5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ea580d63-ed16-4ce3-b6ea-cbb36de4d2e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         76441690-6792-4dfe-a2b2-17312721f9ea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8fd0702e-501d-4122-82dc-a4f32a05fdac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         181b4e86-d59e-4065-8089-27f059f53445)(content(Whitespace\" \
-         \"))))(Tile((id \
+         80c10669-cf5d-4f7c-affc-1bb7609a8ebf)(content(Whitespace\"\\n\"))))(Tile((id \
          40018b43-d841-4623-8f42-5225a32082f4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          53723eb8-8e0f-4e57-a280-ad230ad507c0)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         aa391a99-b228-4633-b874-205d2269d558)(content(Whitespace\" \
+         \"))))(Tile((id \
          a2218f56-420b-40c4-921f-6ce23eb63c46)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         b13d95d2-5d47-485e-94e1-a2b325cbd6da)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         34807c3c-2272-4b67-83fd-17db2d649cbb)(content(Whitespace\" \
+         \"))))(Projector((id b13d95d2-5d47-485e-94e1-a2b325cbd6da)(kind \
+         Checkbox)(syntax(Tile((id \
          0b36a2d0-f718-451c-ad30-9263f727faa7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2573,46 +2226,31 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2db1413e-a529-43db-8605-1565953ac914)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e5b2bb67-09a5-49b0-bb6e-d281976152d8)(content(Whitespace\" \
+         fdeb289c-9535-4cbc-9747-d86f7c9c6778)(content(Whitespace\" \
          \"))))(Tile((id \
          0fd8002c-4b13-46df-b28e-bd964e7e61ae)(label(\"\\\"concat(header(t1), \
          removeAll(header(t2), cs)) has no duplicates\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         17a2fe72-b75e-4278-b1ba-363706deb465)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e688298c-3132-4b73-9f07-ed6139ba68f1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a94ecf7c-be7f-42f4-82b3-a939f9979e80)(content(Whitespace\" \
+         a0dac9af-0cf2-4a7d-b7d6-ab0b20ec7cfc)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         93477ed3-11a6-4db9-8705-d97311d4bdbf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6815044e-2006-4cab-8cb6-bc76b97d7bb2)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         531552d6-a1dd-482f-b5b4-9215165924c5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         624d5e47-0905-403d-9c38-7422df5582b9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         efebfef2-d8bf-4315-aa3b-6861d3e9f0ae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         85c8e291-ad39-45d2-891d-74c3719cdaef)(content(Whitespace\" \
-         \"))))(Tile((id ecf1fc0a-51c8-4871-93b8-a21a0e5a651d)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         aff06fc5-8faa-4760-b7c3-bd2c7e03049b)(content(Whitespace\" \
+         15202d15-2b91-40aa-ac0c-69d1596e29cf)(content(Whitespace\"\\n\"))))(Tile((id \
+         ecf1fc0a-51c8-4871-93b8-a21a0e5a651d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         89e4efb1-b1fa-4fc7-9c7c-0d3a58260112)(content(Whitespace\" \
          \"))))(Tile((id \
-         563192ed-12ef-46ad-b914-267677a9baac)(label(ensures))(mold((out \
+         563192ed-12ef-46ad-b914-267677a9baac)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         3cc7d2c9-0903-4f20-a421-ae852f679631)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         04f1259e-b5b4-46e6-adbf-ec1f9db18cfb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a57386a3-21e3-445c-9414-c4be0b06eda4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         daa79089-033e-4be3-8672-f7aaf5051256)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         64bdc405-fb8f-4160-9ac5-2496360af197)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4b771d4a-1b2e-4d0d-ad59-a8a6c58a0adf)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f0b75e41-cba1-45b2-b2bb-bac9d1ba1130)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         a48aeeb2-3611-4713-837f-69d3c445548b)(content(Whitespace\" \
+         \"))))(Tile((id 3cc7d2c9-0903-4f20-a421-ae852f679631)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         3a6ffc12-9ab2-4f6f-b4b7-175f9ce1a006)(content(Whitespace\"\\n\"))))(Tile((id \
          75d151bb-765f-4176-b1ad-33007ca06b74)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2641,15 +2279,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dfe930e2-2360-44fb-a3c8-b8e7bea0b912)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f1830154-5c13-49f9-9c79-f588cb137015)(content(Whitespace\"\\n\"))))(Secondary((id \
-         87475136-8520-4a04-8d08-b47932707c4c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c530ee7-004c-443e-b6d9-d16ae17545ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c45ac032-cdda-4f2b-8366-6a085081901e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ea61838-da6d-4be3-9649-634146583d9c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         2a485723-a110-42f2-9033-5032074466ae)(content(Whitespace\"\\n\"))))(Tile((id \
          3183fe86-a345-4566-bcb2-d4aee7ec034a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2678,15 +2308,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          329ff388-688b-4e72-962d-81e0a6e9bffe)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0cd6e16e-6b5e-4dce-b39d-b64750d56cfc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cd2511d3-c2db-4fc3-bfd1-161213a0dc80)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         17b8b1b6-7607-49df-a5c6-a63b40738890)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7615b10e-4f6b-4e03-80b4-d06ed2b201f3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32e9d596-e62f-4b97-932a-d3a9a815fc42)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8cec3029-15ae-476e-b0f7-bb218e9a16c8)(content(Whitespace\"\\n\"))))(Tile((id \
          e174bf52-6289-4a39-8834-aafeff44a3e0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2715,25 +2337,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e8d9ded7-4089-4e7b-86d7-8376538bea9c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b261899c-4e23-46a0-b03b-c67bda8258c5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b9ba577d-c9c3-473c-81f9-cc11ee666883)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         14303f7c-ba41-4637-b342-451ae42e17c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bf207e55-e5b4-41ce-9c22-e6953412f163)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aee6f1a7-6062-426f-a212-591bc2328055)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ae0c0a2d-a202-4130-a768-7d0ca215e451)(content(Whitespace\"\\n\"))))(Tile((id \
          c2f763a3-7415-4302-81bf-d908f616c54f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         7f41c769-fb07-4279-b3df-1329b8ce147b)(content(Whitespace\"\\n\"))))(Tile((id \
          097b4901-b9e7-460f-aff3-fbc78f4b0e98)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         08c90334-1ea5-4a53-a83c-a0f46d0a78d8)(content(Whitespace\" \
+         \"))))(Tile((id \
          0944d4c8-b8b8-4e9d-aabb-f9cc01d6f6b1)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         ee6ab916-e410-4c88-8359-2a04d73b6e50)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8fdb93ea-9980-4f22-90b3-0fa1afc8870e)(content(Whitespace\" \
+         \"))))(Projector((id ee6ab916-e410-4c88-8359-2a04d73b6e50)(kind \
+         Checkbox)(syntax(Tile((id \
          8c08f14a-1b0f-4916-9356-097ffafa5ea6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2743,87 +2362,59 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9353d7f3-1193-4ea5-adec-e862bb877d29)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b8357200-5f49-45c9-880b-502f00dcea00)(content(Whitespace\" \
-         \"))))(Tile((id \
+         2e310556-c558-4c48-8f04-085c22866d57)(content(Whitespace\"\\n\"))))(Tile((id \
          8a6ebb02-f92c-411b-b19e-2e8ce0d67423)(label(\"\\\"nrows(t3) is equal \
          to nrows(t1) if distinct(selectColumns(t2, cs)) is equal to \
          selectColumns(t2, cs), otherwise each row of t1 may have several \
          matches\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         50e855c6-e231-4d7b-8214-cc90d169c977)(content(Whitespace\"\\n\"))))(Secondary((id \
-         53e89726-7f53-4241-a943-149cc21eb1a9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         54c4bd71-8a25-42b0-965f-4c2bb7db3ed8)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d3d12ed5-a0bf-4b9b-a3c3-2a51cdac7073)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         172f0fb1-9401-4f2b-838b-6dea17438f4a)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         ef626cb3-81cd-4ef3-95cf-a45a627295a2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8eff028d-157d-4999-944c-8dbd5bd2ef17)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0b1e78a6-d6f3-4c88-a842-f765758c00e8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fb32a935-6af2-4130-96dd-c41da2ff8237)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc5a736c-228e-4a7b-bb60-b16ad3f26974)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         a68b69d2-491b-44e5-b027-408e2135b205)(content(Whitespace\"\\n\"))))(Secondary((id \
          f69c5503-fa14-4918-802f-2b1cefa6de97)(content(Comment\"# Since we \
          don't have the schema as a runtime value there's no way to \
          dynamically build up the right table columns unless there's at least \
          one row. So we extract the columns from the first row. \
          #\"))))(Secondary((id \
-         9d015973-72ed-46a8-bbeb-062f036a528a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         447ca403-c3a2-4f2d-bb30-0721adbcef6f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5bd72601-a0e7-4051-8696-92815cc55a03)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         6084a4f7-0a53-4710-adfe-474e43f795b8)(content(Whitespace\"\\n\"))))(Secondary((id \
          140cf500-e6a9-4611-bfd0-9f9a3c1b6b80)(content(Comment\"# If there is \
          no row we just return the lefthand table's columns \
          #\"))))(Secondary((id \
-         cd25043d-7394-49a9-a0fe-a18fed6fae61)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e27ae39b-f9ea-471d-bc19-fb388d52003d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1284a653-296a-4236-8c07-5e95dc583b06)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         e51a780b-0856-410a-b55b-05e8034e9a8a)(content(Whitespace\"\\n\"))))(Secondary((id \
          57ec5cef-534a-43fc-b9fb-adcbdb9e688f)(content(Comment\"# All the \
          columns of the right table are wrapped in an option type since they \
          may be absent#\"))))(Secondary((id \
-         82d9b02e-d3c1-48a7-b944-176efbc2f810)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4d701a0e-3613-4de7-a658-8e0322abb311)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fda7a641-e68e-4588-890a-f3137ef4aed1)(content(Whitespace\" \
-         \"))))(Tile((id 8e9e8484-815e-420f-8b35-1642e2e2d8da)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         cd9df30d-d367-455d-91ba-1d35e0298351)(content(Whitespace\" \
+         aa28e45a-b8aa-4bf2-aa1a-9cb95edc74b3)(content(Whitespace\"\\n\"))))(Tile((id \
+         8e9e8484-815e-420f-8b35-1642e2e2d8da)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         c458b67a-bb61-4ea1-bcf5-22f8e29b2ed8)(content(Whitespace\" \
          \"))))(Tile((id \
          bb25203f-cb25-454a-9560-10b0642e4ce4)(label(left_join))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ede31446-3643-459d-8c42-0c6a6ab1753c)(content(Whitespace\" \
+         c9200919-9d10-4a7a-99ec-e2dedbdf7fb9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5e707f6e-9712-4453-9563-4ebd0cb34c53)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d4d6fefa-0f1f-4431-a862-ea62343d94cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d9b1f5e2-804e-42f6-b539-6a200bb5de5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cfbacd3b-8457-45cd-a24a-32ddf72ebc60)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         72c1643a-0a63-4026-acc4-0ea00b165d5e)(content(Whitespace\" \
-         \"))))(Tile((id a737f08b-28b4-436b-82a5-eb174cd67396)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         8242daac-3d27-42ee-bbc0-106ade759207)(content(Whitespace\" \
+         2b46116c-1495-4a65-8d10-863ff776dabf)(content(Whitespace\"\\n\"))))(Tile((id \
+         a737f08b-28b4-436b-82a5-eb174cd67396)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         78c40938-7b4a-4993-ab88-1102adabdc8c)(content(Whitespace\" \
          \"))))(Tile((id \
          9330d6b7-cf17-491d-9403-541b77d0e8a6)(label(project_labels_str))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         702f39be-0812-419a-bb19-793537062218)(content(Whitespace\" \
+         47950b0a-546f-4e3e-aea0-25b27e25c50f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7daee76c-0601-4980-bf44-15bbdfcf2f69)(content(Whitespace\" \
+         53dc2485-0daa-4181-8596-2f560967a076)(content(Whitespace\" \
          \"))))(Tile((id 3f0dd586-d775-469b-a4ee-d1eaf2eb16dd)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         414cc461-5617-461f-8a1b-644d45db1d08)(content(Whitespace\" \
+         32bb3d36-913f-4b5f-ad21-d35f87b6eae7)(content(Whitespace\" \
          \"))))(Tile((id \
          20953c2e-0ad9-4766-a819-578229d11827)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2833,13 +2424,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          f0300a00-0a67-4927-8504-a59897030090)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         dc8f091b-5b6a-4a1f-94dc-48998df01a8e)(content(Whitespace\" \
+         \"))))(Tile((id \
          72835515-75b3-407b-bd3d-76a3ac203262)(label(cs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         5d63c23e-5223-49fb-a15a-fb39cfd2513a)(content(Whitespace\" \
+         4b0b6e4b-1cf6-4dcd-9254-6fc497a8b8fb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ad314376-305b-43a2-bc15-ee91098dab26)(content(Whitespace\" \
+         5b461727-d3a0-427a-9702-54ec2d48a28e)(content(Whitespace\" \
          \"))))(Tile((id \
          ae41f5d0-7d5e-451d-96bb-dee8bade6712)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2850,12 +2443,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          da965945-bf5f-4314-b4dc-e1292edd95fd)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         2ff66116-21e9-4b47-b76d-ad06c1e09e80)(content(Whitespace\" \
+         5ba49335-6ecd-4bab-b2ee-4257366497b3)(content(Whitespace\" \
          \"))))(Tile((id \
          05d1428a-f336-4eb7-91f7-6b37e1ff4089)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a46cba20-50fd-4322-8a36-42fecd82def1)(content(Whitespace\" \
+         9c6af515-27d9-4775-9729-c1a80e2b79e4)(content(Whitespace\" \
          \"))))(Tile((id \
          0ef60946-1dcf-4f1c-9160-db553e515d16)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2869,18 +2462,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2f5eca4d-fd22-4ade-8904-1fa95f98f557)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a28a55fb-9dd4-4fce-94c8-dcc603e550b1)(content(Whitespace\" \
+         ef630609-e154-4ef2-b3f2-8f898be10b1b)(content(Whitespace\" \
          \"))))(Tile((id c69e5e04-b2ea-4b60-966b-0843c81c1964)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         9fb60887-b95b-4e27-a61e-8c1bb760f38a)(content(Whitespace\" \
+         89c51d20-4e9e-4156-8d22-33ad88171590)(content(Whitespace\" \
          \"))))(Tile((id \
          012906a1-5a8f-49e3-9633-2ce9c1cd8b44)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2c279368-cdc9-4267-813c-c73024023de7)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         1dce9ada-a05f-4884-9c0b-46b1613d334c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c2084967-f04e-4891-8823-fa1800c3b5e6)(content(Whitespace\" \
+         \"))))(Tile((id \
          55999491-bf32-472b-aec9-7fe88b0a9fad)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2892,7 +2487,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          2f115fa2-f293-4f6f-b397-4fa9e78000cb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d10ce823-0451-4ece-8017-daa5b5343abb)(content(Whitespace\" \
+         \"))))(Tile((id \
          87077d23-e811-46f7-95ba-e1fe2a20f1a2)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2902,43 +2499,35 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c31f34ab-645c-4942-9df8-e117abeb32ed)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         c2c6ba6b-dd84-44ed-bad8-022c3cd1c9fd)(content(Whitespace\" \
+         43efb2d6-dc18-4e2e-bfde-c7fe2250c039)(content(Whitespace\" \
          \"))))(Tile((id \
          4ab95a5e-2e95-46cb-93e4-ebfe105f5860)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         295f2239-b176-41b1-b8ea-914b9e9d86a4)(content(Whitespace\" \
+         9e38f7e0-3a1d-4e94-aced-cbc5076af874)(content(Whitespace\" \
          \"))))(Tile((id \
          6891a5ad-42b7-4a30-a446-64b6f82f24ba)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b22222d4-6bd8-4019-89ca-4e48aa288ae7)(content(Whitespace\" \
+         5c12565d-1be5-43d6-8347-df93137de8bc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ef8f300b-2fbb-4ef3-aaa2-7c9dca94a8ff)(content(Whitespace\"\\n\"))))(Secondary((id \
-         71e3f8bb-cd5b-45aa-8ea1-f5038fffd461)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c440cea1-6ea9-4324-9e88-4c971b65e9f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f21c532-466b-4373-a262-19a74e55b570)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         325256b9-ff40-43b9-b9bb-c36df29bec15)(content(Whitespace\" \
-         \"))))(Tile((id 31dca943-9560-4081-9cad-cc1800957f77)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         0985d597-5500-412c-b6bf-cd37506a2a87)(content(Whitespace\" \
+         291283ea-d372-495a-925d-1c0adc9b4b50)(content(Whitespace\"\\n\"))))(Tile((id \
+         31dca943-9560-4081-9cad-cc1800957f77)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e87687bb-d473-4516-8af1-bf274fbdff98)(content(Whitespace\" \
          \"))))(Tile((id \
          bc352c8f-0db9-4e74-ab2c-40a30dc1306b)(label(omit_labels_str))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e55eccc6-7996-4604-9650-2c886d7a3c70)(content(Whitespace\" \
+         26770865-e23b-49c5-a648-5e853d643b54)(content(Whitespace\" \
          \")))))((Secondary((id \
-         65a1a521-81e4-4021-852f-a1aec5971a52)(content(Whitespace\" \
+         1b49568b-460d-422e-a983-fe495cf406f3)(content(Whitespace\" \
          \"))))(Tile((id 966c625f-81e9-45a0-ba45-633ac5e57fa8)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         c38031ea-9fee-42be-8e63-03eb9d21c49c)(content(Whitespace\" \
+         bcd1f906-0b49-42cd-809b-efaf4253c8f0)(content(Whitespace\" \
          \"))))(Tile((id \
          7a59c25b-9031-46c6-9274-2c3ff41249d7)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2948,13 +2537,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          c9e756a9-e747-49b1-96dd-3a6a24eadb73)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         158c7636-4998-40e8-9a68-f01f8513cc43)(content(Whitespace\" \
+         \"))))(Tile((id \
          330da8f4-71a7-48bf-af93-a3deec761d6f)(label(cs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         555b06d6-6f55-409e-adbb-5b34f77e6434)(content(Whitespace\" \
+         5913c346-316d-4ab7-9af3-1ce5d426896a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f482b7d9-ed5e-4925-8930-07de68c471ee)(content(Whitespace\" \
+         50066058-d6ec-4328-acb1-11880b5825dd)(content(Whitespace\" \
          \"))))(Tile((id \
          06338aa4-b4cb-463f-bf81-c6c8277a1ba0)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2965,12 +2556,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2c2b6149-ba9f-43ee-ba8a-da6d7f427c99)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         205476d7-45d4-4c4f-ad58-99f9615e53ac)(content(Whitespace\" \
+         7c45f0f5-0b8d-46db-b50e-4b2475e6e997)(content(Whitespace\" \
          \"))))(Tile((id \
          270d981d-9975-45a5-af4a-18613c2212ce)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         04cab507-8894-462f-8d1a-55dd1a6f081f)(content(Whitespace\" \
+         e68dc07f-4621-4f3e-bfc3-4dc60c5e36ef)(content(Whitespace\" \
          \"))))(Tile((id \
          f9931006-0528-48f7-bbcc-8c74b9530184)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2984,23 +2575,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fdecc706-3c6f-4747-b71e-6ebc8078f9b3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bf0f1652-5b70-455c-af0f-b991e0d32077)(content(Whitespace\" \
+         a0222d24-fcb6-456d-8444-b8f5417bcb2c)(content(Whitespace\" \
          \"))))(Tile((id b1dd6451-3de9-4cc2-8dde-5be19b79e924)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         d4697800-bb9a-4483-ad5b-36f2b7034986)(content(Whitespace\" \
+         aef8517d-f713-48db-81fb-b756371792c2)(content(Whitespace\" \
          \"))))(Tile((id \
          663fa96d-b170-449c-9419-0a60d384b154)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d27ee3c7-bd50-4149-b1b1-84cdb7bc361d)(content(Whitespace\" \
+         cb72a8d3-bc1a-4633-911c-95847123f0ad)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2d175c15-0d1d-497f-8916-059302ae93a9)(content(Whitespace\" \
+         f98a12a8-6ea3-4d3c-b108-a4d8d60d3834)(content(Whitespace\" \
          \"))))(Tile((id \
          5c939ca4-502f-48a8-937d-75d34da9846f)(label(!))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b5a50aae-a6ed-4731-a4a7-87c550fe8a6f)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb26af67-acca-49c9-888d-65c29fc99219)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3012,7 +2605,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          f03368e4-ffe4-4de7-b8fa-47d0c9a03a9f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cabf3411-c8ed-47c8-a688-2f0f22b03a16)(content(Whitespace\" \
+         \"))))(Tile((id \
          05ca575b-3601-4234-8469-04dc8f047154)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3022,43 +2617,35 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4c25d7e9-ba52-4977-ba2a-7ea52cc0fd8a)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         9caa8260-cfff-48d8-911d-f983e56764a1)(content(Whitespace\" \
+         64cc3c66-249e-4523-b42f-eff99737d77c)(content(Whitespace\" \
          \"))))(Tile((id \
          d7876d46-41ea-436e-ab78-84f4619b1a19)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         653add2c-8cb1-498d-addb-f3d1118021dc)(content(Whitespace\" \
+         ec75b3be-25a0-4f13-a83a-dbff8be8d5df)(content(Whitespace\" \
          \"))))(Tile((id \
          01df9242-e20c-46b3-856e-85dd632daa85)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         8bc5fc27-57b8-4731-b18e-a1ecaff1241c)(content(Whitespace\" \
+         7e4c7f0f-da2d-4a39-a2a8-6f7d45237aca)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a7566513-cf0b-490c-b04e-86b3716345e3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1186f644-f9e2-4c82-b758-ae482ca807b2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9d8e037b-3169-4407-9bc0-771b15c74bac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8a838532-bf11-4eff-9c6f-75f33b96bf40)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ef6cd6bd-7ef4-44d6-9bbf-6b604b1545dc)(content(Whitespace\" \
-         \"))))(Tile((id 7669e309-01a7-45ad-986e-56e21335188a)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         0e7bc3fc-00da-465c-9492-d93d9961866a)(content(Whitespace\" \
+         eb666069-1cbb-4fa1-a735-d35b722f269d)(content(Whitespace\"\\n\"))))(Tile((id \
+         7669e309-01a7-45ad-986e-56e21335188a)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         8b8e08f1-e7c6-40b4-8811-04086d3a8f16)(content(Whitespace\" \
          \"))))(Tile((id \
          e5f7c692-062e-4ab7-a84a-d986626d5f9f)(label(make_optional))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         4e1ace53-7cba-420c-bca9-b48d0f9537ae)(content(Whitespace\" \
+         bcd7d2b1-29e3-4fec-8f68-b075cbfb69b7)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5a2e2ba3-2c04-4089-8641-2da878389efb)(content(Whitespace\" \
+         df6d991a-788d-4c95-b09c-be2a49978d4a)(content(Whitespace\" \
          \"))))(Tile((id a230bb33-f7db-42dc-9dd6-af7e56d62228)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         c2b7ca2b-864b-45d4-9e6b-5fc330e34c47)(content(Whitespace\" \
+         e8655757-a6da-49ba-9b91-92c30cd47827)(content(Whitespace\" \
          \"))))(Tile((id \
          064e5114-01f6-40c5-98af-2bf24d4bf296)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -3066,9 +2653,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          df282788-f442-4f20-9b0b-90fcb922b029)(label(v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         7919cc34-800e-4ba6-b9d3-318791dbac64)(content(Whitespace\" \
+         2cb42f8c-7daa-47e2-a041-d0d8eb180e0a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6422859b-914e-4236-ba80-9773b269d0c2)(content(Whitespace\" \
+         fed309d7-2453-4e3a-acd8-cbc726d80c08)(content(Whitespace\" \
          \"))))(Tile((id \
          d6758c2b-4395-47a6-926f-17cc13c29696)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3079,12 +2666,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          edcd1dd8-d5f1-4932-9255-c207c66a06de)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         31bbde55-89a7-4a65-9c2f-6c80b5b2a972)(content(Whitespace\" \
+         181bd3af-5556-4826-8fbb-011a8ba607a2)(content(Whitespace\" \
          \"))))(Tile((id \
          3441c372-3d92-43b1-a2e7-94eabfc51f59)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         063d28dc-39c4-4eb5-afa7-bbe6bdd4f0ad)(content(Whitespace\" \
+         35ce78e2-e943-432a-805e-2af1def9f8f3)(content(Whitespace\" \
          \"))))(Tile((id \
          cc6f4e04-d48d-45cb-817e-c5b14bcaaabd)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3098,39 +2685,43 @@ let out : string * Haz3lcore.PersistentSegment.t =
          699fba86-5b7c-4a95-b1b6-b309d2f319fc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         03d207d0-eee1-48d8-b1fd-2dba362cb056)(content(Whitespace\" \
+         7d423b72-e80e-4ae7-98fe-073c38eea55e)(content(Whitespace\" \
          \"))))(Tile((id 4263d2ac-68a4-4832-9b53-4a3917f3e61a)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         0f6872be-118f-4299-994d-911784dc9ac4)(content(Whitespace\" \
+         b1059f95-494b-4dfd-82d3-cb4f4fafb77d)(content(Whitespace\" \
          \"))))(Tile((id \
          f99d561e-d6a5-4aa7-b9ab-808650c6722b)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         80979b05-c1d9-467d-8a17-41b7f08f3a8c)(content(Whitespace\" \
+         8809cf41-b144-4198-9e56-31747a58457d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         865f2684-2701-4f14-9f72-07aaa809cb96)(content(Whitespace\" \
+         2b0c0f89-281c-478a-b512-87f95f43bd12)(content(Whitespace\" \
          \"))))(Tile((id \
          d97139c7-1587-4172-8a26-709c0f179abc)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         17740b27-2c7c-4e88-b52d-73a567b39bdd)(content(Whitespace\" \
+         5f8545c2-9227-42e4-8c71-579d1ee43236)(content(Whitespace\" \
          \"))))(Tile((id \
          6c4f1db3-4ca5-4afa-b9a3-93e38d4d1629)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         af392b37-0a85-4bb4-9ca7-eeb99374e325)(content(Whitespace\" \
+         f7bcfd28-2876-4608-b83c-a605e15e0546)(content(Whitespace\" \
          \"))))(Tile((id \
          0d015015-158b-41d8-8398-1101045ee726)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          63ca72ab-1654-4335-b3e3-a8cc637cc44f)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         70db846b-7b28-412c-9264-ed5310a7ce5b)(content(Whitespace\" \
+         \"))))(Tile((id \
          83849295-6812-4105-aae4-1fa27cc0076e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a3bde68f-3ecd-4ba2-973e-a7c80f0a43f7)(content(Whitespace\" \
+         \"))))(Tile((id \
          b7bc6f25-8bbc-4d06-a6e6-ec66777fece1)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3146,139 +2737,100 @@ let out : string * Haz3lcore.PersistentSegment.t =
          98afc5e3-2fc9-4b87-83ef-ff92ce8a93d1)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         e68d9568-c7ad-486f-9857-75e38e36d207)(content(Whitespace\" \
+         474f8bfe-d92a-467d-9873-6c13df7b1a30)(content(Whitespace\" \
          \"))))(Tile((id \
          7b8fd5f6-ad16-4842-a3d7-175648843031)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3a239199-cc23-44f6-91a8-434e796e5603)(content(Whitespace\" \
+         5f92baab-d846-4d5c-949e-221aa400f941)(content(Whitespace\" \
          \"))))(Tile((id \
          afe4c501-4093-43fc-8450-85ec8444fcd4)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         ed7ad580-3626-4e17-b19f-25e00ca68d93)(content(Whitespace\" \
+         f4afa1cc-7229-417a-b58e-4d65a9e74237)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d20c9fcc-9dbf-4ac7-ad74-e15b02f21d16)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         85d42af0-a86e-4755-8a62-2f64ca1721c0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e7add0d0-6197-454b-bceb-57f1942d0c98)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         caa866d8-f0e6-4cc8-b595-2321efb8f4ea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6452be50-357b-495c-9bc9-666bcbb98ad6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd377b0f-e1cb-42e1-98d0-2d10b7dd6e57)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5314c035-b1ab-4961-8d7e-3961a580cc8c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5bcf20dc-b085-4610-8005-686045072196)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d61e0f65-aed1-44b3-89dd-9060cad6e4d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb086de3-ec46-4d60-b31a-d81be33746b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e99b150d-f2fd-4cf6-ad7f-315354209a03)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d3c45077-dc37-489d-8666-78281dbd9ad4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ff05a216-91ab-4dea-ac43-d42ac637230c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         abe89573-30bc-4a32-a24d-c369277c29bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         294277bb-ca52-4ce8-bf95-a7ec948de759)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c6b092a1-cb50-4c66-bacf-cf25d1a5a480)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4b90cd21-6186-44bc-8948-0f7c315aec22)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61aff885-e1ff-4e4b-ba81-cf1589b69106)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c1780ee-81a8-4c84-9564-c0354a54c73d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         297028d5-c235-49a1-8724-0b5e33ba8f61)(content(Whitespace\" \
-         \"))))(Tile((id e4d8e636-f836-4a2b-a71b-7a7c06c340a4)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         1b06951c-5487-432e-ae27-6829be8675cc)(content(Whitespace\" \
+         4f916e60-07cf-4166-9462-ecefbd51b848)(content(Whitespace\"\\n\"))))(Tile((id \
+         e4d8e636-f836-4a2b-a71b-7a7c06c340a4)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         64081961-76c0-4701-a49f-a68e98d894bb)(content(Whitespace\" \
          \"))))(Tile((id \
          3e75c35d-64dd-4907-a456-0bdb59d50f37)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          8a83e991-1ea9-4ecd-aa4c-b6ba9dd01e30)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         269837a3-1833-4bf3-b5d2-280237f63202)(content(Whitespace\" \
+         \"))))(Tile((id \
          a31ad631-1dab-4ead-b94f-161137aaefb4)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         e3edfbf1-73b5-4983-989f-ab4f79d89624)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ebbc3cb5-ce5e-4e4f-b4f9-f57919dbd2c3)(content(Whitespace\" \
+         \"))))(Tile((id e3edfbf1-73b5-4983-989f-ab4f79d89624)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          d7611a13-53e1-4a36-a30b-1446776bdb45)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          2f47a73f-5f90-4a12-85e5-cf6aa3d60e95)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         e2761bf7-9406-426b-80cd-1932565902be)(content(Whitespace\" \
+         cf14208e-0a33-42e9-bc1c-7e715e4224a3)(content(Whitespace\" \
          \"))))(Tile((id \
          2de93b9c-90d0-4d07-902d-736bd0a4102d)(label(t2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         d7696edb-4046-4559-a6e1-7b3c910f93de)(content(Whitespace\" \
+         \"))))(Tile((id \
          49bb2409-90c8-4faa-bce8-26d6bfb5dd47)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         3fdc1022-0ee9-43f6-be12-4ed8e47d3080)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3bafd4f1-f103-42fd-a64d-0ab296bde657)(content(Whitespace\" \
+         \"))))(Tile((id 3fdc1022-0ee9-43f6-be12-4ed8e47d3080)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          b2fa94be-6d74-4db1-bcec-8a2557ca6dbc)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          47b69ef2-5c3e-47e5-bdb3-93e8c252e3da)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         118620da-e88e-4e17-a167-46fec73ba2db)(content(Whitespace\" \
+         00756cf2-0fb8-4c24-84c6-1dc61d4bf272)(content(Whitespace\" \
          \"))))(Tile((id \
          55d01d48-b289-44bf-bfe3-a463bffef256)(label(cs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         926e6c9c-07d9-40ab-bcea-d0e66be0e09a)(content(Whitespace\" \
+         \"))))(Tile((id \
          3c31c519-2812-42de-930d-b1b06ffe05f0)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         f5b1b3a1-fe81-4316-b784-045f4b737721)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6536969f-7f15-4f6f-87bf-7827dfba17e8)(content(Whitespace\" \
+         \"))))(Tile((id f5b1b3a1-fe81-4316-b784-045f4b737721)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          642e4424-997f-49dc-9ff4-0ba71bf57a43)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         862161bc-e177-4b5c-8ffc-3bd221b3aec5)(content(Whitespace\" \
+         bc239df4-906d-45c3-bdd4-edf7d9ec6e55)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         84b628da-f9b2-4fd5-aab7-80654a47ac06)(content(Whitespace\"\\n\"))))(Secondary((id \
-         850a54ae-2091-454e-a77c-02ec0360ab97)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         50879342-cf0a-4cbd-a37a-fd638d929a95)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd273ee9-ae7b-4798-97c6-0a082c2519ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e900200-b110-4222-80e2-8e737bfed36f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8b1528e2-a30c-4d19-91ec-67c363326a6f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04caa02a-65e8-4cc2-a6ff-69dfb7c53d3b)(content(Whitespace\" \
-         \"))))(Tile((id a50a7822-acc2-468b-b8ce-5f0e0920ec08)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         a732ab7a-2607-4b3b-aff1-91a9fb5fada9)(content(Whitespace\" \
+         ba8cd352-a0ff-4191-89ca-74de51601e72)(content(Whitespace\"\\n\"))))(Tile((id \
+         a50a7822-acc2-468b-b8ce-5f0e0920ec08)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9afd2907-1710-4175-a53c-dcf9e9d32fef)(content(Whitespace\" \
          \"))))(Tile((id \
          24d3df3b-5af0-4921-bf2f-834d355647ec)(label(right_columns))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         39c4b43b-89d9-4367-98dd-ddd171a63df6)(content(Whitespace\" \
-         \")))))((Tile((id 3c258fd8-56a4-4da1-9992-0c13d95d2979)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         52ccc08b-ebb7-4c0b-97a0-e9747cd5b1f2)(content(Whitespace\" \
+         7a0ddf62-8240-49da-ab2a-e28204b7a918)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         10695764-3d03-4676-ad13-89460fab9aed)(content(Whitespace\"\\n\"))))(Tile((id \
+         3c258fd8-56a4-4da1-9992-0c13d95d2979)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         6e2bd451-0889-4bd0-b182-a0d62d1fe039)(content(Whitespace\" \
          \"))))(Tile((id \
          408fac2a-a55c-4b1c-9c56-e7a7ec8badc5)(label(hd_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3289,48 +2841,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c26cfd27-9239-4d16-a1c2-b34259ec40cb)(label(t2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ce9af711-42ba-4197-9557-0b66ad01f66e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b38465b-a0db-46e4-bff6-5055d1d2f1be)(content(Whitespace\"\\n\"))))(Secondary((id \
-         214cab09-8e68-446f-b0ef-8d521cac2fee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c7e3b90a-a158-4215-87a5-245a327becdb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         07f59c10-6bfa-4f4d-b7e4-0cea4e41133a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d22e74ec-9d65-4df0-a74a-c8b2e6698735)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         409d21a1-e27d-4e1a-8a8d-4383461a55ea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7692b545-71bb-4d6e-a2e9-3f07f2c01be3)(content(Whitespace\" \
-         \"))))(Tile((id 6e7382e8-d6ae-4695-9832-b140fdbac569)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Tile((id \
+         4cac45fa-914f-4d5e-9be5-421af9b612f4)(content(Whitespace\"\\n\"))))(Tile((id \
+         6e7382e8-d6ae-4695-9832-b140fdbac569)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Tile((id \
          fc663c3a-ca48-42b0-8135-cac0d8730576)(label(None))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
          112709a3-96e4-48d3-a4f8-c1f32b3ef069)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         \")))))))))(Secondary((id \
+         19c7560b-0195-454f-a49b-efd37fc8c69e)(content(Whitespace\" \
+         \"))))(Tile((id \
          2eeffdd9-3c51-469c-af56-112f72c4af4b)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         17925356-098e-4494-8687-0ec0799328f5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b5de9081-d1c1-4d64-84c6-e2ddc6335d92)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         707f5709-37cd-4a95-a018-799bc780173e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6901e602-7865-43e9-9e02-0c5792bf7b15)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         609610f3-c02c-4b9f-8546-d2654b5c5b8c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1e5b7c12-2ac3-4c96-b609-2f886b7f833f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3439ade6-bdca-4aa2-b5ed-9e0bab5bda27)(content(Whitespace\" \
-         \"))))(Tile((id f6e73c63-9d91-4bb4-bab3-0450ee9b913d)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Tile((id \
+         fb6800f0-ac53-4db0-955d-1927ad38e463)(content(Whitespace\"\\n\"))))(Tile((id \
+         f6e73c63-9d91-4bb4-bab3-0450ee9b913d)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Tile((id \
          15cdeb1a-751c-4629-bbaa-853e6a891095)(label(Some))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
@@ -3341,7 +2869,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          c1bb50ab-8b2a-4f19-b676-6212b741a9e7)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         \")))))))))(Secondary((id \
+         bcd6b1ce-61dd-4567-8fc0-ab9469b8d8a9)(content(Whitespace\" \
+         \"))))(Tile((id \
          a86d0cbd-3f2f-43a7-a752-fe64787b313e)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3351,11 +2881,13 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ef641468-834f-499c-9a29-75434e5c7d0c)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         30ae05e2-7484-4896-8e95-0fc88f1f2727)(content(Whitespace\" \
+         677e52d4-8add-4f27-87e7-bdc6d20315fc)(content(Whitespace\" \
          \"))))(Tile((id \
          4190d833-a7aa-4915-b0e3-cfac10668320)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         96624832-f350-4c59-8869-c2e51afc1af3)(content(Whitespace\" \
+         \"))))(Tile((id \
          47035ec0-3bcc-4778-9bcd-ac6f54b04342)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3367,17 +2899,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          9369f20a-df4d-49f5-abd2-d371724a9c79)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         52d0aa85-8dfb-42f8-bf33-c418ab00cd09)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f49d3bab-7118-4f4e-9066-be790dd9b9cd)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bbc87b49-327b-4736-816d-ab0ace641af7)(content(Whitespace\" \
+         \"))))(Tile((id 52d0aa85-8dfb-42f8-bf33-c418ab00cd09)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         099b3723-b8ca-4df3-b242-6cd6bdbf18fc)(content(Whitespace\" \
          \"))))(Tile((id \
          374bf508-abcd-4697-97e6-4aee219bb62c)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         74ce28f4-96c1-41a9-8870-6769388f206a)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         b89607e1-8629-43eb-bbdb-4e170d2057ec)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7fbdb031-add6-40f6-b996-82e3de1dd44a)(content(Whitespace\" \
+         \"))))(Tile((id \
          fefaeddb-b1ff-4531-a5a7-265515dbf54b)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3387,90 +2923,46 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c8dc730f-cd3c-4b3e-8e3c-78bf473ed24a)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f3be7a0c-0a62-41d9-9c88-d9c8c28174ca)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0db4c701-bc7e-492f-86bb-155aa7924ad9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         72f8c7d3-34e2-4a0d-8649-e975d0a4dcb9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         07365fb6-2f71-422f-b7b1-55ef778e50ae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b03554a8-4391-4665-b559-a17cc76752e6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         325ea18c-2040-4fe4-94b7-aff5bea7e34e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a0483d20-a8de-41eb-ac0b-a1df78607093)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         145a8aba-7e87-4f4a-891b-c62df4b78f2f)(content(Whitespace\" \
+         c00daf66-530e-4d52-a2c8-a182d53f9465)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         334ec18e-7884-4797-bf07-19dd3ff6583b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         139db1d7-defc-477c-9551-415a14048b55)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d92b6d83-e361-4463-8e26-e68746576147)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2d152f64-e416-4f60-87b1-557e1f898474)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         df410796-dc92-4af6-a382-736e4f98a442)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a02654b4-d69f-4eeb-b1c3-601d9ec71852)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32ebfb48-87d4-4edc-b1f5-f2de2c51b049)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5045b8d0-2936-4ad2-9dd6-afe52170ef84)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5276998a-3f8e-4641-9133-55e229789921)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f685632b-8393-45e0-82eb-0d739317478c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         269eaa84-1e79-4ac0-bb27-eb7af8f29cc8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         2bea256e-38d1-40c3-8d45-b5b5e0e5b21b)(content(Whitespace\"\\n\"))))(Tile((id \
          82013131-127c-4332-a1db-242fded412bd)(label(flat_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          af9fd0b2-486b-4dc1-ac4a-a18dee3bf3d5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         5fd4f5a1-ee1b-40cc-8271-6f489589fac1)(content(Whitespace\"\\n\"))))(Tile((id \
          4b66b511-184a-4836-831c-3b70e3ec5807)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          20c74364-4eb4-4aa1-b06a-1a139b3a45a1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b3e098a7-2626-46c6-8c31-3699742af5f1)(content(Whitespace\"\\n\"))))(Tile((id \
          8e4ecb08-7ef7-4265-8639-8beccbfb4a15)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         57163d4f-aa54-433c-8321-b49dab861688)(content(Whitespace\" \
+         1bb9069e-feae-413e-8f1b-6ee1384ee75a)(content(Whitespace\" \
          \"))))(Tile((id \
          4c48d77d-2c75-450a-9fe5-e365a2d5b18f)(label(r1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5873870f-2f15-4bc6-8de0-5f569b1dbb6e)(content(Whitespace\" \
+         8aaf51f5-1b43-4ec5-905d-de31b7c4007c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         919ecd12-4169-408c-887f-061a1386d209)(content(Whitespace\"\\n\"))))(Secondary((id \
-         540db753-daa2-43f8-a7ff-794586e0ab48)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4550f495-9850-47a2-aed0-a71c286e75c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a2e0e610-3e2e-44c9-91f1-d151631296a6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6facca79-d326-40fe-8163-2f56125f519a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         67346df7-b49c-46fc-a8e1-07315041b989)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         09ba18a0-b78d-4379-8b1d-dc5e11b32bb8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         334457b0-7b22-4070-8bbf-161a8f4cb98f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dbf39be7-cf12-47fc-b3bb-28326ad6350f)(content(Whitespace\" \
-         \"))))(Tile((id aa666ec3-841a-4076-b01e-69743ca60374)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ac6c8ef8-d042-436e-99ad-242036128989)(content(Whitespace\" \
+         16ab7ddf-1a14-456e-9705-b6cdb84a6100)(content(Whitespace\"\\n\"))))(Tile((id \
+         aa666ec3-841a-4076-b01e-69743ca60374)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         b3de2faa-0403-4084-a40e-0a7fd80f9a0d)(content(Whitespace\" \
          \"))))(Tile((id \
          b1a913e7-45e1-45e7-a2dd-0f0f7026e074)(label(matched))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         aae80912-0648-4486-9856-e87b70c5e366)(content(Whitespace\" \
+         98d53c27-6b95-4dfd-820a-4b7b7f4744a8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9c477265-ba06-434e-9d82-c34128fbf245)(content(Whitespace\" \
+         c4c36dd7-f7b8-48df-b226-809f619236ac)(content(Whitespace\" \
          \"))))(Tile((id \
          8ed27c1b-99d3-4805-b82f-cbae2da6a0e8)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3483,17 +2975,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          96000271-8ca5-4bf6-97d6-a21427ab79a6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e2a9926b-261d-440c-963c-c7b5dd5cdf73)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         fdd920f2-7d85-46fd-87b3-35c269cf58f2)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         52c6b1be-954e-4930-804e-2225900a53c6)(content(Whitespace\" \
+         \"))))(Tile((id e2a9926b-261d-440c-963c-c7b5dd5cdf73)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         bb7e8be7-5b12-40a1-9efc-961529b17f3b)(content(Whitespace\" \
          \"))))(Tile((id \
          17087e75-7718-483e-a4d2-f11246a42196)(label(r2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         09094472-89b2-4484-9cd5-9fa530df1eb0)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         1ce88db2-0fac-42c8-9404-6d320ce278b5)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         024ab97b-13e2-41ee-83ea-957d348a1c50)(content(Whitespace\" \
+         \"))))(Tile((id \
          7ee3724a-c80a-441c-b80a-ac9128779eae)(label(project_labels_str))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3505,16 +3001,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          0dd3a21e-39c4-4562-bf38-5683a9ea8e3e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         20ded671-2a48-4bbf-81b8-aaaa9d3d5e0b)(content(Whitespace\" \
+         \"))))(Tile((id \
          ac5990a2-b26c-4cb2-9468-3aebf84860b3)(label(cs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         90d8acaa-d733-4fa2-9203-8c2ed1fd12a5)(content(Whitespace\" \
+         f2fcd286-8afb-4602-a216-1319d7ff14c1)(content(Whitespace\" \
          \"))))(Tile((id \
          caeafb3e-16b2-4961-a1ac-b11f56b5fbed)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cd82934d-a8de-4059-a723-68e6ffacf8bd)(content(Whitespace\" \
+         93d4df89-2a70-4294-aa15-a7b270ab7754)(content(Whitespace\" \
          \"))))(Tile((id \
          798b8791-a0f8-4c35-b96d-47a5b700779b)(label(project_labels_str))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3527,74 +3025,47 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          a3c9b575-9c5e-4097-94f7-9f87039787e8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         12ba78f4-77ed-4f6e-9f69-b012127d5bc3)(content(Whitespace\" \
+         \"))))(Tile((id \
          ccd6949a-597a-4fc7-a42b-dc97c2859b34)(label(cs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         7b22c8f8-5fa4-4f64-b676-f1d48943e5ca)(content(Whitespace\" \
+         de2cbe00-046c-476f-9af0-68fc19cd65c2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         be65892d-2aad-40d9-9487-58f3cf725b5d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         11d20a31-7430-4b07-b0f6-abc6c4524fac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         09f6bcae-c17e-45bb-956a-12ea5e7a2103)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b1c4146-250b-440e-b142-156cf02338c9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         09a94e78-2716-4d98-b5a9-439f12e58377)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         35b002a7-8a0c-49f3-bc7d-bdf2fe43ec22)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dcae4a0b-f028-47bb-90c4-d8a6ee513f49)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f67fa1c2-85ba-4c47-8785-7e8a848b68d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e06d460-84a2-4857-bb21-c7ccb5ccc91f)(content(Whitespace\" \
-         \"))))(Tile((id 4ea8c85c-b8a6-4d37-93e1-6ceb76f1612f)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         b1f0012a-8542-4f73-984a-453483665fd8)(content(Whitespace\" \
+         84379178-e872-4dbd-8050-d6605e0b219b)(content(Whitespace\"\\n\"))))(Tile((id \
+         4ea8c85c-b8a6-4d37-93e1-6ceb76f1612f)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         a442cf76-8a9f-4a9d-8f79-1139a20187fa)(content(Whitespace\" \
          \"))))(Tile((id \
          7db0a739-9df1-4e46-ae11-ee5707aa3b3e)(label(matched))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         fca18280-2580-45d4-89ba-393ed964fe38)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2dcd0cb4-0dc4-41cb-97bb-d39432e86885)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4255781c-37bc-41b2-811c-3042af43cb60)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fb3a1c61-9b94-490a-ad00-94068d7bf33c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         874bc4f0-f3f2-4ab9-85e9-7997c023d11b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         76ba81a9-45ed-442c-81fb-a370a35c9721)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e7e768d9-4888-48fa-86cf-d70ceabadda9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9cdf1182-6e2c-4539-bdac-62e60d6c6e8f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         72d46984-c73e-414c-bd82-85c6bb516dc2)(content(Whitespace\" \
-         \"))))(Tile((id 769c73a8-8631-4410-b935-db28325b17f9)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         d8350319-6995-40ae-8165-d69bfd8a38bf)(content(Whitespace\"\\n\"))))(Tile((id \
+         769c73a8-8631-4410-b935-db28325b17f9)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          e52a49cd-7869-44d1-a90d-77f7fb46ddb0)(content(Whitespace\" \
          \"))))(Tile((id \
          3e1a54a4-9a71-408c-a7a7-facb6a928efa)(label([]))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
          3c1ba9ab-6d25-4141-9a31-c6d2449c464a)(content(Whitespace\" \
-         \")))))))))(Tile((id fe5b9be6-a0c1-437f-b973-29064f812a47)(label([ \
+         \")))))))))(Secondary((id \
+         83685626-06ae-4bc6-b0da-293bd6ff2bf5)(content(Whitespace\" \
+         \"))))(Tile((id fe5b9be6-a0c1-437f-b973-29064f812a47)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          43220ba9-174e-4157-bf84-36ff673fcef2)(label(r1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         7ac0967b-0ccd-400d-917e-f91f19c98159)(content(Whitespace\" \
+         94cf29af-6c05-4502-a106-cc83f0dce10c)(content(Whitespace\" \
          \"))))(Tile((id \
          d4089b03-8cc1-47b0-9475-750c23ecc660)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         635a8910-aa9f-4964-bcf2-3ebff167769a)(content(Whitespace\" \
+         8bbd46fc-2f8a-4d5f-835c-263681974159)(content(Whitespace\" \
          \"))))(Tile((id \
          aecb6888-f1e3-4214-a664-717c44b886e3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3660,69 +3131,67 @@ let out : string * Haz3lcore.PersistentSegment.t =
          01c1444c-45e0-4e77-bb8d-a003feb4e935)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5cac2293-072a-421c-b949-d655751f45db)(content(Whitespace\" \
+         18729122-deac-46d6-bba2-24f514ceaee0)(content(Whitespace\" \
          \"))))(Tile((id 1293d000-0e66-400d-8f9a-218fca441c95)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         34cd4c1f-7589-4919-8629-21b481f69aa4)(content(Whitespace\" \
+         1191900f-962c-45da-a558-1b5912cf0bb0)(content(Whitespace\" \
          \"))))(Tile((id \
          23d676f7-e96f-496c-9362-be486e9f3d84)(label(lc))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3900b709-f944-4933-a410-cf1763e791d9)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         092a5df2-56ed-4d11-9a82-6106f1ee5427)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         29fab656-6074-4553-92f8-62bb205c8884)(content(Whitespace\" \
+         \"))))(Tile((id \
          3922ce20-b4f7-49ee-a12b-9f4b7b79ca91)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          a4b3d351-bb48-48e8-abcd-05f394c3e3aa)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         00b7c5ef-f281-47f1-a489-723ddbbe38e8)(content(Whitespace\" \
+         \"))))(Tile((id \
          89c31b9a-c8cb-40bb-b207-d40bfa089df5)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bb75275f-9c31-4af5-bfd9-7b81e8a0e3df)(content(Whitespace\" \
+         \"))))(Tile((id \
          eb19aebc-79d7-4958-8bd0-eea885f43dc0)(label(lc))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          2e002565-9d52-47c3-bdee-6c6c22cc0c74)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5d784908-aee5-46b2-92fb-fe70c53c1d49)(content(Whitespace\" \
+         \"))))(Tile((id \
          82a61d2e-eb5f-4f0a-8b06-ea8c800a91df)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a10a8e04-bf6c-4936-adcf-5b1cc5ba174b)(content(Whitespace\" \
+         \"))))(Tile((id \
          9640a7d6-d6d5-4094-abff-fc181f1a95ec)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         650a5105-1c33-4860-9399-26c02f51342a)(content(Whitespace\" \
+         \"))))(Tile((id \
          a66b8cc9-6574-45d7-b20e-f80a9694dc06)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))))))))))))(Secondary((id \
-         d59ef822-cc79-418d-8a89-ecfa89ec6f13)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f60637f9-828a-4280-88db-659cdb41afa4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0c86475a-ad84-4602-8480-20fa74babe1a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4368632f-272b-4584-b38f-bf80651b037d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9eb87161-0df0-46d3-b244-521517a62a92)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aef2ebf1-5160-4cd6-8062-768505bb7cfd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         80356b49-4503-4024-b3ac-defcdf6a9e5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         05e35612-6845-4fd4-8d29-db8c4691e2cf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e476ca9-e5d0-46bc-a627-faa63a25e12f)(content(Whitespace\" \
-         \"))))(Tile((id 5ad82b4b-f6a1-4843-9491-aac7523a2fb3)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         ecf59856-3f6c-4696-b93d-4663a4c96a57)(content(Whitespace\"\\n\"))))(Tile((id \
+         5ad82b4b-f6a1-4843-9491-aac7523a2fb3)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          d60cf0c6-ced9-4df2-9da8-0c079deca2a3)(content(Whitespace\" \
          \"))))(Tile((id \
          051c6b36-2e90-4537-8054-aab2adc70823)(label(_))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
          27cb5e34-f063-49ff-a295-1fac2928cbe4)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         \")))))))))(Secondary((id \
+         5866133a-b589-478a-8336-3815451428c8)(content(Whitespace\" \
+         \"))))(Tile((id \
          d92f07f2-b957-4710-ba54-3b0bc443012c)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3734,26 +3203,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          e97fb7a1-6b02-4bc4-b389-96342fe16d3b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a34bcfe7-549e-473e-af98-96f5622218f6)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         0067ddfb-2c80-4b8d-987a-337794ae669d)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         df8ac275-3c66-4926-833a-481756c5552e)(content(Whitespace\" \
+         \"))))(Tile((id a34bcfe7-549e-473e-af98-96f5622218f6)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         caf37f54-137e-456d-a750-81de2ae34ffc)(content(Whitespace\" \
          \"))))(Tile((id \
          fdd265be-1bd3-4337-a97d-90f8537c345b)(label(r2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8cc22759-cabc-4055-88c0-4f0a1a7dd30f)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         49ab4561-1625-408d-8bde-b0c00a039c93)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3c2bb71e-83fb-47f9-bc18-24e5d16b1776)(content(Whitespace\" \
+         \"))))(Tile((id \
          a90cb026-13cd-4a82-8f82-8e15fbd7ddd8)(label(r1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b42f52f4-dfe7-430f-bbe9-1ee5ff28c426)(content(Whitespace\" \
+         8e341c77-bdb5-41c7-a83f-2d6d68202a2f)(content(Whitespace\" \
          \"))))(Tile((id \
          76fab3f3-6b74-43e0-96c9-ae4b7e59a238)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7318304a-ce0c-4a91-977b-9cf80f6ea46d)(content(Whitespace\" \
+         aa5f6dbd-b28b-440f-be99-0a6502bfc84f)(content(Whitespace\" \
          \"))))(Tile((id \
          a27803c2-3843-47aa-974f-b1f3ed8d2e9e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3775,70 +3248,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          be3ffd26-cdf7-4e97-898a-988074087563)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ca130287-c45d-48cd-83cd-146e5c0faf84)(content(Whitespace\" \
+         \"))))(Tile((id \
          2ac23b7b-262a-48a6-8941-0b1334da129a)(label(cs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         1b4a5ce0-3f91-42fa-ad58-a68308447c05)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         634259f1-faae-4858-ac2e-64855aadcaf5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         930cfb02-83d2-4e5c-9b4f-5023492dbc32)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cd810657-5e15-43ca-a774-cbc58941ab93)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c0ca50f5-5c46-4f09-bb98-582f811f76cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b049ce60-d103-4aff-a4d0-3e92745f8cca)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2290bef9-0a57-4e5e-8701-253442b513a9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         029913ec-9225-4402-916f-c57f15004919)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         22cbcdc9-32bd-45c5-83c2-aae59c2573c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a7e3072-8013-40f2-aa03-fdd07141b779)(content(Whitespace\" \
+         4943c205-d80d-4bfa-be05-ec9e0e8e777c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         2ce3c31f-af50-463d-afb2-4ace1a392736)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         cce2e13e-3a84-4a77-bd2b-1241b6951fcf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         629fe4e2-7ab2-479c-8a1f-997371c93e68)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f8232553-15fb-4764-ae38-608e45ffc56a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f9b0a27-23a1-41a0-8b51-5ef06518b7e1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8cfb00fe-bea2-41ec-866a-de452baf7494)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e0e97472-d950-43e9-90cd-2608b311790a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8468aabf-bcdf-47ef-9470-80a039d4b99a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0066e7af-4a35-4d9e-8178-ab2f5431aa1b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0a85bbda-6d0a-4690-8e85-d3430d4a8dab)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fdd1f4da-c183-4003-bee3-35ab78de17d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a0a43c9e-c1cd-4ed4-b170-90c1b9d35acf)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         726ffd1d-b2cf-47f4-907a-9748c2226b28)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c18f9b2-9630-405e-afee-576be8da0510)(content(Whitespace\"\\n\"))))(Secondary((id \
-         129ac914-8aff-40bc-b84f-6d706a29732d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2acfa8a4-4fa4-48a5-b2df-45a0fde1e115)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8a31156-cc58-4244-a9ed-3bf5121bd84c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0b39179b-4244-479f-a14e-d6ce93bb392c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8733a952-6788-457f-b48a-204553806dd1)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         1835cacb-ce3d-4202-88f3-8c1ce3ee4875)(content(Whitespace\"\\n\"))))(Secondary((id \
          041dc87b-22d9-4936-917c-832bbc85a7aa)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         00d2bc84-2236-45c5-97b9-c805cb82e134)(content(Whitespace\"\\n\"))))(Secondary((id \
-         be0d9f14-a446-49db-b0c8-72c8edc83c2f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f39183f9-ad36-4836-809b-5e64da807ac5)(content(Whitespace\" \
-         \"))))(Tile((id 800d5526-b82e-4abd-a89f-fec691f7d969)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         d4bb2a66-51e6-4c6e-8e89-9768d3f7c2f2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         297ec38f-4cc5-40fe-98d2-76c7aae333e4)(content(Whitespace\"\\n\"))))(Tile((id \
+         800d5526-b82e-4abd-a89f-fec691f7d969)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         d410fca6-03a9-44b0-9633-4fa3ed08d1f9)(content(Whitespace\"\\n\"))))(Tile((id \
          3fde6c5e-d954-4fcf-8189-1c6b6d0fcf08)(label(left_join))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -3851,7 +3278,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8de908e5-7dd4-4bc7-96f6-ad08f91f6ee8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3b71d0b7-7859-404d-b28c-230ae47545ee)(content(Whitespace\" \
+         238f4d65-42bb-4110-a8eb-a53be85f1cd9)(content(Whitespace\" \
          \"))))(Tile((id \
          a32c2ec6-6168-4163-bbcf-4e68021c6921)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -3859,7 +3286,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fb7ad032-f070-4799-94a6-7b5a360a15ac)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb854ef3-b9a2-435e-89af-02d29bfbf74b)(content(Whitespace\" \
+         0d50c5b8-9e9c-495e-8f09-fa46ed62c523)(content(Whitespace\" \
          \"))))(Tile((id 0f52b9b1-a57c-457d-93c9-29a7b16e7386)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -3869,39 +3296,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          31b370cb-210c-4ef1-bf45-7e0e7bf3816a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         abf00772-c340-44a3-9ad3-396c9e467268)(content(Whitespace\" \
+         c105c06d-c68e-4f15-a393-6e093f1c113d)(content(Whitespace\" \
          \"))))(Tile((id \
          57c530aa-feca-4ea8-8347-f4b2dd01f760)(label(\"\\\"age\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         694d6c82-eb5f-483a-b9d9-535766976899)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d72a18e9-9160-4514-b69a-6e36ef8a677e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8ae298e5-d61d-4c62-a27a-91ec78634244)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3abd1ac9-4dd3-4ffb-9d26-19d084d9c1a4)(content(Whitespace\"\\n\"))))(Tile((id \
          b40b81f3-ebb0-4795-990e-bb5967705600)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         25e43ec1-e712-4dda-b99f-41290f2f5fcc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         29ceec92-5bbd-4d12-b07b-38a6fbcf022a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fc53cc3a-7f8a-4c7f-b272-449c43e8209f)(content(Whitespace\" \
+         20334d1e-152d-40c6-8655-f8eabb7c5d41)(content(Whitespace\" \
          \"))))(Tile((id \
          32341bb2-bea4-43db-8d7c-a1a4bc9fab8d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         c5a767f3-d73e-4c65-924f-38050b776723)(content(Whitespace\"\\n\"))))(Tile((id \
          5d230e0a-64b7-4dd8-9a22-9fd7df0dfd7d)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         786f05f6-3c61-4bfd-97be-596920ed3e58)(content(Whitespace\"\\n\"))))(Secondary((id \
-         24987feb-fcf9-4643-92d2-bd0795817f77)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         05232a27-5791-4fae-8f40-e2f7a8a31945)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         336dd4fd-9425-4413-acd7-6fc93ac5b6f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c18904ca-1d5b-4772-949c-f5c4ef40d9c6)(content(Whitespace\" \
-         \"))))(Tile((id \
+         2b7c5c11-c21e-43e4-abcd-ec3cf001935b)(content(Whitespace\"\\n\"))))(Tile((id \
          237667bd-2a48-46af-8c24-1db5cd2509bb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4011,15 +3424,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          932030b5-cabd-4107-9c52-e24b6daae8bd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         32927fbb-f11c-4d8f-8da0-028809406701)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ce6f036d-bebc-461f-ab04-7eb8a22d94a5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4992d57f-c4e5-4181-b922-5c51de856480)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         52bcb757-f1af-49ae-96d4-582ff3f08a79)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9c523d8-9ffc-4507-ac84-3f369d36f4e3)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d56b36a2-d5fb-4e18-8943-7b0cdebd9124)(content(Whitespace\"\\n\"))))(Tile((id \
          3ee850c9-6151-4c29-9b38-569d913ceb42)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4129,15 +3534,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7f680d0b-1260-4a3c-9e9e-86cab8585170)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b180b2a5-affd-4139-a06d-3500489ac1cc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f721bf67-9532-4fde-ab6a-d60585f0f452)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e75850c5-36c7-4a27-ad4a-6ff07333ad59)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb00244f-d27b-434b-a814-31f4db565989)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aaa3c530-b0e6-4978-b284-9ed2644b2b0e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         fec9dcd5-c8c7-45f6-8b2b-8ce5d5000ce4)(content(Whitespace\"\\n\"))))(Tile((id \
          ac311c48-c135-4f24-bada-63545999899f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -4147,7 +3544,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9ec7b6c3-8520-4241-af0d-eae3314d3322)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         73756fda-d090-49af-8afe-97dfbaf45b90)(content(Whitespace\" \
+         e5dc3853-1418-4468-8df5-08f22f5a5fb1)(content(Whitespace\" \
          \"))))(Tile((id \
          c6263418-798a-45cc-a386-01e95d54a25e)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4155,7 +3552,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3fd475bc-1c43-4e2b-8e18-e2a3637997cd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         45462811-a077-4c95-96f1-0381b1bce5b1)(content(Whitespace\" \
+         923058cd-5d73-4383-ada6-1a0f8e1e50d6)(content(Whitespace\" \
          \"))))(Tile((id \
          757a9863-3ae5-42cc-b11e-c3dd26a27194)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4163,7 +3560,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0424b1fd-67dd-47dc-a68e-92b1f677ecd0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5958cda6-b726-4fd9-b47d-1b65668073c9)(content(Whitespace\" \
+         66fc23aa-af9e-49a2-be3f-3751798bc649)(content(Whitespace\" \
          \"))))(Tile((id \
          db5558b6-9cfc-4619-8aaf-9c3f1bf402c7)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4177,7 +3574,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          34977d82-83db-47d9-9330-0b76df8d878a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f2b8592a-1d16-4141-bc40-3ecc83ae89a8)(content(Whitespace\" \
+         deb8002e-1cc2-4f9f-9c04-9e42b03f7476)(content(Whitespace\" \
          \"))))(Tile((id \
          4e4e7bf6-8c82-4bb7-ae5b-b13a2618a919)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4191,7 +3588,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          afbd6b28-5f4c-4e9e-9c1c-46787e62701e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5607b534-1211-4007-b532-2a36244a0f7b)(content(Whitespace\" \
+         ac1d3925-ae07-4f3f-ae25-c9f3c4f12e1a)(content(Whitespace\" \
          \"))))(Tile((id \
          f8ecb907-a069-4d16-af78-5cbbe7ea1b26)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4205,7 +3602,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d9a5439a-5d00-455a-add2-e3b58190c1ee)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cdd486dc-6807-46ca-b6a5-a2d1caab572f)(content(Whitespace\" \
+         7150c5ef-7399-4373-9530-03116eb95992)(content(Whitespace\" \
          \"))))(Tile((id \
          fb82b639-3071-436a-8728-33a0906216a2)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4219,7 +3616,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7bdcf150-24bc-4c5b-96e6-193bd3582959)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8c9d7fdb-8cb1-4f92-a018-7feecce98564)(content(Whitespace\" \
+         f626f966-017b-42fd-924e-637a062de914)(content(Whitespace\" \
          \"))))(Tile((id \
          3b6b41af-c72e-45fc-a179-27855714075e)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4233,7 +3630,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7267ba8b-471f-4c91-8c16-c02e09fd93cc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         43e60c78-b2a7-4f3b-8697-0c4dd70a5cc1)(content(Whitespace\" \
+         4b989b9a-837b-4622-aa06-2b4f77cefa51)(content(Whitespace\" \
          \"))))(Tile((id \
          d61c6151-7486-483f-b64a-fd53dfe97e83)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -4243,168 +3640,191 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          b8b9b82c-ec68-4c08-bd47-b20f31abe336)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         1ba6cf2c-543a-4d38-b6bd-3493b11bc41a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         1fb4251d-23bc-4744-91b4-d6b22f7de823)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         ddcf9f53-637b-4638-b99a-07db7cb545a3)(content(Whitespace\"\\n\"))))(Tile((id \
          4717c4bc-644d-4747-be30-ea3850ac0792)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         32dd93b2-3852-4aa4-86f5-fe3923499de5)(content(Whitespace\" \
+         811ab04f-8b58-4210-91ba-756ced8add0e)(content(Whitespace\" \
          \"))))(Tile((id b22005c4-30d1-4868-afd8-840126598f08)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Secondary((id \
+         f4a99e7e-1da4-4133-b020-61ba2a661084)(content(Whitespace\"\\n\"))))(Tile((id \
          23959342-4645-4ac4-9b88-9c85003d6ebc)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         Typ))))))(shards(0 1))(children(((Secondary((id \
+         faa63eba-126c-4c71-89e1-9a92b4802068)(content(Whitespace\"\\n\"))))(Tile((id \
          48b101ec-3c5d-4663-8cdd-90f18c25a3bb)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6565b957-68a3-4b59-93e7-986329b60119)(content(Whitespace\" \
+         \"))))(Tile((id \
          9a534828-0c59-47e8-8731-58c3a5e344e3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b64d782d-22e4-4fa3-a96a-03f9c5b74ec1)(content(Whitespace\" \
+         \"))))(Tile((id \
          f1319e35-72b9-4403-bdca-a57231b6b56b)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d7476459-e961-43d5-9090-581b69345636)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2f35d1d0-dfaa-4f70-a2c3-8e11534d7863)(content(Whitespace\" \
-         \"))))(Tile((id \
+         af869315-f48d-419a-9907-fcceec198d3a)(content(Whitespace\"\\n\"))))(Tile((id \
          5a9a7220-0780-49f7-b487-bf016a283407)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         276479ae-d1a1-4c6d-af00-d7746cb2b95d)(content(Whitespace\" \
+         \"))))(Tile((id \
          38e45f91-b909-4546-8c0d-0af6a8d2f792)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fa2e7536-834e-462d-9677-2fd339e93c4e)(content(Whitespace\" \
+         \"))))(Tile((id \
          c22ad9d8-70d7-4975-846d-0cb0e926b900)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6f48859d-379a-4917-a6fd-7753cb9494f1)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c227b246-17b4-444f-9bb9-3faa6d0c0928)(content(Whitespace\" \
-         \"))))(Tile((id \
+         77c9bb8f-3af9-4ebb-818b-fb2daa14e448)(content(Whitespace\"\\n\"))))(Tile((id \
          eb1d1f25-1206-4684-8a34-7bf8eb4d363c)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4fff22af-a6a5-4259-95aa-e8ebd443c083)(content(Whitespace\" \
+         \"))))(Tile((id \
          7d055563-a2b8-4463-a233-0526a457de41)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2433e8e6-730b-49fd-adae-23710866d8d7)(content(Whitespace\" \
+         \"))))(Tile((id \
          a5cb1aad-c844-4586-ac2c-bd16ce9f84a4)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          32206f80-b109-42c6-a915-239db1ac68b6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6634a994-43c9-4db6-9340-2ab288b3d087)(content(Whitespace\" \
-         \"))))(Tile((id \
+         a4f4256d-98ee-4081-95a5-ebad7da3310e)(content(Whitespace\"\\n\"))))(Tile((id \
          b38a77eb-f35c-4cdc-be57-68cad057ce38)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2b5a7a89-7bba-4591-96b0-f7bd335e9bbd)(content(Whitespace\" \
+         \"))))(Tile((id \
          e9577802-3efc-4ae3-9ad0-6cf8b3c1db5f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b25b1325-6aec-4cdf-83cd-bdff388bc099)(content(Whitespace\" \
+         \"))))(Tile((id \
          bfd94ff3-1f95-4d5b-9d5e-e5e3c51dc049)(label(Option))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          05bf1229-b2e8-444d-b8e4-b0e20877abdc)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9f02e892-e372-4f01-ba0a-466dc773ba3b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ae29894f-80be-44e7-ae39-56e9db42d905)(content(Whitespace\"\\n\"))))(Tile((id \
          1996747d-3111-45fe-ab64-474f1055f020)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         927738be-3b7a-4683-a590-8bac251a186a)(content(Whitespace\" \
+         \"))))(Tile((id \
          1fd53ae0-66f3-403c-860e-6e53edba60fb)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         497afebe-65c3-4e91-a8d4-96ce3bfd7a57)(content(Whitespace\" \
+         \"))))(Tile((id \
          704aa97a-2aac-4d87-97d5-32edfd66776f)(label(Option))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          700a45bc-95b8-499c-850b-f80e7eb7610f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a3a33d6e-0d93-4469-bb7e-0522407536ed)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e8d3428d-ecc6-49d5-ac05-6b82b4e35607)(content(Whitespace\"\\n\"))))(Tile((id \
          97e265ea-9797-45f7-96fa-d19f9f41fe8f)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5a2c14c5-bf79-428b-8a28-0f84a59612c4)(content(Whitespace\" \
+         \"))))(Tile((id \
          3f01b79e-04f2-4fa1-9c08-3b8944a8208f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bfa65586-7301-4a50-b0d3-7a04c6513f20)(content(Whitespace\" \
+         \"))))(Tile((id \
          c006157a-0d69-4de7-9520-5f34cc502ac7)(label(Option))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7a3782a1-b1d5-4517-98d4-a0e8ff639d5f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5b0203c3-aa1d-4307-b631-74f90b8a73e1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         9125d6a0-4009-4c58-8caf-bc199514a6e0)(content(Whitespace\"\\n\"))))(Tile((id \
          da5cc7a4-fdb8-45c2-a2c5-0d0e45c4ea27)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         16eb856f-9f35-48e9-9ec7-8bd250fa5f3a)(content(Whitespace\" \
+         \"))))(Tile((id \
          4c344cc5-91c1-4a22-81d6-9286dae5c330)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c45ce413-6cd5-4ff5-b2e0-87a8b30f8772)(content(Whitespace\" \
+         \"))))(Tile((id \
          f9e01b5c-6ebc-45e3-a992-bad1da81a7e8)(label(Option))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f0d382e3-8356-45bf-b616-85c62edfdd66)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         78653d0e-229d-4ed3-aed6-36cd52d3eced)(content(Whitespace\" \
-         \"))))(Tile((id \
+         63d85455-7533-4052-b369-36d91b8ab5b1)(content(Whitespace\"\\n\"))))(Tile((id \
          c2bbe6e1-5865-4515-bb7d-33fe10f6f8fe)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bb44e964-0edf-46ce-852e-c85443ca308e)(content(Whitespace\" \
+         \"))))(Tile((id \
          45e16829-be71-4529-820a-683653fc6cd1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3aac8d20-78e4-4274-a579-19eb9ea68ae6)(content(Whitespace\" \
+         \"))))(Tile((id \
          1eac146f-32b3-43b7-9162-ed0c7f788a56)(label(Option))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          24d774f9-5e71-47a4-b0a6-231295915048)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         16e05f9f-cfc6-41fd-93f1-0f552e0f62b1)(content(Whitespace\" \
-         \"))))(Tile((id \
+         693e07d0-c1f9-450a-ac46-7408df46f778)(content(Whitespace\"\\n\"))))(Tile((id \
          00a5fe44-f57f-4a84-983c-48dd71e7e6c7)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0f71bb71-88ad-468f-9719-d9d238b2f4fa)(content(Whitespace\" \
+         \"))))(Tile((id \
          4e327df1-034d-4228-87c9-4f48b770e1e7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         49b19601-7f8e-4f95-9c8c-8c5175363d4c)(content(Whitespace\" \
+         \"))))(Tile((id \
          5fee5496-7183-4655-8db8-55761166bc29)(label(Option))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         6de8c966-055f-4a8a-b7bb-ecc84905352b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         de111aaf-fead-429a-8b90-c5c357a7bf74)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db01186a-2ca5-468e-982c-ae13a16eb0e9)(content(Whitespace\" \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d9a07b00-74e1-4051-b90a-f3fb12108260)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         ffcb3d8e-1e90-4a8e-af6a-9fd084e9ee90)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         ca69e18b-cf57-409a-bd48-daa533896679)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         ea94f4e8-fbd3-412d-a121-daffab06c60d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ccbde852-ad18-4957-8b99-b96d10bc0dc6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0890d55b-7c72-4df8-bdff-78420f0d1140)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         d13a5aec-d0cf-4875-af8d-97b2b8f0636b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         233a87cd-ab01-49c4-a31a-5dc3668ae821)(content(Whitespace\"\\n\"))))(Tile((id \
+         2b9d9a9f-0b61-4a9f-808e-1b3157130a65)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9b8d8cd0-fe27-4b86-823b-0f7bc368e169)(content(Whitespace\"\\n\"))))(Tile((id \
          8607712d-a58c-4678-a8ef-347b6002296e)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         521d05a0-3f6a-4632-8e46-4d29eded2c88)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
-         let students : [Student] = [\n\
-        \  (\"Bob\", 12, \"blue\"),\n\
-        \  (\"Alice\", 17, \"green\"),\n\
-        \  (\"Eve\", 13, \"red\")\n\
-         ] in\n\
-         type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = [(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")] in\n\
+         type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = [\n\
-        \  (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
-        \  (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-        \  (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
+         (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
+         (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
+         (\"Eve\", 13, 7, 9, 84, 8, 8, 77)\n\
          ] in\n\n\
          # V1: This version is idiomatic but is a higher order function \
          requiring the caller to construct the resulting schema by passing in \
@@ -4413,139 +3833,156 @@ let out : string * Haz3lcore.PersistentSegment.t =
          option type marking the whole row as present or absent. A future \
          operation could turn a optional tuple into a tuple of optional values \
          #\n\
-         let v1 =     \n\
-        \  let requires=[\n\
-        \    (enforced=^^check(true), \"cs has no duplicates\"), # Ensured by \
+         let v1 =\n\
+         let _requires = [\n\
+         (enforced=^^check(true), \"cs has no duplicates\"), # Ensured by \
          projection function #\n\
-        \    (enforced=^^check(true), \"for all c in cs, c is in \
-         header(t1)\"),  # Ensured by projection function #\n\
-        \    (enforced=^^check(true), \"for all c in cs, c is in \
-         header(t2)\"),  # Ensured by projection function #\n\
-        \    (enforced=^^check(true), \"for all c in cs, schema(t1)[c] is \
-         equal to schema(t2)[c]\"),  # Ensured by projection function #\n\
-        \    (enforced=^^check(false), \"concat(header(t1), \
+         (enforced=^^check(true), \"for all c in cs, c is in header(t1)\"), # \
+         Ensured by projection function #\n\
+         (enforced=^^check(true), \"for all c in cs, c is in header(t2)\"), # \
+         Ensured by projection function #\n\
+         (enforced=^^check(true), \"for all c in cs, schema(t1)[c] is equal to \
+         schema(t2)[c]\"), # Ensured by projection function #\n\
+         (enforced = ^^check(false), \"concat(header(t1), \
          removeAll(header(t2), cs)) has no duplicates\")\n\
-        \  ] in \n\
-        \  let ensures=[\n\
-        \    (enforced=^^check(false), \"header(t3) is equal to \
-         concat(header(t1), removeAll(header(t2), cs))\"),\n\
-        \    (enforced=^^check(true), \"for all c in header(t1), schema(t3)[c] \
-         is equal to schema(t1)[c]\"),  # If combine function is just adding \
-         new column#\n\
-        \    (enforced=^^check(false), \"for all c in removeAll(header(t2), \
-         cs), schema(t3)[c] is equal to schema(t2)[c]\"),\n\
-        \    (enforced=^^check(false), \"nrows(t3) is equal to nrows(t1) if \
-         distinct(selectColumns(t2, cs)) is equal to selectColumns(t2, cs), \
-         otherwise each row of t1 may have several matches\")\n\
-        \  ] in\n\
-        \  \n\
-        \  # We just require the caller to combine the resulting rows. The \
+         ] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(false), \"header(t3) is equal to concat(header(t1), \
+         removeAll(header(t2), cs))\"),\n\
+         (enforced=^^check(true), \"for all c in header(t1), schema(t3)[c] is \
+         equal to schema(t1)[c]\"), # If combine function is just adding new \
+         column#\n\
+         (enforced=^^check(false), \"for all c in removeAll(header(t2), cs), \
+         schema(t3)[c] is equal to schema(t2)[c]\"),\n\
+         (\n\
+         enforced = ^^check(false),\n\
+         \"nrows(t3) is equal to nrows(t1) if distinct(selectColumns(t2, cs)) \
+         is equal to selectColumns(t2, cs), otherwise each row of t1 may have \
+         several matches\"\n\
+         )\n\
+         ] in\n\
+         # We just require the caller to combine the resulting rows. The \
          closest to leftJoin would be to just wrap the right row in a new \
          column. #\n\
-        \  # The caller could also decide to flatten the option type into \
+         # The caller could also decide to flatten the option type into \
          individual optional columns #\n\
-        \  let left_join =\n\
-        \    typfun r1 -> typfun r2 -> typfun r3 -> typfun k -> fun (t1 : \
-         [r1], t2: [r2], proj1 : r1 -> k, proj2 : r2 -> k, combine: (r1, \
-         (+None +Some(r2))) -> r3) ->\n\
-        \      flat_map(t1, fun (r1 : r1) ->\n\
-        \        let t2' = filter(t2, fun (r2 : r2) -> \n\
-        \          proj1(r1) == proj2(r2)) in\n\
-        \        case t2'\n\
-        \        | [] => [combine(r1, None)]\n\
-        \        | _ => map(t2', fun (r2 : r2) -> combine(r1, Some(r2)))\n\
-        \        end\n\
-        \      ) :[r3]\n\
-        \      \n\
-        \  in \n\
-        \  \n\
-        \  # Examples #\n\
-        \  test\n\
-        \    left_join\n\
-        \    @<Student>\n\
-        \    @<GradebookEntry>\n\
-        \    @<(name=String, age=Int, favorite_color=String, gradebook=(+None \
-         +Some(GradebookEntry)))>\n\
-        \    @<String>\n\
-        \    (students, gradebook, fun (s : Student) -> s.name, fun (g : \
-         GradebookEntry) -> g.name, fun (s, g) -> s ... (gradebook=g)) ==\n\
-        \    ([\n\
-        \      (\"Bob\", 12, \"blue\", Some(\"Bob\", 12, 8, 9, 77, 7, 9, 87)),\n\
-        \      (\"Alice\", 17, \"green\", Some(\"Alice\", 17, 6, 8, 88, 8, 7, \
-         85)),\n\
-        \      (\"Eve\", 13, \"red\", Some(\"Eve\",13, 7, 9, 84, 8, 8, 77))\n\
-        \    ] : [(name=String, age=Int, favorite_color=String, \
-         gradebook=(+None +Some(GradebookEntry)))])\n\
-        \  end\n\
-         in \n\n\
+         let left_join =\n\
+         typfun r1 ->\n\
+         typfun r2 ->\n\
+         typfun r3 ->\n\
+         typfun k ->\n\
+         fun (t1 : [r1], t2 : [r2], proj1 : r1 -> k, proj2 : r2 -> k, combine \
+         : (r1, (+ None + Some(r2))) -> r3) ->\n\
+         flat_map(\n\
+         t1,\n\
+         fun (r1 : r1) ->\n\
+         let t2' = filter(t2, fun (r2 : r2) -> proj1(r1) == proj2(r2)) in\n\
+         case t2'\n\
+         | [] => [combine(r1, None)]\n\
+         | _ => map(t2', fun (r2 : r2) -> combine(r1, Some(r2)))\n\
+         end\n\
+         )\n\
+         : [r3] in\n\
+         # Examples #\n\
+         test\n\
+         left_join@<Student>@<GradebookEntry>@<(name = String, age = Int, \
+         favorite_color = String, gradebook = (+ None + \
+         Some(GradebookEntry)))>@<String>(students, gradebook, fun (s : \
+         Student) -> s.name, fun (g : GradebookEntry) -> g.name, fun (s, g) -> \
+         s ... (gradebook = g))\n\
+         == (\n\
+         [\n\
+         (\"Bob\", 12, \"blue\", Some(\"Bob\", 12, 8, 9, 77, 7, 9, 87)),\n\
+         (\"Alice\", 17, \"green\", Some(\"Alice\", 17, 6, 8, 88, 8, 7, 85)),\n\
+         (\"Eve\", 13, \"red\", Some(\"Eve\", 13, 7, 9, 84, 8, 8, 77))\n\
+         ]\n\
+         : [(name = String, age = Int, favorite_color = String, gradebook = (+ \
+         None + Some(GradebookEntry)))]\n\
+         ) end in\n\n\
          # V2: This version works by dynamically building the schema from the \
          first row of each table. It closely matches the Table API but does \
          not gurantee many constraints. #\n\
          let v2 =\n\
-        \  let requires=[\n\
-        \    (enforced=^^check(false), \"cs has no duplicates\"),\n\
-        \    (enforced=^^check(false), \"for all c in cs, c is in header(t1)\"),\n\
-        \    (enforced=^^check(false), \"for all c in cs, c is in header(t2)\"),\n\
-        \    (enforced=^^check(false), \"for all c in cs, schema(t1)[c] is \
-         equal to schema(t2)[c]\"),\n\
-        \    (enforced=^^check(false), \"concat(header(t1), \
+         let _requires = [\n\
+         (enforced=^^check(false), \"cs has no duplicates\"),\n\
+         (enforced=^^check(false), \"for all c in cs, c is in header(t1)\"),\n\
+         (enforced=^^check(false), \"for all c in cs, c is in header(t2)\"),\n\
+         (enforced=^^check(false), \"for all c in cs, schema(t1)[c] is equal \
+         to schema(t2)[c]\"),\n\
+         (enforced = ^^check(false), \"concat(header(t1), \
          removeAll(header(t2), cs)) has no duplicates\")\n\
-        \  ] in \n\
-        \  let ensures=[\n\
-        \    (enforced=^^check(false), \"header(t3) is equal to \
-         concat(header(t1), removeAll(header(t2), cs))\"),\n\
-        \    (enforced=^^check(false), \"for all c in header(t1), \
-         schema(t3)[c] is equal to schema(t1)[c]\"),\n\
-        \    (enforced=^^check(false), \"for all c in removeAll(header(t2), \
-         cs), schema(t3)[c] is equal to schema(t2)[c]\"),\n\
-        \    (enforced=^^check(false), \"nrows(t3) is equal to nrows(t1) if \
-         distinct(selectColumns(t2, cs)) is equal to selectColumns(t2, cs), \
-         otherwise each row of t1 may have several matches\")\n\
-        \  ] in\n\
-        \  # Since we don't have the schema as a runtime value there's no way \
-         to dynamically build up the right table columns unless there's at \
-         least one row. So we extract the columns from the first row. #\n\
-        \  # If there is no row we just return the lefthand table's columns #\n\
-        \  # All the columns of the right table are wrapped in an option type \
+         ] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(false), \"header(t3) is equal to concat(header(t1), \
+         removeAll(header(t2), cs))\"),\n\
+         (enforced=^^check(false), \"for all c in header(t1), schema(t3)[c] is \
+         equal to schema(t1)[c]\"),\n\
+         (enforced=^^check(false), \"for all c in removeAll(header(t2), cs), \
+         schema(t3)[c] is equal to schema(t2)[c]\"),\n\
+         (\n\
+         enforced = ^^check(false),\n\
+         \"nrows(t3) is equal to nrows(t1) if distinct(selectColumns(t2, cs)) \
+         is equal to selectColumns(t2, cs), otherwise each row of t1 may have \
+         several matches\"\n\
+         )\n\
+         ] in\n\
+         # Since we don't have the schema as a runtime value there's no way to \
+         dynamically build up the right table columns unless there's at least \
+         one row. So we extract the columns from the first row. #\n\
+         # If there is no row we just return the lefthand table's columns #\n\
+         # All the columns of the right table are wrapped in an option type \
          since they may be absent#\n\
-        \  let left_join =\n\
-        \    let project_labels_str = fun (v,cs) -> to_lvs(v) |> filter(_, fun \
-         e ->mem(cs,e.label)) |> from_lvs in\n\
-        \    let omit_labels_str = fun (v,cs) -> to_lvs(v) |> filter(_, fun e \
-         -> !mem(cs,e.label)) |> from_lvs in\n\
-        \    let make_optional = fun (v) -> to_lvs(v) |> map(_, fun e -> e ... \
-         (value=Some(e.value))) |> from_lvs in               \n\
-        \    fun (t1:[?], t2:[?], cs:[String]) ->\n\
-        \      let right_columns =case hd_opt(t2) \n\
-        \      |None =>[]\n\
-        \      |Some(v) =>to_lvs(v) |>map(_,fun e ->e.label) \n\
-        \      end in  \n\
-        \      flat_map(t1,fun r1 ->\n\
-        \        let matched = filter(t2,fun r2 ->project_labels_str(r2,cs) == \
-         project_labels_str(r1,cs)) in\n\
-        \        case matched\n\
-        \        | [] =>[r1 ... (from_lvs(map(filter(right_columns, fun e -> \
-         !mem(cs, e)), fun lc ->(label=lc,value=None))))]\n\
-        \        | _ =>map(matched,fun r2 ->r1 ... \
-         (make_optional(omit_labels_str(r2,cs)))) \n\
-        \        end\n\
-        \      )\n\
-        \  in \n\
-        \  \n\
-        \  # Examples #\n\
-        \  test left_join(students, gradebook, [\"name\", \"age\"])\n\
-        \  ==\n\
-        \  ([\n\
-        \    (\"Bob\", 12, \"blue\", Some(8), Some(9), Some(77), Some(7), \
-         Some(9), Some(87)),\n\
-        \    (\"Alice\", 17, \"green\", Some(6), Some(8), Some(88), Some(8), \
+         let left_join =\n\
+         let project_labels_str = fun (v, cs) -> to_lvs(v) |> filter(_, fun e \
+         -> mem(cs, e.label)) |> from_lvs in\n\
+         let omit_labels_str = fun (v, cs) -> to_lvs(v) |> filter(_, fun e -> \
+         ! mem(cs, e.label)) |> from_lvs in\n\
+         let make_optional = fun (v) -> to_lvs(v) |> map(_, fun e -> e ... \
+         (value = Some(e.value))) |> from_lvs in\n\
+         fun (t1 : [?], t2 : [?], cs : [String]) ->\n\
+         let right_columns =\n\
+         case hd_opt(t2)\n\
+         |None => []\n\
+         |Some(v) => to_lvs(v) |> map(_, fun e -> e.label)\n\
+         end in\n\
+         flat_map(\n\
+         t1,\n\
+         fun r1 ->\n\
+         let matched = filter(t2, fun r2 -> project_labels_str(r2, cs) == \
+         project_labels_str(r1, cs)) in\n\
+         case matched\n\
+         | [] => [r1 ... (from_lvs(map(filter(right_columns, fun e -> !mem(cs, \
+         e)), fun lc -> (label = lc, value = None))))]\n\
+         | _ => map(matched, fun r2 -> r1 ... \
+         (make_optional(omit_labels_str(r2, cs))))\n\
+         end\n\
+         ) in\n\
+         # Examples #\n\
+         test\n\
+         left_join(students, gradebook, [\"name\", \"age\"])\n\
+         == (\n\
+         [\n\
+         (\"Bob\", 12, \"blue\", Some(8), Some(9), Some(77), Some(7), Some(9), \
+         Some(87)),\n\
+         (\"Alice\", 17, \"green\", Some(6), Some(8), Some(88), Some(8), \
          Some(7), Some(85)),\n\
-        \    (\"Eve\", 13, \"red\", Some(7), Some(9), Some(84), Some(8), \
-         Some(8), Some(77))] : [(name=String, age=Int, favorite_color=String, \
-         quiz1=Option, quiz2=Option, midterm=Option, quiz3=Option, \
-         quiz4=Option, final=Option)])\n\
-        \  end \n\
-         in \n\
-         ?\n";
+         (\"Eve\", 13, \"red\", Some(7), Some(9), Some(84), Some(8), Some(8), \
+         Some(77))\n\
+         ]\n\
+         : [\n\
+         (\n\
+         name = String,\n\
+         age = Int,\n\
+         favorite_color = String,\n\
+         quiz1 = Option,\n\
+         quiz2 = Option,\n\
+         midterm = Option,\n\
+         quiz3 = Option,\n\
+         quiz4 = Option,\n\
+         final = Option\n\
+         )\n\
+         ]\n\
+         ) end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIConstructorsvalues.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIConstructorsvalues.ml
@@ -1,24 +1,23 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Constructors / values",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id 2032cc86-c867-4617-9f4e-2ddb5b550f1a)(label(let = \
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         4baca0a1-e96e-42aa-9187-1ee079450bd8)(content(Whitespace\" \
+         7be9a29a-b233-40f1-9304-92955754af8f)(content(Whitespace\" \
          \"))))(Tile((id \
-         015556db-0123-4259-967a-36a318d57459)(label(requires))(mold((out \
+         015556db-0123-4259-967a-36a318d57459)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         10c4d7fe-f157-4543-8687-430ab7c187d3)(content(Whitespace\" \
+         52846a67-58da-4d75-b708-1c21857d28d1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2ed462cc-1de4-4726-80e8-026963571197)(content(Whitespace\" \
+         1d7df3a5-6854-45cf-a867-7a0aaddaa486)(content(Whitespace\" \
          \"))))(Tile((id 9255c477-883e-4346-86f4-ab9c978e5330)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         cb5445f5-a677-4470-be22-2a7ac6d5c6f1)(content(Whitespace\"\\n\"))))(Tile((id \
+         b6056144-1fdc-4f3c-8b3c-a2c247355ec5)(content(Whitespace\"\\n\"))))(Tile((id \
          e142e970-c459-45b3-a0dc-c7c16f0a9867)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -47,17 +46,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2735729a-77a4-4183-a209-c78a24b6323f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         95a9ab17-2b6f-4005-8081-4e1693dad082)(content(Whitespace\"\\n\"))))(Tile((id \
+         a39d4a99-82c2-4abd-af05-0f1148e184f5)(content(Whitespace\"\\n\"))))(Tile((id \
          e2b567fa-3736-4e70-b712-84a96e8d11dc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          78069428-e154-439b-8e68-6ac11a733503)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ea0dc282-5912-4e2a-ae69-7939cb067cda)(content(Whitespace\" \
+         \"))))(Tile((id \
          49ade24f-e037-44b6-a154-a46dc781f7dd)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         6e92b18a-f642-4177-ade1-0afd694b583b)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         735e2436-7dfc-48b9-a085-42fb575afa45)(content(Whitespace\" \
+         \"))))(Projector((id 6e92b18a-f642-4177-ade1-0afd694b583b)(kind \
+         Checkbox)(syntax(Tile((id \
          3793f7be-52e5-43bf-beec-f2cd7fbcd74b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -67,30 +70,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          24084707-0050-42fc-b490-de082335512c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f9234ea2-af12-4028-a28e-7bff4132725c)(content(Whitespace\" \
+         1f6266ad-ee10-45b3-bc6d-80a00b0d1195)(content(Whitespace\" \
          \"))))(Tile((id 6fbd42d1-7c06-4cee-86ce-55f5deb5d4d4)(label(\"\\\"for \
          all r in rs, schema(r) is equal to schema(rs[0])\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         a3f8e277-2405-4b6e-8b0f-7b0b0fd40ea5)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         932cf2a6-a6a5-4e54-ba11-9707fbdcf20d)(content(Whitespace\" \
+         12bd9283-7688-4c58-8960-b59f095a2813)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         59452d71-42ff-489b-84a4-edc11e5721e4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ee8b137c-b725-4bab-b677-ffc3b60f2f63)(content(Whitespace\"\\n\"))))(Tile((id \
+         c97ec32f-46cc-4baa-bb4b-0d21dac2ab50)(content(Whitespace\"\\n\"))))(Tile((id \
          1db36776-7eed-4bd6-bbfc-d0b9d69f020b)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a182cc8e-7186-4c57-a6f9-655fc7a28963)(content(Whitespace\" \
+         d935d13f-dc3e-4cab-b0e5-61c293cf0836)(content(Whitespace\" \
          \"))))(Tile((id \
-         7696d94a-45b2-4989-9cbc-d867f340d088)(label(ensures))(mold((out \
+         7696d94a-45b2-4989-9cbc-d867f340d088)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7518419a-26d6-4434-9e38-ed67538acb4e)(content(Whitespace\" \
+         4b337604-4551-45dc-88af-35fbed721c2a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f7aee380-0394-425b-9077-8162bcfde498)(content(Whitespace\" \
+         033d9fab-4364-4618-889f-66ed52b105fb)(content(Whitespace\" \
          \"))))(Tile((id a60e17b6-c853-4609-87fe-566233fd79f6)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         8b78698f-7e3f-4e17-8bcf-028e15eb9897)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          43806d82-f9f2-4a99-9985-c14c86832480)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -119,17 +121,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7f561a81-4b62-4de0-902c-9c0e26843dc9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         06f6a2fc-4cac-4848-a553-0d70133f56e0)(content(Whitespace\"\\n\"))))(Tile((id \
+         bacba813-8894-42a0-9224-f088c400d16e)(content(Whitespace\" \
+         \"))))(Tile((id \
          e6c395d5-f1b3-48a3-9e3d-54c46e284d26)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          186e4118-9608-402d-80d9-7de8a2200c59)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         79a86b0a-550d-44f4-bd4f-cff2bcf1a0a5)(content(Whitespace\" \
+         \"))))(Tile((id \
          c6b4d6de-14f3-4d70-be3d-6d9909fb3096)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         f1c53646-dc07-46e8-82a3-60aebaf08b21)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9430afc2-301c-42cf-9093-c562a3fa2d36)(content(Whitespace\" \
+         \"))))(Projector((id f1c53646-dc07-46e8-82a3-60aebaf08b21)(kind \
+         Checkbox)(syntax(Tile((id \
          d4aae91e-32e7-4ae1-a1bc-4078539363af)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -139,84 +146,84 @@ let out : string * Haz3lcore.PersistentSegment.t =
          26e25b07-5fb4-44de-8430-3b3de2c77e6b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e638fdf3-76ad-4204-985d-15acaf87b041)(content(Whitespace\" \
+         661f110c-0ca9-42f8-a3f5-4eb415159749)(content(Whitespace\" \
          \"))))(Tile((id \
          1a020b00-58d0-4568-aa95-c442e5cd592d)(label(\"\\\"nrows(t) is equal \
          to length(rs)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3064ec24-8d18-4f54-a628-abd8d8f89cde)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         5cffb6a5-fc90-4155-88f2-f1c7bfb6797e)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         aa335378-c420-4616-b513-7245daae120e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c2a16205-8536-4cce-a6bd-62052d0f64cc)(content(Whitespace\"\\n\"))))(Secondary((id \
+         453c9c9c-5383-45da-9809-ead7aca37a95)(content(Whitespace\"\\n\"))))(Secondary((id \
          16b26455-df4d-4598-8b80-d592f60c5735)(content(Comment\"# Hazel's \
          tables are lists so this is just the identity function \
          #\"))))(Secondary((id \
-         6a3595f4-2aff-4853-adbf-1802f0590c31)(content(Whitespace\"\\n\"))))(Tile((id \
+         321c364a-87af-44c9-a05d-306c1c7bea30)(content(Whitespace\"\\n\"))))(Tile((id \
          3512d69a-1a04-476a-8136-066587330f12)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         91a996ee-8c01-49e0-a65f-efd68a3c4cbb)(content(Whitespace\" \
+         f2de0424-bbde-49c4-a1f0-2dd992a37624)(content(Whitespace\" \
          \"))))(Tile((id \
          e0874a2b-bec8-42a8-a6a5-debc3afcb022)(label(values))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         3ddafc62-5820-49e3-b5d7-263bd20fbb5d)(content(Whitespace\" \
+         11213dd3-b0ba-4da7-9889-ec998433279a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         790106ab-7021-49fa-aa1a-72270ff4868d)(content(Whitespace\" \
+         70c06b7b-06bb-40d8-859f-3f3ddaafca84)(content(Whitespace\" \
          \"))))(Tile((id 872ce046-5307-4981-b186-b26f57bdbe14)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         fa545e04-7b04-488e-a433-5d202722b515)(content(Whitespace\" \
+         0d634c6f-f893-40a0-81f4-846c06d5bbed)(content(Whitespace\" \
          \"))))(Tile((id \
          b8928539-3cd5-4f00-85ae-06a58a089353)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         9441f19d-5a4f-40b2-94dd-bec307f89ab8)(content(Whitespace\" \
+         20665f17-0974-457f-8521-07e87c79d3f4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5f083ccc-2db4-47f2-921c-b2d790de41d8)(content(Whitespace\" \
+         4b293381-f76a-4992-aa0a-94a9f737ff1d)(content(Whitespace\" \
          \"))))(Tile((id 4174f8a6-92f4-4bde-9ca0-a929ed7ab5cb)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         8219b1f3-508f-4486-9ff7-93b9a2bc02cf)(content(Whitespace\" \
+         1aef52a6-bd1c-4fe8-92e1-449850d60499)(content(Whitespace\" \
          \"))))(Tile((id \
          875ef29b-8905-48a3-a149-fb69da9cf3c2)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          1536dd72-d29e-4feb-9c54-ba25693ecac8)(label(rs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         deaeafe5-de37-421c-8681-5d21b6c2feec)(content(Whitespace\" \
+         \"))))(Tile((id \
          e1c190ba-3171-44f2-ada5-0d7a46f6a18d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2e0e0a67-ce4b-4a6b-a1db-6c2bce838028)(content(Whitespace\" \
+         136899f7-53a8-4231-91b3-20677b9adda8)(content(Whitespace\" \
          \"))))(Tile((id c15bbc58-a65f-403d-b1f0-53b311d47262)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          fdcc633f-d5f9-4cbf-aae7-d65d5f4bbd29)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         8f515f1a-d181-48e2-a528-5717c7654b9e)(content(Whitespace\" \
+         c0598453-a12d-4273-ae9a-288673ebf855)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2137d68b-6649-4784-ad2e-f150bf8c74d6)(content(Whitespace\" \
+         05acee88-6054-4797-a38f-0ed12ec4df40)(content(Whitespace\" \
          \"))))(Tile((id \
          dd099def-ee3d-427e-a7b6-c16381844470)(label(rs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         016b803d-0724-4bef-837f-453d388ad81a)(content(Whitespace\" \
+         0713a3aa-4585-488a-b1f9-36ba88ae15cf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         22a122d0-d4e5-4325-94eb-90168af239a5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         89a8d72c-b759-4d37-afdc-03f589e343a1)(content(Whitespace\"\\n\"))))(Secondary((id \
+         030079c8-9fb8-4329-bf22-0e544ddc0bab)(content(Whitespace\"\\n\"))))(Secondary((id \
+         0d52ada8-a1e4-4ee0-b1ec-dd1ec760d2bd)(content(Whitespace\"\\n\"))))(Secondary((id \
          7abd84fe-2784-4583-9ff1-5acdc6634d9f)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         e9db73f0-31f2-4a45-845b-dfe986a50208)(content(Whitespace\"\\n\"))))(Tile((id \
+         807d0184-0411-4b4e-84be-a17a057dd0bb)(content(Whitespace\"\\n\"))))(Tile((id \
          8e6ee5b9-e5e1-46aa-923e-d04f8f949902)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         71a889d5-897b-474f-8d23-9ca63f103109)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3693d84a-8388-4d9b-936e-6831f1aead45)(content(Whitespace\"\\n\"))))(Tile((id \
          18248abc-3733-454d-b236-d3b12a720d04)(label(values))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -228,10 +235,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          d6b7fec2-0e05-4028-958e-00d1caeba994)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9b6e5a37-cdc1-42a4-a570-3238df7890b1)(content(Whitespace\" \
+         \"))))(Tile((id \
          949767da-f03f-4cca-ae83-e63285e83ee2)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         756f6018-1c59-40b9-8b3f-5e771dbd71cc)(content(Whitespace\" \
+         \"))))(Tile((id \
          20a9086d-152e-4872-abc5-bef622666f29)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
@@ -247,12 +258,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b30b820e-518e-4f02-b66f-2fd37f68558d)(label(\"\\\"Alexander\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         c8b7a835-9adf-4889-bca7-a4dccd113b6c)(content(Whitespace\" \
+         6fe7ae03-692b-4555-bbda-1b377385106a)(content(Whitespace\" \
          \"))))(Tile((id \
          d46e9321-f884-48a3-b776-484a9c1116d2)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         76e02569-85d8-4a17-b0d1-455751736947)(content(Whitespace\" \
+         0a7d1977-c753-46b0-bc49-a0927e526e14)(content(Whitespace\" \
          \"))))(Tile((id a744fa53-f6bf-4365-9cd1-329788d489c2)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -261,28 +272,33 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          a556325c-7669-4919-8f62-c189181d4509)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7bb641e1-75a4-4d27-8955-92ed419f1997)(content(Whitespace\" \
+         \"))))(Tile((id \
          30f3ed77-608a-480e-8eee-3ec063af080d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         aeda5392-bc5c-472e-8958-642b368c06c6)(content(Whitespace\" \
+         \"))))(Tile((id \
          72ff8cbe-ae2b-41d6-b507-c4d6eb05c02c)(label(\"\\\"Alexander\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         22e8319f-8557-480d-82f9-768bc4b43eaf)(content(Whitespace\" \
+         a13a2a2b-59af-46e0-87fa-1dcabd36c79c)(content(Whitespace\" \
          \"))))))))))";
       backup_text =
-        "let requires = [\n\
+        "let _requires = [\n\
          (enforced=^^check(false), \"length(rs) is positive\"),\n\
-         (enforced=^^check(true), \"for all r in rs, schema(r) is equal to \
+         (enforced = ^^check(true), \"for all r in rs, schema(r) is equal to \
          schema(rs[0])\")\n\
          ] in\n\
-         let ensures = [\n\
-         (enforced=^^check(true), \"schema(t) is equal to schema(rs[0])\"),\n\
-         (enforced=^^check(false), \"nrows(t) is equal to length(rs)\")\n\
-         ] in\n\
+         let _ensures = [(enforced=^^check(true), \"schema(t) is equal to \
+         schema(rs[0])\"), (enforced = ^^check(false), \"nrows(t) is equal to \
+         length(rs)\")] in\n\
          # Hazel's tables are lists so this is just the identity function #\n\
-         let values = typfun row -> fun (rs: [row]) -> rs in\n\n\
+         let values = typfun row -> fun (rs : [row]) -> rs in\n\n\
          # Examples #\n\
-         test values@<(name=String)>([(\"Alexander\")]) == \
-         [(name=\"Alexander\")] end";
+         test\n\
+         values@<(name = String)>([(\"Alexander\")]) == [(name = \
+         \"Alexander\")] end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIConstructorsvcat.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIConstructorsvcat.ml
@@ -6,14 +6,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         bc293dff-95f4-471c-a389-6be39f3d23ad)(content(Whitespace\" \
+         b0b23d71-168d-45a5-ba14-3dccf87752f2)(content(Whitespace\" \
          \"))))(Tile((id \
-         88ee8559-58c4-4788-93a7-a7c603cccf7b)(label(requires))(mold((out \
+         88ee8559-58c4-4788-93a7-a7c603cccf7b)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9792a7a5-5d75-4e7e-9dbc-e38b6c267354)(content(Whitespace\" \
+         6893c073-9e1f-4494-b6a7-87d27dd41b82)(content(Whitespace\" \
          \")))))((Secondary((id \
-         04573f5c-db66-4125-b499-1f416bb3955a)(content(Whitespace\" \
+         01b4a3f0-468d-455c-b749-de6660b64e21)(content(Whitespace\" \
          \"))))(Tile((id 20cf6cd5-cf09-484a-a802-2086472c3114)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -22,11 +22,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          7935ecf7-6676-4be6-ae28-146da04e55fe)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         53d6f188-d943-45f4-b5fa-fcfcd88b92f4)(content(Whitespace\" \
+         \"))))(Tile((id \
          c4f6ba4d-7cae-4e82-8ee1-353c8e19b88d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         94b9bfeb-933f-4cc5-939b-04df4b99da3b)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c772ba7c-6023-4056-8949-c570923666fe)(content(Whitespace\" \
+         \"))))(Projector((id 94b9bfeb-933f-4cc5-939b-04df4b99da3b)(kind \
+         Checkbox)(syntax(Tile((id \
          f37cc049-9ecc-44fa-aadf-7b89691d098d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -36,34 +40,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          437d4863-dc53-4cba-81f2-47b852e8fa94)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b45519b0-beb3-4f4b-8969-e4b07536336c)(content(Whitespace\" \
+         9feb7b35-dc31-4b01-943e-17a720205675)(content(Whitespace\" \
          \"))))(Tile((id \
          8fb07d50-2b52-4e8f-8ab4-a6f1a0dcd5bf)(label(\"\\\"schema(t1) is equal \
          to schema(t2)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         4f9582b7-240b-415a-beb9-161ca4b3babd)(content(Whitespace\" \
+         28490626-c78a-4117-91d8-9e2b688ff48f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4d6ac78a-b8a3-4d2c-9009-691a62af2484)(content(Whitespace\"\\n\"))))(Tile((id \
+         afbfca61-ecbe-4240-afee-5eb767fda750)(content(Whitespace\"\\n\"))))(Tile((id \
          212fa0ff-cb2d-44b7-887d-eb068eb9da88)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         81a8853f-b48a-438c-99ed-34a4a9ff9d3c)(content(Whitespace\" \
+         ee53ac4d-596f-45f9-8d83-c0a62228f3ad)(content(Whitespace\" \
          \"))))(Tile((id \
-         a9e120e0-d188-44b7-8240-a284844e34b2)(label(ensures))(mold((out \
+         a9e120e0-d188-44b7-8240-a284844e34b2)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         fb98b7ef-0d86-48b7-828f-e6389596068f)(content(Whitespace\" \
+         369a9ab7-3de4-4c20-a6a3-2109a3c84b5a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6580ab19-24ea-412e-b958-b660605af879)(content(Whitespace\" \
+         592616b3-b059-4636-b8f7-cd63adfb2541)(content(Whitespace\" \
          \"))))(Tile((id f1577622-3497-492c-9f6c-4faf6c11d272)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         e9ab7502-e7fe-4f1e-b3db-4a6fe21f5350)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eb039438-ad2a-4167-97b1-854a9056b56d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         87715e26-8cb4-41b1-baf4-3208d43f0d9e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         595987ae-ab21-4b8f-9f73-602bd5a9e50b)(content(Whitespace\"\\n\"))))(Tile((id \
          23e9a96c-e611-49f2-af36-5e6f853dce86)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -92,21 +92,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          894fb7d9-2d3c-4fa9-b55e-fb0ca2522c22)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bfd07204-a1de-46e4-98b6-1bb3ae521caf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4133b029-0d80-4bec-b5bf-ce51099dd95c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3f7bb95a-fdf6-429d-a395-837acf668021)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ec4d5e59-b1f2-4431-a03b-5086a1b5f0a9)(content(Whitespace\"\\n\"))))(Tile((id \
          1f011a84-b417-441f-9b5b-78f5a4d2a2c9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          651b099a-49f8-4366-ae89-5890d8fb3c1a)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d7aaba18-72e8-484a-a7ee-4b7951a3aaa0)(content(Whitespace\" \
+         \"))))(Tile((id \
          6181169b-21be-4b02-8e53-c27d83aa1bcb)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         4e005abe-905e-4526-92bf-01a8df7af9aa)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         23a08afa-5409-4af9-b614-411516f086be)(content(Whitespace\" \
+         \"))))(Projector((id 4e005abe-905e-4526-92bf-01a8df7af9aa)(kind \
+         Checkbox)(syntax(Tile((id \
          9e1c9dea-5dfc-47fb-9655-7f6d045c2185)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -116,201 +116,193 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9807d4fd-ae82-462b-8fc2-752dff9b424d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c51e6502-787d-4898-920f-2f9592e7d601)(content(Whitespace\" \
+         ef3872d9-a121-4d90-ab67-855c8d13d9a6)(content(Whitespace\" \
          \"))))(Tile((id \
          49e804a5-cdd0-4c40-9433-189415a1bfb3)(label(\"\\\"nrows(t3) is equal \
          to nrows(t1) + nrows(t2)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         09b980a3-416f-423a-bbc2-cb0092acbd7b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a0cc2628-3bfa-4175-8920-f5663ba64254)(content(Whitespace\" \
+         5909cab9-e668-44aa-879d-7bc8fdedece8)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         2148121a-c7f0-4898-9dda-922f4d860e38)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0e941ee5-b1c9-46f7-8f9c-3ebe064487a3)(content(Whitespace\"\\n\"))))(Secondary((id \
+         3e4ac527-0f72-40ae-bd19-4636aa4761ca)(content(Whitespace\"\\n\"))))(Secondary((id \
          9be57a43-a7aa-467c-8fac-64a47f8e59f2)(content(Comment\"#Hazel tables \
          are lists; so vcat is just list concatenation. This is also the same \
          as add_rows#\"))))(Secondary((id \
-         4adb46fc-6d53-42f1-bd4e-df2401270a3a)(content(Whitespace\"\\n\"))))(Tile((id \
+         53a46768-7d7a-4762-8b30-64a2f1248042)(content(Whitespace\"\\n\"))))(Tile((id \
          af3c0cd0-c2ff-42a7-8d0e-64bb211ca4ae)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a7004a09-a23a-4574-a3aa-9eb6c1c047c0)(content(Whitespace\" \
+         d0e68100-8fc5-4c37-b78b-f6a6e1a9e490)(content(Whitespace\" \
          \"))))(Tile((id \
          d7feae9d-65e3-445e-ae1d-fdae37a13f5e)(label(vcat))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a245465f-8800-4738-9f2f-0580b1acd043)(content(Whitespace\" \
+         f9e76005-c119-4b0a-9e83-cfe4f4b04d3e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         dcbc3ab2-40f0-4a2e-8315-4e8076ba0dd5)(content(Whitespace\" \
+         2e3ce8cc-aa4b-49a3-afed-8899217ee99d)(content(Whitespace\" \
          \"))))(Tile((id eb870342-0a4e-4eaf-bbc6-e58876301f2d)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         fc8d8c08-5e1d-46bf-8721-e9218cf886e6)(content(Whitespace\" \
+         d2d22cd2-8c42-4069-a406-15f75647a627)(content(Whitespace\" \
          \"))))(Tile((id \
          2b94d55a-a192-46cc-8ae5-43a195016099)(label(r))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         64c553b9-cf0b-4a7c-9b5c-2e9b50c0d707)(content(Whitespace\" \
+         d5729aca-1098-4be8-a646-fd86753c14c8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2615969d-7210-49db-b5e8-6cf27d711a70)(content(Whitespace\" \
+         648a7866-a022-4793-bc2e-96d3913ff88e)(content(Whitespace\" \
          \"))))(Tile((id a685a255-702b-43cb-ae2f-fd36903d7738)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         d7ed40aa-6fb7-4b2a-881c-aec0aa666bd7)(content(Whitespace\" \
+         a250fc9b-acca-4188-a2ce-8a479e8218f1)(content(Whitespace\" \
          \"))))(Tile((id \
          edf5faf2-96ab-4708-95e3-80dc5c222a8e)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          2e484296-fe4e-4f02-90da-74e8c3c469b7)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0c48f98a-2ab3-4741-a8a0-6ac5da04b1b1)(content(Whitespace\" \
+         \"))))(Tile((id \
          e0ec9341-c6cf-4d96-a6fc-bc1fad5acd9d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         b1ebfe41-da74-4a43-8dae-236697d8472a)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ed02d107-41be-4125-be5a-cbdab35da138)(content(Whitespace\" \
+         \"))))(Tile((id b1ebfe41-da74-4a43-8dae-236697d8472a)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          c61b34c9-0114-45ff-8210-bf42f569b97a)(label(r))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          095ea174-8410-46a2-b8b4-778373f7da39)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         3d3e5a8b-d3be-4721-af58-404523237b78)(content(Whitespace\" \
+         c0df7350-cfc2-4f78-b169-bec783ab945a)(content(Whitespace\" \
          \"))))(Tile((id \
          a1083c4e-53d2-4019-af01-b1e450b6ec50)(label(t2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         53083d8a-21fd-4a4f-9b52-9a1f97ae96d3)(content(Whitespace\" \
+         \"))))(Tile((id \
          75a1d749-9f3a-49ba-8dfc-9f6793773f88)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         703e4ec0-9c9a-4dfc-ad11-90fd1d19b296)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         199b3322-48b1-4ca3-b776-5a0d001f03d8)(content(Whitespace\" \
+         \"))))(Tile((id 703e4ec0-9c9a-4dfc-ad11-90fd1d19b296)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          3b1aed4c-a8e1-427a-a05a-49d555cb7e08)(label(r))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         9a0d7aa4-b463-4ccd-9521-c59c2b17ec56)(content(Whitespace\" \
+         850325d7-c302-4ff6-b5e2-ff2decc1a1d3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         083b29b5-7f2f-4b2e-84ea-620af8ac42fc)(content(Whitespace\" \
+         1e9c2e84-0cca-471c-a041-0a0559feba2b)(content(Whitespace\" \
          \"))))(Tile((id \
          d867b13e-9790-46e8-8f2b-20decb26a270)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         a7deea70-af3a-4b29-9012-0ae051608491)(content(Whitespace\" \
+         ba0305f5-c7f4-4f98-8bb4-0053dd4c7954)(content(Whitespace\" \
          \"))))(Tile((id \
          9896fed6-d800-4468-a5d7-4a9f6b4253bf)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a889d047-8531-4e3d-94d4-ce99aebd2ab2)(content(Whitespace\" \
+         5c83a422-580c-49f8-ab12-beef50b201f4)(content(Whitespace\" \
          \"))))(Tile((id \
          89fa5487-a8a5-43f4-81cb-164b73855dff)(label(t2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         5e7073e2-6109-4c81-b433-4c8354cc5d46)(content(Whitespace\" \
+         7cdada7a-4502-44d1-9b9b-47e9ba183c36)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         56638c4b-e7b3-4be1-9e7a-4b76c6eeaf9d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0ec0ec92-9333-44a9-b880-6915e2c19740)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3268e7a1-47c1-4f18-ac46-cc08766a2b40)(content(Whitespace\"\\n\"))))(Tile((id \
+         8d7ba231-1dd8-42cc-9031-5a55ae4b36fc)(content(Whitespace\"\\n\"))))(Secondary((id \
+         34d91c73-9d90-4d7a-bc6e-9bdef2f34f1b)(content(Whitespace\"\\n\"))))(Tile((id \
          d09babbe-545f-4d61-9b37-9698ff9815ac)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         7cbaf0e8-f307-47cf-835d-505db829ab4c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         056fb427-4e3c-45e5-9d8e-9a1519341db5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e2043b67-9611-4885-baaa-727f55faeefc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f4a60edd-673a-4507-9cbc-0daa9051f452)(content(Whitespace\" \
-         \"))))(Tile((id 1ae925ee-276b-480c-a26c-1d6e2b1826ea)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         f095f0e0-951a-4c32-877a-0032572d2632)(content(Whitespace\" \
+         835700a3-fb74-4530-84b4-e9a680471d95)(content(Whitespace\"\\n\"))))(Tile((id \
+         1ae925ee-276b-480c-a26c-1d6e2b1826ea)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         6aeef155-0995-4886-ad41-9c44dd4fbc4c)(content(Whitespace\" \
          \"))))(Tile((id \
          598b0385-e2c5-4f69-8f86-124b5840a586)(label(update))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ab64d14b-7574-4bb5-88a3-4af32485f509)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0bfcfcfc-77ef-4bc4-b3fc-b82ae23aaa0e)(content(Whitespace\" \
+         d7537bef-d18f-4dad-8868-1e32fd76cda3)(content(Whitespace\" \
          \")))))((Secondary((id \
-         849bc324-7b81-4435-b037-fe0a6828b5f4)(content(Whitespace\" \
+         0aebf86f-74b6-42ae-995f-5a1f1ce03fdf)(content(Whitespace\" \
          \"))))(Tile((id f520d04d-3bfd-4a3c-8261-832e2e781274)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f7e710e8-0231-42e3-87be-d5371106dcf8)(content(Whitespace\" \
+         f35af31e-184e-4413-a529-b845d7aa3fd1)(content(Whitespace\" \
          \"))))(Tile((id \
          73d51c9c-53d3-40f9-9e72-a5514571fa28)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         42d480d3-e697-4c79-b32d-61febd48c625)(content(Whitespace\" \
+         d499f7e7-5a50-436d-bf52-eb9dccbd5bdb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b3636809-5302-44d7-bff8-691d66ce0801)(content(Whitespace\" \
+         705660db-5fb8-4fd0-a87c-8f108176ce2b)(content(Whitespace\" \
          \"))))(Tile((id 0c676269-387d-4d0e-aecb-c692e346b152)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         c46152f8-e717-4e87-a45d-0d3b6800bbd3)(content(Whitespace\" \
+         71865e7b-231c-4e4a-a237-fac1364fa8a0)(content(Whitespace\" \
          \"))))(Tile((id \
          caa9dbcb-c983-414f-ba73-990013c0d9b6)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          401dc4cd-80a3-443e-bc43-5950dba52180)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         301ad298-6b8c-4476-a174-15a9feb1b2a3)(content(Whitespace\" \
+         \"))))(Tile((id \
          96c5248d-3154-436c-988d-534eff824171)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         88f619e8-40bd-43b7-82d8-b66e3ee234ec)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9a3894ac-b225-4e8e-92fc-d4c26d436800)(content(Whitespace\" \
+         \"))))(Tile((id 88f619e8-40bd-43b7-82d8-b66e3ee234ec)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          f776a9a3-d544-45da-a8bc-ec91166e150f)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          070adbd9-8b4c-403d-99f0-d997827ab0c2)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         e7a4e3cd-eb54-4213-83b6-c18cc1381f6a)(content(Whitespace\" \
+         0ae8b677-7d10-415f-bdf7-1167404fbb4d)(content(Whitespace\" \
          \"))))(Tile((id \
          3a571235-82e2-498d-93cc-dc8632ebafa0)(label(f))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e962be09-1c03-4900-b4ef-7055fbccd362)(content(Whitespace\" \
+         \"))))(Tile((id \
          5ebb4621-c5ad-4790-a0c1-87fda9d9bb11)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6348f642-5dc8-4643-ac07-eff443606c1a)(content(Whitespace\" \
+         \"))))(Tile((id \
          9f1285cd-75d2-4a4f-bddc-2105b004c3fc)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          44a4e579-1004-48c7-989d-fdd376871aa6)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         19adc1b9-6089-4e6d-9f16-d1b11b156702)(content(Whitespace\" \
+         06fbfa5b-f367-4e8c-b8fe-0318cb05fa77)(content(Whitespace\" \
          \"))))(Tile((id \
          a20c3f7d-04d9-400b-a7fc-992cc053cc99)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0c14037d-2e01-4a6c-849b-38f4d4d4b343)(content(Whitespace\" \
+         b227fc58-1a10-46f0-9d58-f85c855f5fad)(content(Whitespace\" \
          \"))))(Tile((id \
          654a5fbb-8f20-4576-9e21-73e9cbefec63)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         c8217180-cd27-4791-b354-fa71dae33df7)(content(Whitespace\" \
+         51858256-5164-400c-a7e4-3fafe1bb2349)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f0981b0e-c938-4bc0-b9ad-0324ff30f20b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f6a8c74-33be-440b-b198-aaab05a27a17)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         baadabdc-6201-40a8-9cb6-c8349fb9320f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b326d56-affd-43a8-a0a6-3ef4c288f1fe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f07c5182-cdb1-499c-a0d0-47914f90ec78)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b6812736-f095-4fb6-8643-7fda59b7daaa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb88a988-39be-49b5-92b5-a765612ca162)(content(Whitespace\" \
+         51e4d333-de8e-4ea9-a7ce-1e6e116c4b07)(content(Whitespace\" \
          \"))))(Tile((id \
          ffeb93ac-7d46-42fd-af3a-22983809447b)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -324,12 +316,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          872430d4-ba8a-4521-b7f8-74af693c3f62)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f1a65e4a-9feb-40fc-88f6-32504719d356)(content(Whitespace\" \
+         f6132d99-90de-45ee-8e91-3e86cc58fe05)(content(Whitespace\" \
          \"))))(Tile((id 3a2c4700-c818-46b2-9dd4-63b0ed8f8cbe)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         dc291511-c060-4d5e-930b-6fe76bb6e9c2)(content(Whitespace\" \
+         7dad3d9c-860f-4807-a8b9-ed720d3eff8b)(content(Whitespace\" \
          \"))))(Tile((id \
          36357d3d-16c1-4c8c-8124-c49698463f54)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -337,19 +329,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          512eb11a-dcc6-466f-92fb-08664ed372f6)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6bcce28f-1465-4f6b-8480-70b15466c063)(content(Whitespace\" \
+         de878e1d-de81-4340-bbda-80773a383a86)(content(Whitespace\" \
          \"))))(Tile((id \
          d8b9797f-9209-42c7-b3a3-0034e229ed6e)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         82228b4a-3b01-4650-b235-45286910e9d3)(content(Whitespace\" \
+         7976e42d-92b9-4299-87ea-82aa1ff6e4c3)(content(Whitespace\" \
          \"))))(Tile((id \
          16ae2759-4053-45f4-af4c-9fc61390cdec)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         dadebbc5-3277-46b4-9e3e-4d531c7bfdbe)(content(Whitespace\" \
+         a435c7af-3002-4619-8f2e-da4d8a1fee9f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0958c865-a659-46c1-b260-ecac55a4d601)(content(Whitespace\" \
+         7b623b12-7dfd-470d-a215-4bd999e7e3b5)(content(Whitespace\" \
          \"))))(Tile((id \
          c3ac8cca-790d-4056-99bb-b5b51075e09f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -357,22 +349,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f6f51520-50be-4a45-80b7-47512e05592d)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         0b846400-1222-4f0b-9c5f-eaca7a48c759)(content(Whitespace\" \
+         b97efadb-3439-49a3-ac4f-f5dd4267582b)(content(Whitespace\" \
          \"))))(Tile((id \
          9040f502-d718-42b5-a507-4e409147f791)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9ee1db50-8e97-4dcb-8e27-7f8ddc1bb17b)(content(Whitespace\" \
+         d823c508-9813-4e1d-8ffa-f1d79848a5f8)(content(Whitespace\" \
          \"))))(Tile((id \
          7e5de862-37b8-469f-be91-28517b1cf8fc)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f02f9d92-eaca-4202-8a4d-66470b074d72)(content(Whitespace\" \
+         e9788892-7fae-44f3-9120-e4c0256dcc61)(content(Whitespace\" \
          \"))))(Tile((id \
          81101bbb-750d-44aa-8db3-00210bdf089e)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9b4a0db3-8ce6-45f8-89d6-1e3e5115ce29)(content(Whitespace\" \
+         d3f30c80-5145-4f3e-90e3-77a83a31215d)(content(Whitespace\" \
          \"))))(Tile((id \
          8549ae9b-bc9c-4511-88cd-5b91ac260d82)(label(f))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -383,119 +375,114 @@ let out : string * Haz3lcore.PersistentSegment.t =
          961066d3-6b1a-46e2-8c5f-fe60444a9197)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         7993bc3e-d41e-4540-bdff-39df3b23cc32)(content(Whitespace\" \
+         16efc990-94e6-4ed2-95a4-61224f590bcf)(content(Whitespace\" \
          \"))))(Tile((id \
          5be70ad4-e748-43a5-a0fb-b906fae3c367)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a6e250d5-b75d-4dd9-962c-1b42de11068c)(content(Whitespace\" \
+         22aab55d-713c-4a85-ac1c-69a81e6466b5)(content(Whitespace\" \
          \"))))(Tile((id 38530c4f-cc70-46f1-bb82-f8cbf1f28c17)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          60d48a97-641e-4436-8851-7b6d6e7b7039)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         5f8b3c81-cd58-4ae8-81ce-6c6079643c4c)(content(Whitespace\" \
+         f584156f-af68-4748-bda0-04fed2b0e257)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ef359221-39b2-453b-a4f4-1dbc5fa0fef9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         acfe1d5d-8225-4b61-bf05-c3c84ae85973)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5487f0f-baa9-41d2-a119-c546d6c9f873)(content(Whitespace\" \
-         \"))))(Tile((id 9a58e545-54ac-4c1e-b0d1-a274be615dea)(label(type = \
-         in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         5b4cbbdf-9b2c-4b6b-8653-e6332a391dcf)(content(Whitespace\" \
+         8ca7043b-65c4-4e65-a4e8-74fd584dced8)(content(Whitespace\"\\n\"))))(Tile((id \
+         9a58e545-54ac-4c1e-b0d1-a274be615dea)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f5678776-1725-42ef-b378-4fa1dd1a2ee9)(content(Whitespace\" \
          \"))))(Tile((id \
          865794f4-04af-410f-8cf0-448c3165bb7d)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         38f8f829-63a0-44fa-8e01-3e109c5abcce)(content(Whitespace\" \
+         54121149-318e-4e05-8dc0-eea6d3ccc01a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         093cb62c-c6b3-41f5-aa34-9f6da7935a6d)(content(Whitespace\" \
+         a82a07bf-28d6-4e37-9827-27abf7057bbf)(content(Whitespace\" \
          \"))))(Tile((id \
          edf6e0b4-98d5-48ea-b8d5-ca178e6c21fc)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          46f45570-2109-436f-89be-f1e6dc863569)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         83241620-aa15-4cfd-8a6c-8a44764bf090)(content(Whitespace\" \
+         \"))))(Tile((id \
          a174f243-fb6c-47cd-8134-0b0ec65ef84f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9c0c5cc5-3197-4bf1-9dd1-54a2b3f21444)(content(Whitespace\" \
+         \"))))(Tile((id \
          12cc4b0a-5989-4dfd-bd2a-f5e54fb8f9e9)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e40e40c5-c71c-4b4c-b9da-c299d55b43cb)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a5b3ec6a-9c77-4f23-9d1b-253002f30108)(content(Whitespace\" \
+         6187f681-9f5d-45c9-a2c5-9beb8d568e22)(content(Whitespace\" \
          \"))))(Tile((id \
          b50ca743-2508-4ddd-9cc8-7024e89fcc60)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7581929c-9011-4f37-9ccb-0843054a1226)(content(Whitespace\" \
+         \"))))(Tile((id \
          af423f25-2998-4032-84e6-6bec0420246e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cee8b81f-0802-442c-a183-778113aef2cc)(content(Whitespace\" \
+         \"))))(Tile((id \
          c895e82d-b38e-4eea-9b32-e933065a4022)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b6a062e1-a2c6-4b6d-a62e-74df3e0c3096)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6835abcc-1e73-47b7-b7f6-ea50cd72566e)(content(Whitespace\" \
+         d0843dee-9988-4814-8352-58545680fd96)(content(Whitespace\" \
          \"))))(Tile((id \
          6696fab0-3554-4e8c-8960-19c4e46eb72e)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         22557479-b8dc-4e80-9084-2540d3deba47)(content(Whitespace\" \
+         \"))))(Tile((id \
          f9a3dda2-bdc2-400d-8604-2717f6fca448)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0865e08e-2ffc-4ea8-a0e0-800b45da04c3)(content(Whitespace\" \
+         \"))))(Tile((id \
          b8ae946c-4c80-4635-a083-ec43a4f02dc6)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a848d658-071c-47a1-afd2-f060fb4ad89a)(content(Whitespace\" \
+         1c791f85-dc70-4880-982d-f3f79a658b18)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3843a07d-bb4a-4838-a81a-58e627490603)(content(Whitespace\"\\n\"))))(Secondary((id \
-         78b0a220-d04c-44f9-86d8-2b6741141241)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cdd9e8ea-6e2b-4914-a7f6-c41b664867d0)(content(Whitespace\" \
-         \"))))(Tile((id 13992a57-5eef-4a0a-9566-dfbf3980749b)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e6ec2c6b-1310-492d-9d77-e3808c6ee09e)(content(Whitespace\" \
+         798dc0a3-57ed-4c07-81a3-448920985605)(content(Whitespace\"\\n\"))))(Tile((id \
+         13992a57-5eef-4a0a-9566-dfbf3980749b)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         52d51201-ddec-4e78-a4f2-b6a6cd87f1a7)(content(Whitespace\" \
          \"))))(Tile((id \
          bb665c35-62b1-414f-8602-172a8bde6395)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f07a61fb-88c6-4d02-bc10-2d947d7ed0a4)(content(Whitespace\" \
+         bee3e914-ad5d-4e57-91c7-90cc7e46343e)(content(Whitespace\" \
          \"))))(Tile((id \
          6b134c11-2271-4aed-920d-a50f637dd2eb)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         aff7a08f-8290-4fc3-a390-5ab6ecb2d2b9)(content(Whitespace\" \
+         56aba37d-10ef-4338-8f05-af706f8392c8)(content(Whitespace\" \
          \"))))(Tile((id 376ac34e-33aa-40a6-8f16-d4ed0c053152)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          1c169790-e66e-4f3c-becb-8216e66e04c8)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         bf8ffa0a-a7bb-448e-a981-5298bdf45380)(content(Whitespace\" \
+         a36455bb-b82b-41a5-8faa-1e01c4a1d815)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a7e149e2-800a-4ed5-af18-1b7c54b4b220)(content(Whitespace\" \
+         86b6e7f0-c168-4e63-bb69-937385eb6d7b)(content(Whitespace\" \
          \"))))(Tile((id c07d3340-b2df-49ea-b125-c7841227ded4)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         c7f1a997-9994-4d41-96a7-6f90b957b93a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4aa2f9af-3887-4077-9396-7c5d74ca6f82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a2eecb0e-f82b-4d97-82c2-9241421f9430)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b0aa5103-4832-43ae-9d6c-8b6cae3b8c4c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f5353840-7c41-493c-97b7-3163c653ce2d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          49acdf68-0030-48a3-9c92-85d8f87ab2b2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -521,14 +508,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          08fe56fb-7a82-4780-b531-ec5672c2309f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         06460692-c3b8-48f4-b288-f6758b5db4b7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3021cb45-763d-4eef-a6a6-7f3219705bda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6ad5e7ed-99c6-4f74-8fa3-6286927fc6a4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4968880c-20de-4318-828f-086ad34621db)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d2d47406-fd17-4f34-956a-cad5ec18e65c)(content(Whitespace\" \
+         65830611-f9e9-4761-91d2-89b1188db352)(content(Whitespace\" \
          \"))))(Tile((id \
          169c4c60-57e1-4ea9-bf8e-00eb873ce45d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -555,14 +535,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2c150f7d-898d-431b-afaf-c2c1bc1a60bb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6b54b026-a392-49f3-9a76-fda8305561e2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cdad2f48-b85c-4e08-9af2-d9906a32de44)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8b3af6e-2c81-4de4-824e-bdea471540ec)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3129801d-2955-48f1-9f7d-8e8bffa92b4f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6901c5cf-5ab2-4222-836c-345ea43932a3)(content(Whitespace\" \
+         63f8c848-e8cf-4b6e-98fe-0e6b4486c45c)(content(Whitespace\" \
          \"))))(Tile((id \
          1178a76e-9035-4553-bf53-ff2eef44798c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -573,7 +546,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          136f8a39-4c69-4859-876c-b344029ed5f0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b8fd5eea-d068-41eb-a9e2-c8038ff45dfd)(content(Whitespace\" \
+         8d335dd4-ab0d-4b6f-9cee-634baafb435a)(content(Whitespace\" \
          \"))))(Tile((id \
          3f8f302a-407e-4997-8424-66a496f61e6e)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -581,23 +554,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e3c514fb-2a12-4ec0-982a-0deb6bad5db6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         31156a3c-02dd-4518-a703-d41526403ce2)(content(Whitespace\" \
+         cd0f862e-49fe-4eab-91ba-6c92344a0a8b)(content(Whitespace\" \
          \"))))(Tile((id \
          706767c5-6426-43d0-8643-ffa946511b18)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6a490246-b7f7-420b-9d23-df2619c701a9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         79f5d78a-25f3-433d-af54-bc805370fb45)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b7abb9b-c90f-41cf-8cc5-1dae4562a56d)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         4e8a9476-ccec-444a-928d-db556c2c3fb9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e112c4b1-955c-4208-a9fd-9863dae84265)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b47d4e4d-1bf1-4e17-b2f7-c8146900a3a7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1f710658-cdda-48f4-99f2-ec0512daa756)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0602bd26-a844-4636-8ace-8c0e18843b23)(content(Whitespace\" \
-         \"))))(Tile((id \
+         d125ee90-b6d2-4cb0-a832-75f5fc5857cd)(content(Whitespace\"\\n\"))))(Tile((id \
          a4b5ecbe-0f19-4589-87c7-04b93b267758)(label(vcat))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -616,16 +580,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          adbf0c05-f31e-4a8f-8f7c-bf155cb1bd80)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8cac3f21-6167-4288-8bec-bdc97d5b45d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cdce3659-d14c-4b7d-9dcb-510e50f91fef)(content(Whitespace\"\\n\"))))(Secondary((id \
-         819886b1-23c8-49ff-b258-fc135a18198a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         144cef43-1368-491b-a40c-d494c0fbf14e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8226180f-0be7-4ec2-800a-ea58a6396097)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2638e172-5d94-460f-8fd8-31475546d4c6)(content(Whitespace\" \
+         4bc5fe42-43e4-4fca-8fd2-9ee2e8c0ee58)(content(Whitespace\" \
          \"))))(Tile((id \
          bafae572-68ce-4f48-af7f-e396fbc5fdcd)(label(update))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -645,29 +600,33 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f9aa1ca7-b9f5-4f90-9c9e-e7b486b85bfc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         146bb4f0-9a84-4086-92ef-cc5b51e1338e)(content(Whitespace\" \
+         0852c1b3-66a3-4683-9b7c-7331341038b1)(content(Whitespace\" \
          \"))))(Tile((id 245318d6-5479-4cab-b6c9-cc2073dd8f96)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         d8d2b5ac-567c-4b26-9a6b-3631c3586293)(content(Whitespace\" \
+         588fb256-8795-4b85-b6a4-3bf44a30dcdf)(content(Whitespace\" \
          \"))))(Tile((id \
          7f88b0fe-cac5-4511-b3a1-00489a779d62)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9a0299e6-f376-455d-a7e9-55d5d56e305e)(content(Whitespace\" \
+         92ee8500-e42b-4932-9129-aa18a73db176)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         79cc669c-62a4-46da-942c-574a6f901760)(content(Whitespace\" \
+         ea041fe5-d6cf-41e6-ab07-f6076ae278a8)(content(Whitespace\" \
          \"))))(Tile((id \
          668b26e9-0794-495e-9cb4-eec8a3418a55)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          2b07b89a-17c6-4779-aa91-980380e1b109)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e6323d3d-b503-4d42-a652-318cfa9992af)(content(Whitespace\" \
+         \"))))(Tile((id \
          b9613dcc-66b0-4338-b32b-a963879895cc)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         20c6db40-61a6-4938-82ed-3903cea501b0)(content(Whitespace\" \
+         \"))))(Tile((id \
          deca7a4b-c7f3-4ad1-a689-35a353bf0eac)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -677,43 +636,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          44fbb4e4-454f-4947-b3c8-64faa6c142f1)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         4084c054-babd-4f48-b8c4-4871b9003933)(content(Whitespace\" \
+         6bd2085b-2716-42a4-991c-3716e6c2b5f1)(content(Whitespace\" \
          \"))))(Tile((id \
          32c65934-e261-497e-991b-9d82f36e1822)(label(+))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d11d1a4b-9332-4ad7-a40c-328f319604a6)(content(Whitespace\" \
+         ce96f61b-d6dd-4bb6-8534-338f0120b671)(content(Whitespace\" \
          \"))))(Tile((id \
          dfd25963-28b2-413c-ad35-380573f29aac)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         cf47ab00-919b-4ea3-8556-72fe30dbe439)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e7ee35f0-59b3-4445-8975-7cd05150ecf7)(content(Whitespace\"\\n\"))))(Tile((id \
          2c733ef3-3fed-4d75-a0b2-82d9e46fa3a2)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         668c4f1c-2880-4783-bd13-86da97872581)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0818ed94-054c-4364-973f-ffcb5068f736)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         84687beb-3018-4747-9207-588d761b145c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04ee79e7-dd58-403b-80a0-305231d31aaf)(content(Whitespace\" \
+         573c781b-4cfc-40a0-a301-8779f1aa5225)(content(Whitespace\" \
          \"))))(Tile((id \
          fcb1408e-fbe7-4dee-b139-fda815f492dd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         64c6e5e0-690f-4e27-81e0-02c278fccd1d)(content(Whitespace\"\\n\"))))(Tile((id \
          923a7ceb-4396-46fb-9d64-a7de315d21e5)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         546bb320-6894-49f8-8991-8b854ef1ee8b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         aba3eaeb-55d7-4d09-9037-29cfd5a9099b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d3a052b0-41b2-48af-a2ba-971d384a0abd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eaaf80b9-c851-4d22-88db-12264eb938e7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1943a9cb-61f3-4b85-a224-6145cb768f62)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          2650ac23-07ef-478b-9ae9-b0c0e509cb79)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -739,14 +684,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8e6d04bc-6583-413d-934d-98964d1c20ff)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3e9943e0-cba2-4cd0-90b6-c7db4a0c1b4b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4f57047b-063f-45fb-994c-ed51fd9bb152)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9eaa5e38-88e4-4e05-9f63-d4aa7cbd9d06)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e56d042-d6ca-4551-be72-2de75a622516)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ff4577e2-2730-4397-9309-76ec61457cac)(content(Whitespace\" \
+         fda51fc6-af85-433c-90ef-9046c0613ba0)(content(Whitespace\" \
          \"))))(Tile((id \
          bb10ae1f-e143-4e41-9202-4f2e31df3a00)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -773,14 +711,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          15df72f2-3fe8-4525-bec9-2d0e79754e91)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dfc151bc-73fe-469e-aa22-2dfbd3285940)(content(Whitespace\"\\n\"))))(Secondary((id \
-         644dc1ed-b661-4f32-89a3-a7b0aef4ba05)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         caf96dd8-08c0-4a77-a596-9afae60b438a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eb87ff7e-8f5a-4967-aca5-b608ed1fecc7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ca053f3c-e742-4335-a834-d4255358b96e)(content(Whitespace\" \
+         9f372a39-8fa3-4e7c-9471-301b64e4a111)(content(Whitespace\" \
          \"))))(Tile((id \
          e804efb5-485e-445d-90a7-353c1a4c82bf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -807,14 +738,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4db9fe12-6650-4303-959f-27635a748110)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7656354a-4f5f-4ec5-8f88-089b8019b068)(content(Whitespace\"\\n\"))))(Secondary((id \
-         31a5c108-10d5-4218-8a87-7f90f6bd76aa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d2700f07-50c0-4eb7-9880-7ee5c6decf85)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         45564aa8-f7f7-4bb4-bd5d-ea8035febad4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ec4827b5-368f-43d4-97db-90bab2ad937a)(content(Whitespace\" \
+         77f41375-82c2-40ba-9c79-315fb3a08017)(content(Whitespace\" \
          \"))))(Tile((id \
          059c01b2-2813-4c28-b321-242ac66b58eb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -841,14 +765,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          25ea151b-652b-4922-b761-62a349437a6e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3874cf04-e97a-4291-b724-d5c1a547f42a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         51abeec8-e8d3-4f69-82da-84a4a13901f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         26ca127b-777f-446e-b333-72502cd397ff)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33fdddd8-15cb-4f23-8c83-076df2aec0f3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         59d5d445-6bc7-40fc-b1f0-7992dacc1d88)(content(Whitespace\" \
+         6e201710-881c-434d-9efa-62b43cb4f073)(content(Whitespace\" \
          \"))))(Tile((id \
          2b1b30f9-784a-4d5b-93f7-a57ec72a39be)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -875,14 +792,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          29cc7bbf-f608-4954-a5dc-1509336b3deb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a4e79d11-b329-458d-b107-3e819d58ec29)(content(Whitespace\"\\n\"))))(Secondary((id \
-         21f07058-2da0-49bd-8547-acf9a584668a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5382b3d-8b5e-4850-ad05-c6e50b2d6d00)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aee3ff9f-fbdf-4a84-9d61-341c3ff9c38b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         204f5421-9f61-455c-b9a4-70339482e53b)(content(Whitespace\" \
+         36875c5c-0c9f-44b5-b227-70ba34627b6a)(content(Whitespace\" \
          \"))))(Tile((id \
          506ea631-c30a-41ef-a51b-9263ae7f63f9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -893,7 +803,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d26b5829-9f3c-41f6-996e-16b776006b25)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8a87f40a-56d9-4f2b-a880-f37c7780ab15)(content(Whitespace\" \
+         8e593153-1bee-4880-9f71-a094c902516b)(content(Whitespace\" \
          \"))))(Tile((id \
          344ce5f9-bf6f-4083-9ca4-7ab76b97f725)(label(14))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -901,60 +811,49 @@ let out : string * Haz3lcore.PersistentSegment.t =
          de83509a-d073-4c16-8311-f12d8c3689eb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2fe9d9a9-d21a-4dab-8737-6f91b865506c)(content(Whitespace\" \
+         97cff549-b404-4c91-a875-cb12eead8c4d)(content(Whitespace\" \
          \"))))(Tile((id \
          17018f34-e98a-4d71-8aad-66f1f6ca8c62)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         88aef5f5-40ab-46d0-97b0-8ab99c3d4081)(content(Whitespace\"\\n\"))))(Secondary((id \
-         927e169a-5831-4b57-86a0-88cb1f35c6d5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bcf4db44-642b-4efe-acc6-b4b23ff92c64)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         119e9430-63f7-4462-95b7-f3b6153f5c7a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         14d1c027-11ff-4e7f-a144-717d8024ebd7)(content(Whitespace\"\\n\"))))(Tile((id \
          0955f289-ab5a-4fbd-98c1-ce6115dd5c8d)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         758f8325-1fda-41af-a86e-6c7a922e814d)(content(Whitespace\" \
+         fcfece1a-81f3-460f-bcdf-88dc2a5b1223)(content(Whitespace\" \
          \"))))(Tile((id bb98254c-564e-4e84-88ce-4f64d1124f22)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          129aaf1f-e5b0-446e-bb9b-fd4995b4753b)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         34e0b48a-0837-4f72-8d1e-fe0cbac12d24)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a566e266-5cdd-4ae6-b254-c59379033809)(content(Whitespace\"\\n\")))))";
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         f9bfc8fb-174f-40d7-aa3b-8ef3f5d56cb1)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c96b2c0e-4b51-497a-bf54-bda21195fff5)(content(Whitespace\" \
+         \"))))))))))";
       backup_text =
-        "let requires = [(enforced=^^check(true), \"schema(t1) is equal to \
+        "let _requires = [(enforced = ^^check(true), \"schema(t1) is equal to \
          schema(t2)\")] in\n\
-         let ensures = [\n\
-        \  (enforced=^^check(true), \"schema(t3) is equal to schema(t1)\"),\n\
-        \  (enforced=^^check(false), \"nrows(t3) is equal to nrows(t1) + \
+         let _ensures = [\n\
+         (enforced=^^check(true), \"schema(t3) is equal to schema(t1)\"),\n\
+         (enforced = ^^check(false), \"nrows(t3) is equal to nrows(t1) + \
          nrows(t2)\")\n\
          ] in\n\
          #Hazel tables are lists; so vcat is just list concatenation. This is \
          also the same as add_rows#\n\
-         let vcat = typfun r -> fun (t1:[r], t2:[r]) -> t1 @ t2 in\n\n\n\
-         test \n\
-        \  let update  = typfun row -> fun (t1:[row], f:(row -> ?)) ->       \
+         let vcat = typfun r -> fun (t1 : [r], t2 : [r]) -> t1 @ t2 in\n\n\
+         test\n\
+         let update = typfun row -> fun (t1 : [row], f : (row -> ?)) -> \
          map(t1, fun (r : row) -> (r : ?) ... f(r)) : [?] in\n\
-        \  type Student = (name=String, age=Int, favorite_color=String) in\n\
-        \  let students : [Student] = [\n\
-        \    (\"Bob\", 12, \"blue\"),\n\
-        \    (\"Alice\", 17, \"green\"),\n\
-        \    (\"Eve\", 13, \"red\")\n\
-        \  ] in\n\
-        \  vcat@<Student>(students, \n\
-        \    update@<Student>(students, fun r -> (age=r.age + 1))) ==\n\
-        \   ([\n\
-        \    (\"Bob\", 12, \"blue\"),\n\
-        \    (\"Alice\", 17, \"green\"),\n\
-        \    (\"Eve\", 13, \"red\"),\n\
-        \    (\"Bob\", 13, \"blue\"),\n\
-        \    (\"Alice\", 18, \"green\"),\n\
-        \    (\"Eve\", 14, \"red\")\n\
-        \  ] : [Student])\n\
-         end\n";
+         type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = [(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")] in\n\
+         vcat@<Student>(students, update@<Student>(students, fun r -> (age = \
+         r.age + 1)))\n\
+         == (\n\
+         [(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \"green\"), (\"Eve\", 13, \
+         \"red\"), (\"Bob\", 13, \"blue\"), (\"Alice\", 18, \"green\"), \
+         (\"Eve\", 14, \"red\")]\n\
+         : [Student]\n\
+         ) end";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIDataCleaning.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIDataCleaning.ml
@@ -1,3817 +1,4115 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Data Cleaning",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
-        "((Tile((id 0b1ea9bb-7f54-4710-8a8f-c14493de666a)(label(let = \
+        "((Tile((id 27594a9d-8e4c-4a54-9d30-ddde11f446e7)(label(let = \
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         d0a65569-6b05-4a04-b0ca-24b9f5bdc6e8)(content(Whitespace\" \
+         b24fa315-93bb-4325-8774-27acbf9f2318)(content(Whitespace\" \
          \"))))(Tile((id \
-         2544ed7d-5d6e-4f4b-9250-54bcf31d757f)(label(pivot_longer))(mold((out \
+         da3824bc-25a2-4916-aee5-f96ebe1adf9f)(label(pivot_longer))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e847b5be-dd40-4d2a-9747-e5d96d7fd6fd)(content(Whitespace\" \
+         cdcc8a6e-620b-4d1b-b352-71205465bfb7)(content(Whitespace\" \
          \")))))((Secondary((id \
-         fadd5cdb-a38f-4d1c-a807-97b84a869d54)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9767742e-292a-44f0-9540-0130e886e8db)(content(Whitespace\"\\n\"))))(Tile((id \
-         dc6de79e-c969-46bd-b1bc-b5ab7659d7f8)(label(let = in))(mold((out \
+         f05647c7-c6b3-4e6e-b68f-18e3a1559ae4)(content(Whitespace\"\\n\"))))(Tile((id \
+         00097cb9-9fb8-4426-8c01-413a86634e6e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1d697c07-7f22-49f3-a179-fd6a435ed049)(content(Whitespace\" \
+         2e5f63ef-294c-402e-81ac-ead87b7a3352)(content(Whitespace\" \
          \"))))(Tile((id \
-         7ed82fae-ecd5-484f-834f-94669d3918e2)(label(requires))(mold((out \
+         58367238-7953-4050-be5b-f4563716dc9e)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         18a8e3ec-ef1a-4669-98f3-dbd225df08ba)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         0ffbd7cf-0df4-4daa-bbb5-e57d7630b328)(content(Whitespace\"\\n\"))))(Tile((id \
-         ceeb49e8-d2a9-4751-90e1-68f6610d6eef)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         73e6caa4-f07f-4188-bb42-9c50709f3004)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         cf6f02c9-66b9-4edb-9413-4753fdb87311)(content(Whitespace\" \
+         \"))))(Tile((id 7e8378ac-cc78-4a2d-8460-4eb60d7d550f)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         96d721d1-3281-4fb8-a0ea-813b3360ead9)(content(Whitespace\"\\n\"))))(Tile((id \
+         0b941d59-23b8-4c65-b295-4326997ec52b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f2192eb8-807b-4ab0-9267-2cd63db36e1b)(label(enforced))(mold((out \
+         a0fb542f-ed6a-4354-b521-962c43aa7203)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         04144858-ece7-4fcc-b65b-340f18a03533)(label(=))(mold((out \
+         6b50b869-7b1a-4c10-bb72-98b35b8dbb30)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         66002544-9b0a-4f46-a98c-fdce61bc5ca2)(kind Checkbox)(syntax(Tile((id \
-         3ab7c764-8deb-4bb5-b019-ddc0d3511729)(label(\"(\"\")\"))(mold((out \
+         c5b789e5-abd8-4bea-9552-8fc7aaf0e2ed)(kind Checkbox)(syntax(Tile((id \
+         e136e0e3-9334-4bd1-928a-ddf2219b7517)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         1529cf61-205a-40b3-92bb-a5d44c48b0f0)(label(false))(mold((out \
+         86ac400d-b8c1-4752-ace5-69cba388c2f9)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         f6181a9c-cc08-4bc1-bcf5-fef4293fe520)(label(,))(mold((out \
+         e90c0c92-6e6b-4d29-be07-d37b16c4aa82)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b3d54480-3eb6-463f-b970-f090589f0582)(content(Whitespace\" \
+         62e8047a-f06a-4627-ada4-c5a5ec477d91)(content(Whitespace\" \
          \"))))(Tile((id \
-         91b4c98f-7a97-4381-bcfb-110abdc2a6f5)(label(\"\\\"length(cs) is \
+         aba3ed03-598b-44b7-a5fc-f31fc1a03b03)(label(\"\\\"length(cs) is \
          positive\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         e50fa6db-96ab-4daf-b85c-5ad2c626904a)(label(,))(mold((out \
+         8d4e9c5b-706d-4dcb-b85e-26f08e044c91)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69fc7af3-1f01-4a2f-a4ae-626ea687a8fa)(content(Whitespace\"\\n\"))))(Tile((id \
-         b09f7eb7-fb82-4767-9e5e-27e67cc8c63f)(label(\"(\"\")\"))(mold((out \
+         d79acf45-8e4b-40cb-803e-06f7d4d9e9df)(content(Whitespace\"\\n\"))))(Tile((id \
+         03f75268-6f94-48fa-be2d-fd68ff67b1c5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         7b487678-b63f-47ed-9cb7-4f980174cc00)(label(enforced))(mold((out \
+         1a895268-83e1-4e26-a1c4-8ec6bc18016d)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c7754c52-2791-4f69-9873-33fc2e8cadd5)(label(=))(mold((out \
+         636981da-a0dc-42cc-ba96-2bcf72922173)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         e5b53d5a-5419-4e0e-97e9-b0fd5d0d5e55)(kind Checkbox)(syntax(Tile((id \
-         ea568889-e7a6-4ab5-84b0-aa7fbd0d4270)(label(\"(\"\")\"))(mold((out \
+         706af9c9-5e03-48c4-a713-afbbb37736c5)(kind Checkbox)(syntax(Tile((id \
+         4b4dc29b-246c-491d-a948-6fcb0dbf9b1b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d6e282be-137b-4a22-a69d-de7d273d1783)(label(false))(mold((out \
+         2156861f-e218-4a1b-bed1-de684f24449a)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         be58307e-206c-44d1-9c02-439a196a9186)(label(,))(mold((out \
+         4cd41d71-1d6a-4b2d-be9e-d274c0970649)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2553dcc4-be40-46c3-ba43-fd79b7bf23f4)(content(Whitespace\" \
-         \"))))(Tile((id 8983a5fc-5679-43e2-89b9-b210c9f41503)(label(\"\\\"cs \
+         708a72cf-f1e6-45d0-9f02-b5a0b2c1ba6e)(content(Whitespace\" \
+         \"))))(Tile((id b2d290cc-c0e8-41c4-a57d-0af472feeb14)(label(\"\\\"cs \
          has no duplicates\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         95298d13-92d4-4688-ae80-718135b6c406)(label(,))(mold((out \
+         3696ad33-184c-436a-adec-53b6a4598597)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69d9f548-9e0d-4008-90b2-0f8b1714a7b7)(content(Whitespace\"\\n\"))))(Tile((id \
-         5fe2d5f7-e7b2-4769-8fed-f360149ac665)(label(\"(\"\")\"))(mold((out \
+         11f1c2ac-8ff5-4231-81f8-00d6967829ae)(content(Whitespace\"\\n\"))))(Tile((id \
+         7ff2bc89-9dba-4430-aa8a-c95ba076a0a5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f2bfcbe7-b065-4e4e-8d5c-174fb07aa7f7)(label(enforced))(mold((out \
+         1f31b7ad-3c84-4e64-8f9c-650d1ce141c6)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b3e6c72b-57b3-4d0a-b9ec-9f1cdc074b98)(label(=))(mold((out \
+         a689fb6a-12a9-4865-b5e4-e07c58a61988)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         3278aab8-6bc4-417d-8a77-190214835c45)(kind Checkbox)(syntax(Tile((id \
-         3afd4f5a-dd56-4723-b828-be86c21657ed)(label(\"(\"\")\"))(mold((out \
+         9447ed49-f978-4458-8127-a55760c66381)(kind Checkbox)(syntax(Tile((id \
+         6b417a81-a055-4be6-b6ec-b59e13e772e0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d02601f4-a0f1-42b8-9706-4be2de08b735)(label(false))(mold((out \
+         4241870f-980f-4617-8544-1f673a580594)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         320ccde6-ed25-4bff-9665-ef9d06ff4d91)(label(,))(mold((out \
+         e3f28839-7d97-45a3-980d-90efc5ad4ac9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         91e3a9aa-fdaf-4c4d-9014-ebe553d54a47)(content(Whitespace\" \
-         \"))))(Tile((id 17486258-72b7-43c5-8877-dd8a4ca3d730)(label(\"\\\"for \
+         2a910e21-abed-44b7-aa21-590b9db27674)(content(Whitespace\" \
+         \"))))(Tile((id c9547bf3-0b37-4248-b192-b5339a39f576)(label(\"\\\"for \
          all c in cs, c is in header(t1)\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d4756d76-ac2e-4d26-af33-3abcf8d3ded9)(label(,))(mold((out \
+         cbdaa64e-ad8b-466a-b59b-c477c3fae769)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5a7aa717-0e80-4836-a3eb-3ea3e13a36c7)(content(Whitespace\"\\n\"))))(Tile((id \
-         ef0290ca-6e88-483e-8547-7158258e48af)(label(\"(\"\")\"))(mold((out \
+         50723f84-98b3-42a1-a644-41260bc59e53)(content(Whitespace\"\\n\"))))(Tile((id \
+         f4abecd6-4bb6-4219-97f9-bb6b50f267b9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         ab0882d2-e3d1-44da-9762-2b919d1db1ca)(label(enforced))(mold((out \
+         c7016836-17ff-4b7e-83f0-6691c982d246)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         527fe59f-3e0c-49e1-994f-71e845ba6f47)(label(=))(mold((out \
+         cd3b4cdf-5fa5-4706-aa8d-e7500d0a17f3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         e15a963d-df53-4a4c-8d83-4e3a66fb987f)(kind Checkbox)(syntax(Tile((id \
-         8c752bfa-5060-48d1-b624-5327090be5f4)(label(\"(\"\")\"))(mold((out \
+         2efa5283-8d84-4141-9153-4875d61972b9)(kind Checkbox)(syntax(Tile((id \
+         21427af5-d7dc-4779-aaf6-38a7152ece54)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         84039f3c-6673-42d3-bc85-73a6784ef955)(label(false))(mold((out \
+         dc067877-22b7-4729-85a5-dceb8b5d8430)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         794da461-43d3-4b41-9fa7-f19da08f3ad1)(label(,))(mold((out \
+         7cc16cfa-36d1-43bf-8617-6a389a6099f5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ae5048d0-aae5-4e7e-b2df-0d40f20ecb32)(content(Whitespace\" \
-         \"))))(Tile((id 4a39c37f-e396-48f1-9f8f-1d154b591626)(label(\"\\\"for \
+         4657b8e2-c5fe-4dc3-9c03-eecd844e95ec)(content(Whitespace\" \
+         \"))))(Tile((id ee011cb0-7d68-4f12-b9f3-e8d47fd13d70)(label(\"\\\"for \
          all c in cs, schema(t1)[c] is equal to \
          schema(t1)[cs[0]]\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         67bf079a-ac61-4460-9565-ef10ecc4fe16)(label(,))(mold((out \
+         04a0df31-1110-4bd2-b92c-8b7455677fe4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         77ae997f-fb2b-4cce-b132-da611579c767)(content(Whitespace\"\\n\"))))(Tile((id \
-         7ce2ab2c-84f2-4304-ae78-cde48426d3f8)(label(\"(\"\")\"))(mold((out \
+         b655d501-750a-401e-b326-997eef416da8)(content(Whitespace\"\\n\"))))(Tile((id \
+         000381c8-e583-4a90-8ac9-f0393e6be988)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d46e1f31-6ffd-4a6b-97a8-7799afb59509)(label(enforced))(mold((out \
+         685732d0-79b1-4467-80c7-ac32b03d8736)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0c9c7210-6cdc-4a7d-9e7a-99cc93347013)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b0c858ba-5426-4cbd-b56f-03b32b7936aa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5dae6efa-a4a3-426b-937b-8bad5bd6a36f)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         e6887f39-39d7-4855-948a-456c26eabbff)(kind Checkbox)(syntax(Tile((id \
-         7cd0a60b-6e37-4de1-86cf-2eb67a30984e)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         51539cb0-9519-47ab-8d23-a7ab80019e7f)(content(Whitespace\" \
+         \"))))(Projector((id a9ff0d32-3440-44b5-be8b-5e84da22de11)(kind \
+         Checkbox)(syntax(Tile((id \
+         d4f9ab8b-5b2d-4d8b-8548-07e16a532b55)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f70f0131-53ce-4eca-bbf2-46a56d2927d3)(label(false))(mold((out \
+         ed96ab16-4cbf-48aa-b765-63f76e971264)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         ca90162e-1754-47f3-b713-ff89c51ac8f3)(label(,))(mold((out \
+         1bda7f42-2cd5-4fb5-b040-f59aa72396d8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         853cdb13-2082-4248-ad70-8708cc7d09ca)(content(Whitespace\" \
+         d497145b-3472-4d9d-aa61-fa0fcac25b3f)(content(Whitespace\" \
          \"))))(Tile((id \
-         2ae42d96-7d29-4f0a-91cf-4a66ec045d6e)(label(\"\\\"concat(removeAll(header(t1), \
+         fad4c8ef-8083-416b-9f76-d096bc465622)(label(\"\\\"concat(removeAll(header(t1), \
          cs), [c1, c2]) has no duplicates\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3ea61e63-b7c9-4a9e-a691-01d124b30dae)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         0fb638e0-e8fe-4417-a7cf-56cba08604ba)(content(Whitespace\" \
+         f6b69b68-a543-43fc-8b27-99f5bca92342)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         6db76f9b-95a2-4b3f-915e-99c161278d6a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0dfa7f85-ab2b-4448-bd1a-1c04a1ba0c30)(content(Whitespace\"\\n\"))))(Tile((id \
-         433809e3-0488-4df8-bec2-e4e51e4e883d)(label(let = in))(mold((out \
+         1cd614cc-b431-4a0d-ae0f-6ccd35e49384)(content(Whitespace\"\\n\"))))(Tile((id \
+         da5b6dc2-2a28-4250-8ae7-d38eb1cc4ffc)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         ea0a5091-7eec-4da9-bcf7-9ee13084f33d)(content(Whitespace\" \
+         f1e1da98-2074-4a6a-82ec-7ab15213ee8a)(content(Whitespace\" \
          \"))))(Tile((id \
-         8d1a801e-05e2-4c7b-bf68-0f8d4f45f69d)(label(ensures))(mold((out \
+         b3bd2afa-86be-4c4e-9e48-371aacc5f4c9)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         281c2539-7492-456a-b59b-b10b4049acba)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         b5eaa3a9-0aca-45f5-aba5-49fd261858f4)(content(Whitespace\"\\n\"))))(Tile((id \
-         fac1b4c6-93cd-4981-90a0-84a62de5a817)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         523a2b7b-cfe0-473e-b0c7-ecda9fb85928)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         99cf16df-781c-4e16-adac-1fde14f121c5)(content(Whitespace\" \
+         \"))))(Tile((id 3186b8af-6091-4063-8054-73169338ccd0)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e0a16a83-844b-4f37-98bf-88d9e2b6e073)(content(Whitespace\"\\n\"))))(Tile((id \
+         2a696494-db2b-410b-9e0e-86b95fc6d7f4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d90158a0-ffe8-4769-bc1c-50f7cf8dffd1)(label(enforced))(mold((out \
+         fc515c29-8713-4eb0-a671-50a1f769ee75)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         146b609a-40e6-4310-aecd-36b15073293a)(label(=))(mold((out \
+         e1b4127b-6ce1-48be-934e-6bbf4786ef20)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         71100e88-fcfe-4eea-a699-7897e9671ec6)(kind Checkbox)(syntax(Tile((id \
-         abb52caa-3ca9-47b0-9a39-0d0c3634ed0e)(label(\"(\"\")\"))(mold((out \
+         515f3ef1-6569-4c1e-8efb-8df07edaf6f5)(kind Checkbox)(syntax(Tile((id \
+         b31a8116-7b80-4441-b4da-a6b0ddad5d2c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         35095554-2dec-45a3-bc26-aefb270c7ff1)(label(false))(mold((out \
+         645a964e-c0e1-453d-ba8e-f88989741731)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         29832b58-1acd-4f4c-8ce6-d1f54b9bc4db)(label(,))(mold((out \
+         38bac37b-40d6-4b37-8315-0809af817915)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         202cdf48-6062-4fb9-a4ff-bbcc18f01a0f)(content(Whitespace\" \
+         1fc6f423-3381-41ee-84c3-47a385dae711)(content(Whitespace\" \
          \"))))(Tile((id \
-         9a983128-3bef-427a-abe9-858c079802c8)(label(\"\\\"header(t2) is equal \
+         115ea044-1c33-4a14-9abc-686a8b51d3ec)(label(\"\\\"header(t2) is equal \
          to concat(removeAll(header(t1), cs), [c1, c2])\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         87d02dd1-f5cb-43d5-b20c-6dc971b0df4e)(label(,))(mold((out \
+         7f4952ec-618e-49c8-bd5f-f47dbb2e04cc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         94610d47-9052-449e-8b2a-c9e2cddd2fea)(content(Whitespace\"\\n\"))))(Tile((id \
-         ee222304-ac3c-47a0-b322-51d2b97eca42)(label(\"(\"\")\"))(mold((out \
+         ff8000b0-570b-4431-a23c-84c9a35db98f)(content(Whitespace\"\\n\"))))(Tile((id \
+         4031ca95-03c3-4e8c-8537-c9c797e56a18)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         26467fa4-5c89-4a5b-9530-618a6e55bfe5)(label(enforced))(mold((out \
+         901601d6-06aa-40f5-9cf1-95fa6f848e58)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a9f59a22-d5bb-4357-bd52-3ec80af2731a)(label(=))(mold((out \
+         b3a33944-3790-4115-a914-08d318eb0fe7)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         d0037592-49a0-4a45-a19a-8dec3988d7a6)(kind Checkbox)(syntax(Tile((id \
-         0ae3c3b2-d7bd-4d2f-a9cc-ac3ff8a27944)(label(\"(\"\")\"))(mold((out \
+         2ba38d51-6c96-4aa9-a2c8-c6e7079de578)(kind Checkbox)(syntax(Tile((id \
+         69873641-7231-45cf-9f7e-2d529054abb4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         8c68a546-45b4-4c42-9121-c2b5b80bbe61)(label(false))(mold((out \
+         f5aba418-a3d8-42e0-a973-73a87eb588f9)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         c932d87c-2786-4e0b-99ef-9fadd387d1f2)(label(,))(mold((out \
+         c7cbca07-ac6b-455d-9e7b-0071a720ea91)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2b2d6dc1-ce62-402a-a41e-eba1cae8c825)(content(Whitespace\" \
-         \"))))(Tile((id 736d1db0-a814-46af-b25a-73d8b3be93dd)(label(\"\\\"for \
+         eaa41bcd-53ea-465f-bebb-0a27cec215c9)(content(Whitespace\" \
+         \"))))(Tile((id a68460cc-e9c1-4fc0-b19a-7f9fae1c03f4)(label(\"\\\"for \
          all c in removeAll(header(t1), cs), schema(t2)[c] is equal to \
          schema(t1)[c]\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         0e4f6fa3-d121-4c44-b6a9-61205ced91b3)(label(,))(mold((out \
+         266ebf58-16f9-4090-bb98-f495745d872e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b7c985ef-7938-4070-b792-5abb1addebf4)(content(Whitespace\"\\n\"))))(Tile((id \
-         360697eb-bb1d-4efb-b4ec-3e7a2ca9a139)(label(\"(\"\")\"))(mold((out \
+         597ff357-7d88-4b25-b8fb-8854738b2752)(content(Whitespace\"\\n\"))))(Tile((id \
+         b5ddf227-d765-4cf6-9885-e98ec3f03c5a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         dff8a56a-0d19-4309-a45b-c5e4287c648e)(label(enforced))(mold((out \
+         ba824a03-229b-470a-b2e6-6dece28b3765)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ff366d1e-bcb7-4239-90f1-0a6c6e979732)(label(=))(mold((out \
+         3c662739-13bd-46e8-b2ce-ff152de6dfe7)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         935d7255-2081-4af9-8114-5a5a7895619d)(kind Checkbox)(syntax(Tile((id \
-         a6350b1d-ceb3-4f51-ae47-8476d5c6f729)(label(\"(\"\")\"))(mold((out \
+         f4f86128-6126-483c-98df-4eab8912c9a2)(kind Checkbox)(syntax(Tile((id \
+         eab1e8d8-be18-487c-91d3-d8699b50714b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         0834d888-6e41-4f96-a8b1-0ae2e64dbd87)(label(false))(mold((out \
+         6ca3c29f-581e-410f-bbc2-38a86cbf726f)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         d673c625-ca4c-450c-ab41-1cb612f2e570)(label(,))(mold((out \
+         c5d6ff35-4c51-4db1-a015-823707fa4ce8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         089ea8c5-5bb1-4497-bd25-eea7def4f3e2)(content(Whitespace\" \
+         9b557410-aac2-4a2b-a90a-ff81859fb66f)(content(Whitespace\" \
          \"))))(Tile((id \
-         f8027bd6-87f4-408a-82a5-8ac514da6bfe)(label(\"\\\"schema(t2)[c1] is \
+         3a75b283-971d-4768-956b-c9003d309cd8)(label(\"\\\"schema(t2)[c1] is \
          equal to ColName\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8fc10e33-8218-4242-b772-2d3f99b352f6)(label(,))(mold((out \
+         4139fb75-b228-4635-9ea2-6ee41abf1127)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3b186727-7be8-402c-b0e2-ffe377977458)(content(Whitespace\"\\n\"))))(Tile((id \
-         8947c06a-19c6-4df9-8061-760f87d9be0c)(label(\"(\"\")\"))(mold((out \
+         f1b01453-0b9c-478f-8fd1-0ea903b9737a)(content(Whitespace\"\\n\"))))(Tile((id \
+         8b3a989d-7ac3-45f2-867a-2b34970875f0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         7ca7f87b-cc95-4737-8a67-d31945a8785f)(label(enforced))(mold((out \
+         fe065815-8289-4594-b215-957fba33d77c)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         99399ce5-073f-4ac6-9b83-99de674cfd5a)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         df1db015-c816-436d-b778-5fb35c774dd3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b91ed8fd-64a0-4913-bea1-76829c48bb6b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         88768c2c-759b-4b6f-b1e9-1a7ecdf6604e)(kind Checkbox)(syntax(Tile((id \
-         c2f9d2c2-5eac-45b2-beda-ca5b9aeb96c4)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1ac2096b-86f6-425d-9262-de60e5ab867c)(content(Whitespace\" \
+         \"))))(Projector((id edca62d2-87ad-477b-af22-fc758cda695e)(kind \
+         Checkbox)(syntax(Tile((id \
+         0bb98013-bbfd-4389-80e2-10c0102eb2d3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         51a970bd-030e-464d-902c-9278419f0988)(label(false))(mold((out \
+         64a12f27-f091-40ae-ac53-42a7b138f66c)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         fe8f526e-b944-46f1-83f0-3dbebdd400fc)(label(,))(mold((out \
+         3611200a-5ded-421d-8f3c-c39083c60346)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         91842a48-aaa7-4fa7-96b4-b2feb3867937)(content(Whitespace\" \
+         1617f71a-9129-4653-8c26-7ee59e3a18e4)(content(Whitespace\" \
          \"))))(Tile((id \
-         4a2714e0-8801-468b-8c85-408e862b040f)(label(\"\\\"schema(t2)[c2] is \
+         322ce3ca-0cd0-430c-b91d-9374d7ac66ab)(label(\"\\\"schema(t2)[c2] is \
          equal to schema(t1)[cs[0]]\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ef147cff-c9e5-449a-b9fc-cd2010ab1845)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         b7adfb96-46c6-4fd5-9795-002d1df95d52)(content(Whitespace\" \
+         3684b7e2-671d-4012-8c95-222ba9b5d177)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         6158c144-c91c-4abf-b127-bf16d319729e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         98e66535-c420-4e7d-af58-2a3f26ed3709)(content(Whitespace\"\\n\"))))(Tile((id \
-         a32802e1-caac-4775-a9f6-9c2141a7dbf1)(label(let = in))(mold((out \
+         86f609d6-da0d-40c7-96f3-e7713c310195)(content(Whitespace\"\\n\"))))(Tile((id \
+         25a88b6f-9a59-416e-a940-29f9c8d056a2)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         4a3eee01-e665-4aed-901f-b0fa4a41b34e)(content(Whitespace\" \
+         15ca0337-75e8-4efa-80c9-f5d445e23a01)(content(Whitespace\" \
          \"))))(Tile((id \
-         db6e9694-70b0-41cb-9178-c5f6ed6f49b9)(label(pivot_longer))(mold((out \
+         8f2b601d-cdea-40b7-8663-d9fd53fa6c1e)(label(pivot_longer))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         82de40d4-9b81-4fc2-9874-25970c3ccd32)(content(Whitespace\" \
+         714aa6f7-375b-404f-95e2-097919765d69)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b06f74d4-527c-4dff-a921-c2377ff9b767)(content(Whitespace\" \
-         \"))))(Tile((id 395f656e-d0a7-4232-a846-a48fa47d4609)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         5daef3c5-8122-4f28-bbec-02202a12dd9b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5b16f0d5-6788-4611-b190-e2284b2ed971)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         5ba62676-6770-4468-abd8-72b8ca8c8b26)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d24b255a-fe06-40a8-b493-1058f1a69675)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         d06970d8-38c1-47b9-8de3-174f45a3c1af)(content(Whitespace\" \
-         \"))))(Tile((id \
-         63932883-6d1a-4933-a850-33cfe511ba39)(label(cs))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         f2df75da-fdcd-4206-b357-476694e201ba)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         97a618ae-1102-43d2-b291-9ad0a3436e03)(content(Whitespace\" \
-         \"))))(Tile((id \
-         22a12ef9-3019-44ff-ac99-ae4dab98bde8)(label(c1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         f1391388-82d9-4263-bbf2-55f03a0a99c8)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         bdc55070-f894-4451-a63b-2922d0ab847b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e0751d6e-f828-446b-9f2a-299f694b2c42)(label(c2))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         eb429780-3b89-4d6a-b158-e8245759b90f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         55ef28ea-3cc8-43a3-b30a-781e4af8c9d2)(content(Whitespace\"\\n\"))))(Tile((id \
-         1f5aef5e-573a-48c5-aaa1-d30ae41b2c15)(label(flat_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9f5d2230-ffc7-4c9c-8ba7-195650d6a144)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         59c2b511-ab33-4efe-b9b1-3a011d271063)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2307c2f0-c48b-4e65-85f5-31683dd09e85)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         32396960-4379-4fd5-a147-c5e1947795ee)(content(Whitespace\" \
-         \"))))(Tile((id 10772720-0512-4c90-80c5-83c169557d72)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         dd498a71-02b3-4ae3-b036-13aa6a6dfb6b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e3edbf49-9384-4906-b54e-65d89fb9a4ca)(label(row))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         6a47216e-2c1e-411c-8d45-36bc56fe6498)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         332f5f86-5df8-48a8-9eb4-3010afbddf1e)(content(Whitespace\"\\n\"))))(Tile((id \
-         8c66bb0b-0984-4cd5-8dfe-b50212ed8161)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e20869d8-7b05-41b8-8678-8c4976d68011)(content(Whitespace\" \
-         \"))))(Tile((id \
-         333edcea-05c3-4c3b-ade0-ef590f844956)(label(entries))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         2c6be03d-f156-4fdf-9abc-503a0f5f3551)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         3a6dc944-12d7-494f-be1c-00531623d9c2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cb321dcc-f509-47f2-a59f-128314eed854)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d17e396d-755f-4cd4-b257-a8b0dae5ecdc)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1d5122ac-2621-4c0b-a861-29b1c60ecc6d)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         41c39956-f24b-485d-9c1a-d89b722a5c19)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b6000a9b-de83-4679-a039-676e4c3a9e06)(content(Whitespace\"\\n\"))))(Tile((id \
-         eba12496-48f2-4769-9c30-3652b76dd2f2)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c7713165-f832-4363-90a3-4455382e427b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6ad2c0b2-5231-41fb-ace6-d5a48ee0c0d7)(label(pivot_entries))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         4a1c9994-6015-4ad2-bdfe-db70050c7f1e)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         e8a35cd0-2b26-4f3d-b9d1-b7f775e30d45)(content(Whitespace\" \
-         \"))))(Tile((id \
-         def4606f-5456-4555-8439-e12077efb641)(label(other_entries))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         7f402878-66c4-4d47-ba9e-203b6e948bbc)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         714d8e5e-7b9f-4401-b453-1548eeb152a8)(content(Whitespace\"\\n\"))))(Tile((id \
-         67425ddd-b85c-4131-956e-6f83456b0b2e)(label(partition))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cccc6d64-d930-4a1f-a589-c1dcb39035bf)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         ecc79fa0-e700-421c-a9ff-299dfa6c251b)(label(entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a86b2d29-66a1-4999-acd4-6fb6c4a52ee5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         974cae43-e2ad-4a11-bdcb-0fc97adcc842)(content(Whitespace\" \
-         \"))))(Tile((id 0a56bfa7-92bd-4422-9a4d-21b873ac0450)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         17ee099a-15da-458d-8a78-944d5e6e13fd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0a9a61f3-299b-49b3-bd08-f7ba63143a0f)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         cb89ff5c-b1b5-42b5-865b-3277f2a26408)(label(label))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         e04049be-87ef-45b1-a5e2-14447e0cc183)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         e4c73513-4a4d-4251-950b-955db392fc54)(label(l))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         9690d5ab-eca0-4354-9b8f-7d48df26146f)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         792f9aea-41d7-4ed2-ac62-8a34f45c1ba4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         91cd6f4d-e6ef-41fa-9074-5f82337ee310)(label(value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         57aa3faf-7d1f-485a-a5ae-c3e479403d62)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         44e5ea07-33d5-46d8-a5f4-37368ab59b2d)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         eb0d3e7a-c7c2-484c-84cb-0d99678f3c52)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         163c95d4-50f9-41be-a5f4-042d9e2b39ae)(content(Whitespace\" \
-         \"))))(Tile((id \
-         68a6439a-d8e8-43c0-8716-9d8ca3531f5c)(label(contains))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d0449102-8f8b-4bc4-bd5e-b402de70d15f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         5413a433-5257-4322-bbe4-35ce1577e33d)(label(cs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         833cd12c-3398-41fd-8e55-ec226b3c2c11)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         12ac1419-b685-4b33-ae7d-a12d810b87a8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         14a6a785-e1d4-4f7d-8698-ffa0b69416d4)(label(string_eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8f93233a-794e-468e-a568-b236613291b3)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6e42a3d8-e7a2-43c7-a1ed-c9f1501dbe65)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b836e2ed-2978-472f-bfa6-b4d9d3211c90)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         85d9f0d0-6535-4f02-a49f-5b72f49e4bcd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         af8be6e8-2bd0-4f4e-a48b-a23ef37772f6)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         759c21c9-42fc-428a-9cc2-9179b0730e4d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         a7e0c4af-fd5f-457b-9ca7-2af74865b424)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f8736a72-7fd9-4a4f-9c96-dddd1a892b31)(content(Whitespace\"\\n\"))))(Tile((id \
-         4fa8466d-c640-498f-bf37-06f1d21d5746)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8e8ca5ab-6748-4277-87cc-02b48f4d58e9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a203724e-6b6d-4b1c-b69d-342654af9a6f)(label(rest))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         f32a4f28-c88f-4ee9-9a22-6795988522ac)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         1d419335-00ca-4262-8c33-bd7415d93032)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aa162425-9a55-4791-b852-b1f66469dd4a)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         90c4243f-85a6-497b-9552-defae92d1544)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d2491e32-0eaa-4c3e-9a36-ee01d8599356)(label(other_entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         29849ff2-ff12-4b9b-920b-c3b29876d486)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f3036372-d451-4fbc-adeb-19675b23ef74)(content(Whitespace\"\\n\"))))(Tile((id \
-         782bd4b3-98dd-4686-bf7a-62086f4b973a)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0f6aa8c6-74b1-4a11-abad-d3a9da70b890)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4f99974f-c908-4f93-8375-88d03e1d0cf2)(label(pivot_entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         723bf4a2-1321-42e0-8262-a3fdeb321b5b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0e5f19e2-74de-42b6-abe6-dd454d05f703)(content(Whitespace\" \
-         \"))))(Tile((id 726abc88-79c8-4d55-b00c-be0357f51fcc)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         58a22525-3854-4875-9d9b-57917ccfdddc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2de72dbe-adf1-4238-9906-a95684f9bf86)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         097fdf58-d5ef-4763-b9be-092005828d19)(label(label))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         14b74d2b-ee71-4fe9-b20d-6b88d32be637)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         13b3ca70-4f31-479c-ad1f-886dafb61227)(label(l))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         81b9c73e-0b9e-4940-a086-64d746886f5c)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         9e95ac1b-139d-42ce-b869-aa0c86bb5d9d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         69d2d6dd-d4ab-4b8f-bbdc-76a083cb64ec)(label(value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         b303f305-22c5-49ca-b049-ad2f0b584d2c)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         09306207-a62a-45b0-b647-083cd32c20c7)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         b6c8d089-27f9-483c-99bd-5ce24bf3324d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         295dc955-c051-48f4-909b-685877f0e8a2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         12663564-88de-4de8-81d3-c6dc911fb9d2)(label(rest))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         6efad4bd-0099-48fb-b7ad-46f9ba2bc6d8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5370b2de-53aa-4a43-8368-c0c4d47cce12)(label(...))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a9fde8c8-8578-40f9-b53c-a74eb1321167)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ef3cdca4-69dc-43fb-8182-a4cd6723e7d2)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         87e737d9-3520-452e-87df-c395e39f932b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         acef7a42-b6c3-4e7f-ade3-c7944d3320a2)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         b3687aeb-d0cc-4e7d-8ea6-3f2c1d466da9)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         44f462e3-8962-4b14-8904-fb7ebf2be880)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         32f0a5dc-17f2-4a2f-92ed-7f74e5458838)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0b25e8f9-540e-4279-9cc9-cad5289d54a2)(label(c1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         97de7746-9185-4eb3-bf02-d84d4e2830d6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ff78fce3-7c6f-46f8-8c1c-7fe1f0d3bbac)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cd50e176-3fd9-4b8c-b3e9-55e42bba1c28)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         120b65ca-bfb9-4d6c-a49c-3ada6ff2585d)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         62551fd4-33a9-415d-9e05-5e0ab8b4de4c)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a15ea1a7-773c-4b4c-9414-70f278ca3b20)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f49ecd52-11f0-4980-a3c1-92aaab5914fe)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e5001266-e102-4e3b-8f0b-645b779339f8)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         a060606d-de84-4d47-bfa0-2b22aa1b1068)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8fd9c66b-862d-4655-8b96-09319209ae6a)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         890224d9-ec4c-4acb-a5c0-fd4681ff238a)(label(c2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6b02e587-0cbf-4c46-b45e-e5d5809e9377)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1d0d4137-83e7-4aa4-a750-bc6bee0fd372)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e154ac31-1c7d-44a3-aa12-3add31fc5342)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         194c1087-27f0-4d63-81c2-c3917d64477d)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         789c1dc9-2330-4fff-8e9c-4bdac72dbdd5)(label(v))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))))))))))))(Secondary((id \
-         2001cc01-66e8-430e-9118-7f152db465da)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         635663ae-6878-46d8-887d-3b38a54da833)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e42de4b1-c819-4f31-9723-1d47153ff01b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         17f4437f-a8fd-4189-bd2b-96355c28a684)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b755a7c7-4b03-4987-8f95-848243f94f2a)(content(Whitespace\" \
-         \"))))(Tile((id b16d0853-e8d5-40a0-90e9-bdd1d079165e)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         998624f4-06c7-4c20-be69-32e09faa673f)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         5d558b0f-c9ff-4e6d-8c9a-44fb7a19d807)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         dc760875-5330-49c6-b92c-fe4b853f2000)(content(Whitespace\"\\n\"))))(Secondary((id \
-         502cfa9e-8cf5-42dd-b482-f3ea2d522d9c)(content(Whitespace\"\\n\"))))(Tile((id \
-         680517c2-b868-4060-9d6f-2eb91e59b37a)(label(type = in))(mold((out \
-         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e163578c-5271-4019-aec5-5323a299c3c2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7fefc0a1-3270-465b-81a1-dd704dccc96a)(label(GradebookEntry))(mold((out \
-         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children())))(Secondary((id \
-         bf525008-9d55-4e73-b192-7d1917dfc40a)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         a987463f-2199-4113-a6b1-ffd19b0986f4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3b65dd79-0b23-4ec7-b485-687dc8050b95)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         88225101-ebd0-433d-811e-85360e3b6fb3)(label(name))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         40cc528f-f3e4-4cc7-b559-b4079751a7ed)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         8589d9bc-ca16-41e1-a40d-92ed8458104e)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         d0532aad-425f-4801-9617-9b0dd3b84568)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8ef82f6d-e7fb-4c20-829a-cd40105e54a7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ef457b47-c61a-422b-8943-a18528b52703)(label(age))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         603c38af-eaa6-4860-97b1-5aa0dbe13af8)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         061e5977-549d-48fb-9f2d-c51548bafcb1)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         856a2776-a1c8-40b5-a3e7-b0757d0dfa5d)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5b988bc1-3c40-4c7b-b113-15af35887787)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d5d6a2f6-aaaa-45f2-ba8c-cc20ecb6c400)(label(quiz1))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         eeebeffc-efe7-436f-9222-f828708f9cc8)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         f6ab642c-8226-44a0-828a-8296a6ead2e6)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         6eafcd79-cf4a-4de5-b12e-1f9a3dc03017)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         79d04921-abac-4fe9-9734-5154a5a08f05)(content(Whitespace\" \
-         \"))))(Tile((id \
-         64f692e5-fe2c-4b52-b563-ac16092a7151)(label(quiz2))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         55619310-dd9a-4be6-9efe-8d9cf3ccefcd)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         31942536-0f1a-4e5d-9d4c-d7be776574d8)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         ec53c318-f13f-4f79-80f6-a0976cafde3e)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d943ab3f-119f-46cc-9879-36bcc686d4c1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         92dcdefc-efac-45d5-81c0-a2a64beeb236)(label(midterm))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         71baf217-da82-4719-90c1-3653c96561fe)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         b895b402-df6d-43b5-91a0-9194961ce541)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         922a1c7d-d0f9-49f7-956a-5d3a6970afd0)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         15df85af-dba5-4a83-8a80-b27f4735e353)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4125c6aa-da61-470c-8b69-ad4b3b5b3649)(label(quiz3))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         624784df-401b-4044-afda-75a8d345ed0b)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         712f9c19-9559-4938-adc0-f54ae61a1fee)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         e273fd3f-ffe5-40d6-b383-6cacefcf62a2)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a114e281-2181-4405-b564-abf9c943f6d1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         07c3cf74-b9cb-4486-87f9-0317493bfc4e)(label(quiz4))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         98708378-4078-4323-89ab-370bc2f78367)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         b1e153bb-03b8-4fac-a300-fa02ddb355b3)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         a17f18cf-ae8f-466a-beac-45b32558c6b5)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         57d41252-747e-4528-9242-90501901d0dd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         23fa6c35-e678-4570-8fd7-b73bb7b4ca21)(label(final))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         da73a147-da07-4d6a-8bb7-b2885fbccbf7)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         ff4b1b7b-5fe2-4acb-828b-5aaecd7ab9e6)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         3cbbbfe5-45ae-4c36-ae8e-24f61160daab)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f9bc7c39-cfe1-4620-b0ce-1fee4d2a5d79)(content(Whitespace\"\\n\"))))(Tile((id \
-         08c53661-1d19-44ba-b490-7c48f20d4845)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         842746e9-b00c-4ab9-aea7-5541c23cfad2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a05186e9-cc33-4063-994d-a73bc13c89c7)(label(gradebook))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         ed2c812a-30c0-42aa-b1f2-3d7fcb441906)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7c5c7801-e5fc-4054-8b0c-9ff7bfdf9131)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b00df70e-5b89-495a-97e3-956b4da9dbc5)(content(Whitespace\" \
-         \"))))(Tile((id 49ea6738-ff7d-4258-94a2-91868ee0e0c1)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         84e42594-061e-41bc-b4db-dfb1997117ff)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         db34cce4-298b-4b77-a691-92f0a7c40d9d)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         495ad157-4391-416c-8a67-630dd1f3a506)(content(Whitespace\" \
-         \"))))(Projector((id 8894e62f-8ba3-4468-ac30-46708fd6abfa)(kind \
-         Fold)(syntax(Tile((id \
-         ad3500f4-c0f5-41c8-9737-8c91567b1080)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         c4ecfeaa-bcfc-40be-bd6d-0ddbb4060bcd)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         0c282732-e136-4b82-81b1-9d60ea78d943)(content(Whitespace\"\\n\"))))(Tile((id \
-         7f7dd6b4-d461-4681-bd16-05ba2a9ca97a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         444c6d49-5fb3-453c-aae3-ee01689aace3)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ba636e3c-11f9-41ff-b1ed-4034551c86bd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         87f23be4-c00b-4f38-9caf-5e33dbf30c17)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         056db9f0-3d23-42cf-95b6-4a7a29c99c25)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6d38626f-977a-48a2-8993-e0ca5bff8b4b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         537b6b25-5d2b-4886-8bc8-f63341963866)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         74274d69-857e-49ab-8fb9-a52b05ecb9ce)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a4c19e46-744b-46d7-a228-aa78c7d226b2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f48cbe9b-0a35-441f-873a-937a6ab998c6)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9548b097-dcc7-455b-bcaf-f53a6c8d9b76)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         35ec7178-d469-49f2-a6bd-fd78c163904e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c3072cba-0133-4c6f-ab32-253b5dc30b23)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a0ab7816-2bb5-41fa-bdc0-0e8431c43381)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c04fd61a-666e-430d-ac7e-e4354b45c4ea)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1c1093a6-e6e6-4966-b36b-3d6187afb7d9)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5d9a5bf9-9fa0-4644-a377-4806586e8b1e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4598b9ea-d38f-4283-b502-22f10316351a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9d6346ec-7902-4cd2-836a-a2644d497aba)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         296c6127-4aad-4bec-8705-cae4b3edef2d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f4716aff-b6bc-4ef4-8561-93b22052b2d9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2f473a7b-f29f-490a-afff-40538aab30cf)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         14901b67-51ff-455f-9a79-291491515279)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10cc7028-0e82-4f04-9f02-8878279167ec)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3151ae5d-1356-45f6-963a-beae9281954a)(label(87))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7b2db6cf-51ca-4ff6-b528-4539b8edb6f8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e2fbe686-60ba-48a6-bbfd-ce743e5d0c75)(content(Whitespace\"\\n\"))))(Tile((id \
-         a4ed82e4-f9b7-4cc4-866c-8e10957ddd2b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         bb5278e6-9e76-4d84-902b-11cd9e13b00b)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d9bf05a0-5e4b-4efd-82d8-0140f0100e90)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d13f0c3b-fc37-4ca8-958e-e70e447a46ac)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4b6615b5-926d-437a-9ad2-61cf9f201933)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         69b537d3-6c5c-46e0-aa87-d30207cfae46)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         81f36af0-8cb4-4824-90f0-106f8ee80405)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6dd3c55f-02c7-48aa-9350-7fc7325facbb)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bc91a6f3-fb8a-4813-9fc4-59ef49187ef7)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f9480b88-4e35-4f91-ba22-3fed2d766ae2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         85d7e7ce-6394-47fe-86db-197097ecddd8)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4f5741fb-b492-4c73-b964-3345180908fd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         03fb6852-41fa-4138-a487-b7e41cc5a814)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9b05170e-31de-461f-b386-63c8cbf3fb42)(label(88))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d416b5a7-8a52-411f-bcd4-b85c8eb5650e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         59d64f63-59cd-433d-8f94-e138660061f5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d78f1f6b-090e-4392-8f8b-64d934c9cc5f)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d2b00cdc-cf69-4f69-9575-b5d5b0347df0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c249e7f4-c664-42f8-8054-1f2d7192ea3e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ca003e1f-b0e5-4a7f-aca5-29946bc4c184)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         79c7143d-2a2a-4717-8af1-7980438feceb)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         57fc7549-dfdb-4b25-9a7c-1fa5c36a6396)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2a012755-a492-498d-9faa-ff8d20198453)(label(85))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         b81c0e82-fbe4-4c9a-ad5f-94dc5990076f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0e5b7630-e833-4881-9ac2-89874407e77e)(content(Whitespace\"\\n\"))))(Tile((id \
-         fd2dce3a-1939-4ded-aa37-79c59b9176d0)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         57f6c13b-65a3-4449-be96-c9a585590ced)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         222e5470-dbd7-4b47-af61-c7698c3aa575)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9563cc84-3032-4334-981f-07e2b00616cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         98db0126-2c62-4352-a86a-2faf53a3fd0e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb2dae14-c063-4250-888d-0e002c5fc8f2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         57cd03a5-606c-4bac-9cb2-159b32faeaaf)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9a745f59-e792-4a09-8da6-5c81efe2e6f2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ac7b5475-8892-4893-bbf5-71d1e6e95aca)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6c19684e-defa-4e2b-91f1-4ad6ec2b199b)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         deec1ad5-8c98-4add-b9dd-9de6d6ba1bdf)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e7385e58-e72f-4d15-be51-28cb7974d671)(content(Whitespace\" \
-         \"))))(Tile((id \
-         543eddf6-5592-4620-86e5-23d2fb052665)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         41aa9fd4-ae14-4bfa-8014-ccfc92131e23)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8a8da059-cac0-4aee-979c-c9e71ed25148)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2b917697-931a-47b0-be07-d90a05ba903b)(label(84))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         55d3da15-56ab-4d7b-b4e1-fb88a8052c5d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5770f91e-8bb5-40b5-b303-6afb127eb838)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ea333a14-4faa-41b4-b9c6-3f36d04c8931)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6863d519-bd85-4752-addd-988582d7e38c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         82264bf6-784e-4c1b-9cc9-c8edf39147d0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         97aed701-42b4-42d9-8bea-202ce16a18a0)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c74a1c69-367e-45fa-abe3-18651e9e7281)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f62d0928-f46d-47ad-8714-3aa1df522c1a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8f7590d5-37ce-4230-b6a3-0cc43266c20a)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b40a8a4c-0f67-489e-b6ae-266ce24a2517)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
-         false)(always_render false))\")))(Secondary((id \
-         1123d825-e622-4757-96aa-7e553e7a2258)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         56610cc1-e9aa-452c-b64d-67e446f6b4fc)(content(Whitespace\"\\n\"))))(Tile((id \
-         5b24ccbd-e457-4876-9e3a-7305e223f25e)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         dbe1ad59-36ee-4c5d-a763-4eed9120a328)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a2faaa3d-6007-4afa-9433-d7c31c67dcfa)(label(expected))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         ef061f30-c4d0-45eb-a941-c6085dd5428f)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         bf06e80c-820b-46b5-87ad-31c4a42542f2)(content(Whitespace\" \
-         \"))))(Projector((id 4acc9fb1-faed-412a-b27e-ff1fff50008f)(kind \
-         Fold)(syntax(Tile((id \
-         2c69e969-e5d4-4218-8144-69d1f7e0e51f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         7e90d1be-1097-40ee-861f-1476d8845841)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         c0e7c5dd-8177-41f7-a145-e04840060c58)(content(Whitespace\"\\n\"))))(Tile((id \
-         5bf6c521-9eaf-4c2c-b42f-ad15e46de57d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         50bfa322-d0aa-48a9-998d-2d5f9958d012)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b70784a9-acc0-4104-ac82-a9fb986216a4)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         771525ec-6bd2-4c6a-ae40-8f77b247c64d)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         36290fe1-53b8-4ac2-9b92-a48166c32f72)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         92fc57a7-82f0-4cc1-b83b-a0bfab01d937)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2c2aabc4-ca51-44ee-9471-b95ab0a10e02)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         055fb64c-16c5-4c75-898b-e6e19e3beb8b)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         2ba0ecef-8726-432e-ab1f-59ae8a005303)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1f839edb-e229-441f-88d3-1396a02bf8f0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b89c9a31-81c9-4674-b8e8-8cab20664870)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f239e5ac-c2f3-4d52-a973-8983aafcd810)(label(quiz1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         003e2bbf-2b91-485a-8c2b-b314ef7aff56)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         15389d8b-2532-42b3-bbff-73bc4ec1d523)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6dba83a5-2b4b-497c-87ba-bfd2af70350a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a5ed7995-ca59-4562-836d-23eb0332c223)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b450d81e-adf5-4c18-b4ca-05f2b37a18e9)(label(quiz2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8c5bf18a-4d96-409e-912b-e1f170f45542)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         883f2086-492d-44ee-add1-d41a8a91b714)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         63efce7b-7875-488c-8ad6-bfcce20a2304)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fa603e0f-0f0a-4360-929e-72f7189a7dc9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ca2ac47c-8757-4965-9a86-26f820c9977d)(label(quiz3))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         961c1351-51c8-4e87-85b9-b8be8a082618)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         b0cb8fee-7734-4154-8b50-0476a5a1a3f7)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0f753226-400d-4b73-a6d7-feb77e457b77)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         778d6dae-01a0-4f66-99ba-65808a3c0598)(content(Whitespace\" \
-         \"))))(Tile((id \
-         390ad08f-2274-41d9-a9a8-036e33b8982e)(label(quiz4))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         926824f4-163c-4f08-873e-70281679d4cc)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         83561b4c-6f13-4b9c-ad26-756dc7916394)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c73bf3fd-dcbf-41b6-b472-d7a538f783ee)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d1b79c26-5d96-4ddf-8a08-873fa0428141)(content(Whitespace\" \
-         \"))))(Tile((id \
-         87fa1297-b2d8-40f4-9aea-358c1af0effb)(label(exam))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         29a9f910-6d04-49aa-9951-0e3275d84f41)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f4fcf1ff-2513-4f89-bceb-eaf7f0b7c49b)(label(\"\\\"midterm\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ba7eb1cc-8f83-4230-8b7e-08a7b9f3ed5a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6364d66b-30e8-4c01-b622-4c7c757d20ca)(content(Whitespace\" \
-         \"))))(Tile((id \
-         568c9ece-7107-4c9c-9a86-be9350d02815)(label(score))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         159f1a85-8600-4931-8afe-5a41f79ff5c5)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a3897eb3-f1f9-4967-8624-3158ed577332)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         5c481ca8-2226-4237-947a-6103e8196414)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6bc8b569-d52b-467b-91a1-c9793128e706)(content(Whitespace\"\\n\"))))(Tile((id \
-         74dfdbcc-e487-4bbc-af4d-bd21718af245)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         e652855e-3115-4f4d-8223-0eda96ce554f)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b028b2a0-0a00-4fbe-a56c-99e8e23ea169)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         88b18931-9fae-444c-92ef-4204a89df008)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0c8e92da-2f63-42d9-9648-932d3be4997e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         684cc9c3-6a9f-4d10-842c-8fb01cd47496)(content(Whitespace\" \
-         \"))))(Tile((id \
-         527c4c94-33db-4348-8f63-338cdc6d0e67)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cf1d80ed-c2a6-4553-9496-ee503e48b0c8)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e33cc602-efeb-4cd9-825d-45c3fe01753a)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c510e970-d1a2-46a3-911c-aa7e1bf3d9f9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8a3a8f89-3ca5-49b1-9578-a584ccfa90bc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b354c67b-328d-4eca-ab40-86e073b88c54)(label(quiz1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f684309e-cfda-4cb5-a30c-1a12b112ef5b)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9f509cd6-2f83-46f1-b9fc-1dfc7171af7a)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         62988c04-5927-48b4-8f87-2bbc78bcef5e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         49dc3031-ccbc-4993-9a1d-e0886dc5ccb3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c8a8820f-0e74-4ea9-a80f-ab54699df8af)(label(quiz2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f85fcce0-a1eb-45c2-8569-7ec8a150e321)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9891b144-1a43-46ee-883a-25063fd8bf98)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d67087cc-2282-4616-b0b0-a00ff71812dc)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e23aa48f-3604-4525-a6d0-f78316b7f29e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fd12a21b-d259-489a-b2ee-c88e94d8eb57)(label(quiz3))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e0c25242-6902-4a42-93fe-990c26fcc4af)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         db57ba6b-0ba5-4cee-ba7f-9e7b32824480)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3edcec0d-f758-4d6d-9bfc-d283f17597ee)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6c3dac74-8356-467c-b0d9-0b225fa08c51)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0a1946b7-5c36-4fe9-8fa7-1b1fcbfe8262)(label(quiz4))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fd033109-442e-4e47-85a6-9230034fead3)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         4799b11e-8eaa-4c81-a30b-34d9c2712a00)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a8b659f1-4b97-4670-b9f0-c5e9967f90e1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5a6c77d7-c274-4eef-88e3-3a1b36ed0d73)(content(Whitespace\" \
-         \"))))(Tile((id \
-         04f7d911-bda9-4b6a-b175-8f0af42f7e7a)(label(exam))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5520fd2c-a109-488f-a618-2ad7d15deca3)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         29fb434e-f248-4f2a-9762-7216bfd2f8c3)(label(\"\\\"final\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         684bf36e-851c-44e7-bb4c-2725504caea7)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6c7aa1f8-3129-4cb7-96f6-ade9045ddd10)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6d8bae67-9401-467c-9777-712e63a1281d)(label(score))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f56222c5-8101-44ad-805a-034d8cbb70eb)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         2ad87acd-1408-40e9-9e43-8ce02114a5c5)(label(87))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         44607832-5585-479e-ba33-45a14df20131)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         acba6d15-f6fe-43a3-86a5-6ad1118a7aa8)(content(Whitespace\"\\n\"))))(Tile((id \
-         06d7fe56-bea9-40a0-a768-4f6cf4a1cd96)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         33a70afc-6b4b-4ec8-8f0d-cfe079e48d35)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8e717482-25ec-4ec1-8c76-3d908d3fa9cb)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         8c62afca-22d3-48ad-8342-789da38fe59e)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4139ba72-2738-483c-90c2-6421e8e80577)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         06c2494f-661d-464d-8e3c-538a89cd1332)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8bf075d6-0aea-4f8f-adc5-1e884133418a)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9b193439-f7d8-4fb4-96a7-d151e364e6c8)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ebf7d315-8b14-49cb-ae40-d015e1a138f0)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         dcabc944-483e-4e30-bf69-957cbdaadaa5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         11eae595-aea6-4db0-8981-2d93e76487ef)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7777fa40-92a2-47cc-bd45-562968865cac)(label(quiz1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b2e83c87-fbbb-4e76-bacd-f6d57d62f594)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f732638b-7b1c-456f-b2dc-2f6b154c521a)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         051474b2-8e93-4131-a867-81919de20a86)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cc6f440a-f425-46a8-b5fe-95fed51d9e4a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a3c19751-c8bd-4f58-b8d2-952cb99f68c6)(label(quiz2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9172df43-022c-4044-ba82-68c878e6c0d2)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         95e48efd-250a-490e-a9ad-495f8c731869)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bd967158-5d95-4cde-97a9-fe23b6a07f41)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         169a9f0e-a20b-4fc7-97fb-189f001338a9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8dcfabed-2591-48b9-894d-a38040669ebb)(label(quiz3))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c52de0d4-3136-400f-9074-e2a9e8eb5fbd)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7468df3b-89af-43fe-af25-d5a1845d32b4)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ad1e0ef0-78fc-4186-aa6a-333f74917ae8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a10280c1-99ec-42dd-85a4-8a74515a2f60)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b6a8995d-b341-4314-9826-47a7079f8a83)(label(quiz4))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         03606955-e7b3-40e3-9ac4-bdb2eb419b29)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         62df1859-a982-4acb-8dd9-702b21da3ff4)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         32cdf210-1ff0-4f37-ab2c-92fbdd85e3da)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7f6de749-60e1-4a64-8bc7-701671773349)(content(Whitespace\" \
-         \"))))(Tile((id \
-         81d858a3-634e-4fd6-8b0a-f40eb7df471c)(label(exam))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bf01bded-acc9-4b7e-9d09-ddf223ecc693)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         4a17f7f7-10d4-48a8-984c-2d6e565a52f5)(label(\"\\\"midterm\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         866fe92a-c5a7-4928-836f-9fd73760d8de)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9f33e91d-ede2-4472-af08-18373b95b16a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5755d93b-147d-419b-be5d-51ee84689bd9)(label(score))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         09cd6165-b54e-4be4-a14b-53a6799cdb4a)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e8baad09-5619-4555-87e0-01e74ac63c59)(label(88))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         0853b660-8eb3-4028-bec0-7764f732510c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         adb7c57d-f594-4fa2-80e2-86d0b1a8baa6)(content(Whitespace\"\\n\"))))(Tile((id \
-         b009c70d-f029-4fd9-a0d9-8423f9860be4)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         532de970-7bf7-4cf1-9ca0-af033171880c)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b6af64bb-5b93-4450-a2b2-ec8a586fa8f9)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         5b566365-c729-49da-8929-6ea9eff44471)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cece8fdd-2585-4d88-8a47-402d0b790ad5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0dad95af-48f2-4802-975e-d935a2ad7ff3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8d538006-518e-498b-89b5-d5ff3f5c9dd3)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         71eb0ba8-c587-4bc1-9fbd-1dcb4af07f62)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         58917f29-5bba-4389-b004-1a267045fca9)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e25ff536-087b-4663-ada5-6c45c46942f2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7f032ac5-3ad7-4ab7-8f1f-782051b3ed26)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b9b32632-ffd9-4d6b-8c48-ddce824c398d)(label(quiz1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5ebf6aa9-9570-4201-8cac-1eb2834185b8)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         46c9fb65-4f67-4c95-9a43-9283b35a5095)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f125f9c1-5a22-4b85-b64d-e461181fcd18)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         89cdffec-b1b8-442a-99b7-6365e8373aca)(content(Whitespace\" \
-         \"))))(Tile((id \
-         be04ca1f-84ba-4870-956a-df9804240106)(label(quiz2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         85b3b38a-3499-4ba5-8bc3-874e8852d30f)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ef85bd03-ad9c-4645-93f3-86537ee66542)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5d930b27-da3a-4104-b51d-96502ece7fb9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a673b0d5-d6b5-4e8f-ac57-b016414dbdfb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         522be570-5504-4213-9df8-358a6283b2bc)(label(quiz3))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d170c810-ae59-4d8c-b6a9-ba9aa45ab5f2)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         1f880632-c205-488a-9c8e-1fafb3ecd0a7)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bbe40b14-b168-45da-8728-a88d884ae1d1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         870a8dd6-0706-423c-9324-bff7e9220950)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7677ba73-f2d3-46ac-82cf-4904e5bf6ba4)(label(quiz4))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0706cfad-f03f-4b7c-bebb-8fc31290771b)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         60ba1306-d2e2-4372-bd88-d5cdfbc6965d)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e5704414-df7b-4233-8522-d27a08bc4b3b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6a735fb2-cc34-4464-a783-5bc87f3639ba)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5dad4f6f-371d-486b-9977-e5f5b9695ea2)(label(exam))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ef06cced-11f6-4576-a037-fa89da04d46c)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         d2bb7210-cba0-4d3f-9446-b8034dc235d6)(label(\"\\\"final\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c5885b2f-b681-430c-b0ac-55f10e1555a8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         79844061-5ca2-42f9-abcc-d6b0030a4bac)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ad7a8929-ecb2-4f6c-b8ad-1343ce6670f3)(label(score))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         03a99c94-e91b-48ce-9c84-eb22a570355e)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         b5d81a73-b557-4af3-b5ef-a05f51c8c515)(label(85))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         01508889-2a1f-4c52-8a2f-f4f00117f5be)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0436cb42-1571-4c3c-b6dd-97fa6283fc24)(content(Whitespace\"\\n\"))))(Tile((id \
-         a2d839fc-e099-47f0-a603-571e0db92a41)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ff5a041e-778d-47ef-9edc-2affa37cde66)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d67195f4-7876-45ec-aefb-f1c338317c21)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         21a989ba-91ad-492d-94f4-676f335adf2d)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         718756e6-d20a-499f-9e69-af6f7927ccfa)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f812e565-d71f-4fe9-bcd2-6f35f5c87a10)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a70a51fb-94ba-4f28-bcb0-a9e93faa01b1)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bfdedde3-1bbf-482d-94aa-6ffdb2d5bf2c)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         6a14803d-7a6f-456d-9596-3065d94ee37b)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e36e54e1-1227-4489-815f-1fb5a64c0414)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5dedcac2-864a-4963-9901-ef274cbffb4d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fe70c388-512d-4bda-a9a7-8ea66d606963)(label(quiz1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b8555919-92ac-4495-8466-5767465a99f2)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         5f7588a5-f8a8-4bc1-8145-be481b01727c)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8309105e-e164-4f44-8fd5-68aec5606ad6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b072cd6a-dfee-4368-b913-af6afc3d5b37)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c54fbe68-8ce4-48a8-9751-466b36683dcf)(label(quiz2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         95a83f37-34b7-40a9-a47e-0111fa914b67)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         34fc3c28-e760-4672-b6ed-c7b147af2aee)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         02d70212-217d-43b5-a92b-4243f73314c3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         083f6d0e-5646-4186-a847-7c007bc8d246)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5bcb575a-e48a-4fb2-8979-3f827dad28b8)(label(quiz3))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3c9c6319-0118-4bc2-8cc3-54f6b906f671)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a095c50f-564f-493c-b3bc-9f7aaa6e7c2a)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0b3db9f6-9d35-49d5-91c4-bf02cb442da7)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         90cd168f-8fda-4937-9dc8-ef5b44ffef50)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bfce3ab9-035e-4490-a262-b765c8963a62)(label(quiz4))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         01fc020d-3611-4c0c-84b7-9992e28a7bbb)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         dfc54594-e04a-4560-8bb9-2b43a195b040)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a5749d27-99b6-4b62-b06a-b3f23bb3ac53)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         48e20e14-5144-4c3b-b48f-e538004576e6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         42236627-2a6f-4b59-85ff-69d8c21cb9d5)(label(exam))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6ed57e51-04c8-4661-b916-8b495f922346)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         73d7af06-e9cf-4aad-b965-0e58a801fba0)(label(\"\\\"midterm\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         60188c64-ee05-4880-97a9-53ce3f0ba4d3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a323b4b8-a278-4298-b8dc-b030f38270a0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2f6c1253-9002-4d8f-8042-bdfe921cbb53)(label(score))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         464cef8f-e4b1-4001-8da9-f1005ff8cedb)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         006a004b-9317-4d13-b749-e9975ccf2c59)(label(84))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8644cbca-22f0-4f57-a1bf-486471f461ed)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a5582e05-3494-418c-812a-49f2e7f7fc5a)(content(Whitespace\"\\n\"))))(Tile((id \
-         0ad3452b-3668-4aed-9cf6-9eefce3b8646)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         4d59e252-d60d-40c0-99f9-dd6568d5805d)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         125dd5b9-16a8-4d20-be4d-7183bb688998)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         57a6be67-f07e-4ec2-99de-ab5c9af72317)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ceae3441-0ad3-4159-aa43-38042dfc372e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e90fa74f-295c-4663-b856-33ba658a5587)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a2c675b8-2cda-40e1-bb02-3d110a86b3ca)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         84a6722e-fde1-4745-a559-9dee2d303cbc)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         1da90090-0823-43d9-b329-6dfb5782ad73)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e5bfe5f6-f1ab-4fac-9833-ba31601acf17)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f4ae2b40-52b6-4cc3-964d-35c912b2043a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f28661db-ee4a-401e-921f-38495fdbe972)(label(quiz1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d3ecff57-e197-46bf-aa42-8b90288ae62f)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         eccc7203-8c0d-424f-b050-1376f75040df)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         28f49a75-f749-44cc-ac7a-8220a8e7e16d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6de52ed0-3f55-4c56-9840-c1c90b974898)(content(Whitespace\" \
-         \"))))(Tile((id \
-         259db1fb-d5d9-4cfc-b38e-2c8f2e1934c5)(label(quiz2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         38a1b281-94f0-4f09-ab9c-9e5d24c7673d)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         96f8157d-c28c-4166-82ce-7a778b0a4385)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         49d8c210-9448-442f-9e8d-9e295302c382)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1e37947b-d3dc-4eb6-9844-54ddf3840eb9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7799ec04-7f1e-4419-b455-6176fc8338c8)(label(quiz3))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b3af8452-1a5e-459e-8819-e3a7464e8d55)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f6a07010-3a5e-4066-aa05-d1eaa0313bc1)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4435e6d2-d969-4739-a990-648229e06ccd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e5f4a5f0-c77b-48de-beaa-1916ba63186b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e9e84474-5798-4db0-9c42-ef060aca1c20)(label(quiz4))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b2e54f32-5273-4906-bed9-f3782222e4e3)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         b6c10fde-27a2-4b64-bcd4-bac6858fa389)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         aacf7ff0-a4d9-4962-b2ae-1fbafaa7b166)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0a1d10f1-953f-4ed1-b7ba-a618c9ea955b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b7b990e6-2d1b-4ef2-81db-3c8b67655d12)(label(exam))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         53d68c7a-d21f-49bc-8071-5b05e5886241)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         6b492006-7fe8-4fa5-a0d6-356847b81bb9)(label(\"\\\"final\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1d6e4bee-3fe5-44ef-8b4d-3e292f5f9917)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cea0f73d-fe1a-468b-9b9b-c2c894a1b05b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aed61acd-68a7-44f1-8f09-0369a5d534ff)(label(score))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a5e16788-4a15-4d09-a6f7-c94e4ba84f86)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         1a5d3f89-94de-4da4-8d68-bb6729a15e0a)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b15ecaca-1ffa-4c50-9e7e-aae07f7a507a)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
-         false)(always_render false))\")))(Secondary((id \
-         9334077a-b55b-41f1-be45-71925752daaf)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         05d43f4f-90d0-4f11-9959-45c12a91bef8)(content(Whitespace\"\\n\"))))(Tile((id \
-         6a854830-e40c-4388-ac49-58e606d63757)(label(test end))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         c6683cc8-ee08-4788-a0d9-5f9998fa90b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a157f61c-5b63-49b2-a7b0-4789fca356fa)(content(Whitespace\"\\n\"))))(Tile((id \
-         5dcd083b-4f3d-4b36-b137-e30e86093b2c)(label(pivot_longer))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5b8869d8-1a56-4ab0-a21f-46ecaf349e23)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         5e1466c2-b4b3-4b4f-af92-47747e76ef4c)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3156df0b-7e93-4a7d-9c62-93fddd341d77)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dea8d235-cc74-424f-be49-b83501f4368c)(content(Whitespace\" \
-         \"))))(Tile((id 8a842add-ece9-42f4-a83b-425d92748bcf)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8fd102ac-74f7-41eb-9463-03fa55d03038)(label(\"\\\"midterm\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         74fd4ff9-f2f5-441f-b291-a11ad1d40176)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         599ac3d9-88e8-453d-b302-77a0ba371eec)(content(Whitespace\" \
-         \"))))(Tile((id \
-         70755cb3-d2ac-4f4d-9147-ba1fa2334c82)(label(\"\\\"final\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         676cba66-9559-4342-89ff-97a4172fa1ec)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         27a176db-2b07-4120-8839-b536b2ef4789)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dfaf69b0-7c2d-47ec-8e07-48f2fed88d22)(label(\"\\\"exam\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a351837d-5a3a-4d70-8eb3-7182c30824e3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10778374-0128-4af7-9031-23c037068256)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a1f0a152-93a8-44f5-95e7-465c74d00d74)(label(\"\\\"score\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1a2af0ea-25c4-4dbf-bb41-8cc535ae3bb1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7572bc47-ecd9-40a5-9147-5393e1125fe3)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9847b190-0f04-41e9-bec6-f987c240b479)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6f5fb645-7f73-4860-bfb1-0eb07651f599)(label(expected))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         fffc3330-230d-43b7-9fd7-f10584594ce6)(content(Whitespace\"\\n\")))))))))(Tile((id \
-         101d6d0a-c29b-4b20-970b-2708f9b74758)(label(\";\"))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
-         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         58b8d094-b743-42ff-a430-fd50a8c8ae09)(content(Whitespace\"\\n\"))))(Secondary((id \
-         77158c37-db9d-4903-982d-fc24abb87001)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2a9c5f3a-d222-4c4e-916c-096601671cfd)(content(Comment\"# The \
-         idiomatic way to do this with concrete data. Giving good type \
-         feedback#\"))))(Secondary((id \
-         cc78f7a1-d775-4710-a7f8-99094515a2a2)(content(Whitespace\"\\n\"))))(Tile((id \
-         b8aac5db-501d-4807-920d-40fc76731ae1)(label(test end))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         59103641-5a9a-4e79-95a8-d8d8fa993ea3)(content(Whitespace\"\\n\"))))(Tile((id \
-         7f1f7ec3-d0cf-4a13-aa44-1a3402e2fde1)(label(flat_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         92738029-596c-4ad3-8c37-692d6b8393c6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         69e51d1f-2b30-4861-9318-a602acadfbbe)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         74d25d5f-5197-40e7-92b4-31fdf208f791)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2168e983-2384-4a67-9590-3026a85433b2)(content(Whitespace\" \
-         \"))))(Tile((id 9fee4aa9-3cfa-4331-a222-66efd05671da)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         5e07d34b-edf6-453b-a294-acf548a04835)(content(Whitespace\" \
-         \"))))(Tile((id \
-         87148761-0e85-4981-9253-18da1393c90a)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         c592d791-c173-4193-b4bd-732eee0d6d7f)(label(entry))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         0e9600c8-97c9-49bd-a3d0-b91a1ba23232)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5efed446-d9e4-4398-9978-485cf20fed4a)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e3279241-6728-465b-874f-4a8ef2cf407b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         85324c4c-a466-4892-9057-b9d716e01296)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         82f64ce1-ecc1-4d1a-9839-82ed8d846bb3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         bc8ce0e8-f332-483a-8d90-0037ab11a889)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         22931c17-0b9e-492c-bba8-bebc0f9a2b76)(content(Whitespace\"\\n\"))))(Tile((id \
-         b0d7d189-b557-419e-9836-1df444c7c383)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bc91dd26-79d0-4e5e-a98f-935ea1026783)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d6337789-bb24-4718-917e-e9b4e04e9e4c)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fc60ac1f-aa17-40e0-8a5e-6213203dc5be)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         977f673a-6173-4082-9868-519cac8f43d9)(label(select_labels))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         091e4b42-9f3f-4b02-827f-69db9507e008)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         733402f6-f4e5-4165-aa55-344834df8d6b)(label(entry))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5e699f1a-f3a1-49ad-b2e0-3c2d630896e3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         00dd26fe-00b2-4e03-86bc-ea4e510651d7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ec68c403-95d7-4954-b7a6-b47acab594c1)(label(`midterm`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         dcd17638-6a5e-452b-8faf-20c141aa20d5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f6c25544-0f4c-4d31-8f84-afd8f365e561)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e2b3401a-e09f-4e41-b781-cd1effd74a99)(label(`final`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Tile((id \
-         5e136399-6023-4744-808b-5bce60108650)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6abaed03-6f4e-4aee-998d-825c44208b33)(content(Whitespace\"\\n\"))))(Tile((id \
-         10c85c07-c4c9-4935-9dae-4e8ebf38a887)(label(fun ->))(mold((out \
+         21084825-ad89-401f-983a-28693a8e71df)(content(Whitespace\"\\n\"))))(Tile((id \
+         4e8ad5db-0e1f-428a-9a6e-1d8b1d613b8c)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         d34a5028-b16c-418a-a9d4-7579b5343d39)(content(Whitespace\" \
+         d5c8faf6-73a4-4b62-bf4b-2df6eb262190)(content(Whitespace\" \
          \"))))(Tile((id \
-         7c345111-c034-4137-86a8-6ef2c7659a2a)(label(\"(\"\")\"))(mold((out \
+         7185a733-2ca0-4b8e-bc0d-24497560eaf0)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         0b1b464e-e352-4f0b-885d-5297130d5333)(label(e))(mold((out \
+         71c47984-3369-4432-be3d-1cd260e3a1e4)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         95d45435-7d2a-4991-a397-9f2c5ac2b13e)(content(Whitespace\" \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         34b57c20-51fc-4b6c-92bb-378cbe7ccd94)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         ba50ced0-18b7-4cf9-8bff-6d6544e4d1e8)(content(Whitespace\" \
          \"))))(Tile((id \
-         335462b8-9c75-4e85-9682-940f3a272ab7)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         87ae842b-dd3b-4fef-83a8-45b4a6291544)(content(Whitespace\" \
+         db401c8c-b3c8-43e0-b75d-9bd8a1776c2f)(label(cs))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         bcdf3518-e3c4-475e-a1e6-b39d61d9d6a4)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         9c44d229-97d9-4f76-9def-7ab4fa3f8c14)(content(Whitespace\" \
          \"))))(Tile((id \
-         ddcfd001-5830-4a07-ab02-b33e2c16b894)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         ff595247-9e26-4690-9af2-9058cfb03a96)(label(label))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         f8f217ea-e564-4e97-9e33-2021e34ab60d)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         0fb8e592-d251-4485-8b10-4a91595e8146)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         8c9a101c-c9be-4913-8d1c-6d44d66076c8)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ff27299b-80a1-4bfd-859c-96d770a00fe4)(content(Whitespace\" \
+         63f163d0-0fce-493e-a35b-e3d141e9f03e)(label(c1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         09d0d5b1-851b-4f15-90fa-f547af84dc79)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         35ef9be4-238f-473c-a507-c967bf34dd4f)(content(Whitespace\" \
          \"))))(Tile((id \
-         e777cfe3-faf9-4403-9d3b-3f06cddec0d2)(label(value))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         318ef63b-a816-45c7-b31f-2580d01063c6)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         ceab25f8-0228-44ab-8aee-017babb93539)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e22d09b8-646a-44e4-9b1d-ea668ac55d86)(content(Whitespace\" \
+         a8c55e10-120a-4734-b33a-29a8f197d38f)(label(c2))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         9a1a108a-5fbd-4168-8a7d-0f6902915798)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         192d095e-5ee4-4dbb-a98d-c8d240f8d1d5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e96beb55-f15a-465f-b413-e9479075d803)(label(omit_labels))(mold((out \
+         1277c723-f9fe-49e5-b0fa-0c6a1ca1ee89)(content(Whitespace\"\\n\"))))(Tile((id \
+         8d8a58e1-04d0-4814-95a0-638e588b8ccd)(label(flat_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         56a2632e-12e7-46e3-9de9-85bcf6d9ec28)(label(\"(\"\")\"))(mold((out \
+         107b9d98-113e-4462-834e-69a2837df41b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         c15c73dd-d093-4db1-8390-acd68a5032c8)(content(Whitespace\"\\n\"))))(Tile((id \
+         d27a623e-b1cf-48ff-be24-956ee6bf8368)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a230e6f8-7b30-4099-a94b-7018db7343ac)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d0bc08f7-145c-4260-9ccc-677b39ba0cd5)(content(Whitespace\"\\n\"))))(Tile((id \
+         792e6ef0-7b4f-4079-9841-32f627dd092f)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         7731f406-b8bb-404d-a5ac-e02702b44fe9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9cac4db0-dd5e-490c-979a-32d7e5a0bf2e)(label(row))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         faf2de54-9516-4c1c-a052-aeda25b21193)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         87c9d6a9-82c4-4432-afc2-f44634fcfcfa)(content(Whitespace\"\\n\"))))(Tile((id \
+         78ed3c01-c075-4096-9b51-9f40c79a1de7)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0eb42512-4336-41b0-87d9-256a5ec8ceb0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         38168634-e494-45ca-a989-325e5667eb52)(label(entries))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         46470b06-cce2-4314-b488-503dc5645de9)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         74b98bc2-694e-4cff-ac73-58436ebb2d6d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         36755b94-50c1-4da9-98a9-1e6c009f8cee)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cd88eb04-9b3c-4249-8218-c1e6e619cff2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         853dedac-673a-404f-a5d2-4408ca0e225b)(label(entry))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         44ec77a1-859d-4309-8a1d-c2f955c2cf43)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8995f8b7-460c-499a-b3d9-75fb3242463c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         781e74ee-125b-4b5a-97d7-d0911c4db5fe)(label(`midterm`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2313ec89-f711-4106-9778-87adeb1bad45)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7847ef7d-7b58-4a1e-9be2-e0800c894e9d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         247dfc16-2a22-473e-ba0e-019c799c97f2)(label(`final`))(mold((out \
+         c1f7a125-04a5-47e9-ae51-c643ae7c646f)(label(row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9d935b3a-74fd-41cc-be71-19f31979b43f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d9ee6d24-3fd3-40ce-ba1b-ca973f904093)(label(...))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0d92c4c8-2109-4c85-8b90-07dfe9a48377)(content(Whitespace\" \
-         \"))))(Tile((id \
-         db2abfba-3cb8-41a4-85b1-2b703e016e5c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         bb9cdb42-da42-40ec-85bb-ef588bdbaadd)(label(exam))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fab68db1-f213-4f4f-82f5-0818f377a15d)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         8fbe4404-3c8f-42ea-ab19-2a9ad35206a4)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         62d03412-23cf-48b3-a8ba-e2ef868709b9)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         fd331e16-5f4d-4d60-ac2b-49c1a0de5413)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         60be7c87-7790-400c-9adf-db766648d525)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e39b4dbb-bd75-4ac3-9b16-251bd32ea6e0)(label(score))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ef8346c5-1679-40bc-93d0-996b4bb08fd4)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         1e47e2f9-a68d-47fc-9192-f14c104d0061)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9c73e74e-6b96-4722-9eda-1800c1bc8796)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         fd935545-9ca3-48e3-a747-181980cba88e)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         ee5678bb-2edb-49ff-a672-6f1f5259fddc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2e531ec0-095c-4cb7-8cd2-3b089c4be61d)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ee0ecdaa-392c-49ef-8f9d-242781c49312)(content(Whitespace\" \
-         \"))))(Tile((id \
-         44b95878-47cc-4e0f-bd8b-eb792c529cf0)(label(expected))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         3b804aba-c71f-493f-ad4d-5d23b543afe1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57ceff32-fc44-4fd6-97a6-9d807f0cba58)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         7f97445c-fe07-4f00-9616-3cfb21b30c03)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         633caed6-d5bc-4065-a726-130da8e5f194)(content(Whitespace\"\\n\"))))(Tile((id \
-         478b0f7f-bf87-45a0-a3bc-f11c838f74db)(label(let = in))(mold((out \
+         94c0d4a6-e3ba-4246-be3a-de3c24859aec)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5c79843d-b044-4c80-a10d-8ca7a48efe62)(content(Whitespace\"\\n\"))))(Tile((id \
+         46c4574f-35f3-4579-aaa9-5b91e8a67b40)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         7c4b7a7a-bc9c-44d6-a6cd-6363d1e90eb3)(content(Whitespace\" \
+         8dc8a1da-2b5f-4623-aa52-02d700c05596)(content(Whitespace\" \
          \"))))(Tile((id \
-         34f1843e-3241-4ccc-a259-c1504da613b3)(label(pivot_wider))(mold((out \
+         71cb5e13-2ea3-4177-afbc-6f52bbcfcc4d)(label(pivot_entries))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         110de997-ae0b-4514-8fb3-267792c91ce5)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         9ba9d355-dc6b-4c20-b5e0-8a6e4e3799be)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9948be21-39bc-4671-afa3-51c5dd662a76)(label(other_entries))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9d19db10-4d92-432b-b211-cb43bb468f5c)(content(Whitespace\" \
+         652392da-e106-4739-b304-a083a3130a96)(content(Whitespace\" \
          \")))))((Secondary((id \
-         de50e9d9-35b1-49ca-8d73-bbcdf7f1d705)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         318325ef-e965-4066-a8ce-9af3d266ca5e)(content(Whitespace\"\\n\"))))(Tile((id \
-         61785c90-f3ce-47d5-abf2-d975bc5e4149)(label(let = in))(mold((out \
+         9ed98c35-4bff-42f2-a144-71f4384fb59e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b2905696-2d33-438e-baf3-146a1e8215ec)(label(partition))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a193d300-935c-466f-86d8-c20f17c078d2)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         453e14d8-f38e-4221-87a0-e300f535fd81)(label(entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f7631c17-84a7-4438-b9b0-a73405c68437)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         13beaaf9-7f21-4562-aae0-1e478526c651)(content(Whitespace\" \
+         \"))))(Tile((id 1b9d4ce8-eb37-4cd7-a5f3-49eb14f36e0d)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         a307cfd5-0e93-4e13-b84f-4480fb2e398a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         17912714-fa4d-4bd1-886a-a4d2960bd31d)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         7b59ed00-f3bd-4dae-ac4d-27742aa0f17c)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         34e0e871-5ff0-4048-a52b-e4159f9035aa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dfb8fa1f-1905-46fa-8c1d-720e50575131)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         eff2d9d6-a165-4b32-a110-347e8d66cf3a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7c973e2c-beab-4e33-8472-8097a7723a32)(label(l))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         aae664ff-5fb2-4da9-813a-ca2e4f5bb403)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         d0790585-019d-4d45-9825-193f02de267b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7c05eb77-c6d8-4a4f-ae6f-8b352975640f)(label(value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3735e8df-b141-49a2-94a4-e57403fd0663)(content(Whitespace\" \
+         \"))))(Tile((id \
+         086cd561-3156-4aa2-9e05-621daf6ffbc5)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         845ddf41-ad92-4941-bc54-5e9d222b871a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5a0ba4c0-b7aa-47c9-aab5-d84f51147c3e)(label(_v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         138aa4ad-df49-421f-8a93-0b041ea8e0bb)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         27db2b20-5199-48e3-afb7-bcf914adb619)(content(Whitespace\" \
+         \"))))(Tile((id \
+         caf3117a-a4f7-423e-a509-a86369c59005)(label(contains))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3f736009-d08a-4a29-bc9f-388547fd6ab4)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         d559402d-8495-4c91-9148-cde2d38aa048)(label(cs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e9ef089a-de5f-4546-9f74-7a24a23e75d1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         76c4f829-ecd1-41db-9ede-c63b3ae755b1)(content(Whitespace\" \
+         \"))))(Tile((id db542b26-337d-48ac-8bd2-396e658be294)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         e05fb8c1-9ce8-46ad-92dc-8d1e39a67faf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1d3f8eb1-6e6d-4ba5-b0b0-0e4b120dff59)(label(s))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         73cb5561-8f9f-4caf-84d7-965f16778dbe)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         aa26807a-5786-4695-9457-3a92d0d90bad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         853181fd-74ac-41f7-b6eb-1b977129bc99)(label(l))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d477e064-ab45-43bf-960c-6363599001bd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5df07054-ca02-483d-abe3-9de1419ae829)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         332e9a7a-342a-44bb-a9dd-ce78b8662f22)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c79407ff-6af0-4229-8fa0-0a40e100d765)(label(s))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         73849e19-1bf7-4432-8a72-799e0de2836e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7e5dec7f-8eb5-4565-aec1-59f8bd35916e)(content(Whitespace\"\\n\"))))(Tile((id \
+         594bc8bb-15a6-44d0-a798-3c94691a33c4)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1cd42990-737d-4cec-889a-77ed700d392f)(content(Whitespace\" \
+         39e4e0d8-2ca1-4f5b-8088-5ac353eb9585)(content(Whitespace\" \
          \"))))(Tile((id \
-         92b7f3f1-76a8-4c6d-98ca-0c0f0461790c)(label(requires))(mold((out \
+         2e8d2900-070d-4147-a1cd-212f90a2e175)(label(rest))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         60256036-09e9-4c61-a1e2-e0aea11c8a16)(label([ ]))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         2882b57c-f86a-4fac-874d-d5d6d04f7b59)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         b51dbc19-53e8-4c52-88ee-ee66d38c37de)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1eeac608-95b0-4a04-bc8e-b21734162b8d)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         143bcbde-8edd-48f6-a8c7-09ce6de7a030)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         b14822b6-1d3f-414c-8c80-fb90cc726102)(label(other_entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         065acd19-3624-4fc3-a4b0-44a9d1b61a17)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         4d7d24c6-8f32-46bd-babf-09405aea4e88)(content(Whitespace\"\\n\"))))(Tile((id \
+         65cb2b0a-ac36-40fc-b585-b0ba7d76ae1a)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1e3265cc-d6ac-4377-8fea-c402686de5d0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         7e371d81-e624-4b21-a94e-ae3f4c19c900)(label(pivot_entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         02fd24d9-3180-4301-b86d-9faa658703be)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e87ab07c-5f56-4319-b4aa-4b8832aaac6d)(content(Whitespace\" \
+         \"))))(Tile((id 2d60212f-04db-4dc4-8ae8-776357190948)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         20b89d98-f07a-4aef-932f-8938cadb6373)(content(Whitespace\" \
+         \"))))(Tile((id \
+         77d440d7-29bb-405a-9166-f6fce8d9a13e)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         387bc682-8074-4503-8cce-0ef33af3489c)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         46e10bcf-3ef0-4fdd-8e19-03c01a4c1a07)(content(Whitespace\" \
+         \"))))(Tile((id \
+         802c3f1c-7863-492c-98cf-4477836a37aa)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         a742e2e4-e6da-4a7e-a916-1cdc5867a976)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b7067e43-8155-45ab-aae7-354f0b7fa70e)(label(l))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         cb452d96-0e3d-41e1-b5e1-4db0d37b743b)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         9294777b-6175-48cb-a50e-ef5e75e9d772)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a3922680-7e1b-4e50-b95b-8b77be2dd3c3)(label(value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e5f65374-0220-4565-b887-1e49dc811f17)(content(Whitespace\" \
+         \"))))(Tile((id \
+         40452145-039a-4759-8ecc-04a894b18c79)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         5a3db12c-912e-4c12-ab01-611808b79a3d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d52b59b4-3665-4210-a98d-cb793736046a)(label(v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         d307f81c-4c95-45bb-a10c-4bbe52d2a75e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         90724519-3c04-4048-b270-8085f727b2b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c26af220-449d-41fe-be90-adc39f89f5d6)(label(rest))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9ac690d2-d2d1-43bf-897d-da8530466de2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b747d554-f9ab-49f6-a34d-e065af865847)(label(...))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b8ceebcc-5b87-43ee-ac79-17bdd393bd94)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b024e196-0ea0-42fe-8e82-4865bfe0ca38)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         0123dc92-eb4e-4bc6-8a6e-41286f6dd284)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e36a7462-3d00-486c-bf8f-e7309b9aeffe)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         cc9d6d15-90c3-430a-ab1f-51c555d8abd1)(label([ ]))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         53db714f-c8d8-40a3-ac3b-aadfab588f51)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         86c6f6e3-aab9-4e3d-bd9d-1d985e84ed2f)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7e22c45d-de0e-4dcc-8aab-be362d66ca70)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         279e8717-909b-4610-9a85-f3566e0848d2)(label(c1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         454fcce8-7ef4-4fd1-a343-402264c257c7)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c7d30fd5-222f-4171-9a8f-79af8f4b91a8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7e0509dc-145b-4f8b-8d20-1c65632623a8)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         33f79c43-2862-4616-b78f-0565df0428cf)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         2276d0d2-a61d-4c06-b134-ac48eaceaf83)(label(l))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         949ec323-7121-4604-b573-c0e27cdb9853)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fff98529-3e45-44a6-bb0e-42f997214075)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0aff2591-e1cd-416f-8aea-8e54aba812f9)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         41a0c96f-569f-4d71-8fe7-b3d7a0be30b8)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         0034b9c5-003a-44e1-a487-be0813c8fe17)(content(Whitespace\" \
+         \"))))(Tile((id \
+         675f87ee-ee2f-4d24-ae34-7c6a28821449)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1d311119-d9e9-4a87-9dc6-f26ce10753de)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c99982ec-c29c-4d42-b852-b63d17936f67)(label(c2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6a2a498f-cf87-4e44-8708-6ff3242710f1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         014640c2-1a10-4a65-8850-19956fda5501)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b13ec8b2-39b0-4854-9640-bdc1af2b0108)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e89eb4cb-88ef-4d9a-8a8e-6282ac944517)(content(Whitespace\" \
+         \"))))(Tile((id \
+         00610fdd-6fc4-4f19-b280-eb4c1b2597ab)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d3132dc5-6372-43f2-bed9-11bae7cfee71)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e3dba796-f158-4107-8ab1-5bf54c095811)(label(v))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))))))))))))))))))))))(Secondary((id \
+         22a8632e-bd34-4b71-b363-b5e766e9afda)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         10ec9918-5590-4ef5-96ca-508a1df1c16c)(content(Whitespace\"\\n\"))))(Tile((id \
+         5ecd0bc8-917b-4de5-ba82-369486490f2d)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1641feda-5d41-4ebd-994d-a965a85716ab)(content(Whitespace\" \
+         \"))))(Tile((id 53976d9d-0982-417a-87b4-1745ca60db1c)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         a6422878-076b-4e13-be4e-7a747e47a733)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         34a6c1bc-4518-46f1-bf64-d1983040d696)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         aa29a9e7-6124-4ac0-bc32-ab07e562052c)(content(Whitespace\"\\n\"))))(Tile((id \
+         982ba5d7-e6b8-4b9d-82e4-3a27d9a79050)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         836832be-b37c-48a4-a805-a673e998365a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         259f03d2-d87f-4c66-be35-ab315f0bdbd1)(label(GradebookEntry))(mold((out \
+         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         6d13a789-d0c7-429d-9dce-7573867748ce)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         34668e5a-2722-420b-a5ed-96ea898b1b2b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         92c220d4-3e14-4b7d-969b-f70d50043700)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         d31713d0-9d97-4e11-a775-b4e4b8e75fa3)(label(name))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f0921c34-995f-4e26-87b4-189d0303b0a7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         358b4a15-516c-4966-a8b1-d22474223825)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5071351d-cf7c-4130-a6f7-afe568054af5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         090bbe03-fd44-49f4-9503-d8be158e00c0)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         0390b96b-a1e8-492f-89d2-08c824a659e3)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d4143d38-92f4-40ba-a77c-43818aa2f87c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5033e65a-5366-4a62-b6a6-e0f8e802c5ca)(label(age))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ae8186bf-cabb-49ba-947f-b86d5f0c32c3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1ca22a6b-2e85-4451-8d84-36c5de343231)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         13ad8268-7044-4711-a40f-742a24161be7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ec17c1ae-4fc0-41f4-b991-92042076d82a)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         df5373c8-66e1-4b6f-b7a4-e7f677355346)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a702ed81-50f7-4178-9d9c-f85401a87498)(content(Whitespace\" \
+         \"))))(Tile((id \
+         520f4f22-4e62-4bf8-8076-98f9d8a9d02d)(label(quiz1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         49b3ec0d-b084-46e1-af23-15629d299ef3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ffbf7e17-bcba-47c6-8ba1-4a6832df2968)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ada58ab6-f4d4-46c8-8858-5ef03b35e35c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e51e75ab-c69a-477b-aefd-12241d3d6116)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         8d8f69c8-a951-4a36-8e3b-d27c72524437)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3a5aa854-c898-4b18-aa24-be026b37098b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dbfed86d-9c47-47b6-9b7e-c43e7bf588c7)(label(quiz2))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6663c9e8-4e4b-4fe1-9efa-32c5552813c5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         291bacd0-376b-41c8-b3a4-6739b949bae7)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b869dcd1-abf5-4c3a-be65-9ec0bc7411bf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6857090c-affb-4000-98f8-2ae75b05a351)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         331a0faf-6a16-4aa2-8b54-3cfd2cdaa972)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         48c70d1a-fea2-47c4-9f61-3f5a55629b4f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         551daf61-22c9-4481-8973-c6779cfd252b)(label(midterm))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c4819d36-9c68-4547-9b4b-cbf69f125b45)(content(Whitespace\" \
+         \"))))(Tile((id \
+         564ca484-aa35-413f-a116-6d9b78c755f8)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e417318c-0410-49d4-bda4-c06309be8b15)(content(Whitespace\" \
+         \"))))(Tile((id \
+         43c6ad04-073b-4ee6-843c-7c829705bfd4)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         34c22f4c-c375-4588-9ceb-d0688ef2019d)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e2770ea5-680e-45a8-a00a-19bbe0f32c75)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cede0e55-a999-436c-a542-8caeb4c37e0a)(label(quiz3))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         76cad98d-45fe-41ec-aa3d-0a2759cf31da)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8356d002-200f-40a1-b05a-a1b631562d6f)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0de15f24-0505-4aea-a5f1-4577872f0aad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0362c4a3-2de9-4bec-949b-643ddb450c9e)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         2b52af0b-335e-49eb-9e01-49688a9d3cd8)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         92d7e69e-0d0f-4729-8bda-3794e0f42ca2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         91f44a8c-58b5-42cb-a28c-329141d048e9)(label(quiz4))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ae0c9dff-26ee-492a-ba14-51da7934e367)(content(Whitespace\" \
+         \"))))(Tile((id \
+         60cbfa36-792c-4fb9-bae5-6234f3f5634a)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         628148cd-d96d-493c-a35b-e1c0d8dc1d23)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f5a53b28-9b7e-49da-b5fd-d69ce219e350)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         c9a8e4fd-9744-4098-ade5-e7f1809273cc)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         45beee01-7270-4ed4-a2bf-4f1c7397b520)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5b125800-e82e-453e-bdeb-14508245c9cc)(label(final))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         915b2831-a191-460c-a304-b70f1dae661e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         19d7a822-0bce-4dce-9d77-f4a8e4cdfc8c)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5c4200a2-1015-4c6a-82c8-1e6e284b8e0e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         15aaa82f-5e78-46bd-b35b-74b1ed2c35d4)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         541c573f-d50f-4671-ab2a-febba6eb5c2e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         be8ecb22-8952-46f0-9ec1-355f613a6fd6)(content(Whitespace\"\\n\"))))(Tile((id \
+         3bca5dd5-d586-488e-b5d7-991e620ece78)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         26ac5894-74d4-4403-b3dc-2d43774ce46d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6baf1657-6e85-4fa0-bf1a-5af3983fccc0)(label(gradebook))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         2d1b3afd-0861-472d-8705-e2346778cc41)(content(Whitespace\" \
+         \"))))(Tile((id \
+         992c0867-35a3-4582-84ce-069b7b7194b5)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5ccea877-d290-4f12-a394-f695ec62a11d)(content(Whitespace\" \
+         \"))))(Tile((id 8ae1c88b-ebd9-4b1c-b0c1-2761a9f3d626)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         20be8412-ca7e-4961-85bd-7afb1e814b6f)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         8ae4f3ef-c690-4102-8d32-f23641f19749)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         cce4f94d-4412-40ed-a6c3-c2956a88c025)(content(Whitespace\" \
+         \"))))(Projector((id 5e9638de-aac5-4a17-9f77-5814b36c04db)(kind \
+         Fold)(syntax(Tile((id \
+         5919e217-d5a7-41e6-9558-b5f9c635f220)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         855ac93f-9ba2-427c-ac16-9dbbbe96d3b0)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         d8bd942d-e798-436b-a7ee-1af71b83e471)(content(Whitespace\"\\n\"))))(Tile((id \
-         4170ea07-6c41-4a88-b0d2-1fe176e2b82d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         d01f0f2a-6aa6-413b-90d5-b76f91adc755)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         80fc279b-6fa2-4fb0-bcb1-11bcc3e8d6d3)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         1889022e-15ff-4dd9-abe2-3f126635392e)(kind Checkbox)(syntax(Tile((id \
-         de877aef-ca98-4e33-97f7-ca9d836f1e54)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         a633a357-b2e1-42f9-b2c1-d497f32e1008)(label(false))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         35a4892f-a485-46c2-9f52-60d68877fd15)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d75a042e-22db-4095-b2d4-90fac84615a1)(content(Whitespace\" \
-         \"))))(Tile((id b3549cfb-9e38-40e0-8f50-7cd78bea71a8)(label(\"\\\"c1 \
-         is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
-         Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8ddcd0e6-73cf-4f3c-8756-842f184725af)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         27a0b669-6e31-4c44-9311-7c7b7c27c3db)(content(Whitespace\"\\n\"))))(Tile((id \
-         41e92826-6b0d-45a5-96dc-c240e1611d25)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         f57971b2-7174-49d7-bff9-d6f636e95842)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         66889691-eac3-4d51-a0b6-99f31947616a)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         37a0147b-2d1b-4501-a700-fe8c3b940f3f)(kind Checkbox)(syntax(Tile((id \
-         df1ec687-b763-4e89-a1e1-997385646b85)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         f55166d9-6f96-4616-aeb4-7e7e7016690f)(label(false))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         a46edd5d-21cb-421c-80f1-0deaf72792d8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aafb7598-0d66-4a19-9180-d678964bc34e)(content(Whitespace\" \
-         \"))))(Tile((id e281e349-0842-4c51-a5cd-a2958ed21823)(label(\"\\\"c2 \
-         is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
-         Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         718182aa-5702-43ab-9bb0-1f0777a71d54)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ac47fa2b-97ce-4e81-92be-a545e8f69cab)(content(Whitespace\"\\n\"))))(Tile((id \
-         c1417c15-a354-4c30-991a-e42e43115d79)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         202c0f6e-909f-4a63-a6f7-143655a08df3)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         026156bc-a7eb-485d-b4b9-1370443f6653)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         0b96e498-268a-42ab-92a1-cd20f2255c78)(kind Checkbox)(syntax(Tile((id \
-         fc0fa4ac-baa0-41a2-b6af-55bbde12226e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         f3687d7d-2509-400b-8718-cd75352f00e0)(label(false))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         fd53ce77-73ff-4b66-958c-83db7d92c792)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7d326645-b827-4f3c-a29b-c5e3f143c364)(content(Whitespace\" \
+         d122872b-e411-45db-9b9c-3ed33c41b5e5)(content(Whitespace\"\\n\"))))(Secondary((id \
+         2c8d4f30-91c2-4370-923b-3df54e89705d)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         aaf877e0-feeb-4adc-b4a4-8aa9966ee524)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         41d0390d-c94c-4446-b86c-027895723972)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         0b82c913-abb8-4e7f-a381-a29495153ebc)(content(Whitespace\" \
          \"))))(Tile((id \
-         cadf05c0-af25-4895-bd11-236ad7f5ff7f)(label(\"\\\"schema(t1)[c1] is \
+         dd00f676-8845-4773-a35f-1acaac8595c1)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ee66a946-c60b-4cde-b904-c7030150645b)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         07b5458f-fa6d-4547-bd38-743d2209639e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         eafd9e48-7ee1-4da1-a883-361323e8d690)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         78031cbc-ce8b-49fb-8c99-3895afeb2e27)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         1d01a5db-26b1-486a-aa59-fe474018a77d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b846998c-8705-468f-8a77-7ee808a463ef)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b57472cf-0f89-4139-b779-8cc68517f94f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         15dd68ed-d55a-41d3-8fd7-43203775976d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d703cb80-3f44-4afb-9eb2-a4ca95a6189b)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1997ce21-a569-49ac-a2fc-805c8c5c80f4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         834be524-216e-45e8-9355-b34098959cbc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2e701cd4-8524-41ab-84e6-77a5ddf20651)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f4dc992b-7fa7-4387-8bd2-916a769dcda1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         788dd9f0-96e7-48ee-929a-eb74d985113c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         412aa36a-a3da-4212-8d91-2878bc5681c0)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d4e78566-f72f-4d82-b9ec-c671f8620cee)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8c6d3019-2d55-4740-9fa5-d30dcd99d70f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         78f960af-ef47-4716-8c5b-e403770cb7c0)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4e2fe35a-f023-4c1b-a2ba-078280ce4d15)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dd469772-f521-47f6-9556-a3625d669737)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3be7be57-23b2-440c-b51a-6f92967d55d4)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         83e765de-caa9-4db0-b890-9be12a7a5508)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0e458341-c7ec-475f-8b80-b1a27eccc919)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6e6b267a-1daf-467c-99d1-bbfeb83049fc)(label(87))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         65a7c3b1-881d-439e-b31d-f41cc176b363)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d84c6646-cf3d-4132-af3f-76c39af708ea)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d341661b-942e-472f-acdc-4e9aa98302b8)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         1c12f69b-b326-4334-8123-09e730a281e7)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         8ca4cbcd-6aec-48de-b552-bb3a28f291c6)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         61cf7ea3-258c-41b2-92f7-5ed9e3ac96ab)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7929768e-e74d-4f96-a82b-9246f67fde25)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         fdb0afb1-a4ad-481a-8f30-51660e506657)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         913e09eb-2692-4923-aaa7-659bbc380d5d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         537d78a0-caf4-4e78-8574-babdaf92db3c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         47c049f9-f354-489b-ab8a-277220f14011)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2ab60671-686b-4be9-9bbe-0a52492d0a21)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b85d446b-a09d-475c-87b8-ce203935d27d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         86f90f44-7ddc-4b07-be34-b6219705f4f0)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c34378f7-2ead-4483-a45d-aa40f9fb9806)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         861ffd07-73a4-40bd-840b-0139f4abcd7c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         615bad4c-4536-4f3f-8123-4212bb57fc79)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         069a10cc-0998-4797-a55e-cad0c75b2da3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         754754f2-4a24-48ad-ad78-d67e24cba0c3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         894e2f71-52b5-482c-9704-df29e4c03c63)(label(88))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ea46d50b-0020-4fa2-a89c-364dfa0fb810)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c3199e8e-4e04-4c9f-9bce-eb3eb10bfab3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2b000df0-c395-4aaf-af0e-9fce3b5a75f9)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ea4eb230-bc79-4cff-affd-9838735a6e9f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2def2ba1-c673-49b1-8c2e-90612a04b711)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5c06b35f-138a-4541-87d7-34ee9bd2ee0f)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0fbf9e13-3251-4776-8cd2-4af509797a37)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         15d1a4ca-90a0-4414-97c2-42a29926cfce)(content(Whitespace\" \
+         \"))))(Tile((id \
+         215b7712-e4da-41a7-a3b9-c1731d26cc10)(label(85))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         61fed911-aecd-45c5-ad4f-ea9cd5189d80)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f8c1b23e-5e59-44d4-803d-aecabc825540)(content(Whitespace\"\\n\"))))(Secondary((id \
+         6e56790b-0111-467e-adc7-436007fb660c)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         95dceeae-7a7f-46ee-92fe-36cd7d8a92c2)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         837e10a5-1264-4452-b6be-ba53ea668059)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c81ae144-753e-43ff-a425-3c60310f3088)(content(Whitespace\" \
+         \"))))(Tile((id \
+         19e68d33-08b8-45b5-a6db-caccf9123bd9)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         e24a1cc7-1bff-42d3-9954-9c2aa52df26e)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1cad2cc6-1dd4-4a3f-8f97-bff14335230f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a1e83051-c65a-49b0-808c-f1c24f787299)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         637e2be1-b591-471b-9ece-7429a9ee1f63)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         e65af9dc-9064-400d-b379-c145d13a1dc6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d317fe00-699f-4e0f-ba0f-bad8969b0084)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         625de9bd-ced2-4c5f-ba95-edd193a24c93)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7cb3f3e8-5832-4fad-987e-8470122e9a90)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2a0eb72e-11fb-458b-8342-11e84ea2edca)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b5c3be98-c886-4bc5-871a-2c1c65da8c47)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         344a31e6-e81a-482f-bedc-3ba196a24ec4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         667cb29d-7c68-43e5-86cd-2fcdd645bc91)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d06c2593-9657-4d33-9d81-ad888554ec7e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a95f7215-4e4a-48d7-aadb-4e85e92309ce)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bb56fcd6-b394-4c29-92a8-a15d5fd9c33c)(label(84))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5d240f24-529a-4119-bf05-19532c6c43b2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         22b883b2-234f-4293-ae9e-0a44bc71ec98)(content(Whitespace\" \
+         \"))))(Tile((id \
+         905199ba-b865-4ca2-9699-c861d9c22d31)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         68faabce-872e-4e1c-b012-1b0f2c3bc418)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9519c760-5088-4c7a-9024-adc2bd74491f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         12a0f4ac-3747-4197-9032-c7deaefa4640)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4c4cf2ab-c19f-45d8-9e43-aeed690788e0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         34e1b191-ed77-4e09-ac31-8e8209460965)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ef4650bd-4186-4277-8eaf-ebccd8d873ca)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         e7af082c-61f4-4609-b377-04e90ea25226)(content(Whitespace\"\\n\"))))(Secondary((id \
+         4f5cc34c-4483-49be-b829-ac26e80e027c)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b3d46ca1-58d1-421c-8dca-7df034111e56)(content(Whitespace\" \
+         \")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
+         false)(always_render false))\")))(Secondary((id \
+         4c06dd2f-4c57-4206-94e2-7ba751d1da20)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         01a00f73-1f44-418d-a39e-d684453c470a)(content(Whitespace\"\\n\"))))(Tile((id \
+         fdfaab0f-4212-4f20-9632-f2f171d32466)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f5b22d33-27a8-47cd-875c-72ae0a7fded6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         41277fd8-3092-4d76-a1e5-5e7d1cad0679)(label(expected))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6c24555a-e0a3-477d-85cf-44dd18ab27c3)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         512f0d2c-ecb1-47f0-b611-bff7936a92d3)(content(Whitespace\" \
+         \"))))(Projector((id b9fc54fc-9cd6-4d1a-9fbd-0345fe381f8d)(kind \
+         Fold)(syntax(Tile((id \
+         48b70665-544c-48c6-ad93-a72d09ac2754)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         5b31a34a-aa37-4cce-a2e9-5c1178e5850f)(label([ ]))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         fd5c445e-9a79-4394-b2b8-22baa571db65)(content(Whitespace\"\\n\"))))(Secondary((id \
+         180a22af-5dfd-424a-af50-b26fbf06a8e4)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         9101338a-805f-4b47-a563-2bd720f821fb)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         f62af190-8dab-42c1-b613-411e4387c2a8)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ac577ebf-bf12-4a9d-be87-ff4325feb8ff)(content(Whitespace\" \
+         \"))))(Tile((id \
+         94e48781-3aed-4a40-b8a5-08600c75bb42)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         22da5c54-8fe1-428d-a433-41139bdd1f33)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e4f3ad50-9311-48cb-a551-4f8829c76aef)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         f3f22de3-f113-4bc9-9c4a-65db6e7742c7)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d8e963d8-dc7a-400c-becb-5d59efa7be52)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f07dbabd-0135-4071-935a-a6ad7eaebd86)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3c6ea0ec-1292-42f5-81ae-f8302b848858)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         46e02c91-2a50-489f-a962-b62bc500b41f)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         689fe97f-b4c1-471c-be01-381a24a4a529)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         55f1cfdb-233b-4df8-b4b3-6da4af4b493e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         03057f10-6707-4b19-b000-abf1b076f0af)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d7068c8f-2da0-4a4c-9db3-feba76b8ec4e)(label(quiz1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         82c23165-a801-4096-9c21-fc4486de1f71)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         36c15655-2119-4cdc-bc52-a6bf998111bc)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7c8e8c83-4447-4188-98b6-1dd166f93777)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         16107cf1-5f63-40e8-b118-c1432c82d5b0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7b6a8144-888f-4ee8-bde0-9cd6afc60579)(label(quiz2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c38fd331-6b4d-4f87-bd63-9101b475d792)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         d11e0c62-2e97-4cd7-8674-5d0839df2d38)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9898db02-9985-416b-a837-419b3f947c65)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         31321b9c-b3d4-408b-89b0-b9fc8840cd54)(content(Whitespace\" \
+         \"))))(Tile((id \
+         25bf8bba-0436-47b4-9d33-e7ca8e545c16)(label(quiz3))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         caa76d6e-745f-4e13-94e4-22fb01c13967)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         6d292034-ddee-4e07-b44c-cfdb333ab58d)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4c62be91-6ea8-4b6d-809d-c756478d7dc5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0c510cf0-e61c-4414-b764-2a4ac90addc1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b475ed3a-9491-4218-ae9b-59397bdfa0a7)(label(quiz4))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bdd433fc-6c57-460a-992f-1b98f741db29)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         2cddb193-6164-4358-b6ea-d1b1244f44bf)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0f96cb2a-3c6a-45e6-90cf-1f3aad168721)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6daaeb72-a4cd-4f9f-a438-91f64d7fdac6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         89a72736-b72a-4d21-83a7-eae5794f1b46)(label(exam))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         02405370-2a6d-47a9-ab92-e7dfa92f77fb)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         afad718e-1331-4397-810c-e4cfeaf41309)(label(\"\\\"midterm\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         60a3b55c-a9e9-4f14-a852-7af1d3bf8e6f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         21a8e67b-4123-487b-a522-d916f2a33db6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c39bedb5-66c4-42c2-8a34-881b6eaf1f15)(label(score))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         85674634-0078-4096-8cf6-80c1fe285e05)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         a25e11a6-d44b-40f3-b820-12d326fa8d4b)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         2f13cd50-5dea-4474-ac7d-602be6514a83)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         12389999-d5f8-4df3-9c61-4695761e45f6)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d2c34243-e201-432e-802f-401046b72864)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         67020dc1-8a25-4e97-a9bd-a25249799452)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         5bb14afd-b2e6-4169-b391-240b6c323812)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         3de3fa95-a580-4716-9f21-12deb1584601)(content(Whitespace\" \
+         \"))))(Tile((id \
+         92e08517-8a3c-4509-b01e-2c78690cff53)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         b4e3a407-1fc1-4123-83a1-35e2868d96a8)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0fec459e-820b-4746-aa10-2766b283cec6)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         5dc34fd7-8a28-45d1-b0b7-d7eecae18ec5)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         368642f8-6d61-4c7d-a270-8650599e8aaa)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7c2c6af0-09ae-44d8-8f14-cc2079acdd1f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f13ef481-18a4-4209-b118-6f43824d9de8)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6accca94-e19b-4850-aaf0-64446a526b03)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         0905a934-0038-4920-b028-8fde6ec3ea17)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         64c838cf-5698-4518-8ccd-f9d3c5d7e778)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7971340a-6340-44a5-9c33-571c6f3d5611)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ed234182-2269-4eb6-ad84-2684d4558039)(label(quiz1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0d9bee38-42a1-493f-b5a3-725c87faed7b)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         3e85449f-c940-44aa-b07d-fc1bb2810438)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7681980c-ec0e-425a-9cbc-27cd4bd55149)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b5bba9e0-ccb8-485c-83ed-46b34ae5a5c5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a174a202-12d5-479f-89b5-bbe576735527)(label(quiz2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f434d233-211a-404d-a196-08ff4f31ce19)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         858307d0-ccf6-4f38-ad4b-30d2874c6d68)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3207bcb7-2027-46e9-b6ae-db1aa5b78ec9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         67717ecd-2af3-4f49-8400-a182127316fd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4b50b8ba-ca89-4493-9661-0041e5697e14)(label(quiz3))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6400fb21-2689-4bab-9987-d7a49eda704c)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         dbb4c185-5f04-4be0-a27a-690ba0888fbe)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         591c18cd-477c-4cf8-bab4-478d09e02c14)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1ec01253-f6df-4455-a713-ba891ee49f35)(content(Whitespace\" \
+         \"))))(Tile((id \
+         68c7cddb-233d-42fb-9393-b08732a8657c)(label(quiz4))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b1f9fb43-bf1e-46cd-9ede-176b97c2175e)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         eb3cab12-022c-4ad7-868d-b4af5b6aad30)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         657e9b44-1cfd-42a9-b46f-834e2cffeade)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         58fd18d0-323b-4be4-8874-9ab1e0a5534b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eae70d91-e2d7-48d4-8002-af51a3c89351)(label(exam))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         582df0a0-305b-48f1-9c6c-5a5ccd75e0d2)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         8541348d-3271-4aee-a64d-812a029c97ee)(label(\"\\\"final\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         223d1be6-89e8-4c51-95d2-4c374df36a35)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ffa5416c-8104-4908-824c-345cc24389cd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f7d0f1f5-cb05-4234-8787-a8cbe8088bb8)(label(score))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7d3f5292-d416-4c2d-8c11-cf57ed105be9)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         2bf5b780-14a4-45d6-be89-ef3392b6e6d9)(label(87))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         b35e8fea-ec96-4f64-901e-8958a0e09579)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         95d7b68b-430e-4268-8fc5-c6e57778c473)(content(Whitespace\"\\n\"))))(Secondary((id \
+         826e4ec0-973f-4f24-b786-7813f5326a7a)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ca08de04-e015-46d4-a1f4-1dc259bdd8d2)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         4acb13fe-7973-4ca5-a596-fcd2a29458e2)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         1e83638b-a3d6-4a1d-a2ee-82ef06ee3da1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         421861ca-91a7-44c0-9e11-5ef9159628a7)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         9330950a-3af8-43ab-bafa-b85ee391cb80)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         92b4b9a8-047d-4b2e-8517-3da8b54fb215)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         43178796-aeb5-4117-8d4d-87648356f094)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1fe2477a-5a2a-42fe-8b3e-a102446c30cd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2e65839a-58a4-40db-afdb-1058f3d0a623)(content(Whitespace\" \
+         \"))))(Tile((id \
+         16112df6-6a19-450a-87b1-d57d4673d5ca)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f93e336c-8480-4de9-a55d-1e977d826699)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         66d069db-df83-4414-ab67-e24b18cddfa9)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         aa0b9a43-e2a2-4839-a5a6-2aa865aa6107)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         45da0252-387f-4ee1-bdc5-6976f67cc139)(content(Whitespace\" \
+         \"))))(Tile((id \
+         91ce9e56-f340-4842-bbca-8e75df76f21e)(label(quiz1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a0cc2acc-f34d-47a4-aafa-62ce43fc5106)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         e0ef465e-b26a-4d66-8227-f633c104f9fe)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6d89c46d-47d8-4fd7-891c-c2fbb8977a53)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         75bdd44c-14f1-46ce-9ec9-a12b6e964c63)(content(Whitespace\" \
+         \"))))(Tile((id \
+         84b28a6b-c1f0-471e-9749-aaeed080b645)(label(quiz2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6fc48cb4-0e8b-467b-910e-e32f428e3c98)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         e216f1b6-d5e4-433e-8751-c74b5ebc4b3f)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3d8f1494-a921-4691-a28f-ce59f7f01226)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c377305b-1d86-4daf-ac63-7501e42d4b6d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         93cda514-761a-41c1-9235-90311efd5eb5)(label(quiz3))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3e8abb96-5b90-412f-9d73-b32e0fafa3e5)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         aaf046f4-01f9-4441-bbf4-e7b849bdc8e1)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6f226b70-5c6e-4be0-8dc2-c460147ce6ac)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         223c0c96-b717-4987-83d3-51780e57074f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b65d7ea0-c817-4cc2-8ec6-636c9fa3f44a)(label(quiz4))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b19ddc52-67d2-4bdf-84ea-d2006cd42078)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         3765c1c3-1236-4c53-b947-893ab4dcb571)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b74527ac-ad46-4816-8e1b-7e5e99d35a65)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6191e776-026b-4d22-8cd5-95fd310dc91c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e2c110a7-c027-4eca-bab7-8c6380d48287)(label(exam))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         34d546b9-15de-41ae-8929-aa67c550e089)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         08922ad9-7eaa-4c4e-be40-443b150439ba)(label(\"\\\"midterm\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         dc8a8fa2-fae1-45a0-9e14-537f23ca9a7b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d93a3e0d-f817-4018-a724-e63aff64982a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         35c6d8a6-bcf6-4fdb-ad55-02711418f796)(label(score))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         286afd0b-03a8-4f22-95b9-27b82f15cfd7)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         2c5d5212-5f75-4221-90af-1eb09c4c53de)(label(88))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         04a4b41e-6ef3-4027-b3fd-ea0acfd3a5ce)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         45650026-2b65-4ab7-861c-59c58f01b8f2)(content(Whitespace\"\\n\"))))(Secondary((id \
+         feebcc12-75a6-48e7-ac43-13c10f7837c5)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         71efb0bc-811e-45b6-856e-4dd54022c229)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b3e6187c-3c7c-4fdf-b8c6-8e04593943d4)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b5b64541-8c68-43a3-987d-67e8f2fc106e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         000d8906-72f0-41ff-9434-d0a543c185b0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         377d9628-4f86-4413-adee-894ffa661daf)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         df8d2ea1-7cb5-41e9-b4b7-8edbad24490f)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         d0382348-80f1-4d30-894b-569c9eaf5ad1)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5722de94-1703-4ec0-974d-eb628d8adb8d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1dbb6c2c-7c48-4887-ab35-adc679930af3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         261e7a2a-ff3b-47e9-8dc2-b01ef31f9ff4)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6477478f-7d60-472a-a0ba-66b753142d23)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         5ba7620c-a599-40d8-b19b-95059338e137)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3b59c0f3-ff6e-4bd0-a85a-08c02d12e260)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         12b299db-6680-4fb6-9cfe-b17e29d8ff67)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f1e38940-0c6c-441b-9cd6-8ab880a6662c)(label(quiz1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         30498281-80d5-4a37-a5fc-1397545ca7bb)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         6b79f29d-92b7-4b8f-95aa-2bcce55501ef)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4fab4a6c-3783-4f71-ba88-64e73b1383bc)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8517cd24-ca86-465b-82e1-7d245500a665)(content(Whitespace\" \
+         \"))))(Tile((id \
+         109bb8ff-c750-4ee7-8674-ae7e371dfe9b)(label(quiz2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1d34c8e4-534f-471a-89e2-6e761760d1c2)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         0c8717bb-750a-4ab8-8e9d-2c859f81f177)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d4af8ef3-1f9d-4c82-a20e-0b5537fb2e48)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         77d8a1a4-7f1a-47cf-82bf-dda2a92c680c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         862f8b15-fd9c-47ac-b316-4a85450e35df)(label(quiz3))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         05637a42-f375-48c7-96a9-6d4bc7c3a1ad)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         2c76d79a-9b56-4477-a5f1-991dea9c99b6)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e9ad1209-26d9-40fa-93cd-fc2e5f2df649)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7035deb9-0299-4d30-8f68-e65e64637081)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6f907246-bb66-4e13-9792-8c1a24af5ca1)(label(quiz4))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         19c10b61-ed26-45fe-94e1-63beaa91dba1)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         90027bef-7a3e-4764-89d9-92e5100e339b)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6f7cb38d-a18c-494b-9521-2dbc846ed204)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9b0f32ed-c0bd-4edb-8705-fabbbbd8fb3b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5828561d-4fc4-4295-a9ce-b2bb38180ecb)(label(exam))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a478b2fc-8895-4b54-a62d-ce2751211370)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         bf44e810-d414-47fb-8141-a3c1852524d4)(label(\"\\\"final\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9c915e3d-d272-479b-8db2-3f016ff384aa)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b2ae9605-ed64-4912-b2cd-edbdf22ce572)(content(Whitespace\" \
+         \"))))(Tile((id \
+         03f1088c-95fb-4b0b-8ddc-02a299d72ebc)(label(score))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4253b998-44a4-47d2-ab5f-562893977339)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         0e87f206-7704-41ea-8f1e-b6e0fe850411)(label(85))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         eb245098-c725-4ece-8047-f52c10d07d00)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7b94c2c4-8f78-41c2-bbf8-1df4aae66ff3)(content(Whitespace\"\\n\"))))(Secondary((id \
+         ec4c7f95-6c0b-4b29-a7b1-5bee96516dc9)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         7d806451-efc1-454c-9cb6-9ed5ee001b82)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b5298bf6-714a-4348-8420-9fdbd8a832c0)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         d3a0f8f2-2758-4d71-9994-9717643d2df4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5b19e318-a2d8-441e-960c-a18ca0a74148)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         95599d2c-5db3-4323-b130-c8847f35d9de)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a97d7d48-e3f1-40db-a482-d152d02d697f)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         b77fc2ef-5a71-4d18-8702-7e1242f28b02)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         29404ae1-be36-4d82-a46c-3f17bd4f35c4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9265127e-9c05-46d6-9efd-3dff68610cbc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7e20761f-2ccf-4ed0-a2a7-fbd8021409fb)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         25433ba8-1097-4a7d-98e3-9c7177e9e572)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         0b05a338-9f9d-4417-9252-c1fd8af0db93)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e4253690-0f3d-4323-a92c-73b0e360e284)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c9576a0a-ed1e-4bea-a461-3002299baf47)(content(Whitespace\" \
+         \"))))(Tile((id \
+         facd88c9-2ac6-4fdc-b1e2-855090666294)(label(quiz1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9ed64e04-7b18-44c0-94c3-88436c519c65)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         453f6b22-6381-44d1-9a13-6aab4242bd36)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1bc4db16-0f04-49b5-bbbf-79345bd42760)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9f9a5fbe-5e24-4331-b3b2-0e07ca0867e9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         590693fa-bded-46eb-82f7-355eca291527)(label(quiz2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b425ada5-060c-4a7c-8f72-ff4b97ec9bc2)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         17f52b9e-f8f1-48f7-a0ba-15a6454ed681)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c0ecacf9-ba70-47b3-887d-b3240e3d7125)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         164525f4-ef4a-4135-ba07-35475c35d923)(content(Whitespace\" \
+         \"))))(Tile((id \
+         97443ca1-0854-4605-a77f-e0273329b7f4)(label(quiz3))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         584b2558-ea87-48fa-ac12-12be8525cbf4)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         ddf238a2-2ee3-4316-89b7-8dbdeb32bb57)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         268f7c33-90d0-4c67-80f3-7c9bb51642e7)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2748359a-20ae-45cb-aaa9-1dcc1c8ec57e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         30e94e2e-b29e-4878-85fa-e3825b0eb5b1)(label(quiz4))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9bfb9a3f-72fd-4768-bcda-19b548e9afdc)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         cc323087-ecaf-4a2f-b433-218b4175e80a)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         94b7f2d1-0dec-45a9-89b8-39061c08b0ef)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c47c6b0a-61af-4293-8b72-5b028de73439)(content(Whitespace\" \
+         \"))))(Tile((id \
+         adb54026-ad58-4577-89ec-6d85a286a775)(label(exam))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         dea7a6bd-8f86-4243-9980-6afa1fbdce90)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         625a7b32-1f67-4446-9272-dcc8096b3988)(label(\"\\\"midterm\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         71fb7d86-70db-44d0-b888-6eb6739db8db)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1e52b09c-f8bf-44f1-8c4f-7ff9e26ef5d0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0f846eaa-3a16-4d16-abc5-7fc89d88b659)(label(score))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e843e192-5279-4cbd-91bd-412313b5264e)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         12456507-a5fd-46e6-9fd0-3f835c1683d0)(label(84))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         ae0d91b1-8458-4f2e-807c-cecee940c176)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ecaf587d-7b58-46f0-a89f-6d5b956a6bd3)(content(Whitespace\"\\n\"))))(Secondary((id \
+         67620795-5fb7-47dd-b507-79fdab4c4fb3)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         2c6d6796-5ece-48ae-81f5-69e95f80250f)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         2992b610-d6c8-4d12-9e9e-8121bf766e3e)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         47b018ab-8745-457a-bca7-81c400338f38)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cdc7c27b-902a-4c81-9885-065537bc965b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         00a6ff40-12f8-4073-b58a-51dff8637d7d)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         15d450e2-9155-421e-898e-413f42e61163)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         c1794a87-a29d-4d21-996c-acabe39f15ef)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d7b21cdf-d43c-4c24-8967-c44380b2e174)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4000349b-3ede-4655-8ea0-1fe1559c58e4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d489ac4e-632d-4c45-b29d-232df86d7bc9)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         aa63b710-706a-4e0f-ab33-0670a065deba)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         2bbd3f2e-e73c-4f4e-a876-6c8d784aed7d)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c0121868-d909-439b-a05a-b8333ec63ede)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         10ff51f1-6e3a-484d-94c3-d18f08c691b8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1ac256ac-7f10-4651-9ce0-1f56ba0898b9)(label(quiz1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ae9e1987-f9b6-4251-8fd9-04a4a6e19fa0)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         1713f001-9c52-4975-91ca-ed2988502da4)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ff56cf97-dcbf-4b0b-a4c2-928ed4e0b916)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         081b6537-c2d4-426b-9869-6a00cd5bd557)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f768c6c6-cc9d-47ea-bc4b-85a254322725)(label(quiz2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3c3d5258-1d6a-4ce7-8f0b-2ae3fddc4719)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         e100ac61-9659-4c2f-938e-2d21158627f2)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cec8996d-2d15-463b-add8-805ea251fa2e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b64ccdb0-00e7-4179-8e48-99254a5bd6b5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         22ca1572-d7fb-45fe-a54f-e4d5ea52d1e6)(label(quiz3))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1e632e46-bad7-4a7a-9a5e-bccec61fa2be)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         949360fe-d265-4bf6-90ab-26c0e5357e2e)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bd96064b-47f1-44e9-b72c-24dad5d0b0db)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f45dc436-8485-4092-9602-a765008ac900)(content(Whitespace\" \
+         \"))))(Tile((id \
+         da1f53bf-a11a-4201-ba4a-5254eb89730f)(label(quiz4))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2b674cad-a135-4d39-ad0c-3a36bc0d3143)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         8705cb5d-a57d-4bb4-854f-e074f3971c73)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bcb8f599-271d-44f8-905b-852ff5046a3e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3059619a-d514-47b7-9ea5-ab6a3481742e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a6d03ca0-bb41-436f-9125-fc037ab5bc0b)(label(exam))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         604f88a2-5246-4315-be9d-380ee8f57352)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         507d0092-1ccb-4972-bdc5-439e843421ea)(label(\"\\\"final\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         77c30ce2-4657-4e3f-b3dd-07a2db02019c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9f18c25a-6820-4983-b0ca-195d56c69c64)(content(Whitespace\" \
+         \"))))(Tile((id \
+         beae25c2-8408-45e4-9824-e9d45fb697e2)(label(score))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         422f7614-e796-4246-a143-5d4a1f5f72ed)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         96c4c3e2-80b7-4a6c-8d3d-cd8307a7ab9a)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         e266cd51-1eea-4adc-8232-f24987d3c3f4)(content(Whitespace\"\\n\"))))(Secondary((id \
+         404a873b-e032-44bf-8fe7-76314ff7b1a3)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         3b640094-d910-4a77-a40e-2625ac125600)(content(Whitespace\" \
+         \")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
+         false)(always_render false))\")))(Secondary((id \
+         a95f9e81-3f4b-480b-841c-cec6394599f1)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7f9b3d7a-e759-420c-88a7-da0e9f138687)(content(Whitespace\"\\n\"))))(Tile((id \
+         c061b458-01cd-45e2-8031-f973ee663fa5)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         c3b8708a-7511-402d-9fbb-7121583bfab8)(content(Whitespace\"\\n\"))))(Tile((id \
+         c14eabc1-1117-4008-be93-5ac83a07f9b6)(label(pivot_longer))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         dd9a6b96-b3d7-4a51-8180-2ef7b5b063b6)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         eaa7134e-b2bc-430b-a08f-219cf348f41d)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         82e34f03-476a-47bc-be4c-a804a84e2826)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         34d1a1a7-e1b7-4e2e-9c68-e2740f8ea844)(content(Whitespace\" \
+         \"))))(Tile((id 5af184d4-b524-4d47-b8c2-f4acd0d80496)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         6178b63b-b825-47c2-80fa-fc4f64aafd8d)(label(\"\\\"midterm\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a3969fad-6cfb-48f9-997d-f25d8e9166f0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         15f2beff-2a02-4f43-9c56-1ca9bfd2e889)(content(Whitespace\" \
+         \"))))(Tile((id \
+         62436dcf-4f57-4051-8146-fea49f6d273b)(label(\"\\\"final\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         b5d5ff48-4c26-4e61-9a83-36f7c2fe177f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5e671bfc-2579-45ad-a59c-19694dbf8b9e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         51bf7440-f731-4f48-8600-df2d4e6812b0)(label(\"\\\"exam\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4b5cc59f-c0b7-4f2b-9307-1ae5d6cbd65d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         099a3441-1b88-4af3-8e43-a203b70f803d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d8787915-7b70-493b-85c2-aa520b4e5314)(label(\"\\\"score\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         a73e0466-4333-4bee-8ef9-010620c9bfb3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         42688167-422d-4e30-9c91-5c123191e93c)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4201b665-0cc2-4d2a-b978-6c6367ec3e59)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c261cd93-8981-4ffb-aed0-e62905943726)(label(expected))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6287b3af-c40c-4074-b50a-5caa66160948)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         1dfa8b3f-a008-4c13-9f24-55458d093877)(label(\";\"))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
+         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d9702275-bcb6-4fc9-a99b-eda43cdb62cc)(content(Whitespace\"\\n\"))))(Secondary((id \
+         c09adc4e-ab4b-42e9-87ea-22e4658eb83b)(content(Comment\"# The \
+         idiomatic way to do this with concrete data. Giving good type \
+         feedback#\"))))(Secondary((id \
+         dd7bda93-245b-44fa-aeef-f9db75255bcc)(content(Whitespace\"\\n\"))))(Tile((id \
+         9061ff30-f4b2-4d45-87ea-055ec9cc208e)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         037ac3ba-b1e3-4efd-8178-fef86e960a49)(content(Whitespace\"\\n\"))))(Tile((id \
+         83587d9e-5d78-4c6d-9cb0-82354b4454d7)(label(flat_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         43ae8b8f-3ffd-47a4-a6e1-a0f17a7d0803)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         d39e153b-1f4d-4fad-9f1c-598b3a756d57)(content(Whitespace\"\\n\"))))(Tile((id \
+         00004566-5be0-4ab1-9015-44d8d002941f)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0cb5be40-ba5f-4f51-b397-4b348f1ef430)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b8b84605-b818-4a55-99f6-aa9ac1fcc33b)(content(Whitespace\"\\n\"))))(Tile((id \
+         55ecf256-ad37-4052-9431-2f534d07ba40)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         24db8389-5087-47e2-aece-ba521ffef49d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1585a1a3-1b36-4247-bfe9-e1c4b41304ef)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         022bd540-2c66-479e-bb47-f00ddf756094)(label(entry))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a084495a-e163-445c-9ff6-5bb5138c9659)(content(Whitespace\" \
+         \"))))(Tile((id \
+         736f45f5-4d39-49d5-90e3-d1c64d50cf7e)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b61757da-f387-402c-8189-013d13dd8485)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0035f59f-bb20-4110-8886-a51b44446fbb)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         f7bd032f-297e-4997-8277-8a9228d9cbbb)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         176de9d0-ee2c-4beb-aa74-9901126453ae)(content(Whitespace\"\\n\"))))(Tile((id \
+         64e1e9e3-fb07-4ce6-92b0-5e58425aec11)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         adc85f63-1449-433c-969a-65af85322339)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         67da933b-45ed-4db5-baaa-1c8f10e53e41)(content(Whitespace\"\\n\"))))(Tile((id \
+         bfbbedcc-a60a-4ec8-818d-417d1badaa9d)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cab79188-72c9-498e-a990-ed4450c8be25)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         431ccc8f-ba31-44b9-a0ec-3310c9df42e5)(label(select_labels))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3df38a1a-c97a-4226-84c7-5ad04c9fce32)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         a0144625-0647-480e-a86a-5c1ecbb748da)(label(entry))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e2c4eb29-001e-4342-af2e-e164eea8418a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7f11800d-2273-4cf5-b99a-24474e587aec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         52bb6060-4672-4536-86ea-1feb233a715c)(label(`midterm`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         57dcfbd1-ed13-42ed-9447-238e8f47be98)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         30c9e202-0260-417a-bef0-9283c0d9de0a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1525210b-7ca4-46e0-bdcd-789c9cd935a5)(label(`final`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Tile((id \
+         328be505-cb10-421e-9dcb-d9b84c7fb555)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         222868e6-0cb2-4fef-916a-3b82cb98c0f3)(content(Whitespace\"\\n\"))))(Tile((id \
+         00def734-d212-4f89-8a4a-302241e88b98)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         c1b3e95a-38d1-4e58-b70d-256000b70794)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3c58713b-b269-400b-b5c9-09b7ac862356)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         06989a79-a479-4de9-b187-7d916053ba99)(label(e))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         7cb649b9-e79e-4195-a604-169b929df67c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         322a60e6-9ad3-4cdb-9ca8-74afb8da6571)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         db3528d0-4378-42e0-a610-b18e61d4d21e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6235fa55-7d2b-437f-9d86-890e08784507)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         e68c460a-3b65-4e78-82a6-eb7f45248686)(label(label))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9c740e53-1838-4d62-b6f3-7b3eb55d7b86)(content(Whitespace\" \
+         \"))))(Tile((id \
+         61e620ab-fc95-4504-8f76-49b55b014eda)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b938b220-542b-4c7c-b2fe-814904900bd0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6bd85337-3d14-4623-9e08-3e93d4bf8bb7)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         850535ae-a2a6-45c4-ba24-e6fb7e48797b)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b7d83044-1d96-4b98-802c-002f874d5f08)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c5a33ca3-fcd3-44d0-8ea9-8257a4d2bca4)(label(value))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e21bc894-66c8-4ca2-bcb4-0f4c6d2c7533)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a9a8b850-80b5-43d4-b0a9-911e8e0dc3c2)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c8a223ba-4572-4f5f-9437-21e5ca89dc2d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7d045c28-e3ff-4338-83b3-f7b52e5478d5)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         bd2804f8-bb42-4096-a5ce-158d885a5185)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f14d9f7a-0e9c-452a-a8ad-30fb3c794da6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c0a17821-1651-40fb-bed1-f2c82cfebe97)(label(omit_labels))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c2d5f07a-cdc1-4d86-b669-f4021d17129e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         736b4022-21b7-4494-bf45-a6b9f5ce725f)(label(entry))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         08758e40-c739-4923-94f5-f37df5abb8bd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         13e93c48-b02a-4c0c-9ad4-60055c839923)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cc6d7473-c708-4be4-956e-621c98b9dcbc)(label(`midterm`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e8b6dacd-379e-4292-aa96-7d67cc5687d5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         062730b1-bc65-430b-9e4c-a435b57329b0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b727eadd-d273-4a6e-a16a-1a6ba95844f9)(label(`final`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         d31cafe7-499a-492a-8b56-13b973734389)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3aa2e1e6-406b-428a-b20d-0468fcdd100b)(label(...))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c5488c77-ec3a-4bac-85a9-c61da5037102)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4d30284a-abad-4a38-b510-072c7080ab4f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         dd387708-181e-49e8-8fb2-df5ae0cdeeb2)(label(exam))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         51ae18c3-4c87-4422-b2a4-9211faadc0d2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         89082f7a-d467-4ead-8cb6-b5417ba5a17b)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         429eff29-b345-4d49-95c1-e7bda51d310b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         537f509b-348a-4b97-b077-ee1a0336ba6d)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6ae3a12b-a3f9-4af9-b712-6544f72d2957)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         c11a8a48-9dbb-4b31-b488-af7d58eefef0)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         197e730b-a1be-42ec-94a5-5ed441c2a9ff)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fb344884-38f6-4468-9312-4ac49935373f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         982f0fc4-5394-4b4d-870d-0dad13309d7f)(label(score))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1e23c441-fef8-485a-8901-f5428f79ad12)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fb026390-453d-45ff-a08b-e890fe79a457)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1d8b8898-aa2a-49a2-9d25-5f82b588a574)(content(Whitespace\" \
+         \"))))(Tile((id \
+         297998d4-5527-4083-8018-a118676e2aca)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         38eb11f5-c80f-4ecd-a1af-773b89421964)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         8d6f4f42-c612-401a-82b9-534d8480c2e1)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         5cc560ed-9a8d-4402-a2cb-ec7b7ddaced6)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         5b65083b-4d72-4536-9323-a668c5bf1fbe)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         640cc49e-b040-4116-87c7-b0bb129b02a8)(content(Whitespace\"\\n\"))))(Tile((id \
+         ca9b5000-5c38-4622-b2c0-5a102197300f)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         84c86a25-d89c-447f-8eca-b8075ebf82d1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0e6df87a-3ba7-44a7-833a-395613760eb3)(label(expected))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         69e98e11-ceed-4aac-99b4-0ab3ef7fea65)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         dbf68039-300f-48d5-93b6-a72faf01a102)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         a17d1def-0a94-4225-b212-189e970707b1)(content(Whitespace\"\\n\"))))(Tile((id \
+         cec10aac-b388-464e-af0a-339a9f4cb310)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         3a0fdafd-0619-4e05-92d3-2867bd80b16b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7d5c466c-6122-4bdd-9bc9-21ac3f264a4f)(label(pivot_wider))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e8ab259e-0122-4e7a-983e-6a468eb2fe21)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         f3d33ac4-6d36-4ea5-8c08-448c6a7cf503)(content(Whitespace\"\\n\"))))(Tile((id \
+         2567ce1c-e32c-4899-9a1a-5e3db46dc9f5)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         b26397f5-7692-4c27-afe4-c4f9a498cf5b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5aa96950-2fde-4f09-9442-7fefc1a057ba)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5292578e-8a46-4e09-8522-bfc74e99b9e6)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         bad21b49-cea6-4410-bfa1-a8c1eafa0026)(content(Whitespace\" \
+         \"))))(Tile((id f5065284-af19-490f-8756-c3d0aa029f6e)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         441218f3-9670-424f-842b-fc7408fa505c)(content(Whitespace\"\\n\"))))(Tile((id \
+         69f3019a-2550-4db2-b506-dd27120d8f02)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         6ca1db79-0060-424e-9edc-a0d9b2755e89)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a69aa4e2-8a3a-4c6e-a3da-727d150b5a4f)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
+         6ffce3c3-f8da-438d-9f41-7f396e5971b8)(kind Checkbox)(syntax(Tile((id \
+         ea7dacf6-ee53-42a3-a9a7-49b77225f102)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         1e524e12-453e-4eb3-b126-c3ba310bd9ef)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
+         5689b5f9-76c9-4ee4-b514-b0efce555bb5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         82590c24-d06f-478d-a8d4-7935804fe193)(content(Whitespace\" \
+         \"))))(Tile((id 82198d50-8a63-46a2-9e7c-377bc996b4ab)(label(\"\\\"c1 \
+         is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
+         Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         b660c83d-343f-4798-9358-427f6e797be9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8622b305-743f-471b-903f-af719b7db04f)(content(Whitespace\"\\n\"))))(Tile((id \
+         2e3d2f44-0ef2-495a-ad11-bfe1ccd92477)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         01446c06-c8ff-4ec4-82f6-935324fe7151)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         203b1c28-b22e-4b4b-b9d2-cf3cb5ba9c08)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
+         41b7b3fa-c69d-4e9c-a128-a802bfd82393)(kind Checkbox)(syntax(Tile((id \
+         63e65b85-8406-4154-be00-86c6f58baf93)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         26048d20-049e-4da9-969b-745a3656cc3a)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
+         8bfd68a5-16bf-4974-b6e0-0ae298bb2be0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         089064cb-3dee-430a-ad94-a3ae432525fa)(content(Whitespace\" \
+         \"))))(Tile((id 3d4c6a78-f9cc-44e0-974b-2c57290f746b)(label(\"\\\"c2 \
+         is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
+         Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         10b81da4-b778-4a36-a339-338254a545a9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         28a74dcb-0ea6-471c-8a5a-69235159ed4a)(content(Whitespace\"\\n\"))))(Tile((id \
+         2691a631-4c23-4ea0-bcc4-6cdfe1842722)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         52ed68e4-380d-4217-ba55-7f5b9d2a0c58)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2ce6fa72-6c39-49e5-a61f-8f014134486e)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
+         1798e143-c53a-43b5-b39d-28b3ee65f02a)(kind Checkbox)(syntax(Tile((id \
+         e57e4a3e-81e7-4b18-a9bd-b1805038e281)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         6ebb6793-4fa0-40ef-8d19-5071b6a48f31)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
+         437611fe-2638-4d04-992a-1b96dac4bfea)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         79be366c-5b2d-4cfd-89be-65ddf3746eb5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6ee20b3e-6245-4e2e-8bcb-f41b47e8bf12)(label(\"\\\"schema(t1)[c1] is \
          ColName\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d905e518-ff91-4a9f-924e-447e1a098720)(label(,))(mold((out \
+         fdd67be1-9cbc-46bf-84c4-22af60b726c0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8b0ffc11-a6fa-41c2-a627-7c578a832ee1)(content(Whitespace\"\\n\"))))(Tile((id \
-         bda2534a-f704-4429-b353-f5622c698306)(label(\"(\"\")\"))(mold((out \
+         39a3d6e7-71ec-4e3e-8c61-56d5f0c453b4)(content(Whitespace\"\\n\"))))(Tile((id \
+         2f962384-751b-4c87-8c63-e5d9de5817fe)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         4adabacf-de54-42fc-bcd8-3541c913771c)(label(enforced))(mold((out \
+         81edcf93-e42f-4530-93c8-c6b26d3aadc8)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a1f1c194-2144-44bd-8d97-60f9667a2f6c)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         22d9fb6b-e59f-485d-92fa-ed58c8317585)(content(Whitespace\" \
+         \"))))(Tile((id \
+         72dd32d8-ec33-49d9-8eac-e6d95c029d72)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         33907662-2571-4760-bcec-e3f425698850)(kind Checkbox)(syntax(Tile((id \
-         6d601324-48d6-4e20-b4fc-794aaa18d92c)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9b219f55-726c-4450-8c8a-d1bf2ef399de)(content(Whitespace\" \
+         \"))))(Projector((id 57018fa2-1403-44bd-bac8-9ef6419cbb31)(kind \
+         Checkbox)(syntax(Tile((id \
+         de84f82f-207e-4d39-ad7d-b5c80df7903e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         51c1e0b0-00f3-4388-a502-c431da17364e)(label(false))(mold((out \
+         b039eecb-17f7-4361-a382-db7e4c8d681b)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         36599d98-bc8a-4c68-89e7-e7d227012608)(label(,))(mold((out \
+         fb2542e3-eacf-4f11-8e5a-9ac6940954c3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8630cff6-f0f6-440b-b8ae-6c3a3fa6495e)(content(Whitespace\" \
+         c8ab99f4-fa15-4b35-898e-8bc12e731e51)(content(Whitespace\" \
          \"))))(Tile((id \
-         769cad10-8338-4f47-a8cf-70c4a20dee6a)(label(\"\\\"concat(removeAll(header(t1), \
+         cdaf8e4f-d549-4fd3-af1f-8e9dc9f2b989)(label(\"\\\"concat(removeAll(header(t1), \
          [c1, c2]), removeDuplicates(getColumn(t1, c1))) has no \
          duplicates\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1eddf667-2f10-49c4-9172-473b9852b035)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         29c72938-55e0-4583-9d39-af300a0a89ef)(content(Whitespace\" \
+         250d572d-b5a8-40f0-97ed-b9eae26d0900)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         1a525e27-cf8a-432a-af30-7993b3d31c20)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         403ed01f-a687-41fe-9bcd-379d822629fa)(content(Whitespace\"\\n\"))))(Tile((id \
-         0d845e7f-378d-4aa4-a54c-ef41f669d9fb)(label(let = in))(mold((out \
+         037ff0b7-1981-4b1f-a5b7-a192e28ea0fd)(content(Whitespace\"\\n\"))))(Tile((id \
+         723ef8d0-aa93-46e3-8717-439f4e8bc7d5)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a7292162-1150-4a04-98f9-cc371d19ea0d)(content(Whitespace\" \
+         2e6eec88-534b-4b52-82cb-c5c131165488)(content(Whitespace\" \
          \"))))(Tile((id \
-         e4fdd807-97ff-4810-b4f4-1fbe202aa8e2)(label(ensures))(mold((out \
+         8fb6b4d1-538d-4429-bd61-28cda2ce9431)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         f80bcc41-72be-4a7e-afeb-d3513741bc7c)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         302339ae-9502-4ed4-b93e-6ad90ab0967b)(content(Whitespace\"\\n\"))))(Tile((id \
-         dab2a5b6-83bd-46fb-9e68-75839ca7fe62)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a9f02f53-4198-4e30-a974-adceceb91d23)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         7c2b64e9-d1a5-409f-9e65-235e1b6fbe0b)(content(Whitespace\" \
+         \"))))(Tile((id cdba63ff-5c96-47b3-95e9-20ece940b67f)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         3434d8bb-b953-4821-abf4-4621aa731755)(content(Whitespace\"\\n\"))))(Tile((id \
+         d5d082cc-8dee-425a-b7f0-faa4e56649a3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         35a6e894-eb46-4039-b52a-ca13b606927d)(label(enforced))(mold((out \
+         4d27c2e4-6420-4669-9146-ca0ab12f640f)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         03ff50bd-f449-47a5-a6b8-e6c2d3720fae)(label(=))(mold((out \
+         32d9841d-8417-404b-ba09-30843d124212)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         e9ca3942-b194-4869-995f-e896cb7a8cd8)(kind Checkbox)(syntax(Tile((id \
-         1ea63c99-4d20-48c7-ae8a-214a7f9054f4)(label(\"(\"\")\"))(mold((out \
+         fedbf7c0-091e-4fed-b0a6-cdc1490fd1bb)(kind Checkbox)(syntax(Tile((id \
+         b16076c7-f05a-485e-aeb8-e0ba27c544d9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f626f5a1-cfd3-4ca3-8a51-01316d8150a5)(label(false))(mold((out \
+         2c16cd3e-db1b-4187-bfee-db69296add4e)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         a135692b-01e5-4f5e-a7fb-28133e9fc0a2)(label(,))(mold((out \
+         4507448b-fd3b-46a7-9ca4-cfa45c6a89bd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8d3da9e5-a03b-4ac6-8293-e01eaf4f8c7e)(content(Whitespace\" \
+         0429c37c-e96e-4ce0-8af9-ae69218b4f23)(content(Whitespace\" \
          \"))))(Tile((id \
-         d46984f3-c08b-456f-9fb4-9fadc0fb7b93)(label(\"\\\"header(t2) is equal \
+         39d38b13-6d87-436d-91a9-15f74716a95a)(label(\"\\\"header(t2) is equal \
          to concat(removeAll(header(t1), [c1, c2]), \
          removeDuplicates(getColumn(t1, c1)))\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         fafacace-0cd8-4b3e-8d04-9dc4e29e9ee5)(label(,))(mold((out \
+         2728c355-698a-4f5c-a332-e1b0278eba0e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4227eed8-7df4-4550-9fe4-b526a28e6ad5)(content(Whitespace\"\\n\"))))(Tile((id \
-         23d09477-db3c-4336-a7e5-03d3e036c45b)(label(\"(\"\")\"))(mold((out \
+         1dd85b06-54e9-4042-8265-b712e927a08d)(content(Whitespace\"\\n\"))))(Tile((id \
+         59d757f0-8e12-4551-ab77-13c845261446)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         ec13bed7-b661-45bc-9589-1465915754d1)(label(enforced))(mold((out \
+         d3c695b3-a190-41bf-815a-5c89621e38e6)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f8d576dd-04b2-4176-9daf-c91ab4d7e928)(label(=))(mold((out \
+         bbf894db-2222-4e69-841a-69731c49ebac)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         4f6c09f4-4608-4059-bf87-039062e8362d)(kind Checkbox)(syntax(Tile((id \
-         d9f07e69-d6cf-401e-9efd-b349542e2fb0)(label(\"(\"\")\"))(mold((out \
+         445b56b7-7f7f-45b1-a8ea-efc86d841d2e)(kind Checkbox)(syntax(Tile((id \
+         a108d884-886e-444b-9376-d641b287cdc7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         2cca8813-23ed-4847-814f-7406f6e62fe3)(label(false))(mold((out \
+         a8c447a7-84db-47a7-a02b-60ab34005ea6)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         bf0acca5-10f7-4f43-a89d-521c915d9486)(label(,))(mold((out \
+         4f7b884f-1784-4618-a15b-1c45efe9975a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         37e43721-c08b-4060-b625-5cb792a786e7)(content(Whitespace\" \
-         \"))))(Tile((id 029294c2-8e25-4ed2-b0ec-3df126cf4db6)(label(\"\\\"for \
+         e11dc2a4-cdf6-4abc-bf8f-239f74be9b63)(content(Whitespace\" \
+         \"))))(Tile((id d1122f5b-3e0c-4ab2-8443-914766935268)(label(\"\\\"for \
          all c in removeAll(header(t1), [c1, c2]), schema(t2)[c] is equal to \
          schema(t1)[c]\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         371cd9eb-cae6-4334-bf25-dbc4956257d6)(label(,))(mold((out \
+         ba2991e1-7d6c-47a4-bafa-34da3d7f1d50)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c48f0516-a702-486f-846c-699c3ae1af97)(content(Whitespace\"\\n\"))))(Tile((id \
-         5bcf2260-87d5-4676-aac4-a8c69730c85d)(label(\"(\"\")\"))(mold((out \
+         4903155f-8ac3-40df-82c8-1927845d047a)(content(Whitespace\"\\n\"))))(Tile((id \
+         f2e0a95e-d3f0-4a88-9da9-c121f4b6699a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         99b448c3-e6b7-46ac-a03c-8291449444a6)(label(enforced))(mold((out \
+         ddb7167e-e935-43da-b1e6-1d1e0c46be93)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         47928ee6-25f6-42ac-a7a8-21e78ba7d8b3)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         274ba384-7b6f-4f94-b0a9-7332c1f2143d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         68e8eded-7f79-4487-bb37-fe71152a3e10)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         cb17cafe-b263-403e-b696-4ecb0ceaeb3a)(kind Checkbox)(syntax(Tile((id \
-         0295b5a2-8e31-44df-aec7-080bacca1a9b)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         08d57556-45f9-4974-ad47-76e709a35d93)(content(Whitespace\" \
+         \"))))(Projector((id d1c443f8-d597-4495-b918-f288b8882024)(kind \
+         Checkbox)(syntax(Tile((id \
+         8d64dd82-1f47-42f3-aec3-3645071d995a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         4b794147-7780-419b-bab5-92f9f2a4d7c4)(label(false))(mold((out \
+         6a5c0824-997b-4548-8ce2-9d2311832887)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         8f670bc1-81e0-4d9d-8f1e-030ad0647d10)(label(,))(mold((out \
+         7344b380-dc20-4133-92ed-d90b50c0dc71)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ee3338ad-2190-4644-83fd-0e55aff11608)(content(Whitespace\" \
-         \"))))(Tile((id a50c4965-6b92-4fc5-9c5b-40e80840ba25)(label(\"\\\"for \
+         1de3f447-1393-4159-86a6-19e31dfa3af7)(content(Whitespace\" \
+         \"))))(Tile((id 01e393df-61bc-494b-8304-f02a29b5fe25)(label(\"\\\"for \
          all c in removeDuplicates(getColumn(t1, c1)), schema(t2)[c] is equal \
          to schema(t1)[c2]\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8dc7441e-14b1-4157-8df0-b189abbcac3d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a94a5b2a-134e-4637-b4a0-779456afb551)(content(Whitespace\" \
+         fdc06bf0-7ede-4234-897a-f4a51f3275f0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         2f49f94f-b5a5-4536-badd-6c8063827cac)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         df041965-1f1c-40ca-bdd3-1475ce338756)(content(Whitespace\"\\n\"))))(Tile((id \
-         a297c3e7-0be4-4196-938e-aa6b765f5341)(label(let = in))(mold((out \
+         788afc95-58bf-4a33-b3d5-9d06844a3a36)(content(Whitespace\"\\n\"))))(Tile((id \
+         10490f32-a4ec-482e-8597-14f9ef67e3cb)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         db24eb4a-9ecf-44fe-9863-155e1f297067)(content(Whitespace\" \
+         e8856eb5-4a6c-4888-bdfc-fd1909349f4e)(content(Whitespace\" \
          \"))))(Tile((id \
-         27742a1e-5914-4ada-b378-d0212b5c584d)(label(distinct))(mold((out \
+         40c4b541-32b5-4982-8639-223ac9aa9843)(label(distinct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e5138238-c457-4fad-811b-ef737e6816af)(content(Whitespace\" \
+         d150c6b4-df97-4682-8d7e-79fe78bf6ecb)(content(Whitespace\" \
          \")))))((Secondary((id \
-         58f812c4-694c-44fb-b038-c3300721d569)(content(Whitespace\" \
-         \"))))(Tile((id 0c4bc6b7-e8e4-4085-a38d-935fffe0370c)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         72ba78c8-91d6-407f-9d69-8ce0465aecc6)(content(Whitespace\" \
+         2bbff4a2-7e88-4efc-b883-00cbad9359bf)(content(Whitespace\"\\n\"))))(Tile((id \
+         1672511f-7f38-425e-8348-f698ffd8886d)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         bc8acb9a-cb93-4f5d-9393-5e3525ace8c7)(content(Whitespace\" \
          \"))))(Tile((id \
-         5ac28e9f-9914-4a11-94ca-e24f952f7bdb)(label(xs))(mold((out \
+         e019859a-dadd-48f1-8a4c-f7eaaf2cec88)(label(xs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7d4f1f9b-0812-4039-ac32-7f0100c8f8fa)(content(Whitespace\" \
+         1398691c-cf2f-490c-9303-c4661ee31990)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fe58d69c-7f1c-46f2-9385-9b684a42cf62)(content(Whitespace\"\\n\"))))(Tile((id \
-         ba98d078-423c-450c-b9c7-9b13fd1379a9)(label(case end))(mold((out \
+         d53f614e-fad5-4938-885a-c340bab6df6b)(content(Whitespace\"\\n\"))))(Tile((id \
+         f0f6eb0e-96c2-439b-b026-c01d5f07def2)(label(case end))(mold((out \
          Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         d8bd64da-7632-4211-b4a6-2b79d2a3d508)(content(Whitespace\" \
+         7e1df6f7-0acd-49d9-a1f0-93c374d8619d)(content(Whitespace\" \
          \"))))(Tile((id \
-         c2db26cc-7cbb-44be-945e-4d4b1266a124)(label(xs))(mold((out \
+         10d27d1e-5854-43a5-b6a8-4ef3f6691ff3)(label(xs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b1ac3310-1dcc-4bd2-aef6-2117f68f229b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aa4d3da4-adf5-432b-893b-e692e7b6c8c1)(content(Whitespace\"\\n\"))))(Tile((id \
-         b094f322-55b6-40d3-98bd-86472ff90bfd)(label(| =>))(mold((out \
+         9835bab1-219e-4782-8707-d007a28b8b6a)(content(Whitespace\"\\n\"))))(Tile((id \
+         cf7284b1-d948-465a-92b6-d6ac57f40298)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2557f458-bdb3-43b9-b028-a10f35cdb458)(content(Whitespace\" \
+         81f5d5a6-6fbb-40d4-80a2-1927e57459c2)(content(Whitespace\" \
          \"))))(Tile((id \
-         35918651-ed02-4041-b46f-094548f7ca87)(label([]))(mold((out \
+         aa9f439c-d2f3-464e-a3ab-e208708e235b)(label([]))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9351e90b-d85b-4780-b31a-a8d5631c6a96)(content(Whitespace\" \
+         8f021194-90d7-4be7-a628-1fb72da990b6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         eaca2c3f-8950-41e8-9a5d-890a1cd648a9)(content(Whitespace\" \
+         d63b340b-7877-4c60-9726-9c758fa9aff2)(content(Whitespace\" \
          \"))))(Tile((id \
-         b22d4bcf-b1c1-497e-b22d-c547bf758001)(label([]))(mold((out \
+         46e2200d-8d7f-4c2d-826d-211a8f4114fa)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         da2f2897-4197-4cef-b2b0-1a7074971487)(content(Whitespace\"\\n\"))))(Tile((id \
-         acc2208a-d2ce-46a6-a55e-c2256d34c4f2)(label(| =>))(mold((out \
+         f02ef678-2472-45fc-b8cd-5b785b11a783)(content(Whitespace\"\\n\"))))(Tile((id \
+         318d504d-6807-4215-8073-e045d936b029)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         dd228a77-e5df-4564-aec8-731f4d729cdd)(content(Whitespace\" \
+         815d87bf-28bf-4ed2-bb15-9ac0851c6f84)(content(Whitespace\" \
          \"))))(Tile((id \
-         a077425d-1224-4605-845d-ca3a84ba0666)(label(\"(\"\")\"))(mold((out \
+         645f9a51-81f0-4df1-bccc-6b67e9902253)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         3eaab6e8-a480-4b36-bcf7-2065187a7bdb)(label(x))(mold((out \
+         2f757db1-707e-4702-81c2-760af39e2d81)(label(x))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         55a7712f-6d5b-4422-badc-232d49bf364d)(content(Whitespace\" \
+         8560054d-0698-4ae6-b443-dcd0cff8c3af)(content(Whitespace\" \
          \"))))(Tile((id \
-         422090f8-e080-47c2-b972-1cfc0af60c32)(label(::))(mold((out \
+         5ca403b8-dfbe-4e6d-b991-bed81920bae5)(label(::))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 29))(sort Pat))((shape(Concave \
          29))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         87959f56-4857-4598-bdb3-c4e8a8a4d2cc)(content(Whitespace\" \
+         74265666-b65b-4cc3-ba04-976076d3688d)(content(Whitespace\" \
          \"))))(Tile((id \
-         dfd0dac3-5d6f-4b19-9087-58619a26deed)(label(xs))(mold((out \
+         48554219-f561-4c76-8e07-95292d51b405)(label(xs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         c6e05405-a176-4bf4-843f-66bbc593ce2c)(content(Whitespace\" \
+         09ad0770-4b64-461b-9fe7-bfec7378b309)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9e476164-b30c-4fcb-bcb7-27bd9170eaca)(content(Whitespace\" \
-         \"))))(Tile((id 8360a8fb-fa69-4fc2-9537-4d3170c7c541)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         a265e3e9-2d82-422c-82c5-f2ec43fd329f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a0e4a265-8beb-4b16-855d-938acd21acec)(label(seen))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         8879899c-51f8-4ade-83e5-21cf9964a410)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         dc2d4cd6-86cc-41e3-aa4d-ebd4cdb76554)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f70a7941-2844-4bbb-8184-f88d292e7e99)(label(distinct))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         625fe0b5-15eb-4ab9-94cf-d86d19fca75b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b2d11865-384b-40c0-8846-f2db431af48d)(label(xs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d61a4ae3-dd13-40d6-80a7-a9a80b4afcbf)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         84293b6a-7dc7-431f-ac81-8cf917b7ad3f)(content(Whitespace\" \
-         \"))))(Tile((id 0ff60888-5d7b-48c0-9070-dd4ad9b61b5d)(label(if then \
-         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         f8ce7b9f-aa24-4512-afed-f47993d121cc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3400fcdd-3ba4-4859-836f-33213a73547e)(label(mem))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2ab752b2-32fe-42fb-962e-c717cbc473e4)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2864cd98-b7e6-4a62-b4aa-1def3d887600)(label(xs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6a3cb5b6-ad82-475d-9366-52973e571125)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         91cba8cc-77e0-435b-99b4-49285d8a3d6b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3b8ea038-39e1-47e7-8045-c3fcfd623c7c)(label(x))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         637efea7-1bb3-43fb-80c9-a0e0343092c3)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         504809f6-483b-442c-a76d-07a52c40bde1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7f81ea54-7766-4b15-a730-61d6eae13cf1)(label(xs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         83e2de3b-ef05-49d9-b958-5f980747b947)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d9d166a1-5d67-4182-ba19-79b091e72e79)(content(Whitespace\" \
-         \"))))(Tile((id \
-         65c75a6c-dfa1-4a06-8b38-4e22139ea5a8)(label(x))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         a23d338e-c4c9-4fc4-a291-37310a88c55a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6ce0e0b5-3318-4e8b-be4b-4af8484d918a)(label(::))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
-         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6ced1a30-2ed1-4f70-adbd-10d11cf9bb61)(content(Whitespace\" \
-         \"))))(Tile((id \
-         caa3319e-1f5d-4438-8a92-d827660d6b51)(label(xs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         9c934b09-d1b8-4b76-bc07-54ba99d214f9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         df8100ea-3377-40a4-8770-1d0c73f66984)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         dedc2074-6d4b-45c2-bdd2-b8089696a314)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         25dd5e1b-1e4d-49a5-82ac-3f9b1408092b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d7172b56-1cb1-4e4b-a7bf-6e031a82e593)(content(Whitespace\"\\n\"))))(Tile((id \
-         9dc238cd-db0d-40c9-b99b-185463763638)(label(let = in))(mold((out \
+         9cc2f362-7eed-4842-b9fe-d718bc1ddc72)(content(Whitespace\"\\n\"))))(Tile((id \
+         39211b8a-5368-4a44-ac9e-2a7065f0308c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1e52df08-166d-4bbd-8930-35f0b0581e77)(content(Whitespace\" \
+         05739cb0-4600-41f8-9d51-989ffc1e6d91)(content(Whitespace\" \
          \"))))(Tile((id \
-         e035480c-cd0d-4aa8-9f67-934a2e1b4e72)(label(pivot_wider))(mold((out \
+         23d5fc78-6aaa-493f-9841-705215e9d566)(label(_seen))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b2b6cca1-619d-4aa3-a6a8-e51c52ccb61e)(content(Whitespace\" \
+         193bb168-55f4-4331-bce9-ce3cac75e338)(content(Whitespace\" \
          \")))))((Secondary((id \
-         64f08dbc-2375-4811-8e31-e30731841bab)(content(Whitespace\" \
-         \"))))(Tile((id 68661c36-fef6-4d7e-ad8c-e15163e4bad6)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         fb68916a-b7a4-4c06-b547-be481617a835)(content(Whitespace\" \
+         10fe71e5-a0ac-4764-a97f-6bd428538ba9)(content(Whitespace\" \
          \"))))(Tile((id \
-         d08a7d93-9f8c-4d92-8c85-7c26d2883267)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         0aa6d086-2072-4712-a4be-3e8e1038c173)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         3632d7f1-791e-45e1-8dea-356ed7baf511)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         379464d3-909f-4915-824c-298e7b59ecdf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         927d3aee-b46a-4c69-9ffb-595be724629b)(label(c1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         90ed898e-8ae6-42e4-9c17-5b59a514be23)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ea4f4e43-cac2-4056-9052-c7f247a6c622)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ab2012a3-9fc7-45da-a1e2-c157860a5531)(label(c2))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         c1d92f2e-6df8-484a-bd5a-738fab401544)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b5705f1a-e349-4d6e-8e03-60941f020920)(content(Whitespace\"\\n\"))))(Tile((id \
-         6c697249-d116-443d-bc21-594123d887ae)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c4ff2212-3ec3-4429-8840-474f21b3b566)(content(Whitespace\" \
-         \"))))(Tile((id \
-         faaf0dc8-3f2f-4a8e-be05-7e0b4d98f498)(label(kept_columns))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         1d05385e-5645-4b6b-bf2d-d2498a9bb1b9)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         d604da1e-9ed5-4f11-923e-2cdf38971cfa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3b30eb5b-471e-43ad-92f6-34390633188d)(label(map))(mold((out \
+         af8c9607-e08b-4f77-97ce-d454b7c738cb)(label(distinct))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4b76292a-ac39-4045-8ddd-1919eec7c097)(label(\"(\"\")\"))(mold((out \
+         cea1548a-4ba4-47e9-9b12-08b09e4185b7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         7c0f5472-71d1-4a65-8c95-7ed4cc0e0c34)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ac44d1b2-c434-4020-94c8-469e3581416a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         180a7837-4981-4134-8a86-6c6030cd463b)(content(Whitespace\" \
-         \"))))(Tile((id 6d773610-8701-4884-932d-644b32c01463)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         dd961852-3de2-4912-a2d5-3c0de756ac81)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e598bac2-0edf-49cc-8966-090c9c3f6562)(label(row))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         b4ad11ba-31db-42be-b291-a5063afc9047)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         af3f3824-8a91-419d-9982-62f929227278)(content(Whitespace\"\\n\"))))(Tile((id \
-         a8e98dee-2b60-4991-a2fc-9df07babd059)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         ae3b320a-f3f5-4b94-89b8-126a5ce833e8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d8ec78e0-423f-46ae-b72b-4bb4877264fd)(label(entries))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         00fc1988-89c9-4ab7-b37f-5e0a7eeba712)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         6e6d10ca-2cdf-4ee3-be32-ad1f15499248)(content(Whitespace\" \
-         \"))))(Tile((id \
-         47f44fc0-e92f-4207-9e5f-6dd0057a378c)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3e919fa9-3c6e-44ce-aaf5-e7e184b6a48d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         894cfbd0-439a-4c5a-9b32-8e9deffd582e)(label(row))(mold((out \
+         5143fec7-a388-4cf5-bda0-4f3f287c9779)(label(xs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         a6ffdbd8-9148-430b-b4b9-f62fadb0154c)(content(Whitespace\" \
+         53c836d0-ddd8-4e77-9fe9-896be6efb619)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3c52a6b0-eed6-4f7d-8648-549e04230820)(content(Whitespace\"\\n\"))))(Tile((id \
-         692d53ba-ce5f-49a4-a735-50d6031922f4)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b9825894-b157-4857-bbfa-c1126ceb1272)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         0889e510-fcba-4796-9699-8c0607b424d0)(label(entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b0d7f458-2d58-458a-8d71-b125a7d17c1b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         27af12bd-23d1-4279-bd5a-464ed7b31365)(content(Whitespace\" \
-         \"))))(Tile((id 86556fcb-b76a-4e91-9f17-a4c220ccacde)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         e0ec556b-e488-415c-acbc-4bfb45a5c995)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8a31d1db-a4ef-4e07-a3d1-be4e4cff99eb)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         3447666f-f905-4577-829d-a4a9ff416523)(label(label))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         7699f970-7819-443f-9588-9473c465dd7d)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         bf7d6f06-586f-418f-93ca-0540923336a2)(label(l))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         9f0e232c-8bc9-4026-9d45-7242fbeba7a2)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         c246ffc5-9216-473a-9b69-8ec7b49f8dc1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         73d95454-ad7d-41ed-a834-01d280138089)(label(value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         feb99455-1c2c-44a9-9351-aa3c990c8f8f)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         aed425c0-f1b3-430b-9134-77f920678c60)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         c3a4af00-7319-497c-bc1d-bae08fe0af05)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         662df0a0-fd01-40c1-a97e-80247c1f1e2e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         62d7dd1c-432c-43d5-875e-628086431cbe)(label(!))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4a480e24-55ac-4687-83c9-10c3e50f5066)(label(mem))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         22afac28-f048-4961-b3ee-b1b4eadf4cb3)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1865a692-05aa-4891-a0d0-ead039262ca9)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         4c74af11-ae46-4ddf-9e87-fa78915657e4)(label(c1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4669ef2d-493c-46ea-bcf6-f6e546c93d5b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3332d995-e709-4f2d-ae73-9ba727a6d85a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a78a2c39-446c-44b1-9408-2239318da205)(label(c2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         6470bebd-7b00-422e-a5cd-f9be32960bb3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2c051cc3-4607-4db0-8264-9879cfc7291f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7c641a39-4b17-4497-9404-021bb8af1500)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         fc201c55-9fca-4734-aede-1d273b13791b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         514f005b-a592-4753-99dc-fc506c45b69d)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         120801e6-8fa2-4e21-9232-a64f7ab4a6de)(content(Whitespace\" \
-         \"))))(Tile((id \
-         160cccad-e3b1-4ecd-bd6b-2b71b3ff6bf6)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6b83e219-b632-4bfb-ad5e-6291437ec08a)(content(Whitespace\"\\n\"))))(Tile((id \
-         93ca35b4-a46b-49d5-acc4-0bdd0991c846)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ff10aaa8-2a9c-4361-baf6-4fbb6d8df5d4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aaba955a-e4f9-4616-8710-6cc422f2e48a)(label(distinct))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         e05e347e-d97f-4b76-aa27-10533b082293)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f976c778-97d4-4633-a192-d06d2221c979)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6b533dfd-a527-41cf-85d9-21e5665b7356)(content(Whitespace\"\\n\"))))(Tile((id \
-         b0165cbe-ead6-4f47-b1cd-5ccdedbfd6c9)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         593e7a6d-4caa-40e5-922a-fcda72b399cc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9b161a8c-e6e8-4db2-a7e3-10ce94a968b9)(label(new_columns))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         aff7052e-b7d5-42da-959f-7544654d55f7)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         909a2b7e-3d36-4b11-a1a8-ffce19c82823)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e6b8ceda-33da-4c01-9fa1-6cc53c474d47)(label(flat_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         16ef3575-647a-41b1-97f1-a298efa7a630)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         35124a17-e1c6-4588-a1f9-2dcb036f4a85)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c525e375-04e8-4cf0-b573-bfb0bea72219)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         36692d41-eec8-4829-a92d-2a1fc94b940d)(content(Whitespace\" \
-         \"))))(Tile((id 9c40363c-dfb5-41a7-8865-b4153135466d)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         44610ce2-be73-4cf8-885b-24038b136fc9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1bbd6922-9467-4beb-83df-0f7ca61e9d87)(label(row))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         4fffdf49-afd5-4740-9d06-8d053212fe2e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         312bc507-83b5-47a7-82ec-8ea2c355070b)(content(Whitespace\"\\n\"))))(Tile((id \
-         043db1e3-7d0a-40da-8186-dede786bca6f)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         74b1ec66-7e5c-4b26-a294-67653b4e5891)(content(Whitespace\" \
-         \"))))(Tile((id \
-         423ba2c3-8ab8-41a9-8896-02e945c0cb4e)(label(entries))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         055be747-757a-44ea-b40f-94ee5e8951c4)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         62fe5415-277e-426d-b302-a1488807815a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b210f8bb-ffe6-42d5-b2e5-f51c8f07528b)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         de1dec3f-fcc5-4aa1-bbfe-ea0e62a882f0)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f8028a49-2182-4a5b-a3e2-9b8251e96b49)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4ba2b5d2-7f63-4424-9788-341d24374109)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         ae8ffe97-1004-4900-af9a-60688180a7e3)(content(Whitespace\"\\n\"))))(Tile((id \
-         c8ab4277-d182-4079-a828-902a1d0fe4f7)(label(find_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f9fbc042-2747-4951-83f8-55e05334b55e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         eb7aeb7c-71e6-4910-8e7c-a9736cf8ad35)(label(entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4943b56b-e581-4ca1-b07c-c5f1950f15bf)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ddfbae0e-a749-4d75-8088-c99da1749f8e)(content(Whitespace\" \
-         \"))))(Tile((id ff9c28ba-b659-430c-b54d-ed1ef9689b09)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         a2119cee-3439-41b2-920f-805c6be4fa43)(content(Whitespace\" \
-         \"))))(Tile((id \
-         284c8d28-9e8c-49bb-b900-437dfa62bc57)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         5ff2da7e-dab0-4c02-a715-103bed61dfdc)(label(label))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         f4fc3265-1943-4bbe-b452-7cdb4dcb620f)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         a2487345-f38a-4037-8c3f-386f815bfbcd)(label(l))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         62b82ce0-6eab-4d49-9890-87a18f3dc449)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         048b4f8b-786f-4b43-b595-102c898fbd95)(content(Whitespace\" \
-         \"))))(Tile((id \
-         55a05d10-fc1c-437c-a9cf-3fa6243a6c07)(label(value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         4a883ccd-b0a7-413d-90fe-1870e4849fa9)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         a6024149-5b77-44d7-9046-a3130a543aa4)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         cc161a0b-6930-4357-9995-88ffb12359f5)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         641c61b0-272a-4ade-8075-a06254efcca2)(content(Whitespace\" \
-         \"))))(Tile((id e4da7547-4773-4e01-bee7-a4fa803f2a10)(label(if then \
-         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         f23d5886-41a7-407d-a26e-b88454a5bebc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a96314e4-73e0-47af-a110-df05504c1a36)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         e7321013-070e-4555-bc01-cb89d069c318)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aaab0e16-e623-4f7c-8526-52ea284a0192)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2493fb98-265e-424e-b9a3-4c97cff3204c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e4d48d24-3d65-45a1-8cc1-1d4e38fb460a)(label(c1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         98f14708-9050-4f9e-9484-7854cdeb4954)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         8a336163-b5fa-4504-882b-c951e39e99c9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c366d6eb-08b0-403f-a865-19233b1b4ffc)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7353b389-f5a0-43d9-ad8e-185023b156bd)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         27154d04-652e-4174-a52e-5fe799cec108)(label(v))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         583ec581-29a7-4402-83a0-516ea4d09916)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         a3014041-1994-4e2d-b13f-45b9eb29f690)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0f53b2f4-b743-4675-93a4-10f06d2ed418)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         133afdb6-fc59-4270-bb59-7d07f01788f9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0b5db0ae-cdc0-45f9-a950-87730026f7d2)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ff9e064d-ae64-4674-a189-1f76b9bb48c3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         14d5e696-9c19-475f-98eb-1ffec1e6ccb9)(label(option_to_list))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         753d9685-857c-4746-af65-84ddcbee1e2f)(content(Whitespace\"\\n\"))))(Tile((id \
-         5de6f076-89ac-464b-91cd-7135b4a1434e)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f19ed466-0814-44a1-9c5b-917005dd84ed)(content(Whitespace\" \
-         \"))))(Tile((id \
-         024f1978-7216-4560-b5a5-de880980433c)(label(distinct))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         80438a01-776e-4895-81ba-c07970e10351)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         a41b2395-b08a-427b-a049-22b623b03952)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         365a1e3a-bd7a-49c2-919a-6e6c82a333f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         216a8701-0271-4323-8c8d-77308be29af0)(content(Whitespace\"\\n\"))))(Tile((id \
-         37a2f6fe-ee65-4f2f-b45d-7125bf58173a)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3d480e2f-c23d-4c13-8b5f-33b4db00d742)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e790444e-a196-41e5-b7a5-477bfdcda5a3)(label(kept_columns))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7cda6131-2b4a-4b9a-9ee5-0bf0f0c1ccad)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1499b45a-ad76-41b7-8e60-34dc18d45120)(content(Whitespace\"\\n\"))))(Tile((id \
-         f1dbf96b-da27-4370-9404-37630d2f16c4)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         b5028c3c-8090-4d70-b91e-2b72e1914519)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1e9bf040-5f5a-44a1-a924-1f3590c7d322)(label(kept))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         f37b36ea-af25-41be-9742-68f90fde2795)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c211e1cb-f894-4a2a-9484-0021a89e5230)(content(Whitespace\"\\n\"))))(Tile((id \
-         c9c47698-ad17-4485-bac9-3d2fe7a4ca52)(label(kept))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         4ed47577-1acb-48fc-a80c-713bd718c7fd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e73227ce-3573-405b-a440-b1dfa183ce98)(label(...))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c6069419-8884-4c29-8022-218a1fd47025)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82ddd22a-5152-49f3-a21e-35021ad6f2d1)(content(Whitespace\"\\n\"))))(Tile((id \
-         0f299f13-ad12-44b8-b7c7-1f6d3679b54a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         abbf7c1c-c38a-47e3-b03a-e77e10513b06)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d21ba138-a3d6-4112-8ce7-d4273f891618)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         7b95cd53-e2c6-4f87-b30d-c6bdd6975d0b)(label(new_columns))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e4fdfbc5-d5c0-4624-8e49-7f668b929150)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         412af34e-d0bf-49d1-9427-8940e3c525a8)(content(Whitespace\"\\n\"))))(Tile((id \
-         cce82ea4-14c2-4515-a048-e669c14a1567)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         00704374-b639-4db8-8de5-795990b45faf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         861cacb0-960c-478b-a484-519ce0f66d7d)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         92c932b8-6981-45ee-8aef-537e9f32015e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f2d80967-6773-4410-a369-6d17cc9fc27f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1591ccfc-40a4-430e-8fcb-c8cda4d7578d)(content(Whitespace\"\\n\"))))(Tile((id \
-         e26cce1a-d86f-4cc5-9d1b-9b4bd8c6948d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         d7fec201-9da7-4083-98ba-fef5106f14aa)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fba061c7-350b-400e-9fe4-b45183a175a4)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9f730ed7-1298-4b84-bedf-15a8ca90d936)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4963adce-519c-4246-b6ca-536d6d5b764c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0d68ee53-4cf8-43ab-872c-41e4ad183ca1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6fa19f2a-dc59-4fd4-b9c7-bdcffbdfd50a)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         79568969-5f40-44ed-8fa2-e79b6b113ae4)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3b2037d3-a2ce-41bd-9619-bdccddf3f955)(label(find_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bece29f5-873f-4241-9c4a-f609d888e857)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         a00535ac-15fa-4074-9952-e102c453f052)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         be974e7e-f8e5-4380-a0d0-979636f04ca1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fce01d18-c23f-4425-a1ce-5e7dbf35ccd9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         49b71c4e-d9d7-47bd-8795-be9b5c3fc52b)(content(Whitespace\"\\n\"))))(Tile((id \
-         e7fc81d9-6029-4409-8edc-0297f8df7b7f)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2f1abdcf-7f89-4c19-9810-eae54f3d859e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4f5f6202-e5b4-41d9-b9c6-79c11ac9713e)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         e7548e2c-34bc-4b75-88ea-d9e1ad9937f1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d281e9dd-8f16-4c89-9aca-5669e3b901bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f183dd5-a3bb-4545-9639-4608fcd67ae1)(content(Whitespace\"\\n\"))))(Tile((id \
-         72487a4b-ada2-44a7-9064-c2f867854073)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         f8d896d0-3e5f-4d7b-a01f-89862d14246c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8b890ddb-3b13-4b90-9ee7-c4433ecf90cd)(label(entries))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         7f3d7896-e46c-492b-aae6-c5906b8e3d69)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         88655cd7-fe9a-49cc-a8aa-cad925340d0b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f1a9331e-f39f-44a1-9655-f13a00e56fdd)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f74f026c-b59c-42b5-8e30-636c42394a8c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         648ffa8a-50b2-4204-803c-c47501adb991)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         2b5ae371-b4e6-4424-953f-6cc113bdfc8c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e9a9f714-7de1-4685-a3c0-e205c596e2fb)(content(Whitespace\"\\n\"))))(Tile((id \
-         cbf65de2-c14a-4929-8845-0753227b385d)(label(if then else))(mold((out \
+         9e832cc9-c95a-47a8-923c-8876d01bfc72)(content(Whitespace\"\\n\"))))(Tile((id \
+         39d00e91-033c-4ad3-b4f8-d7a2263e9c9d)(label(if then else))(mold((out \
          Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          36))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         80c321d6-8b10-4758-a1f1-8dfb7725a3a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e1950926-6075-47ee-8a66-9db6ec34efbf)(content(Whitespace\"\\n\"))))(Tile((id \
-         ecbbdeee-3c7f-40e5-95cc-5677c8e872fa)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         465c2f7a-e145-469d-b89f-9b229bde4aaa)(label(filter))(mold((out \
+         5f75922e-364e-4866-9a39-782f5cae4c9f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cc19b26a-89fb-4d48-b238-00bde138fabb)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         32fe953f-b20d-44cb-be14-76f6aed224cb)(label(\"(\"\")\"))(mold((out \
+         12fdfc7c-3a8f-4c09-b772-5adb17bec415)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         057d4bbe-6d68-4efb-877d-15ca89455eff)(label(entries))(mold((out \
+         5cad6e83-77eb-47d7-b42d-e83bdc7c9362)(label(xs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         94e4da16-70a2-49e4-8508-f7c6d815b87d)(label(,))(mold((out \
+         9d521288-d1ef-4774-8e80-2c21cc14e5f3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         643d2f09-fdcb-41ce-bf11-076885d4d3ca)(content(Whitespace\" \
-         \"))))(Tile((id 0cb3163a-1614-4f0b-8104-be42b30a018f)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         57ca6433-f397-429b-8c4a-4540c79b6b37)(content(Whitespace\" \
+         2f663bc5-e686-4e19-bdbe-e0c7335758e9)(content(Whitespace\" \
          \"))))(Tile((id \
-         7b3a580e-92bd-47d2-ae85-0b38fada13ce)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         0e3d5335-ab1a-41db-ac9b-37cb03a0204a)(label(label))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         c674b5e3-ae7e-418a-ab32-5115a0031455)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         166cab2e-f768-4c86-a3ce-39d640ac0550)(label(l))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         4cf84194-c49a-4e7d-ae6c-2177b975af5e)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         8b016672-5700-4452-a013-b36cdd0e30b5)(label(value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         f7f1cf38-907f-484b-8d19-6e2ddb43a38c)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         b0c744a3-00b4-4437-816a-513d7e2ddd34)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         522f2fd5-eedf-48f2-bb67-7e9d4f826c7c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9fec79ea-ac1f-4881-babd-be8376fb8132)(content(Whitespace\" \
-         \"))))(Tile((id \
-         14fbab93-ddd3-4e09-99ac-cd79202aacf6)(label(!))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         37929534-26e0-4223-be40-105e379be3a5)(label(mem))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5ae85bf8-b0bb-4939-8612-c43a257700d1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         bca2721c-c325-4bf1-a22c-7132dcef0d28)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         b022404f-9cf0-47c3-8b70-d355f77143c3)(label(c1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5b6f1717-dc90-4d18-be4f-648f08ba0bd8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         38f885be-35c2-481a-9a9e-12fa45ec8ab5)(label(c2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8d86526b-79af-4d74-895e-98b4b1fbee97)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cae988bc-726c-4f07-85d0-c2f195b8004e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6e8e7f53-d30f-4904-b09f-74e809bfe4cc)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b08b402e-1204-4b71-9bf3-fa51713026b0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0e109aad-7f20-46e9-a55a-322da39dbb86)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6a80d83f-51dc-4496-987d-b6700ad30d4b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         10e868a5-c8d0-45f3-bde0-08f516c615b0)(label(from_lvs))(mold((out \
+         bb25904e-0590-4d40-82ca-cd5b0c2d8755)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7f8d00f7-3afd-472f-b48e-39cfaa208d67)(content(Whitespace\"\\n\"))))(Tile((id \
-         27eb8af3-5cda-4554-806b-48953060aeca)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4ace9daf-a44e-4651-9d36-930df140b914)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         988455be-164d-4d3c-a85c-c7829b91a5df)(content(Whitespace\"\\n\"))))(Tile((id \
-         84710815-3370-4767-a648-893075f25f3a)(label(kept))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         5434ecf1-5abe-43d2-96a5-8246f66de2f9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         499d5343-45ed-4062-a4f7-94462a218f09)(label(&&))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 32))(sort Exp))((shape(Concave \
-         32))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3c8da894-2002-497b-baeb-0c3f4129b68d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4474d64f-22cb-4a24-9b66-00da98f6b1fb)(label(find_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a8b05adb-db06-4118-a327-2e72043a4516)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         fa75f076-a212-43fb-b821-36503ff7257e)(label(entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         aade1796-72da-4c22-b059-6341d6df66d2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d4d13363-3a67-4d0a-aab4-8d6bb582e384)(content(Whitespace\" \
-         \"))))(Tile((id 6a942764-ce90-4811-8b59-e7d54934f580)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         100c33c6-68af-4b7c-b634-a0abaf019ff9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         babf37a0-bc45-4b2f-a021-2eec659e4f28)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         d628b805-f860-4861-9afe-41c5a72d92b0)(label(label))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         484237f3-1f1b-474d-ab6d-80e0e11e16cb)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         c148d94c-3695-4d8b-a012-b3e853b0ac87)(label(l))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         df93a78f-fc8d-4da4-ac92-a1cde88de7a5)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         c353b292-3672-48b9-a5c2-045303aefa93)(label(value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         ef345b7f-71b1-4293-bd3e-0dd937374458)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         9dc607aa-d8d0-4657-a34a-f9c4826aa69e)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         7abc8f33-a49a-446e-b624-4c63b16e2401)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         cd0fbf2c-c454-4753-8e6c-ef86df54fe32)(content(Whitespace\" \
-         \"))))(Tile((id 374358f3-c592-46e1-a31f-f46c553c552f)(label(if then \
-         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         5f12a784-2e67-4c4f-a299-0f9715b84809)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4b45a79a-fc06-459c-b860-884f6a03eab1)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         be1c297a-40ff-4ba0-b84a-3cdc68505328)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e4754ee1-13ec-4bf3-b336-763c56219f49)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7811c865-4dd4-4919-a623-0f4d35bb4b9b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         114b3bc0-57d3-4829-9390-f117ce19d2bd)(label(c1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         2bdac8a6-710e-4c24-af99-fa342ca340a3)(content(Whitespace\" \
+         a5f6585c-e261-4090-8fa9-49a070750eb0)(content(Whitespace\" \
          \")))))((Secondary((id \
-         356d2fc2-ecb8-4381-9172-c7bcd3c71e1b)(content(Whitespace\" \
+         db91919d-f548-44b9-812c-56760e222add)(content(Whitespace\" \
          \"))))(Tile((id \
-         7af74f61-9fab-44a6-8ccf-c7678dd093fa)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bac8c3fd-0c65-4566-9963-c3edb1fe8d89)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c0f678d3-488c-4733-84f1-b1b9ed98f653)(label(v))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1d3aa022-a83e-407d-9dc6-802ff87844bd)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         dc06d7de-4021-4b93-adcd-a5c918cc35e5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3b61dfb3-b5f7-44e7-a9c4-00b594848bef)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4b2c06ec-7621-405a-8a33-5414a8134471)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4c59d67b-c9e0-4ac8-b58f-568599cd48c9)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         60b7a7dd-5a3b-4b4a-ac35-86861acd46c2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d0b86dd0-1231-4cdc-bb4a-ca26040d8f29)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         83fcff2b-9dfb-4c62-9cd3-907ef9f4e916)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         032d481b-acf5-460e-86ea-92561811386b)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         185a8452-c307-44d7-a76c-85e07a8728d0)(content(Whitespace\"\\n\")))))((Secondary((id \
-         1342b5b1-d392-4c9a-b40f-01082e286138)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c80f300e-cb16-4d3d-aef4-38b747966b86)(label(find_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         766a3754-58fd-404d-9a34-7073f43eb22a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         7784b709-85cb-4771-9594-305aaa3844f6)(label(entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ea4853e0-6103-4e43-84bf-c8234285f61d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9c644559-ad14-4708-9a84-4d1cc462d149)(content(Whitespace\" \
-         \"))))(Tile((id 1edf684f-31e8-4f7c-8b0e-869bffbf1d8a)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         db83b139-a01d-40ef-9968-a0658dd7b410)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c19f8432-81f3-4384-9519-ea2c09dd319f)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         e0274012-3b8a-4b32-a15d-ba4d04564a61)(label(label))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         1bb85fb1-0f25-4d25-b596-a8047764cd47)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         a4190517-436c-4e23-b64c-9988ed867c5a)(label(l))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         aa565399-90c6-4544-9801-d571f927151b)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         dfb9fdc2-33f3-482a-a951-0a53f0917fca)(label(value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         9b6b947d-74c9-4457-a125-f0fb2fa48157)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         1c4a1af8-d2dc-4f06-9ba5-cf2ac86749c8)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         664291ed-3448-4936-8910-f80b891957b5)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0211d158-d19f-4d2d-9a9b-1689dfffe4a5)(content(Whitespace\" \
-         \"))))(Tile((id 88df9eae-7f24-40e3-be1f-9c7ce50889f8)(label(if then \
-         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b7d63e65-49c6-430f-aea2-4a0dea614ad3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5e8f94ca-7d15-469a-87d1-e19c28098fd9)(label(l))(mold((out \
+         ab882335-39cc-46f9-a481-f8982942400f)(label(xs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         79dfc856-4cc5-4e16-a871-092f48795f91)(content(Whitespace\" \
+         0e9e5006-a7da-46b6-a53d-e1d6273c1b2e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f00e8c03-80b5-4172-9339-2f3261f6d699)(content(Whitespace\" \
          \"))))(Tile((id \
-         401451f9-283d-4bf9-8cae-dc6a8f8f2ced)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1bad4fb1-b837-46c1-8f56-43af69aedb54)(content(Whitespace\" \
-         \"))))(Tile((id \
-         de6df7d9-3486-44c1-b037-12a935e40ac3)(label(c2))(mold((out \
+         4fad13f2-9ad8-439a-b2ad-48f13ff021f2)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         2b68c5be-127e-49fd-8dfe-5fc872300431)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         edb7cf51-1d07-4bd9-9940-d8edcb003205)(content(Whitespace\" \
+         dd2b9335-2c47-4065-b1db-e4dff686d81f)(content(Whitespace\" \
          \"))))(Tile((id \
-         a50c4d80-defc-4cf3-af84-8af21281bf45)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c4dde9fc-51b9-4c99-9ad3-cfc772e27fcd)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         5065e7c6-7e9d-496b-aeb2-28e675600572)(label(v))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         2c25e653-7630-477e-98b4-a6980159cd9b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         193df72b-9875-4a68-aa2e-8e8cd13fbcaa)(content(Whitespace\" \
+         7b191b83-0a8d-44cc-9879-91562b025875)(label(::))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
+         29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6abb9843-74f3-40a2-8bf0-a23b3c8734f9)(content(Whitespace\" \
          \"))))(Tile((id \
-         0bd86c72-4ac0-4fd4-afd6-ae011091034d)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         118000fb-e26f-417c-b80f-96990a5e7161)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         c66df0bd-1a73-4660-9044-7019697ec79b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         63910ada-57e9-45a3-92c7-5e139421df14)(label(None))(mold((out \
+         fc00a4e8-fce7-4a54-b3f2-4657e6ffe8a1)(label(xs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         5c23fe45-c6be-430e-b25b-0cc254557879)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         ca544148-b1c5-4d73-8a41-acdcf8b70580)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e5681e66-a2ce-4388-9a23-c4d6b2cd5ab3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         325143d4-7289-446d-a1a8-abe2b610edfb)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         76822e4f-d407-47a1-b24e-c9df1ec68856)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ba7cf95d-e186-4108-b6fc-d222d83c546a)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5b54dbd2-82a8-405c-be8d-473118ea2c27)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         d939ec70-71bd-4c2d-937b-f1287c53859c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         64950375-6cfa-47d2-a24f-96e8ec40e2e8)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         af10fb9f-1605-49f8-9c72-0a7503e9c84c)(content(Whitespace\" \
-         \"))))(Tile((id 82956d2a-a29b-4c52-a101-a197276fdaba)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         ddaaf26c-335d-489b-bdf1-276600b60d79)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         4df76e75-14dd-4325-9641-512084a920ca)(content(Whitespace\" \
+         b19909a4-f0b4-46f4-b825-64939bdf17f7)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         1cc783b1-cd66-4dbd-8a3f-5abc5aa25d60)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         47e8e5f6-6997-49a1-a53e-5dede95fed98)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2fca0887-36e9-40ab-b314-654851804adc)(content(Whitespace\"\\n\"))))(Tile((id \
-         db30ac2d-5876-46d7-a669-84973795b1ed)(label(type = in))(mold((out \
-         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8db92ccd-498f-4bce-8eef-6167e7909db9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4360b2f7-1a47-4366-9b38-0f51e80d55d9)(label(Student))(mold((out \
-         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children())))(Secondary((id \
-         7d179fb7-ffec-4426-90de-fa8a5dd6a90e)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         47905bdb-50bc-442b-9ccf-31a273d0634e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e035b4cf-fa6b-44c0-a445-75ca1e9d9f59)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         b25c606f-8042-485c-ad21-8c3768b2a57a)(label(name))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         5c84fa12-d0bf-4311-a6a0-38e4b682a6e2)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         0ba94961-7674-423f-ad27-6447392b3aff)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         3ddd7c65-7809-45b3-ae9e-f8ae144236cd)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         78d09f05-d81a-41f3-b6b4-262d71452e70)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6bccc108-8c18-4ff2-90d3-8488e9ee4b7a)(label(age))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         ec0bbe02-e1aa-42fc-b1bd-402a8a590835)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         fef25539-73e3-4e5f-af51-c2a678ed66c9)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         635a4698-fb42-4a2e-b22e-e2580e6b6dd5)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ed3e088d-8912-491a-9881-538c119be6de)(content(Whitespace\" \
-         \"))))(Tile((id \
-         209b29e8-960b-473c-b56f-40d82846bee5)(label(favorite_color))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         bf34050c-2f79-41fa-86a7-ff4339beef76)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6d3a431d-608e-47d8-bd32-2fefe0db7695)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         bc4fefba-c4b3-45f3-a1c8-ac52288715bd)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4180a4d3-21e1-4e03-94a7-22ca5e292792)(content(Whitespace\"\\n\"))))(Tile((id \
-         f2f89806-6bd3-4623-a599-4e1469118391)(label(let = in))(mold((out \
+         4e4ba27a-a3a6-4d4c-9840-766baaaccb23)(content(Whitespace\"\\n\"))))(Tile((id \
+         3cc6a281-5d43-45a0-a385-4f9baf7b16be)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         7c9798e5-75c9-4ecf-820f-38711c788e15)(content(Whitespace\" \
+         65f04bcb-dfbf-409c-b60b-225bdaa57f7e)(content(Whitespace\" \
          \"))))(Tile((id \
-         c0fc58b9-e098-4431-8f72-1a5ac75cc62f)(label(students))(mold((out \
+         dc6ea21b-d761-4eef-82cc-f812242873d5)(label(pivot_wider))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b64eaa78-178f-41e6-8f8f-5e2f7603721f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ef04ca6b-7a31-46dc-a756-f3b825345549)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a68dd5d6-c013-44bd-b285-8c05e1d6e1f5)(content(Whitespace\" \
-         \"))))(Tile((id 0dae30e9-b81c-4da7-bdb0-3196c319d452)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         ad218ce4-3f0a-49ac-855b-eb701040b3eb)(label(Student))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8a9921df-eeb9-410d-9154-f7b27e0411c6)(content(Whitespace\" \
+         7d976ba5-2983-415e-8f32-104489523788)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0672fa45-94e7-4131-a07d-9d4d04507193)(content(Whitespace\" \
-         \"))))(Projector((id f9a59373-b762-4fc6-908d-0de544e935f8)(kind \
-         Fold)(syntax(Tile((id \
-         2d4f3194-aac3-4818-9986-5b988eb7dab9)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         a5547a58-31b6-465f-9861-9e5342b0be85)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         68c8a4eb-8bf3-4ce2-8b43-c36cdc5cc856)(content(Whitespace\"\\n\"))))(Tile((id \
-         bd2642e3-f89d-4890-bae2-930306d8491b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         9d453eb6-8a24-43e0-a786-75de39e5f89d)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c2bf085d-73b2-4842-872f-b693f0b8a38a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4c7472ff-d2e3-4552-b768-9a1dfc8f105c)(content(Whitespace\" \
+         c2958af8-f780-46dd-bbd3-69171255a6c2)(content(Whitespace\"\\n\"))))(Tile((id \
+         fb3ca4f7-bb83-4f89-a9a5-a2ab9e11ca70)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         27b9348a-d846-40dc-a34d-055e04055f14)(content(Whitespace\" \
          \"))))(Tile((id \
-         34aa933f-cedd-4dc3-9584-c892de27fa2a)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2b692bb8-8f21-4fe3-bff2-383160164142)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e5e3a063-f636-4dd2-ae8b-36b6c289d467)(content(Whitespace\" \
+         9fae2b5d-fe1d-4922-ac31-83fb35d56ac7)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         bf60581a-ff67-49fd-bc9c-47070a882eaa)(label(t1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         af16ec8a-51cf-4678-93f8-64d3f9bc6409)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         a0f77c70-8989-463f-a6d3-3b20b3c9b8e3)(content(Whitespace\" \
          \"))))(Tile((id \
-         f308cf1c-0fae-44d8-873b-e5b1f67ff0e9)(label(\"\\\"blue\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ef80ef25-661f-45c2-a9fa-8b20e72655fa)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4b8fdb5d-502c-4716-8936-c1e32e0ccc2e)(content(Whitespace\"\\n\"))))(Tile((id \
-         2648579d-6202-4183-933a-bcbcff3a995a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         90071407-3f6e-498c-9554-5c14fc6d5fad)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ca181806-f24e-46fb-8859-9970a6d10792)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         30646b42-c6fa-46e0-a689-420ee01ca0f2)(content(Whitespace\" \
+         11cadda5-a17b-4a4f-8fc1-2b7ceff8637b)(label(c1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         79f4c2d1-28d3-4fa0-8df0-1ce254c2a23b)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         4b4ac5b0-be46-47f3-9520-42a6fa3405d8)(content(Whitespace\" \
          \"))))(Tile((id \
-         28fe3af6-e26e-4cc7-9d26-f40861f1e888)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b1f64617-e533-44d8-8dce-ecafe77fc919)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e1d2bd74-a574-44f5-a430-c59388074baa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c90118e9-1590-4b4b-a5dd-9379a3fc6a35)(label(\"\\\"green\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a3065350-383c-4482-a171-7ce241f367df)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5e2a95c3-035a-43b1-a4bf-37dcb4cef593)(content(Whitespace\"\\n\"))))(Tile((id \
-         99f79f3c-4bba-4120-b262-5e3c676913ec)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         0fb1010b-3eaf-4ddc-bde8-ded67d816761)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         577d2de9-43f5-46ed-9013-4a67682afda9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7a7811df-8ceb-4268-997b-33f3b751940b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f682b0fe-ffa1-4a5c-ab08-d1c70f6e32c5)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ad7caae0-9169-44cb-8d03-98654c062991)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         760f9a55-c2a2-41a1-ba9a-46a9f1ab478c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f2d4cb66-abf8-4f6a-8c3f-98cd967dd553)(label(\"\\\"red\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         131a2c19-1a87-4b27-b433-2271c07eaf3c)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
-         false)(always_render false))\")))(Secondary((id \
-         5517af6a-530a-408f-85fe-58e8c2469330)(content(Whitespace\" \
+         4875993b-8050-4822-afa9-086a20a95950)(label(c2))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         6f837317-9015-468f-bd23-efd4db56cc04)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3d6dd19e-3dc4-43f9-925b-28007404a0a7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         81af03ff-39ea-4644-8249-670be4d7722c)(content(Comment\"# We are not \
-         flattening the rows in this to coallesce the sparseness \
-         #\"))))(Secondary((id \
-         34141797-c3cf-486c-8cfd-6d86d234735f)(content(Whitespace\"\\n\"))))(Tile((id \
-         8a676ba1-30cc-4518-b6d8-f56ce3781784)(label(test end))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         6bf84217-7c7a-4358-a920-c74431381c05)(content(Whitespace\" \
+         e7f2434c-3516-4f92-98b6-644275eda741)(content(Whitespace\"\\n\"))))(Tile((id \
+         2d8cd8ab-3e92-42c1-a630-c4535c94f949)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         22c20417-f4ea-4eee-9788-7ef39fc19d44)(content(Whitespace\" \
          \"))))(Tile((id \
-         5239e98b-5219-4621-bf62-6b59ce25b40d)(label(pivot_wider))(mold((out \
+         9b5ab0ae-fabd-4d17-8b1c-6d10d7281150)(label(kept_columns))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b7074e48-7926-4487-a129-b366deeb1a8a)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         5d577396-f0e4-4aab-b7dd-3663b4dec5df)(content(Whitespace\"\\n\"))))(Tile((id \
+         3bb8f4c6-6f57-464b-bcc2-4cae11add8c0)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5edcccc4-7aa0-477f-88e4-55e50261b947)(label(\"(\"\")\"))(mold((out \
+         d8aef302-8fc1-4474-86f2-3433885db15d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ecdcb6f8-1f63-4f3f-a658-501d8031fb04)(content(Whitespace\"\\n\"))))(Tile((id \
+         80abe099-524b-4e38-a20a-1f99da2654aa)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3d8f424d-3e9e-4e22-8431-1e55becd2932)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         83a9430a-932a-49ec-8bcc-19dabeab50a3)(content(Whitespace\"\\n\"))))(Tile((id \
+         7c3a1c49-1b4b-458d-9c94-3772f3e9cd96)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         1c4de3d2-7ed6-4400-bfc8-e480ef8a98dc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         974f8590-4a3f-47bf-b987-dc431351d08c)(label(row))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5e1c8797-589b-44ea-af73-4532be72bc22)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         72a9aee5-9a7a-4411-abf9-8318ddc71e77)(content(Whitespace\"\\n\"))))(Tile((id \
+         b8ab2e30-895c-4055-b2f2-c9fc00764a61)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9b6ba5e5-e3cb-405b-8a2d-a4fbb1c88862)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3a597874-0b87-41aa-a73e-ec109808f4ef)(label(entries))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         154a882f-a6a6-4c90-bb32-d5d0760bd0b9)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         544912b6-937a-473f-a0ac-29c2fb62548b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7a3faafc-5638-4a1e-beda-374eb5b5994f)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f0fe5f1e-7b63-43b9-bd71-b4e5fb635bca)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         10557480-d75e-4831-9e32-a15d037fc22f)(label(students))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         03084e0f-a5c8-466d-b273-6d569627fcab)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0e723270-47c7-4cd0-872c-1f54fe695aa1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         acfe885c-3059-48b8-933a-b8994202e260)(label(\"\\\"name\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1c99915e-5803-42d4-bb01-fe66abc62aff)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f3d225f4-7fad-4520-a6ef-09c1fa86e32c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e40334a5-f8ea-46b0-8f15-594780645c3b)(label(\"\\\"age\\\"\"))(mold((out \
+         5c1068ad-b01d-496b-b2fb-08b4970eb487)(label(row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         0420c8cf-911c-4591-a425-9d93b0af012c)(content(Whitespace\"\\n\"))))(Tile((id \
-         a4cc309c-dbab-4894-aaa6-48f9775fb0bc)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         004d00a6-ce4a-4547-be1c-59c7c56f0031)(content(Whitespace\" \
-         \"))))(Tile((id 404dd086-ed25-4bdb-a803-e329f726b265)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         55548218-8027-4505-99d4-9e994c8b69cc)(content(Whitespace\"\\n\"))))(Tile((id \
-         0f3c5358-c765-441d-a0e0-54dcc18ad75d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         4cca7db0-8274-4f1d-b7c0-647744f279a4)(label(favorite_color))(mold((out \
+         5d16ddc1-6388-49cf-848f-f5b842a7ba27)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         a1d3eefe-fef4-4bba-b833-13e06f91aba4)(content(Whitespace\"\\n\"))))(Tile((id \
+         e4cad21b-cfd5-48ac-8687-9cd6dd049fb0)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4c30a3a8-a863-4f43-ae1a-461a6bbd614b)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         01e03590-c435-46f1-9dd8-61a2cddc3a07)(label(\"\\\"blue\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b58b4a67-8791-4973-9d80-19863aad2955)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         84a85d3f-d9c4-4b4a-9ec2-50b593be3d3b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e41d0467-774c-4436-a3be-238ac8bc0781)(label(`Bob`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8cf8ac23-65be-4eae-a55a-cfafa11ac92b)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7548255c-6e82-479d-9b9a-ae6f622e56cb)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7d66e036-c291-488c-95ff-8f311f8bc13b)(label(\"(\"\")\"))(mold((out \
+         f6aeb503-bbfd-4b70-b08c-63a1380f39a5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         76623ca5-435f-43e1-8670-dc1965cfb116)(label(12))(mold((out \
+         9fc8b40d-af2a-4dc6-9978-5c8f6af58c08)(label(entries))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ec38fb5f-2b07-4492-ac19-ce6ef34f0f05)(label(,))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bfaad1f0-4058-497d-be97-d6091e22e162)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8441e68b-cd15-467b-b753-0464a6cb2b26)(content(Whitespace\" \
+         9b544a0b-1106-46a0-9d78-2d81fbe0aeba)(content(Whitespace\" \
+         \"))))(Tile((id af97f259-0173-423c-94e4-9b4726c47b96)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         432cad45-cf9a-4b08-8833-04ee1f2ed5af)(content(Whitespace\" \
          \"))))(Tile((id \
-         c7495d74-6190-408f-906e-1a6dd0803b0c)(label(`Alice`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7f2123f0-7887-4675-9408-f64409c98ea9)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3fdbe6fa-891e-49e3-822a-df2afbf85a3c)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bd27414e-b386-4808-b1ae-854137f85499)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         310b9236-69b9-4142-98b5-95d71cfa6526)(content(Whitespace\" \
+         d4cc6357-b5af-4e13-a8a2-499f3c1dbd00)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         3a933159-e2f9-47c9-ba84-81d5c6db291f)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         7d8bc51a-049f-4435-9b95-6ba76145d5ad)(content(Whitespace\" \
          \"))))(Tile((id \
-         54b197ad-76f9-481f-b40a-b72609bfbb19)(label(`Eve`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         14a8e695-0f86-4a49-b9cb-787833bbf2ed)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         2a6233c6-66e7-45c3-a034-c6344ebd21bb)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         0818c925-0751-49e1-ba73-db99ec91617b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         70499459-91eb-4d50-9bae-5cff127f58a2)(content(Whitespace\"\\n\"))))(Tile((id \
-         8be0cd5d-9b35-4609-87a3-6e0d8a5bfe3f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         f7410402-2697-4c9f-9329-4d3460bae7bd)(label(favorite_color))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bcf24b2e-774e-4ad6-8e8d-da58212a7e57)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         30b0a490-7419-46cb-b889-8f386a65602e)(label(\"\\\"green\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         acee138c-2bd1-40f6-8bdb-c37ff4ef929b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         23ba03db-4796-4dbe-aeda-f233f50941fa)(content(Whitespace\" \
+         0ed4bc2b-42bb-4d49-bbe9-ef2b5c5887c2)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         155739f1-6ad5-46a1-a9d6-98531a00e1b1)(content(Whitespace\" \
          \"))))(Tile((id \
-         b38362b1-2dd2-41b3-ba9c-8d6cdbe6495c)(label(`Bob`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         300bcad1-8dd5-4937-8289-65f60a254afe)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         4b6e5bcc-748f-4435-be65-ac7d1e7ef3c5)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e36e2c7a-ff30-47ef-9473-87d08f473076)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         29d7da67-abdf-4ebd-90e8-3aa42aa84ef1)(content(Whitespace\" \
+         34e8c664-4f91-4e08-ab2f-18f486ecc667)(label(l))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         47daa2e2-8366-458f-bd13-52a36ff859b4)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         0ed7dc91-6b86-40ae-878d-bee7f1297c7d)(content(Whitespace\" \
          \"))))(Tile((id \
-         5c9f92e5-b76b-4766-87b2-d252230f3add)(label(`Alice`))(mold((out \
+         741dbc4b-407f-4cda-b2e4-9c10c0df452b)(label(value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f8273c2e-fc5e-4adb-9617-3d5606d3c543)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b40cd8f2-ccec-49d2-8f0d-fa1cca7f5089)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         9a369671-ef66-47de-aa0e-ba786fa56107)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8c867cd6-12fe-4558-9c7b-b7f9bfc7d7e7)(label(_v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         8d8f5ce1-6d9a-4298-b2ed-92f038aabc3b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         8b7ab1b2-5fc9-48bb-b3b8-528956b9443d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cb6d1f2a-36fe-41fc-9eae-52a321454d8b)(label(!))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a38d297b-e405-405c-9db9-362e65988b5e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         be1454a1-8080-42f3-8400-2c6c6c691e7e)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         486d20d0-ebc9-4ff2-8f38-f834026fab18)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e476f6e2-def5-4ff8-80e3-cb9dcdf50d05)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         775fe756-fd20-413a-abbb-d0c293e1d84c)(label(\"(\"\")\"))(mold((out \
+         98d96896-6500-4ed8-a4d4-66b2e2ac46bf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1774b9f3-ac2f-4633-abef-d6464581d289)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         161186f6-019f-411f-93f3-ecf765c8193b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         854d961e-e42f-4700-b4c0-e31d9206875e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ae7dde18-9df8-46b1-9c31-5f97477f6a72)(label(`Eve`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5dfbd782-a1ac-46cd-b532-cfabe9f2f94e)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         8557db12-294a-4c79-91b7-95bf0251212f)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         f3629324-f959-49c3-995c-ce559f5282b2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9a22c8c6-fb82-4dd1-8a2a-e978c3285a47)(content(Whitespace\"\\n\"))))(Tile((id \
-         1a98a226-d2ba-40ca-b5aa-8452dfa5eb7a)(label(\"(\"\")\"))(mold((out \
+         c47ee25a-505e-4c6f-877f-9cdf713c0a57)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         396de905-8895-40b3-9119-0188defcb1c1)(label(favorite_color))(mold((out \
+         a47edfbf-65c7-49d0-826f-00b9e6e13577)(label(c1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ec70937e-081d-4e23-bb4c-501381ca8cd4)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f52fa2a1-1ea9-4f23-923b-11edfcbbffc1)(label(\"\\\"red\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6add0d18-a048-4108-a97c-34c1e4e63298)(label(,))(mold((out \
+         a330b44b-cb2d-4e56-a274-09421457ed7b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fc461adc-9234-42b2-8298-04565b0e6ac4)(content(Whitespace\" \
+         3b573389-471b-41e8-9800-a869e2257214)(content(Whitespace\" \
          \"))))(Tile((id \
-         e870856d-ba64-4ae0-a63f-b43dbe4e8cca)(label(`Bob`))(mold((out \
+         808fbce2-b88a-470a-a0f2-8b7ae427148b)(label(c2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b61e6242-96d5-426a-8c8c-49fce77d7e13)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         cf15fa3f-16aa-46ed-bff4-8042f343a7c8)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fd004485-33b7-4e8e-9580-5123407d240b)(label(,))(mold((out \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         a8221ff6-d381-45ca-a211-cb19532955f2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         51f881a7-befd-41f7-bb27-1bc03cbc58ab)(content(Whitespace\" \
+         4e97033f-81ff-47be-8048-50b4742b4d07)(content(Whitespace\" \
          \"))))(Tile((id \
-         5640615c-79c6-4092-bcb8-b402e7d80476)(label(`Alice`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         971ad807-01f3-46fd-bc1d-f047e0fcbc0b)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         49ac5f00-c0e5-48ad-8e22-f20c36b3bbc1)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7dbdbae8-34bc-44d6-bc4a-b111d185faa0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9cebfe25-c691-42e2-8753-158f93b8bcd4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9478be76-3a63-4c9c-a74f-2906ca2338ca)(label(`Eve`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         df72e23f-35cd-495c-9266-9765137672ca)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0e21db5d-b335-4c90-a508-ce00a6386109)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2ab82f4c-5b28-48b5-897e-e1f33953ae78)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         55553fca-9522-4584-8f99-6ae0d2a9484a)(label(13))(mold((out \
+         ee9c0723-4d00-41c7-97d3-bdef3c4cfa39)(label(l))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b3abdb75-8f40-4280-8995-3055466ef658)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ab7a446a-bb74-4f50-85a3-60bcf088dd2b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ecd72222-0e90-4f81-84d5-abbfc8fca0cb)(content(Whitespace\" \
+         fd2922fe-9c44-40e7-8b5d-1bc2ad3372f6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5ecfe1b2-51de-4cf5-9fac-12ae185d4b50)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         50d0c4be-348a-4c94-b1bd-a99e40a0248f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         76d545cb-de1c-4b38-9a8e-50a6782c1942)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         db4a1f18-7532-4ea3-8c69-3a6cf76d050d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         2514f284-2c4e-41f3-a920-898de407d9ea)(content(Whitespace\"\\n\"))))(Tile((id \
+         6ead1630-8c96-4123-adf0-300ca1b8c068)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0f3f0ab3-39d4-4683-b410-3f2a252c9f66)(content(Whitespace\" \
+         \"))))(Tile((id \
+         05dac250-8678-44d6-98c0-b904375ca3a1)(label(distinct))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9dd7bd69-2dab-4157-94b7-a31f467ec458)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         821a4677-4d38-4dcf-899b-17f677cac257)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         6866f84a-65f5-4193-b0d6-465b2f5cd09c)(content(Whitespace\"\\n\"))))(Tile((id \
-         71a47feb-aace-4ee6-92d9-3d28f47cc4f1)(label(?))(mold((out \
+         14cd6aa5-9c04-4a8c-aba8-61af17b2df7a)(content(Whitespace\"\\n\"))))(Tile((id \
+         60770010-51d7-48e3-91d5-1ca02c547596)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0de2379e-d30f-4cfc-b295-b10d26918f2f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         058c2206-68d0-410f-b729-3b4c161531e0)(label(new_columns))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6b25d920-30c5-432f-a527-a04e543f19c1)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         1866821f-526c-4e5a-beaf-9576887c1333)(content(Whitespace\"\\n\"))))(Tile((id \
+         a90ffa31-10dd-4465-b43e-0363ec984fa2)(label(flat_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         af447ecf-68b8-49be-ac30-661da7bf4fca)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         de29cf2c-cfb9-40f8-9aa5-560e007dc954)(content(Whitespace\"\\n\"))))(Tile((id \
+         d2b4c9d3-b2de-4c17-85ed-e1317c2d0b20)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         157b8a08-f257-4c5c-9b09-aeceeb897f58)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         da9275de-9e5d-4597-a0d5-fff80eade249)(content(Whitespace\"\\n\"))))(Tile((id \
+         49cfca7b-c1ee-4b05-9e78-d5dc2936cfc4)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         57bce191-178a-4936-9437-513daeb11855)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c2ab63a6-283e-4954-b765-2d0667512e8f)(label(row))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5581b70a-3fbb-44ed-ae6f-26f97c376ccb)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         51099845-414b-416c-a629-4992381fbc6f)(content(Whitespace\"\\n\"))))(Tile((id \
+         f268dd50-1dd9-4347-98cd-d49448eea6c2)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f0c78c02-065d-446a-9430-9dd170fd1ec4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5fc4f639-e4c4-46a8-8f21-e6ae4a9b7864)(label(entries))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0a3dad72-b6b7-4603-9ebf-b62680214a7b)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         c6054d2e-e6cf-4ffc-a26c-595261d74ef1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0627495c-d185-4005-9c9b-240beb048216)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         be8f1ff9-8101-4b1d-8300-a85f17adb26a)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         7ddcc1da-a6d0-458f-bbb3-b6d91787d694)(label(row))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         f88a5962-9ff3-47d3-a5fc-d0cd1d422d78)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c9f37798-44e6-4029-bbba-65dcc44b6a32)(content(Whitespace\"\\n\"))))(Tile((id \
+         b3815977-55cb-4b9d-a730-0f713f2066ab)(label(find_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4a7eb2d2-55cd-4add-aade-f89646f18aac)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         1dab5517-bf27-446e-95d1-0bd3eeb74b76)(label(entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7d754436-73e1-4620-b090-c52a5b92d1e6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b4395b6b-7181-4c89-bf98-ee576c0e3e2b)(content(Whitespace\" \
+         \"))))(Tile((id 762a1b15-8c7a-4c18-9558-47fb32236445)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         e82e45e7-1308-4889-ba57-59292013a667)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e5a4617d-9676-4085-abc4-08d2760d2199)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         c744ca4a-08e4-46c3-b2c2-3d4750ea5d50)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5345c0b1-2488-4184-b226-275633ede6fa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5af7febb-8ceb-4cd2-8b91-5ecaf4949226)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         f8087675-e4d3-4718-87b0-27a2fe4897ae)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9a23b36a-afc8-4f31-912f-20fd00b220d6)(label(l))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         06972c9d-aea6-476c-9326-a702b1d16cb1)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         93b2e94f-5871-4e0c-9f09-bdfb39dcfa2a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f276b8d8-a9ab-4e30-ad01-ac1d35546a52)(label(value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1ef3509e-95ec-4c33-b925-2c0b9888bad4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f5f930bc-0ebd-4e06-adb7-0851df067282)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         5c456dca-e88b-40e3-81bf-c57817ea8902)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f601b209-f323-4d24-99fe-9ae4c8295884)(label(v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         deb250fe-6cb1-42fd-83ad-0051a54712a4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         624a2034-bdb6-44cb-85cd-0ebbede9a356)(content(Whitespace\" \
+         \"))))(Tile((id d0e7e90b-4dfc-4166-bc1e-4be8864137e0)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         0d5cae84-f1d8-432a-afb1-52b45f37ab48)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c55d3ffd-9a86-414d-bdc2-8b7d9d7b6075)(label(l))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         64b068de-6edc-4061-955d-e025962a789f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         837cf77f-997a-4a61-af2a-cd9d6fe3d7da)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e4030c89-8e7d-438b-8d97-11344a749be6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2050d828-cd63-46fe-9248-a84e7b64b569)(label(c1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         5afde7ad-83e0-459a-913e-a2c928aa12f7)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         79a85eb3-b8fa-4a4d-8548-fb6d6a0aff80)(content(Whitespace\" \
+         \"))))(Tile((id \
+         12e95581-8003-4ee1-b98e-2cd15efe5115)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e77daf31-81b3-4092-ad98-424d3383be4e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         fcff8e64-88b2-4395-a9fb-fab53ac0659e)(label(v))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         2bd79ebc-e465-4b74-a435-68ce08d88fd4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         11dc3bae-7908-4055-8f2a-6f61ba709c4a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         43dfa20b-6ef5-40f0-a550-4601d47f83aa)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         177cf2da-df9b-414d-9322-3e4a05551e0e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d7ad075b-0524-4214-876e-f1721bd7a495)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         acabb8ee-45a8-4295-992f-587da1862052)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4f9d1bea-550c-49f6-ba34-c4c93d4f5fe2)(label(option_to_list))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c65d2f8c-c4d2-4991-8474-fe669005fbd1)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c3ddc777-d421-46ec-b999-742eb281f954)(content(Whitespace\"\\n\"))))(Tile((id \
+         b69f2f58-857e-486f-b587-98a2a4848b89)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d5db1e1f-5fe0-4ff8-9edb-d96f79aa527e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7a7cf67a-fe17-4eef-b748-abbde13848ca)(label(distinct))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3d45f31a-c9ac-4510-8af4-c5adb2cd6c45)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c2aad9ca-e807-4966-b375-d81bbe722eb2)(content(Whitespace\"\\n\"))))(Tile((id \
+         32a097b2-8954-445f-be81-f255e43d5a16)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         afdc004c-2b4c-4a07-95ef-9f362b95e48b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         754f7e69-ab3c-4cfb-9f3b-32a3bc41fca2)(content(Whitespace\"\\n\"))))(Tile((id \
+         db99cef0-c029-4bf8-a160-c36d08a9040f)(label(kept_columns))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         aefe280c-e2cb-45c7-a471-f7d08bcab4bb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         23d7e095-ee4f-4bbb-9c88-40ee45c46307)(content(Whitespace\"\\n\"))))(Tile((id \
+         3467db7d-8102-4c72-a96e-419e3639bb70)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a19bd059-87b3-4538-b4ce-65fcaf5a3794)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f73a88f2-5e62-425a-a21d-e874ec3133a1)(label(kept))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         594042cf-0aee-48ff-8609-50825bf03dbf)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         96b6c4a5-e386-4151-9899-d0adce2d9fec)(content(Whitespace\"\\n\"))))(Tile((id \
+         09a03e0d-951f-47fd-b55d-f53e230ed9d7)(label(kept))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         249f2dae-3d2d-49a5-a2ab-e59de3b5d39e)(content(Whitespace\"\\n\"))))(Tile((id \
+         2222002d-e3c1-46a3-a9d6-95eabecaf5d2)(label(...))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c6896581-e9eb-48ec-8124-dce6ec9074e6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2612c079-0a2e-490a-ad44-3a418577d68d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         5d323dbc-9f62-4f6c-85d5-4827c4cf8016)(content(Whitespace\"\\n\"))))(Tile((id \
+         5bada004-6106-4d4d-9339-c7a60d7ae059)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         05593f73-6563-474a-960e-2dd588d084a5)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         0ec6c803-1040-4dd8-b378-ebb41d9515b7)(content(Whitespace\"\\n\"))))(Tile((id \
+         9458bdd7-b704-4616-9d42-7c13da457318)(label(new_columns))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2867e0bc-9da9-40e5-b252-70428d1030cc)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1f72375d-337f-41c9-b3db-85c6ea1c48b6)(content(Whitespace\"\\n\"))))(Tile((id \
+         ec145b3d-81b2-44e4-ad7f-a849ee89bace)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         2ca6a1bd-45ef-4722-9a6d-b9d98a356681)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3184ea0f-a477-4fa1-834c-8ba9c9c4d07d)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ad552ca7-9593-417b-b8e7-97d793fefc38)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d8f83ef5-fd45-4169-badc-58e0bc974fee)(content(Whitespace\" \
+         \"))))(Tile((id \
+         30275e36-7281-4cb6-83f8-9f58a4bcadaa)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         32cce82a-b615-4ed2-9bae-b22750568935)(content(Whitespace\"\\n\"))))(Tile((id \
+         d75ee43e-b917-4087-ae7f-0771f06e1133)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         cfff0b1b-1ce8-4157-bf6e-afd36daf871a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         24b88038-ba4f-4f9e-af58-be0ba92003ac)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2a94706f-8b76-4116-8a5e-43962ca90b91)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2faa8429-a552-458b-a22f-78488796812a)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e55bfd20-8a32-4abf-bfcf-af4e03f5be8b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bd18a0af-2147-4e87-942d-3a8ebbf9fbe6)(content(Whitespace\"\\n\"))))(Tile((id \
+         ab1e47ac-b25f-4836-89a8-abf37dcee095)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3f7fe99f-a547-4733-9bf9-1d0526dc8c04)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1134c6f6-c4e0-499e-973c-61d133cf9957)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a86ffb93-d26c-42d4-84e2-5edd20937fef)(content(Whitespace\"\\n\"))))(Tile((id \
+         89d75c9e-c404-4aeb-9d16-74de1869549f)(label(find_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4beaf774-f967-4ca4-91ab-51bd7267b612)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a46f8ee5-27e9-4fc1-91c9-91ee26e11f40)(content(Whitespace\"\\n\"))))(Tile((id \
+         518a2a72-6879-448b-b95b-c6501ea8f525)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b2b3332a-2511-4f4f-a0d3-ffc74c2cc440)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ade6ebc2-84ef-427f-a75c-b27ff1da14c3)(content(Whitespace\"\\n\"))))(Tile((id \
+         e4affbdd-dc8f-4459-927e-8db5268d3401)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         6c3698b6-57a9-44cc-b513-3b577f18d931)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c95f1028-bb6b-487d-9ede-3aead4567032)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         82a9d807-add0-4972-834e-25ba4724c7c8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f58abfa9-c4d0-4c46-aded-116e114fa428)(content(Whitespace\"\\n\"))))(Tile((id \
+         9a17954a-13d8-4544-87a1-b07498797c5b)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e4526bfe-1e42-48d3-8f82-59562526ed7e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7895a0d8-76b6-4785-902b-4bf148594548)(label(entries))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6ce900e5-692d-4a0b-8222-c2e8c2da8bb6)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         86c2b341-0b0e-423d-a938-ad735c3eb393)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e7040150-988c-44e1-b863-f0b16da9005f)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         20cd86db-d1b7-4b9d-8ed8-c7187afc2fe1)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         9dfaafc0-7916-4d5d-9c52-a6afb3023468)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         f5726ceb-4519-462f-a39c-2e78bc113ddc)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         bc860a2f-c85c-4dd8-8da5-05fea919e03d)(content(Whitespace\"\\n\"))))(Tile((id \
+         3ee64c78-bdb7-4e5f-bf5f-4c1facd44c44)(label(if then else))(mold((out \
+         Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         36))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         615cc778-5acf-4fc5-bc83-fb3aea5fa1ac)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dff8df33-6a81-48ee-adbd-cb991c4273c7)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         e7ba2775-dae8-40cd-91a1-823ba28f24e8)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f186f68b-959e-43cc-af3d-a26c11eb6a1d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         89db11ff-d287-49d9-a350-1f010504751c)(label(entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0794a4c0-2a5c-4d97-81bc-885645cbefd4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fe79b233-3f1f-4570-a881-05a7623901dd)(content(Whitespace\" \
+         \"))))(Tile((id 88f2efa8-92b2-4c51-b3f5-d1c8cd9eabf1)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         80a935fc-c8b4-4b61-b3cf-6dc0c8f0a00b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2cd1a13b-0f09-4a7b-8567-f61099efd1a8)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         13c8f9ba-ad2e-4628-b9b6-424bf0e64e40)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         aca0c8b2-5a2b-403d-98fb-fce3752b41fa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8cbe7031-8b13-4f6a-b5ce-368faa425181)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         22be3ebf-bcde-460a-b3b9-255ad4767af6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1a64fb43-9080-4f3d-89b5-17326bab4221)(label(l))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         037d5664-d8f8-46d3-b432-671d8c17e82c)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         33272fc3-8251-4b42-9f39-4e402b8961fb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2fe6f00b-175b-4874-8533-eae48d8e7ea7)(label(value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         649f65df-e5dd-4443-8fa7-a5c7fd8cbd88)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b9ebea56-c5bd-4ba2-9c32-2a74ea0f3513)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         5a7f4d8d-0c5a-4df9-9883-0280743ee514)(content(Whitespace\" \
+         \"))))(Tile((id \
+         73b64300-25c6-4839-a533-95a52d7b1a8a)(label(_v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         b4c9531f-aec3-4dab-ad1d-8fb634b1f018)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         615020f0-82aa-47da-b8ba-3900ea320f9f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c6822426-358e-4356-935a-c5825fa54c6a)(label(!))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         dbf01085-2e79-4bff-a5de-2b4e8ae947ed)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f96e7d86-3c82-448a-a6b9-db0d163e2c90)(label(mem))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         598bc6d8-f997-4efe-ac6f-719e1a1faabd)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         fe015bd5-3a5b-4059-8a01-b1bb119e6cc7)(label([ ]))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         187fc631-1689-4faf-a165-abdb3f42cf38)(label(c1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         240880cc-c6eb-4a1b-ae8d-864fd43c97ff)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         b2843a3c-aef7-482d-97ae-1aacf0b3a26e)(label(c2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         637d00b7-6dbd-47b5-8635-1d4ace415bf0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6d3fa045-8d2e-47b8-97f4-4b10f0d90e34)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e74bd18e-3019-4e54-8491-7ab25e79c0e0)(label(l))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         1389103b-a36b-48bb-9e07-4e21f682a802)(content(Whitespace\" \
+         \"))))(Tile((id \
+         88fbb05f-ea8c-4693-9e73-562e556b2a4c)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         572dce2d-4115-4324-a493-d7ef1c9532ea)(content(Whitespace\" \
+         \"))))(Tile((id \
+         be1ce627-31ad-44f0-b24d-b3cb901d2aca)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         0c2643d1-3c35-495e-86a2-2d7f328eb99d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         81809206-3bda-416f-85a4-7df582dad825)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7fd5e23a-9f14-4fd2-9e97-d5487850c8c4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         08c271e3-df70-4f76-a8a3-bf0241022829)(label(kept))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         74d2e521-e657-4080-a243-a7793ed82647)(content(Whitespace\"\\n\"))))(Tile((id \
+         e4074b82-60fb-4467-87af-bb12f4bf2bcd)(label(&&))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 32))(sort Exp))((shape(Concave \
+         32))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         285d5ba3-6174-4018-a920-f48ee76f5711)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9f7dfb38-ecf2-4c38-8b98-d4f89ab779c9)(label(find_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3816e3f1-c3eb-48f2-9f8c-dbef8c290c9a)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0ce1e4f2-6e01-4cda-992d-459054584fe8)(label(entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f9acb48d-bdf1-45c2-8549-6986c12f1af0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         90ee48e7-6df4-4cf7-832e-8c6b1b2a4b73)(content(Whitespace\" \
+         \"))))(Tile((id bb9b4891-978f-49cf-85c1-d60199668fc2)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         47bee3e6-36b2-4afe-897f-2fdb30ee3a9e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4235a71d-dd16-43e5-aa3f-18e7e08da6bb)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         28471c91-5415-47fb-8a02-ad85d3e85e1b)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         39507975-aca7-4d7c-bc36-15fd30805360)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0927659c-a58f-421c-b4c9-7fb4f18fb890)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         ee6bb0dc-1afc-4d40-8e92-3dc4452b6f09)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5252176e-bf49-4195-8857-63188f08647a)(label(l))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         ad8548d2-2099-4011-8de2-97262b0f5f2f)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         a201b4d1-6dd8-4aad-82f5-13c1b1e36f4d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9afb9ee5-6f33-4d0b-8332-feea1302f47f)(label(value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         94bf5af1-e09d-43f3-9449-f4b764fa95c3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2b052749-3d8a-41f3-b681-e5248e6c380d)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         56a8e2d7-e05a-4538-a39d-d0079f07327f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         03690026-5f40-499b-a480-d3ff391c632a)(label(v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         6e7bc545-4297-4f4a-a65f-ebf209bf6c6c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         74d6f2c2-5e73-4f13-8a34-e919174406ac)(content(Whitespace\" \
+         \"))))(Tile((id 64170b50-03a7-4023-b177-e2dda0f43809)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         19f8645b-1015-4125-b984-72317721e760)(content(Whitespace\" \
+         \"))))(Tile((id \
+         360b3b8f-317e-41e1-aa52-120ff5a95a4c)(label(l))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d309d9a4-a6e1-4478-abaf-563a5ac63ef5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         61f992d5-1410-4d54-81d2-d263839a342b)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6a1c76cd-0c40-4f9b-832f-ca8525c1454f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         32ba4b5c-489a-4da1-9099-6ed4ece99b3b)(label(c1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f5e137ae-0bdb-431b-9a88-42e347e9dfbd)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         6b3a2403-c59e-4e4b-aa6a-a402b42d5775)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0e118c36-a32e-421b-aab7-94ec8e561031)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         96ed43fc-336c-4c3e-8370-e7f7b29226f9)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         029b3bc7-0fe2-4d9a-a91a-93b2c91514ec)(label(v))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         2f9dfa95-9938-4419-b24d-839c07d512c3)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         29f88c62-997b-43ea-a584-0c5bed7b665e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d66881ed-e60c-4bc4-a02d-90988ce0406b)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         a32be598-863d-49a8-b73b-a0fa84ebe8a7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8d3ccdf7-ab4b-4d33-94dc-e5a5b5b24192)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         90e988e2-7f36-4adc-bd15-b87ee3b22e20)(content(Whitespace\" \
+         \"))))(Tile((id \
+         76c5f482-4131-4b80-935c-5681dedb6c48)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a1250b74-ff6d-4a45-be2d-98c968ee41c9)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         2ec09954-509f-491e-9b39-609cb86b844b)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         60b51830-a19e-4389-a02f-5a565569e541)(content(Whitespace\"\\n\")))))((Secondary((id \
+         4386b20b-52fd-4e3a-841d-2bf93504f26d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         39b88fe6-d40c-4707-b284-7ee74eb6e12d)(label(find_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5042937b-51ae-4f0c-89af-5a9e99cc4b7f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         ebd74cff-615c-4461-87c3-1ba2c6adfc79)(label(entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8e5aa510-9a00-4d99-81b8-10835094bcc7)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d7b76702-90ec-46b8-a703-7f9d834e3192)(content(Whitespace\" \
+         \"))))(Tile((id 19285746-c5da-4c6f-94cf-6ea628f30a25)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         7a64abd8-0a62-4f14-a926-c447500163b2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e9190fd7-43c3-457f-9c11-67bcc247ea3a)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         719d9f6f-bab5-4b6e-8e96-1a068c46a5e5)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4ca3da6d-c5d0-4428-aaa4-262dcbdda509)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f9467320-aa79-40bb-85fd-833292071bf0)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         57646326-09da-475e-a231-943b2618c4d6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cb29ab2d-334b-4015-a40a-9ad2b188ac66)(label(l))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         b0efa77d-1e4c-4011-86fc-979d29ed9a5a)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         97247717-5405-4e62-8c18-9561316fa4c5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e28f8d71-0200-4445-9ae1-067be19b489d)(label(value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         81fc90e3-54a0-48fc-a065-e2dde46c114e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2c51d931-90cf-4c9f-a753-0e687696d6ff)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         7e327a50-96aa-4574-85b3-563a2fc240b0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         adb38dff-0746-4734-a253-8e2e23432a09)(label(v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         3c035115-ac86-4df5-afae-75537c430475)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         74ca1091-5266-49f5-b5c3-5fc054227732)(content(Whitespace\" \
+         \"))))(Tile((id dbcee73d-2751-4185-8f43-f04fb0f5b997)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         2161f4ff-c90b-466a-8757-1bc264fb5024)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6e479a6f-3c9f-4dd9-be7a-32299c5b7ff0)(label(l))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         13d8b0cc-6dd8-457a-980f-2c68033767aa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         892558c2-5e9e-47ff-843b-66322953360d)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f37c0588-927e-41c9-9f84-e85d9f8d8ebf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         71ad1a93-dcef-4d95-845d-87200d19c2bc)(label(c2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6109d849-1179-46c1-8c89-8618b4a49f28)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         ecc3038e-fc9d-4346-9b4f-43446e140d5b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9dc0acef-06f1-4628-b17b-72aaaa11ada9)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         32a63747-954a-4ba5-af72-366f396e7551)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e595c163-656f-4328-98e5-e214ed30870b)(label(v))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         0dbaf1b7-f814-4e6c-9370-cb2f8ff484bf)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c1d39022-a6af-4189-ab80-b3a736d5edbd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8f9a793b-3ee3-4b91-a70f-e2b136b0ced8)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         b132fa81-d213-4985-a1ca-fe6bd2ce6b3c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         a22d10cc-fa29-4e97-a228-577edd0dd58a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fec463ff-8d69-454a-9f7d-f327b6fb5080)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8c1c5814-04d5-4e34-b7cd-fb6fa57e933c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         5f1c5488-3835-4f2c-b7ac-d535457913cb)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         47f36798-6ce6-4e74-b837-d54ab78de6fb)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         1170c2d9-e2be-4c0f-b559-56b82b48bc14)(content(Whitespace\"\\n\"))))(Tile((id \
+         8c2bc2e3-aa5e-4fa6-af18-a8d5ca21f5f9)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b9f71450-9ba1-4a96-a725-a13e7f25f412)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d14f0c18-f1e9-4612-802e-de740acb9a53)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1642dd9a-250f-46e2-81b4-d114fc188ca6)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         a5098786-d443-4671-b855-9b26c9690457)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         3f3853e3-6c3a-41ff-ab53-c14a00aa2729)(content(Whitespace\"\\n\"))))(Tile((id \
+         d9d40aa1-0b17-4d72-8971-a275f99ef525)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         10acbaa7-bb7f-4642-9964-bc3239005e3d)(content(Whitespace\" \
+         \"))))(Tile((id d3ffbfe2-aacf-43c9-8ced-3d447dbd9d97)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         e6fc7545-139d-424e-8d2c-1d240e7a5d7f)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         767c74fa-219b-46a7-a1fe-705f36beb381)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         b8d2279d-5947-47ac-8bf7-be670d6ae8a8)(content(Whitespace\"\\n\"))))(Tile((id \
+         079217f9-209f-4b8e-a251-848fbc04bb6c)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f7f9a6d2-d932-4ea9-a943-2cebc87fc21a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9303baa2-29f2-4617-8e68-3a418c9c46f1)(label(Student))(mold((out \
+         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         0ed67667-6dd5-4095-a701-7a8fa9b15473)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         1e29409b-8544-497d-8c26-3b0f57d60c71)(content(Whitespace\" \
+         \"))))(Tile((id \
+         09704eaf-2f9d-4467-af6e-8fd833a5110e)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         e8d4bf1d-0afb-4c80-a71b-8f5f9ed93b32)(label(name))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6989d3a0-15a2-49dc-af85-f4ce6f2a44b6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f550f672-b291-4ecf-9d4e-ed25a5fd087b)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9d206656-3cce-4d6b-a6d8-2f73476fad2f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3d7e61e8-985b-48e0-8303-39187bbc6e8c)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         f10e1ecb-6ce8-4067-921e-28a5593cfbed)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c82c0eec-aa2a-4573-a876-5e1c9a8115c0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         569fbb37-9e5c-4a5c-a43d-0aa9290da2c5)(label(age))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9fcd181f-73f0-4b45-938e-efb33d40719d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f9292089-8d12-4e94-ad05-1882a50fcf4c)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         05fed53f-28ca-42bc-b21a-e04ef480aa22)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a6d71c5c-9180-44cb-9db0-a11385368b4c)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         c7d4f3ee-0dde-460f-9f47-0ce63ff219a4)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5c3dfebd-5359-4c17-9250-e2f2bcbefce6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ab4d222b-4780-46cc-b46a-497632ef8473)(label(favorite_color))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b8520dfb-8ecc-43e9-9144-3c6fc9050c87)(content(Whitespace\" \
+         \"))))(Tile((id \
+         47b9ad24-12b0-463f-a086-1341abb8b601)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fa74e1f6-f060-4fec-a97f-53f236d22526)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3168579b-8f4e-485f-a902-1d13402dabf9)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         169fd8d0-16e8-4f4a-99a8-65fe0d49d2ec)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ccdfe8e5-7c49-4ae9-950b-8633966926d8)(content(Whitespace\"\\n\"))))(Tile((id \
+         d0186246-6403-469c-ab47-7042aba3e9a8)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         20ca40fb-d2fe-4976-8333-dc67a1a30870)(content(Whitespace\" \
+         \"))))(Tile((id \
+         04412230-5c7b-4957-a368-a1532f9306f8)(label(students))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1f5ff2ff-a809-4ddf-bf2c-d669a1f389d2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         558bc20a-324f-4413-830b-903d0eaf194f)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         56c6c24b-517c-4876-8667-5d741372a522)(content(Whitespace\" \
+         \"))))(Tile((id 2386e195-563d-4865-8238-4f669fbc9ad9)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         93ea3955-5a6f-4e2e-bde0-26a28c4f2aa7)(label(Student))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         c0857de8-fe88-4334-abaf-740e733c771a)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         d85bd927-784c-4864-886b-cb3ba53ca784)(content(Whitespace\" \
+         \"))))(Projector((id 4d1ddfa8-c90f-41a9-b7f2-4a14a6f03e4e)(kind \
+         Fold)(syntax(Tile((id \
+         aeb023f9-f6e1-4e87-98bb-4dbd8bd664eb)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         e860efd0-1417-406b-afdd-ccde5ee989d4)(label([ ]))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         5c119602-fb17-45f2-9c55-881b8d92e254)(content(Whitespace\"\\n\"))))(Secondary((id \
+         3c7317b7-1522-497a-8eec-f469f8be7dac)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b6c62a6f-dffe-4677-8c35-0d5b29171d0b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         50d2f3ed-ee45-453d-93dd-cd89cba6ac6a)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b17ecc68-5d05-40a6-9ef7-1ea6b03e5821)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0d15311a-9af0-44c4-8bf7-8e779ce98a72)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         9de70255-37b9-4d28-815e-54a54888524e)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5ef61533-20a6-4ed6-85e9-882a05ac3770)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         77afefe5-5ce3-4b96-a0a7-b5ca3b6902d8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8f7890ce-d5c2-40e6-ba70-e61bf8074dda)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         98473f0e-35a2-4e8c-ac38-f5a0efba79cf)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         aa62937a-d94a-43ae-be8b-176e84fb670f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2fd0876f-3823-45e9-b9fa-7f7280fdf74b)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         eafdb953-899f-4229-b9bb-1d9dc8acd21a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         87f94e2b-85fe-49a0-92bc-728dad0da901)(content(Whitespace\"\\n\"))))(Secondary((id \
+         9e03948f-b99c-439b-b1b7-5ba2f9f1678f)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         b90ac8f8-0233-4356-b34c-3192fe69a30d)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         081aa481-a97a-447c-b9f5-c2b45032cdde)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         1d50daa0-bcf2-4f21-a1e3-6a8359f8fe81)(content(Whitespace\" \
+         \"))))(Tile((id \
+         69e83da7-751f-4511-8041-9f70f96eace4)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         cc5b9b64-6789-4af2-8a71-3ea4ea68489b)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2ccea4b9-aab9-45e6-b799-9d7c0a132864)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         28dd4157-6830-47ab-819a-06f8e81eedaf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8dfb67b6-4d06-4ea3-bd30-ce657a78d24e)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b4b8174c-7e7c-4b4d-93e1-86d3234daa6b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         14cfd93b-3149-4862-ab73-fc47149bbe9c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d5d4d54f-5a77-47a1-b9b8-239f060b62b3)(label(\"\\\"green\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         9506991e-e17d-4d1f-846b-715d7d4b27a5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         efc31a60-3528-4ace-ad4b-039df2481468)(content(Whitespace\"\\n\"))))(Secondary((id \
+         0bb49e03-aae4-4829-a135-b123f1d4fc20)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         43fc1650-6323-4f2b-a23c-cbfbe6e83ab8)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         06f30288-a27f-476b-a463-e6b9b90ed7a2)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c7ab3cbf-d4bb-4d9e-90a5-4c43e8b283c0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         add5e5e9-474e-4071-9fc6-bec3f4ef4b75)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         7ae099db-6f71-4868-8ebf-ec33a0f9e515)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ae833aec-d4f6-4405-9bbe-1a80bdaa9cd3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0207c945-3abb-4540-b6bf-f4a6e1be8ab7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         133c0c73-7aca-41a3-9968-1ad593fb0d82)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         86d649d5-0f35-4104-9d8a-7e8b642fc302)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f043d773-4ddd-454d-9b68-e249161bd320)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b82c02e1-3758-4f61-9d6b-d35e3856e1cb)(label(\"\\\"red\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         d59255f3-aab8-4b39-88ad-ed7e20a6463e)(content(Whitespace\"\\n\"))))(Secondary((id \
+         8a81db0a-5c38-4400-bed7-99494801e08c)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         050a8d56-25c4-4eaa-8154-35af1a2e089c)(content(Whitespace\" \
+         \")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
+         false)(always_render false))\")))(Secondary((id \
+         b01ae20d-9478-485f-898c-95dc4249d4fa)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         af3b21d5-b1db-436e-a647-aba96b9af8de)(content(Whitespace\"\\n\"))))(Secondary((id \
+         843c8f21-66a2-487c-a070-286a54069ee1)(content(Comment\"# We are not \
+         flattening the rows in this to coallesce the sparseness \
+         #\"))))(Secondary((id \
+         b00ac5bb-a497-4973-897d-cfe4a602c783)(content(Whitespace\"\\n\"))))(Tile((id \
+         be7aeb3c-8476-4931-b77c-c3949198739f)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         eff65be2-7aca-461f-8eed-88d499cda5cf)(content(Whitespace\"\\n\"))))(Tile((id \
+         de1ed246-2543-4b9a-854f-c0c68abee92c)(label(pivot_wider))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         029af6b5-59b3-4087-b27e-5bd711c0d734)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         84008eb0-b3d5-4ac1-8f47-6e9a0ce4b4ac)(label(students))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         109a5f7f-c498-4a92-bbd9-68dd706fddf8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7590a580-10df-4e01-b69f-c328f935ed52)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e3adb7e1-7102-4e55-9275-8585b2170b89)(label(\"\\\"name\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         11a091ed-67b6-4b7e-9bc1-06fb559ed0d4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c7da5ffd-c6af-4b44-b6bd-3a60c91ca8a7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7d854e8b-c336-4c7b-bc1d-d35f5e22d1b3)(label(\"\\\"age\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         dcf08533-6ca0-4f05-9fb9-713b5af181f0)(content(Whitespace\"\\n\"))))(Tile((id \
+         c127e0a5-3233-463b-b528-8c922723ec60)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         063791aa-3286-4576-98cf-36b6da5a7a47)(content(Whitespace\" \
+         \"))))(Tile((id 9223dd4d-1c00-4e48-bbbc-4135ae565f64)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         4f6c6fb7-55cd-4b14-927c-7ad74444e836)(content(Whitespace\"\\n\"))))(Tile((id \
+         69c8402e-bdff-4646-b5de-ecdaa4508276)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a5adb6ea-3e2d-4442-b63c-433b79a5a687)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         23dc0edd-e03b-420f-b66a-de0c42f28800)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         a0e169d6-7274-40eb-9c64-ad24cc6961ed)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ea1b1f89-01aa-4350-8bfa-af38e4bcb84f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b65e2f70-ad49-4db8-bfa7-1b111c11732a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e12011e1-65ae-401d-aeae-a3d7a2f9c363)(label(`Bob`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1bfa20c4-c851-4db4-b9de-dfc320f841f6)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         c755dda7-35bd-42fb-b2b2-b3dde7665c26)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cd29cef4-d49c-4332-9e8f-17dab12a2529)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         908c2203-c806-410d-9876-0de313ca6e5f)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         f59c1dc5-5210-47e8-99e3-3326f09e66c1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ea12ddea-cca8-4ad4-898c-41a52883957b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         242f1bd7-37f6-46af-a0a9-0c31657d9143)(label(`Alice`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d71fcce6-2cc9-4a84-a937-5bb0d8fad4fc)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         a8d2fada-6507-466f-8c87-f74633ef2f38)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c07d4870-1821-43e0-ad35-0719e12d31a8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         081bf5a4-ccd1-4cf2-95b6-fbc57df67de8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         856621cd-3f2b-4ec7-a5a3-d6e1eacdaf63)(label(`Eve`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         de69e209-568c-4658-917e-823511f2aabf)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         be7c07ee-5812-4da2-9bf6-c476ceabecb6)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         05960869-4b85-4cc4-96b8-cfbd56a7f98c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d2ba0afc-9693-41f7-aca0-2ae336304df9)(content(Whitespace\"\\n\"))))(Tile((id \
+         2c67cabc-dd75-4230-a2d7-81046a4b37bd)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         53f565b7-8f0a-4f0f-afb5-2eebdb33512f)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bbf57e4c-99bf-43b6-bf27-e458dfe2316d)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         7614f72d-4b6b-4c76-a466-8235f05c6091)(label(\"\\\"green\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         349fb87d-8525-4a19-8cf0-ff288978881b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         39b20acc-ef42-4c22-9e3b-6b3e0b8b1d33)(content(Whitespace\" \
+         \"))))(Tile((id \
+         76123793-88ed-41a0-91b3-f6df3680c0c1)(label(`Bob`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cce05f11-a32a-4a17-88cb-be0cfbad069e)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         b5f4f5d5-1731-42f0-95d4-0f8bfe1522b2)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b860f804-28d9-4e83-bd9f-81505e95b0e1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         28913926-2cdc-43b5-b81f-148d41d7f162)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fd4d94db-aea2-4f67-a8b9-a463fc4d437b)(label(`Alice`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f87f558a-e5b4-4ef0-88bb-17bc9198a9ea)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         ac7350bb-f81f-497e-a80b-7bf2914b6759)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c73e75ef-8e12-4ecb-878e-7c74396f3b6f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         93ea92ab-2bfe-4fcd-b4e3-2768dd111d1a)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         0e0b04bc-729b-4e71-9534-b50b976e445a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e08d681e-6acb-4d84-bf1b-e148904b8c53)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fa55c488-540d-42a5-98c6-f7d444f45345)(label(`Eve`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1eff64ff-7459-4e4b-ba67-6b29c2f5cbf9)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         d3a05e7a-28f3-48ee-bcf8-6dd526936150)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         37b3912e-ae3b-43f0-b28a-941208fd8f1f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f03699a5-8bb8-4b43-a17f-429c263670d0)(content(Whitespace\"\\n\"))))(Tile((id \
+         2cdbdd9c-9ae6-4838-a21e-e7cabc379b3e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         b0790bef-6336-4a16-bed6-8a51e792748f)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f017478b-6d24-4a52-9bd5-f0042bbb372a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         06b19c45-ec27-4d1f-af9e-8c333268f878)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         70be7482-2dfe-49d7-9b5e-eaf0848bc5d9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1ef5e76e-fa0b-4af2-b2cf-3eb0ecf1b4a3)(label(\"\\\"red\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8444e8ec-3587-47e4-9f32-2b3f9c0eaccc)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3ea87c92-0738-42ab-b659-22b3354b75d9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e3a5e31a-e70b-4ccf-8205-ca650fcd246d)(label(`Bob`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3393482b-3eea-45ef-a21d-bcd094689c4f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d5c6ae11-1a50-45d9-a76b-b19435ef2081)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         71d55167-7ec7-487d-b193-add028cce7ba)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d2bab93f-a957-41a6-bc18-9353d5666d4c)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         52a30c45-d70a-43b6-855a-3b95b363998e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6a4b7f0e-d244-475f-b57f-aa20f8ac6968)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1fbdedb3-2f00-4134-ace4-881165a40802)(label(`Alice`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         969408a9-0f0c-457b-9b0c-9512ae2e51c0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6e280358-1653-46f4-aa85-3dc997049fc0)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a8994b75-49d7-4d63-a1d0-9a5e9d085d0a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e7ba99ba-c22e-4c28-b53d-a7fb26a0395d)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         318b71b8-b6d0-4aa1-b17c-492421be417e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         aab54157-8bbc-4e5c-ac2e-6e99c73c9053)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2406c28a-636e-4652-b733-ec47e680bb0b)(label(`Eve`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         11c1d056-84bb-4467-babc-715f3e6fad2c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a215fb67-5719-4e08-b7a1-e67419263148)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b642e4af-f35c-46db-a4de-c19703150af2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7fcfb3ef-caab-4263-b7f6-9360ca63644b)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a4e41256-8773-4dc5-b34a-4e7586fdc9bf)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         985c2228-abb8-46c0-a8df-942602e9b7ee)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         f69d01cf-01cd-4b73-afa3-9964a5bb64df)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         e8dd610a-228b-4606-92f8-c595ccb58f9e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3bed05b5-e5f9-4984-a30f-229ec939629a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         01658fd6-3840-421c-946e-617aab13f551)(content(Whitespace\"\\n\"))))(Tile((id \
+         e4b1246c-8c7b-4cf7-bf7d-35c4abf5e7d7)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))";
       backup_text =
-        "let pivot_longer = \n\
-         let requires=[\n\
+        "let pivot_longer =\n\
+         let _requires = [\n\
          (enforced=^^check(false), \"length(cs) is positive\"),\n\
          (enforced=^^check(false), \"cs has no duplicates\"),\n\
          (enforced=^^check(false), \"for all c in cs, c is in header(t1)\"),\n\
          (enforced=^^check(false), \"for all c in cs, schema(t1)[c] is equal \
          to schema(t1)[cs[0]]\"),\n\
-         (enforced=^^check(false), \"concat(removeAll(header(t1), cs), [c1, \
+         (enforced = ^^check(false), \"concat(removeAll(header(t1), cs), [c1, \
          c2]) has no duplicates\")\n\
          ] in\n\
-         let ensures=[\n\
+         let _ensures = [\n\
          (enforced=^^check(false), \"header(t2) is equal to \
          concat(removeAll(header(t1), cs), [c1, c2])\"),\n\
          (enforced=^^check(false), \"for all c in removeAll(header(t1), cs), \
          schema(t2)[c] is equal to schema(t1)[c]\"),\n\
          (enforced=^^check(false), \"schema(t2)[c1] is equal to ColName\"),\n\
-         (enforced=^^check(false), \"schema(t2)[c2] is equal to \
+         (enforced = ^^check(false), \"schema(t2)[c2] is equal to \
          schema(t1)[cs[0]]\")\n\
          ] in\n\
-         let pivot_longer = fun (t1, cs, c1, c2) ->\n\
-         flat_map(t1, fun row ->\n\
+         let pivot_longer =\n\
+         fun (t1, cs, c1, c2) ->\n\
+         flat_map(\n\
+         t1,\n\
+         fun row ->\n\
          let entries = to_lvs(row) in\n\
-         let pivot_entries, other_entries =\n\
-         partition(entries, fun (label=l, value=v) -> contains(cs, \
-         string_eq(l, _))) in\n\n\
+         let pivot_entries, other_entries = partition(entries, fun (label = l, \
+         value = _v) -> contains(cs, fun s -> l == s)) in\n\
          let rest = from_lvs(other_entries) in\n\
-         map(pivot_entries, fun (label=l, value=v) -> rest \
-         ...(from_lvs([(label=c1, value=l), (label=c2, value=v)]))) \n\
-         ) : [?] in\n\n\
-         type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+         map(pivot_entries, fun (label = l, value = v) -> rest ... \
+         (from_lvs([(label=c1, value=l), (label = c2, value = v)])))\n\
+         )\n\
+         : [?] in\n\
+         type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = ^^fold([\n\
-         (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
-         (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-         (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
-         ]) in\n\
+        \    (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
+        \    (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
+        \    (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
+        \  ]) in\n\
          let expected = ^^fold([\n\
-         (name=\"Bob\", age=12, quiz1=8, quiz2=9, quiz3=7, quiz4=9, \
+        \    (name=\"Bob\", age=12, quiz1=8, quiz2=9, quiz3=7, quiz4=9, \
          exam=\"midterm\", score=77),\n\
-         (name=\"Bob\", age=12, quiz1=8, quiz2=9, quiz3=7, quiz4=9, \
+        \    (name=\"Bob\", age=12, quiz1=8, quiz2=9, quiz3=7, quiz4=9, \
          exam=\"final\", score=87),\n\
-         (name=\"Alice\", age=17, quiz1=6, quiz2=8, quiz3=8, quiz4=7, \
+        \    (name=\"Alice\", age=17, quiz1=6, quiz2=8, quiz3=8, quiz4=7, \
          exam=\"midterm\", score=88),\n\
-         (name=\"Alice\", age=17, quiz1=6, quiz2=8, quiz3=8, quiz4=7, \
+        \    (name=\"Alice\", age=17, quiz1=6, quiz2=8, quiz3=8, quiz4=7, \
          exam=\"final\", score=85),\n\
-         (name=\"Eve\", age=13, quiz1=7, quiz2=9, quiz3=8, quiz4=8, \
+        \    (name=\"Eve\", age=13, quiz1=7, quiz2=9, quiz3=8, quiz4=8, \
          exam=\"midterm\", score=84),\n\
-         (name=\"Eve\", age=13, quiz1=7, quiz2=9, quiz3=8, quiz4=8, \
+        \    (name=\"Eve\", age=13, quiz1=7, quiz2=9, quiz3=8, quiz4=8, \
          exam=\"final\", score=77)\n\
-         ]) in\n\
-         test \n\
+        \  ]) in\n\
+         test\n\
          pivot_longer(gradebook, [\"midterm\", \"final\"], \"exam\", \
-         \"score\") == expected\n\
-         end;\n\n\
+         \"score\") == expected end;\n\
          # The idiomatic way to do this with concrete data. Giving good type \
          feedback#\n\
          test\n\
-         flat_map(gradebook, fun (entry : GradebookEntry) -> \n\
-         map(to_lvs(select_labels(entry, `midterm`, `final`)),\n\
-         fun (e : (label=String, value=Int)) -> omit_labels(entry, `midterm`, \
-         `final`) ... (exam=e.label,score=e.value))) == expected \n\
-         end\n\
-         in\n\
-         let pivot_wider = \n\
-         let requires=[\n\
+         flat_map(\n\
+         gradebook,\n\
+         fun (entry : GradebookEntry) ->\n\
+         map(\n\
+         to_lvs(select_labels(entry, `midterm`, `final`)),\n\
+         fun (e : (label = String, value = Int)) -> omit_labels(entry, \
+         `midterm`, `final`) ... (exam = e.label, score = e.value)\n\
+         )\n\
+         )\n\
+         == expected end in\n\
+         let pivot_wider =\n\
+         let _requires = [\n\
          (enforced=^^check(false), \"c1 is in header(t1)\"),\n\
          (enforced=^^check(false), \"c2 is in header(t1)\"),\n\
          (enforced=^^check(false), \"schema(t1)[c1] is ColName\"),\n\
-         (enforced=^^check(false), \"concat(removeAll(header(t1), [c1, c2]), \
+         (enforced = ^^check(false), \"concat(removeAll(header(t1), [c1, c2]), \
          removeDuplicates(getColumn(t1, c1))) has no duplicates\")\n\
          ] in\n\
-         let ensures=[\n\
+         let _ensures = [\n\
          (enforced=^^check(false), \"header(t2) is equal to \
          concat(removeAll(header(t1), [c1, c2]), \
          removeDuplicates(getColumn(t1, c1)))\"),\n\
          (enforced=^^check(false), \"for all c in removeAll(header(t1), [c1, \
          c2]), schema(t2)[c] is equal to schema(t1)[c]\"),\n\
-         (enforced=^^check(false), \"for all c in \
+         (enforced = ^^check(false), \"for all c in \
          removeDuplicates(getColumn(t1, c1)), schema(t2)[c] is equal to \
          schema(t1)[c2]\")\n\
          ] in\n\
-         let distinct = fun xs ->\n\
-         case xs \n\
+         let distinct =\n\
+         fun xs ->\n\
+         case xs\n\
          | [] => []\n\
-         | (x :: xs) => let seen = distinct(xs) in if mem(xs, x) then xs else \
-         x :: xs \n\
-         end\n\
-         in\n\n\
-         let pivot_wider = fun (t1, c1, c2) ->\n\
-         let kept_columns = map(t1, fun row ->\n\
+         | (x :: xs) =>\n\
+         let _seen = distinct(xs) in\n\
+         if mem(xs, x) then xs else x :: xs\n\
+         end in\n\
+         let pivot_wider =\n\
+         fun (t1, c1, c2) ->\n\
+         let kept_columns =\n\
+         map(\n\
+         t1,\n\
+         fun row ->\n\
          let entries = to_lvs(row) in\n\
-         filter(entries, fun (label=l, value=v) -> !mem([c1, c2], l)) |> \
-         from_lvs)\n\
-         |> distinct in\n\n\
-         let new_columns = flat_map(t1, fun row ->\n\
+         filter(entries, fun (label = l, value = _v) -> ! mem([c1, c2], l)) |> \
+         from_lvs\n\
+         )\n\
+         |> distinct in\n\
+         let new_columns =\n\
+         flat_map(\n\
+         t1,\n\
+         fun row ->\n\
          let entries = to_lvs(row) in\n\
-         find_map(entries, fun (label=l, value=v) -> if l == c1 then Some(v) \
-         else None) |> option_to_list)\n\
-         |> distinct in  \n\
-         map(kept_columns,\n\
+         find_map(entries, fun (label = l, value = v) -> if l == c1 then \
+         Some(v) else None) |> option_to_list\n\
+         )\n\
+         |> distinct in\n\
+         map(\n\
+         kept_columns,\n\
          fun kept ->\n\
-         kept ... \n\
-         (map(new_columns,\n\
-         fun c -> \n\
-         (label=c, value=find_map(t1, \n\
-         fun r -> \n\
+         kept\n\
+         ... (\n\
+         map(\n\
+         new_columns,\n\
+         fun c -> (\n\
+         label = c,\n\
+         value =\n\
+         find_map(\n\
+         t1,\n\
+         fun r ->\n\
          let entries = to_lvs(r) in\n\
-         if \n\
-         (filter(entries, fun (label=l,value=v) -> !mem([c1,c2], l)) |> \
-         from_lvs)\n\
-         == \n\
-         kept && find_map(entries, fun (label=l,value=v) -> if l == c1 then \
+         if (filter(entries, fun (label = l, value = _v) -> ! mem([c1,c2], l)) \
+         |> from_lvs) == kept\n\
+         && find_map(entries, fun (label = l, value = v) -> if l == c1 then \
          Some(v) else None) == Some(c)\n\
-         then find_map(entries, fun (label=l,value=v) -> if l == c2 then \
+         then find_map(entries, fun (label = l, value = v) -> if l == c2 then \
          Some(v) else None)\n\
          else None\n\
-         ))\n\
-         ) |> from_lvs)\n\
-         ) : [?] in\n\n\
-         type Student = (name=String, age=Int, favorite_color=String) in\n\
+         )\n\
+         )\n\
+         )\n\
+         |> from_lvs\n\
+         )\n\
+         )\n\
+         : [?] in\n\
+         type Student = (name = String, age = Int, favorite_color = String) in\n\
          let students : [Student] = ^^fold([\n\
-         (\"Bob\", 12, \"blue\"),\n\
-         (\"Alice\", 17, \"green\"),\n\
-         (\"Eve\", 13, \"red\")\n\
-         ]) in\n\
+        \    (\"Bob\", 12, \"blue\"),\n\
+        \    (\"Alice\", 17, \"green\"),\n\
+        \    (\"Eve\", 13, \"red\")\n\
+        \  ]) in\n\
          # We are not flattening the rows in this to coallesce the sparseness #\n\
-         test pivot_wider(students, \"name\", \"age\")\n\
+         test\n\
+         pivot_wider(students, \"name\", \"age\")\n\
          == [\n\
          (favorite_color=\"blue\", `Bob`=Some(12), `Alice`=None, `Eve`=None),\n\
          (favorite_color=\"green\", `Bob`=None, `Alice`=Some(17), `Eve`=None),\n\
-         (favorite_color=\"red\", `Bob`=None, `Alice`=None, `Eve`=Some(13))\n\
-         ]\n\
-        \ end\n\
-         in\n\
+         (favorite_color = \"red\", `Bob` = None, `Alice` = None, `Eve` = \
+         Some(13))\n\
+         ] end in\n\
          ?";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIMissingValues.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIMissingValues.ml
@@ -1,2347 +1,2542 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Missing Values",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
-        "((Tile((id 9270fc4d-f8a1-4fe3-bc52-ff6d9a205b26)(label(type = \
+        "((Tile((id 6d793b48-3e53-41c5-8bad-4653d13612d0)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         0dc786c2-8d12-42e7-8afc-ad43d0f07ed6)(content(Whitespace\" \
+         21f696c8-a7fc-4d77-91cc-0f17f56c21ab)(content(Whitespace\" \
          \"))))(Tile((id \
-         52a7c60c-d9f8-4eb7-a0c4-b667742ff7c6)(label(OptInt))(mold((out \
+         1da981cb-5a98-4bac-a380-cc8d57ff84bc)(label(OptInt))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         13b5e0a5-98af-4954-82b9-5684520b4980)(content(Whitespace\" \
+         24ec9b56-8145-42a1-a270-4bdb2bc0abfb)(content(Whitespace\" \
          \")))))((Secondary((id \
-         dc7e4110-150a-4019-858b-49a13bc4d131)(content(Whitespace\" \
+         149a7967-2fe8-4db3-be73-5c2543d2f041)(content(Whitespace\" \
          \"))))(Tile((id \
-         f2c96511-eaec-4c54-bd8f-ede1b778d344)(label(+))(mold((out \
+         f22948b3-67fc-4262-af1d-a3206c66e417)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         795d1806-07d6-4213-83f1-f3fb6c494c74)(label(None))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0cc922a1-e8c1-46d2-a5b7-a3894c7119a7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         849d9352-8eb0-4079-a983-9717c1746ec4)(label(None))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         d8f04914-af1d-46a2-b44c-af911d6d1cb9)(content(Whitespace\" \
+         4aec569e-0c24-4667-b638-2e28e7efb6f7)(content(Whitespace\" \
          \"))))(Tile((id \
-         ce08dfef-db34-4b9f-a834-7d1a46408eb8)(label(+))(mold((out \
+         832d29ec-bd5d-48c4-b28b-b115bd65d69c)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
-         12))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         8d922d99-bcff-42ac-a9a8-d8081fe6bb11)(label(Some))(mold((out \
+         12))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         03605eb7-3304-4725-bd40-9c6600c0a81d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         65d6586e-8426-4089-8fbb-08532b14dfe6)(label(Some))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         27abf446-5ffa-4002-9765-32579154d41d)(label(\"(\"\")\"))(mold((out \
+         4bb9b5a1-d737-4dcf-9649-eab6a751d059)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape(Concave 11))(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         1bdf93fd-d400-4318-8afd-dfaaafbc3ed4)(label(Int))(mold((out \
+         65c9dba5-83a7-4c76-ac3d-71911eda2ebe)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c9e41fe7-fc73-4a73-9aae-e98e26bd8f14)(content(Whitespace\" \
+         08991c0b-98ac-426a-ada1-13a0da0c9a13)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         10b1b00a-a76a-4e58-97b3-cfa2d98dd6fd)(content(Whitespace\"\\n\"))))(Tile((id \
-         186eb1de-903b-4682-91ad-c67d65b66231)(label(type = in))(mold((out \
+         6026468c-d845-4291-8583-b509541e4dea)(content(Whitespace\"\\n\"))))(Tile((id \
+         de720326-abd5-42a9-99c6-0bf2adec9f56)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3e1fea29-ca4d-4077-acea-6e3cc2fb2214)(content(Whitespace\" \
+         f752960a-ad2f-4b7c-b5fd-f4398ec6c78f)(content(Whitespace\" \
          \"))))(Tile((id \
-         80fa852c-471c-4b49-befa-41c30ee7a294)(label(OptString))(mold((out \
+         8778f2a5-52fb-4833-a0da-93d073b23429)(label(OptString))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         3fa8e71e-02b7-4afd-9731-2103eda7afb9)(content(Whitespace\" \
+         44b6d714-1f01-49c4-9c1e-c218181d8b85)(content(Whitespace\" \
          \")))))((Secondary((id \
-         99411f2c-dd76-4c7d-a4bd-02bc6bb1a838)(content(Whitespace\" \
+         d53caa11-eef4-4f6c-925e-a8eb0495e0ac)(content(Whitespace\" \
          \"))))(Tile((id \
-         81595ea2-41bf-462e-ab4f-6896f0ac57d0)(label(+))(mold((out \
+         19a85e1d-2a24-4a6e-8b33-2b49f3d84f03)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         7a630660-92b2-415e-aceb-4c42e5e84a0a)(label(None))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ec1c89c5-f501-4e1f-87bc-b12c11b211a4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4b98ffda-f648-4655-a0cd-0f7ced554d91)(label(None))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         e42038d5-663c-46cb-bd0a-67f79c6600da)(content(Whitespace\" \
+         b0348fbe-0dc3-402c-a6cc-9286536c7770)(content(Whitespace\" \
          \"))))(Tile((id \
-         d4738860-5806-4e20-9390-2d6cad19aa42)(label(+))(mold((out \
+         f8f7cf43-08d2-4b2a-994b-33f30a546f6d)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
-         12))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         9c256ce4-0ce8-497e-afa3-2c2a5b80c810)(label(Some))(mold((out \
+         12))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dc82728f-e5bd-4ac6-917f-9bf1b68a1e46)(content(Whitespace\" \
+         \"))))(Tile((id \
+         27be4bca-c3df-438e-a744-0c8cd99ee949)(label(Some))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         f37256ec-e3a1-44cc-abdc-b5938f642fc3)(label(\"(\"\")\"))(mold((out \
+         f9f3b491-7ccc-48a8-bb3f-ba23493c4019)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape(Concave 11))(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         209938da-eebb-426d-8298-f612ca7ed883)(label(String))(mold((out \
+         b9542736-644f-4f07-8736-4ca94ec006f3)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c2fc0643-92b2-4968-acf9-8a1e34108c9d)(content(Whitespace\" \
+         b9fb7aec-e7f0-4f54-bc0b-4c91b23d7189)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8971683e-1217-43ea-9652-af55cdd91de4)(content(Whitespace\"\\n\"))))(Tile((id \
-         b26879a9-86b2-4b35-bc5f-d2d5ce2e456d)(label(type = in))(mold((out \
+         afea0e4d-0596-4023-a108-524a28a48d35)(content(Whitespace\"\\n\"))))(Tile((id \
+         470d1f03-968c-42ff-bacb-7d2e19e969dd)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         2f9dbaac-100d-4a55-847b-dcec2d5483ff)(content(Whitespace\" \
+         7775e6a0-85d5-49b0-9a36-9410d30607ee)(content(Whitespace\" \
          \"))))(Tile((id \
-         9836064b-3251-4174-bba7-affaca2a9856)(label(StudentMissing))(mold((out \
+         feab2d35-bd20-4c24-8060-e2d5e3d1cceb)(label(StudentMissing))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         0e85f4e1-c0ea-4feb-8a8f-95326dde804d)(content(Whitespace\" \
+         f82f6276-4e00-4564-83a6-77a23a65292a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         626422e5-1150-4881-b7d4-e4ad5959393d)(content(Whitespace\" \
+         5699744d-c9fe-4ac6-9f3b-63d3a1ccb232)(content(Whitespace\" \
          \"))))(Tile((id \
-         85be433a-5f67-4fa2-90af-eeb6084ad51b)(label(\"(\"\")\"))(mold((out \
+         f98592ce-01c7-4583-9f23-9fcc84551089)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         99f517ad-0dbf-45f4-8bec-0aad1db7dd5a)(label(name))(mold((out \
+         c809a4d0-e49f-4f93-9101-ac200c8ca633)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         54251951-aae1-4299-8680-df48885ae03a)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1886a9e6-f369-418a-a484-cbf2c6c5d2f7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ed1cf68a-f9be-41ce-8e47-0b67ec9b9af9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         966f8047-762c-4592-9277-4963ae101b68)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f2ae026d-a70d-469e-a3a4-fbb430489876)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b6f0bc95-f4d5-412f-96f6-10f744b2687c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         7452b22b-62fe-4d87-99a3-0578665254e2)(label(,))(mold((out \
+         6a7689db-5292-4fac-a85c-dd45074fce6a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2203fa93-e219-4fff-a275-8b39c99f14e9)(content(Whitespace\" \
+         52a55452-4feb-4eaa-8ca7-c77500211f16)(content(Whitespace\" \
          \"))))(Tile((id \
-         d8a1f1d9-6ee2-4ac0-b839-29e6c23ca456)(label(age))(mold((out \
+         4b4a5515-cdad-4a5d-ac56-0722876e6b27)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         9ecf40d7-0680-4222-a063-850ef7d84eea)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c3d19259-23bb-4296-9e81-285feb65da8f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9e9b1d4f-e1f0-45e0-a528-d7a005c32d22)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2100795e-2cc5-4054-a196-de3d5219abfb)(label(OptInt))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         770f5c99-ad23-42ca-b274-4fd58eeedbee)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b1d98d13-4864-40ff-937a-49985b4d93c4)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         c09db47c-229e-4e3c-90a1-108b084bda48)(label(,))(mold((out \
+         148cd683-9c86-48a0-bb89-8cb1008c047b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ef064bc8-5f21-4d83-8fe2-a167b3c19b18)(content(Whitespace\" \
+         0392b538-051c-4fd1-8def-b46ec900c669)(content(Whitespace\" \
          \"))))(Tile((id \
-         fa557bbd-33f6-4503-94c2-f33adcbb9f7d)(label(favorite_color))(mold((out \
+         ee06b5ee-4b7e-4bd3-b073-69913fb9aaf6)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         3e6b22a0-61c5-4a10-a349-45740ea6548b)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6b0665c5-34a0-4acc-896d-4390dcc4a3cd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c3ceac76-c6d1-428f-890e-65950b604bff)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         3983f8e0-b84f-409b-bcd6-99b738a3f66a)(label(OptString))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d15865a5-d7fb-4ac6-8aa2-8a258f26aa28)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ec04107a-cea3-4e83-aeab-36d85e5fdabe)(label(OptString))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         99b3fe41-1ad3-49a8-a353-b7f7db63273f)(content(Whitespace\" \
+         2c7ecf85-126c-421f-a8ff-32c613ef196a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7900f230-2d2d-41e2-852a-f424a1544ee1)(content(Whitespace\"\\n\"))))(Tile((id \
-         053cf906-a14e-4eee-9825-4d22420c43be)(label(let = in))(mold((out \
+         240b8018-5382-4e52-956e-71dfa03d1881)(content(Whitespace\"\\n\"))))(Tile((id \
+         9dec3062-941d-4582-9b61-199209f68c1c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         404c2938-421a-4a0a-beeb-85fdf7355c4c)(content(Whitespace\" \
+         1a3a6130-1a39-4e65-b6d5-c23b8c2c3275)(content(Whitespace\" \
          \"))))(Tile((id \
-         569da6b5-1560-4e4d-94a4-dae2cd12e388)(label(studentsMissing))(mold((out \
+         536ffc95-9264-4dc7-b0fd-03c2f2c0ee36)(label(studentsMissing))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ce6968ff-a1a7-4bd6-ad02-bc4102e990a6)(content(Whitespace\" \
+         0c0304b3-23fe-4c3f-814f-381511064637)(content(Whitespace\" \
          \"))))(Tile((id \
-         9f75c282-e2fa-461c-b23d-b2a1c24f4858)(label(:))(mold((out \
+         56d86985-90c5-4a8b-8cda-f53e4ad6a748)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8229f860-4129-40cd-ba08-bf015d45c05b)(content(Whitespace\" \
-         \"))))(Tile((id 95a00019-6b82-490d-9785-410dfec671e7)(label([ \
+         36b42488-db7c-4ce9-9736-280d4f586602)(content(Whitespace\" \
+         \"))))(Tile((id e57f1ead-a8b3-435e-b9ee-f31cf9d6846e)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         1e303548-ea6b-4029-9add-9c17bffc323e)(label(StudentMissing))(mold((out \
+         a492d2c1-08f5-4bc0-bcea-be8841867598)(label(StudentMissing))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         66ed8cae-e8b5-4a3b-92c3-e87db7877da6)(content(Whitespace\" \
+         8baf57f0-baac-4e52-9d47-b1b993a0d24d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         49855be7-c1ec-47e4-8946-f6fd50677db4)(content(Whitespace\" \
-         \"))))(Projector((id 94e36445-153a-475c-b3ec-0f49b59557eb)(kind \
+         93e54819-e5a1-40a9-8bdc-54216550fa74)(content(Whitespace\" \
+         \"))))(Projector((id dfb4083d-376a-4b78-9ebc-62f1b648a467)(kind \
          Fold)(syntax(Tile((id \
-         544a79a2-9a7d-48d0-9108-2bd5b4e7f65a)(label(\"(\"\")\"))(mold((out \
+         f8ea3884-84a7-400b-a0f8-c8b0617fcaf2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         4d904c29-8849-4b3e-800d-89aebdb2cdbf)(label([ ]))(mold((out \
+         adff74c7-8793-4f38-8405-765a5a8f1da8)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         53c8f66c-69f6-488c-871f-e821356238b0)(content(Whitespace\"\\n\"))))(Tile((id \
-         4d9fc15d-4b49-48ae-880a-616898365666)(label(\"(\"\")\"))(mold((out \
+         e0b7e091-378b-4945-8517-1aa7ac66a5fb)(content(Whitespace\"\\n\"))))(Secondary((id \
+         8d80aee7-a74f-44b0-a815-8417eb8fcf31)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a4bf7f08-82f5-42ab-a03f-355286eb17b0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         66a878dd-78b0-4ace-97d9-2e6e0ed63ce1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         5b0b3d94-7eae-4792-91e6-f9b09a3dfff0)(label(\"\\\"Bob\\\"\"))(mold((out \
+         3b3d80f7-9de0-4176-a5ec-dee4877c47e7)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         91a5fb0e-dbea-4a37-b83a-40452abe1621)(label(,))(mold((out \
+         a74d3583-7267-4319-9951-0ac85fae9ced)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d04252e7-584b-4951-b3b8-412494bbe2a7)(content(Whitespace\" \
+         5adc502e-2d45-4312-899f-6f1f69dc488d)(content(Whitespace\" \
          \"))))(Tile((id \
-         abf2f898-8747-4502-9104-0904007ff165)(label(None))(mold((out \
+         39b235d7-aa47-43e0-8e8a-ea7e8133f76b)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         bd5c58dc-2c88-465f-9c94-3c05008c8c6c)(label(,))(mold((out \
+         5b124503-ef4c-4d35-9075-0aef028e03ba)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f815605e-145a-475d-8ca9-8d065e0fe61c)(content(Whitespace\" \
+         c9e0d5e8-66a3-4fec-b787-d3148585fdab)(content(Whitespace\" \
          \"))))(Tile((id \
-         99dd26ab-81ac-42ab-854a-1631c73408c4)(label(Some))(mold((out \
+         033eadaa-c7ff-428d-b6e2-ceaa909f197a)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d5c9b59b-ebbd-4858-ad6d-5223d40b1b0e)(label(\"(\"\")\"))(mold((out \
+         f9ed1ffd-61c2-4174-ad56-662cc0d387b7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f49c4bb2-c68a-457a-9d89-ac8248cb43fe)(label(\"\\\"blue\\\"\"))(mold((out \
+         4377299c-277b-4e1f-8bd0-3af243553567)(label(\"\\\"blue\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Tile((id \
-         b70d3eee-e7fe-4a04-a3ee-f40833f71c1d)(label(,))(mold((out \
+         486655f8-189b-43b1-a67a-06d29da32b37)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d5ef3821-5b60-4b5c-99a0-279b9154a9bf)(content(Whitespace\"\\n\"))))(Tile((id \
-         5be12d26-fbf7-4008-bd04-c15b33e58892)(label(\"(\"\")\"))(mold((out \
+         dc00e230-a999-4d6d-ae3e-1a26845bf421)(content(Whitespace\"\\n\"))))(Secondary((id \
+         206a8503-b127-4acc-b192-55f1933bd66b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         5ece783b-d4c8-41a8-9b4c-8a12217fb2bf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3447b009-f130-458c-8f54-854d7c1cfa36)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         c3921f87-cd39-45ba-8f54-11763ffaf8c1)(label(\"\\\"Alice\\\"\"))(mold((out \
+         23a9e876-ba7d-4e42-bcd8-1d1f72fe5a41)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         9340e6e1-44c9-4413-b844-e8f2b2b0a66c)(label(,))(mold((out \
+         4563e2d1-0bcf-4fcb-bd53-2df57cbe537d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         abeba3be-0d94-48ea-b365-127c50ef79dc)(content(Whitespace\" \
+         00c939dc-333f-4916-94fa-23d16e304c49)(content(Whitespace\" \
          \"))))(Tile((id \
-         dd01813c-dcef-4fde-ba7c-2719f69e3148)(label(Some))(mold((out \
+         b39c86f2-4058-442c-ab6b-4b09c8ad6530)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d8556949-0939-4bd2-974a-1b62ad1b400d)(label(\"(\"\")\"))(mold((out \
+         1b9ff7e6-fa18-40c2-8273-a30a7005343b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         a764bea7-b10e-4d82-85ab-88795511f15d)(label(17))(mold((out \
+         a355eac6-61d5-4d8d-b438-2c5a5c5e521c)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         b326f528-3c2c-41a6-8d41-d320fc7df5f2)(label(,))(mold((out \
+         2792c7f8-6197-4c9d-8a60-41e77ef5ef9e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cd32f6d2-e8be-40a8-bbad-d27e6d7fdadb)(content(Whitespace\" \
+         cd4f2981-a749-4885-95c8-049cb2268973)(content(Whitespace\" \
          \"))))(Tile((id \
-         05a5cef3-c572-4dd6-be21-1d952d7f27db)(label(Some))(mold((out \
+         fef282b5-e265-42d7-b424-82f6049c3ca8)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         9a61a9f9-ae4d-49b5-89b3-0788c77371dd)(label(\"(\"\")\"))(mold((out \
+         f3bdaa61-6137-43c2-8cc0-191da3de75d6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         36abd3b4-0932-41c5-ad72-acf06429ef0f)(label(\"\\\"green\\\"\"))(mold((out \
+         57992e2e-e7ad-490a-ade6-c00bd10b9bd4)(label(\"\\\"green\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Tile((id \
-         3779f44d-f40c-4d55-8e26-946c4d68db19)(label(,))(mold((out \
+         be1767e4-0cf2-4726-a414-9f6659d3b395)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9a7470c9-04b9-4ebb-8fbf-8cceb0e086e9)(content(Whitespace\"\\n\"))))(Tile((id \
-         53162d3f-0f8c-49a4-9430-25d5b155f929)(label(\"(\"\")\"))(mold((out \
+         afada8f0-c0f0-4010-9614-841b36caa20c)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d8072cff-d5b4-42ca-9b2a-c9a27311e017)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         e7af3451-c3a1-488b-9b94-53c51ed50878)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a0c32889-1080-43ea-84ac-8f2fc1e62efe)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         0146ee17-de9b-4852-b36c-987d456704b8)(label(\"\\\"Eve\\\"\"))(mold((out \
+         9ff53e3e-59d1-4926-be4e-94e0bf3ac9fe)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         11081de1-f7ab-4294-93ed-a6c57a40df13)(label(,))(mold((out \
+         ce3cbe2d-7d97-4af2-8667-5e35f597140c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3d1b0ebb-382f-46a7-8223-cd7f073163cb)(content(Whitespace\" \
+         fa1f0d07-b64d-49c9-a927-15f058e11d54)(content(Whitespace\" \
          \"))))(Tile((id \
-         02397e90-8147-4302-a3db-7a5572940c22)(label(Some))(mold((out \
+         d5bf7ddf-fd1b-4779-8fa4-737ef542357f)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         8c71092f-6b08-4a75-a20d-f008e8403b49)(label(\"(\"\")\"))(mold((out \
+         defde0c0-47e5-44b3-9b74-f70cc03cab81)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         75a3ad94-e3b6-4654-b545-4614b542a9a4)(label(13))(mold((out \
+         a8b0d8c9-4ee2-4a8c-85d7-d7e038c69333)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         f1bc3cd1-ce0f-4217-a97e-b088e4278006)(label(,))(mold((out \
+         4d4776d8-61c9-4106-bbf3-07e41545ed85)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f07ac642-e5f1-4c28-860b-2bc5c094823c)(content(Whitespace\" \
+         5349e4cb-1913-41aa-812f-196eecffdfa4)(content(Whitespace\" \
          \"))))(Tile((id \
-         b94f1710-961a-4a37-af73-54943f6a7cda)(label(None))(mold((out \
+         3f108db1-b696-4968-8323-f30713f73be5)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         37a510dc-64b4-4bd8-81c9-8163ef58b1aa)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
+         932c85f9-1dac-47d5-96e9-f52919c9c81b)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         e76f9ab8-1fed-4bd6-a45f-6cc356dd847e)(content(Whitespace\" \
+         e298db99-4bcf-43e6-b099-a794377f22d7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2a60c2b9-3440-4cef-a49c-1c81254ad1d8)(content(Whitespace\"\\n\"))))(Tile((id \
-         788dd312-c45b-45c9-bef4-185f1b785f34)(label(let = in))(mold((out \
+         1ca8c643-68fd-4205-971e-d965d9c2cc2c)(content(Whitespace\"\\n\"))))(Tile((id \
+         1dae29f6-4876-4e60-89ff-0e3f2b742b6c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         d6928120-e742-4a80-add0-277ad64ef850)(content(Whitespace\" \
+         262bc127-a460-49f9-8064-5f18c6eb873b)(content(Whitespace\" \
          \"))))(Tile((id \
-         cbb6efc0-c56a-4a71-9cbd-4e254a2d46c4)(label(complete_cases))(mold((out \
+         db5e6931-0779-44ec-8ebd-56771924a788)(label(complete_cases))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         17c0ecb6-27c0-4175-987d-1445b7f4f5d9)(content(Whitespace\" \
+         4cba3f1e-c915-44d1-ad3d-9c84fdb34745)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d9ff3c1e-ff15-4445-8af5-4e638d6c2f9e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9ba9b0a-d3e2-47c9-a5a4-9270b74372ce)(content(Whitespace\"\\n\"))))(Secondary((id \
-         04b97276-2282-411e-84b9-10e88fb69243)(content(Comment\"# Instead of \
+         a0906e00-633c-4d04-9765-74f5eaa1a10a)(content(Whitespace\"\\n\"))))(Secondary((id \
+         39ce1d3b-0037-4c3c-ba45-4aebb5874b77)(content(Comment\"# Instead of \
          taking a colName we're taking a project function to make it \
          type-safe. #\"))))(Secondary((id \
-         d7893e0a-cde5-40a4-9cf5-c2848e116025)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9e978e71-1f14-4762-9541-24272bdd0b9f)(content(Comment\"# This only \
+         83387325-69aa-478f-aa8d-8eb68ed5100a)(content(Whitespace\"\\n\"))))(Secondary((id \
+         2f826961-e060-4a5b-9094-046718f814d5)(content(Comment\"# This only \
          works for option columns #\"))))(Secondary((id \
-         c511eb15-8d2c-4287-9e8b-6c0e3a9c6f12)(content(Whitespace\"\\n\"))))(Tile((id \
-         24818c65-7c0f-4623-b731-fb9ff538ca46)(label(let = in))(mold((out \
+         7cab2a70-3531-44df-a356-01ea98c9e619)(content(Whitespace\"\\n\"))))(Tile((id \
+         b9665524-7779-4140-a62c-c84dfcb10e6e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         5d541f33-ffd3-4ebc-addf-3e91ee153a58)(content(Whitespace\" \
+         98b39702-d771-44bd-ad9a-e250b26bf40c)(content(Whitespace\" \
          \"))))(Tile((id \
-         f03e1e1b-7430-446d-926e-088588d84d46)(label(requires))(mold((out \
+         ab2a55c2-56b7-4113-b3f3-e00f5bb457f0)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         2c1b9284-93b8-4eac-aba7-b6459765018b)(label([ ]))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         06845ed8-4fac-4edd-8383-af03445a3e3b)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         16e13e85-3c0f-4393-ac99-74df0be871a1)(content(Whitespace\" \
+         \"))))(Tile((id 6116efc3-6a58-4940-8ff7-6f85574d1b54)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         01cd1925-2a1f-4e27-b15a-f77a92fa27a1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         09f038f0-85a1-4595-a0e3-45e4bd616719)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         bf415490-634a-4fd6-ac08-38a753eb2d0b)(label(enforced))(mold((out \
+         c41330c2-f93a-4280-b5df-4fd881c3a241)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5fef6a30-2f6e-4cef-921e-4d68893d0947)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9f03aacb-2538-4774-8456-5202dd979a50)(content(Whitespace\" \
+         \"))))(Tile((id \
+         12ee31ec-6a98-4d64-8727-933b56cbc4e3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         f1b537b7-21ea-441b-a90d-9cec8bf02090)(kind Checkbox)(syntax(Tile((id \
-         d2802de2-8fdd-493d-a257-a910d68d9283)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         58b3d93d-cee9-47dd-b61e-a6c466d62e17)(content(Whitespace\" \
+         \"))))(Projector((id 6581fc28-58b4-45c4-8b9e-0bb0c7c0622a)(kind \
+         Checkbox)(syntax(Tile((id \
+         1b243122-e4d8-4d6e-b7ad-5c9ef2f44fb1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f4a6d420-095c-45be-bf80-2a364bdee7f1)(label(true))(mold((out \
+         4b407e88-d44f-437b-99fb-75bfff7f1519)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         134c7d37-e5cb-4ff1-bfc1-c0ef10a65a56)(label(,))(mold((out \
+         8ff772e5-6d3a-4733-ad8e-76107e37feb2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8a00bffb-54bc-4d7d-a2c7-8f94dc36e2f2)(content(Whitespace\" \
-         \"))))(Tile((id 8e301e31-bd9f-4e58-b4cc-1d3e5bc8de72)(label(\"\\\"c \
+         57081cc7-f112-402b-a560-9591caab06fc)(content(Whitespace\" \
+         \"))))(Tile((id 91fa6237-1207-45cd-b095-3efaff5a4ee5)(label(\"\\\"c \
          is in header(t)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         659ebc8f-a4ff-47b1-9b71-4ad90d6615ae)(content(Whitespace\" \
+         de3d4edb-4317-4f5b-85e4-557b04c56f6e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ce25f033-e7a1-4b98-be37-f265bcc85942)(content(Whitespace\"\\n\"))))(Tile((id \
-         d0a259ab-b749-46b0-8873-0f747b30f805)(label(let = in))(mold((out \
+         558b8618-162e-477f-8698-847603ef1ded)(content(Whitespace\"\\n\"))))(Tile((id \
+         7266303e-3328-4069-b21f-b973df61dd06)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c9c3cdb8-629b-4695-86e6-c8f0d28bce4e)(content(Whitespace\" \
+         106ce05d-e61d-4332-ab78-b480c69ffe1d)(content(Whitespace\" \
          \"))))(Tile((id \
-         de1dd7b3-1b4d-4f77-9c71-4677366cdc84)(label(ensures))(mold((out \
+         13ad0d08-414c-4543-9c72-c8dae75f71b4)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         b4d9bd81-95a1-41d9-b065-291a7646931e)(label([ ]))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ec7c0e38-958d-4674-b4e6-b9a2b365ff9e)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         8dee78b6-72bc-4a30-a66f-c3bcfb33aa9e)(content(Whitespace\" \
+         \"))))(Tile((id aeb9dd5e-6538-4105-9f06-a01e7a04587d)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         350377d6-9119-4df9-a8d9-e564909c13e8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         3afeffd0-92e6-4a2f-acbc-09681e8aa259)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         1937049a-dfeb-451b-9f6d-b7f27d57fefd)(label(enforced))(mold((out \
+         d2faae6e-2b58-4b69-b3e5-501bc38946e2)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fab91587-fad2-4ea5-b269-f9010f16fbbd)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         0f1f7dd3-f671-418c-aa04-74d4d705ee44)(content(Whitespace\" \
+         \"))))(Tile((id \
+         82af8a63-a468-4c15-8140-aadbc641028c)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         b9e074b9-7605-4729-a56a-4cb9da9a21a8)(kind Checkbox)(syntax(Tile((id \
-         0adfd345-1014-4ebc-95cf-45a219d4e088)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8c46f8e3-9a02-4b98-8457-534efc444180)(content(Whitespace\" \
+         \"))))(Projector((id 4b3d5fbc-2653-4298-ac4c-e774ce4236db)(kind \
+         Checkbox)(syntax(Tile((id \
+         83f42468-5214-4c09-b168-3ce8f301f858)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f3d17dfc-4ec1-4a87-9bc8-52433801018e)(label(false))(mold((out \
+         092fc6b1-7612-4882-aafa-10c9860e1174)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         127ddfc6-f805-471f-bec3-4019096fc0df)(label(,))(mold((out \
+         b46f6aae-bb7b-4999-b0db-54e5320f4798)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         756117ed-11e7-4223-8f93-92522ae4b58c)(content(Whitespace\" \
+         0291d72c-a75b-4395-865e-1c3cf7902bd8)(content(Whitespace\" \
          \"))))(Tile((id \
-         6122d0ae-dc74-416e-9ace-a98d8b86159e)(label(\"\\\"length(bs) is equal \
+         6d960669-6f7f-4ee4-a749-49c5938969bf)(label(\"\\\"length(bs) is equal \
          to nrows(t)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         a3e80aa7-d974-4f94-9cad-55654a1da39b)(content(Whitespace\" \
+         58d02eb4-d309-4aab-893c-b97f57997897)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fc941aed-0929-4806-af4c-56f954e322e1)(content(Whitespace\"\\n\"))))(Tile((id \
-         3d6b2e9f-4738-42dc-aa4b-f28e9ea77788)(label(let = in))(mold((out \
+         de2b4c9a-cbd1-4c31-9a3e-2796f58673b2)(content(Whitespace\"\\n\"))))(Tile((id \
+         036b33fd-f066-4673-b235-ded6704f7c34)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         cece0478-2854-4e00-8d6a-fab562e89759)(content(Whitespace\" \
+         af1bfdca-cc59-496e-b8fc-5b2764d0a897)(content(Whitespace\" \
          \"))))(Tile((id \
-         154c7612-73d9-4d6f-86d8-75bbca5baaed)(label(complete_cases))(mold((out \
+         51073624-8f86-4f1f-9f01-4660fc1ef423)(label(complete_cases))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c820623f-50dc-4242-9132-9ab82a2ad79d)(content(Whitespace\" \
+         7f51080c-5c31-444b-905a-7cf4956efb58)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f8808dd3-222b-4909-89bc-20ab045ae742)(content(Whitespace\" \
-         \"))))(Tile((id d80bc893-418e-4151-87f6-8039ef94e25d)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         e0d61bc5-145d-4630-a9c1-54de4a7f43f1)(content(Whitespace\" \
+         abf01d2d-bf08-4fce-93ef-ea46cdbb6526)(content(Whitespace\"\\n\"))))(Tile((id \
+         128ec957-5080-4890-9d33-112eaa8af520)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         4e80f9c3-b399-42b9-8137-fa494dbcd653)(content(Whitespace\" \
          \"))))(Tile((id \
-         1c343f2e-1aec-4397-8f75-d3c2ebd43e75)(label(R))(mold((out \
+         a270c278-72fd-4a89-88ad-9e3b86731c32)(label(R))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         b14598ce-7b2d-4f90-a259-f61fbfd4926e)(content(Whitespace\" \
+         f9e8b47e-7865-4318-9ef4-adadc8ad1627)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         11c7efc1-0f4e-490e-907d-0c02084abb4c)(content(Whitespace\" \
-         \"))))(Tile((id 27951534-74ae-4ea5-93b1-6afce85cfdf9)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         4282d2f2-3a83-405a-8d50-1517f6845189)(content(Whitespace\" \
+         1900d9f4-0220-48f7-88b2-9d062a2659ee)(content(Whitespace\"\\n\"))))(Tile((id \
+         aac32581-51a3-4aed-a127-1ba8666766f5)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         54d196a3-fb96-4fc2-a7e7-d3a64e660289)(content(Whitespace\" \
          \"))))(Tile((id \
-         7ff6f42f-fe19-41ac-83ea-d1eaaaf2c0e5)(label(C))(mold((out \
+         9db024cc-fc11-4582-9dc4-ac6fb16874ac)(label(C))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         db091aca-eb8f-4303-a5ef-28bb4f6e98e4)(content(Whitespace\" \
+         0ffa01a7-1c66-4bde-937c-e3f243f319da)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         611a3d98-0985-4be0-80e1-cde46f8d89dc)(content(Whitespace\" \
-         \"))))(Tile((id 0e122ba6-f0ba-486d-b843-951e92ee6e23)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         1d95f116-f06d-4ac7-a3f6-865a2e8c56ce)(content(Whitespace\" \
+         b4f9c964-2cb7-47c0-a951-2f1b8d9daceb)(content(Whitespace\"\\n\"))))(Tile((id \
+         d61aacca-0249-4d9c-98ad-cab9e8f5caad)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         f9ba969a-768e-44aa-8fdd-0e97669d86ce)(content(Whitespace\" \
          \"))))(Tile((id \
-         1f6321ba-05e0-4d86-afac-747960b0982e)(label(\"(\"\")\"))(mold((out \
+         8f8f9b32-f229-453b-bafe-149d000f26d3)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         3ee234bf-c5a6-46c7-85ff-fc1119ce445f)(label(t))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         9b15a9ac-049f-45b4-83b1-61b5d9102bd8)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         407ad394-667d-4ef9-9292-1f1b265c977b)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         7bb7cf7c-6a62-4b86-a9d6-a7e0dbeba801)(label(R))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         c601e11d-9708-4646-9f75-4f030326e8b9)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         6f07570c-6d9b-494e-b5a9-273f6fe639a7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         070f26f4-ab44-4501-b0d9-ccbe4e1ebcc9)(label(project))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         00859adf-5382-48a4-80e0-4d4f2cf89f31)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         53ae61a4-5267-4996-9710-fd0d15b66bc1)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         27f19b05-75c0-445c-90fa-8d43bbec1bbc)(label(R))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Secondary((id \
-         3e5f273d-9f2f-4b64-93b2-50bf4a77de58)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fadb5ee2-24c7-46ef-bddf-e25133528ec8)(label(->))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
-         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f16c4132-8def-4d1e-9a67-bd6c53d16f72)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b1b7069e-614e-4acd-b2bb-22c5922b0b18)(label(+))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         3ee4e0d7-3502-4106-9276-bae142a39d2c)(label(None))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Secondary((id \
-         385e48db-f004-49e3-ad62-4be7f9f55781)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fd01cb1a-8f0c-4d55-9d26-7197cc19936c)(label(+))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
-         12))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         9056b3a4-52f6-47e3-a6b7-a8085641e149)(label(Some))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         ad88668f-4b56-4f6f-8d5f-98b41e478959)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape(Concave 11))(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         e0a1dfac-d293-4d27-921b-a6213fe43e9c)(label(C))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         4ffe339a-c80a-42be-b0ff-94cd3197ad6a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b8462c5c-6c0c-45b1-b955-6b916f5dae9c)(content(Whitespace\"\\n\"))))(Tile((id \
-         5eb7b923-5666-4bc1-bffd-28603a43ce67)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         48375d36-bea6-4926-baa0-4278ab30d3e7)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         5a5da31f-e013-4726-bfbb-1fd676af3611)(label(t))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f02b3b56-15a8-4782-93a6-0d1c3f6d6307)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8610e32d-1d5b-402c-ace1-5e638ea15b70)(content(Whitespace\" \
-         \"))))(Tile((id a78486e4-bd0c-4e63-8922-8a086a0e58ae)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ef150c00-ce81-446d-8631-54cce3f4a416)(content(Whitespace\" \
-         \"))))(Tile((id \
-         28787023-81ed-4e51-b518-16eca97bc0c8)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         10c7da5d-f4f6-4245-aa3b-0aed4dd50ac4)(label(r))(mold((out \
+         4acf126b-eb06-417d-b56b-8476297de708)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b7c08ad1-e380-419b-b375-bf9008671439)(content(Whitespace\" \
+         756093a1-9930-418f-b542-f3ead62754f8)(content(Whitespace\" \
          \"))))(Tile((id \
-         f7999345-1f41-4761-9c65-040b3d3087cf)(label(:))(mold((out \
+         e0632822-3241-4548-81c2-739099af6c07)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         44d504c8-28b4-4484-86f4-16024d67a810)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cc5f5f86-9310-4c77-9028-cd8ed57a3d95)(label(R))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d4b71c39-a3b8-49e0-9d0f-e628f0b7942e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         33d9a4fa-4a98-44ba-bae7-60db9dcaee5b)(content(Whitespace\" \
-         \"))))(Tile((id ce594c2d-9f99-417e-93a3-a039781c6701)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         99c92848-a73e-4bb2-82b8-de22a07208e6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fd1826e8-7301-44df-b2e5-66626938643b)(label(project))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         14239820-e03d-443e-bc49-aee8330ff899)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         68ca758f-f510-48cb-b16c-b435fd18648e)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1058f82f-86f7-49a1-9723-c48ec37596b2)(content(Whitespace\"\\n\"))))(Tile((id \
-         d8e2d6a0-0f3c-43bd-980a-127363c627ad)(label(| =>))(mold((out \
-         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
-         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         6535b422-2f1a-47dc-9798-497159da9421)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8bce8654-b4f2-40d2-a0a2-3a693e036b95)(label(Some))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         84564871-f4f7-4ac0-9cf7-b10516e35983)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
-         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
-         1be67fa5-e1ce-4adf-b4cb-dd9a7afb8015)(label(_))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         b884b78e-c353-4c69-aefd-1f10311acf49)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         44b83787-2ee5-4a30-84ba-957821609434)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e8e9dbed-6eb1-422a-981d-f220167bf455)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         c25a6a37-ff68-4737-bee0-228f7498bcff)(content(Whitespace\"\\n\"))))(Tile((id \
-         e1987ab7-59c9-43bf-a575-feb3917d74f1)(label(| =>))(mold((out \
-         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
-         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f663df96-98e7-4a2c-bf9f-fb3dde995c34)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5185c01e-d8e3-421a-8c6e-05d1141f977d)(label(None))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         7d5ac5b7-16f1-4d07-8f87-c41b45c019e4)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9d80d6cd-bb7d-47d6-98bc-7cffb1f4c787)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f218b9ed-8c4f-4c70-b62c-79ea50c07ad6)(label(false))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         946f3f37-d830-4156-8ca9-c85acf36c689)(content(Whitespace\"\\n\"))))))))))))))(Tile((id \
-         f7a6b9bf-681c-4d3f-a441-6b2c6ed65822)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         52229fdc-3fbb-4735-a3b6-d83644e3a1ca)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         35ba2ccd-c2f0-4f84-8c93-6e8f64d78987)(label(Bool))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         4853e341-d43d-4488-b12f-e0be64a90848)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         5ccf0c45-867a-4080-a402-621404d03659)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2478ca8f-d122-483f-a067-402b0bd20589)(content(Whitespace\"\\n\"))))(Tile((id \
-         a2072668-ec7b-4b46-ae0d-54cc9a075538)(label(test end))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         24010ed0-a6b3-4a43-be09-b76110896475)(content(Whitespace\" \
-         \"))))(Tile((id \
-         998c245e-905f-4c8a-949b-92193f34ab27)(label(complete_cases))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         97f914e9-4b13-4e66-b67c-45ca6e578ca5)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c5d43ffe-76b3-411e-ad2f-9cc32f363ae0)(label(StudentMissing))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         d3f94626-5087-4bbe-83fd-5aae84e0c0f3)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e62eb164-d1c0-485c-8f7b-848d74e8ab85)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         b84dd5ae-c1b4-4c25-a77d-93f0af86b9ec)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9a7b39a9-90c9-4ee5-a80c-7b735ba6b353)(label(studentsMissing))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         91e00863-5574-464c-bb2a-c960bf818632)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         21c4cd2b-9c0d-4231-a2f5-3be4ae2cbc60)(content(Whitespace\" \
-         \"))))(Tile((id 68c47153-eb4a-460e-bb70-b9587c9f41ee)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         eb8ff523-3cfb-430c-9bc2-e251ef7a6341)(content(Whitespace\" \
-         \"))))(Tile((id \
-         529a12d0-551a-4556-99ca-9c609662ad22)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         b47da390-5ea8-4c87-bb07-4f25151acb83)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         43245a1a-980b-4894-9f00-527f69ae2ca3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6fb92802-8e3c-4e14-b76f-ecf4f67985e5)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         172ba567-7f91-4621-a559-4ee7e78c246f)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         5d492d2a-1e34-4c5a-84cc-8f33aa67c0b5)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d3017f04-7eea-4bdc-b66c-4dcacd537a67)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4fa5d15a-05b1-4cf0-9bfb-624a5a0826a7)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8d86e046-0ec9-4a59-958d-4ea72d0c47d9)(content(Whitespace\" \
-         \"))))(Tile((id 80152585-d4ba-4d72-99e8-6d8ad2c5d749)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f62746eb-09e7-4030-8516-26d553cf43bd)(label(false))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         68cc687a-1e8d-4144-9cce-eb5a5d3666a5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a9c45dca-0f99-40b7-ba55-3800494529dd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ebf965d2-2e45-4208-a6c6-8fed22f56178)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f3a4d44b-7d44-4d15-8146-fa7f67b201e0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         81e96a75-4ef3-4b1a-884b-0092038518a6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9f06aff7-0d70-4fe7-a1ca-79ee7cc7af9f)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         86236802-759e-45d3-90fa-ffe97fb0821c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4384f8a2-28b1-48ad-b414-473bb571470e)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6e0d3706-3d3c-4fd3-a595-35adf233da4c)(content(Whitespace\" \
-         \"))))(Tile((id e5cd450e-858e-4c34-9f68-8bd0bc470d92)(label([ \
+         eafcd7c0-7808-4c46-b5b5-298a3fe6e9de)(content(Whitespace\" \
+         \"))))(Tile((id f9fe3338-ced5-41b2-8f9a-54da770dd7a7)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         09304a7b-fc12-462c-9314-d8e6dd6c7580)(label(Bool))(mold((out \
+         8c49d3b5-4b6e-45a7-864c-7f1a6b9df17c)(label(R))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8155719a-b43b-4589-bbe3-2b09dfdc722b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         01b079cb-04e0-4ed0-8946-b8fa562219a1)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         f489a812-d40f-4bb6-9785-051314b2ce39)(content(Whitespace\"\\n\"))))(Tile((id \
-         44f3b05f-2847-4ad2-8272-26322ee023a0)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         9cb9f78b-0eab-4f2c-99b9-6d2a71598859)(content(Whitespace\" \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         65f29451-2656-41e0-a543-d5e7b682bf7d)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         88109eb0-217e-4037-94d0-6d23c8531e65)(content(Whitespace\" \
          \"))))(Tile((id \
-         80ec614c-7e60-4487-9807-6ef4d2a63074)(label(dropna))(mold((out \
+         c03d1e3f-35fb-4355-8517-08ed551e0c39)(label(project))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9902fbd7-a503-49b9-8894-750dafd9b7f7)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         602eec47-919d-4355-a873-93b087d66b92)(content(Whitespace\"\\n\"))))(Secondary((id \
-         16a78e7a-dd66-4579-a732-5983cc62099e)(content(Comment\"# This only \
-         works if every column in the dataset was optional otherwise it will \
-         get stuck in indet #\"))))(Secondary((id \
-         b28aa183-0987-4b0f-8292-1d3b757fa12d)(content(Whitespace\"\\n\"))))(Tile((id \
-         c80dd9ed-b727-490b-85e3-3b440c81dfdc)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3be92f16-1719-4377-b23d-95c97bea2224)(content(Whitespace\" \
+         fc73e884-74b8-4de7-9304-b7fbe04c748e)(content(Whitespace\" \
          \"))))(Tile((id \
-         147718e8-062c-4f52-b852-d6649ae51190)(label(requires))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         8b8293ca-5a7e-4e46-a2e3-111dd49c5ea1)(label([]))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         6a5cf6dd-477a-4e50-8a92-7e166e3ecd31)(content(Whitespace\" \
+         5f3d3c40-976a-4486-a5f5-2318ff457016)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         508db269-259c-469b-90f0-36372f83007c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         72277443-8efc-4168-be21-c69fd031a36b)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         6ee0c52e-9944-4e41-84ac-3efc0e23c0fb)(label(R))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         26fe0f0b-080a-4f4c-9b2a-eff8a3a6c56a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         186026fe-bf0f-484d-85a9-14e28df4be60)(label(->))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
+         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9580aa33-25d3-4650-bdb0-581ea921ec33)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4f7d7439-669f-4821-a6d1-cab5db7b66c8)(label(+))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9e51018b-6fe5-4a98-99d5-963bca55729e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f42729ef-a2a6-44e7-8d45-d0ba75482863)(label(None))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         802ba33e-514d-482c-b439-bae353a08a9c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b7e46239-8f6f-42bb-b4df-1d12e8465ca8)(label(+))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
+         12))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         26d4b36d-81c6-4ff7-90d1-256885dc65e4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         25d8e77b-3779-4418-a651-d0cf4c35e69b)(label(Some))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         0369e70c-2472-4e6c-99b4-aa483ae9d5a9)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape(Concave 11))(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         7772698d-6201-4c1f-8cf5-39ad7208f09d)(label(C))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         857a04c3-be9d-4ced-bfb1-e2411db56c91)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e0260a25-ae03-4f93-b715-fdd64c0cddfa)(content(Whitespace\"\\n\"))))(Tile((id \
-         28c6878f-85d3-400b-badb-9f59de6db8a3)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         5c4f978d-8f13-4e17-8518-7c64f5c0c892)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9f4b3843-b6db-452c-a4d1-75598371879d)(label(ensures))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         0c64956c-77ab-44c9-8482-f3a621f97394)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         f998b60b-9f3a-4d22-8a8d-763bd6e09729)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         b971b884-6248-4efb-9a77-202a0d30b75d)(label(enforced))(mold((out \
+         14edfd5f-d39d-4557-8fbe-97e5088038f1)(content(Whitespace\"\\n\"))))(Tile((id \
+         ed458fec-cb86-4440-bcae-05eb21e65557)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7f226e04-bd90-422d-99ba-222f695ed399)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         b3ebcb0d-37d0-42e0-a99e-91b5508ea91e)(kind Checkbox)(syntax(Tile((id \
-         714693ee-6e5c-4083-a01e-06678ff3043c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         4e7b4df8-4ac7-4c08-bb9a-39f488a5cc45)(label(true))(mold((out \
+         0bff1811-8605-4d23-a1e3-f7282ab1944c)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         68d1a02b-cc58-405f-8194-81ddced1091c)(content(Whitespace\"\\n\"))))(Tile((id \
+         3e943b69-e498-4fdf-a5b8-e1dc236f755d)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         faca364e-d1f6-4fec-9d9e-ed6b99c993d5)(label(,))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ccdeaa30-9463-4852-b085-45f882d022cb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7756a5a1-6c5f-4662-a87a-769fce1bd360)(content(Whitespace\" \
+         501f7ffe-a9d0-44ec-b29f-0b53616b1104)(content(Whitespace\"\\n\"))))(Tile((id \
+         3e2241f0-5ca4-4af0-be2b-ccceffcf229c)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e6bd96f6-93e0-417c-a495-147537bcb942)(content(Whitespace\" \
          \"))))(Tile((id \
-         ec31a8f4-736d-42f9-bbf8-ebe472193e73)(label(\"\\\"schema(t2) is equal \
+         3e31a45f-48d3-4557-8825-dd8cc2a251f1)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         2971fa07-31c1-4eb1-9976-4c1b86b92ad8)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         9055fd5c-06f6-4d5f-a97e-74e7a2dbb798)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e1d6142b-cbc0-44dc-a931-ddbf537773b1)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         557a862b-01b2-453d-86ab-5e1e25d2992f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b02a1e97-1c84-4137-985b-8f6b0af40ea1)(label(R))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         cec8603b-8727-4111-8b9e-34de380cf03c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         4356abab-a805-43f3-839d-7468aa619fbb)(content(Whitespace\"\\n\"))))(Tile((id \
+         c138242b-618d-43d5-b248-b52d47f95a80)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         d7ebca82-ec7c-4d80-b8e7-14eac1c6b654)(content(Whitespace\" \
+         \"))))(Tile((id \
+         30752d85-b7ac-42b4-930c-848f1c7e920c)(label(project))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         213daa34-55b5-4f1d-90db-74386ddbe91f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         35c7ccf5-45c5-4f42-bee8-11cdae1ea8f1)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         e839b9a4-39f9-453b-9dde-b4a5a11f66a7)(content(Whitespace\"\\n\"))))(Tile((id \
+         ed0e2ecd-0699-4fb5-94e3-907cdada4912)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         56edd50b-3500-4227-ba05-086f208564b4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         41277ed7-8235-44b6-ba37-45dcd74c4670)(label(Some))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         fdc6c336-d786-4c37-a6f0-3eaec0e20385)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
+         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
+         4bb7ff53-5616-46c0-8786-2f58f083e40b)(label(_))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         d95b8586-2e01-4f82-9192-9134d8dec172)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         571b5338-2011-452d-a482-24bc8a54597e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         60b993ba-3e01-42be-ae46-2a10079be8cb)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1ec85c30-fe11-40fa-88f4-a7b0be11ba51)(content(Whitespace\"\\n\"))))(Tile((id \
+         c0b37b49-17eb-42ba-9764-2b64236ee573)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         06ff1b25-80b6-41a8-ab89-ad681dea9f6e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         97cdddf1-705d-483a-b6cd-d051aab5cfa7)(label(None))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         072ae3f6-86d1-4c1d-87d1-c60fabbf00ab)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3954c7e1-560a-41f8-8cd9-3f03fc9f3a2c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         12b5614b-89f6-4f13-918c-7fe1442c4d87)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         62a9d628-e682-411c-b766-21be50ff5e86)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         fe2a619e-26b0-4900-83db-343ab15dad57)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         0c4cbfb6-651f-492b-8e07-dadd40885ef2)(content(Whitespace\"\\n\"))))(Tile((id \
+         f334f802-81d2-4994-8e60-6d349e901938)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6c4208e8-016f-441a-a583-699ec31f4a86)(content(Whitespace\" \
+         \"))))(Tile((id db0ac0d1-12cb-40ff-a1de-9041407a6820)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         10f0e954-e6cb-43a8-b88e-72cbf022e6a6)(label(Bool))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         29aed7a5-0152-4d46-8142-56f0fc768f8c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         84eed091-7902-4067-938b-866cd860e4a1)(content(Whitespace\"\\n\"))))(Tile((id \
+         f6c3dc2f-b430-4d62-b3f5-b448e390efd8)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         ad753624-9830-4e54-9089-e3045aa105d8)(content(Whitespace\"\\n\"))))(Tile((id \
+         21d2d685-bdbc-4005-bd06-6971eefd2c43)(label(complete_cases))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ccd5af44-8615-4c55-a8f4-b0143d2f2c1a)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         54798a39-e12b-4dae-8dc2-09fd34b9b413)(label(StudentMissing))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         0ec8e3f7-6fb5-4b32-b12e-458aeaff9d1c)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         288896be-d16c-42f9-bd04-6c5e42f44c32)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         388ecfc9-fe84-406a-8986-27fab79f281e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         9ea5256e-cefc-40ba-95b9-7bcca91fba7f)(label(studentsMissing))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5abcb47a-5d8e-420c-89be-654a043531ce)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f6d5ba58-5ccb-4795-b50b-1fb969e450e1)(content(Whitespace\" \
+         \"))))(Tile((id 8461badb-e501-48a2-862a-7725eb7da852)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         69529e0f-ee17-4235-bddf-e973082719ba)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c45fb571-e796-4694-89eb-3ce3a36f20e1)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         114763c6-f885-4cf9-bc88-bf3528d4aadb)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d1147a4a-6c91-479f-83f4-7ffba49232a9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         38ad36c8-f913-45fa-ad15-03124420f625)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0fe1b34c-0b1a-494b-a9a0-cc4628b4ad53)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         f550ace2-79da-44d0-8f9e-cc2ad9aba125)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         4f846ced-0dc9-453f-889c-7fcc99c99f0a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b425c12c-870c-4892-8787-0735a1331d19)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         353803ae-6439-45c3-b1c6-518b8438dd7e)(content(Whitespace\" \
+         \"))))(Tile((id 069c6aa6-9bef-4b78-b192-84f60617683e)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         d45a049b-219c-49d9-a9c0-4a533fe16b16)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         168800f2-67e2-43ff-b98f-428038898e2f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1ab8692b-14b6-4b31-8c05-2cfc30aba4d8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ea51d189-b82b-4c80-a999-8c5ed43f337c)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         65d665b0-aa4b-49d9-8512-0fb3d1ec145a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8add7e58-755e-4140-9a47-c8f93db1aefb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7344f50b-9cd9-4ba9-bb69-af1ef16f1180)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         79ab02e7-8289-48aa-be34-b3c34832c4fc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5ada3bb9-04b8-4e2e-be1b-e914a6afb337)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6550c2fa-7989-4e5f-9d19-208b7fd6acc3)(content(Whitespace\" \
+         \"))))(Tile((id 348430c2-2480-48a0-bb49-f343ce745ed8)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         646799a6-9b40-49b7-ac87-eba3a6674790)(label(Bool))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         f67f2283-e44d-49d3-b6f2-18c0fdbb11d1)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         97aa9526-4b27-48df-a04f-de442b56e8b1)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3e284066-998f-4e1c-96f7-4fd987a1827f)(content(Whitespace\"\\n\"))))(Tile((id \
+         300f7f5a-d15a-4066-b876-c3af9fc2be44)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f257813c-9cc1-4d71-8062-7998f7aaacdc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7b550140-cca2-41b4-8e63-1d8f5d18db09)(label(dropna))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cd6ea957-80db-49a2-91b6-dc501275c18f)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         32bc8088-2cf7-49e7-83b7-fb88f45b1b8e)(content(Whitespace\"\\n\"))))(Secondary((id \
+         f8eba9ff-8d6d-4c42-b429-5189c4167a9c)(content(Comment\"# This only \
+         works if every column in the dataset was optional otherwise it will \
+         get stuck in indet #\"))))(Secondary((id \
+         6a3672b7-bf4d-4a10-b8bd-164c5d38b5f0)(content(Whitespace\"\\n\"))))(Tile((id \
+         188a2a7b-6a27-4191-82be-568fc9670ef9)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         2061d1d9-b05a-4a0a-b7bb-9ba2563491ad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e0b20a6a-d58b-4a00-9bfe-158e3527b346)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         66faf3c0-9303-4283-b2dc-8d82e769de75)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         a564a0d1-d81c-4162-ac33-a9025033dc93)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b244d8ec-46e4-424c-9b57-08115846efd3)(label([]))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ef6df9a0-cfc5-4296-b54e-604aa819a38b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         0d2c7103-8c93-45f6-b4ad-ec924b11c8f4)(content(Whitespace\"\\n\"))))(Tile((id \
+         9fd28b04-e26f-49c2-9f64-d28f74c3ecdd)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         63c04556-7e98-4037-881f-ee101839f7dd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4d9e7d81-ebff-4d95-8132-0fbb04c806aa)(label(_ensures))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         42676533-0499-48ce-93a5-fbbee739d7d0)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         3b96589a-7961-4896-a300-4ce8766e4de8)(content(Whitespace\" \
+         \"))))(Tile((id fdefd540-292a-40cf-8c76-3dc3e0e9105d)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         bc021604-7603-461d-ba74-3446dffa7f73)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         fcbcb09d-8670-4645-bc9c-33388ffc5111)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         dd15b09d-ec62-446f-9d16-a00920adcf20)(content(Whitespace\" \
+         \"))))(Tile((id \
+         54180acc-3752-4052-ac57-d0b1cbc03dbd)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         45656ccb-8b47-4adf-ac23-0a0c1a6e0565)(content(Whitespace\" \
+         \"))))(Projector((id b290470b-a448-44e7-8402-880c1322c79b)(kind \
+         Checkbox)(syntax(Tile((id \
+         6b7c2373-1153-4b8a-a8ab-928cf414c727)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a0da238e-c7dc-4f80-a8cf-25a3d4b8cf10)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
+         10b55732-0aa6-486f-baaa-92440375ed31)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ec56497c-8ff5-40bb-bfa3-aabeeba6bbee)(content(Whitespace\" \
+         \"))))(Tile((id \
+         46be3794-3e28-41f7-97b5-ff16e507eff8)(label(\"\\\"schema(t2) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         260b0219-af41-4b39-b2a3-dcf57da87740)(content(Whitespace\" \
+         4b717dc9-1e3b-4c31-8fa4-698bce479d63)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         96731ac5-9139-41d8-a512-4dc65518b676)(content(Whitespace\"\\n\"))))(Tile((id \
-         590b0cf6-9bec-47c5-82f0-35f750cd374b)(label(let = in))(mold((out \
+         191a9e16-2791-4edf-9bac-067bdd8b30f2)(content(Whitespace\"\\n\"))))(Tile((id \
+         eb937b13-2423-4ad9-95db-4de25078a87d)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1d4eadb6-61d3-459d-8493-254a9a5df772)(content(Whitespace\" \
+         3c3bd919-594e-45b2-9e56-64c5e06e2bef)(content(Whitespace\" \
          \"))))(Tile((id \
-         d8de9f5e-1495-4d1c-8ea0-5b18d5b34fe2)(label(dropna))(mold((out \
+         6ee84fae-ad22-4a64-a3c2-07a82cd79ec7)(label(dropna))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a2808eb8-d671-45d0-8c10-4aa059af2dcc)(content(Whitespace\" \
+         65630c51-6ebf-47ed-b2e7-839646e655a0)(content(Whitespace\" \
          \")))))((Secondary((id \
-         82145a25-0847-47ff-ac94-ece608af82b0)(content(Whitespace\" \
-         \"))))(Tile((id 3415a817-d614-4807-bcd3-f1f90c7fb2ac)(label(typfun \
+         f95871a2-3e14-4919-9426-17a8f27af330)(content(Whitespace\" \
+         \"))))(Tile((id b4749bb6-5065-40e5-a843-8d5165515962)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         34b3ae51-430f-403d-bbfc-0ed714d75798)(content(Whitespace\" \
+         6dc13da9-d200-41f0-81f8-a072752752a1)(content(Whitespace\" \
          \"))))(Tile((id \
-         75970f37-a8f4-4d72-8e79-b7bef3fdf1aa)(label(R))(mold((out \
+         d079b521-7cca-4cd0-a042-7a1bd51b755a)(label(R))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         c61b83eb-3df4-4a37-a828-1f5764d847b1)(content(Whitespace\" \
+         8a924e9e-a58f-4ea6-b5a3-a4472bf5f945)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1884b299-0c0e-4e39-9b7c-0f3ebbb0f899)(content(Whitespace\" \
-         \"))))(Tile((id eadc7f5f-5bef-43af-b0d4-3afe2473886b)(label(fun \
+         71a8ef62-e3ac-41fe-8fb6-4c986191b902)(content(Whitespace\" \
+         \"))))(Tile((id 7ee2cd07-527b-4886-b384-4fe9713133f1)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         0a19100a-4f58-4bc5-a598-6940375b922a)(content(Whitespace\" \
+         2622584f-17b7-4651-8e95-fc3ffdbc237a)(content(Whitespace\" \
          \"))))(Tile((id \
-         efca1cac-7fe3-4dfc-8d9f-dc45e5cbede8)(label(\"(\"\")\"))(mold((out \
+         087da82e-e12e-4ab9-a58e-a030523a907b)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         127c1e01-294c-42dc-b2b7-3d38187f9c66)(label(t1))(mold((out \
+         a1285ff0-ab0e-49b7-95f4-40a7409c591e)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f4e4313d-eb3a-47d6-83f8-1201b0f65079)(content(Whitespace\" \
+         fc6a3b90-d27a-4637-98ef-adc25d183b3b)(content(Whitespace\" \
          \"))))(Tile((id \
-         f617bee9-6b5d-43d3-b205-62ee65b76c89)(label(:))(mold((out \
+         73422c9f-7ba2-46b0-90e5-962cd774bae1)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0cf973b8-4de0-4b78-8710-fbb64909fbd4)(content(Whitespace\" \
-         \"))))(Tile((id ab7ce20b-3c84-4146-a8bf-0c64c59f7f7f)(label([ \
+         d3e5e258-2181-4b54-8b5b-870498596b8f)(content(Whitespace\" \
+         \"))))(Tile((id 69e4c3df-4325-45e1-b0c2-5019828e0959)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         7ebba160-4aa5-4769-b7ff-2ee1b203b129)(label(R))(mold((out \
+         73b95492-d35d-4a78-9833-fef41fd01ddd)(label(R))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         daba98a3-b3b8-43bf-88c8-39c0a8208552)(content(Whitespace\" \
+         11d8c8d8-0b7d-4cc2-ac5a-502cf83161fe)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4d6356c0-d73b-4352-80b6-2225456949bb)(content(Whitespace\" \
+         12f4939f-2e3f-47e6-812c-500efb780fa2)(content(Whitespace\" \
          \"))))(Tile((id \
-         30b71e1d-bb62-49a0-a5b4-8469f8541a5e)(label(filter))(mold((out \
+         65021d00-ad10-4413-a6f0-57d99aa6afbd)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         1a39c95d-9553-4d7f-84ff-56aee841e907)(label(\"(\"\")\"))(mold((out \
+         1baf6329-c81b-4873-a862-5a14f7ae6051)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         99303c03-c59b-495d-9952-c3d2ecf86c1a)(label(t1))(mold((out \
+         44056dbc-81fc-4841-8536-397b8a37f11a)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ccd298ed-5f57-4567-962e-10cc099beaee)(label(,))(mold((out \
+         568f3630-c4e1-49aa-ad34-543301b6e393)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         41f175da-62a0-42f6-9fa4-732cf0022530)(content(Whitespace\" \
-         \"))))(Tile((id 70c1d8b5-c17e-43f7-9e18-e8ae028c4ea1)(label(fun \
+         6ff058f6-4371-447f-aa1f-94dbf613f0ce)(content(Whitespace\" \
+         \"))))(Tile((id 26313ad2-de64-41d2-abf5-9ad39553b6fd)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         cccbc664-6ac0-42da-8c01-530a07e8ef08)(content(Whitespace\" \
+         40167dfa-5045-4143-a0dc-b3fe6cd4a015)(content(Whitespace\" \
          \"))))(Tile((id \
-         8dea196d-c586-4a19-8f6c-089b6373f0ac)(label(row))(mold((out \
+         f8b31249-163f-44c6-98c7-df93d7710581)(label(row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         158f6118-832c-4801-a2aa-68670fe9f541)(content(Whitespace\" \
+         d003ad64-b835-40c5-bd65-dd716f3733ec)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         bf615469-f7f0-4040-afb6-43d316ae9dd4)(content(Whitespace\" \
+         7e97b24b-0e18-4b41-99b5-6c7a9e235676)(content(Whitespace\" \
          \"))))(Tile((id \
-         cdb85f94-d40d-493c-8102-9b174469404e)(label(!))(mold((out \
+         4bf43600-f67f-4deb-a046-98e5a02767c2)(label(!))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a9b409ad-114c-4661-b938-470d35aa462a)(label(any))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         54148fd6-8353-4ef9-a450-0f11071abb5a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0c0d2284-1904-4f8f-9d7f-ef3d68a0141a)(label(any))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c353b09a-9c42-4f8a-b2ec-47e2a8e92059)(label(\"(\"\")\"))(mold((out \
+         35fb69e7-5bc5-4fe1-a740-efebfbf1dd5b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2a79125b-c7e2-4bf7-ae11-aadad0871d62)(label(to_lvs))(mold((out \
+         7aa1e3ab-d098-445a-9e27-08063a1f8c3c)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7add85fe-90a8-4422-8c11-a37d1887628d)(label(\"(\"\")\"))(mold((out \
+         4dd58c5c-8aa7-42ac-9bfb-0f0a24bb126c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6ec26fe0-d921-4a95-83a3-4f16b92e93a6)(label(row))(mold((out \
+         c6726193-6318-4852-9789-018e75884839)(label(row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         788edde7-112c-4965-9c2b-f49b7493487a)(label(,))(mold((out \
+         bc2c120b-792f-4ece-b706-819292b33c4b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         01576d71-a8ba-4c36-8976-2dd3c0de463c)(content(Whitespace\" \
-         \"))))(Tile((id 449fe607-7187-47ee-ad3c-ed1bd55935d3)(label(fun \
+         881a3665-dae1-45a6-b89f-2845c7670c05)(content(Whitespace\" \
+         \"))))(Tile((id 3fee1c4d-c891-4de7-8b7a-47df190d1260)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         60e3c08a-3d50-4f8a-adff-581c5a26bb9e)(content(Whitespace\" \
+         07924ef1-0b48-4c75-9790-8e2f6a6846c3)(content(Whitespace\" \
          \"))))(Tile((id \
-         80e5aecb-6e3d-4b3f-880c-7283079a130c)(label(e))(mold((out \
+         7f70a770-724e-4ae0-912e-fbfdc1aca0b3)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         4837e464-a55c-45f7-a826-d1f47faa0dfe)(content(Whitespace\" \
+         c608b761-54ef-4329-80f6-642c7f8b3f83)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7c1497e1-e919-4d9b-a6a6-ebbbbd960295)(content(Whitespace\" \
+         a8889dc4-b098-4789-87a3-4c35a83bc15c)(content(Whitespace\" \
          \"))))(Tile((id \
-         c759d570-904c-49c0-88ed-ad18e213f860)(label(e))(mold((out \
+         a18afef3-0258-4369-b863-32cc1cf00b23)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         028d4830-2014-4d40-8c8c-5cc1324e0e15)(label(.))(mold((out \
+         4ef2f0e5-14ab-4f69-b51d-36741f6eb708)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         dfcec685-f43f-46e8-8ffc-c2a3ba10d177)(label(value))(mold((out \
+         daebff96-f2c5-4eab-a4e6-fc45eb82db67)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         9d998960-c589-4d98-aa80-f24feec2a720)(content(Whitespace\" \
+         a979c813-2b08-4894-a9f0-2ff7836fb40d)(content(Whitespace\" \
          \"))))(Tile((id \
-         a23b48fb-ef81-4a51-af1a-cf759359972c)(label(==))(mold((out \
+         ecc408a3-7c44-46f2-8b12-3c49f6fde1fe)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         da96399c-8f86-41c5-be8b-f8aa3294d400)(content(Whitespace\" \
+         20c36be6-a9f1-405d-b3ab-175f9447f98f)(content(Whitespace\" \
          \"))))(Tile((id \
-         1c17081f-5477-49ae-a31b-cc216f883e99)(label(\"(\"\")\"))(mold((out \
+         c402f0fa-cca9-483b-883a-f385d508bfdb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         3232226d-4c25-4a0b-8716-83f3d8aa68d3)(label(None))(mold((out \
+         78c1edeb-1902-410a-9e25-354c829d3d52)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d13226d8-7387-4246-ab88-8c149601f17d)(content(Whitespace\" \
+         64ed9ddf-9a16-4137-b7b6-8649ba2c2e2e)(content(Whitespace\" \
          \"))))(Tile((id \
-         20b19d2b-515e-4e01-ac31-8d5210e3a12f)(label(:))(mold((out \
+         81a7ab8f-8e08-4e4e-8eda-15b9eda05699)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ab64d734-7269-448e-a12b-e73318ed1f4e)(content(Whitespace\" \
+         d7be92c3-2d70-48ca-a9e8-2cf5b5d4bde8)(content(Whitespace\" \
          \"))))(Tile((id \
-         54ef044e-81d7-49cc-aafb-4de3efb82e99)(label(Option))(mold((out \
+         65328761-46d9-43c7-b9f2-8cafa28b1f65)(label(Option))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         a7fff8e7-7e0a-4e16-a144-1b800f3b349b)(content(Whitespace\" \
+         c73c3a06-da32-40a0-90e4-099830679917)(content(Whitespace\" \
          \"))))(Tile((id \
-         be40cf71-7d56-4589-bc8a-38dd4f92d78a)(label(:))(mold((out \
+         da66e14d-6322-477c-bfae-fd0ac160c04e)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9d6d0f25-5f57-437b-9177-416daf68dc6f)(content(Whitespace\" \
-         \"))))(Tile((id bf1ed63b-2f80-4c76-9aa0-ac5ff37ce703)(label([ \
+         27257213-7e8e-45dc-8fce-0ed1368c6203)(content(Whitespace\" \
+         \"))))(Tile((id 8e8b559b-929f-4bd0-a029-a1b0eff2b136)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         6093f09c-a99d-4c32-ab83-df33ef309bf2)(label(R))(mold((out \
+         5a75dc08-dbaa-4aa8-a71f-6261bab9f1f3)(label(R))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f689cd4b-0de2-40be-9005-cb1cc6d5199e)(content(Whitespace\" \
+         43bc5836-9d37-450e-8bf4-73a2187d39e4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d8d970bb-3f29-411f-b05f-0346acb82a96)(content(Whitespace\"\\n\"))))(Tile((id \
-         2bab6ed2-91a8-4f45-912d-7717dd007681)(label(type = in))(mold((out \
+         b67727fd-e5ed-4a27-8bb1-3c07de7239f7)(content(Whitespace\"\\n\"))))(Tile((id \
+         c5d1b18d-46ba-4db6-835d-34432a9ffbc3)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3842fb3a-36c1-4988-9ed6-bd97c082bf71)(content(Whitespace\" \
+         93427507-6e3f-4bd1-b9d7-083b8844e8bf)(content(Whitespace\" \
          \"))))(Tile((id \
-         53f06980-fb4c-4e49-8943-29f8e759e30b)(label(StudentFullyOptional))(mold((out \
+         958d5eb0-5afb-47ef-8417-53220189d77f)(label(StudentFullyOptional))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         07fc5f6c-5070-49e5-81d6-3636553b4055)(content(Whitespace\" \
+         56709c02-bb09-4289-b5bc-82a57740d23a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         40d01b6b-caec-4bc8-a4f4-ece4adc71bd3)(content(Whitespace\" \
+         af5add92-82c4-426e-aa17-57c379841f14)(content(Whitespace\" \
          \"))))(Tile((id \
-         82210365-2b25-4d24-9bfd-8eb3e52d990c)(label(\"(\"\")\"))(mold((out \
+         5edee245-409f-4bc1-bb0c-2488e4411ad5)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         8c758ef0-0b49-43ca-97ae-903bfe4c45c6)(label(name))(mold((out \
+         43c72481-f4d8-4f64-8c10-f1def292931e)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         7bbfb6c6-d920-4058-9d85-146fd9bcd09e)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7aa2331e-0de9-437b-bb8b-2dc17911d157)(content(Whitespace\" \
+         \"))))(Tile((id \
+         84e6c770-dfe8-4985-af73-26f6de183ad1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         4f927f52-1c41-433a-860b-e44267c162e6)(label(OptString))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         acaaabbe-0ca2-4821-ba8c-c2b890d5227a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         35e599f7-4bea-4ab8-8908-5d869e0e8498)(label(OptString))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         5c6abda3-b578-4f87-b003-3954832f107e)(label(,))(mold((out \
+         41468bb0-84e3-4946-adcc-0ee77c46cc0d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e862a0b4-1ccd-4c2f-afe4-aed18a8b511d)(content(Whitespace\" \
+         47ee7628-c297-4d88-b1ba-737274c7a7eb)(content(Whitespace\" \
          \"))))(Tile((id \
-         4d0a0193-1bab-43a4-bea4-4e0ed9d66b4b)(label(age))(mold((out \
+         24988e2e-83e0-4e43-88ab-62dfac28ee78)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         8f446464-c433-4410-aebb-96c7820392d2)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e2316972-3a19-4dd8-8e8c-1b9ab8835756)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a1b56a2f-0d2a-45e4-889b-a239960ab61c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         e0638fa8-67f4-463c-b34d-dd2d3132693c)(label(OptInt))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9b94a564-0ca8-44f4-a27e-40ceadc80de8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         84358849-ea54-453c-8420-42a279fcd7f1)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         8e7a7832-e06b-43ca-985a-567ba8a04803)(label(,))(mold((out \
+         19676fdc-7bb6-4a3c-bd88-cadc146117cb)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dde75318-1338-4520-a718-e1de22af9bd4)(content(Whitespace\" \
+         c9ac4657-767b-4885-b09c-9de5950fb6ea)(content(Whitespace\" \
          \"))))(Tile((id \
-         2e6e411d-d1d5-44ef-85f6-ec7304d9436d)(label(favorite_color))(mold((out \
+         8359810f-b0e7-43a2-ac53-f6749a22b211)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         525470e5-f19f-4a83-9d30-4baaaf73cc94)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         437a3593-a2c1-4ecd-9cb1-fee1c8eacada)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b415b240-ebf1-4ca8-bf21-8523f530f9de)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         bbb4990a-32d7-4bf7-ad38-f01ce07f5e78)(label(OptString))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         95e391f2-5ddc-4cb0-bce8-9462ba89ad8d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         455fe077-7425-4f6c-9e11-ce0df9a42fab)(label(OptString))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         3d5bb75b-94d8-43c1-afa6-dcaf26400a59)(content(Whitespace\" \
+         1b236e47-d2dd-4a6a-8299-979c581e5efd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f141ee8f-dc55-4a4a-a1ae-cb237cc6ebfe)(content(Whitespace\"\\n\"))))(Tile((id \
-         f516a9b6-c6d3-4007-85be-79825d8f1cd7)(label(let = in))(mold((out \
+         6f49aed1-123a-4432-bc37-3a8ff041cf3b)(content(Whitespace\"\\n\"))))(Tile((id \
+         6729ed47-0773-444d-a265-59988faf726c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e9b99981-5b45-40b7-b111-df2a22ac4db0)(content(Whitespace\" \
+         0c313205-c5c7-4ccf-bc47-930ce13ddd96)(content(Whitespace\" \
          \"))))(Tile((id \
-         083f2414-f863-43cb-905b-8c7ce81ccce6)(label(students_fully_optional))(mold((out \
+         50f7c4fd-825e-45e7-8643-3cd4c5bf5425)(label(students_fully_optional))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f2573a23-72fc-4df8-93a1-580b48745b62)(content(Whitespace\" \
+         1f3d239b-3189-4997-b015-f3caf7489723)(content(Whitespace\" \
          \"))))(Tile((id \
-         be3ea430-acd9-43d5-887b-33dce50fb86e)(label(:))(mold((out \
+         eb4ac9ab-78ae-440f-88b8-725dd8e0697f)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dc3ca1ef-cbb1-45e4-bfa4-ea8c8e018813)(content(Whitespace\" \
-         \"))))(Tile((id 468feb56-f868-480a-be7b-aedd7aced23b)(label([ \
+         72a4535f-c003-4650-a633-b89ee96a6847)(content(Whitespace\" \
+         \"))))(Tile((id 5988fb6c-8b50-4b28-b7e6-6daeb09defbf)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         3edd18d1-d22a-4ee6-ae80-64d75dacdaed)(label(StudentFullyOptional))(mold((out \
+         bf41f2dc-6e65-49e9-9699-f23ffccb3450)(label(StudentFullyOptional))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         9b1f3e37-9ee2-4e61-bba6-1001148e0f5e)(content(Whitespace\" \
+         d6b9e455-484b-4670-80ef-3228013998eb)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e4c64045-fbb0-4f35-ad97-d1a1dd291dbd)(content(Whitespace\" \
-         \"))))(Projector((id b2374495-8ccf-4ad2-8281-2104b865558b)(kind \
+         5c53cc8e-d5e6-41ed-9975-593dbb05ffc1)(content(Whitespace\" \
+         \"))))(Projector((id c566bf79-71a6-4d98-a961-3df0aa2451e8)(kind \
          Fold)(syntax(Tile((id \
-         b00ef1b3-e41f-4cf6-80c2-36372838e8df)(label(\"(\"\")\"))(mold((out \
+         9a35ad54-9fa8-4f51-b598-f0b1711616d0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         13089552-e005-4a9b-8103-4f8d2cbae714)(label([ ]))(mold((out \
+         11a3d69b-2dba-4043-9268-fbe67535f6c4)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         156e8936-8ad4-404c-ac9c-e545a8a29632)(content(Whitespace\"\\n\"))))(Tile((id \
-         37f3b75d-c8cf-4215-a7f1-c20a5686f9ba)(label(\"(\"\")\"))(mold((out \
+         c9fdfff0-f06f-49bd-b949-4e10794e8d46)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d3bb8573-6b62-4925-bbd2-b5bd4d7e3795)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         23f6158b-6a2c-4208-94eb-4d9c126249e5)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         54920ca6-eb3d-4e0f-886a-2a6945126332)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         88b1f1c5-3de3-41dc-a218-5b97b72f83f6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         86419677-b69e-4219-900c-cd1d4dd5950c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e9b762be-74a6-4802-a98f-01136069f4ab)(label(Some))(mold((out \
+         b059f9dd-9818-40aa-bb74-d5822b5bd7c8)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         78c9756d-cda3-4601-b72d-26418a13421c)(label(\"(\"\")\"))(mold((out \
+         27e0c968-624d-4469-9dd0-d06451e5f7a2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1f26f8cb-47a6-4fa4-adff-1c5a3ca2c845)(label(\"\\\"Bob\\\"\"))(mold((out \
+         98f9e04f-0dcc-49c2-a2a5-29372e35ccb5)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         747568a2-d065-4980-992a-045bcd2f0e7d)(label(,))(mold((out \
+         f2ca37ef-9067-4a59-b5e2-54d22051f703)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2c816069-e66d-494e-9deb-ab5199fe3eeb)(content(Whitespace\" \
+         0313d11b-5ea1-46fe-837a-7f5a916f17fd)(content(Whitespace\" \
          \"))))(Tile((id \
-         f4e58a37-350b-4154-bb95-65553e6809c1)(label(None))(mold((out \
+         a9a25b95-1f36-4861-b2d0-e168f5304f51)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         32fc40e9-4608-464d-a2f1-1778964956e0)(label(,))(mold((out \
+         28d76a2d-f1ce-4017-a1c2-8401321ddd9c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3584bb3c-f82b-447a-b647-e82a3936cfb2)(content(Whitespace\" \
+         d748af74-3df2-4c52-80a3-fc9c240bb28f)(content(Whitespace\" \
          \"))))(Tile((id \
-         c0ed5864-00b1-4eff-a767-feb8989c2d3a)(label(Some))(mold((out \
+         5a5487c0-7d48-4364-b94a-c56bdc5de88f)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         0e83b78b-790f-47d0-8a5e-5a2cedb802e5)(label(\"(\"\")\"))(mold((out \
+         debb94dd-819f-447e-83aa-e4e93a366934)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9af0bf0a-4059-4016-bfa5-b724d4120e9d)(label(\"\\\"blue\\\"\"))(mold((out \
+         3c097c93-3549-4e5a-a4ee-9e6f7c1d1961)(label(\"\\\"blue\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Tile((id \
-         ffcfc85b-7ff2-4cad-8c81-6382c0d8fa3b)(label(,))(mold((out \
+         85a824b5-6a89-4749-ae7c-a8703fb682e3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e9762f91-196d-48e7-b917-67999f4268d7)(content(Whitespace\"\\n\"))))(Tile((id \
-         470354df-0087-4963-9cb8-1fb45b6681d0)(label(\"(\"\")\"))(mold((out \
+         b7eb3ad0-57bb-47e9-b2ba-f5c1dce6176b)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d9bc9f1a-f749-4aa2-9865-332a63809db1)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         8784d947-8f9f-41bd-8f7a-29944a7a9dc6)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a1d706d6-82d0-459c-83c9-57ecc0f0d726)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         425cfaed-0cd4-44ff-b91c-a132f1ba3f10)(content(Whitespace\" \
+         \"))))(Tile((id \
+         67b3122b-3afd-407f-b129-8464047781c8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         c921bbb2-57a9-4674-8edc-aa426f48a003)(label(Some))(mold((out \
+         491bd1ab-9896-4dc2-bd91-8be276f63257)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         87575cf7-e141-4e59-8b4d-5a4ccbdc5e3a)(label(\"(\"\")\"))(mold((out \
+         ced1a872-ae5c-4a4f-a8f0-b95f94879860)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9b28fc0a-92ed-4cfb-982c-daf2f9aae39c)(label(\"\\\"Alice\\\"\"))(mold((out \
+         d43c126d-c351-44f2-8a54-05fcfaa4ae11)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         fc9d72c5-9a6e-481e-a814-17d4abc90bd4)(label(,))(mold((out \
+         bf2471ec-9c75-4a7e-9960-da0b4467bbe2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10800909-7657-4f71-b233-26d7c5dc33df)(content(Whitespace\" \
+         5387d8ad-4786-475a-915e-39bd5d97a254)(content(Whitespace\" \
          \"))))(Tile((id \
-         2c68bd2d-124d-4d96-b9e4-a22bd3d08e2c)(label(Some))(mold((out \
+         87ec2c87-d9f4-47aa-9184-e3688116d415)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6c0f8f87-aee6-44e7-a384-4d1770a666db)(label(\"(\"\")\"))(mold((out \
+         e857b2ed-c5de-4a3d-bd96-3b8ba2307861)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         13f8c3a2-2cd5-4721-8399-9a8e924bc4bb)(label(17))(mold((out \
+         832f78e7-a648-4ca5-986d-a025523c6477)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         1ac5cba8-6855-44bb-b7d5-b749a51f091f)(label(,))(mold((out \
+         1034d4a4-08be-4366-9cf0-a5f6d7f03876)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b370e623-d55a-4154-91b7-4581589ce9b3)(content(Whitespace\" \
+         78da863d-27b5-470c-8b4d-f354ac3cc9f3)(content(Whitespace\" \
          \"))))(Tile((id \
-         6d358695-b974-4e60-97aa-1765da7d4be7)(label(Some))(mold((out \
+         45592397-ec80-44bb-9b39-8ccf584be889)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b2d3bee6-81cc-47aa-a2c3-5a77824bb5c0)(label(\"(\"\")\"))(mold((out \
+         c6f8357d-b5d7-4362-88de-f62929f9ae7b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         81657101-8697-48e9-b691-9a47f17ea738)(label(\"\\\"green\\\"\"))(mold((out \
+         eebcfc65-315d-424c-babf-b98186c9a24c)(label(\"\\\"green\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Tile((id \
-         58569351-1ad1-4886-9c9b-e0fdf1bcbc68)(label(,))(mold((out \
+         9b6e1e3b-4162-49b5-b201-95cabe3f37de)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         58973e5f-c075-4130-bb6b-94f59f98035c)(content(Whitespace\"\\n\"))))(Tile((id \
-         d52f8d00-1a79-4ed7-8cc4-065ec8617a17)(label(\"(\"\")\"))(mold((out \
+         8f31d921-80e6-4948-8cc4-55d86d5d0d64)(content(Whitespace\"\\n\"))))(Secondary((id \
+         933147e4-c6b1-4561-9d5a-90778c6d0a1f)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         867073da-a44c-4174-9575-6de83368d747)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         f73d23c5-a202-4cc5-a133-bd7b2bbcfe43)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         d5ac03cf-09a1-42b8-a6b2-e5879ca140bf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6e73c220-7e82-43d2-b8e3-bf9a01f310de)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         113a5754-dc8c-4930-9acf-eb7a1baa2a73)(label(Some))(mold((out \
+         5d916c3c-f80d-4556-b4d8-5602f9027867)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         08bc23b7-6d8e-4939-a089-f0db32cba3a1)(label(\"(\"\")\"))(mold((out \
+         ba6f36eb-be9d-4532-aff1-d00f6205ecec)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d25c9abf-ac22-428f-917e-60922e465b1d)(label(\"\\\"Eve\\\"\"))(mold((out \
+         dc0dbf02-1c7e-4f17-8f21-0da27413ec7c)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         6debc338-f25e-460f-86a5-863b3b4503e4)(label(,))(mold((out \
+         5127a5a0-38fb-482a-84f3-fe9ddff10892)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9a835d99-d600-482d-8fa1-0d8cc8643d53)(content(Whitespace\" \
+         883efdf0-a8ec-4a44-b718-41902b5041e7)(content(Whitespace\" \
          \"))))(Tile((id \
-         9d476a89-90bb-41ac-b884-c085094ffb77)(label(Some))(mold((out \
+         952ff0c3-679c-49f0-b2a7-0c5ecdf38aca)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7384ef8c-eb03-4850-99b7-3e954f8097c0)(label(\"(\"\")\"))(mold((out \
+         970dd408-90c0-4aa5-86db-76e2fe8e8145)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         a01d714a-2d98-48ca-8e23-0a9baa12d802)(label(13))(mold((out \
+         1a04eca1-b9d3-49ca-9111-feff8db20bb8)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         509dfaaf-b718-4c87-8472-b73ee85aafcf)(label(,))(mold((out \
+         e56dc704-d268-48cb-b7b0-bb61dee4d082)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         85b8c3a2-adf3-4c24-92bf-29664bb9ff87)(content(Whitespace\" \
+         9650c222-dc98-4c43-a0fd-a3c317c54c69)(content(Whitespace\" \
          \"))))(Tile((id \
-         dcc84188-a243-4d2c-93e3-834d35119c44)(label(None))(mold((out \
+         5ac60761-3dd1-456b-b86d-f2767cc03deb)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9d3c2267-3be6-4dd3-ba3a-e85bc92419cd)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
+         da927c7f-8b2a-47d5-b34d-2f978e000787)(content(Whitespace\"\\n\"))))(Secondary((id \
+         9f8865a3-7403-48ac-bd07-ead9fad0362b)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         9221cc22-493e-4790-8cb4-3834f3ca9d9b)(content(Whitespace\" \
+         \")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         d5826b64-61ea-4791-9ee0-26c0e69c920a)(content(Whitespace\" \
+         67f42d92-f015-46d8-baf1-e532eb475946)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         00549760-763f-411d-800f-3d06a9e22518)(content(Whitespace\"\\n\"))))(Tile((id \
-         6f0f3a66-bbba-46b1-88d4-0f277c0ea8b4)(label(test end))(mold((out \
+         befe59f2-8d11-4717-ba6c-45cee2c19f19)(content(Whitespace\"\\n\"))))(Tile((id \
+         62b79a91-7ca1-42cc-a72b-77cd39ec53ee)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         cad267f3-6f5c-4fc1-b2bf-21397a49753a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e5adfb71-1229-4b6f-9d0f-5e7db6314021)(label(dropna))(mold((out \
+         fb484fb1-b386-424d-98aa-a38149c38a29)(content(Whitespace\"\\n\"))))(Tile((id \
+         c569cb93-025a-49c1-8caa-23ff37111c01)(label(dropna))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7e62179e-572b-478a-86a1-2b8c07e9a4a6)(label(@< >))(mold((out \
+         95dc12c6-c322-4afa-adcb-544274e0aba0)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9c80479a-edd9-4a86-9b10-ca8891584a93)(label(\"(\"\")\"))(mold((out \
+         6b40fd11-2763-48d8-abaf-cc591ff0b642)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         7d636ad3-f40a-4908-a4b0-70809ea05ed9)(label(name))(mold((out \
+         221c8ec3-a731-4c0e-9656-e231a84fa2dc)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         823fcd9d-43d2-4b3e-bbb8-70ca91267d64)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7bc136af-3cff-4ac9-8354-24b6a1021372)(content(Whitespace\" \
+         \"))))(Tile((id \
+         94366e57-57b8-48ac-8637-6d93feb81eae)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         0c8ef8c4-97ca-4efb-b93e-ab5e37bb82ae)(label(OptString))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5bf8dbbb-ef45-44d2-a23e-cc16cc2260b6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8236ae43-0eee-488d-8a4d-87e06bdc3b7b)(label(OptString))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         acd925e0-b658-4ec2-b79f-09300e063730)(label(,))(mold((out \
+         1ce6b88c-02f7-405a-9832-4892c95e0285)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5d88bc4e-b83a-4863-820c-124ae7f1f0f8)(content(Whitespace\" \
+         8333aaf6-85f3-492b-ad3e-b750f5d9662a)(content(Whitespace\" \
          \"))))(Tile((id \
-         640a7de2-b3a2-4ced-aa1b-1706641fa99f)(label(age))(mold((out \
+         d5762f50-20ab-4b2a-866f-47ddb4ac3d42)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         5129ab70-4d63-441a-bf33-d89410ca36cc)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e2fa78c1-d4f0-4b63-b5fd-0a621ae0d80a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         18bb64a1-7abf-404c-895c-e8e12842b00d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         197a5b79-81b9-49dd-a916-ec0d7b76e557)(label(OptInt))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e1792603-d8ba-403b-8802-bbda29f1cc05)(content(Whitespace\" \
+         \"))))(Tile((id \
+         385cf096-9f29-4c76-bdbf-f28cb548e326)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         2d2ac730-937b-43a6-95f5-c11271c47da0)(label(,))(mold((out \
+         3407f4c8-9a92-4590-883e-787814896ace)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2871530b-f5ac-4ebf-93b7-9836a92d1473)(content(Whitespace\" \
+         22bd3487-19d4-4e0b-9c48-bb90aebd9944)(content(Whitespace\" \
          \"))))(Tile((id \
-         4dc99ce3-9784-4fa1-ad24-c366fd6f7f32)(label(favorite_color))(mold((out \
+         dc5080e5-23b4-499e-8ed9-0e3de7e10e6f)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         47a251b6-8275-4372-9e4a-6094f0a2c1c1)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         204fe027-d3e2-4bbd-a884-2c8b1a2dd045)(content(Whitespace\" \
+         \"))))(Tile((id \
+         042cff19-462f-4c29-9382-fc5c53dc420e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         f354a4c8-e4f6-419e-8dcc-a9ac256acc12)(label(OptString))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b58f9eba-fc32-43e2-a923-6c57dd45b0d8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9a2be638-84a3-40a2-99ef-f8d3ad227fb9)(label(OptString))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
-         3a939d9c-c6e0-482e-91c5-c11b3a0553ea)(label(\"(\"\")\"))(mold((out \
+         58ed3af5-c0d6-473f-81f8-d35451b8574b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         89891a7e-ecba-42f9-a5aa-ffe50b10ca2d)(label(students_fully_optional))(mold((out \
+         06943c50-a96a-40b1-ad83-916b2881c1a0)(label(students_fully_optional))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         dffbc79b-8e1b-48f8-b317-3109086e1958)(content(Whitespace\" \
-         \"))))(Tile((id \
-         eb3c31dc-6d11-486e-83cb-507c0454c351)(label(==))(mold((out \
+         b6e8b372-5964-4b39-8e2f-8624d63d1c78)(content(Whitespace\"\\n\"))))(Tile((id \
+         98f00a5e-fb32-4c67-b18a-2e19ea3be1a0)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         39af7c7a-9d72-4f79-9e60-ca42459c9e6c)(content(Whitespace\" \
-         \"))))(Tile((id e8871a17-d673-4690-8415-743cebe4abf0)(label([ \
+         aa58a0c7-6153-45ea-b8f8-63934afaeb86)(content(Whitespace\" \
+         \"))))(Tile((id 39113b1c-d96d-4934-bca8-2004166e3c99)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         9a575d32-c183-4bb2-b1fa-4cd16c54b38c)(content(Whitespace\"\\n\"))))(Tile((id \
-         b64c147a-c66a-4de2-bcc2-085007ea650d)(label(\"(\"\")\"))(mold((out \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         6fe74cc8-f0e9-43f8-bd3b-a60bd917ad85)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         911379a6-da2c-495a-b028-ac4ebdfd65ee)(label(Some))(mold((out \
+         617a61f1-2e73-4a43-87b8-acd694b2620b)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         efb47ed7-e72b-4136-9e40-9973372018c8)(label(\"(\"\")\"))(mold((out \
+         6922338a-a2d5-4d20-9ce1-1cdb03f2534d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         cddb843c-3c84-44e1-9ad0-77cf171ea061)(label(\"\\\"Alice\\\"\"))(mold((out \
+         55704180-e306-4f1b-8b1d-dc9d2de2e91a)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7adf6905-2f47-4500-af23-e5a4acc55c4a)(label(,))(mold((out \
+         06b65a9f-135b-4e97-bcef-9abd8b9c1b4d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e39e095f-2044-4a20-bb8b-f32e8b325b1f)(content(Whitespace\" \
+         2b3bb729-9227-4119-baf0-b04731198de7)(content(Whitespace\" \
          \"))))(Tile((id \
-         990d5ed8-9d13-440b-9d96-f4a85d035bde)(label(Some))(mold((out \
+         8f8be930-256d-4b24-a2ff-15b217fd1fe2)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6b49357b-3c02-432a-ae5a-409946846dd7)(label(\"(\"\")\"))(mold((out \
+         a31d0637-ba32-48bc-9577-61a4e47ff74c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         71036ead-4f6c-4508-8599-7363e980c4d6)(label(17))(mold((out \
+         3f810ed7-b773-43b7-a304-d5c725be69a2)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a3b4f4b0-8cb6-41f5-8e88-d4c0eef112bb)(label(,))(mold((out \
+         80f8d44d-d09e-4138-82a2-b0a84165cc89)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0adbde24-516b-4023-80fc-0448ba54db06)(content(Whitespace\" \
+         7da820b4-e3f4-4460-a5d0-dac7420ed338)(content(Whitespace\" \
          \"))))(Tile((id \
-         6e12afb2-f5ab-4969-b186-1ac25a4301f0)(label(Some))(mold((out \
+         605c6cef-7a47-4f5c-9769-7e7611152b4a)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         8aef44ac-0ddc-4aa4-8ce4-a0a9972478ec)(label(\"(\"\")\"))(mold((out \
+         f81f4862-364b-443f-b55a-4aedc0514d89)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         42da6905-a25f-4390-8aca-a81e9731dc71)(label(\"\\\"green\\\"\"))(mold((out \
+         8b8f5743-884f-4cb3-b4e2-5ea5363265da)(label(\"\\\"green\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         bce147d8-e10e-490a-8cb2-ef2fe6f6a93f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         383e5151-c83b-4f85-bbbe-ec2e7691111d)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         67d35223-c4f9-44b6-b6e3-985323c13dc0)(content(Whitespace\" \
          \"))))(Tile((id \
-         ae9a1ed5-ab3f-4ea7-bbcc-493a5bd63029)(label(:))(mold((out \
+         02c6d129-7f8a-45e9-90bd-e854fc868026)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         90cdb639-e0e7-4c65-af60-6f62745dfda0)(content(Whitespace\" \
-         \"))))(Tile((id e66cabe3-f911-4e88-9ea1-57277ed35b7a)(label([ \
+         6c048b33-b2ad-43f9-9bb5-dc0ba20c4f9c)(content(Whitespace\" \
+         \"))))(Tile((id 4075ada1-1549-46d6-8e15-dff78b06455f)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         7bf48aa0-90af-41a1-b800-a8be0fba26ba)(label(\"(\"\")\"))(mold((out \
+         80c15af7-a50d-4967-83d6-6c34731a4551)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         0a984f69-e563-487e-b726-26344fd596a2)(label(name))(mold((out \
+         2714d1bc-49d4-4f55-a5cc-9bbc52506678)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         e528c224-abdd-4303-aec7-e4680d7923fc)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         05019ce6-7def-433a-bf77-cd3e96202230)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b99169da-3611-475f-a71a-b8f21064c48b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         81021ecd-0461-4325-bcab-784d8fc5ed5d)(label(OptString))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         83eb8658-3fdd-4741-9fdb-ae1149b48707)(content(Whitespace\" \
+         \"))))(Tile((id \
+         06cb4eff-7286-4ef7-93ed-bead0e3e879a)(label(OptString))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         9b681d1c-84b6-48cd-8b89-dbd8251563b7)(label(,))(mold((out \
+         b2a76f83-01c6-4b5e-8351-36e33235a2d3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         67322b18-c4a1-45d7-a7ee-943e500c5079)(content(Whitespace\" \
+         5e89ea1e-e0df-4f16-888a-f32d82f400b7)(content(Whitespace\" \
          \"))))(Tile((id \
-         414a1812-9ee0-4a9c-a75d-aa43263c82d9)(label(age))(mold((out \
+         10012877-1d24-46b8-9a64-dcc6883a1273)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         deeea929-9f72-4bda-a9c7-2734a6284db3)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8dbfedef-f02b-405e-a39a-e01b78553ade)(content(Whitespace\" \
+         \"))))(Tile((id \
+         317ae116-bdf7-4eb4-b790-cdbb9516685b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         35d16562-8e0b-4322-8353-0ff983b3abc0)(label(OptInt))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         57690240-3b82-453f-b354-6dd8cf40301e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         39d7d423-4ed3-4c3c-8a78-090a18861c2d)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         2dfd76bc-e7ba-472c-8c73-775f3b4562d0)(label(,))(mold((out \
+         5f110013-3084-4691-a0d5-0a1775126d75)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         70b59b2c-d0bf-4e89-b9d4-edd224c1e0c7)(content(Whitespace\" \
+         1a20915a-5fee-4175-a611-604d10cb232b)(content(Whitespace\" \
          \"))))(Tile((id \
-         97918bb7-9a89-4a9b-8b54-0182c6b920d8)(label(favorite_color))(mold((out \
+         f9a1b986-b8cc-45b4-ab06-d919aaec4773)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         dd1ceb18-df06-40e0-8632-d2f85a9ee48b)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ddaad294-0fd2-4c26-87af-403ce94117a9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c21d8d0e-5417-42b4-a4f9-8c4a3405649b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         4ef78369-ce8f-4c98-b259-2d46f58e9927)(label(OptString))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         89f118e9-d325-4eec-9b15-ac426dbdfdde)(content(Whitespace\" \
+         \"))))(Tile((id \
+         96120f27-0eb3-4531-bbef-764a59a7b037)(label(OptString))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         06e427cd-6c07-49e2-8e32-558bb3fd255f)(content(Whitespace\" \
+         a0df8cb0-bf89-45b9-9c18-33cb284f5dd1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fb8872b7-2707-486c-873a-b00f95b62d98)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         f5707afa-830b-4993-9d2a-e32427308d6a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         96a3c7c7-1656-409c-9abb-4e810afd2a66)(content(Whitespace\"\\n\"))))(Tile((id \
-         4a06bd78-9e9b-4055-a076-186fdd95974c)(label(let = in))(mold((out \
+         90ae72c8-ab15-479e-98ed-744d893c7ed2)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         4c4cfd41-b2e0-4fad-a425-8afcec0f8f79)(content(Whitespace\"\\n\"))))(Tile((id \
+         36d95959-7c33-4884-962b-556cc0ca3699)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1dc4bada-f86d-4428-87ac-c2cb8f67a129)(content(Whitespace\" \
+         a62da0f0-b708-47ae-8359-6b69f853a563)(content(Whitespace\" \
          \"))))(Tile((id \
-         79d61e57-ca7f-4e75-a291-e870df927669)(label(fillna))(mold((out \
+         2739c4c0-a307-48bb-9ad0-6cc0a85d8831)(label(fillna))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e14664de-d120-4161-89a9-033d8b7a62dd)(content(Whitespace\" \
+         b1718bf2-a97b-4a7b-8751-de0e357d5f00)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c206fe1e-4986-4cc4-b529-7da5959199c8)(content(Whitespace\"\\n\"))))(Tile((id \
-         fe8602dc-b892-43ce-ad91-34229f902e81)(label(let = in))(mold((out \
+         0be4cbb7-a8e2-4a50-8879-643b5900109c)(content(Whitespace\"\\n\"))))(Tile((id \
+         79023870-2254-4cc6-893e-8d9619e3b7d3)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a8c57840-4a2a-426f-b71d-55d799e70e39)(content(Whitespace\" \
+         69a01cea-6c43-4881-8530-c31e28d0a07c)(content(Whitespace\" \
          \"))))(Tile((id \
-         299f24f3-3352-4204-8e66-e39e92906ba2)(label(requires))(mold((out \
+         4f5646ec-32de-41ea-b627-ed151d7189ad)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         de5d2b00-417f-4057-898f-c9b618885cb1)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         3c2efb88-aba6-46c2-82c9-a8593df94746)(content(Whitespace\"\\n\"))))(Tile((id \
-         d3ef6613-d60e-43a8-8dc4-b831d0dba455)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         58932bbc-d3f4-4a89-8c86-d4de91a775b4)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         5fff8785-4c7b-45c0-b66e-0e842ee93173)(content(Whitespace\" \
+         \"))))(Tile((id d76087c9-a2d7-437c-9e2f-d8b1183c9efa)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         6546ab0e-d2b2-427c-afe2-bcbcb3d32843)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         3df35d5b-ef6d-48aa-8101-7c0863a44a12)(label(enforced))(mold((out \
+         77673efd-0afb-483a-bf48-227a5e18fd4a)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         19a4017c-7603-4924-8779-beab93c90e36)(label(=))(mold((out \
+         91a038f5-c54f-4d49-834f-e3bd352e40ff)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         3c5abb5f-6215-4978-80a8-c03666243050)(kind Checkbox)(syntax(Tile((id \
-         babf8c5e-3345-41fc-8b33-666a002b0170)(label(\"(\"\")\"))(mold((out \
+         690e90c8-2adb-4c24-8925-16d8ae44739b)(kind Checkbox)(syntax(Tile((id \
+         8a6e6720-ec56-4324-8776-05a4a71a14d2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         66d43831-9606-43ed-85b7-8c87f298d04a)(label(false))(mold((out \
+         d0ef3f6e-eaf0-433b-91df-3dff7eb7585b)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         08f2135a-5120-432d-9b59-b33d4854cc6c)(label(,))(mold((out \
+         ec892da4-ef35-4635-a9dc-3aa6092d38b5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ee107dd7-dffc-4b9c-a7ce-62ad4aaa7839)(content(Whitespace\" \
-         \"))))(Tile((id 91c15798-1d47-45ef-adf4-e069e3fddbf2)(label(\"\\\"c \
+         da95fa60-3180-47d4-a65b-87f06fbca66c)(content(Whitespace\" \
+         \"))))(Tile((id 484ff0f5-e980-4444-a83a-17850d6cf0d9)(label(\"\\\"c \
          is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         b2a518b7-761b-47cc-b684-04283e4d728c)(label(,))(mold((out \
+         4226e656-7bd1-45e0-91ee-070cb7013d0e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         879e5523-f76f-4479-952f-3e3fa8dfe65b)(content(Whitespace\"\\n\"))))(Tile((id \
-         f772b115-3887-47ed-8db5-7f8636539d06)(label(\"(\"\")\"))(mold((out \
+         7a21301c-1ae8-4bf2-9077-fd0978136e5e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         07c07f22-bcf1-43e5-850a-81a69a70a384)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         2e857246-ca3c-4b36-9ae5-1305e07826d8)(label(enforced))(mold((out \
+         59a56f7c-3151-43c1-b566-670e019ac733)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1cd07a8d-7d6e-479b-bd02-3e26f9743244)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         798252aa-cc8f-4f90-b457-0d63ffc9588f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         690ee73a-c4a1-430e-9177-8bc4a7a0a18b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         e10df8b2-bcef-4bdf-bbf4-7828d6b1b081)(kind Checkbox)(syntax(Tile((id \
-         c7c1e5cd-15e8-4570-9825-ee6ca8f17dfc)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c791aa66-a809-4a94-822c-6bb2a9d6294b)(content(Whitespace\" \
+         \"))))(Projector((id f68e2bc4-556d-4cb7-94b6-60c33a9694e4)(kind \
+         Checkbox)(syntax(Tile((id \
+         2cf43036-2226-4ddc-9524-17bb58e8bf16)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         fc337d22-9491-4947-ad2c-3c6ab80759fd)(label(false))(mold((out \
+         c0a873a2-2d41-4f19-ad99-c8dbd6ba1e6c)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         82db42d0-b4f4-4a8b-9516-00be9fc1de86)(label(,))(mold((out \
+         8bd17b25-b009-4e29-a16d-3ad3c7645282)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f52630a7-adbc-4c64-87cd-caa952ec10ac)(content(Whitespace\" \
-         \"))))(Tile((id d43519c7-5cc6-4f49-b432-2f4fc33ec413)(label(\"\\\"v \
+         74fa24bd-a9e4-4f23-94aa-34190a4535d9)(content(Whitespace\" \
+         \"))))(Tile((id b94c9bf3-ec5d-4940-8ff5-de6eee3f0d1c)(label(\"\\\"v \
          is of sort schema(t1)[c]\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3dea6e79-03dd-4e55-9678-84600ea2b660)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         3608c7f2-95dd-45b3-9dcd-a1fb2e5cad34)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         45c4b753-f314-4cdf-9b17-355d00b25371)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cd734331-e903-4bcb-8061-a15253e62f46)(content(Whitespace\"\\n\"))))(Tile((id \
-         2c8b42b1-f146-4890-90a9-3c5da91b7538)(label(let = in))(mold((out \
+         9c262681-8da6-4b13-acef-dd6be83ddfe6)(content(Whitespace\"\\n\"))))(Tile((id \
+         0c4c3e40-dc67-40c6-bf1f-fe49a88442e5)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         dcd0b922-8486-41ca-b22c-be4a859d2430)(content(Whitespace\" \
+         6b699fb1-45dd-48ae-922d-a3f023af1bd9)(content(Whitespace\" \
          \"))))(Tile((id \
-         4b7b735f-d540-47ab-832b-03987d643881)(label(ensures))(mold((out \
+         64453326-d919-4011-aa0d-d52d6219edb7)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         0565f90f-386e-4659-8102-5340ad7d3c78)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         eaca3f0b-7921-4681-a38b-2fa546f98588)(content(Whitespace\"\\n\"))))(Tile((id \
-         ee47d4a8-693c-45e2-8558-c01c7874ebce)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         71a97370-7a2c-46ca-a512-946f8048f81b)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         0e42c7ca-8bed-48cd-b733-0b03ba298e1f)(content(Whitespace\" \
+         \"))))(Tile((id 417b675f-1671-4cc2-a003-6542d6f2ce97)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         29546749-163b-4f01-9a98-414d0a8367d0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         42d4b59a-a662-46e4-b72a-14a25b103d45)(label(enforced))(mold((out \
+         3e15ddb1-4fd7-4b39-b004-f67df52e9a5b)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ace73f6a-5280-4f83-b590-cfd82487cfef)(label(=))(mold((out \
+         792e461a-3758-490b-be14-20a6a33525de)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         a1f629c9-d415-486c-8f3c-c11695457ce6)(kind Checkbox)(syntax(Tile((id \
-         c2086994-5e87-4a91-b347-9c0a71df36fe)(label(\"(\"\")\"))(mold((out \
+         5e92ec1b-8589-4b2a-9bf1-68fc7b2acb8d)(kind Checkbox)(syntax(Tile((id \
+         dfe3c3eb-69af-45cf-af89-66912a4f9b46)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         27187746-f623-4b91-b67b-936e515940f2)(label(false))(mold((out \
+         c921d40e-3f64-4337-b672-b0a6ff020361)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         ff4bf1e7-8b3d-48e7-893a-26e3d9366139)(label(,))(mold((out \
+         215dc27b-9c6b-4e6d-8cbd-18befd7780d0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a3450f5e-9d51-4ad4-a531-12c0bd2243d9)(content(Whitespace\" \
+         a614b46a-7ebb-4dcb-bef9-cc7717a08a24)(content(Whitespace\" \
          \"))))(Tile((id \
-         0afe2600-a0e5-4126-9ad7-dfeaf32ec116)(label(\"\\\"schema(t2) is equal \
+         f6c6f36f-0d76-4e7f-b6d4-0077a6484616)(label(\"\\\"schema(t2) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         37c40c14-ff69-417b-8032-51b45a90d74d)(label(,))(mold((out \
+         8cffa60e-c5c4-4e29-88d3-bd62739e7db5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7c6709bf-5afb-4b97-b01f-3ffaa37a188d)(content(Whitespace\"\\n\"))))(Tile((id \
-         890308b9-7274-4de0-b06c-eeb51d8e113a)(label(\"(\"\")\"))(mold((out \
+         7ab759fd-2196-41ee-86ac-a0e0b3284d74)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ffb8ef82-ccc9-4428-8269-a2a1a3577e39)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         fc1206a0-bfba-4d5b-9b4c-a74d74089c01)(label(enforced))(mold((out \
+         6043101a-2d9a-4c7d-8282-7f5706abd3aa)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b9bddd6e-eccb-464a-974f-3bb023670ad2)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8652c19d-31cd-4545-b48d-479b856dfe6f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b5216765-b73c-4728-97cd-6b924d565f48)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         f791289c-d830-44b5-a121-1c849cd65632)(kind Checkbox)(syntax(Tile((id \
-         4efce64f-f87e-43c6-912c-f743910e1c8f)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         80ab0180-2193-4a61-a05b-53c97f32dbb4)(content(Whitespace\" \
+         \"))))(Projector((id 135729b0-408f-4d7b-88bc-dbae29ca792f)(kind \
+         Checkbox)(syntax(Tile((id \
+         eb39d7be-7535-4d27-9ee0-d45f92ac6de7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         441aae6d-38d5-482b-b7bc-ab1a50e6e964)(label(false))(mold((out \
+         9b49df2b-e4fa-434d-971f-1535e8973929)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         c7d6b8f0-ca73-454d-acba-f045e739ec17)(label(,))(mold((out \
+         7c3edbdb-2663-4f3e-b4c1-6dfbbc25f1a6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e81efc14-3616-49c7-8b0f-1be8cb36cc1b)(content(Whitespace\" \
+         4b3e7556-4a3f-48f0-888b-905f9e6367e1)(content(Whitespace\" \
          \"))))(Tile((id \
-         bca3265c-01d0-4921-9a6d-96f308ab62d3)(label(\"\\\"nrows(t2) is equal \
+         9d23ca46-8031-46ff-b5b0-f85fc53f1436)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         96178d06-215b-4462-8e83-6999373560e6)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e6fed15e-9c2c-4f5f-84e7-e9947bbaebd4)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         df5a5b10-2934-4251-b80a-ee972e408f14)(content(Whitespace\"\\n\"))))(Secondary((id \
-         27e16e40-0abe-4b46-9db2-35f875796b0b)(content(Whitespace\"\\n\"))))(Tile((id \
-         5f7f7268-88e7-44b8-ad97-6551fa0677c8)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         91f4749d-5193-4b57-9374-210098871a39)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3b0c8d0b-8591-4a0d-a812-7442a2582ad8)(label(fillna))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         e0c3b425-bf90-4308-ac6a-648ae69decd4)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         1e222317-ede9-456c-87b9-d15bef687c52)(content(Whitespace\" \
-         \"))))(Tile((id 336ac834-97dc-40c9-b658-318b0d7ec6b6)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         4a16eff4-20a3-4228-89ea-4d3955b3d321)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e980301c-1242-4790-be9b-702e4f79a937)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         efc04fcd-4872-4a5f-942c-b66dce6c77b2)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         cb6b9751-0172-4e63-81d9-24bc7c85c53f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ed280feb-0744-4b88-b8a8-8a29bec4f8bd)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         695f3566-82c3-46cc-82be-18a6abb21cc2)(content(Whitespace\" \
-         \"))))(Tile((id 76111707-8a6a-404f-a2cb-305d97756b04)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         b13144ec-4ea1-421c-bf0e-0a314a37ac93)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         a1f020ae-0312-4bd2-bf06-5d448692e5c7)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         dca47f67-6d2f-494c-a6d2-64d88d35e01e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         10fb6338-ba9b-438e-a676-9b84d7594906)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         94e64993-7848-4c83-9bc4-3171230e36a4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         53dcb776-1770-43b8-b1c0-5c7f7e8bd41e)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c32e93b6-0eff-49b4-be4b-8c764d9fe5f8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dfe81837-fbc3-46c4-a6b1-fc58ade06bef)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         d7fa000a-5984-4ff5-b9c9-efd799dc3dae)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         66702a55-b8ce-4297-a433-858999d070a9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cb080418-5579-406b-b9f7-2441f0585c84)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         9f3f4b58-8d65-496b-bae5-83ba22562c89)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         a872452e-08e1-41b8-b761-228f064008c1)(content(Whitespace\"\\n\"))))(Tile((id \
-         26bd2aeb-35cf-4fd3-9070-186bc7e0f956)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         b2332c82-eb3d-47f4-87b3-2e269e0d70b3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         602801e6-b0f8-4cab-8495-d2302ad932eb)(label(rows))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         60b6f6e2-d5b0-42d5-9ce8-75e102e7413f)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         44575c92-e065-479e-942b-e51a77f50a81)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d6a302e2-28d8-4552-806e-01d8699a7fac)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         40d941f9-c5be-4892-9324-2875b54e9617)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         62406466-a9f1-40e2-86bc-700e572c845b)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         984b49bb-2613-486b-a964-4d9f9449f9aa)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         afbe0e15-7d75-421e-9165-e7126e63add7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2df361cc-0ea2-4a3c-8e29-43eaaf84ff11)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         23e51b76-384f-409d-af16-ab4bfdb3d928)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         bba1135f-3754-49c7-9546-6879b5b5aa4a)(content(Whitespace\"\\n\"))))(Tile((id \
-         2f1ead0e-20c2-4d52-8d05-2f147c81d301)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         bfe4898c-fa43-446f-b628-f726be6ce366)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9b34c9b6-6e11-483f-9007-915c082cb9e3)(label(mapped))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         1fab9b63-b375-482b-92d0-2543ca39eb77)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         61b138ae-c668-4e29-8bda-78d51d9e287f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         91bf9a59-2947-41d1-82c3-dd852ec01bcd)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0b165114-62f0-4a82-9b29-fbbe93426f47)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d2558a20-158d-48eb-9864-33c590560245)(label(rows))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         821ae6db-9fc8-4f43-92f8-d6d777c95380)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         96bed138-8d29-4b29-ad5e-9f72b78d1a44)(content(Whitespace\" \
-         \"))))(Tile((id 2c554853-95ab-40e2-873e-6630cc74ffae)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         121da634-d807-45fd-8106-149af3a72dfe)(content(Whitespace\" \
-         \"))))(Tile((id \
-         038393e3-efad-473a-95ac-da5ea314a4d6)(label(entries))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         8ee2e6a2-2ec7-41c8-9dfb-795f7af195d5)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         92d658ac-f32b-4abf-aee1-42cda05dec39)(content(Whitespace\"\\n\"))))(Tile((id \
-         c62656db-38fb-4eb2-bdb4-bf2514f213ac)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         66c710d0-8c1a-418c-a7ea-ea1b66f0ad93)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b78a92ce-77f8-4b76-9571-341e6062030c)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6505a1bd-8fd2-4e84-a33b-9e9fe4b5c2e4)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         21df92a9-39b9-4f83-bad7-74a0ab42b605)(label(entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9074fc6b-e922-4834-b134-1728534c018b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         30daf172-8f81-4fba-b240-05af8697a7b8)(content(Whitespace\" \
-         \"))))(Tile((id fab8f0a5-3156-485a-80b3-25b4dec213af)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         bcecba4e-b521-46dc-873a-718cbbeae235)(content(Whitespace\" \
-         \"))))(Tile((id \
-         94559b3a-54e6-4bc9-9b5b-2b48549186d8)(label(e))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         46dbda94-2597-4d33-b3ea-26e2063056cb)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         18ca6bd7-693e-4e2e-b512-f45f2c0cf41d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1954c902-6904-43e3-b28e-b99ed90bf0c6)(label(!))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2db453a6-eb64-40e7-979a-4f2f5568f002)(label(string_eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2fdde6ce-b35c-4034-8f86-d69ef4d458cf)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         897b83d6-d7e1-45c4-9435-d2de52c8bf42)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c25e493b-4c87-44e4-a35b-26893dd43916)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         4d49ca82-2a61-4c49-a65b-210bfc61562f)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8788c4c7-9ba9-4f26-8f65-03cc1182c408)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         31516180-1053-4bb6-bb5f-a2410b2dcbe6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c6e2db53-ac1c-484e-aaf1-352a07739634)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         ea14c562-0288-463f-94bd-3afc3f3aaee0)(content(Whitespace\"\\n\"))))(Tile((id \
-         e41a0273-0a8c-483b-b90e-f9f1b0a22ab1)(label(@))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
-         30))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9ce3af36-da86-4dda-aa86-7e392f1334ff)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         d9595948-ac37-43d8-9cb4-8ebe522206da)(content(Whitespace\"\\n\"))))(Tile((id \
-         95893c9b-ae7f-4084-a1bb-d473903eb298)(label(case end))(mold((out \
-         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         2c9b26ed-b1c9-4a38-acb7-01cf421e8367)(content(Whitespace\" \
+         c18065fe-aa92-4d60-bb72-9a872b3163c0)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e2ea2973-5f1a-4efd-932b-e4e276ee5ed8)(content(Whitespace\"\\n\"))))(Tile((id \
+         795c9770-bb31-40b0-8666-25c0649d3200)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         8e3411d9-8618-411b-90cb-d50a0393166f)(content(Whitespace\" \
          \"))))(Tile((id \
-         32f6c9a1-0db6-4957-9c03-dd68b81f9f95)(label(option_bind))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a3ed16ae-f3d5-49c6-89f2-d320d22a6336)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b07eea74-bd8f-4e59-9865-d497a18837dc)(label(find_opt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e880fa30-0e92-4176-b736-98050259b0b9)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2365f708-6d65-49b5-bc5b-98b685e65b7a)(label(entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         25f0ed12-ee5e-4348-97f3-b0113fc687ca)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d46cd0c6-0c35-4bde-b687-c123364267ee)(content(Whitespace\" \
-         \"))))(Tile((id 1bcf3fad-4d8f-468e-8fa4-e441c9763a54)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         2909058a-ba1c-412e-9759-f334ec0af500)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8c2f5fde-5ed3-43a2-9bea-7e3b50d88b98)(label(e))(mold((out \
+         c4bfa195-740b-4aef-ae12-8a47a0bfaf9d)(label(fillna))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7512b405-1673-488f-ae50-ff6cc87db074)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         895b04ea-b9a2-47f9-b20d-a28f04b8ef4c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         df452fbf-387d-48a8-95f9-c73057efb793)(label(string_eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2221da15-c5e9-4219-93fa-3b18c74e6dec)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         47981c96-8d84-4761-a7b3-89de6f3f9cb1)(label(e))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0b7643dd-9c20-48fe-98c5-ceb84a07e761)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c23c4178-4f58-4069-98c5-4496fcc25f09)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3f35dcee-ede8-4c13-a3cc-99e452536e36)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b8e70d7f-9adf-4fa5-b361-f53a33503c7b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cda61a13-e78c-4e3a-9f01-e9240a66b5ea)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Tile((id \
-         031719c9-7823-494c-8aef-be6fb033ed2e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         160d218a-cee0-4242-a60b-a8f7bc16a214)(content(Whitespace\" \
-         \"))))(Tile((id ffb8cd44-7262-4315-8c3f-1910b2a6cdee)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         aa39ddaf-d0be-4bf3-91b8-a61462af0da3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6940f19f-b210-41ba-a411-e519c577a5b0)(label(x))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         ae67841e-dfe5-47ea-8d58-6342259d2150)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f1e57171-3939-4e1b-9293-81b6350d7f04)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6ac53c53-7e0e-4467-9d63-56f8160a00aa)(label(x))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7ca2967f-c1d5-42c7-81a0-ee0caa6bd6b4)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         397cee76-b647-40a3-a326-522218227a30)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7f9e28ca-7c7f-40c5-b8c7-7ab9ca56c85b)(content(Whitespace\"\\n\"))))(Tile((id \
-         23eb139a-a9f0-4ccd-b85a-2779f9f6f55a)(label(| =>))(mold((out \
-         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
-         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ca2db0e7-5bdb-4d86-91ad-fc8e905279a6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         17e31409-bd6d-484f-9245-617ef517c78d)(label(None))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         0db85fe8-c4e6-42dd-916e-68df915190a3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f629c0ee-883c-4bef-bc49-ab019c798d12)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c0575b1b-3fdb-4204-91db-f4e9391e3f5e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         b64c1dee-1853-413e-bef2-3accbc8981c4)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a392490f-e93e-4e14-990c-55abb3668a1c)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         5c643e2e-b24a-4b2e-b82d-ea7222b9953f)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bcbee5d8-9a31-4438-b585-4be8cbd95bbe)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f01b1ad3-109d-4a7e-b15d-26597f50d64e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c796d1ef-8d87-42f6-83cd-ad649239fd2a)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2ef901fe-d40a-401d-92ed-b4313c025945)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         bf6aafe8-7ee4-41a7-899b-2c134d1f5f9a)(label(v))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e8675a14-3337-4378-947e-c02d09e5dab4)(content(Whitespace\"\\n\"))))(Tile((id \
-         7739796f-34b9-4f05-af1d-a0150168a11b)(label(| =>))(mold((out \
-         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
-         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         53bd39a8-46dc-46aa-aee9-8e96fc85cc09)(content(Whitespace\" \
-         \"))))(Tile((id \
-         020b6d6d-44b2-4e9c-aaf3-e2ab78b8c6ee)(label(Some))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         386d6366-29fd-4afc-9633-06a1ed14fbd2)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
-         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
-         73a623d2-8f40-4a56-9be5-b0c39ae11a74)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         56218b24-f45b-4818-946b-1714fcdea233)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         11048525-f260-490a-beed-9091e6d07981)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e05fdc96-4b20-43c0-b1c3-85a3e08ebdee)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         2405e680-7979-4565-8c78-86d00367c468)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         01dd667d-b2c8-4a45-b6a9-7c1bc9fd6f81)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c5af8de7-9bf9-4b45-aee1-c187d60226b2)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         00bdae92-6c66-4d0a-a4ac-d2191f681ba6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d58a15b0-d715-4f61-9950-4db2ab1a9b24)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cce23381-449f-4bf6-b232-28654c414e04)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4d5b22ba-448f-4a37-9998-79092853d1a2)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         78d70e9a-ff91-4c6f-abb4-9e33a9aa5860)(label(v))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         042582c3-33ce-46db-a0d8-0fc404bca99a)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         2fb10ce8-23ee-40b4-bfe8-b74fff0f3bcc)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         79eb2c74-7fe2-4084-ae33-73df6a1ca159)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         df0341b4-8a86-48a6-b379-30664ee4ed6d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8f34564f-8418-47e5-b7a0-35098c11428f)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5d7edd59-16ab-4b4d-a683-21314c7082df)(content(Whitespace\" \
-         \"))))(Tile((id bebb9b76-f16f-4800-9b1d-be72de845ca8)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         5f257e1c-e81f-4460-91fc-f59ec4788678)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a66135fc-964d-4a7e-9cce-5ce45e4e411b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b97ea910-5be0-4159-97aa-5238ba5dabdd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f35e801b-722f-4711-85fd-6d6f546ee282)(label(mapped))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         646bee43-10d4-45a1-b13e-5b262e9ccc12)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9571c46b-2818-49ff-8848-742585e09336)(content(Whitespace\"\\n\"))))(Secondary((id \
-         445ade2e-ab78-4f07-965c-543af21b4089)(content(Whitespace\"\\n\"))))(Tile((id \
-         c953af8a-6d45-4b52-b40b-83f496dddb7e)(label(test end))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         e4bd0eaf-2f9a-4574-8540-75dc71ec8ad2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         297cd2b4-2b37-4221-bfae-754246a32f54)(label(fillna))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ab74e522-2cc9-4112-a476-003d59d59ee6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e351ed9a-d21e-4980-9b11-40bd0c45237c)(label(studentsMissing))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2243fe6a-1e38-4d56-8c2b-a46b2193ea57)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7cd5467b-8600-43dc-9fbf-9395f20db9d0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e661f237-55e5-4943-af4c-300388d3553e)(label(\"\\\"favorite_color\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c25c949c-4547-446b-80d2-68c1c37a681f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c8f5c60c-ae1f-42ea-addd-6752bcb13f23)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8f426429-7671-4274-a1fd-72dca6b1a3c5)(label(\"\\\"white\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5a960eae-bba4-4760-8607-6aafb502f7d0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         264b3236-e4f6-4f24-bf35-16d3d30f4b2c)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0af79dc6-253c-440f-b5f9-269d9cf102ed)(content(Whitespace\" \
-         \"))))(Tile((id 3ea91aec-d351-4e48-b58b-3f320622d2e0)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         b7e6cf08-d1ca-4b8f-a68c-b45a1ea26af4)(content(Whitespace\"\\n\"))))(Tile((id \
-         88dada69-9d46-44b2-ac2f-f43aa7bfe4f8)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         2f7305af-2cd7-483a-9f5f-9bcd473a41d4)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9e7dc29d-2be6-4930-8b27-6a9cf18f0ce7)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5771b440-3958-4626-8b76-c1772f2d0d20)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fe9e1362-6f6c-4ac0-b4e5-f91de35fcd3d)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         827a6a62-a151-42dc-a13b-1f4ee47af64f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         df6ed502-8694-4f85-a0df-9b60c84bf0e8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b4ddd2c7-1b98-4048-988a-bafb3fcb0637)(label(\"\\\"blue\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         49bded21-ff76-4caa-8375-95433a1a2856)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aa077955-e4c3-40fb-a633-3c1d829e37ea)(content(Whitespace\"\\n\"))))(Tile((id \
-         b5e59137-08c2-4ed3-9993-15e1c95917c8)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         5aab5999-378f-422a-ba90-095e61aa775e)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5a06be2e-0935-4c56-bb41-eb2fcd4dc2f5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3c999531-6773-4522-bdb3-82304b5c8b7c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c5ac0c43-4530-451e-93aa-eb1b17ed3273)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a4695880-6b7f-4f35-b1c4-8dbdec56dbdb)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f0786aec-078e-4eaa-9576-57cef51ae911)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7b9c3942-d621-4458-b42b-7cd68092fb0b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8e4497f3-df7e-4173-859b-1d43e5b6816e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d2c4317a-b987-4731-8d42-0af212fbe236)(label(\"\\\"green\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a07645d0-73ba-4350-972c-ac3d7a98a349)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         259d1e0b-5ac1-48d2-8577-74d1bfff6cb8)(content(Whitespace\"\\n\"))))(Tile((id \
-         4cfdf853-21b3-4e1a-9c15-bf9d1db1d951)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         03236e56-029f-4f8f-8e03-ca7440fc38c1)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         145f32fb-bae6-42fa-9426-368a9752cfa2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5c70bb21-4378-40b9-84aa-dd826fe2c32a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9a8d4ac1-5e8f-40ad-a9e2-f308c320f018)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         504ed0e6-c5a4-4f86-a37d-0fd06458687d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b3f19336-dc19-40e3-9010-02dfbe6c38ae)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         32b3633e-fd60-4022-9b00-a3b2a59b9562)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0c1e41ec-8d96-422e-afa3-94f5d8fecb87)(content(Whitespace\" \
-         \"))))(Tile((id \
-         881c64bd-9d9c-4cfc-a75e-f4a4f4aa873c)(label(\"\\\"white\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4bab9eff-4ab0-4a84-99bc-bc29f2e1ae32)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e896a274-09fa-4d0a-8eed-ef774de77231)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a096477b-adcf-4dc9-aed9-c2759905a7c3)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b52ac0ab-89c7-4c18-a6c3-9afce1fee5ca)(content(Whitespace\" \
-         \"))))(Tile((id 40c2748e-8c68-4c5f-abb2-f3f2809d003c)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         cec47d96-2f9a-437f-8e2f-640d303f1806)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         7f207fde-1a99-40dc-9030-d7692f9b0e36)(label(name))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         9c3c8755-4e0d-42bf-9ad0-64b959d6592b)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d5da6613-cfe3-4707-8101-cf6823ad7b62)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         16aeaf8a-b39b-4eff-917b-2310e42098e1)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4e5011f6-547b-4921-8fd7-6235dca15f71)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9bb4726c-04f7-4f56-a913-4022506503c6)(label(age))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         40b792c8-8ff1-4c86-9f24-33340fa26bbe)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         9bb0cdc6-565d-4858-a6c7-64e71e0ab2b2)(label(OptInt))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         ece03eb6-9dfe-4125-97c1-640bfad1435d)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1572494f-66bf-41ae-839b-ba1e130ce677)(content(Whitespace\" \
-         \"))))(Tile((id \
-         455cc955-cc34-4f0a-a282-7a1ed75cb247)(label(favorite_color))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         ae63a2a4-3062-4db1-8051-4961343b2905)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         ddd75b0e-f7ed-4eab-8253-a00a0e00ff54)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         f01a7ed0-29c8-4eba-af35-09c85f135ade)(content(Whitespace\"\\n\")))))))))(Tile((id \
-         449fd447-a47e-4302-8735-55f2c6168a69)(label(\";\"))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
-         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ab09011b-992a-47ca-a23a-738d745ee715)(content(Whitespace\"\\n\"))))(Secondary((id \
-         068bf2f8-f4a5-41be-b629-ad382b5ad99f)(content(Comment\"# The \
-         idiomatic way to do this would be to just map the column. This gives \
-         you the schema safety. #\"))))(Secondary((id \
-         c8b7a19f-42ab-4053-80e2-dce2dd13f00d)(content(Whitespace\"\\n\"))))(Tile((id \
-         cda95015-f0a4-4836-ac9e-c964eaf2ebb1)(label(test end))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         b541e806-f7e7-46b3-a396-bc7e7e172090)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         973036bb-137d-45a8-a52b-71cbc5c985b1)(content(Whitespace\"\\n\"))))(Tile((id \
-         4b9d7e29-62aa-4737-9757-00464a956445)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         99c6e5ae-2988-4494-a42e-6d7cfd09d1dd)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         7b9b18dd-1a3c-4a08-87c3-c891a80faddd)(label(studentsMissing))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         08b92ae8-fad3-42b4-bdfd-8042f18dfdb5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f4ec69b0-939a-4f21-881a-1b9a9805898d)(content(Whitespace\"\\n\"))))(Tile((id \
-         c1fee1bb-e963-4372-ad49-9d38ea34096c)(label(fun ->))(mold((out \
+         01cf6d64-d181-4af8-a2df-20c63cb927de)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         585dec2a-554c-4c70-836a-9de87e6091b2)(content(Whitespace\"\\n\"))))(Tile((id \
+         9600337a-48e8-44de-852b-bc210972a09f)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         dae7c416-7c7d-4855-b120-42dd4b5ab5bb)(content(Whitespace\" \
+         2957f159-ec3a-4a3f-978c-b02066546dab)(content(Whitespace\" \
          \"))))(Tile((id \
-         2224dafd-54ba-47d8-8fdf-2fa75a9a9414)(label(\"(\"\")\"))(mold((out \
+         21c0ecf0-f05a-4d8a-9f39-81735ceb981a)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         8fd06213-fee3-4143-a136-480339a64678)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         a157787b-c591-4bf4-b38e-6f4cd4c96cc2)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         66e46173-5919-4d1a-b265-7db7a6570415)(content(Whitespace\" \
-         \"))))(Tile((id \
-         241fe068-a62b-4ad7-a45f-5745759af312)(label(StudentMissing))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         9da738ac-71b5-411b-a40a-75d143aed092)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         56a82627-53a2-46cd-a5d4-93e5189e385c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b94cef2a-5ecd-41bd-80e3-3255071c298b)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         97fd06e0-3568-4f09-bf22-a0db6c75cf55)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3d35679e-39ea-4646-ae8d-f76974280daf)(label(...))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         98dd9fde-46f1-4d52-9d4a-a0c557ed8b25)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f734b384-7155-42c3-a560-64b2a472731a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ffbca65c-9f66-478d-a6e8-93ffee1f28a4)(label(favorite_color))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e01f3d25-ff08-45c6-904f-16e4838f7010)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         1a617ce7-9d16-4624-964b-9aba7f4a9e8e)(label(case end))(mold((out \
-         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         1c64bd27-a24f-4148-b901-3c20cc743039)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2a4edbc9-7e23-4c76-bc68-7bb94b340dee)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ba6cd25f-ea9a-41c5-be0a-38eb9884805f)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         59859d4e-de9e-4141-adaf-1f42bbf1fd18)(label(favorite_color))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         e8f9a0c2-ddb7-4167-9e0c-edf9d5981535)(content(Whitespace\"\\n\"))))(Tile((id \
-         1c967101-ffcd-46be-8a93-77a156639f32)(label(| =>))(mold((out \
-         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
-         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         890def24-4d8d-4e82-8cd8-a94f79335855)(content(Whitespace\" \
-         \"))))(Tile((id \
-         474f1dbb-99ad-4a7e-a012-30dc9bdc1629)(label(None))(mold((out \
+         5e55d4db-d498-42af-a628-1626b4aaa8d1)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2a5e5a83-ad2b-457e-8c00-2e9f0d7cdd33)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         08b7801f-448e-486b-b80f-1254f17bf60d)(content(Whitespace\" \
+         49e419e0-bd04-40f8-9240-41ac842cdd45)(content(Whitespace\" \
          \"))))(Tile((id \
-         5afe0c38-a59f-448b-9cb0-dc39112e9c4c)(label(\"\\\"white\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         43f76c9e-5b2d-4261-b93c-962e22417fd8)(content(Whitespace\"\\n\"))))(Tile((id \
-         5dc7827b-fd9b-40c9-a84a-9ce1ba2a458f)(label(| =>))(mold((out \
-         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
-         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2af34c30-6f96-46c4-b5a0-dab718d342f3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         01c5a503-d862-4abf-ad50-afe7312a0d1b)(label(Some))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         e7bea13b-946c-45e5-bed0-88bc985ec889)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
-         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
-         2bb38db1-2dae-4786-9338-8e69289a8638)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         bea4b0fc-651d-4fe8-95c9-fdd06569e082)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         1df6c397-e913-4659-8c6d-60e41a5653d1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         75bedd72-27da-478b-8ce4-53bf31fbe719)(label(v))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         470cc3c3-d4e8-4ffb-8e98-19bc01b19750)(content(Whitespace\"\\n\")))))))))))))))))))(Secondary((id \
-         4b672ff7-d6d8-4480-a699-60c114cb7848)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9befa01e-3e24-43f8-8fcd-af17f8ae26c5)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         04bad14f-e389-439e-9a83-d6841ab6d537)(content(Whitespace\" \
-         \"))))(Tile((id 2ad0ea5b-7f3f-40d6-b9c7-c50e4f87cfce)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f29bf1b9-5ce4-4b01-b918-e594a36f8953)(content(Whitespace\"\\n\"))))(Tile((id \
-         fe6e2516-49b0-44d9-9b8f-5c1d6afd8551)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         3349de56-a703-45bd-a5b6-77d5bce60215)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         eb66ef27-9547-495d-96aa-f8d61e16ad53)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7763c6e0-b53a-44b8-90ef-d6721df54805)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ddd46755-6aaa-4864-91fc-43b9308849fd)(label(None))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e7f2a2b4-391a-4173-9d32-676f7b69b643)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0a1d4ab2-e9f5-46ff-9f19-fbfbcd3261c4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fa50235d-55c8-4aaf-b06c-0a801d3076b0)(label(\"\\\"blue\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a7560438-8cbd-4919-a57c-f4060d3ac920)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a16c2805-4c07-4644-86dc-ac037881a68a)(content(Whitespace\"\\n\"))))(Tile((id \
-         52809786-a4e2-427b-85a4-bbe8a561c55f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         cac7f647-dad0-4804-9d7d-3ac2880cbfb6)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0ca319e9-9d71-4791-be9d-da86678717be)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         befa8680-5311-4646-b8ba-91b6cf6f3442)(content(Whitespace\" \
-         \"))))(Tile((id \
-         06a5a001-b800-45ee-9f0b-2e908fad1331)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         180c934d-e1d0-4e8d-82d6-14bf481d9c53)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f81c9946-99a7-48b6-acb8-4b1e2b5af2cf)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         dab2439a-e7ec-4ec9-86ca-d457e5ce4068)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         be17eb8c-e552-45a6-b99d-d2cab2fe8068)(content(Whitespace\" \
-         \"))))(Tile((id \
-         86afbfb2-1418-4d0a-8dd5-7d537c90850e)(label(\"\\\"green\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d510dbae-e6dd-4e6d-a6b7-6d9db1e3f640)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1b7853d6-25b4-466a-b776-35aada570572)(content(Whitespace\"\\n\"))))(Tile((id \
-         939b48fc-1733-41d3-99f7-4fe947438b84)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         32e9f637-27a0-4af6-8efe-fddd93d25ebc)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         34b8af06-09f1-49db-b523-3f2ab9ee74b7)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f05ea9fc-162c-44f3-89b9-d7b0f7350cbd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cf84dfb4-14a3-4365-925f-ae7acd7822c7)(label(Some))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c4076ed7-13e3-4bf9-8d52-af61626a205d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         89f5d5be-f2ff-496f-bd17-c1a5ada013f3)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8887d9d4-3fb2-4daf-b45c-5709ada0d790)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         326b71b1-cbeb-43c5-bf9d-f234c476afc7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d8db2e86-ef67-4040-943e-cb1e0616c514)(label(\"\\\"white\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         649feb0d-4d64-4d11-af32-052d72fa1be2)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         f22f636f-082a-4ae0-b28b-f239ed3534e7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         abaa12b2-c431-43a1-8b79-b570b0df2182)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         49535deb-04aa-467f-bf1b-e9419d22edce)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bbab5fd3-7b16-4494-9654-66c6c38d4f47)(content(Whitespace\" \
-         \"))))(Tile((id 66eeda8c-9308-4318-912d-c711c00995c3)(label([ \
+         01e198c6-fca0-4f02-8fbe-4fac9e3ec0f9)(content(Whitespace\" \
+         \"))))(Tile((id 39aeed13-81b8-41aa-afd6-1d5c26aef806)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         9088e6fd-3b67-408d-92f6-4ae1bb01005c)(label(\"(\"\")\"))(mold((out \
+         4dd2d082-99c4-41b7-bcbb-06e8e19b50a8)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         56aee361-e101-44d0-adb7-13f54f7c2607)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         00b01c45-54b8-46d7-b999-bbbe3e139103)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2d4690c5-db12-43ed-8540-12ed5c04877c)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         39f085e2-2ddd-4cda-9712-0d8f15fa4f26)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9d0d29c9-44ae-4a06-b0ab-85316f47b2cf)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         40d19542-0935-4d3b-b334-440eb3aa6691)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b0fcabc9-0e73-46a1-93c0-ff4d9c9c1e13)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         7fa7c5aa-4332-4bcc-811b-a70955cf4fce)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         f343fe61-70e6-4c01-9149-37d1da63cf41)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a5e6c0eb-9bea-40fd-8be6-07401c733bff)(label(v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         8dc8d328-8974-43cd-a904-180a7d5b8626)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2a3b121c-5c0b-41f2-aabd-7dc183a52b0b)(content(Whitespace\"\\n\"))))(Tile((id \
+         68bbaa38-53dc-422e-ba00-561633ff88b2)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f67cd383-d324-4838-9280-315b452fd90f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c4fb8ddb-d570-4704-8928-0d284f246f87)(label(rows))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a59e944c-3ba4-43f5-a159-04f8c7520e84)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         a8e30505-286e-4e6e-bf39-b82bdb8ba12e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9ae0bcb3-0596-4250-820b-96252bfdaa75)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1adad4da-c2d7-4e09-9bd6-fa7ea76dc3aa)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         769e38dc-e190-45cd-ac95-95bd69218bc4)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         41a3f9b4-f0ef-4ea9-b417-2528f0344e9e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         67f98a19-0d83-4dea-a5a1-16e2340edb19)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0fc69a7e-148e-4c12-a236-8fb96ea336b8)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         ef5699dd-855e-43d1-86e7-5098a13b959d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         62ecd1eb-4f67-450f-af95-e5fdae111e19)(content(Whitespace\"\\n\"))))(Tile((id \
+         9577f6ae-cfcd-4547-9f3e-13143d9b9054)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         20a3d140-9d5c-4339-8583-374c3d8dbbd3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         feb9b44b-6510-4618-9f57-1846287e68ea)(label(mapped))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         d782ee12-2f17-4440-950f-40b17bd9aa3f)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         59dd5951-c1a7-4842-ad62-0d5bf029afbc)(content(Whitespace\"\\n\"))))(Tile((id \
+         b2017164-8648-4db5-a066-f3386bf1f316)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         44e878b4-ca74-4532-a9cc-43c42a1888ee)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         c0df0ad8-fa42-4673-ab52-b0c10c735404)(content(Whitespace\"\\n\"))))(Tile((id \
+         2a1344ea-ec47-40c5-bd21-aace641f37ba)(label(rows))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         eac70f6f-b7e8-4228-845d-d22eb1b9f1ed)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b8b8a971-20f0-4710-a117-561677d9e7b4)(content(Whitespace\"\\n\"))))(Tile((id \
+         f0522cfe-c529-4dcc-b226-3c0e261384fb)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         b30580af-4cf4-491d-80a6-98f8c7838e8e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fef76803-c46a-4a6e-88d0-a79685ef6cde)(label(entries))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         429b0e38-4209-4821-9d64-6e233ccea81b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ff045fd3-85dd-4932-897e-6a0c9e6f8743)(content(Whitespace\"\\n\"))))(Tile((id \
+         149f2920-e6c1-434f-a370-d3eeb836ccc8)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a71a6879-1ed9-4485-b123-d82e71a45ad2)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         85b786cf-017a-4039-8198-9ab2d1bef377)(content(Whitespace\"\\n\"))))(Tile((id \
+         ed29fb1e-1f94-4d9c-9a11-a70017b34685)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e99e3acb-e4dc-48a8-a190-aa25d51a51b2)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         f0f33116-e5ac-48cd-942f-5847df423b9a)(label(entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         622fff95-842d-4b74-b65e-e8f337633cc0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9a5b8336-69fc-4d3e-ad6d-9f1a1945a5c6)(content(Whitespace\" \
+         \"))))(Tile((id 5a3957b7-4de2-45a5-982d-445b4c3a1d17)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         e1e73cad-997e-4f90-8063-cec183a171e1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         af9b5874-a75a-4783-9c36-20d4aaef80c1)(label(e))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1580970f-3317-4084-998e-f145dc0137e2)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9f18a937-ad7d-421c-bd13-4858d6647e68)(content(Whitespace\" \
+         \"))))(Tile((id \
+         01b765f5-42e1-4eef-9523-f3ab03fbdff2)(label(!))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         97bbb8f5-6296-4ca5-8c23-c03b0a422bc0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5b1a535d-1063-4365-9cbf-1ead185f9986)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         1ecccb50-bff7-46f9-87b6-d947febe421d)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cfb5a53a-856d-406b-a1e6-bb5b71bc8449)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         9a9d6152-833e-40a1-8383-fb4f10e4ed58)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         47f6eb35-c7aa-4cdc-858f-9d1eedb00cad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d2bc8d52-b5fe-4d6d-a107-d0adb6eb070a)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6353b7d9-65e2-462a-b05b-d4f686f5a0f3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fe74fd64-e3f7-44c4-91ad-313a31784859)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         535782f1-f3de-42ff-a043-4400d1e4ec25)(content(Whitespace\"\\n\"))))(Tile((id \
+         025341fe-b7d6-48f7-a974-b0dc5d87e4d5)(label(@))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
+         30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ccac3f64-b9e6-4091-80bc-ddf7a5487f56)(content(Whitespace\" \
+         \"))))(Tile((id 7b899746-db89-4797-abd9-47bd9e1fe1cc)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e9425457-fc36-4439-8486-db5772f1d24f)(content(Whitespace\"\\n\"))))(Tile((id \
+         a899cb60-e0ba-4d9f-b435-966b02b0e612)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         829419c1-d9af-4155-bda8-03ce17c007a5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         54c1bae3-f873-453e-ba54-a14ad03cc2f6)(label(option_bind))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         695e0845-eddb-444d-80ff-87b63d48e6ee)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         c5b16821-c1d7-4d89-b080-0af6ef6b53ec)(label(find_opt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cfc08b22-9953-48e4-b879-885bb42e7de0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         7eacc835-3ff8-4fd1-8ace-00d4ee82e5af)(label(entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cf32a402-0d2d-491e-823d-65e24240b5e6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d18e3861-f22b-479a-a78f-d5ea16300916)(content(Whitespace\" \
+         \"))))(Tile((id 551390a8-8103-4eed-9398-ed70736e8543)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         af805f70-b789-42b7-ac46-4bb74f0d3a45)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ae4aa306-0e47-4413-9d6b-9e3133192bd5)(label(e))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         bee1395d-d130-465c-b38f-65d325f5f3ef)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         313966f8-27f4-4e0c-87f8-6c0a3ecf9771)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a8ffa749-c646-4128-ace7-68bb8b82ed0d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ba5a7b10-bc2e-44e5-af2f-c4f7e2b9e025)(label(e))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         91ea6c6a-6466-4cc8-b1f4-03c56a655f7d)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         2c1175d3-9d09-4bdb-95f4-5c8d6d8ffa68)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         5cfae5ed-a5ca-4277-a90b-1c0d3c6e550f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2b900f82-5b2d-4987-b2d1-5f1d80918a32)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         eb3999a3-5baa-4f44-830c-21f025ef41b4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f2a9ab40-5fa7-4e25-9b5b-d4f50dba18f2)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Tile((id \
+         a615a961-fcaa-4ac5-893d-ba6fdf06104b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7a11a3e5-e9db-4783-a703-8e338324c15a)(content(Whitespace\" \
+         \"))))(Tile((id 436aa021-f06f-452d-8344-2d647a2277d6)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         5280553f-bbfb-41aa-8df3-fc7bc4855f9d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         57368aeb-40f1-409d-8d8a-6e7ff806a348)(label(x))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4fe3d60e-c396-42b6-ba27-95e412ba4b4a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         57c08c91-c2dc-4f26-ae91-4d8c387404b4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         722dcc17-3653-4c2a-9967-966eca696a54)(label(x))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6405a389-e894-4cd3-a67d-1557b9c737c3)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         5c50fc36-ad38-4d2d-94d2-52313aace27d)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         c75021be-9278-4d35-ba35-7dc646157ad0)(content(Whitespace\"\\n\"))))(Tile((id \
+         411edb76-ae91-41c2-b460-4ce3b4e792f5)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         7f353c29-53ed-4827-8caa-e630b831e089)(content(Whitespace\" \
+         \"))))(Tile((id \
+         162526c3-1150-4369-a89d-1fa4f19b17a3)(label(None))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3789da2e-a76b-4138-85ea-ffe73b9cbed4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         67fbdab1-9003-4335-8d47-7ecac10916b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e41f1ed1-1908-457a-a514-e8f4b07daf15)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         f8a7ee34-3f30-41e3-947f-65ed3255f880)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c70291ea-0881-4d17-81eb-b4a1a1c01fd0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cee6aae8-e5b7-425a-8b61-4d64f8267471)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cf593ad0-00bd-438c-86ed-5f8430b65892)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2d104754-8efa-40c3-86c4-b6fb2ea4b0af)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9e8c4922-1473-425c-93d6-6d785dab44ba)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9b546406-28d8-4241-a99a-d24ee92db04c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         85d76568-b475-4a82-84a2-71c792daaf4d)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e57a1080-61c9-493a-9b5c-d8991c3023ab)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f67ea267-609c-4d32-b71c-39eaaf0a9878)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e4ca5f66-0324-48e9-abb4-c8f999325a21)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8d58f5dd-74eb-4a91-8d6b-d063f9ac005c)(label(v))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         6a308f63-ce52-4ef7-a0f2-7949ea6b599e)(content(Whitespace\"\\n\"))))(Tile((id \
+         5c114e33-b26e-462e-8332-6d4c0b808801)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         c3a90196-91d8-47d5-896a-bbcee08389cf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d5fd91ff-d0a2-4114-9893-2830bef827b3)(label(Some))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         44a9956a-fddb-4a9d-b2e4-7e3992ac5f15)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
+         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
+         20a57d73-40fe-4cdc-831f-894d9cab9bdc)(label(v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         5b740807-74b7-4d5b-80f6-e065e868c6be)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         304929b1-9f4c-4667-a396-54ab41504f80)(content(Whitespace\" \
+         \"))))(Tile((id \
+         51718b81-daaa-4ea9-b5b2-7184e216d0b6)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ca2b1b06-d376-4325-8b3b-f058a4d31c6e)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b2fceb9f-f01e-4663-8a88-8a74080a29b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         388e0a22-945f-440a-b635-ca48ae416036)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b6608ae8-99c9-45af-9afc-9b68c9acaa97)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3ba20e3a-a7d9-47d9-8c48-7490c0d3429d)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3a2e3aa0-66e1-4013-931f-37fc7975b614)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         53d1bae1-e3f3-4e23-973d-546d9e7081d1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8b63a05f-40f1-4cad-a1c4-8323d187b874)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2cdbded5-43c8-4a10-80a4-8fafc98d640f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         de2308ee-00b9-4474-948e-ff2acafae8da)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         834cce42-681c-4fd9-8df6-e34bd79fbf8e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4c46cf2c-2f75-42f4-a64f-a46a8b9904b8)(label(v))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         f621469a-b71e-437f-b0e5-729025351a9f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         cc471fe4-7f73-49c3-a2c7-8fb69f7c49a6)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         2815272b-0815-40be-93ef-e89131144804)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         f9a6b391-eecb-43e0-92e3-d1e8b41cee2b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         0064eb29-3cb6-4b11-91ce-103e506b48ec)(content(Whitespace\"\\n\"))))(Tile((id \
+         def2b4c3-c775-4632-bc7d-f2400a6126b3)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1b25867b-ebc8-4374-852d-5f38f21ec950)(content(Whitespace\" \
+         \"))))(Tile((id 9b53b8cc-6b65-40c6-bec6-6d8778a10591)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         66692e2d-991c-497a-b3d7-c6d68e2ad909)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         e2c29463-09ef-4c8f-970c-9cffc3d0a3fd)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         03eb2998-914a-42ce-84e1-8eccf3a1bee8)(content(Whitespace\"\\n\"))))(Tile((id \
+         1301f301-6286-487d-8fa1-439a7815930e)(label(mapped))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ea86b4f8-facc-4aeb-a557-abbcac0e6770)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e64925ae-603d-45df-aeff-6e0eb2b89901)(content(Whitespace\"\\n\"))))(Tile((id \
+         59da67c1-5b7a-437a-a823-0626d9edde51)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         9d14b0c5-4d37-47cd-9f4f-062a327e879f)(content(Whitespace\"\\n\"))))(Tile((id \
+         4c2b9a60-d671-4c5e-8bfe-7ecee610c658)(label(fillna))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8022ad39-1c54-43e7-ab54-85536e24ffe9)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         b13cdfdd-fa31-4d63-9380-ae243ff191c0)(label(studentsMissing))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         373c849c-38bd-4ac3-8510-d793b671e37d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ed8d54d3-fd3e-409e-8efd-3a104d523885)(content(Whitespace\" \
+         \"))))(Tile((id \
+         44613278-5db5-4672-9cc3-998006e94bba)(label(\"\\\"favorite_color\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         561d26e6-7ad8-47ce-86cb-be9018fbbd4b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e6115355-862d-406c-8264-6c00503f963f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a2748a29-3871-436f-85f8-0c7ff650efa8)(label(\"\\\"white\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         b6cbb0c6-d737-4cb9-888b-1a61ac051be1)(content(Whitespace\"\\n\"))))(Tile((id \
+         755bf186-2655-4803-b4f0-fea4e08c64d4)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         de32284f-d455-4bb2-b083-3ee8cbf76166)(content(Whitespace\" \
+         \"))))(Tile((id 778896d9-4faf-4705-9465-48a931c14dbc)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         41e72d5c-74a3-4003-99e0-59fcb446cb2f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         11947539-12a8-4ded-bd18-54a6ef226789)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d04ff73d-9f77-4afa-90c3-a1c8fc86a6fd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         57523f17-b01b-4f4b-85c3-5b593f9d0b84)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d0ff37c2-af35-4658-8715-64da1562a0eb)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         299e400f-dd51-44bf-9767-63ef9ec53340)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         191efa2f-760a-4464-8aaf-b3335dbd710c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a2fba811-f533-429a-8f21-eba4d78cd1de)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         f66dfe0e-0a5c-4582-9675-8c968ce13886)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9e7315c2-9c0e-4373-892b-80dd4f02ddf0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f92cade7-6268-40dd-8689-98805edb4e5a)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         8b1d75c6-3df1-44a2-b400-d07be7caab14)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         05eb2c05-0040-40d1-8d5b-9b78b54d75f1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         71d7fe6f-fa51-4e1d-a26c-be749bbc1539)(content(Whitespace\" \
+         \"))))(Tile((id \
+         50f48b37-90c6-42f2-949b-907aa0a21417)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6433fc23-5ad1-407c-99e9-0bece4843331)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         57838db3-cc0a-405a-acd9-5129ed40c289)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         654f3cda-f3fc-45dd-9a35-d9adf9835cd6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0b23fbf5-3c9a-4a65-9daa-82f8753a1784)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aec28124-0b36-4100-8469-3ffdf366b1cf)(label(\"\\\"green\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         96430848-90c8-4fbb-ba96-ef468f52a22a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8742dfc4-dcd5-426e-853d-f852799052fe)(content(Whitespace\" \
+         \"))))(Tile((id \
+         08518d36-50a5-46c5-8e4a-822cfa82a568)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         40f80b9f-c847-47a4-bacb-c2f023645ead)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8521ccff-bd80-4eb1-adc1-1932ea8a8c63)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         45a18831-7e43-41c3-917e-2731d31292a1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d7ea937d-3f84-40c8-8976-d7465a465cf7)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6608a283-81ea-4cfc-908b-05600eb351e0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         591ec957-18da-44c1-a11d-bf0404720b1d)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         f9022c60-d01b-4d45-a98f-82e775afd5d3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f22ee6ea-9ae6-410c-8bc2-d640f9f1b9a6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f3d826e6-a050-4770-8fc3-f55d19b86077)(label(\"\\\"white\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         d37d0b51-f3ca-4d38-ab97-5f86c78866eb)(content(Whitespace\"\\n\"))))(Tile((id \
+         166648cc-2389-4f6f-80d5-f5dd0e3e04d9)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         25a73479-2205-4a5a-a884-61d714b1fe43)(content(Whitespace\" \
+         \"))))(Tile((id 3d5db08a-9449-470a-8a35-cd7a9353dcb1)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         1671174f-fd21-46bf-a56d-4f70eadfcb2b)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         f416ce58-1b32-4bc5-a402-1d52ca652e21)(label(name))(mold((out \
+         eaf45997-cbca-420b-9537-3bd292a8fffd)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         eeea576c-9df7-436b-94c5-fa77ca26b313)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         72fe809e-79ae-4736-b41d-b0103b551663)(content(Whitespace\" \
+         \"))))(Tile((id \
+         20346708-2fab-466e-8d75-f7bac55280bb)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         a7fe0b40-045a-44b7-9e87-444a273e2332)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d3339661-0b68-4674-9cff-7efe289c32fa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6b37f798-923c-45aa-9522-a8554768f97d)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         d6c6da7a-ed3d-4207-ae0f-3136ea1d5201)(label(,))(mold((out \
+         32cca998-2a38-4f2b-829c-ea89b225b228)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9ed49494-acef-4f23-a5de-8d56977c7a1f)(content(Whitespace\" \
+         e8abf448-0e2b-4fdf-b46f-8fc83efb579c)(content(Whitespace\" \
          \"))))(Tile((id \
-         2f05e577-7289-4cb1-b1b6-46e30ba806db)(label(age))(mold((out \
+         e488352e-ebfa-4476-b84f-b84d67b36331)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         f094f344-1edc-4000-b8c4-80a00b2d49f8)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         949a6f22-653b-4b85-9521-cef38d1d7aad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aca7f424-59a2-4c46-8b36-e34c25870f91)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         30659145-6a6b-4c5b-ab76-a04ac7c39a15)(label(OptInt))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d6498d3f-c7a5-4b7e-afc7-50b660c91960)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d48ecc84-6a9b-4712-a296-b8f5dfc08c66)(label(OptInt))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         fb46d21a-ab16-4ef0-928a-bdc732b7bc26)(label(,))(mold((out \
+         c2ce2c6a-ebbf-424f-8d3f-d117375ccf3f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0965bef4-c0ea-4433-a955-d0df0ba6217b)(content(Whitespace\" \
+         4c4af351-9a9d-45c6-9f28-1a09aaa1cfb1)(content(Whitespace\" \
          \"))))(Tile((id \
-         7ac571d5-c407-44ba-993d-eccfdc8a63a5)(label(favorite_color))(mold((out \
+         c54fd5ee-1084-48cd-8014-3bd0cbbe5189)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         8e9a8f3d-bea7-46b8-a83e-3dbfe5d72465)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a10fc267-1fad-4450-a270-12e26f1f4c44)(content(Whitespace\" \
+         \"))))(Tile((id \
+         393b8647-eef5-4e9a-85ff-8aa258d7a813)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d9a3d156-0746-42ca-8089-7f74767f681e)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6370740e-9399-4c4c-a14a-0f6ec0cf00ac)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2c40c730-4271-4357-89ef-62db56eac753)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         448117bc-2529-4470-a08a-0141e38b6413)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         fccee20e-5d63-41b2-a8c3-b573c9c31b54)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e7fbd703-937c-40eb-8b46-9a48500595c4)(content(Whitespace\" \
-         \"))))(Grout((id 89e21385-b080-41f4-bd3d-1159c364b645)(shape \
-         Convex))))";
+         a8d50df9-fdcf-4625-8853-fcc9dc34e526)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         07ae6a74-de0e-4c6a-be05-bb80619e92ba)(label(\";\"))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
+         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         65bec672-0ad2-4a95-8bf7-1b4c0b2b1e70)(content(Whitespace\"\\n\"))))(Secondary((id \
+         8236aec3-3041-4f8a-8749-d6c0ec4091be)(content(Comment\"# The \
+         idiomatic way to do this would be to just map the column. This gives \
+         you the schema safety. #\"))))(Secondary((id \
+         e2921926-2135-48b6-aed3-963964835c75)(content(Whitespace\"\\n\"))))(Tile((id \
+         708660dd-d6a2-4e0a-a130-0a37519d13b6)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         1d3c15cd-ccb7-4f0c-b36b-0ff2dc0cf022)(content(Whitespace\"\\n\"))))(Tile((id \
+         44a8e874-a91e-494e-b18d-52319007533f)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1183bf00-3d6c-4d68-a7fa-8d4cb1c6c78c)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         19853632-9986-41bc-8687-ac8d2844d04d)(content(Whitespace\"\\n\"))))(Tile((id \
+         720f90e8-e761-415c-99b1-6d39013aed0a)(label(studentsMissing))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         890027ff-2682-4d6d-a75c-77533daa3b8a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5a51ffb9-bc23-42e1-9d54-76299f47eae5)(content(Whitespace\"\\n\"))))(Tile((id \
+         4eec99a5-4c4f-4916-ba92-cd41d31640bf)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         80d34628-b18c-487b-9b03-ffd759edeb53)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2e0dd88b-cd9c-44ee-8f37-fdc295f21645)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         8d11da1d-c43d-4fe6-a80a-15e3382b9609)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3afb0ebf-e7ae-48c4-813f-903a0b92a963)(content(Whitespace\" \
+         \"))))(Tile((id \
+         915e7c03-1ed8-4e79-9ffc-d7f1344e9a82)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a90ace98-48b7-4e4b-b8a7-2346ccba785d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         11813b3f-4c1d-4e4b-b4e9-2f279e64e7dc)(label(StudentMissing))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         6e688a3a-e608-451c-a343-6f33a3465fd9)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9949f306-7b22-4761-bffe-9c5addba5981)(content(Whitespace\"\\n\"))))(Tile((id \
+         1602b20d-964e-408c-8140-0843693eb2c4)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         26df126a-3c4c-4234-a565-a335928d9e8e)(content(Whitespace\"\\n\"))))(Tile((id \
+         aa638c18-d3ac-44ca-8e4c-694acc21d3b0)(label(...))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         52486cac-820f-4a8c-a2db-cbc8db8ae850)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e0d59d4f-b62c-4e06-a9ae-3354138a6563)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         021596ed-79ab-461d-bdf8-027cc6e01cd9)(content(Whitespace\"\\n\"))))(Tile((id \
+         141d7051-3939-4f5d-80fe-31dcfd9dea64)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         002b159e-88ad-4250-821b-e6bd71255a97)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7035de9c-d93f-4f63-afa7-f44c773d3a16)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         de6b690d-537f-4a46-bf33-a2cf7a4a4a87)(content(Whitespace\"\\n\"))))(Tile((id \
+         785254fb-ab87-4db2-a119-8ca89b933e46)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         5936c26d-816a-4905-9d9f-6ce8c881e3f1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         27f5ea52-5ff4-44d6-92e5-7338b20a08fe)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ce8df28f-a08b-4ea1-aac1-ed4090047b62)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         a1b3c6db-4e8e-4af6-a5e7-032d186453ef)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         33168183-f26c-481a-92e1-5fc01530ded4)(content(Whitespace\"\\n\"))))(Tile((id \
+         f53f7259-0fa7-4e5e-bf8f-8709bcb5d15e)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         365b5a18-ec27-4092-9f39-89f85120d912)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dc34b030-a2f9-4fa3-b578-8ef254db6c28)(label(None))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         584cf47d-80ac-47f7-9003-27c8aaaffad5)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         b1e015c6-2600-4ecb-889e-a34c82431a12)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8e829fe8-dff0-4b50-bcf6-0262f1264be4)(label(\"\\\"white\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         db3818e3-0f5c-4d71-95f2-c6c7c293f69c)(content(Whitespace\"\\n\"))))(Tile((id \
+         9fc09b2c-f51a-4946-99e7-53d20ec949e5)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         1bfd58bf-0f00-4c69-af7f-03a46d95dd86)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0cfb92e9-1aa8-4ca3-88b4-c1cfe924d53e)(label(Some))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         bb319648-a234-4975-b20c-001a6c449396)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape(Concave 23))(sort Pat))((shape \
+         Convex)(sort Pat))))))(shards(0 1))(children(((Tile((id \
+         844ecc59-3466-4338-93e2-2cee25317e61)(label(v))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         c758ff1a-db69-4267-ae20-512565d94009)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         498b8726-1bf3-4c1b-a9c0-0af6d50d4d32)(content(Whitespace\" \
+         \"))))(Tile((id \
+         20252933-37e1-4a97-908a-fe36928f5edf)(label(v))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b2e18907-e7bc-4692-acb7-4a2f0ca58688)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         aa5abd8e-a5ce-4ad9-998a-ed3b69ff0ec1)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         f822c74d-5da1-4776-a2fe-686b5c2a2d7f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c0e91693-ce91-4ff4-9e06-d340e5250fb6)(content(Whitespace\"\\n\"))))(Tile((id \
+         3d41fc50-e906-420c-a489-c3c9efc26734)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         af074815-4bd5-4680-b975-8fe763808119)(content(Whitespace\" \
+         \"))))(Tile((id 6e2d2d2f-b04a-49b1-bd24-9713afeaab80)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0d8455af-9bc4-465a-9668-e543b716f1ce)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         5701060c-75ef-482c-bc62-cad96e0b73ba)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9c48f975-229a-4a2f-8cf7-e77a5f94ef58)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a91f13ac-fe40-443c-8da9-1aac6a5c33a8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d3d0163b-4db0-433c-8725-ee1a83362e41)(label(None))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         10e2f24d-f20c-48a0-871e-4745f6a1e5c8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6d657794-8b48-4574-9d96-1fe69e247454)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b734528a-8858-4ff8-90fb-e2ea20f042a3)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         28b5999c-c973-4ab8-bf7a-ea561c3b702a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         488231bc-8a74-4b81-8065-c2986db8516b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         44e8d712-9f13-4c5c-9449-170bf861ddc0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         28ce8ae2-68ca-46d6-bf9f-a06ff16047c8)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a0dbccb5-3b32-4d47-a038-9a5af67664a5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2afdf2c9-f893-4a01-a0f3-db096a165483)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0f0eae55-0543-4c7e-8def-1c98c9c74447)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c995eb0f-eebd-429e-9c29-0163aab1d8a3)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         56ded5d4-6e42-4e50-bec4-b0eb09291afd)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         e21e3f08-eca9-4c4d-8c8f-ed82652a8813)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b92f9c35-703d-49cb-8e04-611bca07b5a7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7b9f2809-bf99-4cf1-b1cd-ec26024b1e1d)(label(\"\\\"green\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         6fe532b2-58e1-4054-97f5-51a0fb526a6e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7a299543-059c-4b6c-95dc-680ab15f2e6d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6a2c1a6f-b3a8-4669-a29d-4f090948f15b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         eb281064-40eb-407c-8b40-d6c5d174d809)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9858e033-17e4-4930-866c-c84b343a2f4b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7285877c-3c46-4b89-baa7-9e349bf84f4d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         443a5395-f798-477e-9242-40de12194237)(label(Some))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         974640b9-fe32-4727-8eda-dc8a931a5a74)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         57cd5d49-f8be-4226-9620-8704cfa7e72c)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         4c0b6da3-85ac-4de7-848d-3ecee0dc029c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a8a1f4c8-f4d9-4149-a0f0-72852fdc935e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3107b313-89f1-4260-9ced-3de3f9513e16)(label(\"\\\"white\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         f952f782-2edc-4f51-8b75-3fbaaa0bc033)(content(Whitespace\"\\n\"))))(Tile((id \
+         f1512af3-aa6b-4073-84b2-33e43b7fa22c)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4c38647d-b55c-4598-9745-a70efeead5e3)(content(Whitespace\" \
+         \"))))(Tile((id 092cb632-6196-4275-909d-c0c5e0816020)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         c320d65d-db3d-4401-ae42-2bb1fb37cd06)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         e70564df-cb70-4479-9769-7eb6f5893d01)(label(name))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0569d03d-a880-4afa-8361-3c33904aa156)(content(Whitespace\" \
+         \"))))(Tile((id \
+         88f38f68-088a-418b-a00a-0d9ac0f7d1a3)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         072bb836-321f-4bd7-ab51-fe327387a113)(content(Whitespace\" \
+         \"))))(Tile((id \
+         22c5413f-1be3-4c84-aa3f-3c5c7b4da9d5)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         c79d1d77-62c5-42cb-89c6-db3dbeb90c1e)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d300688e-e3f7-4411-a92b-5e828d96416a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         78d6f37e-acbf-44a4-8678-03a1bc23ef7b)(label(age))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         46669e6a-d5f8-4a34-b1e9-e07597a1cfea)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f96208ca-8adb-48a7-88b1-ca61d3d68304)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dec43a4c-8732-46fd-9d67-c80576f4529e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7b55aee7-2392-4fe4-bc8c-bece169a1550)(label(OptInt))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         dce2a213-379b-4f36-8c45-58bb23e7e9a9)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         64c51f08-1a4a-423c-b4e6-0a34b690c981)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e8a61591-3ff8-4b79-9ed2-c457aa9ed09a)(label(favorite_color))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6576759b-40af-46ac-a451-1789511d90e2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8e594236-d36e-458b-84de-8d2efe6e0e67)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         af0b57f2-a4c0-4b1c-9505-4727dee741dc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f38e72d4-c7ac-4542-ba1d-5f8867b9922c)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         0ec85f76-7007-4828-9174-20b2a20fca4b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e4a10c99-7172-4c45-9dbf-72552064fd29)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         25087b01-aa57-44e8-84aa-8f01e7e1dfbe)(content(Whitespace\"\\n\"))))(Tile((id \
+         beaf0521-1983-45a1-9ef0-b22aac985467)(label(?))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type OptInt = +None +Some(Int) in\n\
-         type OptString = +None +Some(String) in\n\
-         type StudentMissing = (name=String, age=OptInt, \
-         favorite_color=OptString) in\n\
+        "type OptInt = + None + Some(Int) in\n\
+         type OptString = + None + Some(String) in\n\
+         type StudentMissing = (name = String, age = OptInt, favorite_color = \
+         OptString) in\n\
          let studentsMissing : [StudentMissing] = ^^fold([\n\
-         (\"Bob\", None, Some(\"blue\")),\n\
-         (\"Alice\", Some(17), Some(\"green\")),\n\
-         (\"Eve\", Some(13), None)\n\
+        \  (\"Bob\", None, Some(\"blue\")),\n\
+        \  (\"Alice\", Some(17), Some(\"green\")),\n\
+        \  (\"Eve\", Some(13), None)\n\
          ]) in\n\
-         let complete_cases = \n\
+         let complete_cases =\n\
          # Instead of taking a colName we're taking a project function to make \
          it type-safe. #\n\
          # This only works for option columns #\n\
-         let requires=[(enforced=^^check(true), \"c is in header(t)\")] in\n\
-         let ensures=[(enforced=^^check(false), \"length(bs) is equal to \
+         let _requires = [(enforced = ^^check(true), \"c is in header(t)\")] in\n\
+         let _ensures = [(enforced = ^^check(false), \"length(bs) is equal to \
          nrows(t)\")] in\n\
-         let complete_cases = typfun R -> typfun C -> fun (t:[R], project:(R \
-         -> +None +Some(C))) ->\n\
-         map(t, fun (r : R) -> case project(r)\n\
+         let complete_cases =\n\
+         typfun R ->\n\
+         typfun C ->\n\
+         fun (t : [R], project : (R -> + None + Some(C))) ->\n\
+         map(\n\
+         t,\n\
+         fun (r : R) ->\n\
+         case project(r)\n\
          | Some(_) => true\n\
          | None => false\n\
-         end):[Bool] in\n\n\
-         test complete_cases@<StudentMissing>@<Int>(studentsMissing, fun r -> \
-         r.age) == [false, true, true] : [Bool] end\n\
-         in\n\
+         end\n\
+         )\n\
+         : [Bool] in\n\
+         test\n\
+         complete_cases@<StudentMissing>@<Int>(studentsMissing, fun r -> \
+         r.age) == [false, true, true] : [Bool] end in\n\
          let dropna =\n\
          # This only works if every column in the dataset was optional \
          otherwise it will get stuck in indet #\n\
-         let requires=[] in\n\
-         let ensures=[(enforced=^^check(true), \"schema(t2) is equal to \
+         let _requires = [] in\n\
+         let _ensures = [(enforced = ^^check(true), \"schema(t2) is equal to \
          schema(t1)\")] in\n\
-         let dropna = typfun R -> fun (t1 : [R]) -> filter(t1, fun row -> \
-         !any(to_lvs(row), fun e -> e.value == (None : Option))) : [R] in\n\
-         type StudentFullyOptional = (name=OptString, age=OptInt, \
-         favorite_color=OptString) in\n\
+         let dropna = typfun R -> fun (t1 : [R]) -> filter(t1, fun row -> ! \
+         any(to_lvs(row), fun e -> e.value == (None : Option))) : [R] in\n\
+         type StudentFullyOptional = (name = OptString, age = OptInt, \
+         favorite_color = OptString) in\n\
          let students_fully_optional : [StudentFullyOptional] = ^^fold([\n\
-         (Some(\"Bob\"), None, Some(\"blue\")),\n\
-         (Some(\"Alice\"), Some(17), Some(\"green\")),\n\
-         (Some(\"Eve\"), Some(13), None)\n\
-         ]) in\n\
-         test dropna@<(name=OptString, age=OptInt, \
-         favorite_color=OptString)>(students_fully_optional) == [\n\
-         (Some(\"Alice\"), Some(17), Some(\"green\"))\n\
-         ] : [(name=OptString, age=OptInt, favorite_color=OptString)] end\n\
-         in \n\
+        \    (Some(\"Bob\"), None, Some(\"blue\")),\n\
+        \    (Some(\"Alice\"), Some(17), Some(\"green\")),\n\
+        \    (Some(\"Eve\"), Some(13), None)\n\
+        \  ]) in\n\
+         test\n\
+         dropna@<(name = OptString, age = OptInt, favorite_color = \
+         OptString)>(students_fully_optional)\n\
+         == [(Some(\"Alice\"), Some(17), Some(\"green\"))] : [(name = \
+         OptString, age = OptInt, favorite_color = OptString)] end in\n\
          let fillna =\n\
-         let requires=[\n\
-         (enforced=^^check(false), \"c is in header(t1)\"),\n\
-         (enforced=^^check(false), \"v is of sort schema(t1)[c]\")\n\
-         ] in\n\
-         let ensures=[\n\
-         (enforced=^^check(false), \"schema(t2) is equal to schema(t1)\"),\n\
-         (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
-         ] in\n\n\
-         let fillna = fun (t1 : [?], c : String, v) ->\n\
+         let _requires = [(enforced=^^check(false), \"c is in header(t1)\"), \
+         (enforced = ^^check(false), \"v is of sort schema(t1)[c]\")] in\n\
+         let _ensures = [(enforced=^^check(false), \"schema(t2) is equal to \
+         schema(t1)\"), (enforced = ^^check(false), \"nrows(t2) is equal to \
+         nrows(t1)\")] in\n\
+         let fillna =\n\
+         fun (t1 : [?], c : String, v) ->\n\
          let rows = map(t1, to_lvs) in\n\
-         let mapped = map(rows, fun entries ->\n\
-         from_lvs(filter(entries, fun e -> !string_eq(e.label, c))\n\
-         @[\n\
-         case option_bind(find_opt(entries, fun e -> string_eq(e.label, c)), \
-         fun x -> x.value)\n\
-         | None => (label=c, value=v)\n\
-         | Some(v) => (label=c, value=v)\n\
+         let mapped =\n\
+         map(\n\
+         rows,\n\
+         fun entries ->\n\
+         from_lvs(\n\
+         filter(entries, fun e -> ! (e.label == c))\n\
+         @ [\n\
+         case option_bind(find_opt(entries, fun e -> (e.label == c)), fun x -> \
+         x.value)\n\
+         | None => (label = c, value = v)\n\
+         | Some(v) => (label = c, value = v)\n\
          end\n\
-         ])\n\
-         ) : [?] in mapped in\n\n\
-         test fillna(studentsMissing, \"favorite_color\", \"white\") == [\n\
-         (\"Bob\", None, \"blue\"),\n\
-         (\"Alice\", Some(17), \"green\"),\n\
-         (\"Eve\", Some(13), \"white\")\n\
-         ] : [(name=String, age=OptInt, favorite_color=String)]\n\
-         end;\n\
+         ]\n\
+         )\n\
+         )\n\
+         : [?] in\n\
+         mapped in\n\
+         test\n\
+         fillna(studentsMissing, \"favorite_color\", \"white\")\n\
+         == [(\"Bob\", None, \"blue\"), (\"Alice\", Some(17), \"green\"), \
+         (\"Eve\", Some(13), \"white\")]\n\
+         : [(name = String, age = OptInt, favorite_color = String)] end;\n\
          # The idiomatic way to do this would be to just map the column. This \
          gives you the schema safety. #\n\
-         test \n\
-         map(studentsMissing,\n\
-         fun (r: StudentMissing) -> r ... (favorite_color=case r.favorite_color\n\
+         test\n\
+         map(\n\
+         studentsMissing,\n\
+         fun (r : StudentMissing) ->\n\
+         r\n\
+         ... (\n\
+         favorite_color =\n\
+         case r.favorite_color\n\
          | None => \"white\"\n\
          | Some(v) => v\n\
-         end)) == [\n\
-         (\"Bob\", None, \"blue\"),\n\
-         (\"Alice\", Some(17), \"green\"),\n\
-         (\"Eve\", Some(13), \"white\")\n\
-         ] : [(name=String, age=OptInt, favorite_color=String)]\n\
          end\n\
-         in ";
+         )\n\
+         )\n\
+         == [(\"Bob\", None, \"blue\"), (\"Alice\", Some(17), \"green\"), \
+         (\"Eve\", Some(13), \"white\")]\n\
+         : [(name = String, age = OptInt, favorite_color = String)] end in\n\
+         ?";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIOrdering.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIOrdering.ml
@@ -2,4427 +2,3814 @@ let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Ordering",
     {
       segment =
-        "((Tile((id 92bcab8d-22c6-473a-b2a6-cd112cb94cd7)(label(type = \
+        "((Tile((id e177c14a-3fc0-4320-87c2-83db1dc6cc83)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         1b92526a-05bc-4d70-a2d2-9970b0fbcb7f)(content(Whitespace\" \
+         a95bba9b-badc-4e1d-9d1a-c4f69f3a2364)(content(Whitespace\" \
          \"))))(Tile((id \
-         0915ba0e-4e05-44f4-b2ec-078f374edf64)(label(GradebookEntry))(mold((out \
+         6691864a-df23-4137-9b18-a4bf23a8b84c)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         7b05b5e7-b62d-472b-ac03-063e2910aa11)(content(Whitespace\" \
+         1845a3b1-f9e8-4ab5-92aa-64c1214e7b1c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0d0a2906-a23d-4101-a419-20d576623125)(content(Whitespace\" \
+         618dcfc1-e299-4009-9e42-27ef7a0b48e3)(content(Whitespace\" \
          \"))))(Tile((id \
-         b10f0b16-e3bd-417d-855f-e18751545e7d)(label(\"(\"\")\"))(mold((out \
+         466872ca-60dd-4448-8a85-a868c3f99b6d)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         223d7843-c05c-441b-b457-6d1e49850bfb)(label(name))(mold((out \
+         7c041a5c-25e5-422a-9098-627f7dc77258)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         72447d1d-5855-4521-8223-c9897cf56a96)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ff4c5389-3b38-4e18-b5eb-0715e66d2dfe)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d69957e7-2d79-4260-9917-5d325b15f2cd)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6c8b0b6c-2608-45be-bc03-e90fb9818c57)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0da4e0d6-d2a6-49bf-adaa-dd48fd76822a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f163e395-5813-4afd-8b7b-1183835afdf9)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         32cd5251-88d0-4747-a58f-53a3962a62f6)(label(,))(mold((out \
+         9ba94e26-6b48-4ae3-ac6f-117ef6ba4f7a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a095737b-6d4e-4871-b36e-7575e59bf855)(content(Whitespace\" \
+         28acd162-903a-4b1a-8810-8f04c4db3473)(content(Whitespace\" \
          \"))))(Tile((id \
-         e7de3ba1-a7ea-4e26-948d-1d8f6994a3e1)(label(age))(mold((out \
+         c937f4fa-15a8-462e-b0da-6bff32cb7376)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         4daaf935-1b1e-4684-920c-500da71915ec)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         fd7d2639-e91a-4b40-af25-eead0b1baa4c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9de3637d-ae27-4f79-b790-1ad4097d0f01)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         3ecfdb64-d469-4888-a2fc-c936cbb0502b)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         842e71b9-548b-4799-a67f-69325030d0db)(content(Whitespace\" \
+         \"))))(Tile((id \
+         da626fa0-3db0-4485-a5e7-ac0271405cf5)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         996499d4-04ec-4df2-a55d-2e2569e6557e)(label(,))(mold((out \
+         fe239feb-41a3-46ec-9329-d33c40d2ff88)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c6c85172-46f3-456c-b343-a985b2c95e9a)(content(Whitespace\" \
+         b4cceb42-02c7-488d-b03f-338e4f19b3d2)(content(Whitespace\" \
          \"))))(Tile((id \
-         6dc3b407-f348-4598-865f-f92d9e3c8409)(label(quiz1))(mold((out \
+         28f8733d-0ee7-49d7-ad26-c66dbf1f5ec2)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         955b9f8b-0b61-48be-b773-db87e7e797e6)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d8528a41-dd12-4e8a-89ef-70aae002ae03)(content(Whitespace\" \
+         \"))))(Tile((id \
+         995f1ba0-ea4f-4c1d-9cae-ccbe21a7d36c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         010b7402-9dbe-4b1b-966d-309431574f96)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7b8572e0-fd73-4d3f-8f31-45e3caf05301)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2320e711-a4e2-4a57-8968-2b1b8c0e0f6c)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         0ee6ccc3-66bc-4b8e-88fe-26752b7287fd)(label(,))(mold((out \
+         2d89cc09-d776-4143-a7e2-1ab4c49d46b4)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8bbc840a-af59-4ec4-9584-d0f0b26c6641)(content(Whitespace\" \
+         d40a9ebd-4235-4b75-861c-8b87baa36012)(content(Whitespace\" \
          \"))))(Tile((id \
-         230ba425-36ed-49bc-af38-8570df77e660)(label(quiz2))(mold((out \
+         09469551-99b7-420a-914c-b00bfe7621fa)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         05106e94-61b9-4ca3-a6be-329e473b845e)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0d68f074-1fc7-450e-adbf-82c667f9f2a4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ced4b89c-20c6-41dc-9056-97c1faf36808)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6890c2fa-290d-44a2-9119-3e2bd8a9ae68)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f83897ff-136d-460b-aec8-20031fbb6015)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6ed7111f-102b-49d0-b7e0-bb38be9a9295)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         27b98858-ad6c-4986-b649-3d17b42df140)(label(,))(mold((out \
+         80d23201-0550-4955-8ad0-c7c0cccca388)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4a665d38-36f8-4ff7-8a67-79b60bc2c283)(content(Whitespace\" \
+         0a791267-c054-4a10-ac88-b01f5429ca78)(content(Whitespace\" \
          \"))))(Tile((id \
-         3e34d41e-7fa1-4a37-ac17-e63aa4dd962a)(label(midterm))(mold((out \
+         20c34a11-a781-4602-831c-8db6e9acbb70)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         c46d878f-bf2a-4d65-ba71-33999fd25780)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         06303fb4-990c-49a1-8182-f33a255d2c0a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b10396bb-4ffe-462b-873e-9034ef1dad15)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c75bbd79-11fc-4c90-810a-9511ccf18d08)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a547182a-7016-4002-9284-39812c263163)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f7286783-7591-4017-955a-a5084dab1edd)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         7808323a-38ab-45ae-8fe0-2e042be06f09)(label(,))(mold((out \
+         18b8798c-e2f2-4a70-8762-8b818b2eda67)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bbbb01fc-dee2-441f-8d7b-a4f291a93716)(content(Whitespace\" \
+         5a1f15be-bfed-429e-8515-115f50110004)(content(Whitespace\" \
          \"))))(Tile((id \
-         fb48bc6b-af96-4f41-ad83-25a2f413466a)(label(quiz3))(mold((out \
+         a01a43c5-80fa-4553-b166-25591469a0f6)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         7a459714-e258-45c7-8d92-14f4388e23e9)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         73976217-1e9c-40d4-b7c1-3ff6c29a56bd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ea7abeb7-8156-447b-a424-d51853ce5f8c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         07e64b5e-0246-4f9a-9ece-232f035527a9)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a7f6ea06-23e9-4fb4-9f1e-edda42b72905)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f035232b-f53b-43e7-bf41-da5e9b2b6ccb)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         14bed6d5-11f9-45fe-b99f-f3571e0e8cb7)(label(,))(mold((out \
+         59d529b6-3bad-43b5-9e80-241a996a87f4)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4fcb848b-307c-417e-9239-7adc60ea3fa3)(content(Whitespace\" \
+         858e249e-5190-439d-8794-81ff2b2500dc)(content(Whitespace\" \
          \"))))(Tile((id \
-         918dffe9-43f3-45d6-aa61-8681b8dfbb70)(label(quiz4))(mold((out \
+         eb00b063-e00a-4a47-8dac-72fb58d1a985)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         a7f33eb2-548b-4c81-a344-0c353213e7fb)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7d49d13d-ec63-4e2a-b1ce-f75a8ad5343c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         42f26385-ad0c-44d2-9910-490042611c93)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         4e8b2034-a169-4332-b454-1589ec4f90e0)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         de7b26a6-2ca9-4832-8938-e01aff00d380)(content(Whitespace\" \
+         \"))))(Tile((id \
+         beae5a04-1d8f-4b21-be8f-5168767d4def)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         2dae5cb7-0499-4d7f-83da-6951e74c76d8)(label(,))(mold((out \
+         8339de1c-e56e-457d-ac76-21995fcac7d0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2ce54582-73f7-440b-9a86-00e99dafbf77)(content(Whitespace\" \
+         b863ee02-83b7-4bf3-97b2-8e371851609c)(content(Whitespace\" \
          \"))))(Tile((id \
-         dd45fffd-b57b-4dc8-a9b2-1cd6a3053431)(label(final))(mold((out \
+         9815cdef-ce0c-437b-9cc4-96538a8308ad)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         7bcdf396-f58b-4d41-833c-ecf0c824898a)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5d30a059-0478-42de-95e0-683c202f57b1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         69181cd1-9170-426e-bd2d-2cbe5731f53b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d1b0ef4c-9b78-4804-aed6-bfb80b0611df)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4439c6dc-9014-4529-bbe8-456ebb9a628a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c237b9e6-3a9d-4c95-b884-64e25dd9ca5b)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a61441dc-5493-44a7-819f-d9ad554077bc)(content(Whitespace\" \
+         9f42f2fa-4fa1-477d-a38b-d2d61194ef87)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         96d679d3-c20c-4478-a80f-69699ae199d2)(content(Whitespace\"\\n\"))))(Tile((id \
-         a7a30a88-c5f4-4b84-bd19-3f0bab9180d4)(label(let = in))(mold((out \
+         26fdd4f4-6a2a-4e2a-81c3-d648ef053fc9)(content(Whitespace\"\\n\"))))(Tile((id \
+         5c361b0c-ab19-4c70-af43-123d4d975ba6)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a11c404d-f115-4569-aeba-4abb63c7f01d)(content(Whitespace\" \
+         46fbf0a6-65a1-45d1-99a6-965a33c0a804)(content(Whitespace\" \
          \"))))(Tile((id \
-         d6e8a575-ede7-4aa7-9dd4-3583a6ab2fd2)(label(gradebook))(mold((out \
+         b49544bc-c731-4aa6-8d6a-71d927cc7f1a)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d155c821-d80c-46b2-af26-7a0de4d0b7dc)(content(Whitespace\" \
+         ef0cd522-474d-4798-837b-a8d3d1ca2fa5)(content(Whitespace\" \
          \"))))(Tile((id \
-         f3c258af-361d-4c88-84cb-4cbd5ba7adce)(label(:))(mold((out \
+         49972805-ac5f-4e4b-bd2f-98a9c88076aa)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         61b0cbc2-2c9b-4607-a606-dc1393539e53)(content(Whitespace\" \
-         \"))))(Tile((id e7267bde-e3a0-4a6c-a63f-6c3eb3912fb7)(label([ \
+         a1a85726-2a51-4682-8685-01551b2e83a5)(content(Whitespace\" \
+         \"))))(Tile((id 2a8c3ff9-a413-4ab1-ac50-02133f1d28b6)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         d1376810-2c66-4502-a993-02e7f96a81b3)(label(GradebookEntry))(mold((out \
+         73f4390c-4c7c-4e34-a6dc-18680f70eac9)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         9d26e62d-a32f-47de-9415-eccc88470b46)(content(Whitespace\" \
+         620eede0-342d-4a2c-becf-5e56e24e344a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e3ccbec0-6713-4185-9c12-ce12617fc838)(content(Whitespace\" \
+         a0799e86-62f3-4e01-876e-9ba2f70cc694)(content(Whitespace\" \
          \"))))(Tile((id \
-         8c3ba7f8-1ae8-46b2-b7e9-5d044158af99)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ebfcfb66-dcd7-4e31-973f-84172e55e025)(label([ ]))(mold((out \
+         3fa3b41e-e436-4e26-90d3-233ba01eef05)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         cc1b9dc1-5536-49ce-bb74-6cc641328dee)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4185e43d-9558-4934-a962-24332c16c000)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         84f4a600-815a-485b-9125-b2d6d249769d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         88cfae32-919f-40d1-b657-7b57c511c124)(label(\"(\"\")\"))(mold((out \
+         3f0c1a16-8ef2-4d70-a427-63b44768d0cd)(content(Whitespace\"\\n\"))))(Tile((id \
+         ad452b2e-7510-4912-b59e-a118c6bb5c7d)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f4e67841-f2b3-4a29-b84b-e7fbae65cfe1)(label(\"\\\"Bob\\\"\"))(mold((out \
+         516b4dbe-ac0c-4e32-a366-c70d07335269)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         0a6d790c-6430-46ac-8ec3-004400841d22)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d3af9093-7e05-41b0-9db9-7444dcae361d)(label(,))(mold((out \
+         7c4e9812-eec8-4263-bd0e-22a38bcc2e2c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6cfdc4e8-164b-4563-a274-f4fefe5be6a3)(content(Whitespace\" \
+         5ab23d98-7cb4-4ea4-8c26-160658c637a0)(content(Whitespace\" \
          \"))))(Secondary((id \
-         2c49f0c5-1759-4552-a167-c5c5289e3352)(content(Whitespace\" \
+         16a9620f-307d-4522-be6c-441c24c23027)(content(Whitespace\" \
          \"))))(Secondary((id \
-         fa5dff69-18c0-42cb-b11f-7330f1963124)(content(Whitespace\" \
+         105c9f48-6aab-4a8a-a080-c100f56f4ef4)(content(Whitespace\" \
          \"))))(Tile((id \
-         0bf55c3d-1a38-4723-924a-9a14248e7e7d)(label(12))(mold((out \
+         f7c4dd6b-4b7e-457b-abce-c51556eede81)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         056a02b5-37c4-4682-9d5b-07eeb3353829)(label(,))(mold((out \
+         f8619ff5-0c5d-4ede-a7e1-b7c3a8928894)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         87736c0f-86ed-4964-a5ce-8baace17e564)(content(Whitespace\" \
+         aa25c69a-2964-46d9-9bd4-416a79e5bab8)(content(Whitespace\" \
          \"))))(Tile((id \
-         e2f273f3-623d-4281-a43e-2d241a1c8d0d)(label(8))(mold((out \
+         5d37b81c-e09a-4a98-9c97-3161880d6f6a)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c2f4e6e8-c736-4964-913d-5a78554766b0)(label(,))(mold((out \
+         36406844-03ca-4c5e-94ee-3db5c446673b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1d977b5a-c490-432c-91c3-ce9d825ab3ff)(content(Whitespace\" \
+         bc150adf-744f-4944-a5da-f5debaea24fd)(content(Whitespace\" \
          \"))))(Tile((id \
-         80168f71-368a-4e12-99a6-196b21013c4c)(label(9))(mold((out \
+         071d836c-c5c4-4d85-8c9f-6d47b2bb8a88)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         01b8554e-8749-49b9-a304-eaa41f62c480)(label(,))(mold((out \
+         93c92378-b8a0-41de-9e43-b6045114cf7a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2ceb3032-75c0-445c-84af-8dd68f31b36d)(content(Whitespace\" \
+         bb1e39f7-f75a-4d90-ba95-221286d95e38)(content(Whitespace\" \
          \"))))(Tile((id \
-         0a0ae600-fc59-46f7-8a10-2e6ccf3a1044)(label(77))(mold((out \
+         cca3051f-1b88-48e3-96ae-3c8666e9be63)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         70788693-56d9-4297-895b-f9abf5ef1adf)(label(,))(mold((out \
+         e8632f9e-1334-47d6-9770-8d7564d9d033)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         19d507ae-13b2-4cb5-bf29-12e19c542484)(content(Whitespace\" \
+         ba4b7cf0-01d9-4d26-a49f-d54ef18c90ed)(content(Whitespace\" \
          \"))))(Tile((id \
-         116cf9a4-3df5-4b7f-b333-37df8673c276)(label(7))(mold((out \
+         439aacd9-2083-4418-b254-7bf3d9dd8259)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6018ec71-8835-4158-bd7f-021209ef960e)(label(,))(mold((out \
+         4412cdc1-7986-4a10-a8a7-656ea390ed21)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         533346c7-1c34-4e39-976e-bfd60f75241e)(content(Whitespace\" \
+         3cd8672d-cd3b-465b-9ea1-b7db1775a987)(content(Whitespace\" \
          \"))))(Tile((id \
-         8e8b583d-c239-4fd8-b9ec-5d3e69509bbe)(label(9))(mold((out \
+         0b7132b2-9e7a-4a8b-b581-cbf0073a4f28)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         fc7afd36-065b-4f7a-b932-c13cc678a8b5)(label(,))(mold((out \
+         f8af4e3a-5d30-4f60-a702-5ee5be77951d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         38e99f17-9617-446f-a712-7febcbbb91c4)(content(Whitespace\" \
+         ad9cfd90-3256-4643-bec5-6a810eaab380)(content(Whitespace\" \
          \"))))(Tile((id \
-         c2d00e8f-ef26-4fe0-8d85-5310ec19f808)(label(87))(mold((out \
+         1b07d993-2391-4f1a-a856-c52fefd81c8f)(label(87))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ddfaae01-8578-4608-8f01-74b4709ae345)(label(,))(mold((out \
+         73a5da07-d382-4d48-9a51-d50ba825a6f6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         465e8828-1705-4daa-8ffd-10f48ba35b61)(content(Whitespace\"\\n\"))))(Secondary((id \
-         caa96e86-0e1b-4704-b144-af8bb323fb6e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58aa2774-a379-4499-9739-a3b724e8842e)(content(Whitespace\" \
+         b07e874f-3c52-437c-b0d6-f99544868712)(content(Whitespace\" \
          \"))))(Tile((id \
-         3705a0d7-898d-4ca5-84e3-1ba80ee96d36)(label(\"(\"\")\"))(mold((out \
+         f72f9329-e3ce-448b-9dd7-81c16da0a6c3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e877cc66-d017-4d39-89e9-17cfcfbf9717)(label(\"\\\"Alice\\\"\"))(mold((out \
+         3349ae0d-3f7b-455d-94e1-ff3b40edbce5)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         79b4ca61-c6d7-49d9-8eb4-cde7924807cb)(label(,))(mold((out \
+         25216d09-a76c-450f-884e-e420253ddca4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e2f4d121-1d17-483f-b1bf-21001936897b)(content(Whitespace\" \
+         dec9d3c6-a76f-4a0c-a30f-b50fefda4766)(content(Whitespace\" \
          \"))))(Tile((id \
-         30effbbc-fe7d-4d17-b2a1-b48c9e528eb3)(label(17))(mold((out \
+         21fefeba-2718-4c39-90a0-6b38a5d515ef)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         45a3cc1a-d6c8-4d2f-b3f8-f362cc607634)(label(,))(mold((out \
+         2910abed-bd79-4241-b803-00d342a49a5b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6eef1738-e19d-49ac-bf1f-2a382271a4f6)(content(Whitespace\" \
+         c5baed90-c94a-4889-8f0b-a6ae6b02ac0d)(content(Whitespace\" \
          \"))))(Tile((id \
-         2803fbf5-5e02-4ad2-8547-45aa085391dd)(label(6))(mold((out \
+         0f0ee4f7-0ce6-4152-b6d2-c2dbee240fd2)(label(6))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         21c92858-7997-4a86-b9c0-479e40b277e5)(label(,))(mold((out \
+         0556ae03-05ab-4c75-92a6-e9fff6fa19e3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cfb9801b-3968-4afa-85b6-1d4ea5d7eb58)(content(Whitespace\" \
+         b5c8e3d1-f888-4e68-8c49-f5b141635e5b)(content(Whitespace\" \
          \"))))(Tile((id \
-         a7f6f149-533b-4276-be4a-5bc79a04db47)(label(8))(mold((out \
+         7509a596-457d-463e-a916-a5c515eda6ca)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         53bc4de6-a7d0-40c6-91f4-f986962df1ef)(label(,))(mold((out \
+         3f7454dc-1f72-4d21-a0d8-256269dc1f58)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9f451ba2-87f0-46f3-bc35-40506e9c3e35)(content(Whitespace\" \
+         60a03c6e-a426-41f4-927b-50fc3a67e330)(content(Whitespace\" \
          \"))))(Tile((id \
-         c3cb7171-d290-4916-99c4-e0dd2c6a4702)(label(88))(mold((out \
+         8db809e0-0bcf-4059-987b-4912401d86e9)(label(88))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         0bf1cdbe-2a38-46fc-844b-f8b4d6e1d03a)(label(,))(mold((out \
+         f93c2fe8-14b9-487c-8531-c4baef4c1a37)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         01c9d0c5-a2e0-4f1e-baf8-f5a83b4e04b7)(content(Whitespace\" \
+         d6655cd1-6598-4b6e-a3bf-b4b1e2afed1c)(content(Whitespace\" \
          \"))))(Tile((id \
-         78d6b0f5-aebb-49e6-8cf3-7d65bb1d5f64)(label(8))(mold((out \
+         f3ebcf41-489f-4689-9130-943b7bd6ed9b)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         858d1405-ce3a-4df7-9fe3-b75a049203ae)(label(,))(mold((out \
+         d7b07f6c-7a42-4d6c-b42b-9939d6fc7ac9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7bea6ac0-0114-4769-854e-59ef8ebfebec)(content(Whitespace\" \
+         49516f7b-7f9e-4fb3-8b01-90054f449f41)(content(Whitespace\" \
          \"))))(Tile((id \
-         c18629dd-857b-4908-92a7-254fedf54ede)(label(7))(mold((out \
+         170c4fa7-3a8f-47c4-b631-e6996d770437)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f4851372-a98e-4275-a380-ad60dcca887a)(label(,))(mold((out \
+         6927126b-4038-4aaa-ad3d-7b1cb5cf533e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cc94e39c-cce7-4932-a7f1-9e8652e5dbb3)(content(Whitespace\" \
+         2ff53c26-d45f-4962-8ed3-2d5bb387f63b)(content(Whitespace\" \
          \"))))(Tile((id \
-         cad3b286-fbd3-4d19-bad0-6d17fae895aa)(label(85))(mold((out \
+         f940a1d3-1275-48a8-b09e-3b7db1dbc5b2)(label(85))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         39fb3e8f-e026-40be-bc78-8e4e542fdc7d)(label(,))(mold((out \
+         5800157e-121c-4bd1-8f2f-b70040c0f099)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7950b7c1-b450-4696-9d34-86605c7500b2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         357c8f45-c0d3-457f-aac0-87e942b0dd48)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a27864fd-e1f1-4f37-ba92-f50901df9b20)(content(Whitespace\" \
+         e37e5a7d-19b3-4ff8-996b-79a0c81a7855)(content(Whitespace\" \
          \"))))(Tile((id \
-         25e7e917-d211-4b9b-8e1c-bc34bbac9975)(label(\"(\"\")\"))(mold((out \
+         c17b231e-eab4-4f35-80ec-38c492fdf5b5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f143761c-7025-4482-9a1b-731020c1b7b3)(label(\"\\\"Eve\\\"\"))(mold((out \
+         ef29a3f6-495f-4e0c-a461-7f12e928ff65)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3287ac0f-f2a7-4308-8dea-c04ed2a2d0bc)(label(,))(mold((out \
+         ca208a80-d941-49f1-8139-ec5b8f06cbfd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6c99fc94-5c44-4a5c-8621-7005ceec7e97)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d27c6a0a-da1e-4f64-bf18-0e0bb5ab1007)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d683463-7cfc-4756-bb5f-af31ea3abcb4)(content(Whitespace\" \
+         24a5708c-cdb9-494b-91bd-e26541b8d98e)(content(Whitespace\" \
          \"))))(Tile((id \
-         b67ba030-8ce5-4756-9e37-1b0a3d0715b6)(label(13))(mold((out \
+         727de5d3-a2b6-4f6a-9a1c-aa0e2142638b)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d5afb04f-87d2-4a7d-a8d9-5aa43f21c899)(label(,))(mold((out \
+         5229c6d3-e047-4b9f-8433-9e331c8e74fd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8b2443a3-8bf2-4430-a4f1-3f331efc7d3a)(content(Whitespace\" \
+         ecdc518f-1e4f-4610-907f-e44587d0ba60)(content(Whitespace\" \
          \"))))(Tile((id \
-         dad227ec-bd53-4bbd-861d-2f6eae886c66)(label(7))(mold((out \
+         4d516c07-eb86-4456-844d-7754748dac83)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         70d83936-117a-4364-89de-8a6d9bd311ec)(label(,))(mold((out \
+         48d4c0ae-591d-427a-a960-25564ee7d5ea)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         06682811-3c65-41b8-b68c-9b4a5c57b148)(content(Whitespace\" \
+         1f6302ac-3282-4a31-b84d-401c50d632d8)(content(Whitespace\" \
          \"))))(Tile((id \
-         6bf0fa07-c871-45cd-8757-47edcddbc833)(label(9))(mold((out \
+         cc610a2c-a3d3-415a-b4e2-476af829b530)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4c75fca7-e238-4888-9d90-d9e91ee63439)(label(,))(mold((out \
+         3afd1ea7-3905-473f-82a6-47144c6606f9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         229f5774-805e-4627-90a0-489e6bbf06c1)(content(Whitespace\" \
+         bbd2f31a-f214-454c-ac4c-1b3322484032)(content(Whitespace\" \
          \"))))(Tile((id \
-         71b1209a-4d22-4f5d-8859-ae262009692d)(label(84))(mold((out \
+         c735c463-42c6-4fcc-97ee-695ef7bd14f6)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d204e94c-638e-4dcb-92f5-363487bef1a3)(label(,))(mold((out \
+         66d6337f-d90d-4e6c-907b-39bd14a5e6f4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         535c309a-64f9-43fd-94d9-74b6b91c59b4)(content(Whitespace\" \
+         009820c0-ea16-40d3-9958-cfaa294ef48e)(content(Whitespace\" \
          \"))))(Tile((id \
-         55797666-990f-4c24-b61b-fe461469db56)(label(8))(mold((out \
+         2d735fdc-627d-43dd-a62f-f9f808988d94)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         738843d8-5f03-4123-80b8-565e2e19bb7c)(label(,))(mold((out \
+         d51077cb-7357-4b5a-b236-f4887701e403)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         eacda6f5-697b-4c20-9982-664bc31988fc)(content(Whitespace\" \
+         a132ee93-034b-485f-8fd1-7f17b5687c7e)(content(Whitespace\" \
          \"))))(Tile((id \
-         7126c707-51b3-4b77-9291-e2abdb3cdba1)(label(8))(mold((out \
+         ed3b2a72-2973-4ee6-acc8-2b357314129a)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7e702c74-cbe1-4b30-b0bd-6b92d3b866c4)(label(,))(mold((out \
+         1d76209b-eb17-4180-9f1b-0f07e3ed3d7f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         919dd991-31c2-43ba-8ca8-aa6e09f4962a)(content(Whitespace\" \
+         910e1bf5-3746-4d5a-90de-6a7a7dbc4db9)(content(Whitespace\" \
          \"))))(Tile((id \
-         5f41c081-178c-4faf-908c-048471038a84)(label(77))(mold((out \
+         fa70b0f8-883e-4ba1-82d2-fd7a136b4f3c)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ed5f91cb-46a2-4043-9d96-363f287194cd)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         2605d3c7-18a9-4b2a-a9f1-029e1d879437)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         eb841c40-2b7a-4312-8bb2-7e80432f9c75)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         7429b049-3f76-4892-ad8c-335b2189bd3a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         02adcb69-7703-42d2-b34d-bcf55c42dcf4)(content(Whitespace\"\\n\"))))(Tile((id \
-         629761e7-72d3-44b1-a8cc-c2a3c7fa4a96)(label(let = in))(mold((out \
+         39c5953b-cfd5-485f-9908-1f483b53eefa)(content(Whitespace\"\\n\"))))(Tile((id \
+         6323b774-a1e3-4f08-b2ba-a7f05b9af223)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c3928386-314e-488c-829c-17d516dfcb0d)(content(Whitespace\" \
+         863734f9-3905-49cf-82b8-66d8ad4718b8)(content(Whitespace\" \
          \"))))(Tile((id \
-         11b3d9d2-8ab6-4d46-9fa8-0a6dbfc3e947)(label(tsort))(mold((out \
+         18fc8f6e-76f2-4d1e-a623-3538b9c263fc)(label(tsort))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6c860eff-9712-4346-9dcf-a533c6ebc243)(content(Whitespace\" \
+         62dbd297-5f18-4612-9118-6022dc964518)(content(Whitespace\" \
          \")))))((Secondary((id \
-         86507333-aa63-4645-a9dc-3afe2826f402)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e1f5b9f0-118d-4973-8667-ab8f819490e5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fd599037-51b9-4694-b0bb-0994c2ccc8df)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5b1c73d1-1a4e-4689-b45c-2e659f7fa998)(content(Whitespace\" \
-         \"))))(Tile((id 16510aa3-69b6-4ae9-8a34-04febe13b091)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         62ff2afa-91af-4090-9b26-3ac2b2466444)(content(Whitespace\" \
+         55aeb2a5-e577-4da4-af94-5ca5f2115b40)(content(Whitespace\"\\n\"))))(Tile((id \
+         5b58912a-b817-4bb0-b31a-162016c80045)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9f184f47-0752-4c12-aa37-9b5fe58f7e27)(content(Whitespace\" \
          \"))))(Tile((id \
-         71075891-e576-4841-86fb-0e3cb83d45f7)(label(requires))(mold((out \
+         bd1bf7fc-d4ca-4962-9bc9-5de90ef81e0a)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         0c7aa21d-ee1b-42ce-ab7a-7302d32645c7)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         f90f7492-6bdb-4c1d-894d-d94de84aee70)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5b31bb91-2b66-45fd-a08d-15550542ac04)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ebe448c-47c6-415a-8289-fc61e7977814)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         af08a94e-cfc0-473a-92e0-ab602b747041)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         321c3760-51b3-42d1-bbeb-f13be361a001)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4e21717f-bc9e-4735-8a88-89d64a93b1a2)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c1236fd5-886b-4b6c-bbac-430550b4318e)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         70bea141-7b91-4a90-a250-18fe76cfac6a)(content(Whitespace\" \
+         \"))))(Tile((id 792bde62-e10d-45c2-b3aa-92d3a87b1180)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         63660f21-1ae5-430f-8f45-3918ad12ed85)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         6007e304-ec5d-42a8-9082-486b06f61f84)(label(enforced))(mold((out \
+         3edeecc7-c0e9-4142-a7fc-b0e5a896ebf5)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5b0c44ec-b008-49d2-a1eb-ed548f85b658)(label(=))(mold((out \
+         82c5d508-2845-4abf-97de-9f2b7511b1b3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         70195230-038f-43f1-b3d9-8f12b0ccbc94)(label(\"(\"\")\"))(mold((out \
+         95911e2f-8150-4ba2-acb9-1b9dcbfcd908)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e1945f4e-1437-48d9-8fe2-3af8c940c459)(label(false))(mold((out \
+         620ff59e-c9d0-46cd-92c6-43710d691d0a)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         77318774-beec-4da4-9b70-80d3ee0f1b3b)(label(,))(mold((out \
+         09de9f7c-a27c-4311-8c1c-0642f6a8ff20)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         23ca6f08-f69d-4c46-b399-f4fed65c112b)(content(Whitespace\" \
-         \"))))(Tile((id d2f3d8a7-6306-40d4-81c6-1526335fb17c)(label(\"\\\"c \
+         cd5af9f0-448c-4aae-9826-a14cddba84dd)(content(Whitespace\" \
+         \"))))(Tile((id d2de9c38-8f21-4eb5-a781-9063030efcf6)(label(\"\\\"c \
          is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7ec9c9ad-2935-482a-b2cb-88e8e27f8bc3)(label(,))(mold((out \
+         42ad6e34-e189-4e11-a8e8-6da69c7be398)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f6ac6118-a801-4c1b-812e-5a6c725ec309)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ff3a1f7a-f6dc-479a-9263-3dc677d63bc0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         09d93ee4-db13-4161-a6cd-222312a0cf11)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d174ea36-80f1-48e7-9211-ddf7f433d325)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3fbffe63-1b26-4055-8d4a-efd41133191d)(content(Whitespace\" \
+         d5f99b6f-8c76-4ea7-a203-1ea40a950702)(content(Whitespace\" \
          \"))))(Tile((id \
-         91134fbf-e36e-4c2b-94a8-369a2cf43565)(label(\"(\"\")\"))(mold((out \
+         965ac1e0-9501-40eb-af11-1c3136e8d40d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         fa57a18c-8eac-4e11-9cf0-992599423c02)(label(enforced))(mold((out \
+         db33d06d-d01c-4f1d-837c-85a84d155674)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6e2fcd45-508e-49e1-9cb4-7070278985bc)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e34bc0ef-c058-4341-8282-f88ef20721cb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4c9eef57-9cbe-43f0-a697-32c4a645e5c4)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         8f1d9c26-b3fc-4cfb-8234-a5a72edfeb1c)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e6a31574-bb9a-454e-8964-4cfd6d42129c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         19ddde19-cf40-4b02-80b3-1529376b80f4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         06f3ea84-c671-4236-a56f-ce8e25253fc0)(label(false))(mold((out \
+         0a7f4c95-e0ed-43b8-99cc-98ab4236e811)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         5b13bd34-8771-4c5d-b11c-458cb261cc82)(label(,))(mold((out \
+         0a33b0cb-715b-4917-9161-345e8685e100)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         34a40bcd-6036-4426-8f23-73af45004625)(content(Whitespace\" \
+         a7286be9-aa74-4109-b5b5-65b746aef53e)(content(Whitespace\" \
          \"))))(Tile((id \
-         c3af9992-45b6-4242-99cd-64825e7c99bd)(label(\"\\\"schema(t1)[c] is \
+         db2de477-5643-4bac-aebe-93758cf93fb6)(label(\"\\\"schema(t1)[c] is \
          Number\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1fb5fe4e-dd91-402a-a532-deb727bd4b45)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b01a96aa-f872-4f9b-a767-079cabaa0e7b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f8e2169-3d4c-48ab-93db-4e841dd8a042)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         4f60ec7b-7df4-4caf-85b6-95a7ddf571b2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         60cb9128-2b4a-4f0e-a6cc-673d8dd95aa7)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         69d5160d-7728-4cfc-8827-b0ab11b8ae0f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         82ac4db3-991f-422b-84e8-e471fd6606b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b3901956-0fa7-4396-abea-0506f704baff)(content(Whitespace\" \
-         \"))))(Tile((id 34959dfb-92e6-48d1-84ac-b07b425c483e)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b7477d90-abf4-45e4-b445-a882ffc93022)(content(Whitespace\" \
+         ecd050c3-4a66-4b53-942e-032719665a0f)(content(Whitespace\"\\n\"))))(Tile((id \
+         51fdeb5d-f960-4188-8644-9b211797055a)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ecb97092-5dea-4352-b2f6-7d04f7ad357f)(content(Whitespace\" \
          \"))))(Tile((id \
-         e492098b-49c3-490a-a8d7-281154eb77ae)(label(ensures))(mold((out \
+         02079467-3853-4e4b-af21-e278e6ac4139)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         8ef2dd1b-69ab-46da-a317-45495ffe560e)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         999d0d68-2664-4610-aa10-81616f0aa0b6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         126a1279-82d9-48bb-b2fe-baa721596f8e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         294f9f0b-b4fb-4ea7-8154-db2ffca8f96f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b12f62e2-7100-4a02-9472-e3043e2f9640)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0be78ed1-e0df-4c7f-9b4f-9c5920883d5c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4cadf54a-ab0c-4ecc-86fe-169a6ff70c0b)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         2c4770c4-789d-4e7b-944c-53f635bcb1ed)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         c82afc2a-739b-4cd1-a295-ed1fd0b1d529)(content(Whitespace\" \
+         \"))))(Tile((id c5e53300-6cf1-4e44-9fae-895737eadf4d)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         2a8a8776-20b0-4892-b107-aa488b322821)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         a8c4bd04-488a-4646-8f49-1b3742b0e33f)(label(enforced))(mold((out \
+         23dbb566-bb39-4077-9003-b0bd81798d12)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4c670878-83c7-4a39-8e0f-4e61edd612d4)(label(=))(mold((out \
+         4a8b873e-6e6e-4071-ae89-b5248a3cc372)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         d9dc1fab-c67a-471d-8379-11af21e29e34)(label(\"(\"\")\"))(mold((out \
+         3856d389-1c6e-45d3-a649-cd588d18a594)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         98c28191-80a5-4b13-98be-1062bb531e28)(label(false))(mold((out \
+         26d434a7-9725-4ee1-92ad-39af0f6a7c8e)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         f72541a2-c6a1-4a24-8670-081ad709d3bc)(label(,))(mold((out \
+         585c72a5-1d96-4aa9-98e0-7ddbbc8e7b8c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         57623096-7862-41b5-b03c-685ad30d0ebd)(content(Whitespace\" \
+         e61a00cd-909a-4425-9fbe-57d2188e2582)(content(Whitespace\" \
          \"))))(Tile((id \
-         516e0c68-f5e6-4b51-8e35-050fbf9a8e5e)(label(\"\\\"nrows(t2) is equal \
+         1c0285b8-f569-4ecf-903d-6be2fd3b072e)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a486da9c-66aa-49ad-a29e-d1829ec6e4e2)(label(,))(mold((out \
+         70d4d0b4-76a7-4f89-aca2-0fcaff728ed3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b7dbcc9c-b460-48e1-aee0-576e68fa0324)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bbc03217-dbfc-46fa-8b12-a4738bfde250)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3048381e-0cd9-4fe9-ac03-cf5fe62ebecc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fe702deb-80a7-4af2-a5b9-0b2792730c30)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         997788c3-32f4-4020-a4de-d5c88302ab5e)(content(Whitespace\" \
+         df19ad68-2f94-4075-b8bd-f32351081071)(content(Whitespace\" \
          \"))))(Tile((id \
-         795104b8-7efb-4ae9-866c-8427be49e871)(label(\"(\"\")\"))(mold((out \
+         f27471df-90e5-4cbc-b075-2a9d1a4cea46)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         c92c6383-e8c0-4358-b134-f42202530b28)(label(enforced))(mold((out \
+         42eb2f73-b6b7-4369-b415-4c8b4d17256c)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3489cf9a-24d1-422a-97d3-5733ac0a5cd3)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         79121a87-1221-48c3-9e39-60d463e79dcf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0cf1fb18-1308-49af-9b65-0f5b7593f207)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9b51bcdf-72ee-41b1-92f5-718e632fa9cc)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         31c26f6b-67cf-4356-a23b-34b5408b1d26)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2f5f4db5-15ad-454b-93f5-4b8244a93c46)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         1e44729e-09a8-47c0-9232-cfcb3e85ab19)(label(true))(mold((out \
+         bd23b548-dfcb-4c15-a47c-d82ca6439ac9)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         e0184216-ec7e-40b9-a3ce-a63c0e30d1c2)(label(,))(mold((out \
+         4756c478-264a-458c-9c22-cf2892a3e4d2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fe75bc7e-df78-4a01-9b85-c0b4dcffd74f)(content(Whitespace\" \
+         0b12fca2-cfcf-48ff-9bc1-3280696344a5)(content(Whitespace\" \
          \"))))(Tile((id \
-         e24472e8-9506-4e65-98cc-5f7636c48425)(label(\"\\\"schema(t2) is equal \
+         dd9851a6-c118-4366-be42-f4ab6a89507e)(label(\"\\\"schema(t2) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4e2f83b8-9e0c-4d06-89d8-38faf3e3d21e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         de216f10-0f00-4af1-9e62-b3d10aaa112e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a571531c-7238-4a6d-9ec6-069f79b2d6e9)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         6dd74061-756a-4d2d-a2ae-0d329188f1cb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5e876b4a-80c6-43da-a4d4-af42e8209c04)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b77dcec2-5bf6-4887-abe8-1ca29514e74e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3646d1f9-59fc-4591-8bf1-eed5a22c0261)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f212350f-a26c-463b-b5ba-cc3e0c1b3d94)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ab4f784-c4b4-4ccb-bba9-9dbb9ab2c3b6)(content(Comment\"# \
+         3d7cc4d9-56f7-47b7-bfbc-60e0d4287b81)(content(Whitespace\"\\n\"))))(Secondary((id \
+         09cb70cb-bdb8-47d6-a832-5453b44bf006)(content(Comment\"# \
          Idiomatically I think we would do this with a implicit comparator on \
          tuples and then project them #\"))))(Secondary((id \
-         6a0e5757-7ec5-4a7b-a1f1-8b0352a223bf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fc8ca716-7d80-42a0-bcf0-2352999bbb6e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4a92ef87-15e2-4c5b-b916-57f621b7fcac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c15fad57-5bdc-4234-86e8-9966f79dc328)(content(Comment\"# This could \
+         93e74887-a619-49a6-8cbd-51affca38641)(content(Whitespace\"\\n\"))))(Secondary((id \
+         f5a13560-6a1d-448a-9583-b0402c92b204)(content(Comment\"# This could \
          be done in a typesafe way if a function was passed to do the \
          projection #\"))))(Secondary((id \
-         81f012af-bf46-4201-ae66-f0994a2d1b7f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f320a9b8-0382-49f3-9f8a-151c38385721)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8f61ee3-c80b-4f05-81cf-31ed41fe0fe7)(content(Whitespace\" \
-         \"))))(Tile((id dedc0f9d-b22b-4535-8932-da40b6ba9a3c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         21b6b61c-691e-4608-9318-f39278b553d3)(content(Whitespace\" \
+         ae9a8a3d-05cb-4dfc-88e4-4a110a39c179)(content(Whitespace\"\\n\"))))(Tile((id \
+         ec851ac0-8596-4240-905a-834ff9ebf6ae)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9a0dd628-607d-4f0e-a32c-3c2a351cce23)(content(Whitespace\" \
          \"))))(Tile((id \
-         e07803fb-6188-4cb5-87f9-7a86755fb065)(label(get_value))(mold((out \
+         426cf957-2501-435b-af2e-d63a89407b81)(label(get_value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         63590177-058d-40d7-914b-6b474a43f83e)(content(Whitespace\" \
+         ed506607-84b2-40b2-a1fe-451f4c7366b8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         49aa50a6-c083-44d5-b86e-1734baf79ec8)(content(Whitespace\" \
-         \"))))(Tile((id 3b245fb7-6663-42ac-bd90-1f7f55489684)(label(fun \
+         530851c4-9a32-43ed-ab1c-2188e39b9c9b)(content(Whitespace\" \
+         \"))))(Tile((id c240a8ff-9907-4dc8-9102-48e66e92e5bf)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         d917f7ab-4b0b-47bb-9d98-527c800a80f6)(content(Whitespace\" \
+         315022a7-85ba-4fe0-8b0d-ca5597768064)(content(Whitespace\" \
          \"))))(Tile((id \
-         25da6bb2-be49-4741-9647-d87bc7a380c2)(label(\"(\"\")\"))(mold((out \
+         f8c978d6-a5c7-4be7-8cb0-82b2bfeee167)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         d0397387-1716-42b4-b2ce-a1a9388ef2d4)(label(r))(mold((out \
+         53204aba-0ae1-4140-b4a3-71f273bc4b47)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         51c9a8c0-023c-430c-9ce4-05beff3cfcd4)(label(,))(mold((out \
+         0d2ffa33-fe50-48e9-a2a9-df2fe8e76e82)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f0947a9c-a753-4d4d-bcf8-eb8bb269bb7c)(content(Whitespace\" \
+         bb92d535-3166-4441-989f-20ba17c406b6)(content(Whitespace\" \
          \"))))(Tile((id \
-         b3370787-39bf-47c9-a3f8-3abb5ffaaca4)(label(c))(mold((out \
+         ace3cc70-8bb3-4292-b0b3-43b71f00293d)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8cf84564-b5d7-4bf6-8996-2c5617cb2bfa)(content(Whitespace\" \
+         bda5e0a8-7119-4174-862e-1710514ef13a)(content(Whitespace\" \
          \"))))(Tile((id \
-         82c213f5-e0ed-466d-96a2-72ab11d5bbf8)(label(:))(mold((out \
+         beb077f7-26e3-4931-a6d7-647ba5c9c9dc)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2e1b9b16-afc7-4d7e-9d4e-77e8beba5940)(content(Whitespace\" \
+         ec847407-e63b-4688-b04a-62edcb487bc8)(content(Whitespace\" \
          \"))))(Tile((id \
-         24b657eb-c976-492f-8dab-b7049bce3573)(label(String))(mold((out \
+         d6d942d9-3b91-411e-8ae7-239666771b6c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0b818118-ea1c-4d9d-99ad-ee62a2b17ff5)(content(Whitespace\" \
+         e491d952-a6bf-4620-8094-852593125bf4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7d5680cd-9745-40c4-a480-5eef82efe9ce)(content(Whitespace\" \
+         8f508b39-db4d-4efb-aba3-2bc3ad6a28ad)(content(Whitespace\" \
          \"))))(Tile((id \
-         9c23c0b4-d94d-402c-b85e-cdea42e56283)(label(\"(\"\")\"))(mold((out \
+         8b9450a2-c822-46e4-9602-d8d7c0ee33bb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         bd52bcbb-b9bc-4e13-b233-98ab4d53a4c8)(label(to_lvs))(mold((out \
+         5172a4a2-0b07-409c-9ae4-c7642a0a48a8)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         41b26b12-2193-4c0b-aa3c-d3daa4b580f4)(label(\"(\"\")\"))(mold((out \
+         ffedf1cd-1b01-4df6-b229-9971e6d3d5a4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         04f67d2a-6aff-415f-8ccc-65885e39af89)(label(r))(mold((out \
+         803317cd-f9b2-4ed2-8426-b07005eb1ca9)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         73a47741-1d98-44a4-b687-dc90951e7502)(content(Whitespace\" \
+         a9237606-12d9-418f-9e18-f3b813be4f0d)(content(Whitespace\" \
          \"))))(Tile((id \
-         d6bedb86-a3e6-47a7-b615-0bfa68c21f5c)(label(|>))(mold((out \
+         c115c0e6-c0c1-4558-8767-7ab635fd34e4)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d0b926ff-a639-4d3b-9188-150418b8485a)(content(Whitespace\" \
+         a1ba628f-4eba-47fd-b445-c988c9a09c41)(content(Whitespace\" \
          \"))))(Tile((id \
-         4eeea834-b2fe-4001-b1db-69fd272506d6)(label(find))(mold((out \
+         85437128-e147-45a0-a6bb-dfd161727153)(label(find))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3911500b-3e7f-4314-9317-208ac2bf3000)(label(\"(\"\")\"))(mold((out \
+         eaad5876-2407-45bb-8ce3-0f7f4a25638a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4cb98856-3aaa-4c74-a047-5030694fa51b)(label(_))(mold((out \
+         e363b484-6fa9-4003-9b0a-1e5366adfeb8)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4fcb33ea-81ec-4502-a90a-f5960accb1e8)(label(,))(mold((out \
+         c0e9b8f9-107e-4a31-aaec-99bf82f8440d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         816e5613-ba03-46b1-ab5a-cff3eb79a138)(content(Whitespace\" \
-         \"))))(Tile((id 211893fa-15d1-40f5-953c-e800b2220764)(label(fun \
+         fb68cb24-dd0d-4b56-a424-f9d591e9fdac)(content(Whitespace\" \
+         \"))))(Tile((id 66a802f8-c30c-4f89-b096-8bf5c73b7880)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         2d38ac9e-5d84-4703-89cc-170ebe8cbf1a)(content(Whitespace\" \
+         6350a616-e1a8-4645-897b-4a732a138799)(content(Whitespace\" \
          \"))))(Tile((id \
-         76f4effd-d4ef-41a9-bef6-f3baf6a3eaca)(label(\"(\"\")\"))(mold((out \
+         6b600cea-9bfa-4f1e-bfe4-b3c4be69c90b)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         eca1fc98-af47-46cb-ae99-8878b17a8a0c)(label(label))(mold((out \
+         0e410af8-cde3-43c4-891f-0508fe8484b4)(label(label))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         c53ec9a3-1548-4fa5-9754-b8c31bdc0317)(label(=))(mold((out \
+         45053b4a-0974-49d7-a647-189a6d352ed5)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
          39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         9d9ba2ed-9c30-4264-9e7b-ac59825d66cb)(label(l))(mold((out \
+         84c7c105-3fd9-4f07-a4a5-d8e27350d5bf)(label(l))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         7c80e8a8-1630-47cc-ab57-7845596f54f1)(label(,))(mold((out \
+         e27ef91e-f5f3-4b2c-98f3-b6c9def2595d)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         9422828a-8d59-4aa5-9e5d-d49f547e2846)(content(Whitespace\" \
+         686b0e27-5e82-4677-852f-8b74f66adf83)(content(Whitespace\" \
          \"))))(Tile((id \
-         e9d97e03-9f01-4bca-acc8-afc7c73d865f)(label(value))(mold((out \
+         ccc6d07a-113f-4a32-b0e0-c8d4e755a3b7)(label(value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         71a3755f-08bc-4325-afd2-03a053d1f1e4)(label(=))(mold((out \
+         deb3b223-c2df-451e-849a-78aec03b2195)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
          39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         00ffd1c4-70f2-47a6-847b-02f603080ce2)(label(v))(mold((out \
+         585763b6-9e5c-4918-9d9f-305a6d7e0239)(label(_v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         d13ac4df-080e-4b36-8c85-b018c078304e)(content(Whitespace\" \
+         52a1076b-d8a1-4588-a131-80a47381726c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d02196d0-b00c-411e-bc6c-9688a318555e)(content(Whitespace\" \
+         b8e35d51-4587-4ead-92c2-0846b61f30dd)(content(Whitespace\" \
          \"))))(Tile((id \
-         d73ccd10-ed33-48db-a032-eac8098d4ae8)(label(l))(mold((out \
+         52caebde-4861-423e-84d5-80f59b2d6808)(label(l))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f630a752-a07d-45ca-b3b6-d3cf1e33af8b)(content(Whitespace\" \
+         7217bd8d-7800-4e6a-a7a4-f5431b16117b)(content(Whitespace\" \
          \"))))(Tile((id \
-         c57c520a-bf38-4272-af22-8245b200acc6)(label(==))(mold((out \
+         fc0eee07-3ff2-4bb5-81fd-03cca368e823)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6cc35352-c592-41da-a2a7-9520b0aceb11)(content(Whitespace\" \
+         538ddc84-4ae5-48f7-9d7d-26291aecab62)(content(Whitespace\" \
          \"))))(Tile((id \
-         fc4d4b45-0ffd-4303-841e-815847bc4675)(label(c))(mold((out \
+         ad21da1e-c840-462f-8f77-e0e6891ea846)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Tile((id \
-         312c1355-c31c-4798-979d-7f91aae38fcc)(label(.))(mold((out \
+         ec6d316b-bba6-43a1-862f-1adec88f3e9b)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         335a67b8-5ecd-4a04-a908-e9cdece53c48)(label(value))(mold((out \
+         e7c65a97-a4a4-4454-8d0d-0ebb3f7aa172)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         4de0cf02-08fd-41c5-862e-17e341870689)(content(Whitespace\" \
+         e38a6742-669d-4c10-ad7f-30cf6ee3f718)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fe133520-af76-4f9a-acf2-0b4110586efe)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6377c8e2-daaf-4a58-8815-e0f298cb63fc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eadef9ae-3a19-48a5-b04b-3ed7971924e5)(content(Whitespace\" \
-         \"))))(Tile((id d6013830-cb9b-4bbe-a128-6077617ca53e)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e232dec7-89d8-438b-87e5-bc08c95ebb14)(content(Whitespace\" \
+         a257ae2d-a49e-419e-a49c-2f8cd0b2eab5)(content(Whitespace\"\\n\"))))(Tile((id \
+         ccdc8ae7-4de6-49fb-ae37-aa874b94e263)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         c12106d0-c3d3-42c5-b5f5-1930f4d229bf)(content(Whitespace\" \
          \"))))(Tile((id \
-         27f6ab9f-75a4-4b8d-8693-8b750942f4b9)(label(tsort))(mold((out \
+         7f40b590-9dd5-4932-9f1a-29f6612e7c75)(label(tsort))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2db6b35a-4173-482d-afa4-292a45be18dd)(content(Whitespace\" \
+         ae7080fb-79de-4140-ba03-6156e4f77b43)(content(Whitespace\" \
          \")))))((Secondary((id \
-         53be20d1-a88d-415f-a0c7-3ab7cc0d563b)(content(Whitespace\" \
-         \"))))(Tile((id a1530df3-9a6c-438d-8d52-ecc6b0c38c5b)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         f6830919-6087-45c2-9c5b-fa5e1481e7e9)(content(Whitespace\" \
+         3e13f21d-45ea-4606-993c-55baf0bfbdac)(content(Whitespace\"\\n\"))))(Tile((id \
+         264d637a-2571-4014-bc83-a351ec814441)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         988f0551-3f96-4d97-83ff-557591e61523)(content(Whitespace\" \
          \"))))(Tile((id \
-         957e15a2-d1ad-4ab1-bbbd-d021072152e3)(label(r))(mold((out \
+         7335d987-eaea-44e5-ba41-79c299983de4)(label(r))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         119924ae-0578-4e5b-86a9-aee80b3116d6)(content(Whitespace\" \
+         46bd4923-e01f-47c9-b086-5f1a2228f689)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c1ec5256-759f-4ba9-b570-00c451a78d6a)(content(Whitespace\" \
-         \"))))(Tile((id e7f8862a-8893-40eb-a35a-b451cb24b1b7)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         aac8eb15-2a06-4f91-8591-6742c44cae9c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         28a5e3e1-e10d-470d-9d81-ab027216484f)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         172e2c48-a771-4e31-b7bd-ce462d4dcb9d)(label(t))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         c64a5097-f658-45e8-aa65-e75921bfc3ad)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a2cb40ef-4ba4-4dff-ad24-fd8141216a00)(content(Whitespace\" \
-         \"))))(Tile((id 804c5e27-d231-4451-bc5e-a51749e3e658)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         97dfd89d-996c-4c8b-bdf7-34229f968e26)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         7989a31a-f46d-427f-8f20-b9d5cc74ad55)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         19716c88-629c-42f4-b532-12f84a873d98)(content(Whitespace\" \
-         \"))))(Tile((id \
-         06257bb4-2616-42b3-952f-14829328177f)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d5b79942-c9f2-47d1-b4da-9d73469889d8)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0e0cd619-c170-4a9d-851c-440ef8f3ce15)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0e97cb55-f5ab-4451-9bc2-2cd069a00f41)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         c55c2075-b373-4b81-8673-841e82942182)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         33d9645f-9113-43e0-b510-ed793fdc9b38)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e5fc2773-e483-4632-93ff-d5142dbfb1d6)(label(b))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d2da8616-9c7d-40cc-a299-ac9e63a838e7)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         eebddd22-34da-4539-880b-2bfa14b5ed4f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a0c234ff-483b-442a-b479-0d0f86e4a50e)(label(Bool))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7f01bc91-0a58-40e0-83e3-a31aa24c62f3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0ddc5638-ecc5-402e-8ab4-f77047143723)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         578280bd-54b6-43fe-adaf-e71ecf21f14b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         96b5d6d4-1011-4475-91c9-0a06c97633b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         315a4131-3e1e-4fff-851c-db38b5fad9fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2529f4bc-fec2-4e0c-9173-ab82e36e27ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         40682811-bd98-41f4-81aa-a61398d43d39)(content(Whitespace\" \
-         \"))))(Tile((id 1a440600-00cc-4e83-a013-c7651e5856e6)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e5622eac-99b4-4157-b46a-547072d289fe)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b503ba5a-fab4-4aa1-b421-a02af1a66107)(label(sorted))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         bde2bad2-1859-4646-b1a5-625594bcc654)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         f8b1d9cd-726e-4a48-9695-9ba739fd117e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3dac96f6-d4b0-4450-b921-585b5fe507b2)(label(sort))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         97d5b792-dde7-42f2-84c4-673476356625)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         98db4f9a-f6a8-4e08-be5b-2ca1439aa231)(label(fun ->))(mold((out \
+         c92ea667-78a0-4936-93fb-ba0773f99cc8)(content(Whitespace\"\\n\"))))(Tile((id \
+         b791b8e5-931f-44a5-a7b4-acf0bd9bb5b6)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         cdfde86c-7350-4ec7-a4cf-751c2cade27d)(content(Whitespace\" \
+         929a43b2-51c6-44f9-884d-37c79b4f8021)(content(Whitespace\" \
          \"))))(Tile((id \
-         0a7970b8-b96a-4d6b-9519-15d34c1c7108)(label(\"(\"\")\"))(mold((out \
+         78614052-66e0-4e75-a2a1-4e2a277fd8c5)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         081b07c0-1e5f-427f-9b31-5661bd3b1d1d)(label(first))(mold((out \
+         2d5f8ba9-7dd5-4eac-be72-4b1f8c0bebd0)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d8b6e091-8a28-4da5-b9e9-ecc1c617eb19)(label(,))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f85f77e7-5c7f-4d80-9d8e-fc5937df714b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b7dff6e2-bf0e-4853-a22a-d8181abe7cb5)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         263e3136-fe40-4db2-8d92-541e55373ef6)(content(Whitespace\" \
+         \"))))(Tile((id f8135b91-fdbd-44f2-a34a-d989fdc990d3)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         503fb709-9320-4af1-8aeb-a668816ba2fe)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         9b38eaa6-1ea2-4788-b7fe-a7994381ff6f)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         e65a42f9-6a85-4013-8486-f83a59368ed2)(content(Whitespace\" \
+         44db1217-f86c-4554-aceb-fdac84fbfbab)(content(Whitespace\" \
          \"))))(Tile((id \
-         f2ae29b7-a663-46eb-8bd1-6b7b0682c9fa)(label(second))(mold((out \
+         1bbf4bbb-3b9d-4bbc-8a30-487fa8d4f335)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         8b097e8e-b3f5-4a7b-91b3-6da0bbd4db2d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ae7434fd-d990-4e88-83a7-4313b7594f7d)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1d38bb2a-3d44-459d-8e29-bc85d12a21f6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         634f2f3f-9efa-4b91-9222-f311cc099c46)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         a949afe0-4c7d-4eb8-bc44-73f97d18aaa8)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         519a98cc-e125-4abc-99f2-edffc7e71d67)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c01f7ce3-9074-4915-b3e8-5e721fdc430c)(label(b))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f071fb95-e60d-4013-8f85-8f9095d902ce)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dd3b7f05-daa0-4fae-b9f2-569f952f8d15)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6b8a232a-a420-47cc-90de-61ec254163e5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2f06dd0c-af5e-4439-bcdb-f9c07c94d8c7)(label(Bool))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         8acf281a-fd2d-436a-bba5-ca8b15ab593b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         6e0c956b-1518-4105-9876-e08515db66f8)(content(Whitespace\"\\n\"))))(Tile((id \
+         4cd1acb8-f194-4be5-b90d-224f9843cd91)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         99168d5b-6c5e-4fdc-a8d6-db8951562da8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         35ccf1d4-fd46-440c-b108-c7adeb917f71)(label(sorted))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e1c41f35-342d-4ae2-a7ca-2303a16af22a)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         214dff67-87ca-4146-b8b1-29d019454f6b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4880ffd1-4e7c-4cb4-bd86-b9e0e5b12308)(label(sort))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         204cb056-4725-46e0-ab76-524b6a01babd)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         fe896108-0483-4654-9fcc-7ce07b30059f)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         67689edd-7d90-41c3-bb46-519d9124ab8a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         817d6328-e210-4556-982d-55825fad030a)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         d299a3db-4260-4f75-a9b6-b3f76829be30)(label(first))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         6e4fa0e3-615a-4bbf-a405-55239cd95cd3)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         40263a8a-946f-44c2-af72-dbe5f12cfb7e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         66108c19-57fd-4609-8984-e19bab808b41)(label(second))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         ec955d29-1b5c-4182-8588-66b351ae59a2)(content(Whitespace\" \
+         838d80a2-9199-421b-bf51-83ef05bec9d0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e91626e2-49ef-4350-9323-735c5f3710d0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         966e3a63-fe12-4cc8-aab9-21379c8f3224)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4b2eced4-e481-4de9-98ac-daa6d78950f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bcf77a9c-99a6-488d-82bd-7bb9fc577837)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d06a4107-72bf-4e1c-92f2-ea8c2efdd589)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32de7ef1-626c-4b9c-adce-5c23916d717b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         335c4bba-def2-4a7a-8245-61bcbaa0bc4a)(content(Whitespace\" \
-         \"))))(Tile((id aba86ef8-4a3c-4ac8-a671-e43b021575a3)(label(if then \
+         81f360fa-94ac-4a8f-95a3-e5941fc0f8d9)(content(Whitespace\" \
+         \"))))(Tile((id 41411639-e499-4be3-b8b1-fc8b4c6c82be)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         f9626345-7692-48b4-8460-2a2c8fbe77b0)(content(Whitespace\" \
+         17a24dc9-b1aa-432f-845e-28a1389eb88c)(content(Whitespace\" \
          \"))))(Tile((id \
-         7cf6ad89-8df1-475e-a517-f7f0dac50d9c)(label(get_value))(mold((out \
+         941f8fce-3ed7-4a8f-9376-ff99950eac8a)(label(get_value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         99a44083-d8b8-4a7e-a6dd-ecaf4b51146c)(label(\"(\"\")\"))(mold((out \
+         5ef112cf-e843-4524-8ccb-c316cc2776e9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         cdd8bc5e-a8b2-4835-9cde-00e09ab4c3bb)(label(first))(mold((out \
+         518bfcd9-fd35-4d48-aea5-b3a08a39b257)(label(first))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b239fc1f-79cc-49ee-a1f5-ee8c6d83a720)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0a11279e-4c87-4783-8abc-9ac1adbb470e)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         95c485dd-8478-445b-8b97-b4e7e3b3cf49)(content(Whitespace\" \
-         \"))))(Tile((id \
-         323bba53-d63d-4a69-95c0-a87d4759fc62)(label(<))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8dcbcb29-640e-4a18-afa0-3eb868098bb1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5ff916f8-09d4-4b2c-96ae-42246254c170)(label(get_value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6c52c900-6f5b-43a0-aacd-7cf61582c23b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f6038296-01eb-435f-9c32-2a10cbbe5e05)(label(second))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d73b6882-23f8-4fb3-9952-dc0e79596970)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ee49d537-4b87-456a-a2e3-15b90efc4602)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         0156dacb-5b34-49b5-9f2d-3cb1b8496c00)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         47bd4e8f-549a-42e1-a366-e7bbe879ae1e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         38244298-e4f8-43be-b160-745ae2690763)(label(Lt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         00394e02-12af-4cc1-89e9-0775193e9eef)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         adab6047-3ea9-442b-814c-d249c756fba7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9fdb5e56-7c89-4b91-89df-20c6a8f27830)(label(Gt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ede556c2-b9e7-4f90-baa1-0dc757711c96)(label(,))(mold((out \
+         b5f9a4f4-be1f-4467-ba29-a6b7608b0601)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a165f94d-cd9a-4883-ae74-b1d0c0e80094)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d90e36c0-e968-465f-af80-4c2556369374)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c8ed51c-99d2-4295-863d-cf0cd9892dbb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f830343-4927-4058-b0f9-753c774ef977)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         78e961fd-4d29-4de6-ad65-7d8567d028bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eb0c58ab-5dd0-4ed6-9e21-cbb61541fd35)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f806f638-9a66-47bf-b828-cf0404ce5115)(content(Whitespace\" \
+         d2af6feb-4572-4c9d-b692-d704c2cd03ed)(content(Whitespace\" \
          \"))))(Tile((id \
-         a77286a0-afff-4897-8f9e-30d2c6c27087)(label(t))(mold((out \
+         614307fe-6394-4752-ab12-fb2158c9ed6d)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         33bc5991-88ee-4050-986f-693bb4954de6)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f7b99b21-f0e8-4e23-995c-d6907136aab9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         772abd99-88d9-4c79-951c-62c5abdd9207)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4e4a64d9-50cc-4e72-9798-4bac77129d15)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         74ed028e-7cc9-483f-a959-fdb7b029b622)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         07e2b7b3-0a06-4060-8b7c-90155a3df367)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3f66c1de-9d44-4c06-abce-9719ccaeb4c1)(content(Whitespace\" \
+         3cf9904e-8f27-42ea-8364-255c33318805)(content(Whitespace\" \
          \"))))(Tile((id \
-         4bffa27f-9dd0-49d7-911a-dd65c560fef8)(label(\"(\"\")\"))(mold((out \
+         2eba54ab-0280-49df-b45f-af45ed7d5b65)(label(<))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4bec3d75-4387-45b4-8d2a-c1a980f58d4d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         df3b1287-acf6-487d-aea5-1b3b748746ed)(label(get_value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fac056a1-e80a-43ca-b9cf-995befbc3465)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0d3920fe-7da6-4fb1-83bd-cae64af8f8b7)(label(second))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         96c1ebc0-390d-4fca-8b63-76f82d82cf37)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d78da248-d993-4de6-aafe-9ef9b28ed011)(content(Whitespace\" \
+         \"))))(Tile((id \
+         042e3984-c099-4cd7-8170-c68c09a5511d)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         3f1e9a2a-59e9-4024-b06d-3f3d141c5f8c)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         6c8ef490-65fd-4756-91bd-379b74052f46)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bfc5cb43-f9b7-4aca-8bc2-647ceb10f3b4)(label(Lt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d336fe05-b668-43ee-abdd-58e06afb6e5a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c57beb78-86f7-430f-9874-88ae98c18645)(content(Whitespace\" \
+         \"))))(Tile((id \
+         24670589-c658-45f4-a44a-03584c343f64)(label(Gt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         06b34eae-d0ed-40f9-a28c-0b06f516fde1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fe7aacaf-8966-46b3-b382-c776bc6fd565)(content(Whitespace\" \
+         \"))))(Tile((id \
+         18bae604-86b2-4aa1-9820-dfb3affe5d81)(label(t))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         ac447d28-36b9-4468-8bc2-0d905651767b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d9026b5b-c8bc-424f-b25e-4693e3549391)(content(Whitespace\"\\n\"))))(Tile((id \
+         a06d9622-99ab-49ad-87df-f91a9e6f420e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         1f64ea30-02f6-4fb4-aa33-58cad8215f01)(label(if then else))(mold((out \
+         d4b4eef8-6844-4ef7-99f5-da33ecc96491)(label(if then else))(mold((out \
          Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          36))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e9375722-13d1-45c0-9486-51bef8446533)(content(Whitespace\" \
+         3a6c3f50-c755-48de-ab6d-d80e6f43e168)(content(Whitespace\" \
          \"))))(Tile((id \
-         27a8d090-a8d0-44a0-aacc-0b39655a923f)(label(b))(mold((out \
+         89c85abe-f404-49aa-9152-f3f969894a58)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c3008d0a-9d65-4248-8602-19bc57f1f93d)(content(Whitespace\" \
+         b7db7c7c-58e7-4141-b31f-a8b89d0b7227)(content(Whitespace\" \
          \")))))((Secondary((id \
-         fe512073-15c2-4a36-9bf4-5a206275cd2b)(content(Whitespace\" \
+         962a7c3a-edb1-46d6-a847-4a124d7ef778)(content(Whitespace\" \
          \"))))(Tile((id \
-         20661e1e-6a3b-48ab-a9ac-650bd74f6900)(label(sorted))(mold((out \
+         6719c7a9-7370-46fb-bdd7-eefd206429a2)(label(sorted))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         1865cdb8-abf9-48f4-8b79-ff165d670fe7)(content(Whitespace\" \
+         925e78bd-23be-4813-90aa-bcceec5fbd0c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4326d8e5-b7d9-4518-8c3e-f7f438546d67)(content(Whitespace\" \
+         36ece1c1-7152-4a1d-94ec-c327607de3a4)(content(Whitespace\" \
          \"))))(Tile((id \
-         ae95a314-f9be-416b-af1d-da6991ab6f86)(label(reverse))(mold((out \
+         d5474051-15c6-47df-bae1-391762856289)(label(reverse))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         9f1fe558-d193-4e84-b521-06d4a384dbf9)(label(\"(\"\")\"))(mold((out \
+         c7485fb5-1bc6-441c-a31c-e6941bc35966)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b1e13390-07a2-4dbd-86d7-93e482f4f94e)(label(sorted))(mold((out \
+         c4819424-9027-4ef6-b121-dd9f91dfb99f)(label(sorted))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         ae87d084-923a-4940-a2c2-8d10cf790fd9)(content(Whitespace\" \
+         7860d5f5-7548-46f3-aaea-c5f2fbc6c5cf)(content(Whitespace\" \
          \"))))(Tile((id \
-         61ccf72c-23bc-49b5-81f8-1e5214e61f21)(label(:))(mold((out \
+         c50394ec-e743-4974-9034-6001bda901d1)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f3a0899b-9911-42ca-ae1c-d51904ee2b84)(content(Whitespace\" \
-         \"))))(Tile((id 413a7dd3-e943-4392-849c-1eb32dafb6d3)(label([ \
+         753e7e80-18f1-455e-846f-0a8ea191ce2c)(content(Whitespace\" \
+         \"))))(Tile((id 0fe54f58-161a-4ec1-8456-8b5844ea673d)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         c94893b1-48ed-48f6-9e69-f0701bf9b135)(label(r))(mold((out \
+         623f05cd-2bf6-4b79-a78d-de268677de9c)(label(r))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f536ce27-768c-43e3-bab5-102cdb15222e)(content(Whitespace\" \
+         6b75e34f-a45d-424d-a4af-d5c1e896e183)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e5b3a207-89aa-4bd2-9483-d8a6bbafe29d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         914cf9d4-9480-4e98-a73c-a84eda2086cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aa478afa-ba9e-48df-80b4-54f046733f3f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         26ca8110-c447-4103-a809-467bd992d6dd)(content(Whitespace\"\\n\"))))(Secondary((id \
-         77f36fbd-a089-4623-806e-02c48758759c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c051557-ce1c-467e-9da0-b9917afe0d23)(content(Whitespace\" \
-         \"))))(Tile((id 5b24009c-5366-49d9-b479-39fd83d149d3)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         7730f6d6-60ad-44f1-8f66-08ab4625fa86)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b5618e1f-242a-4df2-8ac1-61bf0d9c15cd)(label(tsort))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         db7495a3-67b0-4d2c-84d0-c6e2b1c28e79)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e52ee97f-5cac-43fd-9cb3-4cd8aa175c0a)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         cad23b4d-0271-43b0-901e-77bd2615b290)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c0da02c1-d47c-4d5d-899d-49469743999f)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f39e13c0-90f0-4356-80f0-5fc73415795e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3ae92385-133d-49b7-b79b-367b8b5f0ee6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         af7f35ed-23e6-4ecf-b2bd-c0791c47b6f0)(label(\"\\\"final\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5e91a86d-ad2f-4644-bd41-33c526d42946)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fc2b8d18-027a-43c5-8980-ddb49f12f604)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6c01603f-b0db-4b67-8f50-f15006d6847e)(label(false))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         27a30dcc-fb66-4a9b-ba6e-88143b007464)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e049382e-5b74-4c52-a19a-9abddff0e066)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b049fabd-9c65-484f-9efc-46827e8f4dfe)(content(Whitespace\" \
-         \"))))(Tile((id 28fdcd26-a70b-4d7b-a357-bd57b38da3e2)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         4962c6de-9161-437b-b471-9b94d37f942b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         99e7e2be-ef8a-4b3d-9809-d1ff4d1de408)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         77d8d3a9-95de-4c68-8659-b169445af306)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         09d846ac-fe07-4e19-a27e-7ddf4e965a82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2d953f3a-ef0a-458b-98c0-039d178a3377)(content(Whitespace\" \
-         \"))))(Tile((id \
-         02a1e2bd-caac-4306-bd38-215c82ff9162)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         f04d95d0-2ff8-48a2-a665-3209af8664eb)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a9b90f5c-a7c8-45d6-ae60-da9a9360730e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         47f750b9-47ce-4276-9d41-68c2a9bcb315)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6947a6fe-60c6-4cba-b08d-0cf4fd43f3a9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bfd908e8-37d6-4319-b79d-bad4c4b73582)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b2c4681c-93e3-4225-a689-385d28f17819)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ac4121ea-77e8-406f-b2d3-f9f413f51052)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6e6189b7-16e2-4230-b1d0-64eb8dc34435)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d3e1e978-134c-47cf-bba3-17d2de4f4dd8)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a13c6e3c-516b-4d06-81b1-5325f1e716fe)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a4318c99-a94a-490f-918a-81689a81576c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d9648c22-d607-48b9-8eb7-721f15784592)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         158c98f7-043e-400b-8b35-bd97df65b816)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fa99c2bd-fa8a-44fc-95c0-06d2007a6dd9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         79dd0d55-7cc6-49ab-9efb-48b0aeef9f73)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0f670e88-90da-4fb3-aff2-02988bbee2da)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bea0a8ff-0f22-4955-b430-ebb36ebe76ff)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c737cf42-e9cc-49e3-8158-1ac9f8da3a6a)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ff3090fa-be16-4dbb-a7ea-f6bed7948c4d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1a4d992f-c484-4070-bc4d-997833dc47a2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         154da442-d425-4487-899c-57cbcc441713)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         57594c2c-282d-4802-af82-d368bcc42e4d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5de10abf-8f4a-4794-820c-31ce9282e508)(content(Whitespace\" \
-         \"))))(Tile((id \
-         42f4b784-6d8f-4fe3-85bb-dd996e9051e7)(label(87))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         18f0f886-f96f-485a-98ab-b2132533eb6f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e7cc4aa0-fdb7-4283-828c-f2a036c0a5e2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c7f54c50-17a2-4ac6-a5fb-bd03b9ac0548)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a024d80a-3f3d-406c-9af0-1967d9022304)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a1305b4e-d5c5-4a3c-8b4e-4ff7cbbb7cd7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9cd4adee-a4a1-4913-bf88-90a0843d008a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e9653d41-987d-4105-ad8c-9bff17994b6a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         b2bd125d-8003-4e94-8a4e-831eff555ec1)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         60ebf3af-b9e8-4a0f-aaf3-f94a56f23f89)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3a9ad800-009e-4478-b453-f7d85cc5336f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fe569c6e-c584-40d6-aa1d-fd6088762f69)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a9dcd03d-a6e4-4f55-a276-faf291509d59)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9b3d4d40-6a7b-4a19-a955-497c9e4aa149)(content(Whitespace\" \
-         \"))))(Tile((id \
-         97e142da-053e-4415-ad9a-79b915a291ce)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7c37cf1d-a122-4b46-9893-b5075f20ab56)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         645bc152-4f73-4600-b05d-90f0bab5de22)(content(Whitespace\" \
-         \"))))(Tile((id \
-         edbb59a2-0f93-4646-bb88-cdcc6075d88e)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         164c94b7-ea94-486b-8920-cfa19b7d751e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         827c4619-394f-4e13-855e-86aa5550e206)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4430919d-31d2-4003-97b3-0cec4860e01a)(label(88))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e6de503d-361e-4cb7-8305-d030b774b143)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         25fc4842-2065-4c10-8014-b418ca52e588)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9e563067-6815-49ff-a1b1-d2e0bd2fb351)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e3ebfb19-6fbe-493a-988e-215820b2b398)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         36352996-2e02-4343-8e41-7c004cb913c4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4b3a5870-f322-4b0c-bc41-67725a1c7f2a)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a380b106-fd4c-48fa-b65e-de1ad3d7341c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6a9e1fd0-c9bf-4872-a9c7-f4337048e293)(content(Whitespace\" \
-         \"))))(Tile((id \
-         938fca74-f6e6-4bc3-bea7-d787985b1fa5)(label(85))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7ad16d83-9dfa-4753-a1d9-585773b8f2ff)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0cad5cc1-1a37-44a0-b557-37051ed2c5d8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         aeefbc6d-1018-4fc1-8c10-f2c2dce426a9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         50179d15-9398-442c-b304-5bb3f7ad7422)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c74181c-e923-47e6-95b0-b4b042ae9b5e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f6b3c797-f06b-425e-bb91-a71a1545bd2d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         099367dc-7b84-4b49-b1d4-090bf1424c91)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         d881e66e-ea2f-4f45-8107-6a2fa3de1b21)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2e1a3506-3867-4bfd-a9fe-a551ead7c64a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         958f1ee2-8bfc-4e0b-b2b8-0a25295395e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         49901d8a-a14c-4eb1-b0d5-3f31733bec81)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de5230f7-2692-4646-a225-9fbfa1dd8f5f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f23aea82-f274-41ef-bc12-899f5b2e7de8)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         050edf0f-9a81-4657-92ad-84f324f16f79)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         73b9f204-6de7-4748-845a-db95aca598c8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9bf29f67-f56f-4432-9d20-ca6db9cd48e2)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e3d96a93-11ee-413d-b18f-aa636f8c9f44)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f9f757e0-116c-44d5-a7b6-22d2240f376e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         128ac861-3eec-4424-9c1b-3766a0f42cd8)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         80e3fedf-6f6e-416a-b5a9-9fe3fc8ec6dc)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8412bdb0-0ae7-4a83-9ec6-9b68a7f032c5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2c4ac1eb-542c-46cc-8a79-3a4a2a9e1380)(label(84))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c6ae1db8-f2eb-4da1-975d-47973759ed66)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1cc2b9d4-4450-4a10-aa06-98a8e992c10e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cf6cf067-ccc0-4f49-8ab8-a93c2941f834)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         525dd34c-d284-4795-8cd2-c7a418e4aaa5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1921eaaf-185a-4907-9e3d-49026cb80790)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ef7f9780-6b59-489f-b4b1-602d5bf5fa84)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e00549b9-8093-4b36-b2bc-069842a8d299)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c6e5eecb-6c61-41ab-b142-688b83faf444)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8bc84419-506d-4800-b9e3-e2900ad63fce)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4e099d7d-c460-4ad6-97cf-af76c2037f97)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2ac2a7f0-ca76-4cb6-9b59-faaa72a56d6b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cafcd2c8-2074-4a70-a085-bc38b44dc04b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         713c6de8-bba2-48b0-b8a1-e2be9d10c0f3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         568072d0-a055-4df2-bc5b-f690eb5fce0e)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         59e3af7d-3d4b-4f55-9e91-cc1e8634f133)(content(Whitespace\" \
-         \"))))(Tile((id 72939f9e-24e3-46e3-89ea-8518c359056e)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         11c20cf1-7046-411b-ab2d-589caa5647d1)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c6108da8-313a-4773-8c6c-5964b43fd3fa)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         314bcb16-dcae-41c4-bd42-38b7751fda44)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         2c859e78-1ff4-47b9-ace9-226a332ff65a)(content(Whitespace\"\\n\"))))(Tile((id \
-         f5043de9-9664-4a7b-9068-75e2dcc2fc1c)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         26dfaae5-5c11-4366-9da9-3ddba3fc43ec)(content(Whitespace\" \
-         \"))))(Tile((id \
-         98e9c8f5-51c9-455c-83ba-3261e3c685c1)(label(sort_by_columns))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         d612e943-9af0-42c1-bb0e-77d72bf6084c)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         2fe9e374-61d0-4f83-b2aa-64876e877ba3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4aa1fe12-94b7-4f2b-b6f7-1b20aa2cdbd9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         02774950-7504-43d6-8f0c-63a34c021a67)(content(Whitespace\" \
-         \"))))(Tile((id 0dc5dc42-76e0-49ea-bc8a-36a825ab8683)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         4f252398-0826-4993-a819-4a2f12153cc5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         92c866ec-31e4-4955-877f-4cd9cca288bd)(label(requires))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         edb4d7dc-3458-404f-b45c-4a1f4209548b)(label([ ]))(mold((out \
+         aa8754fe-98c3-40fd-a2de-3708ac192fe5)(content(Whitespace\"\\n\"))))(Tile((id \
+         8fda61b7-999a-4f9f-9842-dd68b82af409)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         51c4db51-972b-4f75-a11e-0edd1d8ba185)(content(Whitespace\"\\n\"))))(Secondary((id \
-         222170d8-bfdf-4536-8eb8-0d4fd7c9e5a8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b4c2de08-8b60-4196-b3c3-a317a38bfe58)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d659a607-a3ed-4389-88ff-2e6807f15541)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         15e30fb6-5c27-4e63-9896-31418cfeb60d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         26e822e5-926b-4c58-ab58-2993e91eecc2)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         9a64bd3a-745c-406e-b9fa-c9e70d115304)(label(enforced))(mold((out \
+         701738a2-ee79-4e93-bb8f-a87cb65676a5)(content(Whitespace\"\\n\"))))(Tile((id \
+         da0dacd8-08d8-436d-94df-47786cee0f4b)(label(tsort))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3b43bdd1-dd29-43cc-b677-aa97a58183f8)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e5675c92-12ee-4c02-b551-192c339793b1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         3823a19d-6c68-44fd-ade8-621bd8cd4ac0)(label(false))(mold((out \
+         f42c66e5-bd5e-476e-9076-27f009fc06b6)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e5d2a3a7-e51b-4fab-804a-0dd8da70eab4)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         c4380f31-2345-4d96-bbb3-a5dfb8135032)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         7bd5bfb3-5c71-41e5-b24d-be7561b3a755)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a50c97f1-0a9c-429b-8673-fcf8a6dd167f)(label(,))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         76df757c-89f0-453b-b9ca-511af392b89a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8eed5c80-8d7f-49fa-8ceb-92727aece914)(content(Whitespace\" \
-         \"))))(Tile((id 782f2f0d-1d7d-42ed-9b4c-b0e898ef9029)(label(\"\\\"cs \
+         e0c2bc0e-ca0d-40e3-9868-170c1c65b22e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d6a484bd-c1ec-4488-a73b-4a0eb1494e84)(label(\"\\\"final\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e27b3f8f-971f-4f17-a1c6-3260140025f7)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7ec609b3-989d-47af-9dbd-2c8f8cb955e6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         86dd2f6c-01d7-4188-9537-16b74cead2a5)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         3a4796eb-26d1-436a-9ba6-71e51c487075)(content(Whitespace\"\\n\"))))(Tile((id \
+         07ccde36-305a-478d-8d21-1a11524ec220)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         10d50a21-3bfb-4f85-8db8-ba598bd94379)(content(Whitespace\" \
+         \"))))(Tile((id 5546bebc-5096-4f02-a44e-f61d48bf9fab)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         15754e35-953e-4a60-9309-70c96826cf5d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         3bb74580-c3be-4a66-a98d-54222bfb55a8)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ef4a91ab-9da4-4421-8724-0b6feb1d3b6a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d99507c5-e4b3-4413-8b5a-1312b929f30c)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         f36f6a8e-8ba8-4546-b105-901158fde094)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c65f863a-bf18-45f0-8f38-9ac5208ea313)(content(Whitespace\" \
+         \"))))(Tile((id \
+         104f6a62-ebea-4846-99c4-5690afebdbd2)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         656b7e82-c813-4230-b0b1-84c80d012b99)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ffad3613-20bb-4867-a6b6-e24f753719c0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         15f31db9-d68a-4ed7-b341-086f68fe80e4)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         73bd030e-b5d2-4c44-8490-6a9d8ab7d2c1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f7a2ed01-0a02-4979-bb49-dbaafcd27dbb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4aba5218-d499-4194-8b2b-ecc83d77bff7)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1fd5f5d6-f7ba-4f37-960e-9fb57bb96990)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9562167c-309f-420a-828d-ab2d506d99c2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b707b4c1-4ce5-42ca-9dc4-2282c1f31e0f)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3327a9c5-e171-46f7-96ed-7a6dd1313e4b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         76804fbd-18bc-4870-b9df-f42925fbcb4f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         111833fa-e19e-4b57-afc8-324865167b8a)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b7e4e7cc-8956-4402-9836-f15041649dd9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         536fe62b-c410-4ade-bf00-2ebf2c03ffae)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5a63e790-4d7c-41f1-8536-97a2f842f9a9)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0a6b1540-fad9-4597-80ff-c4e04431b4a1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         054eb1ad-13cd-47a3-ac8f-75a0ab59dbfd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3081d5a2-a3c9-4cd2-8f21-71f29061438d)(label(87))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         701fd786-1d64-40e5-98bf-c21f2f771e03)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         054e59b5-8a68-40ab-adce-11d18ec0db25)(content(Whitespace\" \
+         \"))))(Tile((id \
+         721bb428-f540-4da0-be6f-5df7ed523bf9)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         c514607b-8aa8-42bb-a8ec-ab7eff6f19ad)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1939960a-6c20-4f03-8160-4dfcf3f5d73e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f9190600-eee6-4b7d-a3bc-1a99efa4bdbc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f5562b7f-492f-41de-97ab-00de54b677d6)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bc4efffb-735e-46df-9587-621cc472c7ab)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8b7baaf7-c737-4f88-a044-6f5a7a97deee)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f7d6d215-6560-4ba6-a3ba-3bfd8fec33f0)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1c01d780-4553-403e-bb14-6d822b0cdcc2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3bcaec3e-2bc5-447f-97fe-dbc09b782dba)(content(Whitespace\" \
+         \"))))(Tile((id \
+         356d3478-5e8d-45e2-bf54-dafb8f637296)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         eba2e901-0e20-4d72-94cc-0d0b28557fd6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         37666652-95bc-47d9-b862-b96c6b05e83a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e4388647-c07d-4650-900f-e71b4d31fbec)(label(88))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         64112f0a-2e3f-49b0-98a2-22f193d13f57)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2736be1e-b7a4-4975-801c-7a25b60e3e99)(content(Whitespace\" \
+         \"))))(Tile((id \
+         007e7b83-1602-4675-a336-608758c79204)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         dc9df911-7ff8-43c9-ae81-414c3fe30fe5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b2a9f80c-6ecc-4323-90b7-0574d29c068b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         119feee5-3cf4-468e-8bf0-a7f399c4424d)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f581697c-790a-4340-8f15-eb2e347d342f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         948c1a7d-f888-4627-a60c-9b5d4b560d5a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6e81415b-03f0-425c-a0b7-3f46d9dce040)(label(85))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         0e257168-2df0-4e88-9b23-538956c9374f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8834f2b4-7f1f-4eab-a1b9-411134cdd5fd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c2c3be31-90f1-49fb-8385-7585d02b33d2)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         bdd228aa-4f16-492c-86ba-15b8bd6a4c77)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         af3470c8-b65b-4c0f-9533-c28c785330a9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ebfd75b1-5d55-4f03-9c7d-1e807ec87395)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c8b404fc-9446-4316-b0c6-4efa41095954)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e2442265-ba55-4acb-ae72-f1f3772f7690)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1b925e79-fce3-42f9-8e87-441708d868c6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         de5dcba6-15b1-416b-8e1f-687b683b1a49)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b6624bc2-57a3-47aa-9faa-4366725ba9d9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         895a0e87-ed93-4213-85c4-67fe621d41f1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b2a68e30-3b8b-4c8b-bfbd-2f2f99207aa3)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f3747516-05f4-4072-aca8-92b1836404af)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         50f70e5c-63d1-4c6f-a6e9-4a199b18dcc6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ea52e8ba-663c-465a-893f-d59f28021a12)(label(84))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9b779b96-850b-4b5b-9ee9-233ac2b6f81e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         819ab9dd-c7bf-4ac4-9a7e-d8ec3f982ddb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3bda3c13-b6d9-46f8-8c6d-e81956758b21)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1f77c455-ee15-487d-9182-19c66c4d59d7)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ad5d6123-811a-438a-85c1-428273cab0dc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         91f6d3cc-8ec2-4ed5-9681-02e0b75ff9b8)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         61ada085-cc3e-43a1-bec7-166918cdbb39)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f09cb096-1e20-4705-a713-c92b35454b4e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8d106da5-64d0-4d25-a748-5937a8c7f039)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         179ac95d-2261-44ed-a58f-7b6e757cae94)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9157267b-bf52-47c8-a8af-e600a2ed8507)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5150408e-e2cb-4a98-8455-eb59a7256b2e)(content(Whitespace\" \
+         \"))))(Tile((id ac650eff-8793-48e1-8bef-7911003e898b)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         483a1a27-b927-4f16-bf41-6be9df3ae5b6)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         1b0eba02-1073-405f-b184-73f9b3dec333)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f2d413c1-122d-4420-b42d-9972154b4ce5)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         88fba842-67ba-4985-97a5-5a1dc32e69da)(content(Whitespace\"\\n\"))))(Tile((id \
+         29e07873-1948-4088-a155-2ff45c08923a)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         4b0ad0b5-f7f2-401d-9c64-cf334774ea54)(content(Whitespace\" \
+         \"))))(Tile((id \
+         42d12d11-68d6-41df-ab5b-9bfb0698dc54)(label(sort_by_columns))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4700a2eb-670c-4f8b-ab2f-96defd51200e)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         bcb81a4d-779c-4da9-9f37-79885a42c8f2)(content(Whitespace\"\\n\"))))(Tile((id \
+         d89b3c2c-099b-4c52-988a-5e368bcb8d20)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e5c516f7-ab96-489b-a516-bda37a233e38)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6491b8bf-64be-480f-a385-71f3970dd001)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3bc26f6f-43cd-4b11-b7fb-28dcf80157f6)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         369da280-87a5-4722-ac41-5712fcb5303b)(content(Whitespace\" \
+         \"))))(Tile((id 2c39eaaa-6e3e-4c8a-99fa-696a3fa5cc38)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         b14be62f-e81f-43ae-97d2-e157b9bd11f1)(content(Whitespace\"\\n\"))))(Tile((id \
+         9b942edc-01d2-4b61-9e93-0227e77ab9b6)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         0e1fc9c7-b1ae-4c5f-a451-4e60126fe248)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c0a8b40a-903b-413a-90b4-5c8dbdcb9426)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         089a0a8d-581b-4f9e-a096-e9708757a8a5)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         30eadf41-76c5-409e-8c1d-9cd8c030c2fc)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         8315c833-cce6-42da-9de3-ffa8bc73d8c1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d3e294db-ff6f-4144-a32d-60bbc94a7c2c)(content(Whitespace\" \
+         \"))))(Tile((id 65b316a3-6097-475e-b517-4b09b0755a44)(label(\"\\\"cs \
          has no duplicates\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7eda7fd8-13c9-4a50-84d3-110436434e4a)(label(,))(mold((out \
+         1f2edf30-b656-4b35-a6f5-fd6b2692b1e0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c293f96f-3f32-4b51-9780-93f1397d4668)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bce241b9-d46d-4161-84aa-044dfefd03ef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e9eac197-f46e-4788-ade4-18a9ece860dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f480279e-8385-4599-9878-4cfeabe4be70)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dda90b02-4a29-4166-a01c-2e212de3957d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e92bbe0e-a0de-4e3d-983b-1ac5be791b8c)(label(\"(\"\")\"))(mold((out \
+         5dcfea5e-329c-40db-9caa-9e0b3b4a4b6b)(content(Whitespace\"\\n\"))))(Tile((id \
+         306dfa7a-93d0-4ab7-a954-ac7fed2cdd4d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         5ad05bf9-9f47-4f3f-b982-73e065d66a3a)(label(enforced))(mold((out \
+         cdee60b7-60c9-4ab9-8628-233ad53cb448)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         eb847005-dee1-46f8-9233-23221dc1d654)(label(=))(mold((out \
+         4eab2be0-6fa1-4a4a-98ea-3d4069b5a074)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a951ece0-cb56-43d7-aede-f1d7fb01b198)(label(\"(\"\")\"))(mold((out \
+         b44235e9-205c-4075-ad15-f425f5e96707)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b1991b7e-2eb0-4870-a68d-5358c08c8883)(label(false))(mold((out \
+         ed4afa4f-89b0-4168-814f-9defa48ce173)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         775a6dbf-6a96-4cff-81a0-63eaeb536146)(label(,))(mold((out \
+         5c0016be-820c-42dc-9580-1992efef140a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1eb37786-b555-4084-b71f-b924c16c0021)(content(Whitespace\" \
-         \"))))(Tile((id aaba00f0-2e12-4dc0-86fe-b250540f4908)(label(\"\\\"for \
+         957fc21a-0a0d-41bd-b487-63200a5843c7)(content(Whitespace\" \
+         \"))))(Tile((id 4ea33f48-d03b-487d-847b-97625669adcf)(label(\"\\\"for \
          all c in cs, c is in header(t1)\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         30cb2097-c91b-4230-b8e9-73da8fb206c0)(label(,))(mold((out \
+         9f6f2603-62f9-42c5-b3e8-760b20728251)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f48c05dd-adb9-468c-928b-4bde1f98fd41)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7ce2a648-45e3-49f3-8f67-2f901ea92290)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c78c6464-d0ad-4846-90f1-d5bb17af5d5a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2e61e55b-5c5d-4d4a-bc7a-043a0d2adbe5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f036c5c-afe3-4a03-90cd-4bd23ff34578)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fda90e91-9530-4526-9206-a1ef8e386419)(label(\"(\"\")\"))(mold((out \
+         acdf4230-5de1-4f88-b25c-dbc688e11ce1)(content(Whitespace\"\\n\"))))(Tile((id \
+         85a88d91-5a57-4038-811d-3428a4746001)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         9704a29d-c332-49d4-9929-4c029b51ed78)(label(enforced))(mold((out \
+         758c3e13-b718-4972-94b8-188ffada2db0)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ddd84027-f0dc-47c6-932e-72207ffd9182)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c243857f-7309-42e8-b8aa-4f54ce3a5c04)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7c7d1bc4-2515-4b19-b6a7-beee4b2bfdc5)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         948f2f52-5a2a-4bcc-a09a-44ae647f2154)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fb6c66cd-ff2a-4a8a-899b-3c055417e9be)(content(Whitespace\" \
+         \"))))(Tile((id \
+         efedae8d-757f-44b9-9096-017411caecd8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         aa039b95-b4fb-4850-b60f-bdd7992baa08)(label(false))(mold((out \
+         8146a42c-2151-4a7f-b341-37702dd28d61)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         c13dbf96-9b19-49b9-bfe5-a01af77d3b73)(label(,))(mold((out \
+         81cc1c3e-10ff-4865-92f8-a5d6450e7866)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a8e5a3de-b209-494a-8d46-6e147562cdc7)(content(Whitespace\" \
-         \"))))(Tile((id 8b7b3596-e395-4e87-b2a9-e6489d8745cf)(label(\"\\\"for \
+         4859344f-8a6a-4a2b-a12d-8b147fa94aa1)(content(Whitespace\" \
+         \"))))(Tile((id e16efee1-b7b5-453e-b3d5-311432517b99)(label(\"\\\"for \
          all c in cs, schema(t1)[c] is Number\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         95f24826-f5c3-4f5f-9b9f-14b41fd93628)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8fcc3008-d0db-4fb0-9006-ba9ec2d77a66)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4cdbbb8c-7214-479d-b748-cecbf750296a)(content(Whitespace\" \
+         8819e6db-f696-4494-9113-c9693f8dbcac)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c1858924-7158-472a-8ae9-d2fff00c8494)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f04287fe-0c35-4735-ad23-56659784fc20)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         04b078d1-4afb-4818-9cea-458b3d6f92ea)(content(Whitespace\"\\n\"))))(Secondary((id \
-         876bd520-02b8-4853-8f72-b0c822b765f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fbad3c6f-6db7-4f8f-b257-65feba296f8f)(content(Whitespace\" \
-         \"))))(Tile((id 1d9a6081-525d-4c5f-8056-a2344fa17795)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e41f3726-2f6b-4591-959e-6dd1d4e754a9)(content(Whitespace\" \
+         6e09e55b-d15b-46c2-8296-6745b2be2f18)(content(Whitespace\"\\n\"))))(Tile((id \
+         4de0d715-2fd1-44b4-93e7-db91ec5b0c8a)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e273a912-771a-42d0-97e9-a04089278413)(content(Whitespace\" \
          \"))))(Tile((id \
-         b5bf0424-7721-4fd5-9d91-3e0dc35777f1)(label(ensures))(mold((out \
+         c58ebacf-6b6f-4aa7-9567-f19e099c8598)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         ed3adb03-b0c0-4d34-8d29-bc168b4142e2)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         d3b3dffa-1041-4038-8e4f-4299930d1de0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a6a75aee-dc5a-4317-a058-5c9492404c34)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6afe763a-d5d3-4273-8d64-6e566b32a084)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         415694da-e4fb-49ef-a85b-9075df38460d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         81f2f09f-8d58-42a0-9ff7-c606054bd931)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f7ceb148-1f18-4287-9f38-c6a19bbcc84b)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         23c0d293-bdef-4184-8e74-75677234ae79)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         739ffe2f-225c-429f-b700-9db13b1d9701)(content(Whitespace\" \
+         \"))))(Tile((id d8b437c4-2146-4475-b8e1-00dac7a75d13)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4e9e9ebe-7ead-44df-8131-d931138c4dfd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         6527c8e2-f708-4252-a90c-8c01d3ba0c33)(label(enforced))(mold((out \
+         380396fb-0199-424f-a013-83017966d5b3)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         71d8fb7a-0084-4f22-8701-a56f2d261bb2)(label(=))(mold((out \
+         82253e82-1027-4448-b2e7-421a634faf08)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         1abf6924-fec4-43a4-b43f-ff1467b7dce2)(label(\"(\"\")\"))(mold((out \
+         e272664a-5a76-4df3-b85e-9312872dcb82)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         1a531715-7dac-4722-a1f4-9cc96eb94d43)(label(false))(mold((out \
+         a837bc1d-04d6-47cc-b17d-7d35afd0ae31)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         29383102-e137-4266-a1f9-36fda54fc795)(label(,))(mold((out \
+         5e365739-3447-4ec4-9eb7-c45e567fad39)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ae5f3867-ff45-4806-8e83-8d427b8d901f)(content(Whitespace\" \
+         3a7a3e26-4f5d-4133-9af3-acd486a593bc)(content(Whitespace\" \
          \"))))(Tile((id \
-         f46b5546-3a76-47ac-ba77-355f99e74285)(label(\"\\\"nrows(t2) is equal \
+         319dff42-f4b1-4586-a143-922fbb0c1b91)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         82dc3053-8791-43ba-bb02-74e4d027906c)(label(,))(mold((out \
+         b7d4fcd6-6c34-4eff-9bf1-ef36bade4257)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8617ea4c-47e3-46a7-b20c-d9ffbc5b7bae)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e501186e-10fc-48f9-9eee-2efa2d29df3a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7cbb9a9c-79da-4bbf-a1b5-0ec772153b81)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5b320814-e1a2-4296-bcbf-a6df86ccafbc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6060cff1-e5c0-437c-b10b-5d4b24fda3c9)(content(Whitespace\" \
+         f4135dab-f1b1-490b-90e0-0d8df7ee41a2)(content(Whitespace\" \
          \"))))(Tile((id \
-         9b1fd13c-42da-430d-af42-60fe6926c004)(label(\"(\"\")\"))(mold((out \
+         9ac420a3-140f-4c0b-84c1-c2a5c0ddb661)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d380252f-054e-4f54-a429-79abfdb6ca3c)(label(enforced))(mold((out \
+         9edd3d0e-b779-40eb-986a-4e6492a6c43b)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         86256030-e715-43f5-add3-528c041440e5)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         61fabb0b-3fcc-4043-bb82-1cbe31249990)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6f61cb98-091d-459e-9260-39d8fa8326da)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         253b044a-9847-4d29-9930-071b95df6832)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         568c75ed-af19-4e74-838b-f97841f20c1d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f640a48c-b534-4bf4-b84a-e7738a64dca9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         6609eac4-364c-4968-94c5-84d471b6a41d)(label(true))(mold((out \
+         327fd4ae-4178-41ae-9b5f-dbb32db8c49e)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         553fedf0-a712-420c-9226-ca2c69595c40)(label(,))(mold((out \
+         5a4e059c-fbf5-4684-a9d8-239014f5b275)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ed8bd967-b48b-41b1-95f4-1623a35f0174)(content(Whitespace\" \
+         048f4d05-8d73-436c-8d5d-ab2ac1862f91)(content(Whitespace\" \
          \"))))(Tile((id \
-         ffd08799-508e-495b-9d3f-80b939a910b2)(label(\"\\\"schema(t2) is equal \
+         7cc72b35-0ebb-493a-aade-1fc5eb1ff96c)(label(\"\\\"schema(t2) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d75b7560-e837-46ca-a57b-c3c6cf06fa4e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2abf3c8e-4c69-4a8d-a1a5-fe27d9474655)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e573eb3a-61d8-4a2f-8ab3-f0d4f7949691)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         ff402210-9997-412b-aa2d-12462818d4b8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         54fd5b83-fab6-4a0b-b100-55568a174aa2)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         ed7643e5-ded3-4096-9bb8-81fb1ca65d6d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2552b5b3-8dc3-4ef4-bf9d-a5884f186d84)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db996c6e-93e5-459a-b37f-24b7d23174db)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e61acfb4-9c3e-4f70-aa1c-0578ddf78fba)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c75c3d9a-54c9-4aa0-a973-310f6a995527)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1378ac2c-d0a6-41b4-835e-d15f0cfa12e5)(content(Whitespace\" \
-         \"))))(Tile((id e04551c2-cd32-4ddc-b349-21befea52a15)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         eb9f7763-a6d7-480a-8e90-e56ab001495d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1417823e-3ff0-4e3c-b1fd-4539daa34ad2)(label(lexicographical))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         7cf52ea1-156b-49d0-a96a-67bff3a9ec5b)(content(Whitespace\" \
-         \")))))((Tile((id 51cff06b-9640-43c6-bbda-a31906eb8d41)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         12b80bdb-2312-4dee-957e-7b349fd7b18d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         54e68f00-4de8-4555-88de-7085b1152434)(label(t))(mold((out \
-         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children())))(Secondary((id \
-         18ea5eaa-6eea-4927-9486-2136e12ef557)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         115758c4-7168-4bfa-9f80-2f4f67867465)(content(Whitespace\" \
-         \"))))(Tile((id 88e25008-b566-4843-b101-62ddcf8a7a46)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         03aec878-1bbf-411e-8285-66ccd0390bcc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ba027563-b5d7-48f7-8087-185b82f89be0)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         354a1357-d666-4ebc-abaa-390c5b56c160)(label(comparator))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         392f077c-e6b4-48b6-a4a9-4ce8e019a4e7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5d7851d7-d8e3-4acd-8036-49f2fb30992f)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         31f37ae5-d066-4c1d-9b6b-64e2b7746619)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9383b883-a7d3-436e-89cc-f560186da351)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         fa0b2da2-e372-4424-b855-ccaf2881aa66)(label(t))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         161e6978-90fe-433f-a38d-624fa931be48)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2c7175f9-79bb-4ac0-9c12-442ea165f561)(label(t))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         eca5c867-8513-474f-abc6-42bf41210664)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cbbb1b76-2443-48ab-a5a1-eff356bc06d6)(label(->))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
-         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         35690fd8-3143-40bd-80b7-70a730a11ea8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         00a575f6-9ab0-4cfe-a782-577f0d44bd5a)(label(Ord))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         074061da-f61e-44ae-888c-ce26b8869160)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         888a42cf-4975-47f4-bc6b-943d5c53aced)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0f48055d-9f15-4826-a0ab-65abfeab8e7f)(label(ts))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         5edaa733-b4c0-418a-9c69-763cf3dd6d46)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f862ae4e-9e4a-416d-b070-f01957fe7272)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         a78f8ff0-9023-4835-a414-856fc2b2fe25)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         a48f630c-ec1d-48d1-b2d1-660a8d76f9b3)(label(t))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         de21100a-95bd-400b-a830-10efa2a61232)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         c09cdd81-9b00-4781-a208-55e361833582)(content(Whitespace\" \
-         \"))))(Tile((id \
-         87b8023c-752c-470b-bc76-a0803ea11846)(label(ts'))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         97231645-3860-4c77-942a-1c3e2dc4c075)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f841b89a-db27-4f91-927f-32cb2532d1b4)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         e9a3e67e-a0ce-4bf1-afd9-ee42d55c0941)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         0bff7765-ca04-4514-85d8-390ab903c23f)(label(t))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         a78d75d0-a105-4e10-a910-dd0e83334a36)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c5fde3f4-979c-41ad-a374-aee50eb074a0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         015a5432-fa8f-409c-890a-6f53041d462d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f991e255-324a-4f37-abc8-087d6e65f9d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ce0faf2-7b88-4bc7-93cb-5ef362ce4c29)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b03dd9a7-1e39-4ff9-8ac7-9412ffb06411)(content(Whitespace\" \
-         \"))))(Tile((id a3e05c8d-d6fb-4a24-8f03-8ebfca97d9c1)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         73e94475-14c7-458c-a315-450eae3cc392)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d24c6e36-4200-413a-a916-5b6c7d474fe9)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         cefae03f-5350-4704-97a7-1cf0a6b6e855)(label(ts))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0250d02a-aef1-49e8-acb4-27b60acc4792)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         84ba5f8f-c087-47a9-a25b-0979d52cebbf)(label(ts'))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         19e302e1-dccf-4534-b294-0cdcb82dfa58)(content(Whitespace\"\\n\"))))(Secondary((id \
-         95b7d0ab-c774-4223-8da2-5a9bb91ecfbc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         138b7b02-694d-4157-9cee-1b8a43b86711)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e12d4327-7be9-4c4d-8e5d-8f40122e8375)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         335d0169-9dc8-4332-a50f-5ea760af1e63)(content(Whitespace\" \
-         \"))))(Tile((id 25c70248-19a7-45e7-b12a-90c9d525f85b)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         100bed40-b53d-4ef1-aa52-bdf8b28de45a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ce1ba140-1e43-4931-ae55-bf031d1229d1)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         38462a9f-3626-457a-902b-8d6b98e787ba)(label([]))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         4a567c21-0d61-4929-b93b-70cab826b3d5)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         0abc98e8-4d19-4637-8a34-806f6f350046)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f7a80f8b-6419-4349-acd1-bdb842d22f62)(label([]))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         60b9a96b-8589-4f87-b2ee-a0dd03e57d73)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         7ff69271-1ab5-4fb0-a806-5edb136a2cb8)(label(Eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         11b4ef18-857b-4a86-90b4-1807b9c169c0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         12956414-aaa9-4a2c-b1cd-8167d2f80bbb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         268f95b8-e17f-4ade-84b8-1a9f0ee07607)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dfe1865a-0725-4b79-b560-15742e42c653)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ef580828-ed35-46b2-808c-049c551ee81c)(content(Whitespace\" \
-         \"))))(Tile((id a8c3d36b-8f88-4f29-8db0-e84ee6db5249)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         6eaf635a-b9d6-42fd-8107-182093487b65)(content(Whitespace\" \
-         \"))))(Tile((id \
-         297425fe-c969-4046-9d23-5e24f729b5bc)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         6e813d90-d027-48b1-8cd8-f488d17288e5)(label([]))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         92a1d8b7-3b49-4b24-a6f9-cb16f4d255f3)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         a514993e-8766-46af-9c61-e27905c13579)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0572a7e2-90bb-4148-804e-b14ae2ba7950)(label(_))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         410377de-8a26-4232-95e4-b9c3b59af88f)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         362760e1-4ee7-4d46-a703-5f71287514d9)(label(Lt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         d00bf504-12d3-4e78-9184-dbff64160c14)(content(Whitespace\"\\n\"))))(Secondary((id \
-         52f29d0d-ad8d-4ecb-90c9-1931f6e7d4f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2bbc9a7a-154b-44ff-a06d-f141c5fc4c6d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         109dd6d8-c93d-4840-87c3-7b9e670b0574)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7d925a81-9c3a-452c-a9a0-6de3168cd8c2)(content(Whitespace\" \
-         \"))))(Tile((id 0fe2ab66-3b0f-4255-98d1-a19a52c7af43)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         53b9285a-6858-41a4-9423-f8a73e53e272)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cb3f57be-2ffc-42e1-b649-a7fc707bbe9f)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         61a11bf3-b30b-423e-9447-b7bef362a5c1)(label(_))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         c46841ae-2090-48f3-bde8-d20dc8199007)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         48aa43eb-ef0d-480d-8fc2-f9166d7f0a26)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5fb973f8-e8c7-4678-9a66-e9b4a2c05e66)(label([]))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         613ca4da-4712-4af1-8a44-7614811c53f7)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         a663f46e-f5fc-455c-959a-6ef1600f32fb)(label(Gt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         db478a9f-ce8b-46e5-85f9-6b74722149c3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         02426b4a-e818-494e-b131-3073930aa888)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1c1db37c-7d75-4fb9-a9b3-1b80878ae01e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         95a8e5d5-f556-4883-a239-0dbdfb6161d8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         600d1fe0-575a-4d1c-80dc-19bfc0a8bf70)(content(Whitespace\" \
-         \"))))(Tile((id c7d7d5df-0347-427b-a9fa-8e3201dd4fcf)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         4f1f0dda-05d8-4158-9261-5f6bf1bd89dd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         391a91b0-a4de-4b8f-b747-a11ce88a8228)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         111281f4-ee8b-4eb6-a98f-0d3e9260d468)(label(x))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         c41e173d-dbdf-4bf2-8ca0-1c99dd803e4f)(label(::))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 29))(sort Pat))((shape(Concave \
-         29))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         051b69df-2889-4a01-b01f-d2123366507b)(label(xs))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         b8ca1676-2f6e-4975-8487-faacd1d3b84e)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         1ac365ca-a175-4a8d-988c-3c0e2aa23461)(content(Whitespace\" \
-         \"))))(Tile((id \
-         41a76ff5-b21b-4dc5-a39b-2df18071601d)(label(y))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         544c9cc3-d1c4-448a-a596-0a34d800fda7)(label(::))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 29))(sort Pat))((shape(Concave \
-         29))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         75d6975a-c339-4d22-afe0-63c1b4d0196c)(label(ys))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         dad86eee-4d6a-455a-a8cf-65b0803885d1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b9ad52f6-1c84-4c6f-9712-b0cf06075b77)(content(Whitespace\"\\n\"))))(Secondary((id \
-         33eb739a-9339-463c-a12c-de2493a762cc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5680bd22-a31f-407f-a3e6-56717c807ce1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bfee9b70-38f5-40a8-9b90-e28bedd1d6de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         379bc879-ff2a-4e73-a259-441fa709f7fd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         caa74c73-ad5b-44e5-9000-1f2900a934ef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3df450da-be7b-4c14-a2cd-c49348d5cfc4)(content(Whitespace\" \
-         \"))))(Tile((id e5d932b4-b8d6-4f7f-8409-19dc51f4182f)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         01ffe8bf-9ebe-4893-819b-9805fa1c8e35)(content(Whitespace\" \
-         \"))))(Tile((id \
-         14b29006-32b7-4711-ad21-e746e245a5a3)(label(comparator))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6e98e897-8dd9-461b-b80c-dec686f49428)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         a0cbda45-8767-48dc-b5bb-99b2b042e64b)(label(x))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         403c954c-5b52-4095-a144-ef82ad1afdf3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0b2da658-05f1-4acc-a624-f6edcb76d399)(label(y))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         28296742-1829-473a-b75b-29bcca8f915c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8317c489-dff7-4733-8b48-6a2f916b64e7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8f7e379-a986-4bcd-b2a2-790ad24095f1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         48e91831-585a-4013-b1e1-cd46e5cbd27b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f4fe38a-4c4d-45fb-ac7f-3ea3627706df)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         880029e2-a776-48ec-99ee-d77ee7b5d345)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab1faa74-4e28-414b-96a9-a07934e0c740)(content(Whitespace\" \
-         \"))))(Tile((id 26f5d8de-376c-45b8-9127-5ccc62ee8b81)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         627d9fb0-69db-4262-a512-cc882c0709f7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8aef1d31-5d53-43d2-8147-667086745a8e)(label(Eq))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         fbaeb3eb-a694-4e98-8f51-2e6c16328243)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         2bdaeed4-7277-450f-a289-0225bfb2631d)(label(lexicographical))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b29f72fb-1d1c-4b30-bf4c-fe5bd86af21a)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         681ada4b-6b4d-4078-a1c8-434d656eec12)(label(t))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         45ab4a12-0d55-46e3-aecf-686d9c5cbec5)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e9338f40-8167-4b5d-a850-a0ef748576e1)(label(comparator))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a4cfe991-299a-4c8b-af30-af320345e299)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e3256b6b-5b79-4fa3-b329-149fe3c85318)(label(xs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         289eccab-a50a-4509-a91f-c82ef76002ae)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         301cb450-f272-42c0-ba65-a789949b40e5)(label(ys))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         96a86159-f1af-4897-aaed-29650eba2c1e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eee23ee4-6b1e-4cc5-a0a4-deffb98c563b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fc17d934-d5aa-4ad1-b360-be754ddaa72b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         90088660-d132-4e83-8dec-33c8dc08e62d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cec5dc53-79d3-4a75-9527-27c4dd1e0a7c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         59c1ca41-bcf3-43e3-a3cb-4285728feb55)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f2589505-80d3-4624-9cb3-54c90251522b)(content(Whitespace\" \
-         \"))))(Tile((id 2e486db7-c350-4f9a-81e1-d750cda22f63)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         de9f8195-8154-4204-9548-6130a6cfd3d2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bd699f95-da80-4f80-9d99-0c9338f59dc5)(label(ord))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         2f49dbc9-ccb6-4135-bf8a-018b092fee02)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         ff0d3a3f-a48b-4e18-805e-c4606c9e6626)(label(ord))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         a79b437b-9265-4a47-bee5-1105029bd7f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         292b9ed4-95b0-450f-a888-f0246a4ded6b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f73e6570-e034-46a8-9563-3d7788e21a1f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         67b5fa1a-4cbc-4688-bb1f-533c9362c537)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d1d4dfb7-4ee1-463f-9fc2-73a8f69e2b06)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         74ee870e-0c33-4477-8724-727ab6d017d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2991e748-a67d-4f97-a70e-ce647a9e95fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         09ebdba2-fd58-4c6e-ba4e-a51b92f19049)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         79926621-26d8-4923-976e-6f9671d88130)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5890e2ad-0008-480a-aa78-c6fab5d93d9e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         916b5078-cacb-4e0c-a237-19322b5bb827)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         279e250e-704a-4e81-8f89-ce9044cb59ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         42afe371-e5ce-4fbc-a5ca-ec7177ac4611)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bf1788b6-26d3-462b-b4ea-65448b3b4154)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c3c45040-e8f7-4017-ab38-d23829ccf9b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         be398e37-1cab-4238-9f00-c929b5ddb797)(content(Whitespace\"\\n\"))))(Secondary((id \
-         236b7a54-fdf1-4689-9064-6245c5c147f3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         21150942-1dff-4775-8c54-c6fb1b052bee)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         95db29f6-d536-4185-a2d0-deb0b1215115)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bfc582e7-c667-4794-9d52-a15bff2552f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f0199299-6385-448a-8d3e-50952c34d670)(content(Whitespace\" \
-         \"))))(Tile((id 19bc616d-deed-4400-b80c-abf54230045b)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d6c98366-b2d7-482a-af1b-8c66cb98e7d4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         65fccceb-837c-475b-91ea-5a62ddf8303d)(label(int_compare))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         5c23fd4d-27f7-42b0-98cd-a8d605190588)(content(Whitespace\" \
-         \")))))((Tile((id 3360e5c5-f5a2-46e6-97f5-9f9fa20cc55a)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         2721cb34-9ad6-423d-af6e-9bd1d2179bec)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c04bc60a-4092-4f4f-b4e6-3d48c4ffe504)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         a5e79f9a-0891-4e21-aca3-ddd3c9fe861b)(label(first))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         14f3b7a1-e4b0-4a07-bdd5-6de532e33949)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         d637d3e7-7415-4017-923a-92626653a9f8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a6afb6bd-995b-4f7e-ace2-4db6d373d9a6)(label(second))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         a0dd2550-03ac-4dad-a727-4020b58eb6af)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d7253218-dbf8-4ce8-8f6f-3180d4217b51)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f9a73fa3-796a-4ef0-8250-1800b85f16db)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         01ad8ca4-f8eb-4d95-b224-b9a4f63f1dd7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         821e83e3-bbe4-4c05-8b4b-006aa00ee957)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61860358-da05-46ab-9967-8d0cf67a31ec)(content(Whitespace\" \
-         \"))))(Tile((id 486a740f-0ac3-4f24-966c-af29d2c85608)(label(if then \
-         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         15277dd9-f3b9-4b3a-a432-70f44e89768d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         24989781-a63e-434c-a9db-18215ae1b686)(label(first))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         a2a55390-48ca-4777-9565-579e11daa4b3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         86feb96f-94e6-4103-85a5-e0f7bec337e5)(label(<))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         70e93cc4-c8b3-4830-b8ad-3ce1a69d83e1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         41f4ed8a-a896-42ca-9252-468fd8ffdddf)(label(second))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         c4cd370a-b1d5-465c-b591-891d3a7af68c)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         b8584127-bb62-45bd-8550-0bfd722641c6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         665233d0-3401-48c3-9c19-36e7937ba537)(label(Lt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         c8e50126-3599-4c81-9c73-c3e0de04a52f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         223912a4-6350-4c15-8f21-5c1f81d5a572)(content(Whitespace\" \
-         \"))))(Tile((id 6ba11dcd-a910-4748-b245-50aa2a6fbadc)(label(if then \
-         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         8e4212c4-41e1-4390-b1c1-4512f3d273fb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e7f26064-6c70-453b-a3ac-92eb9085f761)(label(first))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         07a283ff-b5f6-416e-b53a-059b271833bd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d6b08c2f-4d19-4857-8971-48fd0b33f4ae)(label(>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         67bf0090-8a7b-477c-a030-fd6600447778)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a45bbd97-fba1-4a46-8a32-e048224cce75)(label(second))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         d6e7d604-01e7-4051-9ea3-921bc52d68d2)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         0633acc7-877b-45c5-8615-fcfd85db1386)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fd3f7ffc-f943-4ae3-a4db-ad4164602f39)(label(Gt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         daf4fcd2-fcec-4d74-968c-19952be9543e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         3d19b9ba-b872-411e-9ade-c7728b7b4093)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b3e39bf5-e62e-4de6-8e45-71893beb0dd8)(label(Eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         26f090f1-c9b8-49a0-8601-16f64203f516)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         a4d57de2-9e76-4319-b5cf-35287787cdf5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3d99a4c6-6818-4405-9da3-bafc482d567e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8ed6c24-e643-4296-80cc-28ff77603ed3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5a16a5dd-4799-4d1c-bf2a-c8e4bf41802c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0eb6e338-2766-4fa3-957f-ad65ed7e76bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32ffd91a-5c73-4bd9-b8d7-424ed69bd061)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d6bc857b-e0b3-4a67-8366-c4afeabdd223)(content(Comment\"# \
-         Idiomatically I think we would do this with a implicit comparator on \
-         tuples and then project them #\"))))(Secondary((id \
-         0a489b30-66ec-4f6e-ac66-7997b5685abb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ac86655e-317a-49d8-9876-e802e9be87d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57d49000-65b1-4fa9-9a08-321fa4201027)(content(Whitespace\" \
-         \"))))(Tile((id 206ae3ca-ed95-4e66-9f7a-642f757b2193)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         19020393-cca9-4c35-85ea-f59b351f12ce)(content(Whitespace\" \
-         \"))))(Tile((id \
-         adaa15ac-88c8-4662-b40b-08e341df81fb)(label(sort_by_columns))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         ef4a822f-e61f-498d-ab84-c6ba681cee29)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         10a05d99-879c-4bfd-ad14-1889eb695bbf)(content(Whitespace\" \
-         \"))))(Tile((id a651d70b-2dd7-4842-80e8-2b277e7b0118)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         d07b8d6c-a463-443b-aa8a-ba8a0baafb80)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bb42c601-5c01-441a-a0ed-97db902f1aa5)(label(r))(mold((out \
-         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children())))(Secondary((id \
-         665631cb-5dfc-431e-b5a0-9fa313db3488)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         1f632602-9dc5-4681-a6a9-610baafac46d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8858d9cc-ab4a-41bb-a662-9a7fb842d1a5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b84e3c35-4a59-4785-8277-46f034bd1565)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         34ecf800-f040-430e-b489-d8e12f3c040d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab0d0e68-b606-4b06-bae1-f1365cb60d55)(content(Whitespace\" \
-         \"))))(Tile((id 7caf0c4b-b185-4c69-a2e2-861ff821bd01)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         5526239a-e333-432c-a0ae-f2dec98e6000)(content(Whitespace\" \
-         \"))))(Tile((id \
-         53c116e8-ca9f-4d8a-996b-b58336ac9844)(label(get_values))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         6ac665c7-2b54-4b01-a180-7e55e7d58387)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         46ec7bc1-17cf-4f0d-a294-257726c90511)(content(Whitespace\" \
-         \"))))(Tile((id 5cf72f6b-7cb2-4e11-b28f-e8b3e8b5f804)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         99fbbb1e-fdc7-4f96-b083-5beacbd5c670)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c7dca617-d237-4848-8c01-6d12d610a2e0)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         d57095e5-74d1-4a19-8c63-ccdfca82a26f)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         ff6fc8e4-776b-45bf-a440-4bc60efc43a0)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         eac22814-5e81-442d-962f-c03757215b35)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         7536aff8-3e87-4d1d-b8db-59f06f71d0eb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7acb8ede-c740-4b02-a8c4-ae219e737ca6)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         70fd6a36-3f48-44d5-935f-b1f41f8d2619)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         3349781c-de11-4b3e-86c4-62b718393139)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         05596203-eb69-441c-a6ac-42d88637e277)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         ef250437-983b-47d7-bcbf-bd986922f1e6)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         5c37d8df-543f-4bb7-9c59-2924a842dde0)(label(let = in))(mold((out \
+         59c681bb-7ff0-4ca8-a83e-b1e15e97ad05)(content(Whitespace\"\\n\"))))(Tile((id \
+         a2953749-73aa-40d5-b9a4-1e3bbed51e74)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         5ba0f4e5-e3f0-4ba3-afff-d7bfa96639f4)(content(Whitespace\" \
+         6d34730b-aee9-4c8d-88ce-c961e00423b6)(content(Whitespace\" \
          \"))))(Tile((id \
-         9de3d061-93c9-48ae-8338-8e5e50c8310c)(label(entries))(mold((out \
+         46daae14-25b0-47b8-9ee9-7c8a8938422e)(label(lexicographical))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         aa26deb9-adb1-4281-9fdc-d1f96d6b3267)(content(Whitespace\" \
+         d4f37134-47fe-445a-928c-ed7b7c2f4568)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ac1d582b-4058-4554-ae3c-7019dd553a4c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         24173282-2a0c-44a2-8828-4e41188b8f66)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ea617ed1-f1b1-415d-b8ff-e24d0c03feb4)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         ea110826-46c2-4720-8f5d-89ae48b79066)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ffb6bac2-b766-488a-985a-4b24eb18277e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8bf9af17-80c6-42b8-9c20-9ae9bb436efa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d6d0dea2-1041-4fa6-9bcb-ae171f3d3e65)(label(filter_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7558d933-c491-4e74-84b0-e6f7fb9795ac)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b60cb353-b6af-40ed-98c2-e18a4aa02df0)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e8eaa0e0-403f-4d89-b467-4a4c6179b1e6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         dd72d1d3-4e07-4dbf-9e91-61a2c0e5f5d8)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         096770b8-ece5-4328-a405-8c9aaf4e6743)(content(Whitespace\"\\n\"))))(Tile((id \
+         6ee3acd2-5ed9-44bf-80cc-928bd0f7616a)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         45b220b6-a392-4b10-9fea-498a130012d8)(content(Whitespace\" \
+         bcdf2ecf-e768-433a-b7ce-16c76659595c)(content(Whitespace\" \
          \"))))(Tile((id \
-         ed17457a-63f5-4a57-9078-d368f5601e7c)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         7649f93f-ef59-4787-8ad8-4fc7114ba963)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e9eabb12-cc3e-461c-ade7-d6b5170051eb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b65ad341-bc2f-4b2f-950b-bfa3b901689e)(label(find_opt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         91c24c6c-5b29-4ce4-abaf-02bbec297e7a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         354dc6c9-68b5-4417-ba65-e9d5b4ce702c)(label(entries))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         376132f5-35ff-498d-8fe2-0bde2b2cc935)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         d0c9b4d2-9a47-41e3-9d83-2deafce68e9b)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         1c28345d-c042-4e33-be2c-7193f10be7b9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2810c595-c2fc-4548-94d6-a72c73172a1c)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         f019a6cb-00ea-4b04-b3b2-7ff0b64f884c)(label(label))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         3ad4b465-3c86-4279-becf-018e9699941c)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         91580096-156b-4949-8dbe-50627a619a9e)(label(l))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         47ccc75f-1bb2-4780-ba0a-b1ee1b3cb0ce)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         2b6fac03-f69d-4b65-ae60-2981bc6ccd7a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9cc6d8d9-ce6a-452c-9489-df2f5152f0ec)(label(value))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         68aed3ec-0323-43ba-ae64-f569d64fbea4)(label(=))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         d68b56ec-533b-48d2-8797-8d92a74ca08b)(label(v))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         02a5303b-2e4f-47ec-acc3-3177f3cb5dac)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         1770187f-1119-44d2-95fa-b56d461528df)(label(string_eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         92431dbf-54d9-4d70-a59a-5b3d0f7eeae1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8b3ebc77-cc7f-4bc2-af7d-27517debf854)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         db4e5bea-7d27-4b92-81b2-6227c2ddc082)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         bb13ebc9-19c3-4c9b-9b3a-b13e3fcbe18e)(label(l))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))))))))))))(Tile((id \
-         e903d6fa-793f-4580-9445-7a1550f47868)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         97738c1c-a6f8-402d-8cef-53efbf8c3a18)(label(value))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         078636eb-9ffe-4691-b24e-535da2b80212)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         dae341ca-0fb9-4f90-8b73-0320df55872d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9dde2332-ba52-42b1-a114-9e25d6e3e5cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ace11ebd-027c-4f3b-a00f-6c82e9354e67)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8e86fe62-c93f-4112-b989-950e66cb2fb5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fbf4bd32-a2ce-44ea-8c9d-854d3be257e7)(content(Whitespace\" \
-         \"))))(Tile((id dcff5906-136a-4e62-b2f6-4308e613b477)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         29723912-abf0-467a-aa32-36dfcc8a1e78)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7050e5a8-85b1-4454-b45a-a283a6d6e26c)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         f6f8c17c-9513-43c2-8e2f-caf45f1f3bbd)(label(t))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         59e06d1e-11d5-4bc8-90f2-2f31d814374b)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         031198ad-19a6-4da3-8143-ca454052121f)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         7ddaeb4b-ae3a-4d12-8e80-18f44c6c808c)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         c9effc7b-ad5e-4cca-a2b8-27f7e4a7e228)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         b5b06163-5d83-4ffd-9ca7-19ae9ea99ab6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4144d3a3-5b41-4a6b-8296-04c165f872f9)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         4882eb01-9d6c-4e4e-8dce-f1e754c68528)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6d76e113-50e8-4b81-9003-2ffd06a3bf9f)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         56f1204b-f8fd-46c8-93a7-aad98efd4772)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         304a2484-d592-41e7-bda4-031bc88a3f56)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8bbefb43-63da-4859-8ffd-ac696371aa58)(content(Whitespace\" \
-         \"))))(Tile((id \
-         de960112-c76a-4341-9745-5c1d854aa8c5)(label(sort))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1bb66d92-49e2-4315-bc04-07676d25c4d5)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         af207da6-5773-4472-a70b-e248b9869a3e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         5551b140-22cd-48e4-b3a7-321edf441cf9)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a241b5d3-1f3d-4b81-9ea3-318800274975)(content(Whitespace\" \
-         \"))))(Tile((id \
-         eb47eac1-dcba-4c23-828b-1b4915bd6060)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         da2d3f1e-466e-4dc9-92d0-d662071ab56e)(label(f))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         7e9950e5-c313-40b9-9cf8-b2f9d6f5c58a)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         75057839-8f13-4bdc-87d7-c16d024f2aa0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         97cee4e5-8e91-46ba-b32e-b37f1c6c7c6c)(label(g))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         6ae5d5cf-fc64-499b-845d-a08b9589380c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         a745489a-8fb2-49f6-a865-e66fc876dcde)(content(Whitespace\" \
-         \"))))(Tile((id a5fcc045-afe5-422d-becc-553d26fcd503)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         41952065-cd0f-4201-8e36-fafa598ea13f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e266246f-087f-4a07-87bf-3bc4fe2d2444)(label(res))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         b83c5ac6-d918-4d04-a9a3-1f1c1fbab0f4)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         0da57c3f-08ac-4ec5-af26-9e768a8936f8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f369cca0-09da-4257-9d33-55c33b95af0a)(label(lexicographical))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         900640ef-a99b-4aaf-be93-5e3656a46792)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e153618b-751f-42c8-819f-412fcbef43da)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         263fcce1-1186-4e8c-a936-9e384a539e70)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         70c421b2-e1e3-4a6d-9412-eb8cad786199)(label(int_compare))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0fae7098-816e-43f5-9b32-c38f28b75f92)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         07fd88c4-9c01-402c-ae4b-c97ad0b299b4)(label(get_values))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         93cb5056-4396-400a-afb7-27c3213f4c61)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9058e4a3-ded4-4e85-8a92-2b476902abd0)(label(f))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         33640357-e539-4ea1-bd4b-c9131835f450)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         830c0cfa-96ba-430c-91a9-4ee0d466d8ce)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         642c39bd-194f-46d1-aa33-4eae09e1bdba)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         77001841-800f-4e9d-8618-7868b80d83cc)(label(get_values))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3801c783-9d7f-4d18-ab96-2213156e018c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         88d191ac-f687-46a3-af11-d19bd2ec143e)(label(g))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         385ca720-0eac-4073-9a01-bdcccb302f16)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         090b70ed-93ee-4852-81e3-1d95b9e8e032)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         5e2f832a-5de0-476a-a1e1-fe4aea78ef10)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         eb1ef743-8725-48ad-a84e-8cb2b33202b7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         115357a8-1e4a-451d-bad1-ee86c0858164)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         70ba3434-37be-4085-b428-94012ef7e02f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         864802bf-47d8-4602-a8df-f5915940dc27)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e86f0b64-de40-469f-9ab0-6ab2ba5088b9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         06c46b22-0814-4c66-870b-42c562c96763)(label(res))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         b9c9b122-e168-4b03-8b12-1d323d6455d4)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         dd32458a-2ad5-4ce8-9cad-c05301be1456)(label(t))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         76ee47f3-f059-4b32-a560-927217dde922)(content(Whitespace\" \
-         \"))))(Tile((id \
-         53d943f6-5bef-4733-b919-c85b361bd850)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b2ff0523-54bb-4cfb-839c-11dbe3c08ed2)(content(Whitespace\" \
-         \"))))(Tile((id f7ec87f9-75af-461e-a4a8-26e34fc592e2)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         8ca8cc5d-52f8-49b9-aba2-f2f1218afe96)(label(r))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         774db238-9b9d-4287-8d23-a6d4ada67f81)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a50e0e63-5f59-4215-b93b-bf072a9966e0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         45ae480d-46c5-47da-91e8-a1367092e02e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         61827290-acf7-4d9b-9a13-b885730ec2dc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8c86793c-e466-4658-86a4-ff49ebfa42d5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e60049d-f0d3-4137-adfb-080c13cebe23)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         379fbbeb-ee66-4319-8a9f-10ccc58976d5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3698b31d-9178-49f8-a92b-bd5820faffab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         12f048d1-e2a7-47fd-aae3-de3d9fc908e3)(content(Whitespace\" \
-         \"))))(Tile((id c9f1f44b-ed35-419d-b9d5-ae9d642c823f)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f8f5fbea-1d27-4275-9fa0-854cd4b04d6b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         48e3492e-6efd-4ed9-8f92-fb5b49dd65d5)(label(sort_by_columns))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4c54cfcc-729d-4343-8967-1b26a19ee9de)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4e24eca1-9891-4d92-ad72-904211da1a9f)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         e1e93c3b-6e37-46fa-a80a-8253479ba005)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d6e86cf3-17a0-40eb-aa6e-06f506b79f78)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         96d236b3-5bc5-4c42-bd33-99a75ff592bb)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7f39bea8-2ea8-48be-906a-d8beeb862ae2)(content(Whitespace\" \
-         \"))))(Tile((id 5c0d5017-4a7d-464d-bb7c-cd8c22d10820)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6e74afb0-061e-4aa1-9fb6-99abb0529ce1)(label(\"\\\"quiz2\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8261077e-71e2-4fbb-a7fb-28877dac4305)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4c2199a4-e396-4b12-95b8-6a77db2d3112)(content(Whitespace\" \
-         \"))))(Tile((id \
-         122869d4-4b41-43bd-951e-58f4dee4986f)(label(\"\\\"quiz1\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         73811ed3-abc4-4767-8fec-3fd900f1dcc6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a8b6017d-5070-4321-b367-71652707f8dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         23ee1ee4-3218-4e70-9e40-43ff37792ffc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dc0a1fb0-3a67-4e7c-ace2-f5b33b9246ba)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         86b0533f-0b10-462d-8220-c9abc8843010)(content(Whitespace\" \
-         \"))))(Tile((id 0f5c4777-094d-4a8d-a683-f318c7e400fd)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         b8b8394e-2892-4594-bb49-f352dd1f46c6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a43c0bb5-bfbf-4d1f-ae98-b89f44afe6b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db96561a-deef-4045-a07e-f0583c8c8acc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ecc5152d-1eeb-4fe8-89bf-c88507184cc6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e0e59b7-7bb1-4f24-941d-a8cd256682ee)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ca7a5676-c52e-44dd-b547-c1b795b4ce4e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         575b090d-8d9b-4a33-98c1-520318d0d66d)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b1551520-2442-47f8-8673-920aa264c4a0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fe916288-2007-4c21-89c1-916f30b356bd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a1810307-1b20-4b52-b962-568c17806012)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         276fae3c-5b10-4b8f-b18f-e41445b4e08b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         27bc1ff8-6857-4523-bdd1-69b3855d4038)(content(Whitespace\" \
-         \"))))(Tile((id \
-         54509ad1-d544-469e-bf57-eb82091460ff)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2feb6db4-3f4f-435a-9313-d95a98e1af64)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         faafbb45-0ef3-4cb3-8c99-a33c2e92d46a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0fcf190c-64c3-47f6-b9ee-32b16ca9f105)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1a8df4c5-1650-4c83-975b-a6340f35a06b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cf1a7abb-0a1b-4454-82f4-449285d00b5a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1cd5c961-525f-4989-9df6-6a45cb54d922)(label(88))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         659814a7-7944-4f76-bf41-a4e55848867c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f4438d9f-8086-4b6f-b775-b838973523c8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         afe50315-be19-4200-8317-21b5b3d74536)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         09fb748c-e0a1-464c-81f6-242627cb757e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5065e3dd-9ca0-4c07-b0ca-4b6474f96def)(content(Whitespace\" \
-         \"))))(Tile((id \
-         176c9e60-2333-4629-a607-e1cd02f185ba)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c1635c89-f501-4794-bb0f-8801b2931ecf)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5ae089e3-a710-4508-b316-f5778958ab47)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3383da11-f35e-4b77-b5c8-dd4610a19b8a)(label(85))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         972c3ddb-7c0f-4ff3-ab5c-ba9ea802e4d1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e9d09df6-2691-4ddc-bb38-bcf381a0fb70)(content(Whitespace\"\\n\"))))(Secondary((id \
-         41bef4fd-e1b8-4d30-8405-48f04e877b4d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a30d29bd-abe9-40b4-aac0-5bd21335b9bc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eff6a759-06e4-440c-889a-d7bb6a55079b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         df52edca-afdf-4dbb-ab52-cd9984eed0f1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b240a352-c78e-4b15-99e2-590c5e995431)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         094c4280-d8cf-4dc0-a6b8-99dd746e9f91)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8b0e5d77-f0a2-4695-9f8a-78363b11c3a8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3cf457ff-ee35-4e82-ae14-e069f8933c70)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b67b95b8-2a73-418f-bec4-fcac85dc64df)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ee5f75b4-7333-4414-b000-7fea4af803be)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1ada5160-c853-46ab-a9e3-f72145194e42)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f0b7da02-a798-481a-8de6-f66755f7940a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b2a31e26-bbca-430b-8d31-34c6304e3a20)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0cd24c1f-1b6c-4a7a-8663-d9f5ad828e11)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a48eb187-3840-4af7-bd47-71cbe06f9929)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ec447a5a-521f-4f92-8371-f29fa1d9eb53)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8d59c076-2cc5-4393-a657-6829f3a0beb6)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         39f3a28c-460f-4542-9445-adbbc6e38606)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         daaa8d5c-b66c-4aca-8aa6-5139121cfa04)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9b4014f0-00e8-4f99-aca9-40ccc70a75e2)(label(84))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9765d241-111b-4ed6-b388-f0946c03ff65)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3b19c23d-eafb-4d50-b108-95982ac6ddf3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9dbd7b5a-3299-466d-b54f-acc71a470de0)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8fdae108-7358-4590-8987-fd8647b64cca)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3bb3d145-d84e-42a8-a54e-a13d44b59b74)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e2876bcc-d5cf-442d-bee8-2843a2ff1728)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0fc26dfe-03e5-4c93-9f23-2c7b83612584)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6037edac-5153-4509-aaf6-0e8b106a3933)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f3e7ee48-d8ea-4326-b918-a4db92792fa3)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         41305fa5-0409-450a-a0ad-a90a3d024d7b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         64d9876d-972c-4664-a0af-a300a7179575)(content(Whitespace\"\\n\"))))(Secondary((id \
-         23d9d528-ef50-4564-99c9-3f0274780b88)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de73aa90-b029-486e-8eee-358ed4494046)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         47761e3f-3580-4f5b-a7fd-48c271e85610)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         66d23782-db4c-4186-a79e-4bd2384742a9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3c9c55bf-b9fe-4ded-a450-bc75d7910982)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         e159d83c-1e6e-4fcd-bf00-8502aeb80463)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ac128176-9c38-4204-93d4-cff091e2fb99)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         23293ef7-0817-4d19-8b07-62d96889e2bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2304ce0f-e59a-4b24-bccd-c77d2ac312ff)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         30e050aa-ece8-458f-a361-c0b93811bd0b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f3f893c2-22d4-438b-a1ca-f774901ff2f9)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6d52380c-dcbf-4335-925b-1319b8ca4d69)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8873f884-9246-4580-b736-8b4532be94fb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c48a16e9-bd94-4f2c-b40d-8f76a0c4415f)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3a170e46-7731-49fa-af78-d95dae2f5031)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c6e2c614-6213-4930-b76d-1713873c3296)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cbf326d0-8e46-4f16-a070-06e404264a99)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9e678da2-0ae7-469c-9d7e-eb7de35d875a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         90d2236f-0373-42e7-92a9-4d29097bdb17)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d29040a4-9f99-4406-8cc2-8d302a689110)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         849b499b-0f98-4cab-948e-3ebe70aecfa2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cd882867-93c3-4590-a612-217096ad2ee6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         47069a36-e806-4306-8e6e-7684521cabfc)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         330a5f90-06d9-4b82-b9e7-9e564210b5c8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         735c0737-c619-404f-869c-e166c6e8f007)(content(Whitespace\" \
-         \"))))(Tile((id \
-         51f47915-9fc7-4399-baea-c7f298484875)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         586f9e31-248d-437f-a0de-04199445c3c6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c38b0e9d-0646-4f2d-8137-286b9122791c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e85caea7-fecc-4120-b175-4d3b53cdba54)(label(87))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3ac90221-b2b3-4d10-932e-2871e4739d36)(content(Whitespace\"\\n\"))))(Secondary((id \
-         dd5c5060-e97f-4cc9-a442-5bbc3567c948)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2438ecd9-5fe8-4311-a963-605169cbaf79)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         3d75b55f-6eae-4468-b3ac-637e5951d449)(content(Whitespace\" \
-         \"))))(Tile((id \
-         18b4d196-afdb-4479-96fb-08a4a60d21b7)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         682ede09-ecfe-4bfd-b0cc-c2f30b2493ac)(content(Whitespace\" \
-         \"))))(Tile((id 7ebd99be-1c10-4fa7-bcd1-e2be2fe0dec6)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         048b4e66-e094-4e1b-8d62-0e3953e29d69)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         3ad343e4-07d6-4c50-ba73-308413c3918b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         5f8d63c6-34a4-46ac-b4d9-f8a611380970)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         85b26816-77c7-4ca7-911b-a96d23d5110e)(content(Whitespace\"\\n\"))))(Tile((id \
-         7ba42c35-8ddf-4845-8641-9f5818fa7e41)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1064e96a-a055-433c-8ee3-078bfa06c9cf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7cac0865-792b-4be5-880c-55265a5219d8)(label(order_by))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         f654c28d-ada1-4248-a903-b55fecd4f358)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         3780fc33-49ef-4f4e-a109-3084c04eaf69)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cac3584e-cd54-43f3-83d0-5adca3796d09)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b54285bb-747a-4b26-9afb-4b2ed96c1a86)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5250a13a-1652-4184-aaff-c612334b5fea)(content(Whitespace\" \
-         \"))))(Tile((id 101e9f2a-a9d6-4c00-8f0e-2a5ada0e7f33)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         f1c07cfe-848c-4646-b45a-929190041db0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0f5eb156-41a7-422f-8c21-d4088eaaef40)(label(requires))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         269500af-4327-45cb-873d-f7e3c16cd4be)(label([]))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         e369a450-32a4-4651-b862-763ead3aaa8c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8282e975-2293-4c63-9c85-06355e003b48)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1e50d8eb-98c7-459e-bdcf-825d97a31510)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82da9027-5541-496f-8f45-e9fdc30c2f89)(content(Whitespace\" \
-         \"))))(Tile((id 83d57b03-096f-4722-b4b0-9db899c160b9)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         2881c8fd-50d1-4e7e-8117-32556350d3f7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f5ffb516-23f4-42f8-b0ce-c2498bd647d8)(label(ensures))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         69b61604-5b97-4cf5-b43b-fb477cd0ba15)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         02f03089-1bf6-4200-b210-69bfd6d71730)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6fdf7926-9554-435b-bafa-1b8804679eb2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b281bee0-517e-40cb-b86c-23e7a2754717)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1414a29-6621-4210-b5c5-19670bf4efb8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac896d55-2c2a-4c60-8c49-8d8fd209547c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         20dbe305-f442-4232-bcc1-06394d9efc12)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ca4de084-5060-4179-888a-75de691ce82e)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cd6cc20c-14cc-40fa-9449-cc896d5b0547)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ee0077a8-83e7-41f7-962d-9e37700e5a1c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         90782f4e-0d79-4ac4-beb3-d710b0c14b22)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d54ceefe-b525-4ffd-8ccd-8592125caf8f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         405794a0-18cc-41b5-8dfc-e9e50f409227)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a9dc5b41-dc0e-4f44-b363-e249b588e49e)(label(\"\\\"schema(r) is equal \
-         to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7aa68d76-40bf-45ee-a6c4-1381c37cb2a2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ce6b291f-eda6-4aaa-bcc8-a51c6c60ef21)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c6b458c8-079c-4c6a-be88-42722dd21116)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9d928a25-9ce9-4225-aab2-bb23456c2495)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bae04f0a-8ea8-448d-a28c-a1a0851d7c7b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb88fc64-038c-47ae-a31d-ad6cedbeb053)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aefa4206-d2e1-46ed-adaf-190d8e949220)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         9959702f-f9d3-4b94-a314-b3f46936fea5)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         74d44272-ecaa-4f3a-8fe7-ce7848bfb7b7)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         5d6f92fb-9297-4b86-a0c1-ec42dd49df0f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         c6e6fc1e-bd18-4441-8238-f066eb7678db)(label(true))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         dbc69b11-b7cb-4e52-a137-5b46567e075d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2c3ac3a0-49d8-4dd1-a8c0-5abf22fef20b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1c893dd4-a108-4067-8951-3018c89726d7)(label(\"\\\"schema(t2) is equal \
-         to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         a668ec06-c70d-4b45-9616-e6fcb36a8224)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e1de8034-27b1-4ea7-b16b-a3d1a35028c2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b01370c1-69d7-4d08-a876-571b894532af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5f303cf1-d7cc-4ad5-bad9-c3546658a68b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ea01963-5ef0-440c-849f-78f08e37c47d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0cb360b2-1617-4e86-943c-9ad7138d8a4a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         203b7002-e8fd-4946-aee1-4d3e18a51b40)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         4475b9b2-673a-44a9-9f84-2ae734fa0ab0)(label(enforced))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b14c21ef-7ec6-4c7e-91e0-21f1cfe68123)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a0361598-f869-44d4-a2ee-884ea160ed99)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ef7332b6-0b0b-407b-84b3-0c8689741c1c)(label(false))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7540b7c4-2983-428e-aae6-99d2d7fa0cc2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         172f7d3e-d11e-4f03-8794-0a2d5ff0495c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d115d25e-1593-4074-9e25-901c78b2e0fa)(label(\"\\\"nrows(t2) is equal \
-         to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         dcd96352-9ccb-4658-8c4b-61eec3cefd45)(content(Whitespace\"\\n\"))))(Secondary((id \
-         efb0d765-fc03-4581-b5f8-70019deee03b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f5b29571-b3e0-4c67-b799-0865982c7b93)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         2a280843-2530-4cc5-af7d-01a03328e7f3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         ee646e88-9c71-409a-b437-20a4be47e288)(content(Whitespace\"\\n\"))))(Secondary((id \
-         231f0614-6fa3-4b77-aa98-02ddf61885b2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         80e89ce1-b272-4bb2-8e1f-01acb82b6d99)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5d5b9e7b-eb5b-4242-a1f9-a5b2487e931f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0af6a630-45f9-4b70-b61f-5c4152889129)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6ce53dd4-0a28-47da-9b24-5968ef4c605e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         79fbb534-4241-4693-ae7a-d0f6955ac662)(content(Comment\"# We don't \
-         currently have a way to encode a existential type for the key so \
-         we're currently using the unknown type. #\"))))(Secondary((id \
-         a19e4b5c-b408-4cd7-9c43-71dca34004c9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         80a81c00-9b44-4e96-bf53-77921a86fd0b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f8a378f4-f4bf-4753-9442-5c837d1080bd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         836ea8e9-9ab2-440e-baf1-83741e78a4af)(content(Comment\"# \
-         Idiomatically you'd just compose these at the callsite \
-         #\"))))(Secondary((id \
-         9c74a24d-0ccb-492f-83da-af4d029c1f53)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ce5edbc5-b9ce-46c0-81ea-5cae56fe0801)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f50b8768-1c42-4f56-ad2e-df6d12dce6e6)(content(Whitespace\" \
-         \"))))(Tile((id 832bf38e-a0be-4dc3-af69-20211bbad28c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         8bc5ece4-9faf-49b5-b30d-1554f0ba9d36)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ab36dea1-0420-4aa9-9628-e304c999e260)(label(order_by))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         5c022455-c5d8-4685-a0c5-325bf949325a)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         bcd58fdb-8be6-4311-a1f8-c840bead0e66)(content(Whitespace\" \
-         \"))))(Tile((id 34525054-8539-47c9-83be-95855944b38d)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         67963b2e-ea7f-4a23-b075-031709d5a1cb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0803f085-e17a-4c20-bfff-e274dc4992fc)(label(row))(mold((out \
+         3c51b753-9830-43b1-ad8a-c6baa6e929c7)(label(t))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children()))))))))(Secondary((id \
-         1c2ae902-50cd-4294-bad7-430209c7bdbc)(content(Whitespace\" \
-         \"))))(Tile((id 017e87a1-e7f2-4b79-8215-201f0b18a543)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         f4a536e2-1be3-4f87-968a-bca18ed7fe2b)(content(Whitespace\" \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         9597b7d7-8a69-4bc1-a033-77278fb2eaf4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         77771227-d134-45dd-9624-8f282f6b2dab)(content(Whitespace\"\\n\"))))(Tile((id \
+         38c1c246-b0f2-4b46-bfa9-63bb6f5aec63)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         5b581ba9-f20d-4d37-bf53-24cbf97dcc5a)(content(Whitespace\" \
          \"))))(Tile((id \
-         925b5091-9271-4caa-88aa-7c903ad0b835)(label(\"(\"\")\"))(mold((out \
+         b3a620f4-2828-4de7-87ce-1a45ef253ca1)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         318049cc-86ab-48c9-acd3-5c72c7ea86e2)(label(t1))(mold((out \
+         99788dde-35f4-4d51-8971-ffe261399442)(label(comparator))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         fb6fd059-b5f8-40fd-90f1-dd60072dbb56)(content(Whitespace\" \
+         3fb083bb-269f-42c5-b94b-9b69144e057a)(content(Whitespace\" \
          \"))))(Tile((id \
-         2fae182f-2de2-4575-8503-eadf275c761b)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         99cb3771-058e-4cac-a65c-b1a8e80f0cea)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         43bd0944-949d-46fc-88b5-68221f36d051)(label(row))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         72bbb85c-38b2-4eb3-96c4-1d96f96b04ab)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         7b407ada-24c5-4c65-b2e7-5d5ffbfaf643)(content(Whitespace\" \
-         \"))))(Tile((id \
-         116e4be2-de57-4b58-8e80-a715869614c7)(label(comparators))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         0a0ef912-d7da-4c81-bf0d-77018eb56e8d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d30699cb-6f7b-4101-b781-8f0ace940c60)(label(:))(mold((out \
+         6c56b4eb-8aa8-45de-b6fc-39f31ec5d5b4)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f77defb8-26fa-4c69-9e74-aa00ad41616e)(content(Whitespace\" \
-         \"))))(Tile((id 4a0fe97d-daff-4894-82ca-1b74f3adf214)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         bd6fe32f-0847-47a3-b1e2-8011b08a6216)(label(\"(\"\")\"))(mold((out \
+         ef54e938-526a-4b51-b316-2debc03b5d50)(content(Whitespace\" \
+         \"))))(Tile((id \
+         99c047e8-c812-4098-8870-20beb2923c4e)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         e5f18e7c-94af-4452-817b-39fdff35340c)(label(get_key))(mold((out \
+         67a604ce-5d86-4dd8-9ce0-c33b605587fd)(label(t))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         22ee76a8-12fa-4eb2-9ddb-01a8a54079ab)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         82902e5e-7517-46e3-b6c6-440a996ba6cf)(label(row))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Secondary((id \
-         b233176d-0af4-4ea4-b155-e20324400817)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c6e925c2-efa8-407a-84c6-b42e48a80513)(label(->))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
-         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d82709b7-5ac4-4a65-abb8-d72a61d6bfd4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6124420e-b546-4ed9-b06a-afbeb5fee13e)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         9f53dad3-b495-438d-b91a-192d46a0e4b9)(label(,))(mold((out \
+         89721b5a-6337-4410-990d-25fc9f38d0e4)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         90c78cf7-854a-4eca-9ffb-252f262ab168)(content(Whitespace\" \
+         195e2614-64ba-4d74-80ba-36c7cbedb1f2)(content(Whitespace\" \
          \"))))(Tile((id \
-         f11c8f05-d018-4fc8-9c88-b6af00245115)(label(comparator))(mold((out \
+         b5cffb95-9ec4-443d-9ef6-32e033edc144)(label(t))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         5f7ef642-3ae5-4da7-b903-c919f68be405)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         14b51558-5491-40d2-b3ee-8b09da9e852e)(content(Whitespace\" \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         cedba328-b11b-4724-a94a-aea8c6055f11)(content(Whitespace\" \
          \"))))(Tile((id \
-         a7fe90b9-feac-424a-ba36-cf43ebe52c38)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Secondary((id \
-         9ee35b79-281d-4626-ab86-e689bd80cb7e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fb379af1-67e3-4319-b454-6f186cf62c41)(label(->))(mold((out \
+         b0b5e59f-1fe1-479d-b162-b8e1d895a645)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4101de81-cd6c-4b3e-a069-f93a657df2b8)(content(Whitespace\" \
+         21e23232-ad85-4367-9bfc-c89896f615b7)(content(Whitespace\" \
          \"))))(Tile((id \
-         a0e01e99-5e5e-47ed-b5c5-88c319275517)(label(Ord))(mold((out \
+         c360639e-f93c-4b98-8469-7778522c47c0)(label(Ord))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         2a7b75dc-09f6-4f0d-903f-3d7868b55fed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b138294b-99ea-43cf-b39a-d787e52f79ec)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         fc55df02-7e02-47f4-86f1-446866770761)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c1586923-1007-46c2-b7b4-8db39796e640)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         39394f97-8cc9-4283-90f6-93ca42057b81)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf6c559e-ec39-45d1-b82f-765a5f01db8c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e24e8f91-21db-47f5-8d9c-3d942abacd2d)(content(Whitespace\" \
-         \"))))(Tile((id d94a3806-69d6-4f93-a653-fbfc9dff2641)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ef9c6e4c-ff4b-4a2e-bba0-dee28efcf42b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e21e36a1-ba2b-4e3c-8218-83bb8d92a2b5)(label(compare))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         fd5569be-5604-4029-984f-2392d5f337a0)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         53ebe223-d93c-4508-a5ab-6198c235c5ff)(content(Whitespace\" \
-         \"))))(Tile((id e7f9d8de-b219-496a-a865-dbde124d94a8)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         f151bec1-5976-4aa6-9dea-3f67d15be171)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fce423f2-1d66-47b2-a4ee-9b1351daac24)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         c75c7d27-2ccf-4f86-aac6-73392ab3fe36)(label(a))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         bf7faf5a-f863-46b6-a41f-554dc8fdd01b)(label(,))(mold((out \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         b712e5e2-8d1f-4289-a5f8-a58184a05ab9)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         68ac260d-16c9-49a1-8fe4-ca04c01e2229)(content(Whitespace\" \
+         e7c459ad-6902-4763-a6e9-84031f35ba96)(content(Whitespace\" \
          \"))))(Tile((id \
-         ee44d0d7-e0f5-4599-b220-1fd8d7347d72)(label(b))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         23c1a131-1022-447e-b788-984d8b2eb66f)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         3b929593-23ce-493d-92df-c31ade348a8d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         84ad3585-b391-4e7a-82b9-9ccb5813ea30)(label(comparators))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         b16e6335-4765-4dfd-ae3b-7f1eb5fa1238)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         17bdb4ce-ad22-4527-9386-ea23792402e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3d13198b-d978-4236-88d7-e7eb76d87eb3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ec84eff7-c553-4121-ac24-adc37ff6e28a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         50a96b0e-6c4b-400c-b164-30ea2bc0fd6b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         758f5fb2-5284-433c-bf1b-4a3db69c5f95)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         264319fb-227e-417e-a1d4-c3febf5996d8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f2d926d6-59da-4b22-ac8a-a38dda9c6972)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b535d68-645e-43cd-a508-111ace3843a4)(content(Whitespace\" \
-         \"))))(Tile((id 1deb8911-70b6-4d4f-8fc8-31f92359b757)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         9eb6b847-7087-4d40-bae8-9905439019cf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f24253c2-a79e-4a19-aad9-d1cc216fd8c8)(label(comparators))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         4281e34e-eb8b-4ee7-bb91-fba5e4fb56be)(content(Whitespace\"\\n\"))))(Secondary((id \
-         02b763c0-ea14-4e52-aef3-5242705ad327)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b23a1403-dfd7-4140-bac7-6ba17421f173)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a80a83ea-d7ba-431b-8ca5-d59bfe5ccfb4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         618477ea-5490-40a6-af57-e07c2ae1b281)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b1991740-c904-4923-a980-6e73a96b14f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d0c4ac69-748b-4198-9471-0cd2bc1eadde)(content(Whitespace\" \
-         \"))))(Tile((id f17713a8-5c0b-487f-92f2-428b3d8ec293)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         af06a8c2-08f5-4d86-bf18-932667c520f4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ee363ba2-80aa-4269-bea4-dc528cd049b6)(label([]))(mold((out \
+         25ba15d3-f943-4ad0-a9eb-a86e1a312ad4)(label(ts))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         956c475a-7c6c-436f-bfba-8661bc252eb2)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e5c6293d-e66e-4581-bda4-e1a67a404211)(content(Whitespace\" \
+         3cf42136-c11d-4c79-8ca7-01a8bd7a9463)(content(Whitespace\" \
          \"))))(Tile((id \
-         4d5142cd-1a1e-4c68-a209-684509e36887)(label(Eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         87219a79-b5f8-47b1-8a47-f9401c028a77)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d5f41177-40c3-4980-a685-7e2185468105)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d761adc7-aa73-494f-a07d-0348aead48e1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1cdab521-fa10-4e2e-a94a-4c8157fd7d67)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         067ddbed-cf84-4507-90b3-a2f9af4d7e9e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         72ea6f91-55bb-4e93-95f6-7c7bf94b789e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d346afcb-347b-4dfb-a61e-9296f0ebdf30)(content(Whitespace\" \
-         \"))))(Tile((id f0a84645-4620-48a3-bc43-b66235719ebd)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         a241b006-ea37-4c7e-af60-1202f1d31864)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f7dffee2-1fd6-4e28-a487-1c4ec5f4ef6a)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         1d2cfb50-cb63-4d67-864e-3687cacd778b)(label(hd))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         aba90394-d9b6-465e-aaee-797877182f92)(label(::))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 29))(sort Pat))((shape(Concave \
-         29))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         a138dd94-8719-4224-83e9-2b0dd9051786)(label(tl))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         1edfb649-56c4-4db7-916d-89a4837cd65a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f04f043c-f300-4426-8b30-408332178e91)(content(Whitespace\" \
-         \"))))(Tile((id 6cdc0998-ed18-421a-a17f-ee175142fdaf)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         3f4502c2-1b51-4324-af22-0d55e73d00af)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a202067f-f45b-411b-a6e1-89518acb3b8e)(label(hd))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6b219fe2-0f9d-459b-b332-80c9fa447ee1)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c6e0828e-bb71-456e-91a3-ccb08f686c74)(label(comparator))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         50a01afc-aae7-4dde-834d-7ef096a3cd49)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1bdae42f-7d49-48e3-862f-43e756a035af)(label(hd))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a6038833-24b9-4403-9f5f-a49a26a71b82)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         4e589512-b831-49d2-ad13-0e6d0dfb4c7b)(label(get_key))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         33f9ca18-809b-4f48-a65e-a884e7fe776f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6315a59a-82bd-459b-b3c5-4981e3948347)(label(a))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         5aa4814f-45d4-49dc-94e8-336f3341a434)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c742727b-0037-431d-a893-b53cbcabac1a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         21049e45-fbe2-4c44-83e4-8e9f108fb819)(label(hd))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a3c5d9bd-c88f-4281-b2fc-ce1222a767d0)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         743a8fc3-9a81-4faa-8276-0b94bfcb8de9)(label(get_key))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ed737730-ae41-47a3-ab2c-7b5bbe573792)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         58eda7ce-051f-4f78-9746-0331a4e0cf09)(label(b))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         72a8e817-3188-406d-9819-16c979309a6b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e5820fb3-3f44-4e18-9d7c-1e03ec6278cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9470d57d-b298-4f69-ac44-24e0181b5583)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7a31803d-14be-419c-a6fd-cdda21bfebd7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aa91a35a-67d2-4862-aac8-92a15714fce0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ff37a99-03d8-4c13-9c49-cd2fd951cbca)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         06add7f1-b667-4b27-8c2c-1301f9d8affe)(content(Whitespace\" \
-         \"))))(Tile((id 509a6515-6456-407b-9c33-3e46591da57c)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         6356a086-b04b-4ceb-8458-7483131eef09)(content(Whitespace\" \
-         \"))))(Tile((id \
-         892eca7d-714a-4e2b-93b4-d17f82f573fa)(label(Eq))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         2b278dd8-029b-4f0b-8649-6a6b69d9be87)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         cca45079-d726-4cb2-b1c4-fe7f34b40ab2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5b5a54a9-c10a-4224-94c0-abf387bd79ae)(label(compare))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d16927ba-cdcc-4a99-9014-5c078ba28bae)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f1c7599b-7a7f-41ce-8e41-20549c1b5322)(label(a))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         947b055f-d6b0-4aa5-af13-30944aa60257)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         40d9753d-ca51-446d-a274-a428d8daa000)(label(b))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         12369b1f-3f1a-4991-afa4-c1a15461c7c9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0e2aaa73-43da-46ba-9469-1a6bc04d245c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         42033f60-a1f4-4f37-9125-dd3224556d28)(label(tl))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6fd7e4db-3383-403b-b652-18d3b6282190)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d7c79407-293c-4901-b7c1-3b0539607618)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         37491b48-d524-45f7-aaa9-aaac5cf03ba7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9cb0d20a-1150-4b75-ab8e-d6a0a5dca00b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e53dc23-c360-4a26-bca6-9b049462a175)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ef84f64e-08e1-46cb-b97a-dbdf9c790668)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         16215db6-f0a8-4fe8-8682-fc2cbc23dae4)(content(Whitespace\" \
-         \"))))(Tile((id a77323d3-da8f-4da2-a0a5-f256e2bd26d4)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         0699ec92-4d09-4f4e-996d-91bd04037cdc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0faeb264-99d3-45f3-8bd7-55bcf3c32114)(label(other))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         e33e0723-f336-469c-bc87-11f2e22b031d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         07c5943e-9b32-43ea-b27b-d8e676db8af4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         291db19b-eb54-418d-9c5c-80e83fd9f33b)(label(other))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         3676403c-3aa2-40e9-a738-c3651e612641)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0e69844b-aee9-43bc-ba17-e0eec1eef787)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         14da2200-96e6-4b41-9823-8dc2be96c102)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4622bdd7-8b42-4611-948c-2cc0df614457)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8eee5d8b-edd7-444c-96e6-eb8287456f42)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b31239e9-068b-45ef-a8fd-0911385245b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         81c5331e-7142-42de-851d-698aa1c23dba)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         46669ca2-c615-4856-879d-55865876b6d8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         57f74d24-0e57-47f3-a432-25325aee9c40)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         92a046f2-1d3e-45e2-b494-4c7ff8a1e426)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         136d2e95-4094-4c83-b1b4-e9ba504810c8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7d76221e-fbcd-4611-a09d-ad9b2d3ed841)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32069da7-3957-450b-9415-dc96ad32ab61)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3dca2607-7099-474d-8668-74b8d735fa73)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         96cae6a2-0097-428d-a054-ca165b6e9411)(content(Whitespace\"\\n\"))))(Secondary((id \
-         193bec9a-01d4-4d85-8fe8-a2a9ece12790)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         904ce3dd-8bd5-4586-83be-008075753414)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         959eecb2-e579-4e2d-b46e-0ba164c315d7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         947585e0-7cc2-4a4a-a2d9-a5ec96830e61)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0b0c4402-e050-4fc1-9810-556472445826)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5b15f837-fcaa-4f0c-ab5c-9fd0d29746a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         73ce60de-0964-4053-a8ff-370ee7808d5b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8d9af83-55ba-4faa-bbb0-49a73d003d96)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f3852068-6b72-43b9-bb15-29ed92aef193)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3c9a2841-912d-4d76-b7f7-6226c33f1ac9)(label(sort))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e970cadc-0d05-4ee3-aaa7-0150d97bae36)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4c42d1a0-55c3-4ba3-bac6-1e6b692850e2)(label(compare))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0e10d8b5-7287-41fa-9fd8-4d5e414725c0)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e59af00b-8939-4209-ac32-d913651a5749)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b008f792-84a4-471c-974c-f36ea40fe7a1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0501fac8-5322-4e03-bf19-f85cf38a7a48)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         dc30d215-2c82-445b-b6ac-5b8d3686a62b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         29c1b198-5d42-45af-959c-01623ad14242)(label(comparators))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ac43053f-3b0c-433e-a0ad-6baf2510cab1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         72636813-5ec4-45b1-9d05-91bb4aed72e3)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         0de406af-3a90-45d7-86fd-8919bd5b3aca)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8cab23ec-60de-46c2-a0f0-e2b35a24f482)(content(Whitespace\" \
-         \"))))(Tile((id a944225a-89c1-4842-b897-dbeee802f8a7)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         f700daff-8357-406a-a2cb-622eebf3ad97)(label(row))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e9ea304c-e1cd-43b6-9075-8bc495e91d53)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         dfb78132-fd56-49f1-b876-f505224a0335)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7dc57b4d-eba5-45dc-83f6-ad4bb3915db6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e7b590c4-3ea9-4c59-a8ac-5866ae2a7d6e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         047962d0-11d6-49f7-9ca2-f2eb8b0123bb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f1ea85e9-415b-4238-abe0-e94aeb86c525)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         683f05c2-abc5-4b32-ab53-5bd899563be5)(content(Whitespace\" \
-         \"))))(Tile((id c10d71ba-e8af-4907-a39a-e21d26cd6880)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         41f8048f-26fd-4d23-9164-dec45a6d3856)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f2d932be-bb6a-4440-9ab0-ecd66a3486c2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ed3842c2-0ba1-4e1d-87dd-d66918a55fb9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         528da6c3-60f8-42c6-82b4-e2e4aa356f0e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         26e89d90-15d4-4ca3-9979-df0534796c58)(content(Whitespace\" \
-         \"))))(Tile((id d8de5996-77da-48b1-812d-4a3a69fe9d81)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         f0705a5d-5570-4e2f-92d9-e533062f4f8a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7ce97682-1a5d-44df-8785-b1bd31bcc2ed)(label(average))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         ec3d9333-38b9-4803-8cbb-fcacc33b9760)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         0c995d29-61e0-4afb-a4b4-c3b495258e62)(content(Whitespace\" \
-         \"))))(Tile((id ba3c352d-8c83-468a-90a5-534bf6019e47)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         cbe5dd1f-33ba-4572-b3d3-68672e982399)(content(Whitespace\" \
-         \"))))(Tile((id \
-         69bb9839-a640-4665-b5db-06c26dc19624)(label(ns))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         a81cd08a-b314-402c-a934-21f938e7806d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b3be0b57-20e7-4f4b-a2be-eeb31f0da4a5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1eda2130-31b7-4a9d-bb70-9692c3156a26)(label(fold_left))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8ad2f834-31de-413e-9662-707f38353719)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         49e5eab5-b9e8-4c59-af68-b629b1c59414)(label(ns))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         171c1192-5ef7-4c55-bc3a-55ecbdc1a176)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         feddf9b8-027f-46d6-bac2-ee251aaec9b1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bf3969e3-23fb-442e-93c7-efe27c6ea11e)(label(int_plus))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         48a9a83e-23bd-444b-9c03-6c51d9867bda)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1661ab7a-f71c-4871-82b9-d190457e7c51)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9a39f26e-1476-4276-9251-35c7d67e317a)(label(0))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6e4b7691-b4ce-4b3f-bec9-822e625aa1bd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e2fd9cde-4949-4a15-98d2-a4a927c02105)(label(/))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
-         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         276a1589-6adb-4124-9662-58288e63974d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         58e4b287-8296-4e74-86d8-7a2ca751223a)(label(length))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         72e625fb-ebcf-4c94-9646-38c06f35a969)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         91316b39-0422-4bed-b90e-55df42d2c77b)(label(ns))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         a3544f9e-f209-4a9d-a60e-9a167e73c3cd)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4cb55407-2779-4ba0-8bf5-0c00a7c53290)(content(Whitespace\"\\n\"))))(Secondary((id \
-         859e5513-2a7f-4dc5-8a82-efad720498bb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a79ad0de-43fb-40bd-9d26-35b028cc6fc3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         31fddeae-35d6-4ec0-b161-a5a5ac42177f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9690d4bb-a71d-4034-925d-dc0574d971fd)(content(Whitespace\" \
-         \"))))(Tile((id 760caed5-98b6-44b6-86b2-864437f019b3)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         1e1fb866-5599-4ee9-8c2e-53492c6db1f8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         493d2c30-0b43-48b8-9daa-71daab4f59c3)(label(midtermAndFinal))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         d6685a58-0e6b-4575-a8d6-7cc8c21f856c)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         f67487cd-c9da-4029-a9ee-fe2aacbb6011)(content(Whitespace\" \
-         \"))))(Tile((id 58eef455-6ad5-4d3a-9810-37c5879003b3)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         e7735e98-5c61-41e7-83c2-90810b9515c6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f5efe268-89f1-49a8-860e-6068212f6429)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         c42d786c-698e-488e-9bfe-15fec2d0495b)(label(r))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         88f8f9c9-8173-4665-af26-52f427f22950)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fc8f45d2-ec0d-489e-afad-a25137382a6d)(label(:))(mold((out \
+         d272e43c-60e9-4b0b-b188-053950972ddd)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         06b22f05-16b5-48af-a6a3-69569a9486d1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9d691805-f120-4f06-91f4-58ec7ae98c83)(label(GradebookEntry))(mold((out \
+         648abb58-bed8-4f2d-9463-6eff13382110)(content(Whitespace\" \
+         \"))))(Tile((id 14058d1c-e9c7-4d46-809a-6fd73721f773)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         b0225d5d-5d32-4cb5-b3cc-7ad1d3829fe5)(label(t))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         4f59bcf8-dea2-4275-b84c-188db2651999)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b32a2df9-095a-46ed-8012-6f929b69f794)(content(Whitespace\" \
-         \"))))(Tile((id 15a7faaa-33a4-40f4-bdac-62136c406020)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         17fae7e6-9600-45b2-9ac2-1b17749e286d)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         57803b56-63bb-4576-9fcd-34fbfb9756f5)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         626fe7b6-0ad3-486d-b00b-dd38c438e02d)(label(midterm))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c2395e7c-41ac-4ebd-be74-926462e4745f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5921b5da-4666-4e45-97d4-f2392f7896c5)(content(Whitespace\" \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         df2ef8f2-a8fe-458c-a6c1-a83bc0e32308)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         f40df674-d6b3-46c3-810f-a1fc0b61adad)(content(Whitespace\" \
          \"))))(Tile((id \
-         c69bb795-71b6-41de-882e-560e2fd33353)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         30bed8df-9e55-40cf-be1e-cddbca4bbe2a)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         379e493a-ebe1-4a4b-a3fe-2a63cac5b391)(label(final))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ac02320d-bd88-4aca-b385-d55f30e79eb0)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         cab4dc3a-0db5-4be1-99b7-8300580fde68)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fe1deff5-c995-4ccd-9069-0ba9e950162c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a2aaeda1-f828-43d1-8658-8183952aa07f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3833ea91-cfcc-4d5b-a9ea-c7af23feca8a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         506efb4f-4a2f-46ed-b6a0-9a4aea0bdc03)(content(Whitespace\" \
-         \"))))(Tile((id ecc79048-bc33-4e2d-b97a-a1ac77860d47)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         197bb825-dfb9-47a4-94e8-832b4bc7c676)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e7585c5b-eefe-4533-8d53-9adc884295a3)(label(comp_int))(mold((out \
+         c2290e0e-c805-4f21-b51a-198e676bed1a)(label(ts'))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         19e8961b-ef4e-4304-bac7-f157e6875beb)(content(Whitespace\" \
+         ed68c049-2467-46de-b922-f8d4b47907e5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         17854653-9813-4e41-b8f7-fd8071674c48)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ccb40424-323b-437f-b22c-01ff394ac702)(content(Whitespace\" \
+         \"))))(Tile((id edd82bd6-94fc-4f23-a1ec-83a42a3543fc)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         d54aeab4-602b-45b7-ba1d-7332b7086eb1)(label(t))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         c21b0842-cfe6-4d54-b3c4-8c35ec66a547)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         419b3fd8-898f-4bb0-98a5-8bbc48b90c7f)(content(Whitespace\"\\n\"))))(Tile((id \
+         2862fb51-ea58-4a14-b193-78b5aa2b6b9a)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         6ca97b53-4ec6-4264-9f01-e3e899a30e94)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6323b182-b085-42b0-b792-eec0086acd6b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         dae0c990-3115-4b2b-9581-efd6eb17b7c5)(label(ts))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ecfb6bba-4591-48db-af57-378d5c67c8d9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         42b68d8c-5c4b-485e-9556-929e6828784c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         15df3244-331c-4e89-af37-f6996bdf3085)(label(ts'))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         2c5d0e66-a106-4fb8-a83a-838e0a58d18d)(content(Whitespace\"\\n\"))))(Tile((id \
+         cf534ea5-ad25-4f01-babe-305bcbd89ad8)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         402a85f5-86b5-4414-9fed-e2214532da1f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         13d28b58-43ed-4e5a-92d5-059b1f4210fc)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         8df62a11-f38a-4dfc-bb76-bcd06163c228)(label([]))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         417f06d0-36cb-4838-a6f4-1c3635d10ea1)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         5d8b24d6-3046-48a3-a8da-a0bcb05df753)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8f96f2c0-0a05-49ce-81f3-4d38a19e0653)(label([]))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         0c8df554-6e94-4e5d-b24a-e74a535c8bf0)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5d69affc-686a-472a-b650-a4cad26b0e32)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a72a2036-f96e-400d-95ec-5e46c8382dab)(label(Eq))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e4699474-4492-4098-80c6-06a435898c05)(content(Whitespace\"\\n\"))))(Tile((id \
+         53e40539-5285-4a64-bd5f-097b19a11289)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         f56b5b84-8d88-4d90-84ed-41f4ad434586)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7cbaf909-8957-4339-b85e-dfbf544d99da)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         637fa2b7-aeda-4319-8efa-4c83243762a3)(label([]))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         df57e8bc-526e-44dc-969a-a47ffb0783d0)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         c5e67267-bfc6-48ef-aa55-9fea61e6c7df)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e18fff41-5cb8-4152-ba31-74d8c86948ec)(label(_))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         4276bb94-0f83-45a4-b657-6ee56139caa1)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e51665fb-aeff-42eb-87c8-55b227c1db17)(content(Whitespace\" \
+         \"))))(Tile((id \
+         19835d5e-e7a1-4ecc-8886-bc9ee2c4f1ce)(label(Lt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         84671e41-ba26-4390-b5eb-7dd922aa17fb)(content(Whitespace\"\\n\"))))(Tile((id \
+         7fc9ce33-b1a6-4785-9bc8-9d3adbba0f9f)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         c5c6b283-1aaa-43ac-a6fe-b4ecd51011c7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5458c268-372f-48ca-801a-a3c325b6677d)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         b5de2e99-09af-4c69-aba6-000cbfaf9836)(label(_))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         552f9109-3f75-46fc-9a4f-b55d1c2d1805)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         79763698-9138-46ff-a99b-68c54b5f09d4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2bffbb48-7c21-43f4-af46-913a448792de)(label([]))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         58d50dfd-5a30-4d1b-9267-8298757ce4d7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         96e43550-0662-43ed-a4a2-d6ac13f6592c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         413cc724-f1cf-40f9-9b88-b53b706d630e)(label(Gt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         006173ab-535a-49cf-8fe6-3d6f6854d591)(content(Whitespace\"\\n\"))))(Tile((id \
+         f2238ddb-193e-4d2b-806f-58468df63609)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         b7e2cb0a-17ec-46ab-82d5-8040f6c530e9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         81db9a80-0285-4cb2-984a-46eb2fc00b9d)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         238adb8b-9de9-4403-889a-765a0c7915b2)(label(x))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         1592d1cb-7374-466e-b951-7d03f0b7d6f5)(label(::))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 29))(sort Pat))((shape(Concave \
+         29))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         276a110a-232f-4109-8c57-466afd1a954d)(label(xs))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         a6101aac-9d5c-4db7-889f-424b8626ac49)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         7a210b0b-8878-4a2d-9cd2-20d2204777a1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         29d6f500-8305-4eab-9b56-eb061dfcf56e)(label(y))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         e9d36978-345b-41d9-848c-7acc644ce448)(label(::))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 29))(sort Pat))((shape(Concave \
+         29))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         1077ee84-a962-4531-abfd-f511637103db)(label(ys))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         6d5bd43b-e8c3-47f1-9624-e6287999f108)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9af70b36-9310-4709-8a5e-d5946696975e)(content(Whitespace\"\\n\"))))(Tile((id \
+         55aaa692-775d-469c-8c43-6b6c18317ac0)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         951c85b4-65e6-4be8-b853-e499de7f159f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c7597a7f-006c-40eb-9bde-3d7a9c17fcf2)(label(comparator))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         23ebc78b-423b-493a-8931-86ddc6a5fe96)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         570999ae-ac92-4b6d-9ce4-cb7fbbc48a3d)(label(x))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0fa02b66-8531-41bf-81b1-48a62766a4ea)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d7a61efa-a111-4439-85a7-9570eb7590fb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         db092c02-4c96-4f3b-bf49-e366a7e251b1)(label(y))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         ece3c935-0302-4259-87d6-b7418390ea3f)(content(Whitespace\"\\n\"))))(Tile((id \
+         703c7618-d6b6-425c-aa9c-c080cbd3d221)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e1ff5601-a1be-44ae-a724-ee67e4fadfca)(content(Whitespace\" \
+         \"))))(Tile((id \
+         09518fbd-8321-4ce2-b784-f25b07ac5a60)(label(Eq))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cfec4863-c315-4ab9-b62b-6ec6d491ec82)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         1c7c97cb-fec9-4868-84a1-8078d2cc65bc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8fde9b0e-d511-466d-ad7f-545a885803b6)(label(lexicographical))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a460ce18-794e-48c2-9a89-e6ff413307e7)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         10a5d7a4-b739-4ae6-878f-5b1aae28aea9)(label(t))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         89943dbe-f182-4916-a4e0-237542457721)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         d2725e88-929f-44f7-9cbe-c5d27515664a)(label(comparator))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ffa6b473-7dc3-490d-abeb-1b8dafc71427)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9c34ea67-7d15-4704-8e2a-4903d44eb66e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         011bedd7-613a-40fd-8d06-1178a0875447)(label(xs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3a6203b9-6d3d-4130-8f15-6629b9a7b75e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c3dc589f-9a6b-421a-92ca-bd32ca7e3fb8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         25d3f5e3-f43e-4bb9-9087-8c722623bdad)(label(ys))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         f2269d79-a57a-4250-bad2-9a37e9c59f72)(content(Whitespace\"\\n\"))))(Tile((id \
+         413362a7-31ef-471b-9404-abbe9ce52f53)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         3f776fdb-e2ec-4b74-bc81-6305be8f8920)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f952a6f2-3f68-4622-9260-95ca5021fd4a)(label(ord))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         84d4d256-1ca2-4689-b563-df88d5a319b0)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         61be6339-3b9d-4f4b-871a-e6dfb1139af9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         547a5cd7-96bf-406e-8896-6f87d2a9f181)(label(ord))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         cf37eb17-a6ae-440a-880c-15362cac251a)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         087f6779-9ff8-4c54-bcd9-aa2f66336d33)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         a80d2a65-710e-4987-b6ff-cdcd6fdff0b4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c18c8edb-1b45-4f45-bc10-e61dba39f71d)(content(Whitespace\"\\n\"))))(Tile((id \
+         f247f8f4-0cef-4d99-b54a-c667c65ed335)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0b11d1f0-319c-4a60-a908-c4b32f4557a0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4a105f83-b035-4d66-86c6-9d062b8593d4)(label(int_compare))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1602d1c5-64f6-4981-82fe-13f6b29ea6e7)(content(Whitespace\" \
          \")))))((Secondary((id \
-         93a0e328-a618-4cd7-9ffe-b7a8bc961478)(content(Whitespace\" \
-         \"))))(Tile((id a50629f9-a359-4a8d-bceb-afa860361a2e)(label(fun \
+         6e7243ad-6d3f-4cde-b7fa-4e33a55e2206)(content(Whitespace\" \
+         \"))))(Tile((id 0f4f9c2c-7d80-4b4d-8106-ff2f25a3056a)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         8c3a34eb-1d5c-4947-9cb5-fbc2c2a20b36)(content(Whitespace\" \
+         0b479e21-688a-4d35-9a08-d948ae71698f)(content(Whitespace\" \
          \"))))(Tile((id \
-         6b744995-5bdb-4465-beff-69455db731ec)(label(a))(mold((out \
+         6a98642d-77de-4892-a811-55bbb1cd9e2f)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         533b7d65-9016-4681-bed9-34804f90aaf0)(label(first))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         8dd7e1e8-2635-42b3-981c-fef0dd8b55d9)(label(,))(mold((out \
+         da5d2e0c-3828-49cb-97e8-d3ce73c9c123)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         2808bf3e-b184-40f1-a57a-e7c821016b8b)(label(b))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         b7ab56b6-df6f-4deb-afbd-d6d50642df9d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d32a2062-e9e8-42c0-9ffa-6c67e2f1fadc)(label(second))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         1f479054-8422-4f38-b35b-ad9664f75908)(content(Whitespace\" \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         555fc09a-fd5e-4074-bc16-add60f711a08)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2bc559ca-d706-4dfc-ace9-8413f5b83157)(content(Whitespace\" \
-         \"))))(Tile((id ceee2069-4b6b-4d43-9683-12a11a7199f5)(label(if then \
+         2f8d002e-3b8e-4af8-bda0-30ad97f903ee)(content(Whitespace\" \
+         \"))))(Tile((id 57f6840c-1736-4d76-8f6e-8c9618bcb93b)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         b6f748b0-107d-4024-a5da-e710b8f52fa8)(content(Whitespace\" \
+         9133c363-606e-4dcc-a751-87603635dc54)(content(Whitespace\" \
          \"))))(Tile((id \
-         4ecc8f1e-fa71-4b11-8e75-785ecbe8c5e2)(label(a))(mold((out \
+         ae96d865-1c67-422a-b68d-5cfb67ebe64a)(label(first))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         a3906e0f-553d-4410-b0e6-28daef1a71c2)(content(Whitespace\" \
+         cc82ff3e-6139-433f-844c-fdbc692a7639)(content(Whitespace\" \
          \"))))(Tile((id \
-         391a3c9e-274b-4ff7-860b-fd88a3615ec7)(label(>))(mold((out \
+         b144afb4-60c4-44f5-a5c5-c26c6fa41612)(label(<))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d2a7c3f3-8544-4bde-9001-d31bdef298d0)(content(Whitespace\" \
+         f8730f98-ee63-4a68-a0b9-eb4a85a490b0)(content(Whitespace\" \
          \"))))(Tile((id \
-         b914bf33-2588-4d07-8f1e-e06fc1c78569)(label(b))(mold((out \
+         cab9e14d-5ce0-4e33-b85d-d5f863fba442)(label(second))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         8e8d1e11-ccbc-4d84-9bde-759debed9d34)(content(Whitespace\" \
+         e361ef2b-5513-4c8e-9255-e1496ec90a6b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6d99f154-09c4-43d8-a7fc-9077a2978e57)(content(Whitespace\" \
+         e886f67f-1717-4e3a-87cc-dc65fcbaab3e)(content(Whitespace\" \
          \"))))(Tile((id \
-         d4d419b3-24cb-486f-8478-501671852dc1)(label(Gt))(mold((out \
+         db13e2ef-c3d6-4964-8567-d3967821b33d)(label(Lt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f0cdc79a-1334-4f2f-80c2-9abc7af56968)(content(Whitespace\" \
+         967f34a3-54aa-4e41-a487-0296470dec2d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b1e18603-b5fc-463a-b0a3-cbc36a370598)(content(Whitespace\" \
-         \"))))(Tile((id \
-         06649fc2-e361-4746-9a14-f0aaa4f8bffe)(label(Lt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         c3f1ddb0-0dd2-44f3-bd29-8cce6a9f053c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f054223d-df6e-416c-9315-51a976ce1ad8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ba4157ec-cc76-4e66-87a6-2e166e473d6d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6723ffb5-89bb-4a2b-9485-352a30e12c90)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         15d7c69d-2f40-4401-9b7b-18806a4c7645)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d89cc58e-73b6-4eba-9aad-4099f0046b23)(content(Whitespace\" \
-         \"))))(Tile((id 09b3f1d3-5da7-4a96-bfe5-1e363d08c714)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
+         a003a6f2-1667-4e32-982b-977b314d7ca6)(content(Whitespace\" \
+         \"))))(Tile((id 0f253be8-a0bd-47c0-88a9-f0ca4c877f5e)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         6b81c962-9fef-460d-89a1-8fad5dec51c0)(content(Whitespace\" \
+         74da9135-41c4-4a61-977c-cde417cabaee)(content(Whitespace\" \
          \"))))(Tile((id \
-         68b922d4-28e1-437b-81ef-c9c393323c40)(label(desc))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         d6dffa17-025f-4b6d-821b-a474d3d541a5)(content(Whitespace\" \
+         3ca49274-9ef1-47da-a80b-96e24f53c359)(label(first))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         73a4081c-6187-4694-9423-a868de60d3c6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aa50770b-bf6c-4818-83d5-a550212d1f78)(label(>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         76a6baf7-673c-454e-9f89-fd82f22e61b6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         01d9b5b7-e6b2-4c74-b42f-df0e1c2c73aa)(label(second))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e4563d1a-4ee6-4257-8846-ae7d732881e1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a7600d1a-ea9b-4f19-a43e-4ed76850dfe4)(content(Whitespace\" \
-         \"))))(Tile((id d5b0e43e-8091-4a1d-a89a-eb49e9f1b8c5)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ceba1994-f7f5-4939-8035-8adef677c37c)(content(Whitespace\" \
+         861e7571-b775-4e87-be14-48a2fccc6a08)(content(Whitespace\" \
          \"))))(Tile((id \
-         9c17cfd1-c8e6-4c68-bf0c-c654a9509c85)(label(f))(mold((out \
+         080d29a8-562b-4712-99c0-071886ab9b55)(label(Gt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         13ff9102-2c6c-4cb9-b016-b160e51201d8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9c75d782-98ba-4575-b047-46bda1cf8bde)(content(Whitespace\" \
+         \"))))(Tile((id \
+         385891e4-4f9a-4d39-944c-1fa9f11c5393)(label(Eq))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         06a34904-aa0a-4f52-8d3a-c5684b3c7bf5)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f726ca09-e29a-4e81-81bb-43ba7248c5d2)(content(Whitespace\"\\n\"))))(Secondary((id \
+         cc16f619-8395-4120-8e8b-4265bfa8178d)(content(Comment\"# \
+         Idiomatically I think we would do this with a implicit comparator on \
+         tuples and then project them #\"))))(Secondary((id \
+         18dffde7-7708-4a3e-ac96-aa104e080d15)(content(Whitespace\"\\n\"))))(Tile((id \
+         60b317f5-9970-44cf-8ded-976f58e3f351)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0c963743-067e-43bb-a818-0eca38208af1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c4d02ea8-1952-4859-94df-2ca58c080006)(label(sort_by_columns))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c466b624-8318-4998-a674-c62275e0f991)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         10feb646-0661-4083-bbb0-1d565e6a988a)(content(Whitespace\" \
-         \"))))(Tile((id f3b43e21-dff3-4b1c-b85f-e76109a75bc5)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         2e1a5b93-8ec4-41bc-8f42-c353845f0202)(content(Whitespace\" \
+         cb4ba7bc-b297-49fd-99b5-c9f91d5ab2d4)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         8d2d6d0d-f328-4fa9-ae9d-742b28d13436)(content(Whitespace\"\\n\"))))(Tile((id \
+         b2558dc8-024c-46ed-a03b-7cfc66afc2e3)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         4c95a620-fd83-4197-abdf-4f6e52490bc7)(content(Whitespace\" \
          \"))))(Tile((id \
-         01a9141b-10a8-455c-a14d-d60600abc56b)(label(\"(\"\")\"))(mold((out \
+         15a423be-eb5d-4d10-9049-00bca9303cb9)(label(r))(mold((out \
+         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         32b8c6f6-8225-432c-a85c-9eae3b2302d1)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ff3afd66-8bbb-4115-9bdc-0897780f9f76)(content(Whitespace\"\\n\"))))(Tile((id \
+         42363111-c77f-4048-91ec-9db4ec79745b)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         5806c429-b4e5-4027-a9c2-559531d9d5e0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7c5c24a5-0ffa-4aa3-b99d-7cf5fb0288e6)(label(get_values))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f0b1310a-2c3d-4174-9b3a-5735f4a3721b)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         8cf83e97-0a3c-443f-94ba-0fffc02c405a)(content(Whitespace\"\\n\"))))(Tile((id \
+         c960a2b3-2142-4a68-b5b4-3734c380e790)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         fa47b2dd-743c-4a4c-aec0-9c15a5a10309)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5684124b-df9c-48ee-9c4b-44b7b399c82d)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         ae267471-ba5d-4d1c-9bd4-1b0775ed816d)(label(a))(mold((out \
+         6ce9cfa7-f1c7-4094-b04a-82f058462a6e)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         f29392fd-22e8-4eb5-823f-2268580cc2d7)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         98b8d1aa-77f3-4a99-a52c-82a709919083)(label(b))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         71576647-e29b-4704-a84b-429ae7317385)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e7f8c492-db69-4d89-836d-d561a002abad)(content(Whitespace\" \
-         \"))))(Tile((id 06e9c1c3-a1a6-4e3a-a9ba-2d4bf8318406)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f0e6de31-d079-42c1-bd29-1c0361f19402)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e19883c0-e948-4670-9027-238f3a8d78b8)(label(f))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         da36854a-7516-42c5-a87a-8153140b4d8e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         175ca22a-09b4-4f6d-9d04-b120fda3487a)(label(a))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2e716dd6-b978-4654-8084-bee161c10e59)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         89d0e1ab-ddc5-4603-a2c3-3ce1a8075e78)(label(b))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7c6c8aa9-a741-425b-b8f0-8f5873fbe3ba)(content(Whitespace\"\\n\"))))(Secondary((id \
-         364d928a-df44-4b0b-91ff-90b74b2ce7c0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         94e468d7-93a8-4f32-9002-4d39960ef0c8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         51cb92cd-4ae0-47d5-86f6-6fec083e440b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc0a5849-2570-457b-a875-f58929d533ad)(content(Whitespace\" \
-         \"))))(Tile((id 571f545d-0ef9-431d-9b68-767578e50473)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         df5658c6-67ea-445e-aded-056d6c66d0c0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         52b8fb87-bc2a-43f7-a3d8-84f0d35fb3bc)(label(Eq))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         8e108a7a-ceec-4592-a8ff-0dc8e16d238e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         6ecdd4e0-23ad-4efa-a875-33cfbc7bf2f7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cd9e9698-2459-404c-b06f-87754a33d9a8)(label(Eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         d7a9e8dc-c83b-4510-bc52-eafe54a7e6e6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8345be97-3610-493c-873f-8e8841e06b38)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5069477f-16fc-4a93-9410-a5d035c91d00)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3314f7e3-1541-448b-978b-8abd6d478134)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cd4fbb49-426f-4746-a6aa-c3f09db5495e)(content(Whitespace\" \
-         \"))))(Tile((id bf44ce18-67c5-40a1-b1be-bbeb3383149e)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         aa899594-e75d-44cd-8972-a28b21c40bfc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         39f07d27-6019-4087-b844-a44792716a14)(label(Gt))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         f6702639-2be2-4ccc-ae8e-4f0902bfaffb)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         af509577-ceff-4175-ba3d-2614f00f2d25)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6c45a009-3320-45ff-8310-2b07fa27aee3)(label(Lt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         c5fe3426-159d-4704-a6e7-58be3ed4aaac)(content(Whitespace\"\\n\"))))(Secondary((id \
-         db532cfe-5191-43d9-bcc1-a5594f2e70c0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         221ac28c-2fc1-4c6e-aa5d-31b31f131555)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         66700dab-1532-4060-b684-52f372a284d4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ec6c51bd-b1f6-427d-b81a-9e1cc0cc6625)(content(Whitespace\" \
-         \"))))(Tile((id 48b51e0f-89e3-4150-a051-2d3bb68fe20b)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         08a386c4-6f55-47f5-83a7-029737c40a09)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ba0f130f-e546-4f77-b089-4d16a87f761b)(label(Lt))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         680bda18-aa11-48cc-9be4-a3ec7217e5b1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         78198ea7-895f-4c04-b28a-7509a792a1bb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         86af2b67-d265-42bc-8359-8f66b66cbd52)(label(Gt))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         19d00058-45da-4ee4-8127-44ad5a9501ca)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8e0ae912-d6cf-4b5a-b6e4-1a1757c70126)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         668eb788-64a9-4da7-bf77-1ac1f9a138e3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb023fdc-09d2-4cd7-bcf3-56ef0f73085e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e32f4bd2-7a98-46a9-91e9-d9ee04b945e5)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         1a35b0e7-46f6-4990-b63b-57f17eee26f3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4b2be9f0-2485-4e0c-acf7-461e20a61977)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c5e544ff-8f01-474d-8298-43816ef08a96)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f8f81a3-7789-4d38-8cee-f3eaaf431f57)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2858940a-c62b-4535-84ea-7be03653dced)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4c61cc40-9336-4f96-8a7d-9bd9532955a4)(content(Whitespace\" \
-         \"))))(Tile((id 874bf523-79f2-471c-b079-78ce8392bf0f)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d204d51e-6408-4a23-b479-5d1da8615a30)(content(Whitespace\" \
-         \"))))(Tile((id \
-         93355c05-a519-46a8-b1ec-260b37dc4d21)(label(compare_grade))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         4903e552-dd2b-405f-80d8-de8a60561f40)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         6c493d8a-5df6-4009-b667-416a8b7af443)(content(Whitespace\" \
-         \"))))(Tile((id 27542024-9d57-46d6-9255-95225b74450c)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         9587e7a3-c293-4990-b08f-41d255de06b8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ac0adae2-959a-4eb6-8334-9f1186bd0753)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         71160908-2021-4552-9cec-115e890db72a)(label(g1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         4c147282-6b94-411e-928b-57122163e483)(label(,))(mold((out \
+         91f5a068-9277-4d6a-a772-38283726b6d6)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         be5ef81d-56bb-4811-b137-2ab98d6d80f7)(content(Whitespace\" \
+         198aa24d-4eb4-4e1d-abb6-052c35cf16b4)(content(Whitespace\" \
          \"))))(Tile((id \
-         c1ae68ac-d355-4169-969a-4e1886bcfd07)(label(g2))(mold((out \
+         2b80f30d-3e96-4292-8368-516fd3269d8f)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e10af478-b53f-452d-99c8-c25cd9f748b0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fa46722b-aff0-4a7c-a793-2a1994e3a50f)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         acf7dd2a-3e83-466c-9af0-1b56386bfa9b)(content(Whitespace\" \
+         \"))))(Tile((id a8ae1e1e-94c2-4d75-a393-082fb80a9fb7)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         01425746-98fd-45e9-b165-7fcbb8db75e2)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         52793116-e2b3-4784-9553-ac783484c746)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7f3b7a15-6b2a-45b7-9325-99bba916aa04)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ee90c9a3-bf67-48b1-8c8a-f3bf96cf7f61)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         914fe33e-661c-47e1-8675-a095c5c2c0fb)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ec03ed4c-2b72-4a4e-b06a-2245892ed5fc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         69f1042c-0900-4f67-8fb5-084c3912fb9c)(label(entries))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cf0956be-a743-4fd5-a668-a77a203f7066)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         c0a0491a-0db2-4a83-b4b7-fabb2e73b5a4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e73b6577-c6f2-41c2-9521-6300c9514afe)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         42016f99-34a1-4c17-bda5-d69b9067661e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         dc94f197-d742-4f74-9bea-42203d03594d)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         61ba3b86-a0fd-4977-aff8-7319b1d8d848)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         0bdf9bdc-92dc-451a-a0f3-4f26bf4fcf55)(content(Whitespace\" \
+         \"))))(Tile((id \
+         73b6ad80-10de-4a9c-9b57-04987a499792)(label(filter_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2a1ace9d-bd6a-4fcc-9da2-490d02d695fa)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0d600175-acdf-484f-9e95-3034b3d7eb95)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e9ea26b2-dc82-4c02-ac29-8940323ab0ff)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         a0756a6c-6cdd-485f-93e0-a29fed78c529)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         4c40b009-b5c2-4f60-8431-46027891ded1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e8538e61-9db0-44f5-b0f2-44f132f0e967)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f3c23611-8673-45b7-b120-53f657866481)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e10061a6-4a47-486e-b274-db4a4c474480)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e724cdc8-184e-4637-b2f2-41111615b225)(label(find_opt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3e6a8f1c-3dab-432b-8c49-076775563223)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4b59fc81-d937-4087-89f9-4190a436626b)(label(entries))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a4085702-7608-4c60-a142-6ff0b56e4c83)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         00cefaae-b1f4-4188-a455-96d2d5a0f6af)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         7a63d707-b00c-448e-b291-8a388ca19d4b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5b328767-f545-4e38-8ee5-0a1b74bb93fc)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         c733c11e-5e4b-480f-860c-c341ad7aa2f6)(label(label))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         94b9c106-ce82-4313-ac0a-0403c62b6002)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         9bf1cefb-0ea6-41bd-b94a-45a3284ac259)(label(l))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         70f4cbcb-d8f8-4802-b791-cda4a320449f)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         045ea499-9f42-4cf9-902c-887c267a5200)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d1b2ef87-66b7-4a1e-8e18-7c23549b4d7f)(label(value))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         fcdd2eb7-640e-4740-b587-18798f935285)(label(=))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
+         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         6fe14832-9b8c-4a93-8bee-fd492e14b0ad)(label(_v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         30439af1-e233-4620-88a5-cabbebee113d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9316ffa2-d643-4247-864d-e30a2fb19fe5)(content(Whitespace\" \
+         2e7e3155-b167-4cf3-b164-997c4bacaa36)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         6c5efc97-6447-444c-9084-be8df1a26b63)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         7fb2ed10-be64-4be4-9570-43c449881e86)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b202f877-1639-4151-9fc2-a289d39c6430)(content(Whitespace\" \
          \"))))(Tile((id \
-         5877ca6d-2caf-4d2f-87da-8df5e347f961)(label(comp_int))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8dc006c3-9db9-43a5-a339-88feebfa535d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8eed4674-ab8f-4c55-a52d-4d0e7132e294)(label(average))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0534f5b7-9736-4126-b638-7a8ef381f257)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         15b3065d-3cb3-44d6-9b8b-8fd3b7e2e8f4)(label(g1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         f7130535-f2ea-4340-996a-81fafe579508)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8cf78033-f283-4346-9e6b-f58b0b6d1c53)(content(Whitespace\" \
+         711fb662-fe80-433a-8bfc-b746372aa67d)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d0c80ee6-5adb-46f2-8425-d34189ea04dc)(content(Whitespace\" \
          \"))))(Tile((id \
-         cb190a67-d8ca-4a3a-b43e-903c1c3e0688)(label(average))(mold((out \
+         0f3b0d9b-bfe1-42e6-8a67-905fbae2ea7c)(label(l))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))))))))))))(Tile((id \
+         0155692a-0ff8-496d-acbc-453594f4b659)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         1692823f-7ef4-4e59-bdf9-baf083385fde)(label(value))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         af9cc178-38c7-418b-8a89-36af6feda899)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         a3844890-423a-48a3-9049-3d99131c3931)(content(Whitespace\"\\n\"))))(Tile((id \
+         3fd4ede9-066e-4821-b77e-d0c1f0cda528)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         34bea9c5-8030-4756-bc24-5a9e8138d0cf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         36b12440-e596-435a-bf63-750f82ae37fd)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         18795d16-9004-460f-a29e-39c8bffe3f1a)(label(t))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4999eafd-d1b0-4344-8f55-7f045e0b56d2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a441052a-5069-4ddf-90b3-af16494cf0e2)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ee9087ef-2dce-416f-91d0-4b989646d43d)(content(Whitespace\" \
+         \"))))(Tile((id e20afe7e-09af-4e89-b642-373de91f5f8d)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         748e23b5-478a-4f51-931f-5cab600cac04)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         0390ce22-5ee9-4ce3-84ef-d3df240848b5)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         6e2ee18c-e11e-473b-abca-47098222f7ec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6d2d65d9-5ba5-4ed9-b116-19d7baad6e75)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4b50235a-7eac-4025-a110-6c8ec9a145d7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6983fc65-185a-4418-afef-cd78b1de2fc8)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0e68109c-e366-4cb9-bf10-18f66a5bb8b8)(content(Whitespace\" \
+         \"))))(Tile((id 4fa216d7-b064-4c87-8fd1-4da9901ef95a)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         09341610-a07d-4aa6-a75c-5f88a22a2211)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         d3b431bf-ca32-4e90-8d1d-3ac525c5a6c9)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7ad26fa9-6bbf-493c-afdc-a35daee38e51)(content(Whitespace\"\\n\"))))(Tile((id \
+         826a7000-b114-4b0b-9d10-d2a9ca9ce8ce)(label(sort))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         054c65fb-f3f4-4649-aa6a-7e6a0d0324a1)(label(\"(\"\")\"))(mold((out \
+         281e492a-5fb9-464c-b6d9-63a88530d320)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8b3b284e-8d62-4251-9235-066d588a3ff4)(label(g2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         39d9baef-24c1-4c4b-b8a1-2277ef2dfd2f)(content(Whitespace\" \
+         ac6c8125-f218-4b23-82dc-37afec2146d8)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         6c782660-26ef-4395-9172-1eee66155ced)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         031791e7-88aa-4700-94f6-be188a230566)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cc95a7cb-82b0-4c50-a76e-b58c624a91d6)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         ec6ab02c-f75e-43ed-8ddd-031027bfc6c0)(label(f))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         4db841d3-b9e1-4495-91dd-7caa8aca7d44)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         e609fb7c-932b-423e-a140-d559850a9f72)(content(Whitespace\" \
+         \"))))(Tile((id \
+         71ea6507-0777-483d-9ca5-addf64335503)(label(g))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         a239d4b8-07cb-43bd-a082-55fff841b662)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a605f99f-56a3-461b-a77b-22225d9d5702)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ee70dbb1-8afe-4491-8ce2-e8b8c18734ad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f5e948b9-5272-4679-b748-8fb062e5edd8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         45313e59-a386-4ca4-833c-1852d0272750)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         033607f3-399e-4439-a8f8-f2fd0bbf21a1)(content(Whitespace\" \
-         \"))))(Tile((id ee58d423-572a-43ae-964f-fee8ce3c812c)(label(let = \
+         d96d9e80-a231-47da-9590-8a34fb968f38)(content(Whitespace\" \
+         \"))))(Tile((id abf400f2-6c76-47ce-875c-8d147550bc41)(label(let = \
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         73d0ab51-f65f-4542-b678-b3cbf8788871)(content(Whitespace\" \
+         ed4ee982-e447-48ed-a806-15f8a008fc4c)(content(Whitespace\" \
          \"))))(Tile((id \
-         bc05f12b-5acf-4189-892d-0b747cb11999)(label(name_length))(mold((out \
+         ef8c0ba5-a8d5-456e-80a0-50f8be1e27c7)(label(res))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         15a61dc3-1540-42c7-93db-16b22f850e2b)(content(Whitespace\" \
+         e022aea4-5954-47b8-b16e-a81a2afb91d9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f76fbf40-4f71-47f3-b345-315e711af529)(content(Whitespace\" \
-         \"))))(Tile((id 100c735d-bb5d-4fa7-881a-11ad41805dd0)(label(fun \
+         b045da65-8d2f-41d6-8e27-91b3a958d790)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1e1a2bc0-a9ea-4be1-a741-cd8a3c8a2022)(label(lexicographical))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         742e5fdd-2a2b-46fb-ad3d-3f203638ad9f)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         365d18f0-75d4-43fa-95bb-64d689b49f67)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         9548a309-7eee-4939-8424-a874558277e3)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0b11ed95-b115-4845-b4e6-2c16fe54e451)(label(int_compare))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b5002bde-f6b5-457f-b0ed-1a5f2d7a43ed)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         ee6505e0-4160-4f74-adf4-ec39841a2a36)(label(get_values))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         41d8497b-4e2e-4b73-8429-85436d8a9632)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         24ddbf09-e377-417f-b1aa-b45b301ab995)(label(f))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fb9d67ff-50ec-4ace-bee5-7b7e3fdca6f0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         ee0def7e-9535-4028-b4ce-72aff950bab2)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         8a0f1ba9-60bb-4a2d-89ee-3c0814bcbe60)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         6f685b99-fadf-45df-882a-edd8c6185ffb)(label(get_values))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ffa8ae03-e8ff-48fc-9467-8c8269e0153e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0f067b5b-ccb0-437a-b1d8-e18dcabcb3d8)(label(g))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4e5dfa95-20c3-47cb-ad4e-f8dbe37de133)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         7d064294-ac04-484b-9d1e-b9e9ec898411)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         2a739af6-c58a-4762-8209-878fe0a8b5b0)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e0621349-7d77-4983-96ba-2d1f263239d8)(content(Whitespace\"\\n\"))))(Secondary((id \
+         11d6c954-ea16-47ec-bf4a-ac201f898e56)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ca9474df-d81c-4ccd-9414-b03ae9f2fb4f)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         aa2f4fd3-701b-427a-9eec-27b05b05f407)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         2a0e7a72-a1b2-4130-ac13-ca56a28e7d47)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         a8353bea-49c9-4c43-b0dd-55ec3d00898a)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         e534e995-f384-4415-8662-68a486ad6137)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         4071189c-5bde-4c64-9a5e-9ce403fc4904)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         cd2f6da2-4514-42f6-bcab-a2346bf45c4d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a94bab16-7b1a-4d4d-8e34-0b7140be2c34)(label(res))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         d2785b3f-8382-49c2-a767-b25931d68806)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6d724b89-14f9-4bc8-a6f4-a22ef715d941)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7f384d7f-0c23-4d36-9e3f-63c438ade618)(label(t))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         9f80a87d-9e36-4b61-8b74-553dcf0a2eed)(content(Whitespace\" \
+         \"))))(Tile((id \
+         113a2b4a-9e7a-4dc6-ac3c-aa25a618b515)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         79899245-71a7-46e4-9153-3def81da9233)(content(Whitespace\" \
+         \"))))(Tile((id eb0fbabc-8e96-47db-a60c-06f234164435)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         7e91b48b-b819-4fea-b54d-327ed93f28d0)(label(r))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         1779df2a-118a-4fe2-ba0f-70dec56386ee)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f07a0fcf-45b2-4dd7-a017-5faeee21fd25)(content(Whitespace\"\\n\"))))(Tile((id \
+         ccc88fb8-850d-4813-8465-ba572b547585)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         42685fcf-97b4-4f51-9492-b53da81bfd9b)(content(Whitespace\"\\n\"))))(Tile((id \
+         c191c694-7b5f-4eee-b08f-6c69681947ce)(label(sort_by_columns))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fb7b64b7-d5ca-4a01-929e-24d27623a9ad)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         57ef28ba-f399-4713-8232-71dad8a3958d)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         cd15ccc1-3259-47f1-8f7e-267be6d4c2d7)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4a21cc65-83f7-4dce-81d4-27121c1f3121)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f324f7c8-e303-4bb3-b2a5-59c4106f39b0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         97663191-c28a-4a09-bebe-562e2ec9e548)(content(Whitespace\" \
+         \"))))(Tile((id ebb5ae92-2bcf-4a99-9a32-5cb44bbf36e6)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         b7fe5aed-2bb8-4489-a1cf-ce9ad40e6460)(label(\"\\\"quiz2\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c3aba989-84bd-410c-b8ad-a4a22b20c9ae)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         12a9c58d-360c-405d-9b12-056be5978849)(content(Whitespace\" \
+         \"))))(Tile((id \
+         db65a36b-ecb4-417c-a79c-918f24791a37)(label(\"\\\"quiz1\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         8652c3c5-6048-4b78-a8ef-6ef02626c782)(content(Whitespace\"\\n\"))))(Tile((id \
+         b00ea85c-0730-4c3d-8362-1d0d196468bd)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         32ec00c7-92d7-4491-bdf9-7ad09fea7c0e)(content(Whitespace\" \
+         \"))))(Tile((id 2771919a-7199-45ec-a2e7-d7cbe7f6b888)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         37f1275c-5076-4f66-9bf9-a1c16a96fc0f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         e1511400-1863-43ba-ab58-c7a468c0cefa)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a15747e2-88b2-408b-9e14-b2c1017e7d7e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         01c30c74-1b63-41d9-b49c-ece912ddff1e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         626bf90d-36ec-459c-9c05-fdebf38d710c)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8267b5d2-f495-4d8d-aa04-78e68cf74089)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bc2b8653-6206-40dc-95a5-61e3d87f612f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         958c10d9-4655-4e8a-bca9-214c929ba8bc)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0b32caba-41d9-4230-b545-2ce657184a72)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c5d0114d-57bc-45ac-9e31-db16a7fadb37)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e4bb0ea3-3bc1-4170-88a3-32bbc25b4404)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         671814c8-def4-4084-8a56-0ef718940196)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         35941268-7347-440d-a4a8-93baacfe6b5f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         14eadef2-2e0c-439d-bb62-92cce1a3ec78)(label(88))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c13c2253-2275-482a-9d01-56752b63f4d8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c814bfe8-348b-4592-8d01-e66a85763bf0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4af1e860-f03a-418f-902f-87012a50072f)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         87a40e97-dedb-4ad5-bd9c-f95f8da5195f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bd4826f3-be4f-4a10-95a1-03aa8dcda088)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6c420020-0505-4d3f-8835-550cde84ffb4)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6d57039e-dc9f-4db9-a881-38f84ee268d9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1d71996b-da1a-4e03-98ce-55de3b990962)(content(Whitespace\" \
+         \"))))(Tile((id \
+         655ced13-1564-4b25-b123-7d1446831221)(label(85))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         7e3a9357-85c2-409a-ac8d-9cefe997160f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         26f65ddd-0608-4ad5-afce-19894a7452c5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d7b2de5f-b91c-40b7-b6be-36ccd71053fa)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         6dd5f138-5645-43b9-a20b-1a18dd206689)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2fcf25d5-9de7-488b-9e20-02c345be8a7d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3b7176f5-727f-4fc8-ae70-c16aa073523d)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         2fc8af80-32b7-47b7-abe8-ec530b3bb38d)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         aa766419-c7a7-45ed-b9f4-232fcc544041)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c7fa48b5-f00b-4134-9b36-4dce676a7a76)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3d8a5fdb-b0cf-4f04-96d7-38a5d7c39e5e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         351d8734-c3d6-4f07-ba55-fc84cd1ad91d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c78f0eaa-23d2-4ffe-a75d-499649203547)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0d8929a6-68e8-4cf2-b7ac-3694b2a161cf)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         34f885d1-38c5-4af1-8018-6b82e80bb90e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         33a2995d-22f6-46be-b5e9-5fbe35cfb58b)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         198cdc16-d21c-451c-9fb3-ffa31e5d9ea7)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         97e1e700-15be-4011-be62-cadff92b90fb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         50859192-b17b-42fa-a2ab-78abdbcd7f92)(label(84))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ad333b04-1d18-4ae3-8c72-400b618b9baa)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         01dbe6bb-dc85-48ff-b531-bd9560231dc2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5e8605e8-d52f-4617-8954-9ff824d364e6)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         69061bc6-1e0a-4015-90b1-6ebf8a602e1e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         78d170e8-0ef9-405b-86be-24f5c8aa198f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f0aafe96-11d8-4143-a0b7-fffca690893b)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         caf0a42b-783a-4a5f-871d-e74a0449bc95)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c115bc34-4f96-4d1e-b03b-b4c2b79b3c1e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f62495cb-e053-4d8e-b339-4f11fa51e2a2)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         76edfe3f-fd8b-42d1-9ae8-94329cda3af0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ae2e844f-43a7-4e7c-984a-5fc726bedceb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         08300435-43fd-4434-8713-8c5f16ac89e9)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         eefe240a-37cc-44f1-becc-62a8c3fcd4e4)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e9a4daac-f524-41b3-a039-131289681491)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a0bec977-5011-4e9b-badd-6b39322426b3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         15dea66f-7483-4682-88fb-635f2182fe67)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6e08cb38-f9d9-4321-b4c2-8c48fd308407)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c296ce66-a3e1-470f-a5ae-918a46020578)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8584c23f-0f5b-4d02-a7de-d978946b2291)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d1e25d9a-d494-439b-8b38-bef3c06b9538)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c68871ad-a1bb-4379-a1ef-5d091c4be342)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7614d5ad-2c98-4241-b316-a4ba7151604d)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a7a9e114-f101-4261-b8dd-33f2f6614cc2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7caaf56a-83e0-4f7b-80cb-0712dd125e4a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0d45440f-7df8-4ae5-9399-3e8cdb1cb29d)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0ef71de7-9e89-43e8-958a-9b2424d32441)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9933a638-0210-4213-81ec-54c6950bb539)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b095eef3-87e1-4de1-b23d-12948b0d92c0)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         019f1fb3-a41e-4698-8856-4a4721e359c6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f8ee63c9-4b86-4bef-ba64-771d26972690)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7f47fb06-d65b-4329-8a70-9d52fd8e5358)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4421a9a2-ab55-4068-9f37-ebbdf90a7a7b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         61fd7685-d547-4b66-8db7-8789c887a77e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d312bdcf-26af-421f-a709-ee2ba57ec2dc)(label(87))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         27483840-751e-4169-bf11-93951b9b2234)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b87b6449-6312-4e80-9c54-08cb7005ac12)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         22e4f516-1aed-4c0e-998b-cde24a05e40a)(content(Whitespace\" \
+         \"))))(Tile((id f8ed672c-02a2-4c4f-9ae2-cc8d79685ed9)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         ae5fa14c-8e5f-4876-b343-2986fcce6c5f)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         ce0b6be4-1e0d-4c7b-bf3f-94ecd7c31f5f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         16570848-df69-4d7a-9a7f-6d347cf3e65b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         266e9524-450d-4cc1-800f-9aeddc25550a)(content(Whitespace\"\\n\"))))(Tile((id \
+         004059ee-cb71-4fbd-b1fd-63e5bf80bed2)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         e3416eb1-48c1-4cb4-8291-ac261bc8a07d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         37ba8f60-a920-4e76-970b-7160ccc1432d)(label(order_by))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         8cd5ddea-3e9f-42a0-8aaa-a8200e694172)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         00f19690-b30f-4200-bbaf-dea1107ff2ad)(content(Whitespace\"\\n\"))))(Tile((id \
+         ad42d47d-5d2d-4655-8f12-c7f9a7184a0c)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         769eb90a-5033-4d1b-95c2-ca30b5249a38)(content(Whitespace\" \
+         \"))))(Tile((id \
+         56dcb45f-02ea-498a-aee6-9c5eedd51b96)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cc83c1be-19ca-4e33-8efc-3f2ed1f6aa61)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         d24e1691-f394-4854-9ff1-70685a75ff0b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b5004d2b-d3c5-449a-9d7f-9cfbbee840a6)(label([]))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c2c8530d-b301-4788-949d-ab68c3c854ef)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5e93c0d4-5ac8-47c0-b654-78cade30e1d3)(content(Whitespace\"\\n\"))))(Tile((id \
+         893eddd2-0a12-4790-a879-94c5ad92801a)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         772f630a-eedd-4b04-a026-01d7fb09d174)(content(Whitespace\" \
+         \"))))(Tile((id \
+         be0215dc-98ea-4ba1-92a9-ad1803e7cfa9)(label(_ensures))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cd84afae-e343-4de1-8eec-5aa192c47b52)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         09233475-5371-44c0-b10e-e582f5aad6f7)(content(Whitespace\" \
+         \"))))(Tile((id 071f35ee-800a-4881-923d-272d17dd70c0)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e4481e4d-813a-4839-b0a0-0ee8f04a64b9)(content(Whitespace\"\\n\"))))(Tile((id \
+         5cc5ebe4-b6a9-4862-86ad-a467f9968642)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         b8471a62-3efe-49ef-a66d-55a94413c77a)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4de95b45-ae30-49b2-881b-088b0f3efd62)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         f5f77ce2-373b-4a3b-ae03-470f1c090c83)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         bcb8c4bb-f03e-42ad-bcaf-e75dd6fa10f2)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         40a6cd5b-7023-4b9b-b173-dd58cd357ff6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5c6adf29-3c52-4790-88d6-936b0059b114)(content(Whitespace\" \
+         \"))))(Tile((id \
+         519526ce-f21f-4070-b86a-19ed736aee2a)(label(\"\\\"schema(r) is equal \
+         to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         b437a2da-93a1-4760-a38f-13963ceb2632)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5082b03d-37b3-4643-8c4d-eed852881dd0)(content(Whitespace\"\\n\"))))(Tile((id \
+         d2113c27-ba93-46eb-a123-3a81b1731ea6)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         179d3aad-7f96-4ac6-8034-3bb0692174af)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2159ad17-4bce-4672-a53e-893fcab11d36)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         e5dd9719-ccc4-4b57-b6c8-53ed7877e13d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         6026d80c-319e-473c-adcd-89883165f648)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         e2d86c2f-e247-4119-8a61-bbcc79b5a3de)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1cdd4066-203f-4619-8555-3aea31734afb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dcc678b0-0d52-427b-9b17-ba6774ca783a)(label(\"\\\"schema(t2) is equal \
+         to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         6c8a398d-e030-4578-bca3-66c234d5b46e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d4298e2e-cb05-44dc-9c5b-aa5cfd8a8cbf)(content(Whitespace\"\\n\"))))(Tile((id \
+         9e063100-f661-44a7-b177-f9dc3a5f8400)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         f9a5c1a9-b907-4b43-92e1-b5a840acef36)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ce4c2c6f-721b-47e8-aca6-ce1566d5c627)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3fc31198-4403-4b66-b314-5b5972d2c9bd)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dc47f906-871b-4038-afbd-6c1a0dec5625)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c2c8eb99-daca-46ce-a113-576132307fa6)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         4abd717a-40a8-4d78-8829-2855a12a8ed4)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         30d77c4c-06b7-4514-ba8b-728757186b9f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2d8adcce-d963-4ac9-8eca-4e8e1f7c5778)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5daec105-57e1-4e70-8cc2-b7282f6e8b2b)(label(\"\\\"nrows(t2) is equal \
+         to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         0983dbcd-6db7-45c1-a3fa-032bba88defd)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         04a8139d-6435-47d2-b867-1f09c08909f7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         dd70c432-9f07-46c0-8939-217de3769b15)(content(Whitespace\"\\n\"))))(Secondary((id \
+         8cf145fe-57c3-4272-bc9b-64b49c624029)(content(Comment\"# We don't \
+         currently have a way to encode a existential type for the key so \
+         we're currently using the unknown type. #\"))))(Secondary((id \
+         dbd1cc43-06e4-4780-a734-9f899f3bc70b)(content(Whitespace\"\\n\"))))(Secondary((id \
+         366a86e5-46ba-4697-9948-c107eecd8d9a)(content(Comment\"# \
+         Idiomatically you'd just compose these at the callsite \
+         #\"))))(Secondary((id \
+         a91687a4-2749-4024-926d-c7e9fb393ff5)(content(Whitespace\"\\n\"))))(Tile((id \
+         1790e7c4-4168-4b89-a1bc-ddefbcb71c5f)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         c0319630-0c2c-4b44-bd8e-b5277adcd2c5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a2df5280-56f6-4692-becb-5cc4f567be30)(label(order_by))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cb0d317d-b166-417d-b522-dfecaec96d6d)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         c4e60402-1a58-4e1c-8801-3b07d4069621)(content(Whitespace\"\\n\"))))(Tile((id \
+         f91353b0-7fc8-4055-9672-2f88dd7b2d25)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         2bfb2a3f-c5a0-459f-ab75-32845aac7bbe)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7592dc6c-be59-4624-b1ac-799c062121a3)(label(row))(mold((out \
+         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         919d676d-1ce3-443d-8d14-3d75e5712ef3)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7b3b2344-411a-47e2-b2a2-fbd1fa2783b5)(content(Whitespace\"\\n\"))))(Tile((id \
+         38ef522a-bf56-4cdb-8a97-897c667fe332)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         7adb0aa5-d5bc-4245-8611-d60b764aa6d4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bd1fb9a7-4c56-4531-93e5-8ab4621833fe)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         21480123-e1b3-4d67-9e12-2522060b50b4)(label(t1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1d795b66-86a6-4c75-9965-2896fe86c451)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0e1fd8e0-2078-4dd2-b237-f7d5ddedf45b)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5a3122bf-cf63-4e97-ba44-0fb7c738a3c7)(content(Whitespace\" \
+         \"))))(Tile((id 96bd4b5f-72e1-4f85-8316-6687b51b3362)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         413c7e20-b9bb-40c3-9954-29bb3da98c0f)(label(row))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         9cefab50-324a-4851-a6f2-b4c2988ae622)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         bd89ec36-28c4-41c1-b76a-9e9964a48a85)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4e3f3570-41ba-44f4-b8ed-25b1901e0e01)(label(comparators))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4d35ca6e-bac4-4538-bf06-ab5be4a90adb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8a448891-03a7-4731-80b4-fbe10e40ce5d)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         63216bc3-6b59-450d-be48-3128afd776ac)(content(Whitespace\" \
+         \"))))(Tile((id 9775040c-7a60-4e40-a398-c856533b122b)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         004329d4-3184-48ad-83a1-08189b98a604)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         58cab0f8-6414-428f-83b0-71430637f7eb)(label(get_key))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0f33bd1b-a36c-4b40-adf6-aef4a8f379cd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         77830a26-a7dd-4f14-a768-a2588c12c6e5)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0e121ab7-5349-4643-81c3-9188b75ec26e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         af29989a-885b-4c12-a770-61f3bd365e08)(label(row))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         126421e6-4547-49c8-afaf-7886f1cea556)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fa255454-234a-4dbb-bfc4-733f4b662cdb)(label(->))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
+         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ee36fef2-936b-41cd-a397-12628008598f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e8a46f53-4d71-4566-ad1d-9c094a4cab9a)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         a86b52c4-961a-4d92-917c-5dc079978952)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7634d871-545d-4c1f-b5d0-a4fc46e7dc04)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a912c242-131a-4f4a-97bf-10a8da75c087)(label(comparator))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6d62fab6-81d9-4418-adc4-c449e2eeacac)(content(Whitespace\" \
+         \"))))(Tile((id \
+         49e3a724-5b7a-4212-b368-7b9ad561c470)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         463c990e-7a99-4f78-b523-7b13835a70b4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         812734a6-9bd1-41ab-9fd9-3e7e524c9188)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         152bd42a-720b-4c9f-93d3-142630796d76)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0f45e621-56a3-4ef2-8633-bf4d1d82faf0)(label(->))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
+         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7393b2d8-bc6e-42c3-a3dc-a07006935cb6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aecd9121-df09-42df-bd8e-41429a77cfa2)(label(Ord))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         8fef6d40-937b-4372-895b-821741e0c8a0)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ff3f19de-2ff8-4a8f-ac6d-79ce51651ce5)(content(Whitespace\"\\n\"))))(Tile((id \
+         1e92d082-7f2e-4208-9f0a-49db57f8a079)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         595eb4d7-daa1-4dc4-9b10-a22d336997c1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         65ca2624-c6e0-4c06-ad27-8f2c69e663ad)(label(compare))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         d03eb048-b40f-47cf-ab5e-a81eff9ede1c)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         9c3586ae-1d2c-4ab2-9368-f63fa7ba9177)(content(Whitespace\"\\n\"))))(Tile((id \
+         9014160b-13f9-4d8e-88b7-55c645a732ae)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         0f42d316-aabc-4f6c-8d8b-d821934713f4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b2cda6cf-405c-4f9c-8a23-8f24f9e58db5)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         aa24a40e-f967-40ee-95d2-a547d2c0387a)(label(a))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         b26f920d-7e2a-480c-8ce5-9ee24b60dc7e)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         eeaedd1a-14b4-47c7-a8b7-28ad50bd1f69)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fe2cb6ed-6cf4-494b-a205-fb014edad711)(label(b))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         f9694ded-435c-4388-85d8-570e40a6ea62)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         e82b1009-81f4-4440-9667-9f3d1ad646b0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         849b15c1-9b86-4b6b-ad2d-921c2a10156e)(label(comparators))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         d5ce6cca-9e42-49e0-8a86-b8a902fde75c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         87fa62aa-b79f-439d-ad76-9540fae0ab5e)(content(Whitespace\"\\n\"))))(Tile((id \
+         c351bb1e-5959-4130-8966-1b9800dec231)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         98be49c5-22e7-4918-b6f0-3c339032940d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         66d00785-8814-4a55-b9c1-269b102b201f)(label(comparators))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         359f10a3-dfdf-47fa-a40d-ab1ff47de4d6)(content(Whitespace\"\\n\"))))(Tile((id \
+         79c5f265-44f0-46d9-979d-ffdfac85e91d)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         5c96ec9a-9bd8-41b0-8258-bfef6b7179b9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d5787e69-1386-443d-a875-f799f0925c06)(label([]))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         845ef1cf-9904-49f8-9f5d-8ca2f489ba3d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c47243b5-f053-4a1d-8e27-d936fa5468ca)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1a8837f5-1d66-4ed8-a599-3132d4e3b3d8)(label(Eq))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2012e855-f243-4b1d-8c3d-3245db0afbcf)(content(Whitespace\"\\n\"))))(Tile((id \
+         bc9f0fd9-f6a5-410a-97ce-683583e4eee4)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         95588ab4-5c3d-42b6-a435-39cdab85efad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bb0072fa-65b5-4497-9ec3-2d7c7df1ba70)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         6f648894-2e33-41ef-860a-bd0c05da7b50)(label(hd))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         94a52737-7de1-4a99-8a4a-292c34844831)(label(::))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 29))(sort Pat))((shape(Concave \
+         29))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         facfe38b-271c-42fb-ba95-7781eb5929c0)(label(tl))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         5868b8fd-4f5e-49df-95ee-72be2361299d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         af60b4e8-97be-4ae8-b4a0-ec5ca7af352e)(content(Whitespace\"\\n\"))))(Tile((id \
+         6f759146-5211-49a8-89fd-1d1f12505241)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         2d3d3969-2b17-4d55-b8e0-f0817d5d3df8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1aa97d6d-e21c-43b5-81e9-097cae874ba5)(label(hd))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bc7fcb21-7bfd-4f2f-b1dd-67c8ea7bcbc4)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         3877636f-83a2-4dc2-994d-dfadc96483c3)(label(comparator))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         310944bb-d062-49ba-b5c5-693f8e6db5d0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         7bb012ea-0f00-48ee-b5d9-ce3674f26685)(label(hd))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         94bf27d1-8807-4571-8938-e4098e6e9442)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         a4d4bd86-e8f9-440e-ad8e-be5f76d6a9ca)(label(get_key))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         aefb8a5e-c66a-4990-9a4d-ffcc15bac638)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0ad00fc2-3e20-4628-b5a7-5c97009e025d)(label(a))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         13a33baf-9b44-4e4b-b44c-9940e4cdde06)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6bb3e61b-e727-40cd-8cb1-617497dc138d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d69f9694-ab9f-4ed9-9be1-4075f8faf202)(label(hd))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         46ff5216-5cc1-48e0-8bbb-5f8e3225a88c)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         f93779f4-56db-4c55-a509-64ba2d94252e)(label(get_key))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         82562c77-d6b2-4c44-ad53-a376719cf1c2)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         e371531e-793f-4176-b3f6-7c2d82211d59)(label(b))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         3b3067c6-4549-45e5-a7a0-ca61e646809b)(content(Whitespace\"\\n\"))))(Tile((id \
+         d5bbddcc-3896-454a-af91-bf77dab31e64)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         11706960-3ed2-4e1c-a74a-d3bdf756ab42)(content(Whitespace\" \
+         \"))))(Tile((id \
+         44a8b8c1-b3c4-4dfe-b71a-bd46543516a4)(label(Eq))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         2efec0c7-d0ae-48e4-a34c-1380a519791c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d19e0f7e-237a-4a64-b76f-35d75291b3a6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         21c59ae5-ffab-4e53-b040-9c14e7829d21)(label(compare))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5837d1ba-0f1a-4bd2-afbb-52d934bc8748)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         88e9dbe4-231a-47a2-9e11-33974ceaef52)(label(a))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e3a98c5a-1267-441b-b7be-5e627bb58e22)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5e443fde-f26a-493d-8fdd-5e9e4c4443be)(content(Whitespace\" \
+         \"))))(Tile((id \
+         910275ae-04c2-4f99-b69a-f53dcae7be51)(label(b))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         371b35a7-f7f1-4837-88c8-47464a68aca4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0c5ae9fa-f9f5-44cf-8d78-8896f14fd382)(content(Whitespace\" \
+         \"))))(Tile((id \
+         89d8e20c-b95e-4be8-9452-a25a35e79d68)(label(tl))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         fb64df47-2aa9-482c-a632-b85dd85c7e9f)(content(Whitespace\"\\n\"))))(Tile((id \
+         9030a542-4519-402c-a135-6372b6117ae1)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ddfbc4db-a25d-4106-a9c9-7acbcb87ebbb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         08c04a95-0a79-480d-8037-a42f0c4836ba)(label(other))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         781819fd-544c-4e4a-a3df-e33f9496200b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         deb643c5-2d00-4c65-8640-9d53b391ca9e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9b676600-177e-440a-a762-2005d6a3dbd5)(label(other))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7522eceb-54bb-4d8c-b8dd-c67b06632f2e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         a2742812-a5fb-421b-aaba-21b9fbfe4f8d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         88d8c9d8-7db9-4c80-b628-4342c7d4828b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         6fe1b270-2dbf-4256-ba66-49692308ef91)(content(Whitespace\"\\n\"))))(Tile((id \
+         64c7c74e-96fd-41de-8fed-a85c70aa2f38)(label(sort))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         533ca5c1-57bd-4c00-9476-7e3c556d1b3f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         805b241f-931d-411d-a8a0-2004890cf095)(label(compare))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f01e01d3-7844-44e5-991f-7430e0ef1a72)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         ab5bac36-4566-4409-bce3-6a998f882d5b)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         793877f3-1a4f-40a2-868d-a8cb500b1b4d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         41925ef1-eb95-44bf-a4fc-61769c018a28)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e8e97c86-b902-4f32-93f6-01422b8f5431)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         7155f511-74d2-4e4a-b317-6d003a53ebb7)(label(comparators))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         57fc4a43-a29d-462b-87d8-ceb2ae8532fd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c1ccdc03-12a4-482f-9084-e00b1df5f469)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0c15d577-61be-48b1-8800-2104b45d2688)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         6b35140e-0c64-41f3-af66-fdd64c82fb19)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dabb9410-6c85-4d83-be03-0e282da12133)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e38c053c-198f-4e17-b2f6-d0ca2d31f682)(content(Whitespace\" \
+         \"))))(Tile((id 4c70ce10-5ff1-4870-9289-79d990f2e66b)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         4a52f18b-dbc8-43fd-baa5-74202f53bcd9)(label(row))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         44ead86c-c5e1-471e-9f9d-dc1912337e2a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         056b6c92-ff95-4fd8-8e2f-403fbb3c1f7d)(content(Whitespace\"\\n\"))))(Tile((id \
+         27d74ef5-cea6-4be8-b162-2254136f2b5b)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         6595d16a-a428-4391-a5a2-c6c77b7de582)(content(Whitespace\"\\n\"))))(Tile((id \
+         ca6568a7-3aee-42c3-a262-7ea986a04013)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         91a95875-4e08-44fe-b569-b7e7155ae87c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         86773c70-1504-41ee-8724-2c66b7074659)(label(average))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c27c419b-9372-407f-b539-0e0c80ae9c4c)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         f773d7a4-51aa-491a-bbcc-00054805a8b9)(content(Whitespace\" \
+         \"))))(Tile((id 7af8c9e4-140c-4712-aed4-504a9f535943)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         d33be76f-cc00-40a6-b63d-e20a3c386876)(content(Whitespace\" \
+         9b55a919-796a-42b0-9af9-002610e5ca22)(content(Whitespace\" \
          \"))))(Tile((id \
-         0c389f49-882d-4d59-9e5c-33a5ba0a70ba)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         9533dcbe-41f8-4345-8327-018e77558e34)(label(r))(mold((out \
+         4639b9df-1c37-4551-b6c3-db481e97456e)(label(ns))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         64059b9e-2a47-480f-9a01-e11d510fa117)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c19cbc20-f130-4ac5-934a-fb1287d05424)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         397ea48a-029e-4985-bc7d-53110cbfbdc3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c0dca983-0b9a-4e65-b100-f7d23fc1166c)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d25d8159-126e-43e4-adda-940feb84bc43)(content(Whitespace\" \
+         d7df5988-cf97-4bd8-9045-6a315e33334d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         adc037cd-5ad6-40c9-ba0b-c91387d677f9)(content(Whitespace\" \
+         3b3ca737-e44d-43b7-ab10-0748d90911ed)(content(Whitespace\" \
          \"))))(Tile((id \
-         ac050f9f-a949-443f-8e7c-ef713b2a0ff3)(label(r))(mold((out \
+         f26e82a7-33d7-49eb-b36b-515a465d325f)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d87391e8-3f47-4986-a0fb-16ab35118ba6)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ddb54e05-db47-4892-b02d-eb772ce35815)(label(name))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         4adfe079-e674-49cb-815c-d137de2627d9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         14935561-3950-4377-9db5-5ccc92e151d5)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c498d02e-a462-44b0-81db-7f472f53f596)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4774c081-03fc-4689-a7dd-ac13ab449652)(label(string_length))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         8505e401-3531-4efc-878e-57478746e957)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         350db01e-706a-4e61-b46c-acee7d8db12f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2cad4655-6a7e-4725-b3a1-77c1a7e4b78d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c51d80b4-cda3-49c7-80b9-b4a366d052da)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         467ebfe3-733c-4dbb-809c-bceafa551307)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bcb84e94-b3f8-4589-aa7b-b734e3fedaa5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ec0f7c68-a515-4460-bdb5-5904c884a7a6)(label(order_by))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         87f58ba1-4ff2-4c2c-96bb-2ced15ec5e8b)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4ebba905-8274-46e9-adde-1bc0ff19cc77)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         d520c94b-63e1-430a-b0e5-baff6ea35539)(label(\"(\"\")\"))(mold((out \
+         88fc41a1-34db-4d60-9dc1-c6357737414f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4e860aef-2744-4ed9-bdcf-48867452d7c1)(label(gradebook))(mold((out \
+         5df9a7bb-f6bb-4cbe-8dc9-c46d0347fbb8)(label(ns))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e4e76365-85cf-4b60-b921-1bf21a06b16b)(label(,))(mold((out \
+         78332a00-6316-4a45-bced-cb04e055c453)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4d0b9fb3-609d-4ce5-99fc-9f663940d437)(content(Whitespace\" \
-         \"))))(Tile((id 9a82de86-044a-44d5-8348-f2e52b2be8da)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         42fb6b01-58bb-44f8-a47e-0f6c6ca9904b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         6e46d822-441e-4b6a-b7ce-be21415bf84d)(label(name_length))(mold((out \
+         471e8ac5-4532-41af-adb7-0405f1f2be89)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8296366a-3fa8-400a-bf1a-fbd01e7a68b5)(label(int_plus))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7f8835b3-73b5-4c23-bd1a-3f0c1cd87c86)(label(,))(mold((out \
+         03518e95-2df8-4d61-9914-59fae6783d86)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3b6c6498-9a28-470a-9eb5-431fb8964cd3)(content(Whitespace\" \
+         3fa4cd2f-0d6f-42eb-b909-6f9116ab5c8b)(content(Whitespace\" \
          \"))))(Tile((id \
-         1324cef8-e787-4d1e-8af8-f9087de65b2b)(label(desc))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         85eb29ee-b606-42b2-8695-2cd010eb7701)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         dc151d60-d296-44aa-a1ce-545c74b5a838)(label(comp_int))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Tile((id \
-         cb1fad8b-90ef-4c3e-bc9c-e2a72b5b8315)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0f142cef-d8ce-43d3-9bd0-ce40f99d5ce8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d7441b8f-46d7-4477-89ef-e2c57691d0a1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         6fa66e05-9bfd-45b4-a12c-0f1dcb6c9fbf)(label(midtermAndFinal))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7f3e3154-2c61-403e-bad9-0bea24f93628)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c04ad287-b19a-4b15-96f3-0a50e1718309)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e83e25b0-cab2-4072-93b1-57a9c39ef8a0)(label(compare_grade))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         9c321089-0d35-4f1e-a1aa-70fd4f61ff76)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c3f2b350-7908-4159-83f1-317da60c906e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bce4a73d-67e6-473f-8b81-1df21f667f88)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cabdca19-b998-450b-9417-9a3dc1b54d7e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         37314c8a-ca69-446c-861a-9e917ddd7b9e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         aad7de36-167d-4efd-902b-2932469b3cc1)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ae9fc3ee-3d1a-4e4d-bd27-035592b75c80)(content(Whitespace\" \
-         \"))))(Tile((id dfb3940f-25c0-441d-967d-f8dec09163c7)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2f3e167a-1c68-4b92-87c1-d2aab1c04b7d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c42e7d53-ae97-4d60-b00d-eca0baaf9b59)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8daebe8c-4434-4994-9467-fe7dbd6b93ab)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         249e9591-d049-4196-a877-7f62f6c7737f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e51ee2c-0903-4d0a-bfd2-df6a6ca33a6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b88db546-2eb7-4ae8-838a-d32f79ddee90)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4d54cbbb-dd54-4323-9a0e-65469850eada)(content(Whitespace\" \
-         \"))))(Tile((id \
-         091c44e5-db4e-46c8-bf92-ec2ad8926ef8)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         b18f9086-3ce3-4798-aa30-fc87007cc7f0)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         65364337-8f65-451e-8ce9-7dadc5ad4250)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3fdf9d6e-1746-4c90-b058-5ab2d9df1933)(content(Whitespace\" \
-         \"))))(Tile((id \
-         97c4767e-7af1-488e-a674-c92b8ecb4fa8)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d70f5aba-4d9e-4cee-8600-47b833bac6d4)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         91c352db-1d4c-48d0-a27d-dcfdd76a4a95)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a11a2f83-880e-4e3f-b76b-f39df561ade0)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7ed44b0a-b6a9-483c-9f5e-b8e2523b62ee)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         60bb4e3e-0364-4da3-a78e-c019b5b5254c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c0ab6196-3050-4cff-9577-943165c75963)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9153e98f-d127-46d6-a2ac-afd225db0c45)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         126774a1-8b41-4b4a-bff2-7cf6572f57c2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f3559987-ba5e-465f-bea8-6cc368bf10a7)(label(88))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4b9130a4-0cd9-4e3b-b726-68c88674f064)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         be0148bc-dfff-46b4-bc73-8fdcb849e5ae)(content(Whitespace\" \
-         \"))))(Tile((id \
-         32fa29e0-2a97-4685-8df6-9664e29b4a88)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         324e6a01-5dbe-49c3-b8a4-5c966974107e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ed8010a9-7891-48fc-a9db-25b5ea44bd00)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5b7eeaae-f975-457a-b4f6-6d424d34028a)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e974d8c5-4b0a-4e38-8777-5a77a9aba0e0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4d80bacc-0376-406b-8a9e-c3c4ea6f72a6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f55af8ac-2cd2-4295-8446-2dad422cc632)(label(85))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         8a9cf2ed-0e5a-4118-a640-99c45f86c7a9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         479a0ad7-027e-489a-9e0c-5746a82a610b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b0f6b84e-5343-4f9d-987c-fec0de1476f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         40d38c01-b8e6-43e3-b72c-ea6f98b42bcd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         08e0bfa6-284e-49d0-9248-8769ccb22f96)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e5fa92b-7e61-4fab-97bb-1179ff44e9f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6412dc22-4706-4181-a5fc-20f2bd2be5fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc1a1b1d-7e4c-4afe-beff-c1457c0584e9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f3019c99-3a75-4fd9-a25d-d23be060dae3)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         0eb0b213-4b9d-491a-8e74-dfb2039df30b)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c7ecb695-5ba2-4548-8b29-26ca369c4159)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         96f3a727-b811-4e6e-bbfb-dc7caa484649)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         25c16d38-4f05-4583-a498-bd53e777f29f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         18413d7f-ab5a-4ff2-835e-1af7315a2a5b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0264cef2-f7d2-4dd9-a207-2b7ceb6f5e36)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ea3f78f7-a84a-4a48-9086-36b375fd5ac1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a265d353-9c02-41ed-9e17-a93c97d0cc56)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b43b1fcf-51e2-4107-acc0-dbdfb7015025)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0e585a49-9045-4dd3-888c-9bfdd61dd086)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         de6527fe-3c3a-4023-87ae-0898ea882cc1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0942154d-9f73-42cf-8eb9-a68b2f9c724b)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         afc05ef3-108f-4479-a9a0-916d325e871e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a33970ed-d661-4897-a0f0-edc10b965a46)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bbaf0984-8ac1-43bd-b12e-18a416d64110)(label(84))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2182c842-f524-404f-a08f-689aae31d362)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6a00b9a4-ac11-4a57-9307-3cd6fad5e0bd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1183cae8-709d-45c2-b83e-ff77b90368e7)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         60de93c1-2104-4293-ac2a-4af1ea6d22af)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f055ec49-a55e-4f0f-b45d-3d06b338c113)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3bb4c789-7d1b-4f29-9cc6-683a2570ed8c)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2cfa7526-c483-4b15-98a6-f99c233df167)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e9a7bb98-f9e0-4c31-9289-3fa27e9cc6b8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         450fef4b-18ab-42ce-808c-4671acefe1eb)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         90edfd8c-9f88-4c61-93bf-a06618749183)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1a591689-4a4f-4cb8-a723-cb037dedee99)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0c391460-26d2-46da-bd70-49bbe34e9313)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b3bdc9f4-5a79-4dcb-96d8-38c6c4f8d86d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f2c11d26-7ef0-4892-9e5f-b53b518c5548)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e5dca587-fac3-464a-b3b1-6074324ef290)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d43d69d-dd43-4dcf-a9d6-e1ba26aaf19f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0d7a4ad1-a9d7-410f-96cb-0629fbc80d13)(content(Whitespace\" \
-         \"))))(Tile((id \
-         49d39aa2-4182-491d-b3dd-062d06a5ed6e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         0c628e33-84e0-48a1-a72e-9c54784d2d59)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         06b3a0a6-2a40-4d14-af92-c152aca1f9bd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1fd4afd0-9283-4bce-855e-c831deafef2c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57d7840f-894e-43e5-9495-fa116043486b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ec82aba-f58a-45c6-8386-912220dddadd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         70faa0cd-9bdc-475a-8b7e-13e917738755)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         db8e3228-352a-479f-9020-5c0092b7bb91)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0c049967-ae03-490c-b632-a81c25605816)(content(Whitespace\" \
-         \"))))(Tile((id \
-         563d0f9f-b9b6-4d0d-b8d5-53245b889288)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         68b9769c-1fd0-4951-a6cf-08d419c07815)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         98fd0057-5887-4cf2-824a-5d6d29a54d26)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ce2ccc15-d32d-4056-a8fb-4c3e025084ed)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0b1670e2-7dba-4d0b-ba78-d93b3edb9eee)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         390f58e2-b112-48f3-807c-52aa80a04eaf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         22358d16-82ab-4549-94fd-84c0b87a6ee3)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e126bc60-8bcd-420c-81bb-5d5d7a7c76fd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7b6bb273-53f2-4ca6-b248-901034944eef)(content(Whitespace\" \
-         \"))))(Tile((id \
-         38ddb664-f99a-4fde-8530-02f23d34f93d)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bf71a2c3-6a92-4b6c-8a66-cfb5f741c734)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ff02a67a-fb8c-412f-86c9-17d70afb2088)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e69bca9b-e637-4d52-beb3-b04464e0f9df)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         67793d7c-c0f5-4bc4-8a26-5c54d4778d40)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2b2bfd4e-9ca4-44f2-902e-35fe781e9257)(content(Whitespace\" \
-         \"))))(Tile((id \
-         48d91ffa-ec36-40c4-86ca-488cf4f7e6a1)(label(87))(mold((out \
+         f724399c-f11b-4196-aec3-5bee4a23c93e)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ba38b7ce-0ad1-43ca-8f4d-b7dac99fd659)(content(Whitespace\"\\n\"))))(Secondary((id \
-         111124e1-9235-479a-95a9-387fb46c5ad1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3a93f378-ea76-44f6-8706-741a4809fee3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5f128d6-a13d-49d5-a7fa-28aa2967aacf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fdde3db9-21df-45b1-8fa9-a8989972008f)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         a99ae48e-0aca-43a7-8ce2-9ea24afab266)(content(Whitespace\" \
+         ec33d488-3274-436d-ab93-4caa582884ac)(content(Whitespace\" \
          \"))))(Tile((id \
-         24e17f87-3e31-4d33-bb85-54a03d864550)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         0bc83551-b1c6-4534-8226-ddeb36a7d029)(label(/))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
+         27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9ec6a8af-ca84-4867-95d8-227f0e266698)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e81330e7-b879-4708-a2ce-9e1fbc50beb4)(label(length))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         13077f15-9f47-425d-836b-e7dd7dc6680f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         b4dd857c-57f4-444c-b501-0a3022d631be)(label(ns))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         55bd2516-f947-4102-9971-4a8fd3ecd15c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         474e10bc-aaf1-4c33-8714-4ac6896962ed)(content(Whitespace\"\\n\"))))(Tile((id \
+         10f7eb78-71bf-433f-90c3-770eb672a94e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         bc761742-4790-4ff8-8d5c-274f53100e29)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ab0d9ae3-445d-4eff-a7f3-c9611e761c09)(label(midtermAndFinal))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cd889205-d684-47ea-a3a5-97a6db7b8d10)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         c12a0bc2-3a84-47ba-bb9d-8f920b5c3229)(content(Whitespace\" \
+         \"))))(Tile((id 4e3f95e1-c840-4b4f-ad15-cc1a7613376f)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         683ef44d-8831-41c4-bac3-00e58b9f65d5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1480f876-e88d-4bbc-bc5e-58a7d57e8a67)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         7bf9ae17-8167-406f-83e6-b9c17dd78dac)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3151ee9d-3b70-4cf5-afa5-6dd07b81fe58)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4c9468b4-f7ab-4344-9c71-3d17d579fdce)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         32b9b62e-0848-44b6-8bf0-4772dbd6f5b9)(content(Whitespace\" \
-         \"))))(Tile((id f74027bf-9549-4993-b9be-a707e339f050)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         1c6a28a9-fc88-4f62-bd64-94caf8c24b8c)(label(GradebookEntry))(mold((out \
+         41bd43ce-4951-44b7-9534-8ee3aeae8c50)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e3c928ec-858e-4150-b8ba-5cc188a914f4)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f9106ca9-5550-4ff1-9051-8ba8c15dc950)(content(Whitespace\" \
+         c50441f3-158a-4f06-88eb-274f459a3960)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0a99f08f-e1b4-45df-b4d6-62d4dc320dae)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         89ce821c-0c12-42b7-b3a0-27dfea4b5143)(content(Whitespace\" \
+         be0344b5-b665-479f-85d0-d93b5257c949)(content(Whitespace\" \
+         \"))))(Tile((id 99b74643-3113-4f5d-9dbc-409a86193905)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4f440781-c8d4-4087-9b7e-8d4901953e94)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         707500de-dbdc-49ba-ad04-fdf762848ad5)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         b4545fbf-8bec-42df-bfcb-77d0cd9a3a88)(label(midterm))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f9fad31a-5e7d-4bd3-8a94-777200fed11f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         589b0951-f608-4c07-aba5-03301fbf9da0)(content(Whitespace\" \
          \"))))(Tile((id \
-         34a16cd5-4970-43b9-a4ed-8c1b5e76a857)(label(?))(mold((out \
+         6e3924bd-d608-4519-a63c-97c9037980df)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a85ff070-e448-4c78-804b-384d5144c4ae)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         6cb04f0c-0562-4294-a64d-44959d9968b6)(label(final))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         35186646-3561-4b0c-b883-90cb7f4f9436)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         72679ae7-1076-45e2-9b77-7501ba4e4a99)(content(Whitespace\"\\n\"))))(Tile((id \
+         52525555-c2c8-4516-a4a8-7961592ad0dd)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         cb5143b7-0c28-4877-acbe-ebce1ff848c5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         433387eb-4fcc-4595-ac03-84422c9193c9)(label(comp_int))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3f98d83b-609b-464b-ad2a-1aa176201d90)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         f33742fc-22ca-49e7-b97a-d906635be83a)(content(Whitespace\" \
+         \"))))(Tile((id 5ec51a1c-4ec3-4ddc-8045-d8d5b91f39b7)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         a1dbdedb-1f7c-4580-88e6-c992d49b5f09)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b146c90d-4b56-4324-b081-cab616b7c42c)(label(a))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         e55d0094-22ae-4fc9-83b3-0f7e6cb8ac9a)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         78dc810d-020a-472b-bfe5-31aa209df384)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bf1fe129-a5a3-40cf-8414-e376f740112f)(label(b))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         34ee002a-459f-4e7b-be04-3881fc9f5cd7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2f372b88-7a57-4648-8912-639afe136bf6)(content(Whitespace\" \
+         \"))))(Tile((id 36925568-35c3-41c1-bdd8-d0cf6b8ec757)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         45c5c852-eeef-4a46-855d-807ec4ec2215)(content(Whitespace\" \
+         \"))))(Tile((id \
+         11fccc6e-f6dd-44f3-ba2c-1384c75e0e57)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f26c7d73-8424-4aed-950b-5a8c3b59baa8)(content(Whitespace\"\\n\")))))";
+         512cb1e9-3c69-4ee2-8f35-0b319987a623)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9fce88e9-083f-441c-a94d-51c66c70f5ac)(label(>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3ab27698-9614-4cc2-a4a6-10238740cc44)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4be22d13-6051-4ab5-838a-0a25e7321c49)(label(b))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f62ac03c-f671-4536-97e0-5614318c8484)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         63e7fbbe-1d10-4b0e-bc83-5795255e0d07)(content(Whitespace\" \
+         \"))))(Tile((id \
+         85677b0a-19a9-478d-a39c-77ba8d4d0a38)(label(Gt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         471c5a1b-3452-4d35-8790-8e536db6a64c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         01c6fa6f-5671-4209-bce7-65224190bee8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ba68db92-19be-42fe-9328-01a5375a8399)(label(Lt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1a63a39c-d009-4a37-ab7e-31c9d7080613)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e0a2cdd9-d687-40f8-a543-465bb5e80675)(content(Whitespace\"\\n\"))))(Tile((id \
+         a66cabfc-7a9b-4151-be63-140cca38dd64)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         8ee38666-0efe-4981-82f6-ca211d060735)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0ee6b9f6-43f2-438d-8415-b0a026ef5ccc)(label(desc))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         54eb0978-dcd0-40b7-b502-8326df5a4afa)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         8ed65e10-5977-441c-a3a7-822f8b56b61c)(content(Whitespace\"\\n\"))))(Tile((id \
+         b6bc9882-d20a-4794-b7d9-f2350da0d511)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         27974578-0184-4bd4-b260-849633ad3964)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dd363b52-bdef-492f-ab5f-bd97550ad00d)(label(f))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         07fa6bf0-736a-4cb3-8b56-d2b0b2974c80)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3cdaacee-bbfd-49d1-89de-b910e7598bde)(content(Whitespace\"\\n\"))))(Tile((id \
+         2a65a205-8174-4352-9b7a-e76f6f7f5ce0)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         fa658cac-5ce4-46a2-9da1-80b5daf59244)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d8c0a5f4-fe1c-439b-a8e7-764663e4ee2d)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         4c665636-4cdd-4a2f-9987-fed86fd9f925)(label(a))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         fc213603-5141-41eb-97cf-8afe83975575)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         2443b207-8cb0-4b49-9069-2bcbf0cc0fe6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         81f7d761-e7b4-4ee6-a0e2-0aa36ab978c3)(label(b))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         9a866128-9b24-424e-8b25-40da6d2b06fd)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7098d8c3-9510-41d6-8964-4bcc7f415a09)(content(Whitespace\"\\n\"))))(Tile((id \
+         749065bc-d2b7-4217-bf0a-7b203a436734)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         764ac5d9-2d93-4d55-b4b5-fc719298a37d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         88c739c6-f401-46b0-9bd4-4cbbd7a3df2a)(label(f))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0794ff10-d7b5-41ec-b656-f0238c842f68)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         9d198edc-2e78-4f27-8ddd-02ce3cfad1ee)(label(a))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f730e64c-38a9-4b5e-861f-b9eab6c8c6bf)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e7f39919-dbc9-4082-9c3b-77439fe2dc44)(content(Whitespace\" \
+         \"))))(Tile((id \
+         af6d6bf7-a7fa-45cc-8e06-f7e8c6eaae33)(label(b))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         17b44575-b37b-404b-b792-2dcdedcd5c2e)(content(Whitespace\"\\n\"))))(Tile((id \
+         97586931-562a-457e-8101-f0e7a7967159)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         7184dea1-b445-4d3e-84d9-17be7d48c5ec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1d85d5f7-75f4-4629-b2d1-3b20cf86ea78)(label(Eq))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         fa0855e0-98b2-4e94-aaa0-7a0a80764674)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         8dab941e-b46d-4d2d-b479-e8283715848f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a9453872-e7b0-4c5e-94a7-b9ba33ea3159)(label(Eq))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b0543aae-0e10-48ac-8037-ae6411336d05)(content(Whitespace\"\\n\"))))(Tile((id \
+         10224fc0-749e-4f2d-b610-ce4339c28506)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         6eeb6c1f-afcb-4f16-9859-9a8a28609dcc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1488ab44-0ada-42e4-a2c2-46b76c185be2)(label(Gt))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         88b70824-3eb6-4a70-a4f6-ff98d9c8046b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3c258a92-a365-401e-8c1a-e71c2ab7ef57)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e2e228d2-c95e-4768-955b-a4c1a25994aa)(label(Lt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e289099a-d151-4ace-aa4a-1e3d829955d2)(content(Whitespace\"\\n\"))))(Tile((id \
+         2c5ded7a-1126-40b3-847c-0b9e43123aeb)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         bfe0df4a-b869-4051-b512-7257c3c7c323)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d13927d2-c39a-4b14-8ba9-47191540eb97)(label(Lt))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5582cf43-6320-4737-a767-b8651ccf3a92)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2a156c69-82fd-4d82-a7d2-a7f617c2eae7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5b37243a-e0c9-49e9-9e59-ac5a947345d7)(label(Gt))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c616790b-7bd1-460b-81c0-bf767b243eca)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         dff5c463-eca2-48e4-80d6-3671b9f8b67d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         11dcf984-479e-49c8-a3ee-98eaa17718ec)(content(Whitespace\"\\n\"))))(Tile((id \
+         1e59ecf7-1717-445e-8226-299ff125ba84)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         d9fec980-c15c-4a33-bfa4-f3574ed00613)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6545275c-baa5-4c1f-9165-640aa09a20fa)(label(compare_grade))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         fbd04617-a578-4f70-a69e-27c05b0c88e8)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         5b87ec1d-055c-433e-b529-9af2b108d7b9)(content(Whitespace\" \
+         \"))))(Tile((id b7ae2568-4ee2-4977-8f02-61e69be906e3)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         3b6e901c-d2b9-431d-8680-75ccdf0a1c3b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bed2f9b9-faad-420e-904f-8ac065317a02)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         16cf27e7-1695-4421-9177-78a71d2052c1)(label(g1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Tile((id \
+         c2c1fe11-a216-469f-933d-89d79deb86b6)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         b0d9dd93-477d-43fb-b2d9-993ed1903e95)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cc0ba60b-1bee-4834-85ab-458f99d3cc7b)(label(g2))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         c4b7b2e6-c81e-44f6-85e4-4aab63007ca6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e6fed100-5f11-4a4c-bbd5-7e9e575828c2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d326f9bb-7eeb-4ede-a271-81b9bdba85e4)(label(comp_int))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         acd59890-1e8c-47c9-b3a6-65df6fd225dc)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         90f20f11-641a-471e-883f-b2d40634c2d4)(label(average))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9d543f0c-572d-443d-a352-e1e6c4936421)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         c3988593-7275-4baa-ae36-2eb0768e2d53)(label(g1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         957fab75-3016-47aa-a9ae-0552e4e4711d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ba9174b5-bb18-4e53-a982-6eabcdd57302)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7912856e-b719-496b-b355-85102a05e2e2)(label(average))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4e305f98-58f0-486b-bc8c-4f935cb13f9c)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         29b07875-17fd-4880-8890-2c33147afff7)(label(g2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         23618ecb-ee4a-44c0-ad92-32846a6ff867)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         6a25b87b-2aca-4397-9974-70c3ac2290a0)(content(Whitespace\"\\n\"))))(Tile((id \
+         7dd7a0e6-9ee1-4221-9b13-6b30245ad232)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         3f30f106-1bd2-42c7-a719-e61e6d7f84a8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4e6f6295-c498-46d5-811a-6e70861ef865)(label(name_length))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3facf7e6-2b36-4947-a875-11c392d7a0b4)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         60c227f0-4e11-48c0-ae45-a1196da87878)(content(Whitespace\" \
+         \"))))(Tile((id a59360a1-0450-4772-9dd9-cb20048a5545)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         d5d69633-337c-41ee-9afd-00c6cc0f47e8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         78cad4d6-10c2-4f58-bb14-02c9ebb70461)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         f735d7ce-1072-4bed-af57-8a03d6db575b)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         77280aee-50c9-4abb-8573-067d4c06f901)(content(Whitespace\" \
+         \"))))(Tile((id \
+         37e8abfc-c2d0-4ca3-a3c3-cfc7427281e7)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         41e5f9dd-77b7-4eb0-82fa-6199b3050930)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ae4520ee-2c07-4171-b3ee-94d05348da4a)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         51ab6142-fe05-45ae-b485-03c8730b19ad)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e065322b-2d36-48e5-aa67-55ce4d584b40)(content(Whitespace\" \
+         \"))))(Tile((id \
+         71b0abe1-500e-4caa-8363-f979c2b26bd4)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         12cd819f-3bbb-4531-a264-ffc1004262f2)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         dd8421fe-72d2-409b-a04c-beffbbb51a60)(label(name))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f6e891ce-1a11-42d5-9d4f-548d7b23aceb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c7d85f07-788d-49f8-af98-829e0573d05b)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         13bebef7-c3ba-4ad3-9d43-2347e023543b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5a9b4d22-9c75-4bbf-85a9-439ed1e16d6c)(label(string_length))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         57329c08-f0ba-467a-a9f0-48b277e0df12)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         6c375dd9-e891-45bf-afd4-8d054e2da171)(content(Whitespace\"\\n\"))))(Tile((id \
+         9d75de42-9f23-477f-8a93-9ff3a95c0bba)(label(order_by))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9b8e3e2d-e9ed-444b-a293-1c2440150704)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4cb2937b-e0be-40ac-b570-c3fdf07dd6cb)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         4570dfbe-12d9-4b97-9f02-98bcca87e5ba)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         56d5c546-1d76-409d-8c9e-29ce58b994c2)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         003162f0-ef6c-4253-a424-e1dc7f3974d9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a45b6eed-c055-4504-be04-89c79dc8ae05)(content(Whitespace\" \
+         \"))))(Tile((id 8efbecc6-3bb6-4938-875a-eb9525b099bf)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         8fce3376-c905-4793-ba11-cab8804485a5)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         799420bf-1474-400a-8c96-f22cfef01714)(label(name_length))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         dbd86a90-960e-4135-841f-93568c117f71)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         265ee537-2e04-4fa4-906d-fce712b177a4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ce024ac6-000c-4cb7-b14c-a02e4e32ed91)(label(desc))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a76d9b70-db79-4418-b2b2-96e9796117f2)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         771f1053-8e85-459e-ad32-691cb88a461a)(label(comp_int))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Tile((id \
+         023e7f1f-1435-4921-bec7-bc208e04c620)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dcb0aadd-417e-48aa-ab5b-ef20f4ebc29a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b82111a7-5906-422d-a983-98406605b1c2)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         c7956edd-0e30-4293-a769-11cb5c7eb63c)(label(midtermAndFinal))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6a249d37-8c95-4f50-8b9b-933aa3d19cf0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cb2512f7-acb7-4456-b32f-acb68cd7c4e0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d8d9b3af-283a-4827-82d9-0afd2be493f7)(label(compare_grade))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         a8165a50-e4d6-4602-bae4-4654f9c2a655)(content(Whitespace\"\\n\"))))(Tile((id \
+         8abc792c-c933-4b01-ac15-767bf176866b)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e73493b0-0f40-45ad-8535-d4c97bf0c881)(content(Whitespace\" \
+         \"))))(Tile((id bae4d3d9-4720-4cc3-999d-f8823963f2bd)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         cd75e69c-fd8d-4833-b33f-659c4d4ec947)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         673aa95e-095b-433b-9c7c-53a2b46e9745)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8c7b5995-cb2e-4336-ac08-38117734cd60)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f07d45c3-3fa4-49b2-ab97-d680d1945389)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4ade34fc-e9cb-4e48-94e0-b75e6204aebb)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e6e6788e-b37b-42e7-a4f0-2f7e50822230)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         638b8d25-3c2e-49ae-9889-7f3db06773e9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0bab07bb-cfad-4da1-8b3a-825ab0674200)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         acabe3c6-a35f-4fcc-90c9-072965a5f569)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         df6f25c0-27cf-40f5-9148-d9f5b5783d62)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7c52daa9-f54a-4372-a959-105f03b63ca5)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3a01ba5e-b5fa-42fc-9a7d-a5ac932170a6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         456ed7b6-3d41-46e5-8365-d922b3f171e3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         021eafbb-7f63-4f7a-839e-9bb8e8471a28)(label(88))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         56b18dc8-7549-42c3-821d-5de8526d691f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3890f61b-311c-47ca-a497-b2cf33fbc251)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5930de34-a299-43fd-9b4a-63e5beb8aa0d)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c75a7b5d-7849-43e0-9187-72b78f125bbb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0c3dac50-5953-43a4-bae1-7ffc1bb19c9c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7ff2ce75-3e6b-4b20-9e53-fe9803c7f332)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2d212e23-a9b8-4301-9b12-5eb50b6b7912)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c6209b0e-ea91-424f-9d2f-d2ab1a2ac4ad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fd9556d7-cbda-4471-ade8-a494bc65240d)(label(85))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         f921e633-5be9-4cb0-b2fb-19b1979dc401)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         296228f8-89e2-490c-93b2-48231c7fddf2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         53f4aef6-9c3d-4f7c-a874-4364d8047ae6)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         a0cde086-b0da-4f9b-8eb2-759d577b4777)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f1dffb2e-b90f-4658-8b42-d9d4900958a9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         130c8684-5d4e-4148-916e-7ee097fba1c2)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         4e5a1ad6-0978-4371-9f79-506956d21d63)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         cc6e3b3f-53d8-43e7-823b-3fa95ee9b687)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9f7a6128-5952-49f9-ad17-2197458b6801)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         77e2cc2f-de20-4c4b-b084-a1229cb6652e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         447d7e95-f821-44fd-9dbf-40a61404538b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6bd2e610-d23b-45ef-98c4-e74196368f44)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         216427b3-e671-47dc-b502-c2b307b521bb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f298a8dc-6c5d-4675-b1dc-a7dcedcfd753)(content(Whitespace\" \
+         \"))))(Tile((id \
+         25e8fb27-cdfe-40eb-8136-a358b5c948dc)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         78287656-2e18-4027-896d-3f0a5b4b573e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dba8f866-ad56-4029-8fbb-b6748992a2c2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         63fb7d93-0601-434d-b0a2-74526b47742d)(label(84))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8ad354c9-b715-467a-89a1-fc4f86636a5e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         89b8e0ab-8757-4dc6-b78b-e66756c9b741)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d1153a48-0278-4bed-a77d-6f549cde0af5)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1d532610-90fa-4a2d-89d5-a410d3a859ad)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d337afc0-c220-4a00-9e4e-e24e794fbbed)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dee7aa4a-c5d1-4f54-88c2-6543e54eedee)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2353ca47-fda1-4c08-aa5c-fb57230029be)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3e96b237-a1fb-448b-91ba-19922b8dc104)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9e123b0c-0951-4a5f-9bee-61f9cf5235e0)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         70380f53-19c0-4d7d-bda0-11078f2a8758)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d03f6516-157b-42bd-9354-74eff47ce35b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         195a8758-9380-4ed6-b384-c96e5d117ab8)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         09021643-0860-4b47-9c0c-e1003991eee4)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b3c69518-de9d-4e4a-ba56-d273089d69bf)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         82ea7b34-75c4-417a-9157-33d59038a37d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bfde6d8e-0fd6-462a-bdd3-d79d7afdb9ec)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         95f51fe5-1972-4e4e-8506-999c376d961c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cee0a38b-bb3d-4a7e-80d1-4a8a0c423433)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5bd7a8e8-2d2f-46b7-a550-2e36bd2f99b0)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c3c98fe1-30eb-48fc-97c5-e2f851f133a4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ed0a40e0-9a1f-426d-83b2-054cbae49306)(content(Whitespace\" \
+         \"))))(Tile((id \
+         01119471-3b51-423d-85a2-741c115da06a)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3596df17-83be-48bc-a3f6-ec34d8a43972)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         26ecb2b0-d7e2-4c4a-9f28-f5b526489b43)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fdcec4dc-3168-45fd-b115-097a88dbeb6f)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ceab53a7-4102-4ae2-a49a-9ee8b15a03db)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4380cd22-2e73-4382-a42b-4697ef16e292)(content(Whitespace\" \
+         \"))))(Tile((id \
+         02052cb2-fbac-429a-bba6-c0b50b3ccde0)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d978a86c-216b-4876-9b5b-9de8fd41b909)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1740fce7-db77-4e8c-8f53-87982db757df)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0322d88a-2434-4815-843e-f9fa27950822)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6700bc46-c9d0-418b-92eb-c22b7f253fb2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4013a5fa-2e4c-46d6-9af3-519618166fe2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4697b3d0-6135-49fb-85c0-c46ea86c0068)(label(87))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         49ba0ce2-3097-4df5-8cfc-7f8bdd3f2496)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b9a7d785-ddc9-409b-9854-7cb903d84743)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8936b552-de2a-445a-83ca-448c6d7b7196)(content(Whitespace\" \
+         \"))))(Tile((id c7a7c093-bf7f-43e9-8288-2e2a708799f4)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         331dac90-fa0e-4215-a94c-fb8b7863d1db)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         79a74bda-ba5e-4c43-b214-37877914d668)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9db4db65-f409-4738-b5a9-b20b03357c47)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d62a6dc4-cb15-4d43-b21d-d287ea365fec)(content(Whitespace\"\\n\"))))(Tile((id \
+         a75609de-3852-47ec-9497-573bc450ab42)(label(?))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
-         let gradebook : [GradebookEntry] = ([\n\
-        \  (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
-        \  (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-        \  (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
-         ]) in\n\
-         let tsort = \n\
-        \  let requires=[\n\
-        \    (enforced=(false), \"c is in header(t1)\"),\n\
-        \    (enforced=(false), \"schema(t1)[c] is Number\")\n\
-        \  ] in\n\
-        \  let ensures=[\n\
-        \    (enforced=(false), \"nrows(t2) is equal to nrows(t1)\"),\n\
-        \    (enforced=(true), \"schema(t2) is equal to schema(t1)\")\n\
-        \  ] in\n\
-        \  # Idiomatically I think we would do this with a implicit comparator \
+        "type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
+         let gradebook : [GradebookEntry] = (\n\
+         [(\"Bob\",   12, 8, 9, 77, 7, 9, 87), (\"Alice\", 17, 6, 8, 88, 8, 7, \
+         85), (\"Eve\", 13, 7, 9, 84, 8, 8, 77)]\n\
+         ) in\n\
+         let tsort =\n\
+         let _requires = [(enforced=(false), \"c is in header(t1)\"), \
+         (enforced = (false), \"schema(t1)[c] is Number\")] in\n\
+         let _ensures = [(enforced=(false), \"nrows(t2) is equal to \
+         nrows(t1)\"), (enforced = (true), \"schema(t2) is equal to \
+         schema(t1)\")] in\n\
+         # Idiomatically I think we would do this with a implicit comparator \
          on tuples and then project them #\n\
-        \  # This could be done in a typesafe way if a function was passed to \
-         do the projection #\n\
-        \  let get_value = fun (r, c : String) -> (to_lvs(r) |> find(_, fun \
-         (label=l, value=v) -> l == c)).value in\n\
-        \  let tsort = typfun r -> fun (t: [?], c: String, b: Bool) -> \n\
-        \    let sorted = sort(fun (first, second) ->\n\
-        \      if get_value(first,c) < get_value(second,c) then Lt else Gt,\n\
-        \      t) in \n\
-        \    (if b then sorted else reverse(sorted)) : [r] in\n\
-        \  \n\
-        \  test tsort@<GradebookEntry>(gradebook, \"final\", false) == [\n\
-        \    (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
-        \    (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-        \    (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
-        \  ] : [GradebookEntry] end\n\
-         in\n\
+         # This could be done in a typesafe way if a function was passed to do \
+         the projection #\n\
+         let get_value = fun (r, c : String) -> (to_lvs(r) |> find(_, fun \
+         (label=l, value=_v) -> l == c)).value in\n\
+         let tsort =\n\
+         typfun r ->\n\
+         fun (t : [?], c : String, b : Bool) ->\n\
+         let sorted = sort(fun (first, second) -> if get_value(first, c) < \
+         get_value(second, c) then Lt else Gt, t) in\n\
+         (if b then sorted else reverse(sorted)) : [r] in\n\
+         test\n\
+         tsort@<GradebookEntry>(gradebook, \"final\", false)\n\
+         == [(\"Bob\",   12, 8, 9, 77, 7, 9, 87), (\"Alice\", 17, 6, 8, 88, 8, \
+         7, 85), (\"Eve\", 13, 7, 9, 84, 8, 8, 77)] : [GradebookEntry] end in\n\
          let sort_by_columns =\n\
-        \  let requires=[\n\
-        \    (enforced=(false), \"cs has no duplicates\"),\n\
-        \    (enforced=(false), \"for all c in cs, c is in header(t1)\"),\n\
-        \    (enforced=(false), \"for all c in cs, schema(t1)[c] is Number\")\n\
-        \  ] in\n\
-        \  let ensures=[\n\
-        \    (enforced=(false), \"nrows(t2) is equal to nrows(t1)\"),\n\
-        \    (enforced=(true), \"schema(t2) is equal to schema(t1)\")\n\
-        \  ] in\n\
-        \  \n\
-        \  let lexicographical =typfun t -> fun (comparator : (t,t) -> Ord, ts \
-         :[t], ts' :[t]) ->\n\
-        \    case (ts,ts')\n\
-        \    | ([], []) =>Eq\n\
-        \    | ([], _) =>Lt\n\
-        \    | (_, []) =>Gt\n\
-        \    | (x::xs, y::ys) =>\n\
-        \      case comparator(x,y)\n\
-        \      | Eq =>lexicographical@<t>(comparator,xs,ys)\n\
-        \      | ord =>ord \n\
-        \      end \n\
-        \    end \n\
-        \  in\n\
-        \  let int_compare =fun (first, second) ->\n\
-        \    if first < second then Lt else if first > second then Gt else Eq in\n\
-        \  \n\
-        \  # Idiomatically I think we would do this with a implicit comparator \
+         let _requires = [\n\
+         (enforced=(false), \"cs has no duplicates\"),\n\
+         (enforced=(false), \"for all c in cs, c is in header(t1)\"),\n\
+         (enforced = (false), \"for all c in cs, schema(t1)[c] is Number\")\n\
+         ] in\n\
+         let _ensures = [(enforced=(false), \"nrows(t2) is equal to \
+         nrows(t1)\"), (enforced = (true), \"schema(t2) is equal to \
+         schema(t1)\")] in\n\
+         let lexicographical =\n\
+         typfun t ->\n\
+         fun (comparator : (t, t) -> Ord, ts : [t], ts' : [t]) ->\n\
+         case (ts, ts')\n\
+         | ([], []) => Eq\n\
+         | ([], _) => Lt\n\
+         | (_, []) => Gt\n\
+         | (x::xs, y::ys) =>\n\
+         case comparator(x, y)\n\
+         | Eq => lexicographical@<t>(comparator, xs, ys)\n\
+         | ord => ord\n\
+         end\n\
+         end in\n\
+         let int_compare = fun (first, second) -> if first < second then Lt \
+         else if first > second then Gt else Eq in\n\
+         # Idiomatically I think we would do this with a implicit comparator \
          on tuples and then project them #\n\
-        \  let sort_by_columns = typfun r ->\n\
-        \    let get_values = fun (r,c :[String]) ->(let entries = to_lvs(r) \
-         in filter_map(c,fun c -> find_opt(entries,fun (label=l, value=v) \
-         ->string_eq(c,l)))).value in\n\
-        \    fun (t:[?], c:[String]) -> sort((fun (f, g) -> let res = \
+         let sort_by_columns =\n\
+         typfun r ->\n\
+         let get_values =\n\
+         fun (r, c : [String]) -> (let entries = to_lvs(r) in filter_map(c,fun \
+         c -> find_opt(entries,fun (label=l, value=_v) ->(c == l)))).value in\n\
+         fun (t : [?], c : [String]) ->\n\
+         sort((fun (f, g) -> let res = \
          lexicographical@<Int>(int_compare,get_values(f,c),get_values(g,c)) in\n\
-        \    res),t) : [r]\n\
-        \  in\n\
-        \  \n\
-        \  test sort_by_columns@<GradebookEntry>(gradebook, [\"quiz2\", \
-         \"quiz1\"])\n\
-        \  == [\n\
-        \    (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-        \    (\"Eve\",   13, 7, 9, 84, 8, 8, 77),\n\
-        \    (\"Bob\",   12, 8, 9, 77, 7, 9, 87)\n\
-        \  ] : [GradebookEntry] end\n\
-         in\n\
-         let order_by = \n\
-        \  let requires=[] in\n\
-        \  let ensures=[\n\
-        \    (enforced=(true), \"schema(r) is equal to schema(t1)\"),\n\
-        \    (enforced=(true), \"schema(t2) is equal to schema(t1)\"),\n\
-        \    (enforced=(false), \"nrows(t2) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  \n\
-        \  # We don't currently have a way to encode a existential type for \
-         the key so we're currently using the unknown type. #\n\
-        \  # Idiomatically you'd just compose these at the callsite #\n\
-        \  let order_by = typfun row-> fun (t1 :[row], comparators : \
-         [(get_key=row -> ?, comparator= ? -> Ord)])  ->\n\
-        \    let compare = fun (a, b, comparators) -> \n\
-        \      case comparators\n\
-        \      | [] => Eq\n\
-        \      | (hd::tl) => case hd.comparator(hd.get_key(a), hd.get_key(b))\n\
-        \      | Eq => compare(a,b, tl)\n\
-        \      | other => other\n\
-        \      end\n\
-        \      end\n\
-        \    in\n\
-        \    sort(compare(_,_,comparators),t1): [row] in\n\
-        \  \n\
-        \  test\n\
-        \    let average = fun ns -> fold_left(ns, int_plus, 0) / length(ns) in\n\
-        \    let midtermAndFinal = fun (r : GradebookEntry) -> [r.midterm, \
+        \        res), t) : [r] in\n\
+         test\n\
+         sort_by_columns@<GradebookEntry>(gradebook, [\"quiz2\", \"quiz1\"])\n\
+         == [(\"Alice\", 17, 6, 8, 88, 8, 7, 85), (\"Eve\",   13, 7, 9, 84, 8, \
+         8, 77), (\"Bob\", 12, 8, 9, 77, 7, 9, 87)] : [GradebookEntry] end in\n\
+         let order_by =\n\
+         let _requires = [] in\n\
+         let _ensures = [\n\
+         (enforced=(true), \"schema(r) is equal to schema(t1)\"),\n\
+         (enforced=(true), \"schema(t2) is equal to schema(t1)\"),\n\
+         (enforced = (false), \"nrows(t2) is equal to nrows(t1)\")\n\
+         ] in\n\
+         # We don't currently have a way to encode a existential type for the \
+         key so we're currently using the unknown type. #\n\
+         # Idiomatically you'd just compose these at the callsite #\n\
+         let order_by =\n\
+         typfun row ->\n\
+         fun (t1 : [row], comparators : [(get_key = row -> ?, comparator = ? \
+         -> Ord)]) ->\n\
+         let compare =\n\
+         fun (a, b, comparators) ->\n\
+         case comparators\n\
+         | [] => Eq\n\
+         | (hd::tl) =>\n\
+         case hd.comparator(hd.get_key(a), hd.get_key(b))\n\
+         | Eq => compare(a, b, tl)\n\
+         | other => other\n\
+         end\n\
+         end in\n\
+         sort(compare(_,_,comparators), t1) : [row] in\n\
+         test\n\
+         let average = fun ns -> fold_left(ns, int_plus, 0) / length(ns) in\n\
+         let midtermAndFinal = fun (r : GradebookEntry) -> [r.midterm, \
          r.final] in\n\
-        \    let comp_int = fun a,b -> if a > b then Gt else Lt in\n\
-        \    let desc = fun f -> fun (a,b) -> case f(a,b)\n\
-        \    | Eq => Eq\n\
-        \    | Gt => Lt\n\
-        \    | Lt => Gt\n\
-        \    end in\n\
-        \    let compare_grade = fun (g1, g2) -> comp_int(average(g1), \
+         let comp_int = fun a, b -> if a > b then Gt else Lt in\n\
+         let desc =\n\
+         fun f ->\n\
+         fun (a, b) ->\n\
+         case f(a, b)\n\
+         | Eq => Eq\n\
+         | Gt => Lt\n\
+         | Lt => Gt\n\
+         end in\n\
+         let compare_grade = fun (g1, g2) -> comp_int(average(g1), \
          average(g2)) in\n\
-        \    let name_length = fun (r : GradebookEntry) -> r.name |> \
-         string_length in\n\
-        \    order_by@<GradebookEntry>(gradebook, [(name_length, \
-         desc(comp_int)), (midtermAndFinal, compare_grade)])\n\
-        \    == [\n\
-        \      (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-        \      (\"Eve\",   13, 7, 9, 84, 8, 8, 77),\n\
-        \      (\"Bob\",   12, 8, 9, 77, 7, 9, 87)\n\
-        \    ] : [GradebookEntry] end\n\
-         in ?\n";
+         let name_length = fun (r : GradebookEntry) -> r.name |> string_length \
+         in\n\
+         order_by@<GradebookEntry>(gradebook, [(name_length, desc(comp_int)), \
+         (midtermAndFinal, compare_grade)])\n\
+         == [(\"Alice\", 17, 6, 8, 88, 8, 7, 85), (\"Eve\",   13, 7, 9, 84, 8, \
+         8, 77), (\"Bob\", 12, 8, 9, 77, 7, 9, 87)] : [GradebookEntry] end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIProperties.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIProperties.ml
@@ -1,51 +1,48 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Properties",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id 534dd007-fc89-4cb6-b5f6-c2769a76240b)(label(let = \
          in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         e9cc7779-afcb-4ae5-a271-0a90c8bc2e2e)(content(Whitespace\" \
+         1cd88870-7957-4edc-a237-67572ac5e508)(content(Whitespace\" \
          \"))))(Tile((id \
          ad108c1b-90d2-444a-b63f-0c37eb5fba19)(label(nrows))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ea698a2d-b227-4f4f-9492-136716593fa1)(content(Whitespace\" \
+         ac37454d-fd00-4dba-a0c1-a61e5577e611)(content(Whitespace\" \
          \")))))((Secondary((id \
-         21e0f8b3-738b-4c9e-b5c9-0d9bfb551fdb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5363a3b0-9337-4760-a9f9-6b52bacf3e9b)(content(Whitespace\"\\n\"))))(Tile((id \
+         b31b8f2b-2392-4f45-a9f0-8b89c5a9e1f8)(content(Whitespace\"\\n\"))))(Tile((id \
          782f7086-b4d0-4212-b551-aff61b865f06)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         d3ab5a54-3753-4772-9a26-c76aa31dce0a)(content(Whitespace\" \
+         577515d4-586b-4807-8c76-2e61ca958680)(content(Whitespace\" \
          \"))))(Tile((id \
-         69668626-b95d-44ad-8bc5-891c493051bd)(label(requires))(mold((out \
+         69668626-b95d-44ad-8bc5-891c493051bd)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c2c4e7d2-3c73-4978-92fa-df170de49ad8)(content(Whitespace\" \
+         a40de969-59a6-4bbf-885c-331f520bce99)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f9bf24f2-5333-4cd5-849d-7142d729d656)(content(Whitespace\" \
+         05119185-9ce1-4c34-b3db-34d3a6b7c4b5)(content(Whitespace\" \
          \"))))(Tile((id \
          694800f3-af70-4e89-884a-8aee486e8332)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         99b9c6e8-31cc-4ae1-b4df-37882e247bd3)(content(Whitespace\" \
+         a3e87dfd-0edc-42e7-8d3d-f8d2d8946a16)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         925ff73c-6d75-406c-a62d-a508adec2113)(content(Whitespace\"\\n\"))))(Tile((id \
+         915424a2-36a8-402c-a2ff-c7b44af50bd6)(content(Whitespace\"\\n\"))))(Tile((id \
          73b4bd83-86e9-4a08-bedc-cff17891306c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c59f69d9-d0d9-4429-8421-e8f9e63aaa6d)(content(Whitespace\" \
+         26e921bf-e2ae-49a5-9f44-7cc21fc26305)(content(Whitespace\" \
          \"))))(Tile((id \
-         5a9599f0-d423-49d1-ab1a-7415da503cd2)(label(ensures))(mold((out \
+         5a9599f0-d423-49d1-ab1a-7415da503cd2)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         311b3671-94a2-46d2-b578-3e2137d26273)(content(Whitespace\" \
+         696a8061-16ad-4f54-8096-463f7069173b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6fd6df7e-628a-4935-9b71-7cad1bdc927c)(content(Whitespace\" \
+         5e0613d2-9829-478f-9273-a862a2795797)(content(Whitespace\" \
          \"))))(Tile((id 834db5ab-ec54-4374-98d7-043001a9ff97)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -54,11 +51,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          cc0bf14b-45cb-4fc6-bde3-f32b57e8ef1f)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a5b60490-1ce9-48e1-8a85-635f3116ab50)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb0c4fb9-5818-4497-a509-e793246039d5)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         1f386034-a215-4c4f-8175-dcda5afefd54)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         87ed0746-3ad7-41df-b7fb-15ef36a8ed99)(content(Whitespace\" \
+         \"))))(Projector((id 1f386034-a215-4c4f-8175-dcda5afefd54)(kind \
+         Checkbox)(syntax(Tile((id \
          229b39fe-472b-47e4-90ee-97c44bfa2bdb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -68,41 +69,39 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f14363fd-9612-4298-bc2d-846b35b0690f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a48f564c-05b5-46b6-aecb-0238b0165d60)(content(Whitespace\" \
+         d174bfd2-7f6b-45b6-bafd-5209cd74c6ef)(content(Whitespace\" \
          \"))))(Tile((id 2b55bf6b-782f-462f-b0a4-97a1fecacaa5)(label(\"\\\"n \
          is equal to nrows(t)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         90f741d3-afff-4fe1-a0f7-0aac38dbfc02)(content(Whitespace\" \
+         2f18dbfc-3284-496b-a531-e4c6d8d430fc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1dd1c6db-9951-4f83-aa0b-2d8315c00a7d)(content(Whitespace\"\\n\"))))(Secondary((id \
+         51df6c5b-4ef9-4603-a659-6b5f95ec6393)(content(Whitespace\"\\n\"))))(Secondary((id \
          efc224eb-e5c9-43c8-b292-3136b3ac8186)(content(Comment\"# Tables are \
          just lists so nrows is just list length #\"))))(Secondary((id \
-         0a593d79-c93f-4fac-bad2-2efc4ed26882)(content(Whitespace\"\\n\"))))(Tile((id \
+         68b190a4-855d-47cc-9b22-d41318c358d0)(content(Whitespace\"\\n\"))))(Tile((id \
          457ca854-cc92-4da3-acf9-8c8c70014a8e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         0b42008f-6303-4860-9299-2c5a6acf346c)(content(Whitespace\" \
+         f1cd4265-e014-4407-bfb0-9affef0f8cf1)(content(Whitespace\" \
          \"))))(Tile((id \
          e225b289-0f10-4cce-b2ca-877607dbbe88)(label(nrows))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         58f83d1c-869e-4e75-aa9a-15f8d9104871)(content(Whitespace\" \
+         0577b136-1af7-4279-832a-6809ef4731ff)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6645a8aa-5cc8-4167-ad14-6b4d0f62bd1d)(content(Whitespace\" \
+         50b53bf1-081b-4e68-bf78-a3c3248ea6e0)(content(Whitespace\" \
          \"))))(Tile((id \
          0aafe64a-2af8-4c8f-9be2-b578319ecb77)(label(length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         1cffb1cd-1d13-49cf-9fd6-858886ca57d8)(content(Whitespace\" \
+         1c5824dd-4f6e-47f2-8842-56dc214a6a8c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         47b614dd-9452-4d35-b7a0-b5e1fca99641)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b326e540-1817-4961-b9a6-1b642975e057)(content(Whitespace\"\\n\"))))(Tile((id \
+         0deadf92-646b-40f9-a340-448326fd89ca)(content(Whitespace\"\\n\"))))(Tile((id \
          ede799d7-aa43-4063-8279-db35043e1b88)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         3b1057f5-87bd-4c79-aa5f-fa7c59797304)(content(Whitespace\" \
-         \"))))(Tile((id \
+         bb84eda5-a48c-4221-adfd-b4dab7ddb987)(content(Whitespace\"\\n\"))))(Tile((id \
          fb968014-c913-484b-86be-5ad103f96204)(label(nrows))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -112,63 +111,62 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8b544241-86f6-4726-9bff-6e60bbfa525c)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8a05aba9-68b1-400f-bbc3-f9e69bf4f12e)(content(Whitespace\" \
+         34c15845-0054-47e2-8b5d-68d4fc4ac7e3)(content(Whitespace\" \
          \"))))(Tile((id \
          b52eff7b-f0f9-489d-b828-5d39e73b154a)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a99e6d2c-3d85-44dc-aa42-b456d2b38038)(content(Whitespace\" \
+         fc0ad7b0-f573-44a0-8102-977edd9ae479)(content(Whitespace\" \
          \"))))(Tile((id \
          d54449cf-0cf5-4074-9a1b-6ab17c5e2c49)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         54f6f9bf-7dd7-4e07-a946-64274a39b187)(content(Whitespace\" \
+         f5108302-8fac-4fc3-a0c1-1878d7e3378d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d6f7d181-b17f-46ae-9209-d5a2612fe9fe)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         4800ad67-7d02-4462-a585-b0a6bc7631d0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d6c87b8e-3fee-44da-8060-cf0e06c0767c)(content(Whitespace\"\\n\"))))(Tile((id \
+         85a99d3e-eca4-4e15-acff-f3c30cdd21ab)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         695c7710-c0ae-46cd-a401-193252cd545f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         b0ff7e19-3d38-4629-b279-a8e5eddec49e)(content(Whitespace\"\\n\"))))(Tile((id \
          6caffb35-994e-4faf-9f18-0ba2cb449706)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         b1ec9536-4cf5-4faa-95c5-d875ad2f35dc)(content(Whitespace\" \
+         1129f951-640a-4352-ac37-6d0d3a45a321)(content(Whitespace\" \
          \"))))(Tile((id \
          440ec571-dc7a-42f1-8327-f59142d259f8)(label(ncols))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5077c0c0-dada-4711-aa93-34179fdb147c)(content(Whitespace\" \
+         6ebc646d-fb34-4f55-9b22-2fc361f81508)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0bcb1eae-abfe-4145-8e65-82aa3781fcf6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33225b5a-f884-4099-9bf8-0951282bd964)(content(Whitespace\"\\n\"))))(Tile((id \
+         9e9f7896-cbcd-43b4-8f97-06aedddcc63f)(content(Whitespace\"\\n\"))))(Tile((id \
          9459559e-6531-4ad9-9f47-90437c41ad35)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         63904c74-8621-49a5-ac9f-3f33cbba0a52)(content(Whitespace\" \
+         bfa24659-fe33-4210-a890-a7897626ec42)(content(Whitespace\" \
          \"))))(Tile((id \
-         f7fa5bec-2059-48cd-bcaf-0c91ccdd80a3)(label(requires))(mold((out \
+         f7fa5bec-2059-48cd-bcaf-0c91ccdd80a3)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         cef7d1aa-20bd-40b8-89d8-4b883808b13b)(content(Whitespace\" \
+         7335f564-3b03-4ddd-adda-95922259141c)(content(Whitespace\" \
          \")))))((Secondary((id \
-         72c5e375-4ea0-4105-9d5b-179f83d68f69)(content(Whitespace\" \
+         42eb0332-b6da-488b-9131-1ce9b1bb3ccc)(content(Whitespace\" \
          \"))))(Tile((id \
          25ec85fe-dbac-4616-8aee-d565d92d85a9)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         7bb957ad-32b4-4631-87d6-7790c330e042)(content(Whitespace\" \
+         3e2ab7e6-e35a-481d-a9f8-241dd96390b7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8263cfd9-ae3e-494b-b78f-3baf01c999ac)(content(Whitespace\"\\n\"))))(Tile((id \
+         bd26de47-fb5b-42b3-9ea0-fff7150533c0)(content(Whitespace\"\\n\"))))(Tile((id \
          a2ff75b4-53bf-4403-84d8-54ee844dc75e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a577b836-050f-4896-94c3-17cda18f5156)(content(Whitespace\" \
+         b713201b-ec9d-4058-afb6-e898fa8048a3)(content(Whitespace\" \
          \"))))(Tile((id \
-         ac2285ca-9672-4cd4-97eb-db099466f2a0)(label(ensures))(mold((out \
+         ac2285ca-9672-4cd4-97eb-db099466f2a0)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2529ca67-7775-44c4-a0a7-03c3d95fce22)(content(Whitespace\" \
+         a980a576-0eff-4efd-bd48-caf97c380a16)(content(Whitespace\" \
          \")))))((Secondary((id \
-         aec23f4c-134f-47c0-a09d-0fa8836809d2)(content(Whitespace\" \
+         d15f2e53-588a-4a69-ac0f-67beec5e95b0)(content(Whitespace\" \
          \"))))(Tile((id 02893a26-cd71-4a3a-9280-e6bd91f73cf0)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -177,11 +175,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          4e347d08-5992-4366-a336-1328faaff556)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e08a2331-3e21-457d-85bf-4f0a2e2031e4)(content(Whitespace\" \
+         \"))))(Tile((id \
          664762bd-5f93-4ea7-8c04-75f1977b4359)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         41b6ed9f-434a-4f67-8d50-dbb5e4f56070)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         17363e3e-5f84-4094-a618-b76aa2f71fe1)(content(Whitespace\" \
+         \"))))(Projector((id 41b6ed9f-434a-4f67-8d50-dbb5e4f56070)(kind \
+         Checkbox)(syntax(Tile((id \
          92e200c7-8fc2-407b-9d1c-c6cd3bb43ede)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -191,65 +193,64 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5c3580a0-5453-4e87-b551-7e9fe36b02bf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bd1c71fd-0998-4cc9-b5a6-82158ee515b0)(content(Whitespace\" \
+         7f5a28d1-e7b5-4324-81f9-dae5ac463877)(content(Whitespace\" \
          \"))))(Tile((id 44f6f78a-21dc-4910-b02c-f6486cdda1a4)(label(\"\\\"n \
          is equal to ncols(t)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b218dd68-a06a-4ff6-b22f-33017bdee8c1)(content(Whitespace\" \
+         711f3097-c480-456d-936c-d048bd9ffbea)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         646d93b2-d846-453d-ac11-793398e54d38)(content(Whitespace\"\\n\"))))(Secondary((id \
+         222f34ef-6edf-4f66-9d48-a1af29da22e1)(content(Whitespace\"\\n\"))))(Secondary((id \
          49c4e74f-ff7b-440b-99a3-89ada995495c)(content(Comment\"# Only works \
          for non-empty tables since we don't keep a schema \
          #\"))))(Secondary((id \
-         3a185761-6817-42e3-8ea0-02629456c129)(content(Whitespace\"\\n\"))))(Tile((id \
+         0a750326-8a8d-4f01-bcb6-0c7fb8bb73dd)(content(Whitespace\"\\n\"))))(Tile((id \
          38f86ba7-ce03-4218-861f-613bfe7c4b10)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         31897792-1df7-48e5-ad74-8e2e077117b6)(content(Whitespace\" \
+         e8a9ac68-5e72-4b38-ab7e-9d3e1eb85626)(content(Whitespace\" \
          \"))))(Tile((id \
          f7335a55-cc4f-4e98-8883-9cee1d021020)(label(ncols))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d9d6baa5-b702-406e-aab5-902e6e6c3d51)(content(Whitespace\" \
+         b8c1fdfc-d121-4870-b873-1f99254d87e9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         749aa8eb-b1f3-43d5-88ed-1ba1231677a5)(content(Whitespace\" \
-         \"))))(Tile((id 7bacad7e-fa0f-4979-a68c-3a91a6ebb4c4)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         3cfde404-6442-40a5-ae37-cc54607e1a23)(content(Whitespace\" \
+         ed81cb39-96d7-4978-91b0-e5304190eecb)(content(Whitespace\"\\n\"))))(Tile((id \
+         7bacad7e-fa0f-4979-a68c-3a91a6ebb4c4)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         6a7f2edc-d84c-434e-8d15-86f58977586a)(content(Whitespace\" \
          \"))))(Tile((id \
          f8bb13f6-04c8-4a7c-a3f0-95c4bd4be32d)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          4170a6ec-c959-408a-9c18-8b8ae7cad1f3)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         794752a8-f130-44d1-9590-86b68809e5ea)(content(Whitespace\" \
+         \"))))(Tile((id \
          bd493832-2891-4083-ae0e-7a3327d07af2)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5f05c127-fe9f-4cfb-b279-1f830e8832c4)(content(Whitespace\" \
+         08eb3dfc-8d2a-477f-b437-7bb93b12705b)(content(Whitespace\" \
          \"))))(Tile((id 782ccc50-0063-496b-b437-fc95c8305474)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          04c6bad4-415e-4906-9b81-0c0a0912ebb7)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         a8088668-849c-41e9-a412-3d496cbb9615)(content(Whitespace\" \
+         708e1a5b-e015-4c0c-81dd-876e701adb7a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fd88b847-3857-493c-b68b-7f91bcdfced7)(content(Whitespace\" \
-         \"))))(Tile((id b365c63d-2c68-4a6a-87ba-e02253fbbeee)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         64b78c52-0ac7-4194-99f7-9a71a0452072)(content(Whitespace\" \
+         1664ef74-6af8-4bbf-92fd-a60d761c9adb)(content(Whitespace\"\\n\"))))(Tile((id \
+         b365c63d-2c68-4a6a-87ba-e02253fbbeee)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         543067c6-0764-4315-ae74-928a2b99e551)(content(Whitespace\" \
          \"))))(Tile((id \
          656b3662-f809-482d-b9b5-80d32898e0be)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         574e6197-e666-4489-bce3-9f3a7ce7f37a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cbb7b45f-ef74-4af0-8c2f-a5c3f7bf3575)(content(Whitespace\"\\n\"))))(Tile((id \
+         7917f00e-55fb-40c3-8363-89b3fd72e74d)(content(Whitespace\"\\n\"))))(Tile((id \
          04ca54c8-a9df-4664-888a-90025225b59a)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -264,12 +265,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4fbe563e-36a0-4df9-89bf-991b8a11466b)(label(::))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 29))(sort Pat))((shape(Concave \
          29))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         b3c3355e-fb2c-4dff-bc30-9add9f35c11f)(label(xs))(mold((out \
+         b3c3355e-fb2c-4dff-bc30-9add9f35c11f)(label(_xs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          2b4051ec-b47a-4e4a-9630-cd0daa485cd8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         42a4686d-40fb-44d5-b091-1a9870befa78)(content(Whitespace\" \
+         860c1f49-cabb-4235-a27c-4a23d084ef2d)(content(Whitespace\" \
          \"))))(Tile((id \
          35383571-3e62-43c4-9fc1-46640a19f0e8)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -280,17 +281,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          715e008c-fcae-4334-9080-d05d8232dcf4)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6fed6248-3aa7-4da9-ac82-8c08d8b6e5d3)(content(Whitespace\" \
+         3ad92c5e-8dca-4eff-b5b2-d1961fb65b8b)(content(Whitespace\" \
          \"))))(Tile((id \
          5691281e-2bed-4849-b93c-56d52cbed921)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8e2bfdd4-8e54-46cf-a628-89d0a81620da)(content(Whitespace\" \
+         5c50583a-403f-437f-8cf3-52fa873c1938)(content(Whitespace\" \
          \"))))(Tile((id \
          0f5d2a55-88ac-4550-a3c4-984192097111)(label(length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d0dd2e8d-0217-4b75-99bc-994f654f4403)(content(Whitespace\"\\n\"))))(Tile((id \
+         f298272b-6524-443f-8046-428abe6d04bc)(content(Whitespace\"\\n\"))))(Tile((id \
          b70e115f-4eb6-424d-8394-647c35ebf61b)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -301,24 +302,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          179607e4-5671-4198-8923-5a65114929af)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c6c96972-ad27-4b47-90a4-ef7669a7f6e7)(content(Whitespace\" \
+         4b32b30f-ffed-4dfc-8e50-8d8810fed0b8)(content(Whitespace\" \
          \"))))(Tile((id \
          e49710d0-efde-4eb4-888e-137fd2a7ac07)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         11d17b2a-0705-4850-a436-0cd083ed4c2a)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         776f55bc-7187-4ada-9591-4b96fe34ced7)(content(Whitespace\" \
+         b927707e-f72e-48cf-8016-b1ce0132b416)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         98ed6425-2251-406d-94ad-5e4b7858e3a9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4a9a22d1-05a9-4ebe-8dc3-5cdf8d1f6186)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f792d6db-9953-45f3-965b-3178b66dd8a1)(content(Whitespace\"\\n\"))))(Secondary((id \
+         4ecf506b-0218-4786-9dba-03ebdf52526b)(content(Whitespace\"\\n\"))))(Secondary((id \
          be715364-86ba-446c-912f-ff352a45f096)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         b322477a-497f-4bbb-9e52-35aaf61f280b)(content(Whitespace\"\\n\"))))(Tile((id \
+         14cf4023-573d-4d7c-986a-687adb08138c)(content(Whitespace\"\\n\"))))(Tile((id \
          09b92d50-050a-415b-b5f1-361d6cef2abd)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         a468e862-b5c6-4caa-873b-4602f71baf81)(content(Whitespace\" \
-         \"))))(Tile((id \
+         46fcd373-41ca-4e79-89af-b2e518f3f78d)(content(Whitespace\"\\n\"))))(Tile((id \
          171d68da-a2be-421f-a598-081c13cba894)(label(ncols))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -331,27 +330,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0fbaee39-2cb2-4e7e-82b8-55f03d0f87e5)(label(\"()\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         2f099015-1d6b-4b07-a726-af21a71e4dd2)(content(Whitespace\" \
+         51bacfc8-2ca4-41b7-aeed-08dfcf4ec5f0)(content(Whitespace\" \
          \"))))(Tile((id \
          eb149625-52dd-4763-b003-11340d805595)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5ab9e132-d997-4c8d-aca2-f64ca202438e)(content(Whitespace\" \
+         30b8e28e-a8ef-4af1-bd61-56a078b6dcd7)(content(Whitespace\" \
          \"))))(Tile((id \
          383e103f-8360-46b1-a457-e58bcd576095)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         81c912f0-3a41-460a-b5f1-0712b53776f8)(content(Whitespace\" \
+         6c960ccc-d7db-4f2b-877b-7bf4beff88f9)(content(Whitespace\" \
          \")))))))))(Tile((id \
          03c4543d-985c-4df2-962f-3d22e198f145)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         544fe3ff-941a-4673-b14d-2dba80654ce7)(content(Whitespace\"\\n\"))))(Tile((id \
+         3aedef24-1cdf-4b48-86f4-994ebf0a3d69)(content(Whitespace\"\\n\"))))(Tile((id \
          dd693bb1-e81b-4e2d-8607-19c271f44929)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         ba8d019f-9fc9-43c8-8d84-59c33f7d3aff)(content(Whitespace\" \
-         \"))))(Tile((id \
+         dcaf6f8b-f13e-45d2-ba32-17968c64ff24)(content(Whitespace\"\\n\"))))(Tile((id \
          b66ca6cc-b915-435a-bfa2-b9bb8bfff8f6)(label(ncols))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -366,84 +364,91 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          c80d5dcb-2853-4b90-a326-d348a65875bc)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         79a83bb2-c4d4-4d97-a1d0-911bde399f58)(content(Whitespace\" \
+         \"))))(Tile((id \
          2f523600-cb8c-481b-b6d6-dc1a5cc5ae1e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2a4fecae-2728-43bf-8101-ef51fcb89b63)(content(Whitespace\" \
+         \"))))(Tile((id \
          929abd8c-98fb-43c9-9c73-96b888186ebf)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          9963de2a-e7a6-41a9-bb48-bb6987e33817)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0cc53542-e658-4106-8042-0ffef7cbd1e4)(content(Whitespace\" \
+         7869ed1a-a545-42ee-b042-3da4257f37e1)(content(Whitespace\" \
          \"))))(Tile((id \
          910e214d-30c3-4380-bdab-3b377321bfce)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7dd09992-aeb7-4fc5-a337-e41e1dfa7779)(content(Whitespace\" \
+         \"))))(Tile((id \
          dbd0046d-26b4-4d1d-acca-07f890e72fea)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c237a22a-d0b6-485c-af82-76768e765809)(content(Whitespace\" \
+         \"))))(Tile((id \
          47f389d8-5367-4ba1-b058-899e91defe1e)(label(2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         13c04eb0-c904-432c-839c-c37df1acc503)(content(Whitespace\" \
+         e9709bcf-9e30-4f76-89dd-5de6abcafe5a)(content(Whitespace\" \
          \"))))(Tile((id \
          cd2fcd72-da0a-48a1-aebf-ca7268e7d169)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         11178d1d-16f4-466a-82ee-9d9b1ce911f1)(content(Whitespace\" \
+         ed4a5073-4627-4ce9-b70f-ba17bd7301cb)(content(Whitespace\" \
          \"))))(Tile((id \
          398c95c2-97f0-49bd-878a-1e82fb6bfc25)(label(2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         083b884e-4c06-4270-bbe3-d3279c5e8aac)(content(Whitespace\" \
+         0176014a-267f-4cef-baa7-6504e9f189ac)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cc4f2477-0b1d-4b45-ba10-894a65ba90db)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         0b36b536-d5df-4cff-a542-b24d8b32e2ff)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8191675d-765f-4697-8923-f918806d3e49)(content(Whitespace\"\\n\"))))(Tile((id \
+         94a03ccd-5261-4c5f-95c8-925faf0d274e)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         eca086e8-2072-4812-b180-478bb712ae9e)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d9bfa7c8-dbf4-47b6-b494-e14167560533)(content(Whitespace\"\\n\"))))(Tile((id \
          29659a5d-fdfc-4b5f-b69c-0a83a79665d8)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         6c5c0785-1408-4bf5-b109-744625e266db)(content(Whitespace\" \
+         aa9ec69b-a715-4af4-b82f-fe88c9fb6637)(content(Whitespace\" \
          \"))))(Tile((id \
          fa791226-c67c-4ae6-b62e-5f8aa0b59a85)(label(header))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         68af6974-9a77-41c3-93a0-eb869492d52b)(content(Whitespace\" \
+         ff2d9864-b6a5-4dbe-a74c-f25f61d51941)(content(Whitespace\" \
          \")))))((Secondary((id \
-         1f8fe158-0ae7-4dc7-8653-e8de7acf4446)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e94b3c83-fba0-48b9-a654-884750aa2189)(content(Whitespace\"\\n\"))))(Tile((id \
+         f3bad824-35f0-4252-81d3-77e7cf088ff2)(content(Whitespace\"\\n\"))))(Tile((id \
          8ed03abd-b9de-4329-b810-dabed2c65c24)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e96fee46-dee5-441d-82dc-708f2348077a)(content(Whitespace\" \
+         87c18cda-7dd3-4eef-85d6-7c422249f31e)(content(Whitespace\" \
          \"))))(Tile((id \
-         a6186a70-d72c-4016-830e-80e945ac109d)(label(requires))(mold((out \
+         a6186a70-d72c-4016-830e-80e945ac109d)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ae43216a-3c05-4646-856f-a2028d237c81)(content(Whitespace\" \
+         e089f092-8765-41ce-8e50-3cffb50bd413)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9361fc55-c789-4b55-a618-941e2633069b)(content(Whitespace\" \
+         405a99f3-45c6-4b9e-adad-b5aaf29713c7)(content(Whitespace\" \
          \"))))(Tile((id \
          938a9a38-0650-4777-a3d6-b4b64e67d511)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         1cf89f58-b32c-480c-89b7-711682b2a513)(content(Whitespace\" \
+         ac1aacc3-1e03-4561-890a-8725f8cb4ae2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3764aeb9-0fdf-48bd-a4f3-ed2eb6ad8bc0)(content(Whitespace\"\\n\"))))(Tile((id \
+         e940faf0-5142-48e9-96fd-d85c194d8f18)(content(Whitespace\"\\n\"))))(Tile((id \
          91dcef49-428d-4e2e-82d0-47f9afd71bf4)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         86150bcd-395c-43b7-821c-9f77d8d81c4f)(content(Whitespace\" \
+         b2c788b2-554e-41f8-a729-f9ece08302ef)(content(Whitespace\" \
          \"))))(Tile((id \
-         c1d2b9ee-4d1f-4cb2-a4a7-a337814f2409)(label(ensures))(mold((out \
+         c1d2b9ee-4d1f-4cb2-a4a7-a337814f2409)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         02835aca-88b0-45d9-8b34-6103885a00a5)(content(Whitespace\" \
+         f8d47132-9491-4829-9dae-739b752bee2e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         589a13f8-45ef-4af4-911c-612673d04901)(content(Whitespace\" \
+         184387e3-f05f-469e-9748-aaf510ceeae1)(content(Whitespace\" \
          \"))))(Tile((id 85c06ee7-54b3-48ec-b0e3-4032663ffcb8)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -452,11 +457,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          2040379d-9c11-4b62-bfc0-c99a61381c4c)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         991c2b45-dda5-40eb-9342-5b2b65ccd213)(content(Whitespace\" \
+         \"))))(Tile((id \
          9e9553fd-5b5f-4659-8ab6-b1a54a0ecaea)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         b434f769-de82-4e37-8bec-b39829ff8f80)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d0706efc-fb45-4f90-b43d-829e81d13359)(content(Whitespace\" \
+         \"))))(Projector((id b434f769-de82-4e37-8bec-b39829ff8f80)(kind \
+         Checkbox)(syntax(Tile((id \
          8b542f12-3841-460c-b8c0-5317978f574a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -466,64 +475,64 @@ let out : string * Haz3lcore.PersistentSegment.t =
          851d979a-a0ee-4c41-b321-f68d7fefd995)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         edc413bb-2192-44cb-a304-50f5f97132b5)(content(Whitespace\" \
+         ec14f8f3-6c13-49e9-83be-ee73c996b8e0)(content(Whitespace\" \
          \"))))(Tile((id a86e3970-1342-47ed-8498-b9e62fc4e32b)(label(\"\\\"cs \
          is equal to header(t)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         bce69183-e494-4136-8644-7a5502c9e5b8)(content(Whitespace\" \
+         a20538f0-15c0-4d88-842d-3a18c2fe8110)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3ff3f5e8-4385-49b5-bae1-0290f1b73029)(content(Whitespace\"\\n\"))))(Secondary((id \
+         4e507146-f631-4e7e-b54d-206f448643ab)(content(Whitespace\"\\n\"))))(Secondary((id \
          82386c23-f199-4cf1-9b3d-76a197b6097c)(content(Comment\"# Only works \
          for non-empty tables since we don't keep a schema \
          #\"))))(Secondary((id \
-         7cfbf4c5-f64a-4879-815c-9db23dc5df02)(content(Whitespace\"\\n\"))))(Tile((id \
+         c4a7220a-3c40-4f56-96c6-d2caa2356068)(content(Whitespace\"\\n\"))))(Tile((id \
          efd72a67-8ea9-4431-ae41-2f366f5590d5)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         0ff3f1b6-da71-402a-ad44-dc92ec4332c1)(content(Whitespace\" \
+         90aaa9de-597a-443a-b933-398dd54cac17)(content(Whitespace\" \
          \"))))(Tile((id \
          8f4f18f8-028f-462b-8868-1241ee548dfe)(label(header))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         fe6fa436-a725-4d57-8f2f-f12b54e8503b)(content(Whitespace\" \
+         6cd6002b-6610-4e21-aeac-05656ac8b4f1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7d9f1a96-00fa-4f84-af76-9c50727e332e)(content(Whitespace\" \
-         \"))))(Tile((id a101f0c8-18b0-4b15-a0f9-adba36076541)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         aa4c1379-fe0c-4446-8cbc-d359ca19a74a)(content(Whitespace\" \
+         cd3490eb-24b9-4034-8f1c-8527b86b4cd5)(content(Whitespace\"\\n\"))))(Tile((id \
+         a101f0c8-18b0-4b15-a0f9-adba36076541)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         89a7c822-23e2-48fe-addf-6ebc1c8ddb1e)(content(Whitespace\" \
          \"))))(Tile((id \
          f7c07fec-a3cd-4617-b4e6-169956aed3fc)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          ed1ff416-4257-488d-ba5a-e31ebeecd20f)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3ddcbf2c-954e-4ae0-92d8-25755455b67f)(content(Whitespace\" \
+         \"))))(Tile((id \
          e9ee2c4a-4bed-4b3a-8317-64314b7a8c23)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         84b6f01c-1848-43e4-956f-11be122fb22b)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1791e186-aec3-4e45-937f-930397dbe826)(content(Whitespace\" \
+         \"))))(Tile((id 84b6f01c-1848-43e4-956f-11be122fb22b)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          f048b688-231a-41fe-9b52-4d33176037a4)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b5603a26-d7d2-4505-9b9f-58ed4db583d4)(content(Whitespace\" \
+         581a1d71-e12c-43da-b173-71798489fe3c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d7eac70d-3e9c-4676-8782-655f54f47dae)(content(Whitespace\" \
-         \"))))(Tile((id 983167dd-2985-45f4-abe3-fa205740d299)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         bcdc913e-feae-44b3-8966-e8cceeb787c7)(content(Whitespace\" \
+         ad32f91b-a906-4398-927f-a6fd7885cb5a)(content(Whitespace\"\\n\"))))(Tile((id \
+         983167dd-2985-45f4-abe3-fa205740d299)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         85460cb6-07e0-43c3-be8a-9e09d48c3930)(content(Whitespace\" \
          \"))))(Tile((id \
          c573a66b-b0ec-49c1-baa6-9297f75b1937)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         4022e1da-a4d9-4470-83c0-55fb5087593b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a2f0c38a-f448-4a28-8721-4d72d73f4c27)(content(Whitespace\"\\n\"))))(Tile((id \
+         73337d18-4405-489e-9da9-5aa854a6fcc3)(content(Whitespace\"\\n\"))))(Tile((id \
          98873c20-6fc3-4e3f-afde-e4819ef5c642)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -538,12 +547,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          47e7d706-19d9-424e-9399-03918902931e)(label(::))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 29))(sort Pat))((shape(Concave \
          29))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         a0f2451a-a400-417f-94cb-d30c9c96db0b)(label(xs))(mold((out \
+         a0f2451a-a400-417f-94cb-d30c9c96db0b)(label(_xs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          9fbf87a0-b54a-4072-b0cb-e4064530fa24)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         41c3ccd2-343b-4da8-ada5-b1cd782532c5)(content(Whitespace\" \
+         95f440ad-d2bf-4a0d-b531-5ce1cf08c109)(content(Whitespace\" \
          \"))))(Tile((id \
          c4581786-b305-4705-9057-19ec2d30df16)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -554,12 +563,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d41504ac-6633-4cbc-a54e-ceb1de350a38)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d74d309d-3e36-4d85-a094-05f2436d780c)(content(Whitespace\" \
+         7e3dead2-acdb-4ed3-9528-d03222a12baa)(content(Whitespace\" \
          \"))))(Tile((id \
          7a7645af-5ef0-4227-ae5d-0dc1aa5e35c6)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         af0e089d-2e4e-4f7f-941a-9109ddb70990)(content(Whitespace\" \
+         70b69ea2-4423-413d-afd3-430ea4b21bb3)(content(Whitespace\" \
          \"))))(Tile((id \
          bc57a194-c5cc-4bb5-a4f9-157639ae9a03)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -573,19 +582,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          eafa4c5a-6e9c-4150-9bef-973e8295ab8d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         345642fe-835e-4c0a-84a8-ab93f434d306)(content(Whitespace\" \
+         ef9bafa7-947f-476d-b7ba-89064efdd7d6)(content(Whitespace\" \
          \"))))(Tile((id 40c64b29-9bd1-4688-bb90-0ec4001b47d8)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         734660cd-f1c0-4ee6-a814-119d34e405fb)(content(Whitespace\" \
+         369a387a-62f0-411c-9d9d-c5ebd5d50941)(content(Whitespace\" \
          \"))))(Tile((id \
          044c8990-4bca-4f6d-ba90-a12977fb1381)(label(x))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a898beed-2b2d-48c5-b7de-94437e6a6e25)(content(Whitespace\" \
+         9e350430-7ff8-4b66-8ed7-63bd30aed83c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ef710b86-18d6-43fb-a5e2-85c94a380b34)(content(Whitespace\" \
+         778eae83-06fa-4086-95a9-c938ed23b711)(content(Whitespace\" \
          \"))))(Tile((id \
          9b410808-8945-44f1-9d44-008ab16bb30b)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -596,7 +605,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          20ffbc0a-1d80-4a77-88fd-3715cde78ea8)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         0c86878e-0494-408b-a96e-66d36c207468)(content(Whitespace\"\\n\"))))(Tile((id \
+         8741b787-4160-4a09-94d7-1528a2ccdba8)(content(Whitespace\"\\n\"))))(Tile((id \
          b9823a26-3ade-4e03-8d7c-2499cecb2c5a)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -607,24 +616,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          986ff177-251e-4809-a69c-5272092cad38)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3cd2f256-97b8-4bfb-a139-02610e816ed9)(content(Whitespace\" \
+         908f76ec-0767-4380-aef0-305d3f6b1c0b)(content(Whitespace\" \
          \"))))(Tile((id \
          907df57c-9421-463b-9a52-35a0d7c8cfdb)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         5f64ab66-9cfc-4118-9ec2-0d86454cf5ca)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e547330c-2c2c-4474-9fe9-562d5392070c)(content(Whitespace\" \
+         c26c4cf9-fca2-4a53-9c70-b31f23151301)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         b6d9e6a3-0cd6-4da5-ba33-00caced8ae88)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6139c8af-6166-4424-b53a-ed03df43d649)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a3436c82-37b2-4c96-bce3-b6b45e3c485c)(content(Whitespace\"\\n\"))))(Secondary((id \
+         bb0cd4f2-018b-454c-8fb3-59089efa3732)(content(Whitespace\"\\n\"))))(Secondary((id \
          c04badb0-1c67-4af5-957f-71a9a14aeff6)(content(Comment\"# Examples \
          #\"))))(Secondary((id \
-         0b9a3c92-8267-483b-9f4b-b6b0fd7d9fcb)(content(Whitespace\"\\n\"))))(Tile((id \
+         26b6dba0-b32b-4b02-8703-c3a86b8535ac)(content(Whitespace\"\\n\"))))(Tile((id \
          d1b5fff1-093c-4e64-a028-cbb7a9a24d9e)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         09841311-58b4-4c2a-bc48-f44a3010bde3)(content(Whitespace\" \
-         \"))))(Tile((id \
+         869bec06-0c50-48f8-a6b5-485df8ee0722)(content(Whitespace\"\\n\"))))(Tile((id \
          0451fb72-39aa-4488-827c-a100091f3553)(label(header))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -637,27 +644,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6582065d-9a85-44d3-8314-6438d1a77419)(label(\"()\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         6e106c1e-46fa-4ba7-959b-3ace28ec5c6d)(content(Whitespace\" \
+         e82d2885-fa5a-4ee0-abe5-d3fb4e87824a)(content(Whitespace\" \
          \"))))(Tile((id \
          2527368c-f6c0-4ece-9f25-d294559df1cc)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8c6b7a90-85fc-4346-8a34-519de3da47b5)(content(Whitespace\" \
+         fdff396b-fb4a-49c5-8e43-c75e0b4b1e73)(content(Whitespace\" \
          \"))))(Tile((id \
          4ac8bd22-a8ce-4222-8940-a6868f7fe117)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         27c79fed-7384-40b1-b5e9-05d0a900c9ca)(content(Whitespace\" \
+         504fa121-4832-497b-91cf-5bacfe1d8b1d)(content(Whitespace\" \
          \")))))))))(Tile((id \
          fe4c8a2b-48e5-4c56-813a-6d6238766482)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         17bd92b0-6726-4ebe-b0b5-db1b1ba59277)(content(Whitespace\"\\n\"))))(Tile((id \
+         4f464b6f-3991-4562-bffc-eec2420ef962)(content(Whitespace\"\\n\"))))(Tile((id \
          a488d206-13aa-46de-90bf-f909229f3124)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         79d049ca-f973-4138-8d20-8ea6cd54bdbc)(content(Whitespace\" \
-         \"))))(Tile((id \
+         44d88231-90a1-484c-97b3-0656f20c42c2)(content(Whitespace\"\\n\"))))(Tile((id \
          8d70431e-be41-418a-a45a-c7f1bbc0b188)(label(header))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -672,33 +678,41 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          84a3ce81-abfb-4080-b99b-4ae89ec6fb5e)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         21d6f164-8fa0-4649-89e9-ba712d4f66ec)(content(Whitespace\" \
+         \"))))(Tile((id \
          b1775dcc-817d-432f-bc4a-aa41721b3915)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2c9581a7-a28c-425f-bb0b-726a0274d5b1)(content(Whitespace\" \
+         \"))))(Tile((id \
          e395cb7a-1603-4a88-84f5-660c6e02351a)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          84312588-e2d9-4337-81a1-cda7691b4500)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bb6ace57-f64c-4442-a0cc-d38641dae3ea)(content(Whitespace\" \
+         3e5bae47-1da0-4f7a-b9a1-90248d32e737)(content(Whitespace\" \
          \"))))(Tile((id \
          a7cb7ec6-b3b6-4c58-a4fc-82790851d913)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2280c5d3-c5c7-4efe-8197-685361ee99fd)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb67b9e9-e88f-4bdd-9c08-fe1d6aa2c923)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8f7ddef8-6308-4f18-90b8-b2fa21cacc80)(content(Whitespace\" \
+         \"))))(Tile((id \
          1067e579-5153-487a-a3f0-2cd4c41cea7f)(label(2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         ba1e32bb-4e21-4dcd-9a42-1679edcea7a3)(content(Whitespace\" \
+         2e78f993-c423-49d7-b5b1-43d057217665)(content(Whitespace\" \
          \"))))(Tile((id \
          033da480-2ff4-4ced-8ced-fbcad098bd7b)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10f536ec-5b11-4eb7-b585-7543a6191f78)(content(Whitespace\" \
+         1e901ffc-83cc-4950-b5b2-bed199448e30)(content(Whitespace\" \
          \"))))(Tile((id f2e9c256-109c-4232-b956-69e5771bb4d5)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -708,52 +722,60 @@ let out : string * Haz3lcore.PersistentSegment.t =
          17aefdab-56d0-4d2d-8443-7f84ff94d3a5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5a87cbfb-3df2-41da-a916-cf1e1c01786a)(content(Whitespace\" \
+         3e6f3b9a-dcd0-4fd6-a3a2-7c9030c37078)(content(Whitespace\" \
          \"))))(Tile((id \
          83aae546-c058-491d-9dc8-186e38848587)(label(\"\\\"b\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9eba4259-1015-4121-ba42-8aab88522a7c)(content(Whitespace\" \
+         a6a093c6-248b-4b02-9e1a-6c0b09b38926)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         07aa01a6-784a-42e1-b8ed-a4972793b9c5)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e4d70bd8-82d0-4d5d-babb-184de4b9807a)(content(Whitespace\"\\n\"))))(Tile((id \
+         ab235562-b0d3-4f73-9642-374af7fdd03f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d1db08d2-e108-432e-869d-f6925cc22b3c)(content(Whitespace\"\\n\"))))(Tile((id \
          76cd59a9-3203-41a1-9adc-d5875e41de71)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))";
       backup_text =
-        "let nrows = \n\
-         let requires = [] in\n\
-         let ensures = [(enforced=^^check(false), \"n is equal to nrows(t)\")] \
-         in\n\
+        "let nrows =\n\
+         let _requires = [] in\n\
+         let _ensures = [(enforced = ^^check(false), \"n is equal to \
+         nrows(t)\")] in\n\
          # Tables are just lists so nrows is just list length #\n\
-         let nrows = length in\n\n\
-         test nrows([]) == 0 end\n\
-         in\n\n\
-         let ncols = \n\
-         let requires = [] in\n\
-         let ensures = [(enforced=^^check(false), \"n is equal to ncols(t)\")] \
-         in\n\
+         let nrows = length in\n\
+         test\n\
+         nrows([]) == 0 end in\n\n\
+         let ncols =\n\
+         let _requires = [] in\n\
+         let _ensures = [(enforced = ^^check(false), \"n is equal to \
+         ncols(t)\")] in\n\
          # Only works for non-empty tables since we don't keep a schema #\n\
-         let ncols = fun (t: [?]) -> case t \n\
-         | (x::xs) => to_lvs(x) |> length\n\
+         let ncols =\n\
+         fun (t : [?]) ->\n\
+         case t\n\
+         | (x::_xs) => to_lvs(x) |> length\n\
          | _ => 0\n\
-         end in\n\n\
+         end in\n\
          # Examples #\n\
-         test ncols([()]) == 0 end;\n\
-         test ncols([(a=1, b=2)]) == 2 end\n\
-         in\n\n\
-         let header = \n\
-         let requires = [] in\n\
-         let ensures = [(enforced=^^check(false), \"cs is equal to \
+         test\n\
+         ncols([()]) == 0 end;\n\
+         test\n\
+         ncols([(a = 1, b = 2)]) == 2 end in\n\n\
+         let header =\n\
+         let _requires = [] in\n\
+         let _ensures = [(enforced = ^^check(false), \"cs is equal to \
          header(t)\")] in\n\
          # Only works for non-empty tables since we don't keep a schema #\n\
-         let header = fun (t:[?]) -> case t \n\
-         | (x::xs) => to_lvs(x) |> map(_, fun x -> x.label)\n\
+         let header =\n\
+         fun (t : [?]) ->\n\
+         case t\n\
+         | (x::_xs) => to_lvs(x) |> map(_, fun x -> x.label)\n\
          | _ => []\n\
-         end in\n\n\
+         end in\n\
          # Examples #\n\
-         test header([()]) == [] end;\n\
-         test header([(a=1, b=2)]) == [\"a\", \"b\"] end\n\
-         in\n\
+         test\n\
+         header([()]) == [] end;\n\
+         test\n\
+         header([(a = 1, b = 2)]) == [\"a\", \"b\"] end in\n\
          ?";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPISubtable.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPISubtable.ml
@@ -2,7039 +2,6632 @@ let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Subtable",
     {
       segment =
-        "((Tile((id 182a7263-6784-4e74-952c-fdda939f5590)(label(type = \
+        "((Tile((id b443245d-4016-4350-bb29-d72537268f4b)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         6a639adf-58bd-4653-9070-e68e2d4c6846)(content(Whitespace\" \
+         e2e4c17b-b6fd-472d-ba04-f9f668960b26)(content(Whitespace\" \
          \"))))(Tile((id \
-         a3710691-7beb-42e3-bc7c-84b27229bf65)(label(Student))(mold((out \
+         8f4a7ccf-e71f-4a1c-b13d-0634ee4d9079)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         01362126-3a84-4995-baf6-28e13fc4e5f2)(content(Whitespace\" \
+         e58de2b8-1591-4a47-9399-e55867afdd70)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ecc5d7f2-41fa-44b3-ac69-157b4386ffee)(content(Whitespace\" \
+         a6a893a7-0695-4021-af18-ab30d724e6ad)(content(Whitespace\" \
          \"))))(Tile((id \
-         24ba340a-e847-497f-bc3f-40d5a8693fe2)(label(\"(\"\")\"))(mold((out \
+         ad0246b0-7f6d-429d-8921-bd6d61ddbb6e)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         110e611a-763d-4b1e-baac-642a2474074f)(label(name))(mold((out \
+         e746d888-367f-45f1-ab6a-e1ea997eb973)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         ddde8554-c3e1-45d5-9936-366f71ffd575)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dae34112-1786-4958-8711-8d93ac15ea88)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2d159c8e-8c8c-4d7f-8153-692323162489)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         0e181668-1982-42ec-a152-b0ffde6f612c)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         30c69294-c3a6-4348-bbec-a601403390c9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         306c3edf-197d-4633-85f2-c55082360b96)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         4a2c055c-fc7a-41e8-b504-cdeb57053f08)(label(,))(mold((out \
+         5554473b-260f-43db-b79d-7005b90a79a6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         236aaa6d-bcaf-455f-ba60-1e45740d6677)(content(Whitespace\" \
+         b286bfa9-cd76-402e-a43e-a14e8a1e81f8)(content(Whitespace\" \
          \"))))(Tile((id \
-         ae2f7a54-b1cb-459c-ab80-e38db1961022)(label(age))(mold((out \
+         04c63361-444c-4068-be83-35b1fec74140)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         1d8c3d8f-efc3-46be-858d-f0e9e2f0989e)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         703e7ae0-7bd5-4322-a4f4-0121d8981f08)(content(Whitespace\" \
+         \"))))(Tile((id \
+         59aeb132-aae6-4d18-b6b2-3034733d5a4c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         5a64da91-0236-4d75-b375-12de94ab692e)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d3686004-9850-4e64-809d-27fc1f1d51ff)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a2686d11-5263-4a5d-ba75-f48debf3d855)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
-         3d236fed-5f3d-4fa8-8abd-98d4df601fda)(label(,))(mold((out \
+         2a5528b4-07c6-47dd-ab2f-f0f7e4aaf331)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fc63bf4d-e97a-4185-b70c-167578d5e899)(content(Whitespace\" \
+         84bc4624-f5d5-42cd-a66d-8919a3d2a0a6)(content(Whitespace\" \
          \"))))(Tile((id \
-         6adeeb9d-1871-432a-af41-8963b10764d9)(label(favorite_color))(mold((out \
+         27598c36-a411-4412-aa98-fa2a1b210fb7)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         fa305bf6-3c57-4562-98b8-f6d080509785)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cbd8e670-b73a-4a88-baf5-46e783655cad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1b0be8b4-a1a4-4645-a093-e4b708ceeba4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         02685b47-eafb-48d3-82d7-97becec3ecd1)(label(String))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bc3929fe-68e3-4707-8458-4a620a058cc6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8a68858e-1351-4518-87e9-4257f4ef3596)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c4e02671-450a-4a7a-b13e-538128af1035)(content(Whitespace\" \
+         f8fc61a4-60c4-4f22-b50d-d002faadeadc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         79212d1e-f14c-4aad-ac35-249a05a58ca8)(content(Whitespace\"\\n\"))))(Tile((id \
-         96dc73bd-ac2a-40d1-99a3-20c7155bc6f9)(label(let = in))(mold((out \
+         b1816d7a-994f-41ce-b31c-0bf1fda9d5a1)(content(Whitespace\"\\n\"))))(Tile((id \
+         e4e28655-4e53-4c8a-a570-dcf25205e5ae)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e8fd95ac-9db1-490c-82fc-3c69a1a306e5)(content(Whitespace\" \
+         52f2a658-86c3-4fdd-ab84-8913e23a4e43)(content(Whitespace\" \
          \"))))(Tile((id \
-         54e7d48b-ce06-4178-9ee7-278dc2c282d5)(label(students))(mold((out \
+         6679a5d9-a537-4934-97fa-589373bd7fea)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         17fd31eb-fa30-405b-b58a-76517d0e0904)(content(Whitespace\" \
+         7bf288dc-008e-40a4-9405-4fe15b66bdbd)(content(Whitespace\" \
          \"))))(Tile((id \
-         54c973f3-04ef-4ed4-8c6f-77b930d6616f)(label(:))(mold((out \
+         1ead807a-7d26-43cd-bd71-92145b3930f3)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         32f15e4c-b94c-4137-8196-44a2b99ad9b9)(content(Whitespace\" \
-         \"))))(Tile((id 3f52daa3-f653-4581-a1dc-c190e9a38e1e)(label([ \
+         51ba8534-666e-4b0c-a298-cc2bf5a89f69)(content(Whitespace\" \
+         \"))))(Tile((id 4ba2f305-46fd-4306-83ea-713462ee4c30)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         969c6f1c-b39a-49ee-b9af-fe44d41eb211)(label(Student))(mold((out \
+         09d977ba-1fed-40f1-9c06-e237bcc99d6a)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         3b33de4a-a7cb-47ca-8dc7-b211e09f243f)(content(Whitespace\" \
+         27161dc9-1581-4d92-9676-4e2a6a9021aa)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6f5fbec9-139e-4f6d-8468-a7913968741c)(content(Whitespace\" \
-         \"))))(Tile((id 473abd70-ecf5-4d0d-8393-758c15222902)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         5a524a37-8e0d-48f3-b0ba-addec11d62ab)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e3959fb3-7f82-4b53-bc48-b4e76a2c026f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         62906506-87c8-4020-b536-cff4a2aa49cf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f55cd34f-14e9-4128-b24f-8f7f7c359810)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         35e4fa29-cc67-4903-b6a1-91f442401b66)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7dcf957f-cdc2-492b-9b50-8485c78a3ec6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb9cf910-2725-4923-96c9-8cad37640eaf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b64b4fea-4e97-4b04-937f-078abb0901e0)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f2852404-f08d-456d-ad43-393f3e364bd5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1ca59efe-1d44-459a-bf98-ae3f296a1a3c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b5213f78-18b3-4801-b5c2-87e6b049ccae)(label(\"\\\"blue\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         0bfa0c57-5d85-4d4d-8768-f357a0828527)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dc8740fa-565c-4d09-b11f-687cecdf9179)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9c645cd6-d2d1-4ebb-81ee-b97acd9964b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         42be873d-213e-46c3-8847-f409c93fc8fa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         906e08d4-e5e1-4462-9178-ac2c586566d8)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         f68901f1-062c-46b2-b9a8-7a78246a0244)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e9282033-daa6-4aeb-b481-5fc92afe9786)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7b7d2208-0283-4c2b-9fff-121c8d6cd196)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3d7e7fe4-51e7-47af-b1d1-42e49955b183)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1967eb5a-b6d8-4b48-b51e-a2fc9986cbdb)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6bca1112-f6c9-4f45-8b1b-05a324fe4328)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d975d680-a52b-402e-9d4a-0a9c79cef3d3)(label(\"\\\"green\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         62ef06c6-a7e8-44ff-90f3-3d465971a44e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         08f2e03b-9ba0-4785-8180-01c9cec03da9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ce9eb552-98d0-4257-890e-1944e2260992)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fbdd1826-b932-4e6e-8d9a-f647013c0c59)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ab8a34fc-57da-4e47-9fd5-3806e8add66c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         211febe9-e56b-408d-b73c-c678a90a8ee3)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         81fecad0-e932-4a6b-9390-a0da05535c55)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         28a89f95-f657-416b-80d8-38edff10e3be)(content(Whitespace\" \
-         \"))))(Tile((id \
-         390eda60-cee7-4f56-8aaf-3b215e6dead9)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7cc6db81-b59a-4064-8d03-118c0d2348e1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d1b0c5ee-be31-4fb8-a966-a7b95fb7d83a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d0ba4c67-b35f-43d7-be21-7d8458c36fde)(label(\"\\\"red\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         11c943d3-c8a3-4d13-9c59-ca2bec68bdf0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         d0b3dc36-ce55-4aa5-9cd6-67fd0b78232b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         19674ea8-2a15-4513-b42a-6417d647cdfd)(content(Whitespace\"\\n\"))))(Tile((id \
-         f59747cc-8ab6-479e-a08a-f7dbec8bebd8)(label(type = in))(mold((out \
-         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         2a027d9d-6739-47aa-8db5-a2ff6b99cd5a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ce8588cc-f6e0-4e28-b814-3065e81d399c)(label(GradebookEntry))(mold((out \
-         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
-         TPat))))))(shards(0))(children())))(Secondary((id \
-         587fe89d-8ecd-4a94-8345-0fe65c8b629c)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         d4942677-59f9-4c5c-bb53-81ceec86c626)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b6e3d468-44bb-4a54-a7b2-78dd40f686d5)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         864ccde3-fd1a-4264-a617-450cfb22017e)(label(name))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         85f81d7e-4006-4cc1-9795-e2b5a3a2f2ad)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c5ae0675-bce1-4886-9149-d4d64379b2a2)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         9541fbb4-4124-4225-b7c3-3ab582923203)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         edd8314a-c2e9-4595-80c8-74ef81248c1f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         10579e63-055f-4a84-8906-6d6a61d9909a)(label(age))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         20352e4d-b007-4a09-8908-215d142fd15e)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         39901b26-5d41-48fd-9f9b-f90033edacac)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         318c630a-f365-4185-ac05-4077471ead56)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fb6cb520-f73f-4dfc-89e6-bf7c3e07bd2e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bc94658d-ad67-4869-8e3c-f65cff5a7ab5)(label(quiz1))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         91c39868-0c83-44cf-996e-5ab03af51637)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d8a393c8-40a5-4372-8bd3-965a320c33bb)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         d1501610-69d7-421f-9bf9-34d288658475)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1619fd82-dab2-4db8-83f6-de7ab64ac59f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c9813d3b-163c-4f1b-95a6-ee82107e10ee)(label(quiz2))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         d7112e3a-99a2-43db-a807-140b2182c449)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         02a78ab6-14c8-4882-8bd2-8a11d9a587ae)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         62c05e4f-2757-4a0f-ac3a-af1eaae61a5c)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         442c9a51-afd1-4f20-8bce-45a0dc2b57f5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ae8281e0-a06e-42c8-98e6-56ce8bf5eeae)(label(midterm))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         9eb1a8e8-9327-46ab-96c8-c1a46d175198)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c988cb0a-4c90-4610-aa28-8be2fd3a075d)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         2dc79b76-65c6-4f6b-9c39-dd7ea8246666)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4e7a6261-5232-41ac-81b0-64b071446a54)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c216b45d-24cc-411a-8f04-e978356bdb52)(label(quiz3))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         2880df76-162d-4467-9a50-83e1c51a4508)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         870a05ee-f119-4fe7-8a1f-70b1bea5233a)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         c12a8ef4-46bb-4775-81e6-07e91d594884)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         063ad9cb-646c-46d1-9b7a-b8a5582a667f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         eeea7a84-b447-48a5-92d6-2426e7e41a0a)(label(quiz4))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         1ab54077-919d-4ee8-a236-1c01174938f2)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         3e1d9c22-968b-415d-a1ee-69c6d9886375)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         76704b0e-67ca-462b-b982-3f92696dad1d)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c9db2d23-b3e4-4217-9c86-daf7f07230b1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ac1da48e-b4dd-44f3-b997-217275cb014a)(label(final))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         12ea13bd-2a7a-4e4a-92ce-8d0ea54e59cc)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         698f90d8-9399-46bf-8daf-37882602a78f)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         61d3d331-093d-4560-8f97-070c55566e91)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         12ecc405-813c-4790-bfd1-7a97a6b87df7)(content(Whitespace\"\\n\"))))(Tile((id \
-         af027871-e2b5-47fd-b8c9-ddaa6204a094)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         332b9263-4b50-4b83-ab59-1074ed6f2069)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6c2c03b3-f5ae-42cb-ba21-ba4af294fc28)(label(gradebook))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         bbf058c4-bfbd-49d6-a9a4-5710baf3fbb2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0d28cc2b-15ce-4b82-8e1e-ba6532722172)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ec96add4-d2e4-4ae1-be4f-9289ead9b0a4)(content(Whitespace\" \
-         \"))))(Tile((id fca5ad04-7f4d-41cd-8ab9-6dc130cc6456)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         4b324e12-3d96-472a-b360-e79e2b319b8b)(label(GradebookEntry))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         bc022c75-541f-426e-939e-e99ec2b36c43)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         ba5625fd-f4e1-4b0c-a88d-3818ebe62102)(content(Whitespace\" \
-         \"))))(Tile((id b40df15f-91b3-4121-8a81-a51c3e197982)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         e41b7b5c-8f7d-4147-9aff-29978970f643)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fa2fad7e-6cad-45af-9a5f-86fcc080687b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c03fc4ab-0911-43a2-a88a-b36d0652a7ad)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b66b31e5-d366-45aa-a171-eb496aa94c77)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         2f8476b9-a808-43cb-874a-da4fdf344ddf)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fe5a152f-7abd-4cd7-8a3f-7cdb278f8cfa)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         55327dff-7189-45a4-a028-a6aba89cf49f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6b40b09f-aefd-4562-8029-75fd8e66d693)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4aca71ca-b9e4-4867-a684-d1d0ef564932)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d2d18061-ea06-4674-a9dc-11c993f9c0b9)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a53b6757-47a6-4343-91f4-b2dc470c4b67)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb08e4f7-9d1b-4c83-b6fd-c505647e22de)(content(Whitespace\" \
-         \"))))(Tile((id \
-         df7d8f76-f129-4f7f-b33e-376c3173d5ce)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         34d20389-4c0d-4470-afd5-d6c4980cb4e4)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0d5a425e-10fc-4b6a-9d41-0344749a11f0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d02897a0-1493-4e1a-9ced-0379586dc4ca)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e00d2daa-62bf-4962-ab0c-8b42b87c89c3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aaf6763d-7fd0-4aaa-b5fd-9e05e3233d5b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         885c39d9-3cbc-4a82-933a-3fcb599eb6cd)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b7a3d682-28ac-474d-a249-c6853ff8dfcc)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a9705b1f-1a76-4b90-98e5-f791bf7b20fd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         647ea718-f095-450d-a365-b9ac1abe4894)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b1c1770e-c39c-469d-8793-b95c4ac6b071)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e8b23c3d-f199-4638-87d3-6bf45ed94875)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1fe215c9-a1ee-483d-936e-789f1da89bae)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c9369e04-37f4-4901-87fa-90c82ac612d1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         603a5636-3dff-43e1-98a6-c764e0d55bef)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8b9f842b-5660-4f88-b4db-b634f41d9ebe)(label(87))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         e0320daa-cabb-41aa-b397-bfc4618a9e2c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         79d700b3-6199-4e91-992e-2b7bb9ea71cf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         578f7cbf-f03e-4734-b161-156b9ea55fb4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7421b89e-9c01-4038-b7e8-95a319f523f7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         be8f00a1-c154-41c5-be10-4911a08dd3cf)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         d1d06038-48ac-4ec6-ab4b-823f9de7f454)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3f1d5741-c15f-41bd-8550-04407404f5b7)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a744330c-5c80-420f-aa2f-75d21adfaacd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         67308a7f-42a9-4143-b13b-357557b5c157)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5f7f7aef-f39e-487a-a4f1-f36438a56f9a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e1206160-02a5-4897-8847-86af3cc0b3d5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fbbe1ec9-bf79-4448-b061-15f4ce5c5060)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         60dd5622-780e-463d-8520-04cddc48d7c4)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d9ee95d4-7a98-42a6-812c-524e7cc4481b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8bd56639-f069-4a51-af18-fafece1ef43a)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d61ec06d-d04b-490a-821b-714a81e78b6f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3254a5ae-45cb-43e8-bdf2-31af76388a28)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d505dc3b-590a-4b1d-9f73-52be988122c8)(label(88))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         066cd6b6-0871-44aa-a21b-1eb140ba1e61)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7fc66af2-2f2f-4592-bbcc-2aaa0b0b60a1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         41b5183e-9f30-4a80-8520-e3e52733ecaf)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         52dcf206-7a4d-41cb-8f1f-137c86bf6dde)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         637821e7-7f1a-489c-bb36-3ea71f25093f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5930aa9d-2a95-41d7-89aa-59d5564759c5)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         33232b20-ca10-44f1-a1c2-22faef35a6c4)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         256fbde1-a887-490a-ac28-6857e0cdf9b9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b74ed431-2c52-44c5-80dc-82791fbafa78)(label(85))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         54ddec1d-55b3-4efa-854a-d175531b6e8b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a9a77a6e-aef6-439f-a928-22d9581a8065)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0d406e29-d860-4768-a380-513f4b031fc2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9c0bfc7d-4140-4f06-9a65-79b6d94b4258)(content(Whitespace\" \
-         \"))))(Tile((id \
-         20537668-217d-4471-8384-6d7a869f273a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         6bae6eb7-346d-43dc-bb4a-6b26091c70ed)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9c71aab1-523e-4438-99ad-1e1f0cbba641)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5bf7c6d2-e3df-40a9-b105-14879c794446)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6838fd00-e48a-492d-9268-8184e3dc3a12)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a1d2bd8a-26ed-410d-9ab5-c2d39cbbf92d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a628ba62-6b68-4a14-b2b1-39bde56c36a4)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a5643f62-4904-4727-8d2d-060112d3ffbb)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d47e5b7b-fc9b-4546-b66f-d561f883aa48)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1321da46-d256-4725-9f78-47337275cb28)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e6b7d468-9b97-41d2-9fa7-e4ecd7f7d5bc)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3f914604-a987-47ab-ac03-c543284e3e3b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d30df499-d784-471a-8740-ae2bb4f1f7c1)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a4314910-049e-496e-a6b6-4491ef8ec18b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3b367fd2-6ef0-4856-8e09-65629c00a524)(content(Whitespace\" \
-         \"))))(Tile((id \
-         abc171bb-97fe-4902-9a98-27f7bc91ac6f)(label(84))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         13c8cfa5-9ff9-4b27-8f2b-e700115087c3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e2bc4f4b-107f-4398-b909-2f1387b48348)(content(Whitespace\" \
-         \"))))(Tile((id \
-         059ac215-5ee9-4ff8-b1e0-4719e6fa3ff3)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9dcf35dc-d47e-4ec8-8628-c136ae6adc26)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ac059eef-2349-4b24-92a6-4f51577a7c1b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         423ecbd3-ce03-4851-b405-5f2ceb1a497c)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         06efb9a2-eb50-4ebf-bb9c-d4431c615966)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         95d0ba09-b34c-484d-a239-ac0e20aff342)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a31503ce-8984-4c9e-bcbb-57715561b330)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         488db12a-59a9-46c0-9648-7630b144a2ac)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         0e9e4d1c-997b-4a5e-8129-825f9d500f34)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         ca868f75-d8b9-4dd9-892c-8acdc50ab03a)(content(Whitespace\"\\n\"))))(Tile((id \
-         de44ec07-1bd7-4ff2-8e9d-37c0139cf461)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         84ae266d-bbe4-4dee-8279-2f230ee6746c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b784d01e-bf50-4715-9833-cde4da1f6a19)(label(select_rows1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         1096038e-2d9e-4524-9269-5dc9b7a58694)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         2595d287-b16a-4e59-bd4a-358d8f2e1130)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a7166ae4-0ddb-47a1-bea7-29dcdc512835)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7a5a98f3-3d92-486c-854e-589ba6931174)(content(Whitespace\" \
-         \"))))(Tile((id 5f65f532-f91c-4c55-b2d3-19a52c2dfc1f)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c99bfea7-dd8f-4306-9d3f-46a46da32a94)(content(Whitespace\" \
-         \"))))(Tile((id \
-         229aa2b0-4621-48a2-9488-b41b48daebd0)(label(requires))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         b01acdc9-2b43-4e1b-8582-efdd94685ada)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         4fe2016c-d45c-482e-95d3-2af840410287)(content(Whitespace\" \
-         \"))))(Tile((id f299d2ac-346e-4e3a-8d3b-0cf006812442)(label([ \
+         3072f4bf-3dae-42b2-a72e-1f3c2872d63d)(content(Whitespace\" \
+         \"))))(Tile((id dbba6ee8-5625-4ec3-9b5c-f5821446752f)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         cf23e154-5790-4bd5-9850-e725395a3bc7)(label(\"(\"\")\"))(mold((out \
+         a69869c2-0050-4425-8a4e-f5adbe7e1788)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e056eb7f-9e8a-4d97-94c9-34c435bc7a7e)(label(enforced))(mold((out \
+         7bd73b10-d534-46fa-b050-307c16dd9943)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         59657cd4-df31-46d5-b96e-9c3ea1479d34)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         f8843495-0ea0-4652-b747-55d7831fe42d)(kind Checkbox)(syntax(Tile((id \
-         af792d75-19ca-4ade-a2cf-4ff948ff4fd8)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         72d18f8e-e162-4a19-98cd-2592f423cf58)(label(false))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         0d87184f-166f-421b-a983-a588903742b1)(label(,))(mold((out \
+         33a028a0-71f3-4a4b-b222-5adfe1c4f355)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8f2a4aa3-bfb4-43cc-94d9-4866d6d78316)(content(Whitespace\" \
-         \"))))(Tile((id 39a46f16-4dcc-43a2-931f-a6f25f2662dd)(label(\"\\\"for \
+         75a56c2e-31e0-4bc7-9d01-17042ce43a3a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         31e76a7e-0f83-4d84-bd68-7893754abcb7)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8e8d3009-412e-4eae-83ed-8f1c316c8655)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bb0fd6b7-7d5c-48e9-8db2-9a1d993001c5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3d4766fa-aaf8-4ac4-a9bd-f61944ea448b)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         9e097e63-fd42-4a73-82ef-523596015320)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         48bfab6d-5cd0-4dd4-b7f2-383cd1f34677)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c2cb9baf-cba4-484c-a620-c0c13ee05a14)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         2b15038e-cd57-4263-a866-575a401c872c)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e9bcbeef-64cb-492a-b18a-70923a563acc)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1322091e-ab2b-4815-9dd2-5560b02de6ad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1e7264fd-b9d2-4e5d-92db-6227cc32af01)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7bdb9071-de7f-431c-bedc-7af5e08eb182)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5cca39d9-0fbf-4604-b412-7db567c75e3e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         99ce7789-7db4-460f-a730-b97d12c1df30)(label(\"\\\"green\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         9371a8fc-6aff-42e0-8bee-1470ddb67df0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3832ec57-0117-4527-9332-6b3a3181194b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4a5a8404-c026-4d2d-92c4-1fb21189c4ca)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         7bc37619-b2fc-489b-9cee-de80cb5ad7a3)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a26a833a-c3f1-449d-9b35-86b9a1394e4b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e6efd810-c9e7-46f0-8bc9-13e3bbb765b6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         81f57934-91e3-4902-8ce8-8b422ff6c9b6)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7e0eb9e2-259c-4f24-a4ea-e9f13cb2a19d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         97227792-ba3a-4df6-a750-be08fd4dc606)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f1e1b08b-1fa1-4233-a697-b5cfff0db893)(label(\"\\\"red\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         5a058008-481f-4c8c-ab06-1e784d3bec50)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         faae3eec-f713-45d8-a586-709161924c7b)(content(Whitespace\"\\n\"))))(Tile((id \
+         d0a1def5-3d21-43ae-a723-aa2a43e749b8)(label(type = in))(mold((out \
+         Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         488bb36f-b5d1-4aa7-9faa-d83312ce0541)(content(Whitespace\" \
+         \"))))(Tile((id \
+         786f1ab9-a58e-4e2b-9389-85561c385025)(label(GradebookEntry))(mold((out \
+         TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
+         TPat))))))(shards(0))(children())))(Secondary((id \
+         ab9a6b74-1807-4f26-83cd-1a7fce92f609)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         fe336bce-0e51-4993-8975-5a7ef1500c66)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a1b142c5-e45e-46b6-969f-ba62acdb570c)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         5cef74e5-4ff8-496a-be9f-e721fa816e35)(label(name))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5642ace4-3a57-4cd6-aa6a-57204f1ac31c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b990160d-dcaa-4dd5-b134-1b43426c1064)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ab123192-7362-4b99-b486-30aee747b89b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dfb3bb60-cc42-439c-b99f-4a0c8aa914e0)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         3b3e07e5-b77a-405d-aded-0b0dfc36f332)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         37aee01f-6811-49c2-81cd-52297b6d810e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         92c1fc37-1ae0-4eab-b946-709088693661)(label(age))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         3e95cc62-f457-4403-9099-674e776edf3c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eaa6af9a-e29f-44e2-9859-8366b1a687b9)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         70c9f1cc-d6ce-4125-afc8-7726838895c0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         233e03e9-2db0-483c-aa43-fa9f3c7bdda2)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         36a0c8de-5d57-49e6-b7e8-aaa08382fe89)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f54ffd23-0606-43b2-a28d-7757fbb41d3a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2dccfe94-6d70-4e8e-bdfb-cee9a983ce65)(label(quiz1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         dcbc2601-4fb6-4f68-b0fd-ab21b6fd3388)(content(Whitespace\" \
+         \"))))(Tile((id \
+         971bf960-ee8d-4014-88c7-58a0cbe4daad)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9736654f-68d1-4360-98a8-c01da6548403)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a616ca90-37a3-49d0-9f9b-d673b6c01fa5)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         20bc426d-c66b-4c96-94f8-64128645246a)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ef3ae039-e9dd-451b-a5f0-0d4e75d7adec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         05fa7aee-c5b6-431b-8d7e-339e7ddbd0b5)(label(quiz2))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         30965345-bde2-441b-a27b-88d2af43612f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         25a4eb8e-dce2-4d48-b025-681773978794)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         675e7e8d-58b5-4568-9a7e-9df58a5141bf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         18008c6b-c623-4873-85d3-dbc2f77a2457)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         1022cfde-a037-4ce4-bc4e-7321a9e3adef)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6481e3c1-6e11-4bcd-ad5a-d514d8fb5e66)(content(Whitespace\" \
+         \"))))(Tile((id \
+         23c1573b-541c-4612-9610-1c208dad7d43)(label(midterm))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         19e0cde2-90d9-44e7-9a31-14dc284d620a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4d96ec1a-9759-4d77-b42c-9fedccbcf01a)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e0a8a3ef-65c8-4f2e-8445-564df3eec983)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dcde3fb1-9673-4961-855b-47088eaff51e)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         f30bf26a-d3b8-4b1d-844b-c20ceeff4632)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         22b44b27-cd78-4b8b-9a8e-448fb5d4029d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         71c18598-e758-4cda-9b3c-22dc27d2cb6c)(label(quiz3))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5ac322be-62d2-4929-87e9-97c78f3aa6a1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         691890d7-1edd-429e-bfe0-d4d626d76d2b)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         97e81012-0a58-449f-a753-abdddd8127d8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f4d51583-0ed5-418b-b664-971b7558721d)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         83454410-705e-4552-b64c-d1c56985d9c3)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ac179a32-dbf4-4e85-a916-f3a49763717f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a358f77f-c03a-4319-91bd-e93383f2871b)(label(quiz4))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8a633f2a-7c33-4c64-843b-42475050a33e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d9731032-9a0c-47de-ad70-57d983b2d006)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8241d37e-b2c7-456a-9d16-41cabc406ff5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2d26b24d-61f7-479b-ae49-1fe87d783171)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         f28d1c7b-39f7-4d62-af7f-78841924a2bf)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         425661c2-eb8a-4e00-83dc-f424fd4abe3e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6c279bb5-b754-4577-adda-cefdc5579f61)(label(final))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         fc46fe5c-ada8-42c6-b272-6146779a2521)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7a028a3f-d886-47e4-b117-08ac88acd67e)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c7c8bc03-e33a-4c6a-918a-231a1ee59df8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4aaeea77-9533-4b56-8660-210baa7bb86d)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         c788904c-f3e9-4f3d-a4e6-314f3dd638d1)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9ca09cf9-32bc-4473-a4ed-f4a238e4ca36)(content(Whitespace\"\\n\"))))(Tile((id \
+         8605be39-8369-457b-8f6a-06b3f2579d41)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         47b7c50f-61c0-4f9a-a352-04ecc6d92b01)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d0a63d97-6a7f-438e-81ad-e1b7f081b688)(label(gradebook))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         accc0054-03f1-47aa-b8fd-0fed0e1f6dfb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d3d4141c-60d1-480d-8485-2147738d33dd)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         824c2d55-a533-4a23-bf46-4598d2b2a85b)(content(Whitespace\" \
+         \"))))(Tile((id bfc0eaa8-b4ca-4a0b-8bfb-22fd4ef8a6c9)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         82772b20-dcfa-43d3-b8c8-f22cfdf0776c)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         f3ddf085-5c5d-465d-94e6-92de29f7ab83)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         4482a690-bae0-42b3-990f-46c6cd3265ef)(content(Whitespace\" \
+         \"))))(Tile((id f144bdf2-459e-4c33-9324-997720d088da)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e909c751-0fb3-4bec-b59b-5d3ae1051714)(content(Whitespace\"\\n\"))))(Tile((id \
+         ddced404-a432-4cc5-8b57-ba49c485f4fa)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         df923adc-6c89-4661-9c13-5cad10915c14)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a41cb73f-967a-4241-9703-b5312bd02b90)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3608bea5-e0d5-43ce-bb77-d6b3d7056bad)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         00ce091e-25a2-4d16-b892-012435ab6d31)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         e5e057b0-df60-4905-828a-a426f472575c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         71f848c6-66af-4440-8641-060535719d77)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1e0858be-cbc7-4704-900f-eb36aef08a3b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         70899076-5861-4591-ba70-5490a28b6e95)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a8244af3-da37-46ba-9618-289852ee3c49)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         37892df8-b236-4b72-9602-4422c70d9b5a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7f19524c-734c-455c-b052-a776ef144e94)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c8546b6c-5fca-45f4-8696-e21ab66a0146)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         eb1cf6a9-aca8-4ff7-9c6c-b1c007b37197)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         06b32b3f-1fde-4ed9-a555-3c9c141c9554)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a5d29c33-7fee-494a-80ba-b09dbd4664a1)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9876fe46-6f3d-40e2-96c6-f3353b38db52)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8aa6bb68-b963-4475-a5f4-9ba61c0d9cc9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         57b30730-8725-4010-baf4-a2cb998631a7)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2bd5fe12-5b8f-4035-8b76-1ee323f6fbc5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1232d87f-bf26-4e22-b7e4-fadc54f535cf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         77c30fff-35a4-4e52-ad31-bd5e65e5b319)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0a0f5986-cd56-4a2d-8e38-ce87e6464c5d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3b90c199-bdcd-42d0-bd84-4c124f22afef)(content(Whitespace\" \
+         \"))))(Tile((id \
+         88b83816-f0be-45a1-8f32-f9409eb93a33)(label(87))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         a7f043c0-1389-4dc3-b2ae-1e64afd0eb30)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1184ce73-bc2c-419d-99f5-fb467112fb6b)(content(Whitespace\"\\n\"))))(Tile((id \
+         1fbac6a6-68eb-4d84-b525-aa77f3fa85db)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         e921654a-1c4b-456a-8492-2b7f748edd49)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c30b8c69-0bfe-40e6-9e61-b6a5429eb355)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7b520822-4cb8-4943-b130-a25c58cef62c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3ed8496a-1075-44fa-ab08-279469832e46)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8599928a-f5f0-4ff6-836a-b932e48bbf5a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6b231cd4-553d-434c-8ade-99bd4b6a6436)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0bdfe063-0b27-4848-9a9e-d138a7b23c29)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e652f3dd-2647-4c20-a741-a5f283269aad)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b7c4ee7f-e3dd-43fb-8060-0565a1392278)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5237c17b-1357-4b7e-a030-7a9dafdb5059)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0ea401c6-dc1c-4631-b087-6482d65f5f8f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         05385b25-8a8b-49f7-8921-b8cad23a90b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e52e9574-3b45-4880-bb29-fa8a99d77ae7)(label(88))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6788ffdc-2398-4135-bc18-7fd38d6daa80)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         50b264e6-6d6a-4cd6-9ab6-55f20f674a74)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cd8814c6-1729-4800-aefb-7949cc8e98a6)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fd666921-af9b-474a-b306-111712dfc119)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ff2ddfaa-5fa6-445f-a2a1-8f787fef689a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         48e7ef7d-5eb3-4ee7-abb1-25e9eae8a6d9)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bed08e31-a727-4c7d-acc5-eec6cef0cca1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         475c540f-937e-4a5a-a6bf-9d393b42364e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1d1dd67d-4a64-4b6c-8bfb-e79784d18680)(label(85))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         0b43fe02-51e0-4708-848d-ad05e9005af3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1cf3da4c-58f1-4ff5-ae8e-a5465cce37c4)(content(Whitespace\"\\n\"))))(Tile((id \
+         a549e7e1-7016-44bd-85ec-8a224605c600)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         1591dbfa-ae6c-4f84-8bfd-8a9d97ab1d92)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         89c8ee58-bedc-42a2-8b72-fe2fa1e19ed6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fae2e318-9bb1-4da5-a9af-92e95bb9731a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c4e2c7ec-2c17-4dab-8d4e-75e459f12250)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2744666f-2404-465c-afc0-2d5af6f7d609)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9cdb336e-f418-4df9-b945-5df79b88ce7e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6287a651-e95a-4ff2-8866-c91a77be5c92)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ac2f0453-ca9e-4fc4-b56b-c8902477cbbb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         31e8802f-ea1c-4fe6-a866-c3e1823550ae)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8c6e159e-0965-4cb6-9520-662fe73d8c58)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cbc29514-6c79-41db-bf0c-62b82ba93167)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         86991618-8fd7-4a49-978e-7825c844114d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         18e9e237-0414-46a7-bfcc-330b3846a133)(label(84))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d3494fc4-50d6-4be9-9cc6-049f4a273b2c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f54d75c2-93ff-4c7f-b190-0af5c66039c2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a46ee6a7-69f1-42e6-a758-eb4d44db4cee)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7d64c072-ad4c-49a1-a199-eecb3c09ad75)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1afa2b17-cd98-44c1-a99d-a2e6ed91031f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         65d497c8-1f0e-49d6-9d64-d00a578c61ac)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         967106e7-c607-4c96-b71c-43f0484697fe)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b20f5d67-d166-4552-a92a-c39ec7427dd7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4f0944bf-0e40-407a-a40c-96a244e380c5)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         111c36f2-e704-4091-a7f2-1880c6d70c1a)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         1fd0f6af-5131-4681-b88b-d2c02e76566c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         95e4c327-26fd-4548-be4b-eabf7233c1c7)(content(Whitespace\"\\n\"))))(Tile((id \
+         2d494db3-af51-4d1f-9f5f-c7edfc96527b)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         19c61610-bb2c-41f9-8ace-0655d6236bed)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dfa76327-bf8d-476d-bee2-5588bd328b60)(label(select_rows1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b1215631-a42d-4375-91c9-9ab79d1b7182)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         f3a216c7-79b0-4e1b-9e19-952a02f1b418)(content(Whitespace\"\\n\"))))(Tile((id \
+         4ecf6d38-9fce-4aad-824d-25996057f045)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         10bb0f0e-3fb4-4322-801e-eda9a418ee68)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6c37839b-5436-4e95-aae3-fd9b4b501a7f)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4bb74c69-227d-4afc-8a45-85f3aafb6627)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         1f692b70-b319-44b9-9799-8cb87e3fb875)(content(Whitespace\" \
+         \"))))(Tile((id ff1a5b51-a994-4cc5-93eb-a8c7a78e60cb)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         1b5e5c6b-2b06-45d4-aa79-eda573bbe568)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         fc016edb-158a-4be8-b9fb-99ae73330f37)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         daf7f0aa-c320-4bb8-9c3b-a61d5fc07ef1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cce224ac-9d92-457d-96f8-d84c1e657bad)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         080ff781-845b-4210-b5a2-fcc334b0143b)(content(Whitespace\" \
+         \"))))(Projector((id ef487745-2141-444f-be1e-cd3cb1704c3e)(kind \
+         Checkbox)(syntax(Tile((id \
+         628f6f36-d01d-4991-bd95-80996c9d49bf)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         1fe3981e-3ec1-4d4a-a798-ad1c85b497d9)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
+         55bfd3d3-efd4-461e-9790-9f0d2f22f408)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2d5541e1-f6af-4f3a-9de1-5cf1e31e6ee2)(content(Whitespace\" \
+         \"))))(Tile((id c287e760-4c0d-4792-bcc1-1d7552f5e4ed)(label(\"\\\"for \
          all n in ns, n is in range(nrows(t1))\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         bdfd1727-3fe5-4bdd-8314-e2afb8f4a6f8)(content(Whitespace\" \
+         085b9d02-3462-4cdf-a304-43e72699d1a0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ff348408-3b4f-4b0b-956b-e2c9d1faa904)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7baed346-8e11-4cf2-96b3-4840429c48bb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d88f67f3-d9f5-4615-bbdc-9849bbf910c6)(content(Whitespace\" \
-         \"))))(Tile((id c981df8b-fd58-472f-a05a-5d1cdd1e7dfb)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         c1fde61a-713a-43eb-aacc-c69c1bbd5cb8)(content(Whitespace\" \
+         b2cd270c-9a96-45bf-9264-15f5f40875d8)(content(Whitespace\"\\n\"))))(Tile((id \
+         c68b5a9d-8e7d-4796-9dd2-7cbcae4e9841)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         bc6e8644-e93b-4216-838c-b76acd7eb534)(content(Whitespace\" \
          \"))))(Tile((id \
-         bc0252a7-2bfe-4f26-92b3-2b8f840c8273)(label(ensures))(mold((out \
+         22614867-c8b1-4883-a0ec-9cdf5be016cd)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         734d7651-4ed2-45a1-8a2d-73da7f0ce222)(content(Whitespace\" \
+         12a5cb2e-05f3-4e72-8d39-2c6fef898164)(content(Whitespace\" \
          \")))))((Secondary((id \
-         10989953-4fdb-4267-89a3-217ac438f142)(content(Whitespace\" \
-         \"))))(Tile((id 6a86dce8-90ca-446f-b39a-afda2b191b2c)(label([ \
+         b0d9d478-6d13-47da-8655-9bfdf6330ebd)(content(Whitespace\" \
+         \"))))(Tile((id 932c1a26-e9fa-4fd5-be94-46ea44e4de03)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ed653c19-6483-44b4-8fa2-4d3989ac1d06)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5ad80e0d-3608-43b0-94bf-79cc2b2ae36c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         16784ef1-3518-4ce9-a75e-eb7ec0cb8e20)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         74048bac-78af-4c63-982f-404c50c2305a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ac15fe8-7858-49e7-8fce-e6e2f8b5c022)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d51035fe-3e36-48b4-8ce3-6901a7864a0a)(label(\"(\"\")\"))(mold((out \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         6fd9ae61-2631-4718-9d06-33f11faddf04)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         eeb74dcf-a36d-4f67-b491-c071616ea236)(label(enforced))(mold((out \
+         1edd2950-2d21-4b6d-9733-37b044e1ba4f)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a5427b60-67d6-4974-9858-c4048c4f0164)(label(=))(mold((out \
+         0276db32-e797-4a70-8123-305d687fa6ab)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         5a3c89f7-b46f-4193-9e9f-9b8713e0bfbd)(kind Checkbox)(syntax(Tile((id \
-         10222d19-3341-426f-9048-753ff5e57349)(label(\"(\"\")\"))(mold((out \
+         44f26b55-aaac-4ce2-a2b7-d402621141b9)(kind Checkbox)(syntax(Tile((id \
+         c54e8e00-5238-4443-91c2-88d687961e11)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         bb2f1e04-01a9-4c52-b92d-10c93b4b91a2)(label(true))(mold((out \
+         c836d65b-2700-4d0e-b856-cb6e88c0468d)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         b9d34f79-411b-4622-a29e-0881ccf11eb5)(label(,))(mold((out \
+         4aae2dfb-a2e9-40cc-9361-50f86f83e8fb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         115030b1-dc48-4de0-b265-d6434de76b49)(content(Whitespace\" \
+         6368e7a9-102c-4086-afdd-7e3fbef13977)(content(Whitespace\" \
          \"))))(Tile((id \
-         8799277a-dedb-4bf7-a3e9-f346926a9b14)(label(\"\\\"schema(t2) is equal \
+         793d1661-20a3-4bb6-a027-a6a508fff9ca)(label(\"\\\"schema(t2) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d5bac35f-15df-4de9-a170-78a05b30eaa2)(label(,))(mold((out \
+         7635711e-9f0a-4333-8efa-22f648cb1e27)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         62278920-1bd6-4398-b3ae-5d55cab5511c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2ca537f9-c8dd-40a0-a9a3-cba38c4a5c89)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea058479-24cb-43c1-a621-5f49204b65f8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f6a28e7-126b-4e0d-90e8-2a2dec597c88)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c5ce90f4-acc8-4695-ae34-09818c4bc1eb)(content(Whitespace\" \
+         0fb31cc3-9d39-4a43-b8bb-6ff8868783a5)(content(Whitespace\" \
          \"))))(Tile((id \
-         b99d48ff-120a-447c-b742-45a6fbcacdef)(label(\"(\"\")\"))(mold((out \
+         c5d29f83-17c4-48d5-819c-84eed91dc53e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         5785985f-dc89-47b1-9a52-fe2a3bf0973a)(label(enforced))(mold((out \
+         a11046ee-db3b-4da2-a70e-09bc229d4790)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0369b425-00c0-45fa-a989-0814d3b6150e)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d3f0918c-fb84-49b3-9db4-9c5abfd4086a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         720bb6ea-0032-4e1d-9938-963382a1874f)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         231bca4e-ccc8-4743-9e54-2ad8f6277683)(kind Checkbox)(syntax(Tile((id \
-         c3df5b7a-821c-4fda-b2a1-6c83d7f074b4)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0e2ed7ea-da62-49b2-8e58-fc72823e9cc6)(content(Whitespace\" \
+         \"))))(Projector((id 302f2c22-9236-4e04-84dc-f49f0b2e18de)(kind \
+         Checkbox)(syntax(Tile((id \
+         c94ac7d8-3544-4c3c-bdb8-8b845b1c03fc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         3d4e8d05-3bfd-4933-a921-368f2f5c6732)(label(false))(mold((out \
+         893628a4-ad2b-4eda-a33a-be6518fde008)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         e42f43a0-3c57-43f0-9f2d-c8ee98d38ba2)(label(,))(mold((out \
+         4bdcd24c-08fa-494e-8816-df54d79741c5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         18bcd021-8682-41e8-9e85-113df3d1f26b)(content(Whitespace\" \
+         a142484a-70b0-43a3-97dd-cddd43fdef5e)(content(Whitespace\" \
          \"))))(Tile((id \
-         389a4856-b7ea-4ecc-b931-c7a27a40c703)(label(\"\\\"nrows(t2) is equal \
+         ca8a960c-63c1-48ac-8e28-48b69094d943)(label(\"\\\"nrows(t2) is equal \
          to length(ns)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         75ed6b9b-7f1c-45d7-88d4-0d9a293aaf20)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2b376e9f-898e-4372-b06f-0bcd8d405012)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6d354f0d-0746-4810-987e-07786bfbeaf1)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         585ea4d9-7a58-45b3-868d-fa7dcf8d5fb8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d949b1d1-3fef-48dc-a256-00105845e434)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         3f424aee-e19c-47e7-9cb2-50ffe7665282)(content(Whitespace\"\\n\"))))(Secondary((id \
-         37b9e1ce-7702-4b98-906f-0fb870a3b1a4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2b90fe45-69a0-4b31-8f20-9fb30c06df57)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6c692f34-c02e-4e2c-9e84-9a3af273e66c)(content(Comment\"# We drop rows \
+         6cbc0347-6b4d-4789-b499-cf6cd7dc9b1d)(content(Whitespace\"\\n\"))))(Secondary((id \
+         4999523d-afa7-4760-a642-e03270bbe8eb)(content(Comment\"# We drop rows \
          that are out of bounds #\"))))(Secondary((id \
-         bea29f8e-6367-483d-a4d8-1e4cbbdba5a4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2e30b492-b23d-4d07-9c4a-17b18bcb7c97)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0e21c41a-8f54-48a1-b6da-25971d1b3649)(content(Whitespace\" \
-         \"))))(Tile((id ccf27c93-604c-4364-b2d3-2cf205c4df44)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         18b6d867-5b3f-4021-b6b9-4d754896214d)(content(Whitespace\" \
+         9baaeb09-1611-4eba-8d36-92d0272d2727)(content(Whitespace\"\\n\"))))(Tile((id \
+         e3289450-e020-4723-9944-e56179d0a794)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ae4f5ab6-b0a9-449f-9627-32bbc7828180)(content(Whitespace\" \
          \"))))(Tile((id \
-         65fd4291-4131-4f9f-a1e7-7952c40652e5)(label(select_rows1))(mold((out \
+         611b8ec1-d35f-459d-a5ff-d923455e8831)(label(select_rows1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d8690c29-d620-4ad9-86e5-1ca8d55377af)(content(Whitespace\" \
+         62fc96df-d9b6-43c4-addf-fa731366779e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0b60da8c-5e9b-4a2d-a674-e6e2df2062f7)(content(Whitespace\" \
-         \"))))(Tile((id 69d3b885-c45e-4bc5-b7e1-82e49377ab7e)(label(typfun \
+         60121bc7-3a7e-49d4-84b1-9c8d634ccd97)(content(Whitespace\" \
+         \"))))(Tile((id 7e0efa72-d26b-429a-a5b8-e1451afb127a)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         51b4ffdf-67ed-432e-9638-c8ea8e1a6b3a)(content(Whitespace\" \
+         069ac236-e7fe-47b5-96dc-4cf0e595e652)(content(Whitespace\" \
          \"))))(Tile((id \
-         301f9b8d-f47c-4f5e-904e-e3b95b195588)(label(r))(mold((out \
+         54674445-aa42-4bdb-94e7-be34311d6b38)(label(r))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         f9cbe7d7-001b-46f8-9f9b-c7e76924f408)(content(Whitespace\" \
+         f9e54900-10e6-4f83-8f72-3e64070eeb16)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0d9d97f8-7753-45ea-8242-2078f5255469)(content(Whitespace\" \
-         \"))))(Tile((id ab886eb0-133e-459d-a4de-89aac2ba68d8)(label(fun \
+         27d0188d-115b-4df8-98ac-e366ed058579)(content(Whitespace\" \
+         \"))))(Tile((id 5da11f44-14f6-4973-b042-217c82dd97d3)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         8d7f5760-ed86-47ca-930f-d9aff3c1a544)(content(Whitespace\" \
+         6a64b31b-614d-4157-8e68-c49cb63a1e61)(content(Whitespace\" \
          \"))))(Tile((id \
-         c842e1b4-9312-4f59-922e-fb727a89d7bd)(label(\"(\"\")\"))(mold((out \
+         92fac7f0-f60e-49d2-b86e-c6baffab4f63)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         19347e23-de75-43de-97e8-24be515a5a12)(label(t1))(mold((out \
+         7827dc51-e122-489b-a60c-44d00232af98)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         e3163233-80ce-49d2-80cb-8bf8f9ba82dc)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f82d8271-70d9-4473-8013-66da5c39610f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e193b3ab-e5f5-4f90-9b1a-a34a43162ed3)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         f57f28d7-9ab4-427b-8bcc-648a1d8da7ae)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         1a604f91-4624-4dd3-ace8-bb971ec745ad)(label(r))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         262d4912-4f49-4ebb-b2e5-e6bcad6448a3)(content(Whitespace\" \
+         \"))))(Tile((id 45d8b002-84cc-48fc-9d8e-7ec400a2d25c)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         586b3808-093b-403d-823a-ee4dbfa154e9)(label(r))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         fedd8b94-104f-4d1b-8148-0b2f01d5f503)(label(,))(mold((out \
+         fda8eea0-e19d-41c5-bd47-eddad4971f08)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         a5deb424-fb38-433f-9962-7aabb6f9319d)(content(Whitespace\" \
+         bd62d78f-aea0-436e-b027-cbe56895225c)(content(Whitespace\" \
          \"))))(Tile((id \
-         c343a428-76a0-41f1-b707-f0fce32640b6)(label(ns))(mold((out \
+         31d43d12-0892-4efc-8576-9a983403867a)(label(ns))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         42870bef-ec3b-4c32-ae6f-13dac73eedfb)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         d4a37c3b-443d-4106-8d8c-1ccb0ed82f35)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1a97f337-70db-47a0-a467-edb7f2ad2810)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         81520546-cb72-441d-aed0-d003a9c32839)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         7927bc38-16bf-49c6-996d-fbff1524b30c)(label(Int))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         45d70622-4a0f-4cd1-9c68-bee0b4eae9be)(content(Whitespace\" \
+         \"))))(Tile((id 1ca28645-a49d-47a4-be63-6adeb8fa2a4d)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         a9e8341a-f5c3-43e0-a89b-9575c7a4ccf8)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         95960dd8-7d6f-437c-b7a9-4980cac03577)(content(Whitespace\" \
+         20cca94a-3cd3-475d-96c1-b18a59487ccc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         be3d4681-488d-42cd-b724-56e766020420)(content(Whitespace\" \
+         298a8767-eb6b-4ba5-ba36-56053bfb5147)(content(Whitespace\" \
          \"))))(Tile((id \
-         d3bad458-dccf-4aac-8b1d-669f3ad88546)(label(map))(mold((out \
+         eed5ee3b-3c04-4589-a55c-0050f3a42e1c)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7afd126e-8b22-4150-8c57-602f78d6ba1b)(label(\"(\"\")\"))(mold((out \
+         913b8310-4b36-4f8a-90f0-bc43e32da317)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2971d44a-ec28-49e8-8219-9af58ce9ad2b)(label(ns))(mold((out \
+         f6761764-f383-424c-8c50-620c7dc84d59)(label(ns))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ae1fbed1-5fcb-44f1-8119-aed1dd802f6e)(label(,))(mold((out \
+         4eaef3e0-21e1-4c42-a6d1-63158849c890)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0b18bfe9-047b-43d2-af01-15d5d729cb5a)(content(Whitespace\" \
+         6351dbd8-45b7-46d2-a99e-873264656f0b)(content(Whitespace\" \
          \"))))(Tile((id \
-         103c3246-0341-4270-8372-e6af799a21a0)(label(nth_opt))(mold((out \
+         ea84ca82-561a-4825-89f2-9d1b23e49ddb)(label(nth_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b279c9b6-ad99-47a6-8c73-8220864c7d37)(label(\"(\"\")\"))(mold((out \
+         2e534782-a7e8-4f1d-9d77-e68f3c0310bb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         91627c18-fb94-4baf-8aab-fe1e83fd97e8)(label(t1))(mold((out \
+         b3cac46c-5d09-4b23-9c26-bb132445d408)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ce483004-6dbe-4ded-8e93-60dca5ed0c5a)(label(,))(mold((out \
+         0bd320cf-649e-4f79-b7b3-6764abd8f1e8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         546a3814-7846-450d-b79b-0cd0483c8554)(content(Whitespace\" \
+         b8fbb0cc-2445-451c-b2c2-7ce9ab3f76ec)(content(Whitespace\" \
          \"))))(Tile((id \
-         56fb51c8-8107-48ba-b89a-870552829dde)(label(_))(mold((out \
+         1eca7437-b162-42b6-88e2-4350b5c68661)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         ab12c098-733e-4a57-a63b-079251acd498)(content(Whitespace\" \
+         d4179655-39f0-4ef4-9022-737d085743fb)(content(Whitespace\" \
          \"))))(Tile((id \
-         0a768881-9d77-4e40-922f-1b93f9582606)(label(|>))(mold((out \
+         30b09e72-adf4-4c8c-8ee0-144550d670c3)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         38024be1-80ee-418c-875d-eacf3da86006)(content(Whitespace\" \
+         41c0acf5-9dfd-4793-beee-99ec5db8c76d)(content(Whitespace\" \
          \"))))(Tile((id \
-         a7d043d4-ab45-43f0-a054-92fe7b0fc52a)(label(filter_map))(mold((out \
+         c5bd58fd-4100-4391-a2c4-361e3b849fa7)(label(filter_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         838f374f-88cb-4805-8057-3503cc8a9ac9)(label(\"(\"\")\"))(mold((out \
+         a945e564-f1e1-45f0-b3be-1d7c8268cd28)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9073a07d-160e-4def-ba42-cff600b6481b)(label(_))(mold((out \
+         f71074b2-be61-48a4-a5a0-466de079e3c0)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6b8b263b-d22a-447c-a8c7-b1bdcdbd5d41)(label(,))(mold((out \
+         9a6827d8-5b7a-4b9d-9186-87c65555faa9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         94d8b524-56d1-4642-b49d-d7b62f99c5bb)(content(Whitespace\" \
-         \"))))(Tile((id 854640cf-4e19-4b28-a4f8-2fd2b228cecc)(label(fun \
+         25c149a0-69c4-461c-b6e3-a07aa6366748)(content(Whitespace\" \
+         \"))))(Tile((id 873ed1e8-359d-413a-965a-1c56b13439c2)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         6f375889-ee94-4e75-93de-fd8113e13921)(content(Whitespace\" \
+         6cc3c3a3-e182-4e9e-a0af-3e1fd956a8cf)(content(Whitespace\" \
          \"))))(Tile((id \
-         8bbfb3c5-1121-4434-8be8-c0b1b7eb3f9a)(label(x))(mold((out \
+         f17ab8cd-43bf-4a17-a2c2-1045bcc1cc61)(label(x))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         4f5c4b8e-c739-41f5-865b-d8841a3620e8)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         c20930cb-0f33-415a-8752-e659fcaa5526)(label(x))(mold((out \
+         4dc142a3-f582-4a08-90e8-8b071a28c23b)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5c29960d-a75c-427d-97ce-bc4a5d9c1e2e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a5ca42a0-7d86-400b-9376-ca65a5a616f0)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4046bcf5-ff5a-426c-ac39-cc31f72fbaf0)(content(Whitespace\" \
+         603e6e8d-c370-41ca-8178-227e4498e28a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         60ccc649-273d-4faa-a7ab-6be2bfc5cce2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b54f3e85-db32-4459-b9eb-fa71218d2006)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1da2abcc-3747-4233-910a-6f0feb81a265)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e401018c-cf06-4835-82d5-729dda874bd1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3c9ade6e-4ee6-47c3-91b9-9fac046556ee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2b4a1b2c-1272-4c9d-8ca9-ee8a49c150a3)(content(Whitespace\" \
-         \"))))(Tile((id b2d8e931-79c5-406e-8533-f7c5ec029d7e)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a4c02f83-3706-452c-86b4-c07b929cd2fe)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0356489b-7c23-4fe5-8e27-6c9cd9d67d4e)(label(select_rows1))(mold((out \
+         cae1c666-8ea2-4db4-a628-8a649f9eae31)(content(Whitespace\"\\n\"))))(Tile((id \
+         b47a213a-1133-490e-bba6-b7ab79dca02a)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         f0a5e8ad-45e4-40ea-9c87-d174e179bf45)(content(Whitespace\"\\n\"))))(Tile((id \
+         597113fb-7480-49f2-b3e3-a510a145e3a0)(label(select_rows1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a1de9207-90e4-411a-96d8-a34b57247fdc)(label(@< >))(mold((out \
+         63cdb359-fc76-4c4b-a820-4969797b14c7)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         51e1651d-a2ce-465f-b603-eb48547f09c6)(label(Student))(mold((out \
+         a9279e58-e188-4dc3-a256-8e8fa9e6e81c)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         4f14ab31-9f3e-479b-977c-f854f2e802fd)(label(\"(\"\")\"))(mold((out \
+         d0302ef2-e7a3-4391-84a6-59b042e3b114)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         56da5c6e-5277-490a-8018-41b7087fad71)(label(students))(mold((out \
+         5b05f750-4866-4825-8025-2ee8b9309d9c)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         264915ee-c222-4a52-a9e4-8839225473af)(label(,))(mold((out \
+         8b5c7813-2c1c-40cd-aaaa-f6f1e494e533)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         95a02a8f-7b9c-493e-a2fd-6b4a2c7eb36f)(content(Whitespace\" \
-         \"))))(Tile((id b3aa13c3-f250-43c8-a971-0af66462095d)(label([ \
+         75e5f7d1-823f-4210-95ef-8104693857d5)(content(Whitespace\" \
+         \"))))(Tile((id 4a2b6c1a-0ff9-4df4-bc35-c39ae7fbbcc7)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9fba5184-4c50-45b4-bc5a-e232a34f1e5d)(label(2))(mold((out \
+         06505b5a-9bd9-48bc-be7f-598c42486961)(label(2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b9b6e32b-2f1f-4890-9a8a-02e707a24af1)(label(,))(mold((out \
+         9099316b-7ac2-43e6-85c7-54dd7cf827e8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         84e830d4-0dfc-41c5-b4ee-5ca0d121e149)(content(Whitespace\" \
+         4aaeb6fd-51fc-4958-9ff1-e92248fd2949)(content(Whitespace\" \
          \"))))(Tile((id \
-         53e0aa39-89ea-4731-b00d-1f354ec0bf94)(label(0))(mold((out \
+         d4835fd8-2889-4e25-b87b-1c595c4cf85f)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         749ad6a4-dcd5-40bc-9c60-e9b369cc195f)(label(,))(mold((out \
+         9203c5bf-74f0-4838-805d-f06872647340)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         982f45ae-714c-45e6-9b10-c0bf39cb0729)(content(Whitespace\" \
+         a576e3a8-73df-47fc-817e-a2950dc83df1)(content(Whitespace\" \
          \"))))(Tile((id \
-         9d092c2f-51a6-49c0-81ec-1c01fc2c8d29)(label(2))(mold((out \
+         28cb7dc4-5f8b-4ede-b761-4bbb53e611ef)(label(2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         abed2baf-d2da-4037-9a1f-9ed11c24a5e7)(label(,))(mold((out \
+         5b4c6419-3a2b-4dee-bfa4-c9ffd07b5df5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fdf7582a-702b-48b8-88b2-6a06d708c761)(content(Whitespace\" \
+         1573d71b-8b44-446e-80c6-555a3d9c3db9)(content(Whitespace\" \
          \"))))(Tile((id \
-         393d5989-34b7-4e1f-b7cb-5c08afa4ef42)(label(1))(mold((out \
+         d62c3c60-4712-442f-87a1-d428a5c4fe85)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         166e38ad-3908-4ec0-a89d-5a3e0b716ac3)(content(Whitespace\" \
+         f5a10ccc-583c-4dca-ae74-f80de80cf621)(content(Whitespace\" \
          \"))))(Tile((id \
-         66209729-4562-4ab8-a906-50912f10e47d)(label(==))(mold((out \
+         a39c8907-d510-494e-b06d-2ce38a51b74d)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         93fbcb36-6c6e-4b79-a5d8-8d4b20756182)(content(Whitespace\" \
-         \"))))(Tile((id b9fd4e1d-ce43-4a55-bc31-276ddea9e1d2)(label([ \
+         1666652a-31c2-46fd-9e78-bc2528d7e1a2)(content(Whitespace\" \
+         \"))))(Tile((id 22562626-6ef8-4520-b4a2-1312d18a97b7)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         74439269-3861-449d-90e9-cdb30762c54d)(label(\"(\"\")\"))(mold((out \
+         52cea668-02c4-493e-9229-e7f52fd32960)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         161024d8-d646-44e0-b1c5-38d6a2e062e8)(label(\"\\\"Eve\\\"\"))(mold((out \
+         c3597d23-d5f4-43ee-a0bc-78042f461d3a)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         de64ec25-5440-4a6d-bcdf-4decbbb69797)(label(,))(mold((out \
+         49be4068-57d0-4ea4-8af5-88eef86f0404)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         54014ad1-ac01-44ee-912b-105ad0d3f23b)(content(Whitespace\" \
+         4c4694ec-57a2-4f35-bba2-68aca23564bf)(content(Whitespace\" \
          \"))))(Tile((id \
-         94233d3c-2948-4f85-ab70-dff706ddcaec)(label(13))(mold((out \
+         71febd69-daa7-4d06-9511-453404625b2b)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a8e20233-5b1c-43eb-8494-89ac6d6a56a1)(label(,))(mold((out \
+         a6c504fd-0fb8-478d-bc9a-1ebbeb2f91fb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c3dc29c3-90cb-4fd4-bfa7-3b3e5d7e2076)(content(Whitespace\" \
+         e0d9d620-89ee-4b52-a549-1697bdda7c08)(content(Whitespace\" \
          \"))))(Tile((id \
-         32c98b30-e689-4093-8fdf-acf373b81bf9)(label(\"\\\"red\\\"\"))(mold((out \
+         1d86504c-ed1a-4ed8-8ca6-fd0ebf31206a)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         4fd1f99c-46da-4676-8834-ef505cafdc5a)(label(,))(mold((out \
+         fd9c7e78-de00-4ff1-943c-a4806764afc8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4f94314a-dcee-4a08-9629-3708ed084ce0)(content(Whitespace\" \
+         df884d0c-0335-40ba-89e2-256d4ddd7d78)(content(Whitespace\" \
          \"))))(Tile((id \
-         cf4f970d-de12-47e4-a399-223e5d8578e3)(label(\"(\"\")\"))(mold((out \
+         ddab41ae-c78a-4cd4-aba0-fa4a47a73ff3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         5d7461ef-bb3c-457a-93a3-409f90fdc183)(label(\"\\\"Bob\\\"\"))(mold((out \
+         55fe7c18-7b17-4a52-b262-9288d717ee2b)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d5c80488-00f1-49e2-9ebd-7a5dc181cf37)(label(,))(mold((out \
+         cc061a3b-b9e8-46c0-86a1-b9244ab544e3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         87ab8e16-f080-4490-a83f-c1f6c21a3f18)(content(Whitespace\" \
+         aafe582c-87ee-4004-a2cd-c3a66d8c3068)(content(Whitespace\" \
          \"))))(Tile((id \
-         f3d611a9-7830-4aaa-8002-fb7ada135628)(label(12))(mold((out \
+         9b4f5e79-2e49-4cec-bb46-866b1b9bf2b0)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         708a53db-f83c-4e9c-9b4f-04026e161efa)(label(,))(mold((out \
+         53f56278-fd0c-4060-a7bc-4ef93773d6d1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         44f12c83-f832-43c9-a4f0-5c03c44d8f43)(content(Whitespace\" \
+         6c0f23b4-1efc-47db-8c2c-38418679e8aa)(content(Whitespace\" \
          \"))))(Tile((id \
-         a7086915-5eb7-4cf3-bed6-fa0e99dbe520)(label(\"\\\"blue\\\"\"))(mold((out \
+         9be41397-2254-468d-8196-ed47c05299d9)(label(\"\\\"blue\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d9aed30b-23d9-4373-8179-8430906fb569)(label(,))(mold((out \
+         9b785e60-dd8f-4b9a-b936-ba999ae6d94d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2ce1eb2e-4098-40f8-90f5-c1e4a4a8506f)(content(Whitespace\" \
+         7cd33ae1-6547-450a-b9fb-eb6166c670e2)(content(Whitespace\" \
          \"))))(Tile((id \
-         b276130c-cedf-4c1d-93bd-5dc84537c89c)(label(\"(\"\")\"))(mold((out \
+         f99d8844-721b-487d-8baf-017cfcc0f32b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         2bd1b62c-1cd0-44b1-8fe5-ffa4710b836a)(label(\"\\\"Eve\\\"\"))(mold((out \
+         18b41cd2-cc76-4785-a0e6-f60a10726738)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         8e847837-32e4-47ee-a8a1-94bc873f43fd)(label(,))(mold((out \
+         ed89d580-6ed1-4590-9efe-b4c07aca6683)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c98e3e64-95cd-48cd-95c7-b5dd5a42698e)(content(Whitespace\" \
+         e4686db8-8b8b-4822-8391-58b0054f6453)(content(Whitespace\" \
          \"))))(Tile((id \
-         5504401d-c2d2-4b94-b057-38849ca9048e)(label(13))(mold((out \
+         3f19527d-67d1-4bcb-8337-6edbc8e080fb)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         69470d2b-401b-4661-b2b3-c61af6e55b06)(label(,))(mold((out \
+         280371db-10ba-4936-ab32-dac295f2d519)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e3258c2e-bf78-4231-821a-5850569d01c3)(content(Whitespace\" \
+         a7f49ef4-0133-4040-84fb-7de6e6b3ed94)(content(Whitespace\" \
          \"))))(Tile((id \
-         6ee20ac3-5739-465a-b7ea-d7638c62f0bc)(label(\"\\\"red\\\"\"))(mold((out \
+         ac7ecdab-fc6f-41db-b9fb-3e512c615a0b)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         423950d4-d2eb-4246-98ec-9cc07ee1f1be)(label(,))(mold((out \
+         95e0616b-97ab-48a9-a82f-cb0283f71c58)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6d57217d-d7a0-4bb6-9311-aec6fcb88c05)(content(Whitespace\" \
+         c9878173-efd8-45ae-8a1b-4bfae3539526)(content(Whitespace\" \
          \"))))(Tile((id \
-         ed0aeeeb-d97c-4f4c-b502-d2f3217ab406)(label(\"(\"\")\"))(mold((out \
+         9c924166-3005-45b8-b520-ba51ee1133cb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         1a7b62cf-a3df-4acf-ad51-a937370b2660)(label(\"\\\"Alice\\\"\"))(mold((out \
+         11902aa0-51ee-40e1-8148-9d02c6f22f0b)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d7ca883f-0bf6-4ab0-b7ac-b5e9ac9f31c3)(label(,))(mold((out \
+         2b2b4354-f2f3-4b01-8ae7-345393c01c33)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3c4b35fa-0a40-4c45-b512-3b74d6c9ddc8)(content(Whitespace\" \
+         0ac428b0-2661-4bf8-924f-99c0027ee8fd)(content(Whitespace\" \
          \"))))(Tile((id \
-         01218854-7a7d-40a0-9dc0-f7ae72709282)(label(17))(mold((out \
+         914e7629-9d5b-4f46-9c76-34801233bd21)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         48dc1a7a-3bf5-48f0-aa9f-85c73b5d7bdb)(label(,))(mold((out \
+         884941b3-9343-493d-992d-02527a2a6210)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fc4360fb-7906-49db-89c4-5a9384f31525)(content(Whitespace\" \
+         32c13f7c-3486-4a87-b223-7cf571d24029)(content(Whitespace\" \
          \"))))(Tile((id \
-         44eb8006-4bab-4754-9855-eae581259a56)(label(\"\\\"green\\\"\"))(mold((out \
+         4047f092-5e1f-47bd-b262-b2c8bc5a9069)(label(\"\\\"green\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d130a02d-669d-400a-966e-d725654c75d1)(content(Whitespace\" \
+         0296d868-b855-4845-b7a5-ce37db69456c)(content(Whitespace\" \
          \"))))(Tile((id \
-         fc561ed2-10be-4902-8706-dc9f4c7b2ec8)(label(:))(mold((out \
+         08e6e46b-c786-4713-a13a-a1064f89dda4)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         45567e35-3eba-4f79-a330-2f809ebc5d77)(content(Whitespace\" \
-         \"))))(Tile((id 6e8a2a12-0e70-42d4-bfd7-513a4c7b35b4)(label([ \
+         6cd9fb7d-f61f-41ce-afce-5bf4780ec5a0)(content(Whitespace\" \
+         \"))))(Tile((id 97279a75-0a21-42b9-83c5-dd0c59ee773d)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         9ab1db71-f21a-4f1a-a8d0-3ac924c4ff75)(label(Student))(mold((out \
+         4e155896-fcc0-4634-8d08-99be00c19fe9)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         9d581820-c82d-4419-8589-4bb6e0184bd1)(content(Whitespace\" \
+         4aa9dfe3-b645-41dd-8141-ad00c9761b1b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a01ef56a-b0cf-49a6-a5c7-b74cbdc4cbec)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a9a878ee-d097-4647-a572-5f8fa7c23345)(content(Whitespace\"\\n\"))))(Tile((id \
-         4621b627-505b-426d-8c88-4e738da4e4b7)(label(let = in))(mold((out \
+         a908d42f-9986-443f-ac26-8e3388a6c225)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d14708c4-ffd4-4c0c-b5e7-c06750c25826)(content(Whitespace\"\\n\"))))(Tile((id \
+         eeaef0bc-b876-41b5-af04-96943aa34eb1)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3b1164db-a096-4dde-b09a-fa292a37cec8)(content(Whitespace\" \
+         16bb1b6b-a5d7-4384-9c2e-6f9a941feddb)(content(Whitespace\" \
          \"))))(Tile((id \
-         aae3add1-f629-46b7-9604-0ac633f3da17)(label(select_rows2))(mold((out \
+         eea1e543-38e8-4801-91bb-5250e607093f)(label(select_rows2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         41964b6b-84cf-46e4-bb21-28f4367ccb5a)(content(Whitespace\" \
+         3dd297c7-46c7-4ebb-a322-351d7b670ee9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2f28dceb-e3a2-44b0-9070-c63c673602ca)(content(Whitespace\"\\n\"))))(Secondary((id \
-         723a64de-69c4-4fe4-8f37-084056b69ac2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ccdb107-5719-4287-a0a2-30fc71994a37)(content(Whitespace\" \
-         \"))))(Tile((id d3851632-738e-4ed7-a120-6206e3b88db4)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         a1082e01-3b83-4661-8346-a4880c33c3d9)(content(Whitespace\" \
+         acea7fe0-999d-4989-9241-a84c3641b3f8)(content(Whitespace\"\\n\"))))(Tile((id \
+         3474d65b-21f5-4f30-bc09-34f82f7e7733)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         45c74793-15e0-4782-803d-09eb1c051cfb)(content(Whitespace\" \
          \"))))(Tile((id \
-         cbc8deed-88d2-4712-86ea-7252358400ca)(label(requires))(mold((out \
+         32320bdd-c21d-4fb8-a454-b52b20057845)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         67324bd3-caae-483a-8479-86af1df1cb83)(content(Whitespace\" \
+         2a4a44b9-8a84-454b-9b9a-a648b35b8d77)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2c66cc79-9ff7-4bc1-b6fd-08a50b05f3a8)(content(Whitespace\" \
-         \"))))(Tile((id 59521b04-a864-43bc-8e8a-2544255f37a7)(label([ \
+         89e30070-ed0d-4605-b627-688cdaac28b4)(content(Whitespace\" \
+         \"))))(Tile((id 1fcb5cca-d0dd-4694-8564-beeb74f48389)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         83eeb0ee-43c4-49c6-bf5f-d28855cbe21c)(label(\"(\"\")\"))(mold((out \
+         b9c33c19-fb18-42dc-baee-d0d502e36241)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         098a6e20-d55a-4930-bd5f-0d0d22751671)(label(enforced))(mold((out \
+         a3cb3048-77d7-4066-ac9d-c92c0922ac35)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         dc43d87f-17c4-4a3f-9cb9-3ddcad9d1afc)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         80d8fa4c-192f-40b7-8723-9da296b15316)(content(Whitespace\" \
+         \"))))(Tile((id \
+         52a7571d-cf69-49c1-8e5c-56115332e088)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         5fa7f075-dc38-41b9-b5ca-c1ff62db8ec3)(kind Checkbox)(syntax(Tile((id \
-         3a630434-eb69-4920-a791-1a3a2a33bc14)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         14dad802-a43b-415f-8d90-698e5e5282be)(content(Whitespace\" \
+         \"))))(Projector((id adfdb440-2769-4268-9f3e-9bca437b01ac)(kind \
+         Checkbox)(syntax(Tile((id \
+         3c51476f-ae98-413b-b9b9-f92d9fcf3c9a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         7e3f6cf3-f5a4-41da-a8b5-21362e165a7c)(label(false))(mold((out \
+         87edc3f6-8ad0-4313-a69e-df0a3d005514)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         63c51624-73bd-4ed0-969a-045d1894eb2a)(label(,))(mold((out \
+         38666352-aa74-4a8c-8d7e-f9676eeeeec0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         01a64d0e-0db0-41e4-9ff5-f264592d8be6)(content(Whitespace\" \
+         cd015e1e-9dcd-437d-9e0a-50d1277c0e26)(content(Whitespace\" \
          \"))))(Tile((id \
-         e9d1b588-a4e0-4cf3-9dfd-d27e8867b8d3)(label(\"\\\"length(bs) is equal \
+         1f635c8a-dcf1-4ad3-8c0d-f2a327329dd4)(label(\"\\\"length(bs) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         93fc42e7-a410-4f1a-ba92-90b142f37267)(content(Whitespace\" \
+         8185463d-418f-4545-8901-a6ad8813706a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2d965ce3-82ac-4b49-a196-6ca77b5c3d1b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b0708c05-0af7-4c26-adf7-c15deede5a08)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3d0e7891-5c7c-49ba-9d88-8fb643288a48)(content(Whitespace\" \
-         \"))))(Tile((id 9f8e637a-d21b-411c-b54d-47f02e2e8cd3)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         41ed8177-29a8-4b7b-9a58-d0048e39b36c)(content(Whitespace\" \
+         d5a223d4-9779-405a-b2fa-f0be76723685)(content(Whitespace\"\\n\"))))(Tile((id \
+         aaaebe30-1bc6-4688-aefa-6ed4454d9f80)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         f0c8c5f5-9915-490c-b2b5-0b588d992a3c)(content(Whitespace\" \
          \"))))(Tile((id \
-         687202b2-b500-4bca-907a-88276391f9ae)(label(ensures))(mold((out \
+         4e785169-f360-4e1e-afe1-5ddb27fd4729)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         95e7a8f1-46e0-4f0b-802d-cd411bfb5813)(content(Whitespace\" \
+         b3c35053-0554-4caa-a52f-1ac04291a96d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         12ee5cd1-4b75-4ed7-82b8-2c9e17ce6636)(content(Whitespace\" \
-         \"))))(Tile((id 3a5fb332-1113-4cc9-8eb9-d4a56e774af3)(label([ \
+         c2522dd7-4a24-4851-ba96-9707443c8284)(content(Whitespace\" \
+         \"))))(Tile((id 2695d788-0b24-4e29-9ad6-af5c1009116f)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f8fed899-98bf-491f-949b-d331be814748)(content(Whitespace\"\\n\"))))(Secondary((id \
-         268c6183-7b7f-44c4-9008-afd9709a48fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c428fefa-ee98-4dc0-aebf-4f8aa821ae5e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9ee295c-7686-46c7-8564-aaec4e32eb61)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f902b328-6e53-4875-bb06-65f70f1130cb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         86c580ef-11e0-43aa-bfaf-c2483f1e50ef)(label(\"(\"\")\"))(mold((out \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         267e8789-eca0-42d0-8650-07d65a2446db)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         39e6bdaa-fd16-4982-884b-b37030a63bf8)(label(enforced))(mold((out \
+         2b4c05aa-c5ae-458b-98d6-133da74012b9)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         48423a23-7284-4d7e-9417-2b077c9ba774)(label(=))(mold((out \
+         7ec1fe4d-ebf6-483e-a8dc-fac19e7b1055)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         28d87761-d74a-4dca-92ab-e02e1070ead6)(kind Checkbox)(syntax(Tile((id \
-         1a73087b-cead-474a-b4b4-9eba556bb36d)(label(\"(\"\")\"))(mold((out \
+         88e3799e-4c8b-4261-bdfe-3e3b2d34a26b)(kind Checkbox)(syntax(Tile((id \
+         df26fcec-1281-42e4-a70d-d4d94d8ad3a5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f659a730-1206-4cf6-8887-ccc4b79530be)(label(true))(mold((out \
+         267cb1fa-f3c8-4bd7-884f-f5ddda79e8d2)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         0276bb06-9f53-4732-8a0e-dfa63779ae98)(label(,))(mold((out \
+         cf6b7f0c-3c71-4a5f-af3a-604ef38aa31a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d310b32a-3d04-47ff-93de-718f1c4da022)(content(Whitespace\" \
+         6261b2ed-5ce5-43fc-b68b-bc61b386b8f5)(content(Whitespace\" \
          \"))))(Tile((id \
-         24c614af-2c35-4b0f-ac84-70cb3b5acbf4)(label(\"\\\"schema(t2) is equal \
+         4efa991d-8207-42a6-9417-155fd42af15e)(label(\"\\\"schema(t2) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         20998035-3a64-4d27-bb82-49638f2f062a)(label(,))(mold((out \
+         d5885e60-55d2-4536-ac9c-236327af2d65)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d2a01bfa-c254-4f3f-abe3-778507d8866a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         dd9bcb88-ad0f-4e5d-9fca-60c08641c2c4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f80c39ef-e584-4e14-a4fd-ab58c3329c11)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8648515-7f35-4e4f-9a57-659293c009d4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         37891b2f-4ee8-4e08-9b65-4d031c448fbb)(content(Whitespace\" \
+         8a79e40c-dd66-48a3-ade3-95ec210d4afb)(content(Whitespace\" \
          \"))))(Tile((id \
-         33684e74-dae8-48bd-815d-f8759e05ae07)(label(\"(\"\")\"))(mold((out \
+         7170e991-a780-4568-ba96-db4f8b79f2c0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         6a004bca-c9de-4c05-b12c-bf14d47a4ce0)(label(enforced))(mold((out \
+         2ba13b36-8dcc-4099-b211-b2d4bc6d947d)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         83ea19e8-a4fe-4a4f-81f5-b3bc8dcb0f2a)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         cffd373b-d107-4dd5-81c4-7db89d856fe6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1541db59-27d7-4720-bf0c-f3371b2a7c04)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         14c5683a-3e6a-4b83-86ae-e480312919c0)(kind Checkbox)(syntax(Tile((id \
-         b36f3820-98fb-4be1-ba50-c18067ae70f5)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         844e939d-dc33-4d29-8de9-7cd5fe8e00eb)(content(Whitespace\" \
+         \"))))(Projector((id ba8b5bf9-4cba-4d88-8da2-8bacb8cd4171)(kind \
+         Checkbox)(syntax(Tile((id \
+         27b5014b-a296-4d1c-940b-2d0302a3572d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         78188f8c-893b-45ca-851d-4428e97820bf)(label(false))(mold((out \
+         2a733cba-2ca3-4872-909e-978767382f53)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         9281ac8d-423f-4595-bdcd-5fdef74a16b5)(label(,))(mold((out \
+         9e12b2e6-aa30-4099-8bc9-32da2d73f2b3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f60f5873-83f1-4bd7-a30f-f5da39ffeade)(content(Whitespace\" \
+         8340c148-7fc7-487f-9d21-c563d2f40f5e)(content(Whitespace\" \
          \"))))(Tile((id \
-         23a9d859-b659-4bb3-a780-3511925fde8a)(label(\"\\\"nrows(t2) is equal \
+         676dcd85-d9a9-42c6-8979-d9501bbe84cf)(label(\"\\\"nrows(t2) is equal \
          to length(ns)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e5a83a01-a005-4a5a-94a3-6e91b98fc4e4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4f762fd8-f00e-4556-816a-b12e5efd7e26)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         62754157-846e-422d-b9d5-11e9733d8c88)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         91b6e1ba-866b-43bf-a706-9b017e1d9312)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         930571a8-49c7-41a8-a332-e9cda1f1709c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4b701061-a9ad-4cd2-8a41-f3d21e5e53df)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7a427992-e7d4-4263-8964-351333d2e1aa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ddb2b694-7989-4525-b6d9-392015aee0c8)(content(Whitespace\" \
-         \"))))(Tile((id 0367e63a-14b6-4fb7-8ebd-0c272358ffa0)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         65fd259b-1b36-49ff-83e6-2fbd1edf9a69)(content(Whitespace\" \
+         739a622a-ee93-4cc5-b64f-77fa685c0278)(content(Whitespace\"\\n\"))))(Tile((id \
+         ef61c1cc-22aa-4b50-8a1d-f96ff4919456)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9196577d-a334-4c30-a951-8b704fe35e3d)(content(Whitespace\" \
          \"))))(Tile((id \
-         1477dea8-a262-4d66-badf-1e34713aa935)(label(select_rows2))(mold((out \
+         38177cad-91f4-4b44-9b03-c7f08d7d3fe3)(label(select_rows2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ade0b9ad-d825-4867-a272-121d80779b37)(content(Whitespace\" \
+         21b2d9a3-84eb-41f1-b9fe-a1874fdc3a7d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         396ed6b3-7a7f-4854-992e-e488cf1ea635)(content(Whitespace\" \
-         \"))))(Tile((id c68e4170-e1da-439f-bce5-1c59bddc33ab)(label(typfun \
+         eef14bb1-b6fa-4632-a6c3-bfec97ce4819)(content(Whitespace\" \
+         \"))))(Tile((id 80f12884-0afb-4f4a-8ed5-85126e4d294c)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         dfd071b5-c684-45bd-9241-5c107dda09a8)(content(Whitespace\" \
+         0b691dc2-cf31-4cfd-af73-824086b733c7)(content(Whitespace\" \
          \"))))(Tile((id \
-         857bbdf1-5a8e-4bea-95c9-b04a310035c0)(label(r))(mold((out \
+         95111692-4823-4c84-ab53-92bf8ab8d7d3)(label(r))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         64ef53ba-bd7a-419c-b015-ecf0087962b4)(content(Whitespace\" \
+         c4acf249-f930-4a7f-b494-65c0a99d31c2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         049c981e-054f-4c82-879b-97fd69a695ca)(content(Whitespace\" \
-         \"))))(Tile((id 3bf59150-7b86-45f2-a14f-6508b57a3eb7)(label(fun \
+         adb3a3fc-2fa5-4376-aa21-f4669759e73a)(content(Whitespace\" \
+         \"))))(Tile((id e1e020de-2f15-416f-bb13-371bbf89fe39)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         864bbee2-5aaa-40bc-90b4-7cc8a9750b0a)(content(Whitespace\" \
+         aa79da0e-c220-4229-8008-5a0e620306a6)(content(Whitespace\" \
          \"))))(Tile((id \
-         e6bee806-1232-4731-99ec-2f4487ecdf63)(label(\"(\"\")\"))(mold((out \
+         9bc6edc6-5038-4d63-b93e-8bd0928f2375)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         16acd09d-9299-499e-8928-dd4160ac230e)(label(t1))(mold((out \
+         588f3119-9879-420b-af73-1bb34329363f)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         05cbd853-26c5-40b1-b3c9-bf11a71c539d)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3cefa36d-b3b4-4adc-9c7e-e7cfdc9756f0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5cf72ee1-d5fe-4fbb-a9c2-4d551ac5799c)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         39c60a67-829f-4a70-8974-db10a5063911)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         a495c6c8-8909-4bfa-ac63-bd2e0f964b16)(label(r))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cdda9c93-4fd8-4215-b772-8165967b9d32)(content(Whitespace\" \
+         \"))))(Tile((id 40c1b5f3-6296-48da-85b3-efbf12bebf78)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         c75e1116-f7ac-48b1-a42e-e0ce5e34758f)(label(r))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         d9bfb5a3-d28e-4567-9a14-7b977303846a)(label(,))(mold((out \
+         2df38316-f104-4595-916f-d9cedacd3b11)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         fea7983a-1c4e-4b63-bf9c-2420d9124b57)(label(bs))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         a72d0bca-0150-4224-ac0a-b6ec691d3e56)(content(Whitespace\" \
+         \"))))(Tile((id \
+         913a4b2e-29ea-4195-b06d-6d6acd342ea4)(label(bs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         236e5737-fb63-401f-bc0a-99a422b5f482)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         37baa4d2-8c69-4d0f-90a9-7e8ffbdeb7db)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0333c6cb-8d95-46d0-9635-306ed9f497c0)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c2912b97-77c4-459b-8121-6b0972b80a33)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         c0276a2f-58a9-4803-875f-bab6b1a86227)(label(Bool))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d4ab7b0a-27d8-457f-ad4d-dea5d2f54c90)(content(Whitespace\" \
+         \"))))(Tile((id 9d2d0ebf-010e-4dbf-926c-2ccc6ea2f2f1)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         d02e5f6e-21b1-422b-b191-24dd08ec04bd)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         2c24b3c7-2c51-4c73-9079-076f1f107921)(content(Whitespace\" \
+         a12996ba-8922-4c0c-bdad-76b3661552f0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         54421bef-3c64-4c3c-9d5a-7b8e64a2ae3c)(content(Whitespace\" \
+         d24ac4ec-4261-4b61-96db-24f6acc2cd4e)(content(Whitespace\" \
          \"))))(Tile((id \
-         ce939b7e-3391-4905-82e2-08da9aad5e28)(label(zip))(mold((out \
+         a47d4676-1dd1-464d-9a85-92b03cd7ba2c)(label(zip))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         2af66e6f-a04a-4ce8-8d8d-dddffd5bfd47)(label(\"(\"\")\"))(mold((out \
+         f60c1997-d593-41fc-a9a5-27468d9ffe50)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d2e594f4-c9be-4419-9e18-04b50da4eb00)(label(bs))(mold((out \
+         49802529-31e1-47b8-ae0e-6233d72e6827)(label(bs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         fb83d9ac-8fe4-4e56-86ce-6fae99120fab)(label(,))(mold((out \
+         a429cf06-593d-4fde-8bc7-6b06743b55a1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8941d7e1-4d32-4305-86cd-8a5aef5b962a)(content(Whitespace\" \
+         84210d33-3e92-43f2-b891-3ab5d862b2f2)(content(Whitespace\" \
          \"))))(Tile((id \
-         11627aab-39bf-42f5-a42f-20ff83666d31)(label(t1))(mold((out \
+         2a52cd9f-b508-49e1-aab6-e38fa392bb8a)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         31d48cd8-779b-445c-aaff-0894e7777d21)(content(Whitespace\" \
+         564c3d0e-ed65-4d99-82e8-0f6b56e05b83)(content(Whitespace\" \
          \"))))(Tile((id \
-         95bf878e-18c3-43a5-82c4-7e50d87ad8f4)(label(|>))(mold((out \
+         875c2bb1-fcb9-45d5-a26e-4a2048627d1d)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         285d5dcd-f29d-496d-b82b-245d1209dced)(content(Whitespace\" \
+         1d8b8c0d-8eba-45ca-9b20-0b7c9eaf70e5)(content(Whitespace\" \
          \"))))(Tile((id \
-         4d56c980-be63-4bb1-b8af-f0ef4b65f24d)(label(filter_map))(mold((out \
+         2a8e312d-f036-4233-844e-a1aa7d4596af)(label(filter_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b3655b00-bb9e-4a47-a457-0143547725a8)(label(\"(\"\")\"))(mold((out \
+         a4077bcf-03c1-464a-a80d-bd6f96ad6f1d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         34c20e57-8747-4719-91a8-4f08facc96e5)(label(_))(mold((out \
+         d22b3345-ca7a-42be-b7cd-6542cecf1d5e)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         960f8b9a-bd73-461c-b531-ac748d2c7b25)(label(,))(mold((out \
+         d165e64b-9545-4e9c-8785-2e109a95444d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7d977471-39e2-495b-94f9-15d25808506e)(content(Whitespace\" \
-         \"))))(Tile((id 690296ca-fe55-4bfa-9773-e1e162ed9a94)(label(fun \
+         d20c981f-5499-4fac-b10c-f60f18c521e5)(content(Whitespace\" \
+         \"))))(Tile((id 8e53ce27-e603-41e0-abb3-44e73981a50a)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e927e2a1-97b5-4855-af71-056c262bb5eb)(content(Whitespace\" \
+         a10255c4-adb6-4600-8a17-fa7efbe06e5e)(content(Whitespace\" \
          \"))))(Tile((id \
-         dd9328aa-83ed-42d4-bb4a-1fdcf29b0e14)(label(\"(\"\")\"))(mold((out \
+         b905d795-e957-4b95-8f8b-1e25ddb0db28)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         a90e1292-7ed6-4693-993e-3018bee3bf4a)(label(b))(mold((out \
+         f9a294c9-7551-4016-bef9-c5ea418c621f)(label(b))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         89a0201b-6398-4ab5-8f19-5b5f68623887)(label(,))(mold((out \
+         85a26e98-8bb7-40e5-b378-2a478b912697)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         9752a66c-8dd4-47f9-9cf8-580b6c4e9fe9)(label(r))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         314f72cd-76ae-4b55-a28c-5afb888d520b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         826b496f-fb5d-4359-8635-84584092df8c)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         3fa9e6a9-2f90-4c3e-9286-8afc61264ea9)(content(Whitespace\" \
+         f197b3e5-5a68-4383-8f09-0aed9b781453)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         10451612-8067-419e-b21f-8e79635bdcb3)(content(Whitespace\" \
-         \"))))(Tile((id ab598c78-30f6-4045-b026-aa13c532223b)(label(if then \
+         5a4c8d62-614f-4cb6-9b1e-aa891d9886a7)(content(Whitespace\" \
+         \"))))(Tile((id 0a58c9ce-0764-4d9e-972d-8cd1718faf49)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         d98ce3ee-3cb3-448d-9b45-4f2176fa7d28)(content(Whitespace\" \
+         cacde991-6dd7-4a72-800d-35db996e6873)(content(Whitespace\" \
          \"))))(Tile((id \
-         1c70b709-38b5-4170-8ace-47777466cf69)(label(b))(mold((out \
+         a3972661-1daf-442d-86cb-9bd4e2a24b6e)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         af6e267c-8a73-4f92-820e-a2429dd63cf5)(content(Whitespace\" \
+         7a4360ad-5f75-42fc-8a2b-ce5be3050a76)(content(Whitespace\" \
          \")))))((Secondary((id \
-         fb86f0d3-d4cf-4f1a-8d51-27ad2a88ca94)(content(Whitespace\" \
+         4d1985db-7d70-49f5-975a-2a740ab081d0)(content(Whitespace\" \
          \"))))(Tile((id \
-         2ad6879a-2192-47ea-aeb7-a2476efc943e)(label(Some))(mold((out \
+         10077566-814d-44c6-96f2-16aeb042a087)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         9c39c003-c08e-413e-b78d-beebf46e9222)(label(\"(\"\")\"))(mold((out \
+         d8e43a37-03a1-46d8-aa35-e46b443bcaec)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2b2e153e-151a-424f-9ae1-1cbdcd1276f1)(label(r))(mold((out \
+         417f2806-bbeb-4a28-a547-82e176237e14)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f4b3d0e8-e10c-4b6d-9475-83280ce3d468)(content(Whitespace\" \
+         cf543088-ef33-4b12-9146-f73cec5629db)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0b8f47a3-73ba-4784-943f-f7ed1d5b5e2a)(content(Whitespace\" \
+         da83b896-0cac-40df-977f-fa7cc4788596)(content(Whitespace\" \
          \"))))(Tile((id \
-         b8a1713f-90a1-4781-990c-2c21a55272b7)(label(None))(mold((out \
+         e3a11e6e-8ecb-4583-a2bd-b5c565667d53)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         84614b88-5d23-4a84-8fbb-7fe966320e14)(content(Whitespace\" \
+         ada7ced1-6832-49ca-b9f1-8f6a55b95403)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f5dca149-7179-4c26-a746-4923c33b7723)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8801a066-2c08-4c4a-908d-375fa5447990)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3c0635ce-415a-4463-9df2-677291af29a9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9d6374cc-7cbd-4396-91a0-42055e9ce4c8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d4d91883-cd88-468f-83aa-fb927318a8fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8bfeea0d-fc60-4028-9731-4a552cbce628)(content(Whitespace\" \
-         \"))))(Tile((id 187b1d8e-2eae-48f6-9e8c-1bd4a30d2449)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         d56038fc-e3ee-4ecd-bf64-3e0ea3fc5012)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f1e280b5-c762-4ad3-a251-ee84820ece25)(label(select_rows2))(mold((out \
+         10b8ec70-a67c-4881-b445-b266d2a2fae8)(content(Whitespace\"\\n\"))))(Tile((id \
+         fa7a7e94-5137-4f08-8b99-25763b36a345)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         a306e9c5-55a2-41d1-a1d7-faffa71ecec5)(content(Whitespace\"\\n\"))))(Tile((id \
+         418a0af3-fca1-493a-b404-df3a1262d04f)(label(select_rows2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         cabcedeb-156a-4ffa-a65e-c5c6568553a6)(label(@< >))(mold((out \
+         e7bff636-58fc-4c8d-bf01-24bd44cfdc1a)(label(@< >))(mold((out \
          Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9ff26f63-2d3f-4e39-94d6-c6b0d89e2fd3)(label(Student))(mold((out \
+         a6b1d054-ca70-4046-8154-fda67502ab2f)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         606d66a0-ef6a-47ff-bd0c-78728dd04cac)(label(\"(\"\")\"))(mold((out \
+         ff705eb2-1476-4737-93cf-7e2b53828833)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d7cddbd0-b4ef-49c0-85a2-e9644ceed568)(label(students))(mold((out \
+         a8eaaec3-6156-44ae-85b8-2f0922b25621)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         dfb12391-0717-4953-9590-0deb369d979d)(label(,))(mold((out \
+         7d8dc6ce-7c03-40cd-a8ae-d2c56da14dca)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         17552020-2c87-4acd-8272-47e0882633a1)(content(Whitespace\" \
-         \"))))(Tile((id 1dd17b69-1a73-4d29-878f-b0c78efcb203)(label([ \
+         d3068792-9178-4044-b844-1f2fd4ffd079)(content(Whitespace\" \
+         \"))))(Tile((id 2cb71f59-8eb7-4ac9-b7b2-1e682c8f6ee1)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         fe7fe713-90a2-4df4-91b4-dbd59f1907dd)(label(true))(mold((out \
+         2b282ded-e191-478b-afdb-8f93869fcbcd)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         33d4c885-5898-4e6f-ac00-43a89ac1d333)(label(,))(mold((out \
+         00b7021b-006b-45ef-96a2-656f6ddd0d10)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         88b48e66-670b-44d8-bf34-6196a2f44fe5)(content(Whitespace\" \
+         79abe169-35c2-4958-8df0-9d0018fd8a54)(content(Whitespace\" \
          \"))))(Tile((id \
-         95134410-a705-47e8-93f0-d5bc2183edd9)(label(false))(mold((out \
+         41b3f52a-5a07-47f3-9e6a-9ceff566b486)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4fc0d251-2eea-45fd-afcd-0d315f1666cd)(label(,))(mold((out \
+         06dd6ae7-5661-48f7-bba6-6a42ff2ac204)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b147a061-8e48-4439-b1c7-320cffb57d9f)(content(Whitespace\" \
+         5c85bcd8-320b-4f2a-9a60-e5fd9b16671f)(content(Whitespace\" \
          \"))))(Tile((id \
-         9a7d47c0-53dd-4cce-9848-8a94f64f7bba)(label(true))(mold((out \
+         8f312f0f-71b8-4686-9c24-ea1865d53ef5)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         f4268d18-3b57-4ea7-9411-bdfe9b57b4ee)(content(Whitespace\" \
+         bcf7fcee-7f07-44fb-b360-a674e5595590)(content(Whitespace\" \
          \"))))(Tile((id \
-         4d54974f-fd3d-4e43-9f81-0da070d2ad80)(label(==))(mold((out \
+         0050efff-b8c8-42bc-9b60-4c3974f0fd63)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b17c4bbc-c989-41b7-9cfe-d00ee4cf9dc1)(content(Whitespace\" \
-         \"))))(Tile((id 9f8fe7ad-7b4e-42f5-95ed-e4aea4dc19af)(label([ \
+         459c0ba9-8563-416b-a9a2-b979dc8428c3)(content(Whitespace\" \
+         \"))))(Tile((id 7f23d560-a98d-4b4a-b7c1-8b33af57805c)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         0cfda4c3-1c91-4df1-8470-dcd781abd182)(label(\"(\"\")\"))(mold((out \
+         9fae97bc-59b3-4ae6-9ac9-2206359a30b4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         64006aa6-19ee-457c-bdb8-5624655da9c8)(label(\"\\\"Bob\\\"\"))(mold((out \
+         8626bdc9-05cf-4121-a1d7-fdfd874ae33f)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         480d87a4-30c3-4001-865c-cefe3d01d82b)(label(,))(mold((out \
+         70e12558-0c82-4df1-aae1-4d5dc036b39b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ae40f4bd-fb81-4900-b5bc-58ff2af578f7)(content(Whitespace\" \
+         6bf09679-78a7-449e-a5f4-ed377faacc86)(content(Whitespace\" \
          \"))))(Tile((id \
-         9ae3763c-3cf1-4de6-a447-437b2b7feca7)(label(12))(mold((out \
+         afc41dc2-b562-43e8-8574-6d3820b6929e)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         be35e012-d49b-47b2-ba24-28366da1dfd0)(label(,))(mold((out \
+         8c9b07fe-8f79-454d-8c1d-cefc0c72d916)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c15f642e-c1fa-4f90-bdff-6132aad07682)(content(Whitespace\" \
+         6b7761bc-1c57-4193-bda2-efb3296c3aaf)(content(Whitespace\" \
          \"))))(Tile((id \
-         3497186a-9307-4d9d-b346-8d1e1d5cd7c4)(label(\"\\\"blue\\\"\"))(mold((out \
+         93dae2ad-e1fc-4c3a-888a-c9402fe330d1)(label(\"\\\"blue\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ccbf1690-cffa-436e-bca5-5c47d1f99376)(label(,))(mold((out \
+         cc890530-0d9c-408a-ae98-1328a60eafd5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0269522e-c282-4013-8391-e6053533e444)(content(Whitespace\" \
+         c046567f-5fe6-47b6-bacc-8d3101b7105a)(content(Whitespace\" \
          \"))))(Tile((id \
-         eb3bb299-df4e-4959-a7ff-567bcfe478ca)(label(\"(\"\")\"))(mold((out \
+         2c7d485c-3bb8-4803-99bf-fef1d2daf856)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         22fcd9ef-74cb-469a-a62f-596a43ab4e92)(label(\"\\\"Eve\\\"\"))(mold((out \
+         2e1693b0-5a91-444e-9a20-289051801bed)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f16e9444-d078-41cc-8b74-40ace0b80761)(label(,))(mold((out \
+         78160988-4939-4db4-8513-c7003a213329)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e7cb18d2-1bd1-4853-8585-4a6b4265f46e)(content(Whitespace\" \
+         348f17c5-1b16-47f5-8d50-bed05e000df0)(content(Whitespace\" \
          \"))))(Tile((id \
-         2765e7cb-28cd-4eee-8cd8-6dd4207a5d38)(label(13))(mold((out \
+         195f33e5-eca1-40d8-b8b9-dac61b9793fc)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         98b8bc17-7bad-4905-96dc-0d8233709bdd)(label(,))(mold((out \
+         f9ee1cf8-9d45-4f92-ac74-ad503aaab148)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         55ce20ee-b6a4-4fc6-825e-390e6862c1f3)(content(Whitespace\" \
+         4ed9aebf-4600-4d60-99c0-8af3bd91300c)(content(Whitespace\" \
          \"))))(Tile((id \
-         77f03d50-0162-48f0-905e-2bb405df8b0c)(label(\"\\\"red\\\"\"))(mold((out \
+         2490c968-01f1-4878-9386-51476aa60c60)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         fefb5958-3cd8-409f-bc0d-37026fde9a31)(content(Whitespace\" \
+         46f45489-ac7b-4c86-a227-8392dce09e76)(content(Whitespace\" \
          \"))))(Tile((id \
-         a6632fab-672a-40b4-969c-3b06ce448e2e)(label(:))(mold((out \
+         cbc73463-7515-4e4d-88f4-1026ec508531)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b94ed8ad-d161-44ee-b1b2-64c1fb0a87fb)(content(Whitespace\" \
-         \"))))(Tile((id fdf88448-d479-4c25-abfe-f4038071b063)(label([ \
+         bbc17a46-0211-4a2e-9022-13cafe0e5b1d)(content(Whitespace\" \
+         \"))))(Tile((id 83166463-0251-4d88-b561-a7bbbe9a5e36)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         a3ed3891-04b1-48ee-94e1-e916589fd5fc)(label(Student))(mold((out \
+         b9636c9c-ce50-436b-8847-0e3dd6728b5b)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c7d9cf97-c39c-48de-a6f5-4c97b702db8e)(content(Whitespace\" \
+         5ad2ae42-58a3-4cbd-b4dd-0e5072ed431f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         efb338d6-8494-4d25-9499-5b261a0740a1)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         e3c8ef53-4360-4ab7-8222-3095b5826506)(content(Whitespace\"\\n\"))))(Tile((id \
-         d8c0f7cd-cebb-412f-811c-4e5d1b587062)(label(let = in))(mold((out \
+         5ac0e349-920c-4dfa-b890-e8826cb374e4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7a0889f3-9bb0-4ae1-b92e-e04ea0d32861)(content(Whitespace\"\\n\"))))(Tile((id \
+         7a1e61c0-f08b-4cc0-abd3-983cb1806991)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3af8ac49-faa5-4dc2-b44b-3ce84aa8045e)(content(Whitespace\" \
+         217740d0-4c4f-4a31-9b12-c8f6c1d529ca)(content(Whitespace\" \
          \"))))(Tile((id \
-         f645b754-395b-467d-ad67-7c2c9462e7ea)(label(select_cols1))(mold((out \
+         fb9ba583-8505-4290-a2de-bb3dbc51d0ca)(label(select_cols1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         fe323f94-aa49-409a-ba48-d083d1e4ce25)(content(Whitespace\" \
+         934aff87-a6e6-49e9-890a-218cb69986bc)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7233e448-9d65-4619-91fd-961c57545c2c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7b211f69-4538-42bf-acc4-b8bd865c9fdd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         63514fa0-7f03-4727-bc01-7aecb8b66b94)(content(Whitespace\" \
-         \"))))(Tile((id 4e4a62d4-961d-4d1b-a763-c4f65800f440)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         95b963c4-583b-4af4-a0a3-1a638ad622e6)(content(Whitespace\" \
+         ef9874b0-f549-4cf4-b1d4-246f35aa51eb)(content(Whitespace\"\\n\"))))(Tile((id \
+         3360ea3d-2d42-41ea-a3ee-546ddaf46c2d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         1434cd7e-b285-4af8-b21a-397833dba170)(content(Whitespace\" \
          \"))))(Tile((id \
-         f11fe82c-c1e6-4808-a637-4311d61b0be6)(label(requires))(mold((out \
+         11f78c06-af48-4019-ab47-e388835deddf)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         070cc507-da82-4511-b188-0ef91b45158d)(content(Whitespace\" \
+         1f4ae0af-389f-4086-9b4a-c9a552b9eb84)(content(Whitespace\" \
          \")))))((Secondary((id \
-         93906d4d-0e55-4fa5-8854-26d7ff1411f3)(content(Whitespace\" \
-         \"))))(Tile((id cd22a019-38ef-4d22-a9e9-f6b775b0bf04)(label([ \
+         1c5b2993-116e-4090-92c1-01c5379de2f0)(content(Whitespace\" \
+         \"))))(Tile((id 46c9ac97-c091-456a-af49-7a068da46fb2)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         ed4527e3-e518-4a5b-9cea-eaee6dec63e4)(label(\"(\"\")\"))(mold((out \
+         8dba7335-4601-44c0-bdf7-4f6a70e75b80)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         a54fad2e-d4be-4517-8103-7ed8884b7c40)(label(enforced))(mold((out \
+         07033186-14d4-4f34-8f06-3123d694a58e)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         67f2cb3b-af3f-4b39-aa22-3c5c633aa05c)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9c2071aa-482d-41e6-940a-9ceb0dd1b43c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2167f808-bc57-4b82-ac2a-6f6e91e401f0)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         0fadbbc6-dc67-421c-8355-66ff0a82969c)(kind Checkbox)(syntax(Tile((id \
-         e13aea4e-fb4d-45af-86dd-7b3d83e4cffc)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4de5723b-8902-4113-b64d-dc72a8839461)(content(Whitespace\" \
+         \"))))(Projector((id 1e4418ae-2793-4fe9-84f2-c61ba45d7795)(kind \
+         Checkbox)(syntax(Tile((id \
+         392f2ff6-6224-4585-b80d-ea4fea188912)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         8a8d9a62-c954-4edc-8422-e6f67c8cb279)(label(false))(mold((out \
+         598096c5-ec0b-4eeb-ab50-e0dcc6104820)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         966ad950-ba28-45fe-b43b-3c40948f2160)(label(,))(mold((out \
+         4df64e25-62bd-4787-86fc-0fd16b3b4e0f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6c84de4d-7d26-4c36-a3d0-1611f0c35c99)(content(Whitespace\" \
+         bb3eda02-3937-4a51-b6bc-68070b40a80f)(content(Whitespace\" \
          \"))))(Tile((id \
-         07413788-a1a8-41cb-93c9-7b8ecbf30a47)(label(\"\\\"length(bs) is equal \
+         6751a812-b60c-4810-abf1-83e367e8e9be)(label(\"\\\"length(bs) is equal \
          to ncols(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         625c7938-0a21-4ca8-878c-a7b4be42561a)(content(Whitespace\" \
+         2c0201b4-48eb-41d2-b280-90d709365844)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         92e97145-48db-457a-9466-cf3276d25e1f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f4ff1d87-3401-44f5-9872-d46c20bc2478)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8ecd03d0-d8ae-43ec-807b-edf8d180a169)(content(Whitespace\" \
-         \"))))(Tile((id bcf7e90b-f0c4-4273-b3cb-89749a56f0e6)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ef4f8a6a-7b8e-441c-bb53-a3891c6a079c)(content(Whitespace\" \
+         199e47ae-b031-43fc-a6c4-c4cfa83cedec)(content(Whitespace\"\\n\"))))(Tile((id \
+         719396f9-f11c-4371-8ce7-8930f4d3c3a9)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ad9cfc8a-8993-4ff4-b275-628d59711232)(content(Whitespace\" \
          \"))))(Tile((id \
-         2bb0bd05-55fe-4564-9012-ac874ad9276e)(label(ensures))(mold((out \
+         cd1ee400-6428-4173-837c-c7ba592b2b80)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         05725c82-2558-4401-b916-c4293c0110dd)(content(Whitespace\" \
+         0e7ce93a-5d77-4637-bf5e-564663b164d3)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7d99442c-f6ae-404a-9f4b-a6d48501c928)(content(Whitespace\" \
-         \"))))(Tile((id c620fead-9f54-44b9-ae37-67521642f5f1)(label([ \
+         c25670c6-3d19-4070-9363-5446b26b11c2)(content(Whitespace\" \
+         \"))))(Tile((id ae591365-04e1-4558-a48c-ef8ad15fa834)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         361861bf-4be4-44ef-af2b-56f63e013d61)(content(Whitespace\"\\n\"))))(Secondary((id \
-         95df5be1-c43f-4b7e-86da-1e747abcb385)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         42610300-eddc-4755-8b86-cc35b6b63478)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         698ce59b-8702-44e1-8ecc-348ec74b2cfd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         18885614-d5e7-49bb-8ba2-31f23a50988e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f19aff92-3ffe-49a6-bf76-b13499ce204d)(label(\"(\"\")\"))(mold((out \
+         97666b57-a06d-4375-bbd2-48b5f670ab5a)(content(Whitespace\"\\n\"))))(Tile((id \
+         c183f404-dd33-491a-92d9-68a300d9b8af)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         df60c590-2af8-4c52-bddf-917b7e9513ac)(label(enforced))(mold((out \
+         98f53642-b5e3-41e1-b8a7-166ac2ef9bb3)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         65b7b315-7668-4632-9abe-c55e6744649d)(label(=))(mold((out \
+         616d5825-cd49-4339-b4f4-070ad6ea51f4)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         cde1de1c-4b8c-49af-91aa-ef0b1997d280)(kind Checkbox)(syntax(Tile((id \
-         98a21ac5-9b4f-4a48-a923-be22e922d19a)(label(\"(\"\")\"))(mold((out \
+         8b505828-6421-449c-aafa-c3fe9d53f519)(kind Checkbox)(syntax(Tile((id \
+         839b99bd-e4bb-480f-bb6b-1b9dce436c97)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         91a1749f-0eec-49b0-8da2-c2d74e9a86a8)(label(false))(mold((out \
+         fd995f08-cd34-4866-b72e-9101fb162c3a)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         18f687fd-bc01-4804-b66b-994f264ab967)(label(,))(mold((out \
+         f820743e-53ef-4e2c-9954-2e9d303d9c27)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b7abb468-4ca1-4631-b5b4-3cb9c13a67c0)(content(Whitespace\" \
+         1e483960-7417-41db-a750-701a7d31c654)(content(Whitespace\" \
          \"))))(Tile((id \
-         e1b1eda6-b206-420c-8107-2ed08ddc680c)(label(\"\\\"header(t2) is a \
+         c8447737-67ba-4e42-844f-614d72c64a57)(label(\"\\\"header(t2) is a \
          subsequence of header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         790f75d6-9295-49fc-b9d7-370300addf9d)(label(,))(mold((out \
+         ea2c3194-b40a-4fba-9da3-59d9207f2538)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2ad26817-1da9-4b94-845b-354a7dd5fcd8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         42f9639a-e492-4b2f-ae81-6eafc95e39bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4385d5c8-3e08-4f7f-bca8-c865c1123bf6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c215f94-1c9f-408a-ba5e-1e69bbb896be)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         29c037e7-b321-4c5b-88ba-85799e2a9543)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e0633e51-66c0-42d2-a7d7-36325eb3ad38)(label(\"(\"\")\"))(mold((out \
+         28eeffdf-cf35-4eae-a507-7b92932d5a08)(content(Whitespace\"\\n\"))))(Tile((id \
+         cb3fd9f3-6432-4521-afea-c477fe1687aa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         3080ce3d-0b42-4d44-8ddd-26a899866315)(label(enforced))(mold((out \
+         39de7f0c-7e5a-462a-807f-e686d431228c)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         908dd341-7361-4688-839e-f6905438f942)(label(=))(mold((out \
+         687ba0a8-35f6-47a9-b213-ec21b5adaced)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         9aa99497-7e59-4117-96e1-e330ea85f5e1)(kind Checkbox)(syntax(Tile((id \
-         b7442cbe-5024-4716-9bf5-fa0d6aa600f4)(label(\"(\"\")\"))(mold((out \
+         ebd4d9f5-36c4-4460-94d4-74360b85111e)(kind Checkbox)(syntax(Tile((id \
+         80f8a710-a785-4dd4-8457-21e4a81605aa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         cd530cae-4378-4357-84b0-97f92a71486a)(label(false))(mold((out \
+         404cafe0-13d6-471c-8110-8c8272642d9d)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         a6476aae-a340-40f1-9b77-1660060410f5)(label(,))(mold((out \
+         a1807461-479c-403c-822b-3e9a9c3d3177)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         08282163-fffe-4d90-bc83-098987ed639f)(content(Whitespace\" \
-         \"))))(Tile((id 872c39b5-5171-48dc-acf8-f6dd1fc0775d)(label(\"\\\"for \
+         c6563699-ea22-46d2-8b0f-c1397ed2059e)(content(Whitespace\" \
+         \"))))(Tile((id 99957dbd-e9f1-4318-b661-c0f87616df89)(label(\"\\\"for \
          all i in range(ncols(t1)), header(t1)[i] is in header(t2) if and only \
          if bs[i] is equal to true\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         c4168a07-aef1-4258-8e69-994583765081)(label(,))(mold((out \
+         d91ba7c8-7f76-47bf-8db3-9853faea6e6a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         923732f8-0bf7-4f43-9a2d-719bc139443b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1a1fe4cb-a64b-4874-973b-fb57a05ad57a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aae08a2e-5b6b-4b56-9707-2707f635bae3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9c1f7b17-8a53-41a1-ba93-22e5708b0cf5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7a8c4661-3ece-479c-beeb-074082899771)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c6cea233-548f-437a-b130-85750a7ecb89)(label(\"(\"\")\"))(mold((out \
+         08531865-3137-45db-a8f6-dd7e1f0da42c)(content(Whitespace\"\\n\"))))(Tile((id \
+         3eeabbb2-1c21-4431-861c-bfccf65899cc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         492f2023-5c05-4088-bd2d-bf5ed01acd5e)(label(enforced))(mold((out \
+         c5eac6fd-568f-4d30-9ae1-402f7000d360)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         814298d7-5c80-4b21-94a1-901efc3916ff)(label(=))(mold((out \
+         b1015a52-a9cb-44e9-8103-5693ed9f64a3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         61d3f315-0b1b-45d7-8333-c0c2dcc1026e)(kind Checkbox)(syntax(Tile((id \
-         533be29d-3136-430e-a95f-bc7a3fc8236a)(label(\"(\"\")\"))(mold((out \
+         b648ad1e-11c4-44db-b2be-c411efec2eb0)(kind Checkbox)(syntax(Tile((id \
+         3bb08e50-47f2-4118-ab1e-e827ac387639)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         4296af64-1ffd-489b-9c73-dc96692820ee)(label(false))(mold((out \
+         e59c39c8-9041-4a0e-a1d8-1a7b0d9f20ae)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         28f83728-522f-40e1-8d94-ec65a88298b3)(label(,))(mold((out \
+         6d0d65fa-d344-4fc6-aeb9-32601a49b786)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9ac96c69-6775-4af4-ab35-dffd0fbabf8c)(content(Whitespace\" \
+         29b380e4-3990-4108-9fb6-9c41c8d7f536)(content(Whitespace\" \
          \"))))(Tile((id \
-         8a59d19a-7302-46f8-9e09-88619768d0e8)(label(\"\\\"schema(t2) is a \
+         805be708-972a-4ca8-939e-7add32792158)(label(\"\\\"schema(t2) is a \
          subsequence of schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         94a47d63-2fdf-471f-89d7-bf46449b9c38)(label(,))(mold((out \
+         26518905-42d6-4485-ad1b-7f830e944cba)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         73f8199f-84eb-4617-aebf-d6cc55c52b0e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         31409485-d9f5-48c0-aac6-2ebea84df3f1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3683f6bf-31d0-49b8-8e5e-b9ff5931496d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac847f3b-3690-4505-b92d-9f7fe6387210)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         62834f02-39fc-4de9-8ecf-5b550697e83b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0bc5c05c-6cb0-4e22-976f-c6c12a4cd84d)(label(\"(\"\")\"))(mold((out \
+         78a1944d-b77d-4287-8e30-c00176e1209f)(content(Whitespace\"\\n\"))))(Tile((id \
+         ea5bc359-d224-4e8a-825f-749ac3b9baa6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         4a1bf2e0-f407-4120-b9f4-091e8a819dc9)(label(enforced))(mold((out \
+         04765e0e-3cd1-4c78-bd10-6bb61c51ef44)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         48cf317f-442e-465e-9feb-560a8af52eca)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         24472de5-2d78-4d19-84ca-84902e3aa251)(content(Whitespace\" \
+         \"))))(Tile((id \
+         905f8af5-d931-4296-a5ae-ce36beef78a6)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         ea4b6383-a15f-470c-b767-5f0720e5bb17)(kind Checkbox)(syntax(Tile((id \
-         5d16606a-13a1-46d7-ae4a-37a8c4a895e6)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         afda8ade-6674-419f-aa83-fa8044bccd0a)(content(Whitespace\" \
+         \"))))(Projector((id 1d56f2cc-e815-4a2c-ab9b-29f30780fbf6)(kind \
+         Checkbox)(syntax(Tile((id \
+         b09a3e6e-142f-4fc6-95fe-058c28e110b1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         3891fe7c-d13c-450d-afb1-7720d8de372b)(label(false))(mold((out \
+         9119fc38-5972-4d6c-94f0-b2778a9a4a5d)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         09499e3b-b97b-4a36-89cc-b3a3d9a4864d)(label(,))(mold((out \
+         bb3fa212-2994-4cd9-ac14-e9cafe8b9cf0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         559f524c-9a92-42ac-9931-20d8a93f2061)(content(Whitespace\" \
+         75163204-1460-4a87-a346-e5ac39825d04)(content(Whitespace\" \
          \"))))(Tile((id \
-         0a2cffa3-752e-4be0-b4f0-10ac9f755c13)(label(\"\\\"nrows(t2) is equal \
+         c2b8a04d-9f05-479d-85a7-d2ef52317d00)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         57b41e5d-81eb-4dbc-b1a0-9c04b7b4e2a9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3004fb2f-796a-4497-9938-13a506fe1798)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5722b417-f75c-4ece-9ae0-b8b1a82405dc)(content(Whitespace\" \
+         00a8397b-d485-4237-a426-79f0c923ccd5)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         59e7fe56-42a9-40b7-ac61-a7925d5f85bf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7e7e8be3-f0b6-4da6-8023-9be85e97a445)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         710bad26-e2d5-4973-8127-bdbfb86656a5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0beef836-1047-48a9-8ea6-5bcb23081829)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         278110ef-8dbb-497b-a804-96fa50f2ba5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ceaa6b8e-a153-41a4-b57e-26ca93e3e060)(content(Whitespace\"\\n\"))))(Secondary((id \
-         acaea2e7-725d-4410-b107-606f2f3e00f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e434ae24-63d7-45f5-a7ba-7a0fec6e194f)(content(Whitespace\" \
-         \"))))(Tile((id 93029f0a-1022-4daa-a2cb-763df3f86399)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         56944431-9c3e-4a1d-a1b9-480640b725ae)(content(Whitespace\" \
+         cb4b0a7a-b181-409d-9454-a98541f80a1c)(content(Whitespace\"\\n\"))))(Tile((id \
+         9a45b184-5eed-408e-83b4-f3fb7de50421)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         17b9449e-dff6-4158-bdce-9ae65450a51a)(content(Whitespace\" \
          \"))))(Tile((id \
-         cd437ec8-d64e-41c4-8ef8-4c7e22cd1213)(label(select_cols1))(mold((out \
+         c07a2dde-ad49-4649-ad93-33a873fd27d7)(label(select_cols1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         48c737b0-4fec-4edd-b5dc-fca64faea53f)(content(Whitespace\" \
+         78fe8981-2eba-4176-8179-e57db95550bd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d718679f-70e8-4b1b-8ba6-dfefd189dbe8)(content(Whitespace\" \
-         \"))))(Tile((id eda96ca2-0436-4485-bd23-1ae03264dea3)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         635ac184-8fcb-44f2-9003-d4005758ef63)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0ce716d8-1250-4d96-a44a-d941597045b5)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         24a54e08-8c37-4b81-9e55-c7313c87d835)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         e660e93d-0626-4d6d-a801-340b9ade6cfd)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2a290422-41e7-4d61-aa4a-966f801610aa)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         2a194d4b-3fe5-4a4e-a4d8-91d2b5e5d82b)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         fcc5bf73-7e60-4bd0-9585-f336842a2183)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         24b8b106-ba38-4831-90f4-4325b307440d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fe6dc406-a0a4-4666-beae-dce3bd4bfa25)(label(bs))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         7505c2df-f784-4335-873e-e63fab1bbfa7)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         132385bc-8923-42c9-91e2-5b9a23f9b9d9)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         aa86befe-53a8-4077-a1ec-8cac44591e8a)(label(Bool))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         c5cbef96-183c-4258-9736-73308e8cdc3a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         1bbff9e2-c0f2-4122-9994-2acfe1c593b8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         77d90d36-f4e5-4848-b6a2-dbf2464139c2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e0a302b-f5a1-4cdd-b7cf-c7c1d28ff316)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d690fb5e-fc27-41fa-a318-a6267f16a9d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61416877-2609-41f6-8de9-13218e9eb407)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c6b17f15-6da4-4195-aede-d64b505806bc)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d9e4280d-89b8-4e48-b37c-b5f854c751e5)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         aeefa624-056c-44d1-81c6-781b1ceb817b)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5b6acab5-f47b-4454-bc35-8d3737774180)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         eed21452-f88c-45ae-abd6-4a679e0e19e9)(label(fun ->))(mold((out \
+         a6d04d15-bf6c-4455-9745-f6b9333a7d3e)(content(Whitespace\"\\n\"))))(Tile((id \
+         cc7d5aa4-dfda-4d81-bdd5-36a7ccdd71ad)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         1afb80f9-d906-4f37-9465-04fbc1be0f25)(content(Whitespace\" \
+         ab2a76aa-5045-4b99-8286-48e2b7b3df65)(content(Whitespace\" \
          \"))))(Tile((id \
-         46b09435-fdf6-451e-a1f8-5e50777ca272)(label(r))(mold((out \
+         17cb041d-00b4-4937-ae91-aec2cc304ff7)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         ba995a53-372e-4170-9f1a-92323d28acbe)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5357a9c4-b675-4466-bfc4-426b6e18156a)(content(Whitespace\" \
+         ee69c946-8230-43d4-89c6-ec15a4fac768)(content(Whitespace\" \
+         \"))))(Tile((id \
+         afb1dee5-18ee-4cc8-882c-45b64b09e05f)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a6acefff-5a5e-420b-aa9b-ae8103f1abcc)(content(Whitespace\" \
+         \"))))(Tile((id fb2d3e0e-6d0d-4679-af09-a3f9f72a8cea)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         1b2f70f4-f63c-4983-9940-67fecfcc0208)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         776937c3-a8a6-487d-9c41-ca38a45e362d)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         78437baa-d025-41af-85cf-9d6e01f97425)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7aa2b72d-f44b-4b56-8f14-cc708039009e)(label(bs))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c1ec6a9b-ee1f-4f5e-a5ad-650944a4f2ad)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e24bf0c5-b2e6-436d-ad29-fa42c08260d3)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4af15790-8f70-45fa-95f3-44d2ff9e0c6c)(content(Whitespace\" \
+         \"))))(Tile((id 4eb2e75b-f1b9-4618-8c96-9fe876ad9a62)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         58faa388-d2d9-4cc6-a772-8e465ed75460)(label(Bool))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         a6ba64b7-4cba-4bdd-9004-80db36a3471c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         42597aea-d65c-42c5-bc59-3bf3db14d230)(content(Whitespace\" \
-         \"))))(Tile((id \
-         388a9792-9aaa-4ae7-9743-e28fa768eaa5)(label(to_lvs))(mold((out \
+         b47481aa-69b8-41e9-b3d8-04ff7a551bd7)(content(Whitespace\"\\n\"))))(Tile((id \
+         8a730ce9-26e7-4052-877d-1bcd14040dbf)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4cec55d7-e903-472a-ab19-2f099c078369)(label(\"(\"\")\"))(mold((out \
+         daeea979-46b0-4f8f-9fff-d712f0ad4ee5)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c7bb1d05-9405-48a5-8541-1f9315fd3b41)(label(r))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b4ab9cef-15c3-4ad4-97c1-9a2e6df499a8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         855aa01c-2671-4108-99a1-7adfc883fbd0)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a92158a1-e161-4212-975a-76b80f28f079)(content(Whitespace\" \
-         \"))))(Tile((id \
-         79c26e76-f7b2-41f9-9b5c-a6d0cb01d0de)(label(zip))(mold((out \
+         f24dae44-1d44-4020-835f-18fe41f30782)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b003252b-d61d-4d6c-9b45-629d4805f989)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6e592213-6123-41e2-8dac-8ce12f7bfe57)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         de6bc8c3-2377-48dd-8c6f-5860be739c28)(label(,))(mold((out \
+         b29151d1-2aaa-4eea-94eb-efc1215ef2ad)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1e5d3a10-d29e-4403-873c-13c417a2e4bd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2257f3ba-f4e5-408f-8ff2-21c4ca3d17ac)(label(bs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fc416be6-2a95-4dc4-ba18-f514caaeb1b3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4dde96eb-bdda-4b54-b57e-3814368baaa8)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         933d187a-e7fe-4be6-8302-01040e8d0fe1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         813dafbd-e4c0-41c3-80fc-879b46d4470d)(label(filter_map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d6ce8d55-17d6-45cc-a4c9-662e81069ed2)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8be39203-543f-4aac-aeac-c1f9a92c6404)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6d6946a4-2f47-4d33-ac1b-4a5ade379517)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         55d7335c-57fe-42bd-b775-7a81e713d1a4)(content(Whitespace\" \
-         \"))))(Tile((id 0757bca3-4089-45ef-92e8-433901d8e754)(label(fun \
+         5ec363c6-600b-4caf-bbb6-4ea7a40e0096)(content(Whitespace\" \
+         \"))))(Tile((id 6dac08cb-6132-4365-841e-34321415aa99)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         d0347099-490b-4f67-9e45-d38d963deae2)(content(Whitespace\" \
+         0487b4d2-ac48-4719-a13c-9a99017aace6)(content(Whitespace\" \
          \"))))(Tile((id \
-         c79e7f29-7233-4ffb-9dd9-eef9df02eff5)(label(\"(\"\")\"))(mold((out \
+         544d7f06-679c-46dd-b104-8ed2b24f97fb)(label(r))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         3c1534d1-4357-47df-81a3-552c2da33347)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5ecb7859-ab7c-4eec-8e2c-7ab8ace37da0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         40726593-3d7b-4ea5-933c-ed1579173c31)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6a4b865a-3bf0-42d8-bd66-b8f6217b4b85)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         7204d9d9-2b92-4390-8cf5-7855a122efbf)(label(r))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         a003801b-863f-424a-999d-5de69733d6eb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f9f5ac59-b859-4729-a25d-f4182dfaa717)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         51dd63ca-eeb7-4b47-9aa6-6a41b4a0b304)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6aeeb658-86be-4e2f-94a2-1fa44e012632)(label(zip))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bb499271-9e8a-4e7e-830c-b71668f192bf)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         742ee77c-bf83-42e8-a196-ac3d01d1e804)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5ed08aeb-7069-4149-8231-d1f468622335)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8511a806-4ad7-4166-a2e6-8b5eff6f188f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b5a7b64a-1d60-4b53-992d-50d96a03326c)(label(bs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         2dc7bdf7-86e0-4c48-bf3b-5c13b739f33c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ab50b0dc-dd8b-4001-be1c-adc981f4fb35)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         89c03f91-8ee3-4e8b-ab80-2e67c83fd4b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8f8f65c6-8cde-486f-a841-9b0ffdc75164)(label(filter_map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         77bc90e2-528b-4360-895a-2c5351e73804)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         865afc86-0ead-4128-8b48-0fe793fc5fb7)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2ed5222b-bb54-4f0b-a006-92cb6a627e9b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         abbdd77a-cf55-425b-bf9f-e71d1a1ff973)(content(Whitespace\" \
+         \"))))(Tile((id 3d71cc4c-5237-43c2-9a36-80287f0ff29d)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         3b347dc9-e0b6-49b2-918a-25516466bceb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f6008213-6c5f-440f-bab3-9a9d3ab8f47e)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         38131b9b-7c4d-48e6-8f24-ca62f6eac342)(label(e))(mold((out \
+         15babae7-1bd5-494b-9886-7ca3ad713c09)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         94890335-eb22-4fe4-a419-010b2b22c721)(label(,))(mold((out \
+         edb63f17-80ba-49d0-a471-bf73efb56214)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         9bc419e3-ece1-4bc8-b892-ccdc78a48162)(content(Whitespace\" \
+         2c855e4e-edda-4898-999d-7f1825d66b9a)(content(Whitespace\" \
          \"))))(Tile((id \
-         9aa5a4c3-773b-44d2-97cb-deda64647491)(label(b))(mold((out \
+         5020fca8-d1e1-4612-9180-9bcfdca9016c)(label(b))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         1fe8a100-6876-424a-ab74-bd9dd40560ff)(content(Whitespace\" \
+         3f476f34-86ef-4a12-a5ae-038a6996b407)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         77b7fa7e-e6d7-40e7-adf6-6cb38f757b60)(content(Whitespace\" \
-         \"))))(Tile((id cffc502b-428c-4970-ac0a-2827935f5bf7)(label(if then \
+         8c62161f-9595-4a36-a69e-8a0c22f92870)(content(Whitespace\" \
+         \"))))(Tile((id 09e67a8c-5158-48fe-8ce9-427313d24e48)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         b3908c74-42b3-4802-b441-19a8e91836c4)(content(Whitespace\" \
+         be29a060-a592-4bf0-b06b-b3b985bf2695)(content(Whitespace\" \
          \"))))(Tile((id \
-         06e1be00-19a0-40ac-8532-48f739133f96)(label(b))(mold((out \
+         b598d40c-4247-4282-9836-5751581f4197)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         fcdbbe2e-b08e-4672-b0ae-834164c354b5)(content(Whitespace\" \
+         23e869bc-181a-4448-ab8f-e261513b70cd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         91426084-e4fe-42db-863b-8b55e4ed85a7)(content(Whitespace\" \
+         6b4a53d7-ce49-4278-918a-d93fe99df0c2)(content(Whitespace\" \
          \"))))(Tile((id \
-         80151aba-9850-445f-b877-8783677861ee)(label(Some))(mold((out \
+         0643500a-8527-44e8-a9b0-5a72caaf8c3d)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ecaa8263-a469-462d-8caf-3abcdf7a590f)(label(\"(\"\")\"))(mold((out \
+         d813523c-27e3-4de5-a29e-af572ffb3508)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f8bd0f20-b555-4ec3-8a82-79a84f28a6c1)(label(e))(mold((out \
+         67fd756c-5715-40ed-bc83-4d63a4a95384)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1e38684e-d422-4dd8-aa77-384da1cb055d)(content(Whitespace\" \
+         bcb80bac-521e-4f65-93ca-a59928e94768)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         08b3c561-2a01-49db-b200-84d26e5c6ef7)(content(Whitespace\" \
+         1d0bf64c-2f43-43b3-a1a3-1137272f3d2a)(content(Whitespace\" \
          \"))))(Tile((id \
-         d2aa3cd2-a833-4492-89e9-14334360ef2c)(label(None))(mold((out \
+         9cb6702b-25cf-4fd4-a39e-aa4032969ccb)(label(None))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8f4a6878-e0e2-45b0-bdb7-eea00b1568fb)(content(Whitespace\" \
+         bea37afe-d10b-442e-b1e0-b99c45dc0a80)(content(Whitespace\" \
          \"))))(Tile((id \
-         597fac67-4c23-4044-9035-6e7d7936f750)(label(|>))(mold((out \
+         5f3f8a9b-2789-4339-9282-8420d79f2122)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         11709f8d-c53a-496f-bdd4-02f0f99d5739)(content(Whitespace\" \
+         d5c8107e-0a98-40ee-bb40-5eb228d54436)(content(Whitespace\" \
          \"))))(Tile((id \
-         a411fd4d-eb35-482a-bd7d-093c34148389)(label(from_lvs))(mold((out \
+         e6330865-44cc-47c5-b5a9-b7bebe9c7011)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         57d043c9-81a3-45e5-b559-e8c718fcab23)(content(Whitespace\" \
+         3cfdc118-1692-4195-8a88-a6f5de84ceba)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1d1d5b44-42ae-4276-b4a3-4688af551a26)(content(Whitespace\"\\n\"))))(Secondary((id \
-         59553b58-1aa5-440b-a15f-e6a47ecd8be6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e060b4b-1787-4ca0-be52-e1edd1ea74a8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         138a5dd4-d84c-4427-a4e2-9603667381f3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         85086965-4820-4fe5-9653-6711c8b0ff19)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0bf1d19c-f19f-4bc1-8bfa-7a05d83a059e)(content(Whitespace\" \
-         \"))))(Tile((id 56f7523e-8f72-4bd4-af03-f1cd7efd2e21)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         b5c951b6-e891-4ed3-a617-9e4f86358d67)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d5ceeb02-b087-49c8-9f1b-a7c91c85d0cf)(label(select_cols1))(mold((out \
+         c2f4370e-47f8-4053-8233-aad119d876ed)(content(Whitespace\"\\n\"))))(Tile((id \
+         8cd9d158-07b7-48d4-b461-6f164666cd3a)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         69ad7787-9f96-45dc-89f8-bdd3ea50f6f4)(content(Whitespace\"\\n\"))))(Tile((id \
+         4ff77496-6e26-4b60-8bce-0104a1f004f8)(label(select_cols1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         735fae86-6996-4af6-a23b-cad54eda7b6e)(label(\"(\"\")\"))(mold((out \
+         f1890ffd-0c76-4668-a215-2a98bf1fcb2c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         9156aa6d-524a-4564-bd54-57a28ef7a746)(label(students))(mold((out \
+         4fcee6e6-0eb2-4f20-9708-e6b94429e50a)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5b5f1372-78e6-42f4-b013-b74fa21070af)(label(,))(mold((out \
+         1f543255-4e3f-421e-8672-47a9465eb507)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         535c021a-cfff-4317-b8ff-39f46aa5e225)(content(Whitespace\" \
-         \"))))(Tile((id cd826343-07f8-4694-8162-df3c0b0e83ce)(label([ \
+         1abee1b0-34b6-49e2-ad0c-e3148bfa8a7c)(content(Whitespace\" \
+         \"))))(Tile((id 910c05bc-28ea-4a81-8be4-d8e1f813c554)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6a91a910-3fae-4a4d-9af0-1d56a2376d5d)(label(true))(mold((out \
+         42672552-f178-458c-81f6-f653750301a1)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         bdf48241-bddf-4136-9232-41e745c6da95)(label(,))(mold((out \
+         7dbd0b93-c23c-4521-9e4a-050093c32d31)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         15cb7642-4ec0-4467-ade2-e0b3016425cb)(content(Whitespace\" \
+         3c7487a3-4ba6-4ac9-a80e-52760c3368ec)(content(Whitespace\" \
          \"))))(Tile((id \
-         4d66c9c6-efc5-4600-8c79-6e6a13d63f6f)(label(true))(mold((out \
+         48d14c62-12ce-47e7-9298-f4fae2a76aad)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a18bdbfd-54e0-4a3d-8c2b-a918ef880d15)(label(,))(mold((out \
+         ea09f01d-ea73-4ac3-aaae-12ea1d43208b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fb14e245-c9be-4ec0-a9c3-dc5bb480634b)(content(Whitespace\" \
+         e46f6c4b-1cf6-4a83-9bc5-0eece3815375)(content(Whitespace\" \
          \"))))(Tile((id \
-         db0b314e-2abe-4818-95e0-b5ae0b4f3682)(label(false))(mold((out \
+         a68365cc-7c42-471d-a18a-3512b620dc16)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         c1c42eaf-0952-46c4-a5a8-cb0089991f79)(content(Whitespace\" \
+         1615ea02-9c98-45ce-896f-302b8861747b)(content(Whitespace\" \
          \"))))(Tile((id \
-         04630c41-617b-45fe-975d-6332764bed71)(label(==))(mold((out \
+         aa4c2f35-d995-4ee0-bbe6-ca69e93cbd29)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         be91a136-f30e-4177-96f6-16c0800584b0)(content(Whitespace\" \
-         \"))))(Tile((id 06137f1e-4586-499f-9c4e-a27caa0d5574)(label([ \
+         f4c60ac1-0627-40b4-bd7d-4d728d00c00f)(content(Whitespace\" \
+         \"))))(Tile((id 6a24ad0a-7708-4f26-a084-ecd5bff5db97)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         f8d844a5-26e4-46c5-b0fa-796b9db83b13)(label(\"(\"\")\"))(mold((out \
+         c40d41a1-8a47-4530-979f-a9286d4ffa84)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         46fa6858-8efe-42fa-b8e8-bb58079f093d)(label(name))(mold((out \
+         bb9a5587-a4bb-4b0d-b3d2-d9a4c3da7d2a)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         39780213-34f3-41f7-ba30-32d44a34e015)(label(=))(mold((out \
+         8fa63250-eca3-4502-bb92-31fd7ca06b84)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c98060c5-9b88-4b46-a0c6-ecea66cbb52d)(label(\"\\\"Bob\\\"\"))(mold((out \
+         59124b4d-5a91-4c68-839d-89ad50d26240)(label(\"\\\"Bob\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         2c12c836-663f-4b0c-b1cf-e80a459803ee)(label(,))(mold((out \
+         1b568099-5275-4fdc-aa96-f5bad217e621)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c4c176d3-b9e3-4035-991c-2e9d6df6111d)(content(Whitespace\" \
+         7ea9b5d9-5f14-454a-85cd-44b5f3f2c366)(content(Whitespace\" \
          \"))))(Tile((id \
-         1db2c90e-68ba-43eb-b02d-7c6e7283185e)(label(age))(mold((out \
+         3fc533f0-5ed4-4d84-a7ec-558c2eafcbde)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d50508ed-1664-4881-9905-671eb61d646e)(label(=))(mold((out \
+         c9c5e398-9ae4-4572-865e-4affcb7f0bca)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a47ac27d-05ff-4867-9b70-c55ab4a06015)(label(12))(mold((out \
+         efb92127-4815-4aa6-81c1-5728c680c310)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         4c077cbc-5dec-4d69-9287-6a4215af98d3)(label(,))(mold((out \
+         e75aab4e-489d-4ec4-8330-b67fbf46c895)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         88511a9f-fed0-47e9-a2a1-4fbb615d68f0)(content(Whitespace\" \
+         2f65b5ee-c351-45c1-9218-86a0d18cdfa1)(content(Whitespace\" \
          \"))))(Tile((id \
-         66e84276-5fa1-497e-b797-03a24b925f42)(label(\"(\"\")\"))(mold((out \
+         547b28c3-edcb-4468-b5fd-ce5346d742c9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d265f4d6-1bb0-4ecd-88df-bfa9ccc84ef0)(label(name))(mold((out \
+         bcf1299f-46b3-4488-993e-3894f05f2d7e)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f494f54c-5c6b-4e31-bc48-dc5f28fab810)(label(=))(mold((out \
+         2d3d59e3-5c49-4a33-838e-21b6386207db)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0053e303-479a-440a-a013-af4848a9f698)(label(\"\\\"Alice\\\"\"))(mold((out \
+         a114b62f-3318-428f-8b0c-bbcdb540e70e)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c7e486c4-3eae-446d-9ad8-4f145dbd0740)(label(,))(mold((out \
+         7105c0d7-c4a6-413b-8078-18d50685d388)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a647a7ca-065c-4940-9c74-75befda0dc1d)(content(Whitespace\" \
+         bd0b3004-d176-4947-b4f5-f62dcc8eb380)(content(Whitespace\" \
          \"))))(Tile((id \
-         79e0e67c-3cc0-4109-a61c-4acda043b14c)(label(age))(mold((out \
+         e7ca1540-7726-4d8e-8f54-c54c8bc43dd2)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         cf9c5493-fd54-4571-b3df-94f0fcc4db54)(label(=))(mold((out \
+         a7872336-5691-4335-a449-78388e593e7c)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         1ec293b4-c069-4ce4-a42e-8487f7ffd04e)(label(17))(mold((out \
+         05165dc2-3b28-49bd-908f-47e43dd4e4fe)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         4eb808de-dfaf-408e-9cb0-3d74417bd5fb)(label(,))(mold((out \
+         6f57ed12-34d7-4f71-a44c-1293a87bcc4b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0d8714f7-7066-439c-8919-0e8a44cc0ee1)(content(Whitespace\" \
+         12881ef4-8c4c-4bb8-82a5-c05cac93d9be)(content(Whitespace\" \
          \"))))(Tile((id \
-         a4620fd0-3971-4e19-ab27-ccabbe117a62)(label(\"(\"\")\"))(mold((out \
+         6e87dc94-6fa5-4246-ab95-4e4fd8e5afdb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d6edf278-bae0-464c-8d5c-2412b616c5ff)(label(name))(mold((out \
+         fe12b98e-2e97-4e88-a639-41708949597e)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         da9d7508-d0fb-4dcd-b969-b06391a37527)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         abc4c8eb-e351-4df5-ab3c-439c0bd3d50e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7364cede-0ab3-4cf6-9807-35ffad16bfc1)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a89f40a2-fab4-4542-9b3b-3ee3a99d3ecf)(label(\"\\\"Eve\\\"\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a80b9b1b-7020-48c7-89b7-c53298dcd8aa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6ee0dfb6-9425-4bf6-bdf1-d070a82a5956)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7f4861ba-6a91-4996-93bc-915dff9d6b61)(label(,))(mold((out \
+         ae3fe896-20f8-477d-a97f-89ce478eeb32)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         92423ed8-4770-4404-bb1e-9c1628fdedf2)(content(Whitespace\" \
+         7dc4c1e2-9e36-4de2-9abe-e43ab56b1910)(content(Whitespace\" \
          \"))))(Tile((id \
-         03ba786a-35bd-442d-92f5-cc2f8f3a3ebd)(label(age))(mold((out \
+         6819634a-c558-48a7-9ae8-d34837f8599d)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         489433eb-4b74-48eb-a13c-dc64f4c9b63e)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ff56cd11-cc1a-4cad-869d-0f89b67a82cc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         42d5811f-9f35-41b1-a89e-c87321973f8b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3644e924-796d-4bd4-a77e-1ba2b96782d0)(label(13))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         09fb295a-3f76-406a-9ce9-f32cdafbe5af)(content(Whitespace\" \
+         \"))))(Tile((id \
+         461c6096-d0fd-4247-81a6-ec8e7a59c8e6)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         6f509aa4-19bd-4010-8a66-36f458f57daa)(content(Whitespace\" \
+         d4b359ac-063f-4d17-808c-ae2b3dc524e7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         313d8e3d-8433-4efe-946f-b16ac6acadac)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         5e364f76-c09d-4a20-9a77-7b2981cefe10)(content(Whitespace\"\\n\"))))(Tile((id \
-         c54dcc89-c251-44ef-95f9-4aeb82a22427)(label(let = in))(mold((out \
+         7f0e22eb-4ffb-44ef-969f-19c455ddeea4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9e72b238-45bc-45b0-b3a0-704e537014c2)(content(Whitespace\"\\n\"))))(Tile((id \
+         a9baaa77-86e0-4505-9cb4-e265aa22ec0d)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         106af983-1b38-4347-9bd3-f8dfcfdbc17a)(content(Whitespace\" \
+         b25465a4-31cf-4a89-be5f-2240163e73b8)(content(Whitespace\" \
          \"))))(Tile((id \
-         4f367c38-719e-45bb-b932-3438659aaff6)(label(select_cols2))(mold((out \
+         1f17c71a-92da-45f4-89e8-1234931a9ed4)(label(select_cols2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0506a49e-fa96-450f-ad3c-841578a195f9)(content(Whitespace\" \
+         2a5448a0-57b8-4445-baa9-d795e2c6fa12)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b2a00ec8-ba4a-4c75-895f-72ead3b7b8b2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         40b3655b-c4be-4328-bb8c-08212f8660e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         571f3ea1-ef19-441f-8987-e6ad1b160238)(content(Whitespace\" \
-         \"))))(Tile((id ec4c3bb6-e58c-4ea6-a04e-b0c1c0df2b29)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         d1cdb50e-1b94-4634-8392-a9ad4c51c888)(content(Whitespace\" \
+         ea89cd3b-8fa3-40d3-80d1-73766e929b44)(content(Whitespace\"\\n\"))))(Tile((id \
+         dddb1ef4-df1d-42be-b416-28cbd1879164)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         7886746e-793b-4a83-9b31-8a16903c5ad2)(content(Whitespace\" \
          \"))))(Tile((id \
-         6ac595cb-f197-4715-a100-8d38708eff42)(label(requires))(mold((out \
+         8a984eb8-ed24-421c-a8e7-7290697198c3)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         dd3e93d7-987d-4f07-94bd-2387059cf1c2)(content(Whitespace\" \
+         26ae28aa-6edc-4cc9-bc85-0ebb447af07e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         74f9b8e0-b721-490b-9fad-886e9553cf40)(content(Whitespace\" \
-         \"))))(Tile((id 7e2687ed-5b3c-4964-8b51-f3bd23938814)(label([ \
+         c900f543-5428-40ba-8701-2b25134ab686)(content(Whitespace\" \
+         \"))))(Tile((id 75949767-b504-4e0b-b7e4-dbc2b7987fc7)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         61c490d6-c08c-4081-8a36-9931c3c05b7f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         61e6d944-bd68-4b21-ad71-3bdb1d69543d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         70872b7f-804a-406c-9d96-efd197886967)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9cf8b4fc-d899-49aa-b3ec-e1e793ebd74b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         008b239f-5877-4df9-9f5a-2c739eeb24c5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8fa4a52e-e736-4a65-b360-cbc8eeb42cfc)(label(\"(\"\")\"))(mold((out \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         c96f6fc9-523c-444a-82ff-40dc6ec7f48d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         0c43a85e-0d77-4875-8d65-1b8cde2992aa)(label(enforced))(mold((out \
+         dcf3b267-6b90-4e56-94e6-e280c01112d9)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         2ac19948-ccbb-489b-97eb-f9bb17987cbf)(label(=))(mold((out \
+         95ec14e4-f7e3-45eb-81d7-592a7a948a79)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         d3ab7d10-1d02-441f-99ac-899c667efded)(kind Checkbox)(syntax(Tile((id \
-         8e67e961-749d-4dfb-86e3-929723870fa2)(label(\"(\"\")\"))(mold((out \
+         e099ccef-8e40-4c36-8590-8fa3157d0ca4)(kind Checkbox)(syntax(Tile((id \
+         ed8bb99e-b831-4b16-8482-7c27538b0c99)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d775aafd-445c-499e-a448-3d0aeb5bff63)(label(false))(mold((out \
+         c5781725-25f5-48d6-afa2-52a8618f07e5)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         651dd3dc-a0aa-4965-aac6-3d1e97a90842)(label(,))(mold((out \
+         e75dd28e-8672-48b3-bf6e-886759925b1f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7b0b8c66-af7b-4299-bc74-eec27ae9704b)(content(Whitespace\" \
-         \"))))(Tile((id 9109ad06-7003-4044-8a08-2b4c6780868a)(label(\"\\\"ns \
+         cf1a0a65-3fb3-417b-b623-70a4eff5a1f9)(content(Whitespace\" \
+         \"))))(Tile((id 8f6c07e1-b70a-4556-8ae4-e99910f0cb76)(label(\"\\\"ns \
          has no duplicates\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         9e64d49f-b01d-47ef-80f8-063c7677d7a3)(label(,))(mold((out \
+         0c6ae3a4-e370-4587-9352-bae307362727)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7193960d-4189-4b3b-b45a-b7faa06db954)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c7848649-0ceb-4b0f-b4dd-eb4f399f842d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         98d16832-d3d3-494e-9f2c-dd42681867a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c916145b-9a3b-4084-b240-44e5a28587cd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         50d61207-a58e-4922-b7c6-24c84d54da55)(content(Whitespace\" \
+         0088d590-ddf4-493d-96d8-2db18992e442)(content(Whitespace\" \
          \"))))(Tile((id \
-         6fb4f822-0722-4605-a813-28273de0b045)(label(\"(\"\")\"))(mold((out \
+         eaa7e492-9823-4c95-9c22-d5db9cc00efe)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         65cd9103-a40e-4f27-ac96-03c333e258e3)(label(enforced))(mold((out \
+         6b79a9c5-d412-40c7-aa2a-a4226b88c74d)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         985ac22b-8792-4435-bafe-babfb8a6e737)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d44a1e81-65a6-485c-9cdc-b2eab434c87f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d4480d86-fbf6-4248-a16e-8bfab8eb109e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         979e3acc-1de6-407b-a64c-405ee0b93f0c)(kind Checkbox)(syntax(Tile((id \
-         565f6d2f-242d-4e94-931a-b4aeb93efdb5)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ec27d3ce-48ff-4a41-8483-d0553dc73857)(content(Whitespace\" \
+         \"))))(Projector((id 5889f125-0cb3-46a2-b9f5-cd6308ab6413)(kind \
+         Checkbox)(syntax(Tile((id \
+         5daa6e89-dc61-44e5-9a21-ad926886a49e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         ffc1413c-a577-41e7-b336-6999193af3b6)(label(false))(mold((out \
+         9bb45b63-2956-41b4-9dbb-c771a1d80dab)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         9906905d-73e0-4f9b-9e19-97f810893d1a)(label(,))(mold((out \
+         8923fc9d-9d7c-4757-8423-edf91b00987d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         29a86fcf-a984-412d-bc97-b452f64173d8)(content(Whitespace\" \
-         \"))))(Tile((id d14c9329-3094-4bd0-a625-76e03fe85617)(label(\"\\\"for \
+         119a2226-e911-4a6a-8730-ab221d1dd4d4)(content(Whitespace\" \
+         \"))))(Tile((id 62b90371-75f2-4147-9e32-6b7e6d7d9a9f)(label(\"\\\"for \
          all n in ns, n is in range(ncols(t1))\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         78cbd0ee-7f52-47ee-8f4d-0e8120a03e6b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a0173ad7-7fa4-41a4-b1d5-9850986e7bd3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8d3385db-d3cb-48da-bb18-bd29527865f1)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         8616d4dd-08fd-47f7-ba55-14ecda5adc91)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a27a71bf-1ec1-4e31-95da-648cc08d28eb)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         c925f3e3-9fe5-4b9d-a5dc-d568a1553e77)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1da7dae0-38b1-4a7c-83c1-f6098cb7be3a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb759472-d1e0-43d3-a33a-b47be665235f)(content(Whitespace\" \
-         \"))))(Tile((id 7d0c3a27-9303-4b46-a19a-57151413d572)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         f65a2136-8af6-43ae-ab30-b9a8af6de5ea)(content(Whitespace\" \
+         06612ccd-be5c-4364-9528-f65a350ea15c)(content(Whitespace\"\\n\"))))(Tile((id \
+         90dc82d0-0682-4618-a911-f5c151062109)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         d7825e63-e814-461c-93cc-8e6605709a89)(content(Whitespace\" \
          \"))))(Tile((id \
-         e1a404f3-4f24-4647-8a81-fab1a9d5dab3)(label(ensures))(mold((out \
+         9048a820-ecb9-4c74-93da-deb0948bac6d)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1112255e-ce4a-4a62-be81-66930f19aba9)(content(Whitespace\" \
+         b0cb04e3-4341-4a61-8327-ceea8c64b592)(content(Whitespace\" \
          \")))))((Secondary((id \
-         028a1263-de15-42ec-8da3-77f6e51d80f6)(content(Whitespace\" \
-         \"))))(Tile((id c74bf023-96a1-433b-a93b-a5de31c06bae)(label([ \
+         7d0d4b8e-cd00-4990-aa45-4a853c3dbf8d)(content(Whitespace\" \
+         \"))))(Tile((id e64ff894-c19e-4884-b80a-197a7b2908fe)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         3ed3943c-064c-4534-94b2-ef0276230f82)(content(Whitespace\"\\n\"))))(Secondary((id \
-         426dc782-48f1-40c9-8208-c9b4bcb0450a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8a8bb323-fe86-49e7-95ef-e73a33c91492)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3c78d130-83ff-4066-a887-82d7e0d2f5e3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         77af6786-08f0-4fc7-beb6-661744aa7342)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a418eab8-aba7-4698-a429-11d55e28aba1)(label(\"(\"\")\"))(mold((out \
+         de964017-4d8b-4d7e-9b4d-6f87284976bd)(content(Whitespace\"\\n\"))))(Tile((id \
+         0eb33053-1936-45cc-a159-e9fcca2fb93b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b6e32a12-ab4a-4c6c-9742-ac1617d20aa7)(label(enforced))(mold((out \
+         57296499-dd29-4489-8766-e7e12167b0d5)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         179bab39-b923-48c6-8bbb-2e1db7e9362b)(label(=))(mold((out \
+         ab3292da-a574-4636-a76d-e247cf90516e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         afc35a21-f841-4fd4-8190-8d8992949252)(kind Checkbox)(syntax(Tile((id \
-         d9ede691-a791-45fc-8115-fbde7b8c92b1)(label(\"(\"\")\"))(mold((out \
+         13d3bf90-d7de-4f3d-83bb-0d7314919ba4)(kind Checkbox)(syntax(Tile((id \
+         ffaca788-5d8c-4dc0-8960-ffa552d9dea6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         55642c9f-d39f-4316-9c6d-82ac852c2844)(label(false))(mold((out \
+         8c645692-e665-44c8-8b5f-490286d89085)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         d924cdd2-432a-448a-abda-b228351882cd)(label(,))(mold((out \
+         b9c03418-e815-4ff8-8a60-d5062d744dd8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3f997b99-d04b-4ac7-be11-ecd5ebcb0430)(content(Whitespace\" \
+         7146511d-26be-45c5-bd79-cdae4e2b754b)(content(Whitespace\" \
          \"))))(Tile((id \
-         3ba59074-099b-42e1-b887-e088f296c35f)(label(\"\\\"ncols(t2) is equal \
+         33f0a4d0-7a99-4408-aa34-0fbe1915b68e)(label(\"\\\"ncols(t2) is equal \
          to length(ns)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         41faac48-6beb-461a-8013-d894f82715b6)(label(,))(mold((out \
+         ed9a1e89-b679-4a0c-b52f-28f1ca616901)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ae4cdb1e-441d-47fa-a090-03aeca8117ae)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1118f23c-9eb8-4c30-97d0-ea8e434a1fd9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9f01252d-dcfd-4929-b064-06fdb7ac512c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c238975f-97af-4228-9413-cfeb48f6de61)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         431d692d-3c9f-4690-a78f-77e178415c15)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7b714d7c-03ad-4771-87e2-f7e7c97aab58)(label(\"(\"\")\"))(mold((out \
+         45bf4d6d-b41b-4d10-a0a4-04209389ddc7)(content(Whitespace\"\\n\"))))(Tile((id \
+         ea870b88-49bd-4482-821c-2d04e1d0f018)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f04efebf-a0bb-4071-94d2-aeadd50d9ba3)(label(enforced))(mold((out \
+         54b6041c-25e9-47bd-ba47-294d42b4bb4a)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         33597d3d-a768-43fb-8ca6-1c532368653e)(label(=))(mold((out \
+         9b1cd856-21dc-4a01-9d5c-67e388c5b3d3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         c17fe619-1200-4234-bf57-3212b8d90eab)(kind Checkbox)(syntax(Tile((id \
-         312e9ba1-8011-44c4-9efe-b82720411a9e)(label(\"(\"\")\"))(mold((out \
+         c7ec2b9f-3c98-4f94-b108-9130d3e21323)(kind Checkbox)(syntax(Tile((id \
+         7a501189-cfc7-4fed-ae33-1c3bf1e3e673)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         2ae20cf2-8405-4539-9599-cc8fd92ccba8)(label(false))(mold((out \
+         c2ca43ca-29cc-467f-9ed4-66b5553d6fde)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         ddbc6b56-b031-4260-b0a1-1f583515ad9a)(label(,))(mold((out \
+         d32a6c47-773f-48e9-abe2-04d831f021b1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9de1d4b8-8de7-4cd2-a215-5733e606e208)(content(Whitespace\" \
-         \"))))(Tile((id 7a591d20-7b60-4038-9c32-6202be508064)(label(\"\\\"for \
+         f15007ab-02f1-4f86-84f7-c96dc71c8aae)(content(Whitespace\" \
+         \"))))(Tile((id 3e16df29-21f4-486b-988c-585e941155a6)(label(\"\\\"for \
          all i in range(length(ns)), header(t2)[i] is equal to \
          header(t1)[ns[i]]\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         e7260aa7-66dd-418e-8a5a-81eaf7a0afa6)(label(,))(mold((out \
+         ce6a5964-893a-47a9-88bc-d458f007b180)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3f23ebca-53f9-431a-9e25-30ed3f8fecc0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6a5ddc95-2c8d-49dc-b1ef-595f8f3d5497)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e4929aaa-6e34-4aef-b47a-c2233b6430f9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         287f027d-f547-4b6a-ab7a-5f702f6d461b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f5565e80-fe30-4cc4-bce8-aa041551355b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d69fbcf3-700b-482c-aa3c-96fc53f12bcb)(label(\"(\"\")\"))(mold((out \
+         9884e55f-83b2-454e-a120-6d34f543c9e2)(content(Whitespace\"\\n\"))))(Tile((id \
+         0d61720a-5740-41f3-a4da-211421369c09)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         79938533-0b5f-4012-a5ff-c1ea469285fe)(label(enforced))(mold((out \
+         0db3d9fc-ca21-4185-95ce-5c422877a523)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         03bc6b57-001c-4c35-a780-c318e0704b4a)(label(=))(mold((out \
+         1275b38e-aaf4-4396-ac23-bf7ec22e4937)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         bdfd4be0-048e-42c4-b2d7-8e19286cde2d)(kind Checkbox)(syntax(Tile((id \
-         5e8e80fa-b4a4-490a-bc99-f121c253e887)(label(\"(\"\")\"))(mold((out \
+         94a0c495-dba1-4261-babe-ce3481556429)(kind Checkbox)(syntax(Tile((id \
+         3f708f45-3118-4497-bcaf-a6b58bfc3839)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         3c9bd569-e90f-45a4-9613-9d667965c9ac)(label(false))(mold((out \
+         1ee25e8d-2634-48b4-bb52-a872333a7339)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         8e9fc3e9-42cf-4183-a540-fb975e52a29d)(label(,))(mold((out \
+         78258d3e-0b40-41ac-b2d0-173e74cb56aa)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         06148f93-8154-4281-b62b-8230dd223db5)(content(Whitespace\" \
-         \"))))(Tile((id 30763720-6b49-4138-875d-b9fb4a907387)(label(\"\\\"for \
+         61ce0c0b-7cea-4ca8-bf01-fd1b6dbea349)(content(Whitespace\" \
+         \"))))(Tile((id f1ae6682-e6e7-46eb-9528-13d2a8264a92)(label(\"\\\"for \
          all c in header(t2), schema(t2)[c] is equal to \
          schema(t1)[c]\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         c06b328b-b9b4-4b19-b23d-35e4ca9806cf)(label(,))(mold((out \
+         896462d9-7d03-4f24-a567-7eccf4acdd80)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d8e6dd4c-989c-4bc0-8bf4-b8b3edb98d3c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         291f988f-9ba0-455c-b7fc-b0c71ac0adc5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e3bc7801-d326-438b-a81a-c1623828f8de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         177a059a-3a00-4cf9-b69a-f9b6d6325df8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         525969ad-f485-4fb3-b352-f58b50777bd8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ef255f95-79db-4711-a6ff-9fa8ab100544)(label(\"(\"\")\"))(mold((out \
+         e935ab06-8035-4f38-9e91-f9f11ee1aa17)(content(Whitespace\"\\n\"))))(Tile((id \
+         f12e468e-3304-4368-a6fe-cb230fc614fe)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f2f90978-b074-4ba5-a899-56c0b5832e7e)(label(enforced))(mold((out \
+         a70a7c9b-0379-4219-a62d-6549dc663266)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3f2a7f27-4629-43ca-8282-62b1160af7e9)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1bee8aae-82a9-42f5-b4e3-998f05b93bb5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d76bbc42-baf1-44da-80ff-932dafb32448)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         17fa38a8-3d46-47ad-9533-71db7cad3e99)(kind Checkbox)(syntax(Tile((id \
-         0e77a995-e8c2-4956-bcba-decac6716f83)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e712d636-2b7f-48c8-8a81-38123de04416)(content(Whitespace\" \
+         \"))))(Projector((id 7809434e-4970-41d5-9c97-5e295392497a)(kind \
+         Checkbox)(syntax(Tile((id \
+         2b47f1d1-dc1d-4ebd-b1a8-e95bce4b9811)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         0153382a-c827-4481-b093-bfce73f173a6)(label(false))(mold((out \
+         7805ad9c-cb36-4674-8f3d-587b038d42e6)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         8e2a884c-2414-4e9b-a96f-4056f986cc7c)(label(,))(mold((out \
+         a018d1d6-ff17-46f3-8371-bfb88a08b5ac)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4e92ed62-d62d-4790-a919-f29ef1ced819)(content(Whitespace\" \
+         51a40483-a142-4e90-8cf1-814f35497edb)(content(Whitespace\" \
          \"))))(Tile((id \
-         76ec00b7-6207-4b00-b123-8a49f1eb2a7b)(label(\"\\\"nrows(t2) is equal \
+         c2d89283-3e81-41b5-98af-3832b471789d)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8c417b11-fba2-4424-bedb-6c46a6998e7b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         42f58503-7630-4fdd-9b9d-3c10a4864e58)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32d664be-68b1-477a-b5de-2a2a7b343d53)(content(Whitespace\" \
+         ed636468-5b30-4712-a76c-949a687dafd7)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         cb2e2666-5842-43fa-af37-1590b4fc8bf6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         404e4fd6-12f7-4245-9393-52da3b760909)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f2554e85-add6-4bb4-895c-cf42f028a685)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3be7c0e9-c0cc-4c54-aa19-c8f7b068144c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ff9cf3cc-46c4-41b6-9d2d-72720762ea1a)(content(Whitespace\" \
-         \"))))(Tile((id 63dfc9e4-f5d0-4415-b33d-8aa95bda90a9)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e849d48e-4390-4a96-8a97-5bee92206ffe)(content(Whitespace\" \
+         914a7a3f-6fce-49c4-85f5-8976cb3e77d3)(content(Whitespace\"\\n\"))))(Tile((id \
+         5edb48c7-11bc-48fc-a5be-d47a06486411)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         66a35ce1-41d5-4662-ad08-fbedd70a3e1a)(content(Whitespace\" \
          \"))))(Tile((id \
-         758d9082-50cf-4fcb-a399-e858303c783c)(label(select_cols2))(mold((out \
+         a8e290b8-4c8b-43e8-8124-4f504a3b8456)(label(select_cols2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1497417b-7e1e-490d-81a6-6acbf64359aa)(content(Whitespace\" \
+         df09041e-0327-46f6-98b6-be8a659bae65)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f977660c-e194-4760-aac8-a59a5f57f308)(content(Whitespace\" \
-         \"))))(Tile((id 097f548e-cbea-459f-b204-f22548694043)(label(fun \
+         3abae3c8-2abe-4278-9929-976b7ae3210c)(content(Whitespace\"\\n\"))))(Tile((id \
+         9cb8a807-6602-4fbb-8356-00ae3267dc78)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         300e2cdc-8868-4d46-a80a-7d882d949ef8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fdd14769-5964-4cb0-be04-8c04cc02a349)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         8e4ca0d7-268c-4134-b928-23455f2b4bfc)(label(t1))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a090e7b5-3f75-42d8-8b13-c4cb96955b26)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2332feec-d594-4546-8393-4b86ccd5c378)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         deec36d2-a5c2-4869-adbd-30652050f46f)(content(Whitespace\" \
+         \"))))(Tile((id a114be93-0d02-4c46-9489-43abb64de2f0)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         9b34816d-1cb6-46ad-af16-435ac2f4c630)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         6f1ecb4d-64a6-4ea9-b210-31643616e83e)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         9fbaf6ed-5d80-4e65-abdc-e97e2a70987d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7765abe8-440a-41d7-a740-7ef64ac1b4ef)(label(ns))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         21b6ee0d-02d0-4c33-8929-5e061d2c39b3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         83e3df78-16fa-41c5-8ecb-d635ccaa245f)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         04dfd499-d4cb-46fd-af23-fa6b65cf4251)(content(Whitespace\" \
+         \"))))(Tile((id 53028777-747e-43ea-b98d-7fdcc3a76ce7)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         7cfe0ffb-c8b8-41c6-9bdc-9e37fd58eb68)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         c8360ace-8cc2-45ed-b750-a6d67aa4d2b8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2b1812cd-f056-40fe-9feb-3b5b7482636e)(content(Whitespace\"\\n\"))))(Tile((id \
+         aa6f8c14-8843-4767-8b99-d4ab04716bad)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9be312af-efb7-4a4a-8b0b-13c5d4c1048b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         a2a4cb01-662c-49d1-836d-b9e85a56268c)(label(t1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3693b010-06f0-4343-b7b3-92aff0007669)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         882b14d1-a6cc-408b-8375-1707ab8ad95c)(content(Whitespace\" \
+         \"))))(Tile((id 13837c65-d94f-4ad2-bfd8-dbdbf08a1921)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         6c0dfbfd-b509-4730-a5e0-7a80b350687e)(content(Whitespace\" \
+         f92de07c-8675-4a29-80b8-1e7abafa2afe)(content(Whitespace\" \
          \"))))(Tile((id \
-         ca23ec1e-1147-4b38-8a40-3857b8fc2983)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         c63a3504-bbbe-431a-8456-c23f2e2f16f7)(label(t1))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         bec23938-9cc0-47b2-b119-0de6dd97b705)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         671d8850-048c-4286-a758-0e75e6981295)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         36b93838-bb44-4ce0-95cb-bea2e6af8ecc)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         88583812-df3b-4d19-9ecc-a6e6d4d81dd0)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         eea621e8-fbba-471e-8e71-a84957a1b5e9)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1125115b-0683-4991-b075-3f29c9f7cc25)(label(ns))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         f1d4bdad-f184-4976-821d-a2d5154f9e80)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         4c7257e7-2ca4-4884-9857-48195bb0cf44)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         a4937909-6585-4de3-abbb-a203bb9bb5ef)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         5341b3fb-4439-4922-b3d4-4559202ab1c8)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4edf3033-23fe-4b16-a59f-520783f2796c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         dfa00c3c-3221-4aab-b55f-90665cec91df)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3baea52b-4135-4a3a-a18a-b91e77e30c0a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b7ddb877-2c6d-4206-8f9a-1a6f8a155a2d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4ae59e50-030a-428e-bf86-41c6649add90)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2e960f91-4ce8-4962-8d85-89f5038ce5e5)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4bd235d5-95b9-48a1-b23e-cccc1785f800)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         03d6cdda-a6e5-4db3-821b-d2a018b11597)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8fc18f15-b2f1-47a3-a203-9b81a283a3e4)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e621cd41-769c-4d19-bc62-3f9c78ebc3ed)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         8f6334c7-78da-447a-aa0f-7113e89903cb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a158af28-9625-45ff-9ad2-fb6034f40d2c)(label(r))(mold((out \
+         f41e8381-654f-4667-843a-2bf2a0efe368)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         59f087bc-3eed-4de2-a939-40d91f0651cd)(content(Whitespace\" \
+         8ac8aad9-2829-4ea4-b7f5-f5a78a7e861f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         db458d9f-0b5d-4a36-b81a-42897ea00b34)(content(Whitespace\" \
+         28bc9f9c-6445-45ee-a7a5-44aabbed2a78)(content(Whitespace\" \
          \"))))(Tile((id \
-         c4a70a82-047f-478b-ab51-5953a08bafa1)(label(to_lvs))(mold((out \
+         2d7dee96-90a2-480f-a53c-db5c9b84a45b)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         8d464937-dfd5-40fb-b5af-cdd60686943f)(label(\"(\"\")\"))(mold((out \
+         78874d2e-a33a-4090-96a1-96a1ae21b4e7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         eeb20110-c391-4faa-b14d-7efe6eb64dd1)(label(r))(mold((out \
+         37c62e78-2122-4f89-aae0-daa36cb5b918)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ce6d4afb-f5ad-4a3b-a6ae-12c917a9906f)(content(Whitespace\" \
+         188af0e7-5217-4b76-a460-1c86f592ea14)(content(Whitespace\" \
          \"))))(Tile((id \
-         3f679bcb-cce7-4558-aba0-350725477fbd)(label(|>))(mold((out \
+         0cc367e4-cd35-4b43-bbc8-16bb103b2f75)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e9e7b4d9-7838-4e44-9eb8-ee7d2533e85b)(label(\"(\"\")\"))(mold((out \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1c899e77-1ac3-43f9-b66d-4b3b5b426523)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bea8d42b-a555-4178-affd-8f5b4657422b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         2f37d18e-8163-494e-8c14-c567cbb13298)(label(fun ->))(mold((out \
+         7e7bb4d7-d3dc-460e-b290-1974133c70e4)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         9bbde33b-b923-4e29-8805-9f92995670b1)(content(Whitespace\" \
+         2f9ff105-da9f-48fa-a0b7-ee1162869a48)(content(Whitespace\" \
          \"))))(Tile((id \
-         4eda2256-f8dd-405a-a0df-d57adf18f570)(label(entries))(mold((out \
+         9974382b-f8e7-4179-99d7-d071c99102c5)(label(entries))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c9ca0543-b1a9-41c0-ae9d-d91ecf1465a9)(content(Whitespace\" \
+         ab29484b-9354-42bc-803b-5db7835f8ba5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a1908617-edeb-4fd5-a657-fcc617c21323)(content(Whitespace\" \
+         351c70f1-ee51-455d-abc3-addbec29b38a)(content(Whitespace\" \
          \"))))(Tile((id \
-         a40f3b50-c93f-463b-8665-fe762c250b38)(label(map))(mold((out \
+         22149221-2ef5-40d2-957a-43be8f6be287)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         bcf6b4c9-0e7c-4a15-a24d-e8b81117a6e4)(label(\"(\"\")\"))(mold((out \
+         166a837b-4141-4865-93d8-9322c26f00ed)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         3ca69ac9-d828-46cd-88f4-26779160ba7f)(label(ns))(mold((out \
+         9c119499-0754-4e27-832e-32196a9ab08c)(label(ns))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         307fe661-1d20-478e-b3d7-0ce9ba528b4b)(label(,))(mold((out \
+         0b7c1119-845a-49ec-b80d-f8375be151e3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a391aac2-61a1-4022-a2b6-253121b2d5f3)(label(nth_opt))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1e05f229-3134-4cfb-941d-660ca28a4ada)(content(Whitespace\" \
+         \"))))(Tile((id \
+         61710c3b-5671-46d7-8632-2479f3b29822)(label(nth_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d768eb66-5f26-4d38-84d3-c875e4fb8cc0)(label(\"(\"\")\"))(mold((out \
+         7a1a8fc4-9f85-4b86-bd6c-e516a424fb72)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         640b38b8-a0c3-4872-9157-a317f2e3d559)(label(entries))(mold((out \
+         68df2b40-a1bd-4119-bd4a-818c8073eb6e)(label(entries))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3db96790-7674-4bc4-b0be-16003e07ac64)(label(,))(mold((out \
+         b2917ddd-8d1c-4a42-8d3e-aaa524f00f28)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         73b0a58b-6c7d-4791-ba25-9267d9c9cd34)(label(_))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c236f62a-f9d1-4613-8c36-3518037aefb2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c2b08664-45c3-443d-a4d6-528f5cc09eeb)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         f0a94cfe-1622-4d27-a26b-22596e407cb3)(content(Whitespace\" \
+         7f8b8caa-e7bb-486d-be77-8852c4292de3)(content(Whitespace\" \
          \"))))(Tile((id \
-         fd6578b9-4b57-4c01-86a3-47281e46413a)(label(|>))(mold((out \
+         cd5948e5-1dd3-4fca-b730-ec311b794397)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e7b6e731-41a1-408b-93a9-b854828a180a)(content(Whitespace\" \
+         f35178f5-2750-4649-9d7e-768121bb716e)(content(Whitespace\" \
          \"))))(Tile((id \
-         cc1be17e-55a1-426c-8745-41bd43a2c8d0)(label(filter_map))(mold((out \
+         94ae70f3-2049-4d2e-a653-ac9486a1c78e)(label(filter_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         da7cfbe2-4b71-44c5-9c72-d9def31d4c4c)(label(\"(\"\")\"))(mold((out \
+         8f65161e-671c-4af2-8106-05cbec11a629)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         7991a08e-5620-4f07-bc4b-bb99b632e107)(label(_))(mold((out \
+         0a210c3d-276a-4cea-8ca2-8cfd16c6420d)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ab6e3e40-dfec-4948-a75c-9dee01e507ef)(label(,))(mold((out \
+         aa818b75-8d23-45ce-9cbf-e7dc088f5ec0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         79187528-509c-420c-a2ea-ab7081ffb67c)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         68f58281-1714-4a06-8d97-42f1d61cc4b6)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         21c29364-fd15-40f0-a241-7a05ad94484a)(content(Whitespace\" \
+         \"))))(Tile((id 954ef9f6-51af-45bf-9b83-cc705f1e6054)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         cdf7e726-6b60-4a34-a34d-0931179f0490)(content(Whitespace\" \
          \"))))(Tile((id \
-         91571a06-05d8-4776-90f7-e5402cd714ea)(label(\"(\"\")\"))(mold((out \
+         bf28ae42-888e-419f-b3ca-ca3b84662262)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         9609cca3-9d11-49ec-9602-5e844f3e6ccf)(label(e))(mold((out \
+         34f776ae-bbdf-4194-ac19-9dedc2caa386)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         8ca69fed-3e50-4d2c-a26d-423c0564e445)(content(Whitespace\" \
+         7293bf1b-2e1f-4b78-8f2d-a08a426d8f6f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         13baabe2-7736-4a16-95df-e17bd3eb8f46)(content(Whitespace\" \
+         8d8a30d9-4a3d-4436-8500-aa2db36a65c4)(content(Whitespace\" \
          \"))))(Tile((id \
-         55598e1a-b1f9-448c-bb85-6c16e82d9106)(label(e))(mold((out \
+         c9b25f01-a92c-4f24-abf5-d644fc75f50b)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1aff6696-ae4f-431f-951e-ea3fb6feb8bc)(content(Whitespace\" \
+         2a8609da-cde2-4830-9bab-a1f13201a805)(content(Whitespace\" \
          \"))))(Tile((id \
-         ad7c73b2-4688-485e-b402-62cf1428e465)(label(|>))(mold((out \
+         816d478e-d668-44fe-84d2-69157378b4be)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         71c9b57b-d670-41ea-a48b-accb311fafff)(content(Whitespace\" \
+         f726768f-229c-4d5b-9c6e-1731006957a3)(content(Whitespace\" \
          \"))))(Tile((id \
-         556924e1-7353-492a-ba3c-c3610169a3aa)(label(from_lvs))(mold((out \
+         2116836c-c433-49f6-b5dd-6ac0f5e32d6b)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         02aa8df2-c910-4413-b277-64d097bbd2dc)(content(Whitespace\" \
+         0e543c07-38cc-4b23-bc7d-570af014954e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1f62e88b-a7fa-4b65-bf1a-b1ef87d8409f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8a56b4fa-74d1-447b-8821-7dfe8280329f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         74226d1c-f208-4b02-be4a-73bceb08458f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1f015eae-d19e-47e6-a98c-bb4fff478186)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0f9b0576-6912-4d0d-bdf7-ce8ea5c3f2f5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c9a4375d-ba2a-4dc9-b494-196ac0421f18)(content(Whitespace\" \
-         \"))))(Tile((id 8ce2f579-c18e-4996-bb5e-032322ad0311)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         42d2ca4c-b7f8-4a2b-b939-b36daf6c3194)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9eb02382-04d7-46fe-9554-fd2a20fda016)(label(select_cols2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ada2fd5f-2069-4e35-8e8a-544059d63a7b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         1752d51b-218d-4029-a45c-47e8b8927b66)(label(students))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c9d5b945-d03d-4a1c-a983-b5f58eb281d6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         86293a38-9a86-4bc5-8201-793fbecd269e)(content(Whitespace\" \
-         \"))))(Tile((id d89a051d-32c9-421d-9bfa-5019cd2c4a4a)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         7889bf06-3e59-4345-87aa-ea96591bad95)(label(2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c9b01f7e-2290-4efb-a604-bbaf79c22548)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d0510fd6-101d-4c38-809d-4a00a0e2ad84)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8773862e-bd39-4dff-bf72-b9193bc718f2)(label(1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         929251a3-a26a-41cb-9e4a-6d43771f25c5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0a7934eb-eea8-4427-a965-e0b244462b14)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2bb3186c-ede4-4152-94f1-60e2bb1b0ce4)(content(Whitespace\" \
-         \"))))(Tile((id 130f47b1-c75d-4ca6-afa5-a1de7b58670f)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         dcf16027-e6e0-4da4-834e-749dcc54c022)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         d12ae972-9d61-4d70-969c-6aa10efb1326)(label(favorite_color))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         90613396-c22b-42bf-aecc-fc2d843bf2c5)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e9757da4-8848-439e-bf53-906675353555)(label(\"\\\"blue\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e3dd0f75-419f-470b-8ce4-30d684d2f82f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6e395975-a337-4174-bcaa-f40d8b567264)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a432874b-3dbf-41d4-8ee1-dc391f5b35e8)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ab4fc35b-f46a-43c0-8521-08fac8637dfa)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ee931cc9-7ae0-4549-8f39-db8403380716)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7c0a8474-2f25-468d-842c-61ae3a1365bc)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1b1f8f25-546f-4aee-990f-b5e0ac02d104)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6267ffc4-7176-4ec8-9fdc-1121763517ae)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         e9c54d1c-d924-4488-b95e-c427c068ac9e)(label(favorite_color))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8cfd61f7-d71f-4594-b523-f842889d94a3)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         8f977e1a-6ee7-444d-936b-d8fb958174b1)(label(\"\\\"green\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         aec568e5-f7b8-433d-8246-131f9162421a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f966514e-b14b-4ea5-80f5-d553f64dd2c4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         36f517fa-999d-4eb1-884c-d9e2e3320258)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8af24973-f9e0-4258-b0bb-337d80a0b80b)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         495ec5ea-75c5-4876-9e80-c325d8dd6273)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         53f3b6db-5864-470a-b247-553b0b9cdaf3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3a184d01-b900-40c1-9ff9-1bfe629d0228)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b89f59c3-d02a-47d2-94c5-0a0260391b5e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         3fb9a690-8157-4de1-a0e1-83b4ad02f865)(label(favorite_color))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5d9f4cf0-064c-4870-b733-c70bc61e4379)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         06b88d27-9c40-4574-8dee-2ab588aac17a)(label(\"\\\"red\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6983d08a-7c35-49db-b4a0-bf91f8028fa6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         59668b16-65ec-4349-9a20-7491a14334e5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5e45ada8-08d0-4e19-92bd-08f298f4ac0f)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         be206845-fb7b-4f94-99a6-4e75a750efb1)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         73ac7723-2b4c-48ff-83fd-51893c2d0cc9)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         778d1e76-e0db-4455-b083-4e5c5ccc4dc3)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         fa88253e-0e96-443d-8506-b4a25eecfe62)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         f7e115c2-e9c6-4027-ae73-7b4779c6c685)(content(Whitespace\"\\n\"))))(Tile((id \
-         9d1b136f-e061-4e92-b9ac-15aa5bff6522)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         5a451470-9b68-4387-a942-b677a6a273ea)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c71717dd-462f-4842-9c98-30a95faba3fb)(label(select_cols_3))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         0c3e7221-21eb-4c83-bc72-63a1cbac6bad)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         4bff2c5c-d2d3-48b4-babf-40bbc3d4fb1e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         70231846-6aa7-4344-ab8f-840d9b107578)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f8ea6e9c-d86a-4052-a163-fc8a5fda0277)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         63d4395e-1fb2-4e9a-bb62-e39e30006b96)(content(Whitespace\" \
-         \"))))(Tile((id bec88249-a1e8-46c2-a47b-59b23897a492)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b350b8ed-3aeb-4338-9702-66c9edd5558f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         072f384e-975f-4ce7-9085-3a4f89f5b583)(label(requires))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         4660100d-0a5d-427b-8e21-81d7ca43af82)(label([ ]))(mold((out \
+         7c73a9e5-bd42-4956-ac4d-bcebae6be22a)(content(Whitespace\"\\n\"))))(Tile((id \
+         bcbb6eb7-cb0b-4b21-a245-65253432d768)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         4e66cf27-18a3-4c9f-8eaf-354f948f293a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5a329844-7150-4aa2-bedf-9d2113eebbd1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         345c88d6-54a3-4581-8a90-2487183c0566)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32021314-b8a2-4e58-9d36-d1be06390600)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9e80583-f7d8-4747-acf1-f78d8391e8f0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e84e1d45-4a9b-424b-93e9-4baf94737bfd)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         6414ec4d-3e02-4ac6-be82-9d8c44107fc1)(label(enforced))(mold((out \
+         862c60b5-d9b9-46c0-a301-bba1f02a442a)(content(Whitespace\"\\n\"))))(Tile((id \
+         81052112-7874-4483-8517-fcac60ce3cb9)(label(select_cols2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         2c147d80-aabe-46a1-ab13-94008832ec9c)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         45b94906-a6c0-4b12-b671-76402607916a)(kind Checkbox)(syntax(Tile((id \
-         4c7323ae-87de-4f31-b4fc-9f905c2c3343)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ff8b89cc-35ee-41f6-ab7d-ca4dcf96e80d)(label(false))(mold((out \
+         89b491d0-0227-4747-8608-5c6aaf153d01)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         47670772-01a6-4ff4-b09c-e3272cdae8d3)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         ead2a9e2-64aa-4a08-b754-fd06cb8686f0)(label(,))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4b555808-7199-4234-8d61-7986de48479a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e94c7e18-844e-45ac-809e-d4a1961f3060)(content(Whitespace\" \
-         \"))))(Tile((id 54d50f9d-d71c-4c13-8da3-defc477bbac3)(label(\"\\\"cs \
+         156ca343-37c2-4c58-8869-3c922281941d)(content(Whitespace\" \
+         \"))))(Tile((id 46329c77-9fb1-4e75-820e-fb04ca8f332a)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         f36c8722-9b93-49a4-ab73-034c359808e0)(label(2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ed517ba2-01e0-4caf-823c-5f6b6e27d8dd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         12b652c1-b5cd-437b-91df-24cba67dc733)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7c8df790-cfee-47b5-9429-010548c70567)(label(1))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         0d3014c9-b7f6-4a3c-8267-150de4dd6264)(content(Whitespace\"\\n\"))))(Tile((id \
+         c1f0b2a3-696a-408d-ae22-c3c6d1f68af7)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a1fbd6f2-2d34-4ad0-bcfa-2e2a226ed516)(content(Whitespace\" \
+         \"))))(Tile((id 8de21c54-92e7-4a35-8430-65e53ca18521)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4c0e040f-0a6c-4348-acde-84e689c438ab)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         309e152f-f004-4c17-a560-b31252c01d26)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9d84c555-80b2-4f51-aa64-ad550e1e01f5)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         7172d5e1-4660-4b73-a57e-268d3da5da48)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9acbd5af-b299-46bd-833c-aa390bd37354)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c1332179-c8d1-48f9-b1f7-be1c821743b6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2bc7d554-e165-4a85-8550-f1416160fa14)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         324189f7-621f-43ef-8665-2120e16df011)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         2230601a-f47e-418a-aba6-fa636fcdd9cf)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         a62cf225-8345-453b-816d-af5c35bf71e2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         aca94618-d3d5-40f1-94c4-bca429a81b5e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6bb3cc38-608a-4d0e-bd8f-23845707e9e4)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         5e2f5459-3b1c-4c5a-9fb8-239e11b9ecff)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         55659ba0-dfad-4125-b0b0-9a6e29f067af)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         a2e27bda-2de7-4782-ad8d-e474027db5ae)(label(\"\\\"green\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f1637070-d273-4548-9155-3643fb18f9f5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         141a15d6-fd1a-49af-9b17-686ea82b28a5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ee910f79-be86-4c95-ad52-e43f292e76a3)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         368ceda0-668c-4513-bea1-804064c60d74)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         f62ec095-e5b3-4ac8-bff1-3b990e0ca276)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         c01bf53a-273f-46a4-b09e-bff95d345738)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c39709c2-ff91-4c2b-a157-95bdb15d2a9c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         219a2b55-9e81-41c9-b094-ba5439866136)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         0a08b6ab-1bbe-4b06-9a3e-b06bb0bf7d36)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d5645a36-ab23-445b-925c-e9d8b0f592c1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ef3407b7-d219-4153-8374-d39b69d82322)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0e80ce0c-3364-4a3e-b073-c7402058ec1d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1f64d940-f5ca-46ce-b99a-2ce9df9b12ea)(label(\"\\\"red\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6c0553fa-9cbe-413a-9882-24f90ef132a4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d0b6a6ba-ad34-457e-8bf6-cd21383fe12c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8c2923cf-c5d5-4746-8c86-ef8310267cbd)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c7eeccf1-f535-453c-8dc2-0a504db39eea)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1c5b1e0b-29bb-42db-b5af-efb7ae9a961d)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4cf8efee-a247-4217-8019-74814aed3cb7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         52994127-5aad-4183-826c-f62b1ae0e79e)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         14723c25-5ceb-412a-8032-de3b775fa6c6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         407d1604-38d1-4aa9-b38e-094ea355fe31)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         6259193c-3ee8-4d0a-af6a-1e77af0b532f)(content(Whitespace\"\\n\"))))(Tile((id \
+         bf4cb4a4-3bd9-4398-9f3d-9b158976ea68)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         9f28bd84-b9ff-46e4-b918-685538f86681)(content(Whitespace\" \
+         \"))))(Tile((id \
+         920124fe-cd67-4dd8-b02c-145dc22ed3f5)(label(select_cols_3))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5ab7d832-9e8d-4568-a84a-8211f9e85b26)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         8021bf0f-a3dd-40ea-974e-b2cbf287153e)(content(Whitespace\"\\n\"))))(Tile((id \
+         f66dea11-b1ae-42e7-bc30-330bf9a00b8f)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         6fad438a-82a2-48cf-aa70-1d6e7032888b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         04d6e533-ccaf-4802-b77a-9170fada950b)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         90efd6fc-e537-42ba-98c3-5f57091e661d)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         03eef277-22c5-4bc3-9961-b3db9ba4d111)(content(Whitespace\" \
+         \"))))(Tile((id 8a751a3f-d382-4888-9e1a-026448c82109)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         8e93a91e-9a9a-4879-9238-75d9a338d61d)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ef2be8b7-64c9-446f-add3-4fba3c043102)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f4c28ffc-7ecd-4318-9942-f5056a4f6aac)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
+         46e2cda9-257e-45b8-8049-d4f4c036c4cd)(kind Checkbox)(syntax(Tile((id \
+         b0f75046-8593-4050-9738-270a8c8d8875)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         2ce1b13a-c469-4d2e-b405-8ab10b5c944d)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
+         f8fe2171-3ac5-4f77-853c-633d2628f607)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f9195913-0daa-4bb7-8d24-566393dd1d58)(content(Whitespace\" \
+         \"))))(Tile((id 3eb77771-fbe4-4efe-96c9-d85afe5f7ff7)(label(\"\\\"cs \
          has no duplicates\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         e61ed46c-3d75-4bc4-8f76-296711799f19)(label(,))(mold((out \
+         fae4562b-4ecc-4748-96b7-f82a5b0809a6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9b478d5b-91f0-4252-90d6-5bb3222da89b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e6c53e3c-b840-41f2-975a-0e3fa576a2af)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c87b3774-6c84-4938-8780-52e2c802458f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         accce1a4-d43e-4173-9ff2-a30f0fdf3a66)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57f30c31-f8d2-4d33-9b56-0c5e430a6237)(content(Whitespace\" \
+         d9f0c78b-3db5-4fee-8b49-ee1203775518)(content(Whitespace\" \
          \"))))(Tile((id \
-         6606568b-450e-4c47-8b9d-0ae41c741d86)(label(\"(\"\")\"))(mold((out \
+         c3e0b97b-9718-40c8-8f24-cbb903107ee1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         c7b94c0e-1b54-4e65-9abc-ecf26cd75c5a)(label(enforced))(mold((out \
+         b54c329d-8346-4e7b-97c0-7de6b5c81837)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8d36e75f-797c-4190-8573-9ed7aac6a796)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ccc83282-206b-47f3-be5f-506ee16aa4e3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1781b4f6-5275-4fda-a1f2-499da8970eeb)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         693d5730-c624-40d2-adfb-e05ee26d5bc0)(kind Checkbox)(syntax(Tile((id \
-         6f56f992-5df6-4ef9-ba68-c9834025af03)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cc35bcdc-3186-4b2f-9bdc-13c5b4c0d365)(content(Whitespace\" \
+         \"))))(Projector((id 046db28c-f157-4cb8-8d89-efa0c32cc21a)(kind \
+         Checkbox)(syntax(Tile((id \
+         8756f0a0-192e-4d0f-8d73-127037f329ef)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         552b030e-6734-4c11-8174-9aefc81e1fc7)(label(false))(mold((out \
+         5338f8f6-1b2f-4bcf-8005-7d339295cb25)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         b7b57877-b7e5-42e8-b0d1-8ea0a3f2e25f)(label(,))(mold((out \
+         ca699139-e799-4c8e-a655-6588cf6b1d3f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b87ebe4e-92c9-4330-9571-98d4bc21e6e7)(content(Whitespace\" \
-         \"))))(Tile((id c1e1db59-f8ae-4c85-ba39-2fd1734cf7bd)(label(\"\\\"for \
+         ee22dee9-0116-40ac-bb28-fc25b2008ac8)(content(Whitespace\" \
+         \"))))(Tile((id fb480b58-1314-45e7-b4ff-d01b6d2d80a3)(label(\"\\\"for \
          all c in cs, c is in header(t1)\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         03e90a25-d471-494f-9b03-7ec40a32e2bf)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e7529d88-917a-485a-bf75-8da3a17671d7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac734bbf-9bcd-4480-a454-5cd9ca439425)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         ecb96301-8335-48f7-8940-0570c4b0c251)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         899e41e8-68c0-4f9b-b1da-0f456955ece7)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         3392dbb0-5686-4db7-b617-49d0d8c8ee6a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         044f62cc-c52c-4c4a-9a41-019956287939)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f2e7bbf-1fd1-44f3-a005-3716c1ef7256)(content(Whitespace\" \
-         \"))))(Tile((id 6756ec13-5069-415f-88a1-f31005e85c22)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         56a28d55-91ad-4f67-997b-1e07e0fed627)(content(Whitespace\" \
+         b00e8291-c8ff-4148-902e-e7c85f6c4fc1)(content(Whitespace\"\\n\"))))(Tile((id \
+         68c2710b-0566-4fb5-b087-cb2948416d42)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         68ac506a-aafa-4fa5-bf27-daa0e06a3763)(content(Whitespace\" \
          \"))))(Tile((id \
-         fba6f0f1-68f1-4d5e-b64e-3a580b8832cb)(label(ensures))(mold((out \
+         ebc8b3ba-f9b3-4553-9e11-f8627a7f3b8e)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         8efd4b43-2b9c-4b38-8756-21b7fac3137f)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         4defcc59-0b21-40cc-bfc7-37268f121951)(content(Whitespace\"\\n\"))))(Secondary((id \
-         18d1398e-7fff-4b1d-98f7-23834bb6c41c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6263b5b2-2684-4f51-8436-319260f004f3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c8c87d42-53c2-492b-8380-5028fe0735ce)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         36a195b1-c0ac-4e37-add1-8e5fe92d90f2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3e20364b-0169-4508-bf80-1fdcdfea0dcf)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         bce939ac-c1c8-453d-b752-30400443816b)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         a5b09d7e-dfd2-4b99-aa4d-d9c59de01314)(content(Whitespace\" \
+         \"))))(Tile((id d3538e78-c74d-4fc9-aa6e-f3db57d4c9a3)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         d05882d2-1507-4235-a014-60530c4b7a75)(content(Whitespace\"\\n\"))))(Tile((id \
+         b7a69c55-b0bb-4f81-b212-3d7d018fd5b4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         a886d36c-0a47-4c9e-a0df-1a6c70d0886e)(label(enforced))(mold((out \
+         eb492cb7-4982-43f0-b335-fc5dc1f2fe6a)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         98b303b3-1c6c-44bd-af64-85084cde494d)(label(=))(mold((out \
+         d64f6998-71bf-4f55-9962-f9c3d0e760b4)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         d55a18d2-e934-4aa7-a1fc-e4786dc6b4f6)(kind Checkbox)(syntax(Tile((id \
-         365321f3-2f70-4b15-97c4-61fc9aa8ff35)(label(\"(\"\")\"))(mold((out \
+         ce1c23ac-95c0-43f7-a899-fac9989f59b0)(kind Checkbox)(syntax(Tile((id \
+         5071ed8b-b6c9-4dd1-8e7b-792bfeb5e9b3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         1e04ae2c-a706-438e-a2a9-2903644b0fe6)(label(false))(mold((out \
+         c5f67361-7e55-47a7-97ed-5e8cb0fa90fb)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         7c0315b0-f0f2-40f9-a204-1244178371ff)(label(,))(mold((out \
+         247dc4dd-0881-4c26-966c-63510d7ef2b1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         96f7f497-78a2-48ab-82b2-91f7f5d49f29)(content(Whitespace\" \
+         47824916-0638-4c9e-8974-c63479fff7a8)(content(Whitespace\" \
          \"))))(Tile((id \
-         7cfbba5a-9162-4d64-ab04-1f9cb4a0fed2)(label(\"\\\"header(t2) is equal \
+         6e026c72-d7e1-4ed4-bc2d-31ec65a1731a)(label(\"\\\"header(t2) is equal \
          to cs\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         9d6f219b-f992-44fd-9ce5-facb8889c97a)(label(,))(mold((out \
+         c3503606-9dd3-483c-af6a-5a411cd24c07)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2888c9cd-de0d-4251-8197-a34878ce73e3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         16820186-35a2-42a4-a607-482e8b217666)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d6c649b3-911d-43c8-a21a-cc52307b555e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aee3cd25-0b4f-466e-b7a5-f8593a789f2b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         434f5131-5847-4324-9d61-9f17d3ae1760)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b17fa204-c9e0-41d9-af3f-2ea2cc78f75c)(label(\"(\"\")\"))(mold((out \
+         e61aa2d4-94e2-485d-a99b-f29cbe32031c)(content(Whitespace\"\\n\"))))(Tile((id \
+         e75e26c2-cf87-41bd-b76e-d4b547d92127)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b2f9f703-1ef5-4ecc-a61c-611b4f2f44b0)(label(enforced))(mold((out \
+         0798d6a6-576a-4ba0-a7cb-d38712072f03)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4de42e24-b180-4a04-a684-339856cfa513)(label(=))(mold((out \
+         5c82baf3-8cac-401f-a454-f9b1ae012e60)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         c000b456-e6f0-4177-9a0c-f966d37b2f03)(kind Checkbox)(syntax(Tile((id \
-         7b6ab97a-9e4a-4554-8c23-db88e1dd73e1)(label(\"(\"\")\"))(mold((out \
+         8da89399-cdba-4ed6-a2c2-763ae0e4c771)(kind Checkbox)(syntax(Tile((id \
+         7f293bce-efa0-4335-aee6-e04eadf95483)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d5a5ba2c-4443-4646-bb7a-bf612b8ab8fc)(label(false))(mold((out \
+         6edf035f-c721-4eb1-b9da-5de980c5cc31)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         41bbb39e-8f1d-4ac3-b371-b1c3bc71707d)(label(,))(mold((out \
+         0ed9037d-5ad2-4982-96a5-ecb7998d031b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         43635116-5e38-4f39-a5ea-1c3a0125931a)(content(Whitespace\" \
-         \"))))(Tile((id cf4d5abf-7fcc-45f9-8c64-b3d3c0b15301)(label(\"\\\"for \
+         3432c529-8d71-4e71-aec3-0dd310fc64a5)(content(Whitespace\" \
+         \"))))(Tile((id 8d6c767e-1e2d-4f3d-a722-218e70c5ee91)(label(\"\\\"for \
          all c in header(t2), schema(t2)[c] is equal to \
          schema(t1)[c]\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         28cff2fd-a2ad-4c02-83f4-3bb33b3a9d1f)(label(,))(mold((out \
+         ad208295-fec5-45af-ad19-3bb076290b3d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1dfa598c-cefb-4d33-9bd0-1d8630e9a0f4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2025e80c-60cb-4570-ae81-68568a365b2e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a35ea578-53a0-4174-9090-1e4ca29d3e3d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b2cc903f-8efa-4550-8e8c-b385b3192880)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32816450-0e4a-4a14-a5fd-003fcff62b07)(content(Whitespace\" \
-         \"))))(Tile((id \
-         84eb1f62-bec3-4c1d-b4d6-d25e20c75f53)(label(\"(\"\")\"))(mold((out \
+         2e2bbc63-0935-4b18-8057-b9b4e28f1b2f)(content(Whitespace\"\\n\"))))(Tile((id \
+         fbe0d175-c6b8-44e9-b4c0-4123d9e34640)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         6db3dfcf-bdf1-4df3-ac5c-4f0e4ae1ab98)(label(enforced))(mold((out \
+         c0491722-dbe9-4122-b673-ba0bf9d9ac34)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f8525f2f-3997-4c2f-a5da-a664bed9699b)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9cd7d49e-367b-41d5-986f-b49ea5d9cda9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         235d2ffe-b8a2-4074-a21c-b85f81f846b3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         74b9c10c-4903-4249-903a-db1bb613458f)(kind Checkbox)(syntax(Tile((id \
-         eacfecfe-80cf-453b-b521-8abecfa0b416)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3e17890e-97df-44c2-b075-954f7097606e)(content(Whitespace\" \
+         \"))))(Projector((id 67fd15d0-af28-4728-b60b-954b50dd8c83)(kind \
+         Checkbox)(syntax(Tile((id \
+         072ba30f-b04b-4761-8090-5b31e981c8d1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         f2a03f52-f8ed-4eb5-8e95-9c2167328ada)(label(false))(mold((out \
+         3674ce05-9459-468f-a35a-dfd5ac9108bf)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         4736d332-3fc3-4aa9-9138-350bef52f7b7)(label(,))(mold((out \
+         43f3ef99-0eae-4b2c-a82d-dde060367604)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c7d8e7c5-909c-4564-bcb3-b8cf825ac3a8)(content(Whitespace\" \
+         a1a4aab9-e024-4d2a-ac4e-ea4256061d2b)(content(Whitespace\" \
          \"))))(Tile((id \
-         78b7143c-02bf-4356-946a-2a0d07944c2d)(label(\"\\\"nrows(t2) is equal \
+         3cc499b1-b0f4-4f27-b64f-7d6c43d5b325)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         66be3654-f913-4d8a-b0b0-e9fe6ddbb23d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         22de4c1e-80a9-46e7-8c2f-70346c45f3e2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ff5a69a-834b-4a43-8661-561aff6d2b26)(content(Whitespace\" \
+         cea87628-9d9a-4b73-8262-a039c0740586)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         4381425b-5709-4ee0-a0b4-9ece80e5444c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b70b2b19-bfb2-49cb-aca3-ace06d95fa44)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         81c42039-c13e-49b8-952b-1e71e4f0bd0e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8429eb2d-2e8b-42ac-bc71-0bfa312d06b3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         78d1a006-46dc-4975-95ea-4c0ca9918383)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cf6f6257-3e15-4f32-abc5-fb97f4654c27)(content(Whitespace\" \
-         \"))))(Tile((id e497b7d8-33b8-42a0-a1cc-509b700f0b3f)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         89d9e813-e853-4bfb-8d00-7150ec986225)(content(Whitespace\" \
+         b00985ff-f77a-44b7-93cc-c09e7831d2cf)(content(Whitespace\"\\n\"))))(Tile((id \
+         2dc9c49a-2e52-4bae-af7a-0b83891ad0e1)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         04f00375-a7c6-4cee-bca0-a69d4caffff6)(content(Whitespace\" \
          \"))))(Tile((id \
-         3fdcccb0-1bc0-4215-8142-58dcdda46a1a)(label(select_cols3))(mold((out \
+         06843693-9fcb-48cc-a0b3-6fa72d582721)(label(select_cols3))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a640bf52-21b1-4196-8b91-37f56e952ce3)(content(Whitespace\" \
+         8444b028-115d-446a-a682-e0f59c09f6e8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         34cee950-dfe3-4587-aa04-e3cab45ffcbc)(content(Whitespace\" \
-         \"))))(Tile((id 4574f298-abb6-4ddb-b561-2fab3d37d0a4)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         98e11afb-6c43-4e81-9df6-fb12d9c36eab)(content(Whitespace\" \
+         03938567-22c1-4a15-92c2-2e6f0d0c42b7)(content(Whitespace\"\\n\"))))(Tile((id \
+         2c9219c9-fcd4-41e2-9be4-b2fc260a5524)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a75a14b0-f966-4a1f-a207-1ece321970dd)(content(Whitespace\" \
          \"))))(Tile((id \
-         4bc859b4-aa3d-4baf-ac21-b5982ec97f58)(label(\"(\"\")\"))(mold((out \
+         10d71d20-f539-494e-8fe1-b555033eba56)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         1de490f3-954b-4f63-a0bc-792b04d8609c)(label(t1))(mold((out \
+         a5cd6a9b-314e-4e88-9c38-38393c187945)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         77fd2bbc-72ba-4c1b-ba6a-fb3bbb1ab30d)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         63e4aaa3-2603-4ec3-bc5b-d826abfa1f23)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3b6c1362-4ad9-4f6f-a222-31d933c09c1b)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2b88a52f-c2af-4f91-8cd9-fa68a8410dd4)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         f4f8a187-dd0d-47f6-bf37-b115a4a83e57)(label(?))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ffc68f9e-cb5f-4391-8a66-7c54f0bb16ba)(content(Whitespace\" \
+         \"))))(Tile((id 35470cf3-d961-492a-a9a8-9d2f4482dedc)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         ee998220-38c0-45ea-a00b-1d504869633f)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         301553db-c20d-484a-a5eb-0db7974a5e70)(label(,))(mold((out \
+         53f427a0-ea16-4cdd-86e0-61806b81f5b8)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         afe153f4-42f4-425e-9f3b-9cf5b7e02ad8)(content(Whitespace\" \
+         ea1f1c17-8ce0-450e-8ceb-f819e7d8c4a5)(content(Whitespace\" \
          \"))))(Tile((id \
-         f2abfaa5-5660-4ea0-8a79-73b219432910)(label(cs))(mold((out \
+         c2d05818-19cf-47fb-83f3-146c492702f2)(label(cs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         af8f26b4-be20-4470-a072-947e8aa65a66)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e6b6d8cc-bca5-47ca-9a91-e18b5316f71b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         36e5cff0-68bf-4db1-bb11-d29e1cc66496)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         f9228c38-7590-4b71-869c-76195079898e)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         69cebcbf-23c0-4e3f-a776-8f3c0b11f81e)(label(String))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c87972fb-f346-48fc-8df5-5f3b22842f4b)(content(Whitespace\" \
+         \"))))(Tile((id 96993e21-cf20-465d-8f2c-ee33191d9275)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         1d9b0612-55d0-4483-98f5-16c6ded7bdf1)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         4493edb6-7974-4aeb-85a0-1f885e904a16)(content(Whitespace\" \
+         8b510b70-844c-47c0-9d02-359458d8fd4e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0e4c48fe-ccee-4288-97a0-8f0edc5cfb51)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eeaa3140-6b19-4b9c-b908-c2f109f3c7e3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         54012555-67cb-44d5-a0bc-bc8f4bcf2183)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         01b02ad1-b113-4b79-b283-67bbc600de1b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b2b7748-fe8c-4538-acf0-635d062303d1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f7d91162-7460-4f6c-8e10-3702b93a343a)(label(map))(mold((out \
+         28b039fe-fbee-4da9-b4f8-2ddd89a2c406)(content(Whitespace\"\\n\"))))(Tile((id \
+         82e1b565-fb79-48a5-835b-1bfe1d64d38b)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         48dbfc09-4015-4647-aee6-a6230b8d99a9)(label(\"(\"\")\"))(mold((out \
+         6e7f7e5e-2bf0-4c0d-b547-650e17cafd5e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         0d0c8781-18b0-489b-b799-4e41d82a1dc6)(label(t1))(mold((out \
+         0dcc5269-ae2c-41bd-bdab-3e0c0ed99118)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7f0d2896-ff84-4755-a3e0-bf1ae5283806)(label(,))(mold((out \
+         8b8bb7f8-5285-4dfe-b254-e5031fd39d21)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         036ad079-2847-4b36-bd23-0707d548a35e)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         0d055f0c-e5e2-4088-aa82-8885a15032b6)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         42fa89f9-2bd0-4bf2-81d6-ced7cc94fb13)(content(Whitespace\" \
+         \"))))(Tile((id a562249c-67ff-4be1-80cd-1de44e245525)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         d46ed2a3-20a4-4d29-bb78-1c9dfabb90f9)(content(Whitespace\" \
          \"))))(Tile((id \
-         ed495ac2-a2bf-424d-b703-04e36b78a058)(label(r))(mold((out \
+         10f30cb9-2322-4c67-9fcc-de9bf91a0731)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e67f186b-e72e-444a-9da0-21a7c6dbcea4)(content(Whitespace\" \
+         bf9a9952-0512-4477-bd18-b4eaf0d07c5f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f21da7d3-77fd-404e-8ded-45c2b8932959)(content(Whitespace\" \
+         f12ebf67-12b7-4e79-b3c4-d63c8369122e)(content(Whitespace\" \
          \"))))(Tile((id \
-         4e455f2d-0d9d-4928-9284-085ab21fc229)(label(to_lvs))(mold((out \
+         c6a8317b-1700-4971-8a0d-fe5fe4b060e0)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f870e905-4644-414e-b5ec-5c3c27784774)(label(\"(\"\")\"))(mold((out \
+         aabc75af-72af-42e7-b068-d3af348ffbe3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         50f07973-1b03-45b7-bd4d-2367594875f1)(label(r))(mold((out \
+         d3ef3b76-f995-4e39-864c-1e6cd0e58139)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         38cdace6-ffa7-4daa-8601-76f3f8e15722)(content(Whitespace\" \
+         cbd6560e-ac5e-490d-a455-23f8b08716e3)(content(Whitespace\" \
          \"))))(Tile((id \
-         ab410631-0184-4bc9-9307-737caf807b23)(label(|>))(mold((out \
+         04536710-cdcf-4b37-a195-1c9a309723f4)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ab734093-4735-4362-9fcf-9b4d8e23f220)(label(\"(\"\")\"))(mold((out \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7d445718-5f15-4deb-b373-1363f43db580)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5d5d65b6-fe2a-430e-8b9a-b1b557b5e3ed)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         3d18814b-06e6-46b7-affe-09ee5bc3326f)(label(fun ->))(mold((out \
+         a4cda934-09f6-4a73-9b02-4958913cd96c)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         fa5e838b-7c88-4233-bd41-170ae6cc0a24)(content(Whitespace\" \
+         04ed31b0-de1e-4a31-a9c8-4fbca82a80c8)(content(Whitespace\" \
          \"))))(Tile((id \
-         10fc962d-243b-4a98-8836-d9fd80f3af0a)(label(entries))(mold((out \
+         ffbfd0da-8af2-4dbd-bb98-bad694eea67a)(label(entries))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ac6ce69f-85b1-4baa-b285-333d49226c73)(content(Whitespace\" \
+         f6af005b-43ed-4362-8a99-5e3a17bea63d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f50b7a68-0258-4cf9-b3c2-b587b2b500a9)(content(Whitespace\" \
+         35e6d5d2-8314-4923-a40e-4360aaeae388)(content(Whitespace\" \
          \"))))(Tile((id \
-         84268866-3aaf-4439-bbc2-65bb928951cb)(label(filter_map))(mold((out \
+         376343fa-6432-47bb-9887-4d86639ba0b3)(label(filter_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         1e5d3f82-27cd-4d5a-8d84-4e9ad98e9d7e)(label(\"(\"\")\"))(mold((out \
+         6e2d1bb1-3d39-4b19-aeb4-915d4caff4e7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         ec938537-2453-45c2-9971-6742ed2d0443)(label(cs))(mold((out \
+         1baf3170-8c5b-48ab-8f55-8e83e8b34c4e)(label(cs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         47c45850-a08b-4a72-8813-dbe6e2af43de)(label(,))(mold((out \
+         28f879f3-6cf4-4882-be6e-6b3ecad1244a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         03218e80-b449-4bad-96f4-1a62d3c87e52)(content(Whitespace\" \
-         \"))))(Tile((id 71fa4c5f-c8a6-4ed4-8d4e-7ee184f4d016)(label(fun \
+         78321a2e-ccf2-4df5-a421-18816690ae47)(content(Whitespace\" \
+         \"))))(Tile((id 314589da-4075-43c9-b26d-38a69366f53c)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         04a889a9-d97f-4b0b-9fd7-c82b26c49ec0)(content(Whitespace\" \
+         be5e311f-939e-45e8-a958-36c52c00e2a0)(content(Whitespace\" \
          \"))))(Tile((id \
-         88e1b8eb-9ee3-4cbb-8b9f-5e11952ff7ce)(label(c))(mold((out \
+         6a5fecf3-181a-4e21-8802-0baf0ad0eed3)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0e847df6-e76a-4c82-b86f-a6a8cae884b8)(content(Whitespace\" \
+         4b83d0f9-956a-4638-b7e1-9defc13797c5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         49fa4789-f163-4249-9562-3f42c50ad312)(content(Whitespace\" \
+         bd3cad28-5bb6-401a-bd06-a22f4aef5dc3)(content(Whitespace\" \
          \"))))(Tile((id \
-         90cd67db-b515-4da3-a0e2-d70a5a212510)(label(find_opt))(mold((out \
+         cc99686b-28c9-4a09-a749-574f0bab8381)(label(find_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a993a5fb-675e-46e7-a9e9-4d39d4665c90)(label(\"(\"\")\"))(mold((out \
+         119af2e1-5551-4efa-89d4-49d75fa86ec2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         ae89e251-ca32-4ef0-b983-7e8526d24f58)(label(entries))(mold((out \
+         d0778a56-d480-4721-8ff4-c4db97974200)(label(entries))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         26721ebb-3884-4fed-b574-9f7a330f522f)(label(,))(mold((out \
+         23ec4174-d448-4ce0-9e05-32eb59eb4212)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1d2fa7c4-814a-4129-a2a1-8f271bdc1bc1)(content(Whitespace\" \
-         \"))))(Tile((id 0d598cb8-3573-4ca8-9f7a-29515b424330)(label(fun \
+         615ec5e2-cc2d-400b-85a9-5d172fa8f43d)(content(Whitespace\" \
+         \"))))(Tile((id 6582f9c4-c955-40e2-89f7-4dbb7d04b65b)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         30490317-dc7d-4659-a012-49d2af20bfef)(content(Whitespace\" \
+         9025ec40-5e08-4b7d-a83b-5ee054ae0dce)(content(Whitespace\" \
          \"))))(Tile((id \
-         d140e35d-eabd-4de1-b922-ad2b7de347e8)(label(e))(mold((out \
+         4bc4213c-a3a8-4e8b-bde4-1eea306e6629)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9a66c9fe-043c-40e6-b593-0f139e4b8832)(content(Whitespace\" \
+         780efc4e-9e16-4727-8809-8c450b9907fa)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d316652d-29f0-4db6-bdad-3d1e0c59ffa0)(content(Whitespace\" \
+         7270fac3-7f7c-4824-9368-1ae451d9602f)(content(Whitespace\" \
          \"))))(Tile((id \
-         e1bf74c9-9ba9-4066-82fe-56600dd4eef0)(label(e))(mold((out \
+         47bff86d-90a7-4791-85cd-d9bbfc3b67c2)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         0fc96291-c1cd-4064-9dd7-015446fb6b60)(label(.))(mold((out \
+         23c20cc5-9b54-4af7-a7f1-d2eb8c7023cc)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e3f5463c-3f8d-49cb-accf-c71b57e8c7ff)(label(label))(mold((out \
+         24a9cab9-b76d-4b79-b4a9-430987c53aaf)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         116fc879-3d34-455e-ab75-a568cbb67055)(content(Whitespace\" \
+         1064a190-1532-4640-bf42-ecebff126298)(content(Whitespace\" \
          \"))))(Tile((id \
-         2ffeb5e3-5082-4ead-955b-680e1cb05947)(label(==))(mold((out \
+         c3e83649-a5ca-4c67-8eb8-99342610f1b9)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0f0d5434-bc48-4743-a079-1bf3e704a014)(content(Whitespace\" \
+         f94b39aa-01c6-4523-b417-6dbfd59e39f0)(content(Whitespace\" \
          \"))))(Tile((id \
-         37bfcc9b-006e-40a6-8052-bae732ddb142)(label(c))(mold((out \
+         a3b2478f-fd32-4789-8738-f85642cc057a)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         218b1661-93b6-4374-98bb-250a14eb1fff)(content(Whitespace\" \
+         077423cb-04a2-4ff6-a487-c1bf34c761f6)(content(Whitespace\" \
          \"))))(Tile((id \
-         7316fbb2-8534-4011-bbe0-435d47a39264)(label(|>))(mold((out \
+         64984c41-f4ac-43c7-a4b1-c5dc8d651dc9)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         688df16d-7785-405a-9659-d4d03c39df64)(content(Whitespace\" \
+         e5f2831a-9991-4317-91d8-056fbfd0e8c7)(content(Whitespace\" \
          \"))))(Tile((id \
-         2edabb9a-6671-48cd-abac-b6dcebbbddfc)(label(from_lvs))(mold((out \
+         fd2bdb6f-f69b-4013-acff-5e6923f96534)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7f15a51a-3114-4d5b-8d53-90ac4db9e174)(content(Whitespace\" \
+         45a83ec1-a617-4f59-b1d8-1e525e6b061f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b8b7a5b0-f9d6-4c29-a799-e63d0aa49fb2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         64068558-2ebe-46bd-b76d-380fc234ee1d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b3ae01f5-0577-485f-a93b-1b089f618b0f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8dfc25b-5283-4387-93eb-6f00e5767822)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a268abd7-4a4e-45c9-85b4-35434f86bcd0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7357b13a-823f-4994-a765-c59fa4b28869)(content(Whitespace\" \
-         \"))))(Tile((id 7d4758f6-f4b3-481d-a5c8-b8c80385135c)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ce495004-f502-474b-af0f-f6a4a7ee4d73)(content(Whitespace\" \
-         \"))))(Tile((id \
-         41f7ba14-19ac-4c5f-bd53-46f70caa0589)(label(select_cols3))(mold((out \
+         91a75abd-f2f9-4edf-acb8-377569e84419)(content(Whitespace\"\\n\"))))(Tile((id \
+         1ff85b80-496f-403e-aa58-8911e2e4aee9)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         14d78fe0-bc8f-499a-8c2a-096488c78101)(content(Whitespace\"\\n\"))))(Tile((id \
+         180e50df-7982-48c8-8cbf-f4bbf3951738)(label(select_cols3))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         4efcdc38-4b89-48d2-97a9-38898add1f8a)(label(\"(\"\")\"))(mold((out \
+         4b0e31be-a05f-48ed-a244-7f6630100d81)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         ce4e3879-09dd-4fb2-892f-438eeb3c2a75)(label(students))(mold((out \
+         da60bbf4-9880-4783-afbb-72d9d37891e6)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         380acc96-d31c-49c3-8968-5efe46ffdbd8)(label(,))(mold((out \
+         09471c6e-58b1-4536-b619-7e7dcc5d0f64)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         82f56f3c-29f3-4854-b1db-7dc46df32f5a)(content(Whitespace\" \
-         \"))))(Tile((id 3a188256-0fe9-4f0c-ac80-6e4b851f3891)(label([ \
+         14f6d5b5-ba69-4bab-bfae-16a3b71103cb)(content(Whitespace\" \
+         \"))))(Tile((id 3c9bfca9-06f0-4795-b013-3b1edb6d08b3)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         41a0e040-9319-405f-96cc-1c8b44d81c25)(label(\"\\\"favorite_color\\\"\"))(mold((out \
+         0ca375b4-ef48-4840-940a-ee7bb1614f23)(label(\"\\\"favorite_color\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         5ed96bbe-87b6-48a6-a485-627493652ff7)(label(,))(mold((out \
+         b743bddf-7414-4a5b-a308-6c499ec4c5ff)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         87f57021-0c06-418a-af6e-7f41d5ce6521)(content(Whitespace\" \
+         38ce3590-f411-41ef-b136-b60c7991353d)(content(Whitespace\" \
          \"))))(Tile((id \
-         aa0f350d-f19b-42fc-8054-80ffba05eea4)(label(\"\\\"age\\\"\"))(mold((out \
+         6109d46f-c0b9-40cb-98a9-dc9a3c6da00e)(label(\"\\\"age\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         8782d23f-07ae-4187-b940-83850d1baea7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ca02f259-2f05-4e03-b680-f6176f2c3de8)(label(==))(mold((out \
+         37057328-ae88-41f7-82ec-35d1e72b5769)(content(Whitespace\"\\n\"))))(Tile((id \
+         a7ced920-8547-4349-a02f-736907b84e31)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0efa34ed-956c-4c4b-8e7b-900ef5018ab0)(content(Whitespace\" \
-         \"))))(Tile((id 6027427f-18b1-4039-a2b2-a890fdfbe732)(label([ \
+         a923e820-92f2-4019-a958-3adedb8dc60f)(content(Whitespace\" \
+         \"))))(Tile((id a0755b25-dead-4097-a70b-bda50ce0cb16)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         54cbbb74-7d20-4db6-997d-efb9e2dca11c)(label(\"(\"\")\"))(mold((out \
+         a81129af-34ac-4ba7-a8f1-073ddecc7248)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         9f02e8f6-a09b-4e78-a366-f2ac2e96574f)(label(favorite_color))(mold((out \
+         e228a564-0e42-46cf-9516-b9ce04aae3f0)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         82b3719d-4a8e-4b8f-9397-7086a8ce270e)(label(=))(mold((out \
+         f8c1d335-3336-4e5d-93c3-a00a05309dc6)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         05f75cde-767d-4d7d-9c70-5b001d55be1e)(label(\"\\\"blue\\\"\"))(mold((out \
+         4f7892e7-07a8-4bc1-9acf-9115e3c06f8b)(label(\"\\\"blue\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         c0b20e5b-bcef-421b-a696-f39f544b91c9)(label(,))(mold((out \
+         387c6d05-ea40-45d4-a0b1-61f4de0aa43a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         db1f6cea-8b8b-48e5-a0c3-5fbc5ac1e973)(content(Whitespace\" \
+         b9c7dfb9-2b45-41e7-9016-03f245a76a91)(content(Whitespace\" \
          \"))))(Tile((id \
-         478e4e78-2c74-4c38-914f-182bb7fef31a)(label(age))(mold((out \
+         2e679584-a1ad-49cc-86b6-ccfbcde9942b)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         8f9ddb99-6f62-4e59-a684-9fa67f61e8ea)(label(=))(mold((out \
+         9772dd81-5428-44da-9727-ed707ab736e0)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         3a044ae6-f75d-484e-b40e-90491139abe6)(label(12))(mold((out \
+         2af1c0ba-0653-4421-9363-77c947a29e06)(label(12))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         afbcf806-0962-452d-b673-fcf52219965a)(label(,))(mold((out \
+         fae24967-a4ae-4f30-ac6d-572ba66bdebe)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         37ab040a-b646-449c-be3a-76cbe9cf67cf)(content(Whitespace\" \
+         4d3bac5a-6bea-4e22-a7e8-236868b8c14a)(content(Whitespace\" \
          \"))))(Tile((id \
-         09a20ad8-321b-454f-9273-67a52082e19a)(label(\"(\"\")\"))(mold((out \
+         723ab381-270c-49d0-b1da-94e6eaf21828)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b84f0d27-77cc-453e-8251-b18a6f67219f)(label(favorite_color))(mold((out \
+         2c101126-7e2f-48a2-8f9f-6fb958d9e8ea)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         03ead4bb-7bbb-47dc-95a7-7adc62f694ad)(label(=))(mold((out \
+         aec44007-9efd-469d-b728-6d9a9129d598)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         1824e717-522d-4f93-899b-4136d8765f31)(label(\"\\\"green\\\"\"))(mold((out \
+         a8289a12-37f4-41b8-9363-8dcb4ebc0e54)(label(\"\\\"green\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7d95d8f2-51af-44a6-a95b-dc7512be2550)(label(,))(mold((out \
+         d3d69a59-49da-4859-aa72-a93c5ab53814)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ba456cb4-1992-4f25-99a0-4792174da6bf)(content(Whitespace\" \
+         858e9e0b-9d8e-4486-ba4f-2602f0818b4e)(content(Whitespace\" \
          \"))))(Tile((id \
-         d0b44b76-0a83-469d-b452-c6258af662b4)(label(age))(mold((out \
+         e4964388-1437-4731-aa59-bc92201291b7)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         890fab5f-6a22-496b-a294-d74013bf8b46)(label(=))(mold((out \
+         ffb4302f-a5b5-4116-a216-0499e07a59d8)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         33896fb7-0567-4945-9bf4-56d13028fed0)(label(17))(mold((out \
+         bc4526c7-3021-43df-bc9d-7a45aa3bbae0)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ac945c48-2727-41ff-8924-7d7d44ae3f9c)(label(,))(mold((out \
+         2f3d28d0-fab8-467d-aead-7ee91407a1bc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         96e66f82-91d8-499f-aab0-bd35b268786f)(content(Whitespace\" \
+         86d6ad97-d01c-4dad-85db-2706ff00a444)(content(Whitespace\" \
          \"))))(Tile((id \
-         7548db75-4c05-4744-a8a3-0be487be7dd4)(label(\"(\"\")\"))(mold((out \
+         144d8d60-0cb6-4eb9-b918-0fec1b8b90f6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e92f0ab1-ebf7-4ffe-8e01-0452e1f1f170)(label(favorite_color))(mold((out \
+         e1e228f3-d08f-4023-887f-c6f1bc3ad4dd)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         35457e99-a627-45c1-af44-625f00fdc3a4)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6f88a9dd-0d8b-43d9-94de-fb94eb8c7ace)(content(Whitespace\" \
+         \"))))(Tile((id \
+         54ad7929-fe8e-4c78-8140-1e4ba6f2d15f)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         a8aaba75-a5bb-4eab-9368-011019f90ba4)(label(\"\\\"red\\\"\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cd068bd3-b7aa-48b1-a2b5-813338f649ac)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aedd7e5f-b19f-45ca-85e7-dff3a5962d7b)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         42e106b3-341b-482e-b141-aeb4583a0592)(label(,))(mold((out \
+         d0aaf0b4-e7a0-4eaa-9594-6df365e9577f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ca64674e-deaf-4145-8b11-f4fb9718a824)(content(Whitespace\" \
+         29f42eaa-9a01-4124-b345-8c779718c261)(content(Whitespace\" \
          \"))))(Tile((id \
-         6aed02a9-cb37-4b82-90d8-1cad6862a351)(label(age))(mold((out \
+         a2c76f2e-fa2d-45e3-8c7d-2088b78b21be)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b2646366-0586-4177-af14-b99bba1a8beb)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         338aa0fe-4427-4898-ac23-37633e019343)(content(Whitespace\" \
+         \"))))(Tile((id \
+         646beb42-697b-4268-ad8f-493fd1292181)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         7291196f-d0a0-4df0-b295-4e66a90ca1c8)(label(13))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         88fd6df3-0df3-4e02-ba5c-529c12e91bbd)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e6c5b843-e806-45f8-8cc8-4cbc473b8e91)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         f1f784f0-f30e-444c-ad6f-fe5d24ae7018)(content(Whitespace\" \
+         1cf0d330-8225-4dbb-b26c-07f76c326b9c)(content(Whitespace\" \
          \")))))))))(Tile((id \
-         cdcf5acd-f82b-470a-81be-1ec2eed50f7f)(label(\";\"))(mold((out \
+         d90a4143-fe88-40a4-bf49-8d05c3f1a1c8)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8737cb48-66cd-41c5-b8e4-dc6f66d95b46)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6feee798-762f-48c7-9701-120ccb3128c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea58455b-1848-4d8c-89ea-9e0973963af4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         20895979-f0ee-4417-992d-e87d0a18d0d4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6177a6bd-e3da-488f-bf79-01f6b5f6b379)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ed78926e-dcdd-4a66-b214-654ab36eca6e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f4189333-acb8-4486-a21d-dacc323b1655)(content(Comment\"# We have \
+         d37160de-80b2-45de-b915-6b405f5793dd)(content(Whitespace\"\\n\"))))(Secondary((id \
+         3387cbdb-7350-4fa9-8b7f-3248148e0cd3)(content(Comment\"# We have \
          label filtering on tuples as a primitive operation but without row \
          types there's no way to give it a first-class type. This is the \
          idiomatic way to do the operation #\"))))(Secondary((id \
-         c9b5d331-c35f-4bba-8ada-cfa4a4a70534)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1a138e15-fd2b-4402-9430-14e537fa04a5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9cba70b0-4a28-4688-8693-a343dd1ccd8e)(content(Whitespace\" \
-         \"))))(Tile((id aba50df9-1b01-4ad8-96d2-93d550e4bc6a)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         448de394-fa41-48c3-ac9d-3a99d2968bc2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a6236d2f-96f1-4007-babd-92fc1752a570)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c414e31e-079d-4add-8956-94d6611d1f5e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         460d719e-3b53-494e-9e80-fe112dd2967f)(label(students))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3b603640-7788-4882-9cf1-a9f95425b332)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         52cd18c2-2fc9-4d12-8c00-d7cdf42a3bd2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8156660a-3a6f-4d4a-806e-86ff524bcc2c)(label(select_labels))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c522156b-ecbf-4aac-b0be-25bef2cb4c67)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         64dec6a3-9e8a-44d0-a3b7-c1f9df9b0c58)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2866b307-a87f-4dc5-9e92-a682b41ac057)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2a6d5fd4-e945-46f5-a8e9-b60f037cd1d5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f8c05ade-af68-4b04-ac2a-8ccdb30e08c3)(label(`favorite_color`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         03ad3fd2-e7b3-49cd-aad7-16f1a751c753)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         87fe4779-ebb9-4109-8eec-2b4c21d49fb8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         872ea5c6-e72d-4279-ad5a-63e99f3b8601)(label(`age`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         7cc95719-a6e3-4847-82b7-746eda294dc1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5a9a5413-7f4e-4783-bafa-df1fd42e5533)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ce8342ec-74a0-4612-9e9f-b057e5b6bf51)(content(Whitespace\" \
-         \"))))(Tile((id 4bfd7c04-7e85-4498-9088-6c1a91150d06)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         bfa05a2b-a430-488c-a5ae-d09fd5bc8d29)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         f10aa469-3212-4594-829f-3c5806e17532)(label(favorite_color))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         657cfec5-c31d-431a-8003-7befde5da74f)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         50b3612a-ec36-4b96-b76d-632f85d9f0f8)(label(\"\\\"blue\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d42a1298-35a6-4228-b3a2-0c4bd8bbee9c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         858c7d5f-4ca6-4eff-8beb-d8edccbb8475)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cbd170d5-1a58-414e-94b7-0811240b420c)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         35c58190-ebee-48b7-adcd-f3fbfcc12594)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         6fcd6667-74bd-4b94-b50e-cb959dc1dca5)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         836962f1-5983-4a1a-b779-700e7164e1ec)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         92353239-a4e8-4513-be57-258131bf6d3f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1c901e45-9eec-4c2f-9b48-7a04d131a894)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         908c59cb-7140-4fe7-a9a9-587e5039f32e)(label(favorite_color))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2d8e9ba3-11e6-4a63-9933-5fc6e708e64f)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         658ad252-c620-48c4-bd1d-3c8b6b5cd638)(label(\"\\\"green\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b031fc51-a9c2-4232-9a1a-bde58f12ed57)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2baf986c-a901-4ed9-b5d6-2df3f73a84ee)(content(Whitespace\" \
-         \"))))(Tile((id \
-         946eaefb-74ac-438d-a6c8-d73ea4ee0c06)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         69fa685f-bea8-4667-a3b3-f1bdca5b6a20)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         2a456fe4-30f7-43d5-b2d7-b01a086b63a5)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         7de12037-7652-4883-a034-7be6397949fe)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4a33f798-1343-42ac-97d2-43207fd2c1ed)(content(Whitespace\" \
-         \"))))(Tile((id \
-         59c9c2f6-8d34-4f11-9d58-cd139c3a9912)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         f5e6bb97-87f5-48e2-96a4-7db98c3f1ca6)(label(favorite_color))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ce15bef6-4163-4525-bec6-4a391395db09)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         cb956221-f873-42e6-b89e-4a14725552d6)(label(\"\\\"red\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         91baa015-0036-4579-abca-d0f803ad7c3c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         32f0d2e1-13aa-4fde-87dd-3aff8eb2f496)(content(Whitespace\" \
-         \"))))(Tile((id \
-         351d838c-7cef-49f7-bcf9-17878ed3d8be)(label(age))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         940a5c37-1005-42fc-a545-a3dc72eeb8e9)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         9cb0c9bd-656c-4ec4-bede-18040824fcb0)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         4835d407-16db-4108-923f-72d4105b8bb2)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         06262bf5-eb8a-47a8-b893-9d8b83933e36)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         7644f624-7313-4135-bb3e-63e18ee45aac)(content(Whitespace\"\\n\"))))(Tile((id \
-         5a3d68b4-27ea-4560-bd0c-eb5d92db01cb)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c985ee76-aaff-463b-a969-dccd8b62b745)(content(Whitespace\" \
-         \"))))(Tile((id \
-         975eb8f5-82da-45ae-9202-468cbbc9c15b)(label(head))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         779a4f8c-4bf5-42db-b931-fc3fdd7b1de9)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         6cf81ea5-d7d6-4f97-b05e-4d03491772e9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2053dc13-4524-4a4d-b665-0dc36f3ffb57)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e1462382-a6b4-430d-8ef6-342939b31802)(content(Whitespace\" \
-         \"))))(Tile((id b830197b-8dfd-407e-ab7e-883c46e15fc2)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         9882560d-e3c6-4c59-a911-710cc984b03a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4eba5119-542d-45cc-bfd5-6fbf26a61af6)(label(requires))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         7cf47b49-2637-4693-9d0f-5edf9808d292)(label([ ]))(mold((out \
+         024a1170-80c1-4438-9fd7-cdd38b153708)(content(Whitespace\"\\n\"))))(Tile((id \
+         8ba2b467-859e-4369-8483-fe3bcca8f3c3)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         9d8ba19d-9d02-4f45-a60f-9f83aad1eae4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         09cfb7f8-6067-4302-9081-1df1b808734c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3088fb5a-76a5-4629-96bf-42bb96d6fda0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0ae88f75-303a-491e-b240-79b2c0b908cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         01c86896-e53a-49d9-bd07-a70e04bedb1b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1521bb32-fc19-4562-ad98-09d9808c6513)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         06efccf8-f52c-4afa-947c-8b9db0fe616c)(label(enforced))(mold((out \
+         270a77bc-c5a1-4565-af32-b5dde693bf72)(content(Whitespace\"\\n\"))))(Tile((id \
+         440e551f-18ec-48a5-840a-7d9554d84736)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         ebb81755-25bb-4abe-99ab-00774470a99c)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         7f2488b4-76b3-49b1-9114-e3a9cfc49d6f)(kind Checkbox)(syntax(Tile((id \
-         53147d2d-1058-4f11-9a68-ad5f06b06121)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         e78feba3-ce35-44d3-be83-55aa872b195f)(label(false))(mold((out \
+         5d7aa1b5-58a6-458a-8cb9-2756b82d2855)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         84830bdc-3489-4fe2-ab10-ece7272e4182)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         82b9cdf3-d038-4c78-a60b-426a89d9145d)(label(,))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7be505b9-0087-479e-a98d-25cd717671c1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8f4e04be-f37c-44a5-a004-6b15020b2e88)(content(Whitespace\" \
-         \"))))(Tile((id 71e5c149-9a8c-4bde-9ec0-350fc8849568)(label(\"\\\"if \
+         48bc1eb4-3fe6-47ad-8a49-18e5e7d60c71)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8a0f2891-d1ea-414a-99f1-074072d568ca)(label(select_labels))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         caa0607f-ad6a-4eac-b54b-a17e08a97417)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         a225ac77-cb43-4113-9699-4eb6a7e44205)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d27924b8-f813-44b6-a965-7a1cc0885438)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b88c38f7-10d6-438a-a3a5-f7567e0a9a56)(content(Whitespace\" \
+         \"))))(Tile((id \
+         31b3395a-8aa8-4e9a-ab61-337b574d70e0)(label(`favorite_color`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         00601f0d-b4fa-45ef-9721-9af3ed952ddb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         061f71a6-e2b6-4ee1-831f-265cb4bf0c6a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9d213cb9-ec8a-4700-bc97-24c1d247702c)(label(`age`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         a89dc78b-87a0-4a2e-aa71-2a5ccf3625e3)(content(Whitespace\"\\n\"))))(Tile((id \
+         87529a43-2c4d-4190-82c0-b9069650bd99)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ccd51df1-6006-4cac-b152-26e908339421)(content(Whitespace\" \
+         \"))))(Tile((id 3f72bf01-35af-4dc6-be71-d0ef952708d1)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         4638f0c6-225f-4c0e-a11b-f5b5b0757da0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         410c7a17-9c6e-4e8a-a194-4fa57bd2c54d)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         91e5908c-030f-4786-9b40-774c8fa27113)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         822fc5c7-f039-4949-9d58-a98b7a7fb978)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         039e5c69-fce6-42de-a0c3-c42cae9e6419)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9689b5ed-75c1-444b-9e59-61f3ea52cc5f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5dfe7b21-0753-454d-ba2b-30544b8a1200)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         34f621de-8ad1-4b57-859e-e914c407d023)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         788bc233-1cc4-4710-ab75-ea25d0803a2e)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         54452538-3eba-463d-b39a-039f314240e8)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7f19fa90-1f22-474b-9c12-44c1fa447681)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c2d82ea6-cda9-4022-bfb8-1821154d9731)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         9d7c138a-102e-4810-92e1-aac30e19e223)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         23f04b30-01ae-4519-8546-6027bc9402c1)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         1572557b-b566-4d41-a764-d045e3d4eebf)(label(\"\\\"green\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         abd4ddf6-4ac7-48c9-bee1-f9e65ed40cb0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         de427110-050b-4eba-8951-3fff2a11acf4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cbfa8028-22f9-4789-942b-2e71667b5475)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6e74dbea-7871-4f9d-b5e0-b49cde26af23)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         7448d544-2759-4a8c-96ff-c18546e34d80)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         0beef7fe-b2be-4b6c-9295-25bc33ec850f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c03a9411-ae23-4e1e-8279-bf50b4a1e7d3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e6ffa9eb-ac28-494e-9bd9-ed3670c9a563)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         68d89776-48ed-4dfc-b71e-191b339f95dc)(label(favorite_color))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         be46cc1b-412d-4ac9-be5d-db5ae4787b13)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bf9fe2c4-3a1f-4414-b0a4-090fc7ce8836)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         15f49882-844b-40a1-8ab2-734993e628a6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         039cbda2-6629-4b97-8b2c-0e7806e3cace)(label(\"\\\"red\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         608bff14-a1ff-42e5-816e-d9e5300497ea)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         57aa86da-5b62-433d-b734-6465ad32210c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         db02361c-a11c-40a6-8f80-d96bdf7bc44d)(label(age))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6a08cbfd-ff36-4c4c-9d56-e1f05fe21e2e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         46eb253b-7b9b-4e57-add8-e7c830d9a6da)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f5ec9b3b-7da0-4dfe-8b07-6092f4480745)(content(Whitespace\" \
+         \"))))(Tile((id \
+         07ef4410-ca43-4b10-a621-2debfd988b48)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         84b5c378-7ad5-41da-a0fc-5d893b5d91c0)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9256abfa-52cd-44f5-a08d-df777ebd59f1)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         07d2989c-935d-42e0-b210-8d72c8c0bca5)(content(Whitespace\"\\n\"))))(Tile((id \
+         ee6108be-f5f8-4500-865a-2eeae7420f8b)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0b0544eb-feef-4ac9-af74-9e536c292483)(content(Whitespace\" \
+         \"))))(Tile((id \
+         47f7aedf-2e5d-48a1-a0db-7e8b117986c7)(label(head))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5cc5a6e8-4bf8-4ddf-800d-c358f0b88c85)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         eb8df6ab-6c3e-481d-a1a2-4668e2336f1b)(content(Whitespace\"\\n\"))))(Tile((id \
+         b73a0b05-d4f1-484a-a8ec-f2094f4a4cb0)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         28b59fef-32f5-4ffa-974e-430117520a5f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6095db92-9cba-4edc-b83f-4370e22939d5)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         7f8e0898-92ff-45c7-a3fd-f316d6d11d6d)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         beb6693f-74ef-458a-a55c-80e8dd2dc778)(content(Whitespace\" \
+         \"))))(Tile((id c148b264-fad4-443b-a7a1-92335e7849c9)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         8f9e0f28-aead-4935-bd0b-02bc3d5fd8f6)(content(Whitespace\"\\n\"))))(Tile((id \
+         c8185d04-c541-43ae-b585-aba32b6d8d78)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         f0d74ea4-d867-4b61-af10-f72d7a2ff945)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7c34c5e9-a6a4-4859-be9b-b24b46f8aaef)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
+         31cd2bd7-3cd3-4bb5-81e0-8c4f184ce33c)(kind Checkbox)(syntax(Tile((id \
+         6c314f46-4276-4e60-995a-39d32af660e0)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         1e61df3b-f43f-4ffc-a6ff-a6dcc48b46bf)(label(false))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
+         3d0684ec-ce80-4396-9232-f06c351d271a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dc315b07-7d22-4e79-9796-7b8aee46cfef)(content(Whitespace\" \
+         \"))))(Tile((id aeef04a1-1e97-420a-8b17-b9bb189a3504)(label(\"\\\"if \
          n is non-negative then n is in range(nrows(t1))\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         9db94a0f-b44c-4859-a989-9ca21c68db2a)(label(,))(mold((out \
+         a12fa4dc-c531-487e-b41d-713170911245)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8c24050c-2dbe-4540-9a24-fb194451de76)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8253bd22-babb-4f83-b526-956c591b204b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bd729842-0a21-490a-8f60-bad094e0f455)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e07d080f-3e1d-4aa8-8601-44d75f2a5dd2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         13591ef2-a92d-4b7d-92a3-133972c59a75)(content(Whitespace\" \
-         \"))))(Tile((id \
-         41834738-debf-4b53-98ee-fc09692309b5)(label(\"(\"\")\"))(mold((out \
+         7f645285-a537-4676-b37f-831eac527729)(content(Whitespace\"\\n\"))))(Tile((id \
+         4aa12ea5-3ca8-450e-b317-6e66c9bbaa63)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         5c3ec83a-cb68-4148-809c-1a84675e581e)(label(enforced))(mold((out \
+         0e1b6f00-25fc-49ef-9d9f-3927ae19dd94)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         36c7e1db-5b96-4575-b9fb-cf1b7db47261)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8da3cfe4-7b28-44ed-8419-c7fbeb4ceb4c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6c049bf7-7707-4f6a-9821-7655177b419e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         21640b47-6400-46e7-9ec3-34dff60ca7d9)(kind Checkbox)(syntax(Tile((id \
-         e0757a0f-c850-42e7-b8ea-054455f5042a)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         877b87f6-3854-49ac-84b1-814389d3b6e5)(content(Whitespace\" \
+         \"))))(Projector((id ca856791-9bf3-47dd-8814-40e044ac3271)(kind \
+         Checkbox)(syntax(Tile((id \
+         0ee4316e-dfc4-4bc8-8813-29101e95b4a2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         4cd9299a-bf1c-4758-a27c-1ea73ebea708)(label(false))(mold((out \
+         f8bf2cbe-68f0-4f4d-bf0d-cc038b026056)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         f54b2d99-1bb2-432f-bdb1-0ac7293a8b36)(label(,))(mold((out \
+         c813f528-22cd-4f92-901b-67f923ade709)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cf41007c-7880-4a22-a10d-c8bb885a3562)(content(Whitespace\" \
-         \"))))(Tile((id 6da054ae-0af3-4c65-a281-9b40a8630400)(label(\"\\\"if \
+         9c39126b-29e7-4be7-adca-44f5328733a9)(content(Whitespace\" \
+         \"))))(Tile((id b6c323fc-b1d4-4b5d-be05-ed7f37ddc4d2)(label(\"\\\"if \
          n is negative then - n is in range(nrows(t1))\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d69903e9-a3a3-42f2-939b-dd4ba4136f02)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3fd6a85e-d906-4360-ad87-9c675970e5fd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0634c9f8-3b64-484d-a63a-cdeab0b2e0cf)(content(Whitespace\" \
+         1c978c53-d6d4-404f-9de5-206fde74c06b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         4eb4e88e-a743-476c-abf5-2d085f7092e7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         95f70c43-c369-4c70-b9df-462e54fcdd88)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         92926178-10ec-4698-b156-95d77d60685f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e14cb745-228c-4c48-9f43-dae3ec00d138)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f62bb7d0-f36a-4a77-8b0b-47ffb9abc406)(content(Whitespace\" \
-         \"))))(Tile((id acf72ba7-165e-48e5-95af-1e19ec047945)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         258680de-92a5-4565-b2e9-e7f328772508)(content(Whitespace\" \
+         151d3e7d-4eeb-450c-b272-57482a34a8ba)(content(Whitespace\"\\n\"))))(Tile((id \
+         1afa5d99-5a11-415a-9846-4e0e3bf3e8c9)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         1d725af5-eb4d-43ac-95b4-b3d6f8c8bcab)(content(Whitespace\" \
          \"))))(Tile((id \
-         41c3ad8e-68fa-4e5f-bda7-f278b2681658)(label(ensures))(mold((out \
+         64ac47b7-6398-4f90-8c86-86ac06c30aa3)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         5bd2cc44-fc9a-45dc-bf60-bcca2e9e1b1d)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         1428e0f2-97da-4f13-8093-267c408a1c50)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7f63d2f1-930a-4d40-b393-b3ee4a47c054)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fddc20d3-3644-4824-a855-6b64b0cdeac5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         db4b0bc2-5c7d-4709-9d18-8dca68316c5b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e413ba4d-0194-4d8a-ad16-7b4e98025c17)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5e2126cd-16f8-4df8-b643-92802aff5d6e)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f67b6b82-10d0-49c5-a898-12c53495f897)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         bffe278e-a77f-4d7d-8bfa-95917ea222d7)(content(Whitespace\" \
+         \"))))(Tile((id ffa40f4e-987e-40ff-adb9-c7b02484648f)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         5047e754-4a93-4192-9b60-9d575c4eb659)(content(Whitespace\"\\n\"))))(Tile((id \
+         bb0d451f-4b8b-42db-9d4e-16a7d78ad6ab)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         cd900e94-28c1-46cc-92b6-86343a0732df)(label(enforced))(mold((out \
+         048cac87-c9a2-4c7f-aa89-e22dc711981e)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6643ed95-5055-4c1f-adbb-f4111e8947ab)(label(=))(mold((out \
+         b9901017-120c-400d-aec1-92b6edd23aff)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         cd8a6b7f-a869-4c31-aa5f-4dee3ff2694a)(kind Checkbox)(syntax(Tile((id \
-         4a8e534b-3180-4010-8255-33a6c66ffb1d)(label(\"(\"\")\"))(mold((out \
+         2148cb08-209c-45f0-9b64-55f79207c2fc)(kind Checkbox)(syntax(Tile((id \
+         41bf4a87-2fb3-44ce-ba43-574c513bd4b7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         df07ac9e-7e58-47da-8daf-3e8b6162c6bc)(label(true))(mold((out \
+         46fbd28a-3173-4ba3-a5a9-0fa75c8e6e16)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         2e3fa252-b383-43d9-9b13-5616a6cbe211)(label(,))(mold((out \
+         0f1b8053-cb28-4001-ba1b-8c99f662233e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         371324fc-1e99-4f44-b51f-6172404002c3)(content(Whitespace\" \
+         94abd14b-4c24-416a-81b3-8b7330eeac4f)(content(Whitespace\" \
          \"))))(Tile((id \
-         741045c5-a6da-4af8-9fda-c9c24fd2ce29)(label(\"\\\"schema(t2) is equal \
+         d23fe710-ff88-4a3c-92ab-44730bff7488)(label(\"\\\"schema(t2) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         77c87669-ebdc-4d1d-8139-396f4d1507bc)(label(,))(mold((out \
+         e6e92144-1394-4c50-a3cd-546e71730c8b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         605ca17e-7fc0-41fc-89ee-ec5db84ced0b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d4bec821-d3da-4fa6-93f4-4a85e7476006)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e97b52f3-bd0b-489b-8487-fc2608316055)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         abf607cf-de82-4d24-a572-b27d59e5dafe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         87896e5c-2ace-4cc5-bfc5-7bc4d194bd79)(content(Whitespace\" \
-         \"))))(Tile((id \
-         533851b4-8223-47e6-bfa0-f67e2fe22250)(label(\"(\"\")\"))(mold((out \
+         b8ca207a-d049-4a6e-91fb-450cf23d2e64)(content(Whitespace\"\\n\"))))(Tile((id \
+         597bc369-3b89-4688-bfdc-2ee8175c5806)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         1539a2e0-8a23-4cac-9c0e-47c74e4a3bc1)(label(enforced))(mold((out \
+         10aaaa86-4281-43b6-aa27-dfe89f22d1b9)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         782e7ced-3dc4-46bb-9b88-4918fcef0b70)(label(=))(mold((out \
+         a763cfb5-4523-4f2d-a9fd-e5a1c37f6186)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         2d75c7d0-b190-4ad5-a4ab-5474d2ee17e3)(kind Checkbox)(syntax(Tile((id \
-         80087309-6715-4f4b-bf45-77166853123d)(label(\"(\"\")\"))(mold((out \
+         971c5596-700e-45f4-bd5f-37838359a36e)(kind Checkbox)(syntax(Tile((id \
+         a5c41326-ea40-45fe-8048-e1f47cd02f51)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         1dea56f9-1c15-46e3-9a96-f911140e2b56)(label(false))(mold((out \
+         7f825ebd-a55d-4602-b25e-ddccbf5d4b76)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         4f2c8a07-2783-4808-9538-8443316bbdf1)(label(,))(mold((out \
+         3f849952-4e7c-48aa-bb8d-4b7b8bb41c56)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a95056dc-dacb-41ee-9bf5-98efbe78d941)(content(Whitespace\" \
-         \"))))(Tile((id 85ab77d1-9f64-4494-9d1b-5ade8cf054f4)(label(\"\\\"if \
+         b480359e-eb52-4a53-b485-a4ef6af6101d)(content(Whitespace\" \
+         \"))))(Tile((id 0e17a587-ae03-4c71-859a-c0d9e761dbd7)(label(\"\\\"if \
          n is non-negative then nrows(t2) is equal to n\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         bdd4dafe-b4ca-4eb8-8a0c-bff73c66406b)(label(,))(mold((out \
+         51578560-5ccf-4a49-ae5e-2b8f9cb9b672)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f9b7b2ad-fc9e-4882-9e63-cceda7825ae9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6134496b-bb0b-4273-9cad-74e5e6a219aa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         03a08b7c-1252-4b33-b865-c6c8f5b5e1ac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3d1a72e1-b713-42f6-893a-bdeb9bf6dee3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c440456e-9f7a-489d-9ebc-0a43e0079302)(content(Whitespace\" \
-         \"))))(Tile((id \
-         acd3dbb3-ceb5-48c1-b5b7-07c6f0248a1f)(label(\"(\"\")\"))(mold((out \
+         500b6c83-1220-4d1a-a8bd-8d57632484f5)(content(Whitespace\"\\n\"))))(Tile((id \
+         0f0a58f1-6a11-41dc-a1e5-8a6d7f6df8c4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         0107128c-ba35-4a55-9f5d-fcbfd04f2964)(label(enforced))(mold((out \
+         b69e05b8-9122-4487-9b5d-021d1eb74274)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         59d267de-33ae-45cd-aed4-5dc573d1345d)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a251f1fd-e12a-4f7f-b2f2-ba6692bbc27f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         74a01bea-9dd4-4da7-bca3-d0cc73fc1d2b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         24527121-a269-4420-baec-3c5ac3ebdf5f)(kind Checkbox)(syntax(Tile((id \
-         bc266d95-e786-4812-99c9-9eed95dd3b41)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         76882b0f-6980-4085-a52a-5e1ef62b4673)(content(Whitespace\" \
+         \"))))(Projector((id b22b0531-416c-4db8-a18d-a43f4267e77f)(kind \
+         Checkbox)(syntax(Tile((id \
+         7dc5ac83-27bd-4812-8e75-3e66fdc0c6f2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         53cc4007-5e15-4e40-a8d7-2504f119531f)(label(false))(mold((out \
+         e84d8de6-58a6-47e5-9c10-fdd60b57838d)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         19a6f11c-998e-4d5b-9d5e-5bb8defc9915)(label(,))(mold((out \
+         dbb97347-9335-466c-a5bf-a233b7267351)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a431aae9-d735-405e-bdac-119eadb391dc)(content(Whitespace\" \
-         \"))))(Tile((id ef043061-1c09-4db8-8d0f-1dfe211eac1a)(label(\"\\\"if \
+         50181e28-6508-49d4-a8a8-30e48863e113)(content(Whitespace\" \
+         \"))))(Tile((id f3e1b4f4-8102-4703-90f6-3372b561e6a2)(label(\"\\\"if \
          n is negative then nrows(t2) is equal to nrows(t1) + \
          n\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ae05397e-dc09-44e1-a478-2583208efb08)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5122222b-072b-46f4-a24c-3ef02417cd15)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a9fe2765-2c0f-48f1-9ec5-011a55901466)(content(Whitespace\" \
+         64d8934b-f458-420b-b4af-b17806b3022e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         74e030b7-41a2-4322-89df-cd45068d8603)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c9323b18-cb00-4454-a3c6-1614f7f7703d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f254612d-a071-4112-aa28-e62a5cfdfa83)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c5f595d3-c6a9-493e-a35e-99f202fd169e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5d1e58f3-7caf-452e-9389-a9a1ed185c47)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2b87a456-0128-4b07-99d3-69865943f1f8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2127196a-1e8c-4831-9654-b1780a09144e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ef323ee-278d-496e-a6a4-9bc9ab75898a)(content(Whitespace\" \
-         \"))))(Tile((id 05448525-393d-4f02-a313-504d3619c6b4)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         13656f84-c3be-4136-8a0c-fa8674d3ff6d)(content(Whitespace\" \
+         e8c3795c-955c-402e-bcce-5a864535a866)(content(Whitespace\"\\n\"))))(Tile((id \
+         3433a2d4-22a2-4abf-a534-722a200e1c5d)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         11d24ceb-f1ad-47ba-be6c-1e78a7905118)(content(Whitespace\" \
          \"))))(Tile((id \
-         7272cd4e-999a-4264-9087-fb564e26ef0d)(label(head))(mold((out \
+         3966dde2-517b-499c-bde2-5b146b793ed3)(label(head))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5ca4215d-7b2e-4b29-a231-112963d05d11)(content(Whitespace\" \
+         afd2affa-dc14-4cda-b9c4-79def1cb9366)(content(Whitespace\" \
          \")))))((Secondary((id \
-         1b70c941-7942-4d9b-8c1e-8dbc96405e67)(content(Whitespace\" \
-         \"))))(Tile((id 8445e422-bb8a-4bc3-a2c2-fd9d70699645)(label(typfun \
+         e06c985d-b414-4cce-86be-ca6480e3824c)(content(Whitespace\" \
+         \"))))(Tile((id 8c977feb-8132-4833-a200-e81a9a04ba1c)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         82cf2752-9e43-4b6e-82b3-3db5f379dc01)(content(Whitespace\" \
+         5f2c2b68-d01c-4feb-a4d7-c22d5ad6b669)(content(Whitespace\" \
          \"))))(Tile((id \
-         697bda62-bbe2-4c34-a28e-bf5dc2f0db04)(label(r))(mold((out \
+         ef0f41da-7fcb-4762-9b8c-a4ace9098ec9)(label(r))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         fe57b2ad-cb12-4648-9943-20ccf4781e1f)(content(Whitespace\" \
+         ba8c7060-ba4f-47b7-ba01-0a9a61119254)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fe947bf8-df6b-4deb-ba5d-98f0fa3ce659)(content(Whitespace\" \
-         \"))))(Tile((id 3211637d-52a4-45df-bddf-ca9f85aa20f7)(label(fun \
+         c8a27cd2-d587-4253-9fbd-114d6a5ee057)(content(Whitespace\" \
+         \"))))(Tile((id e4c6798f-88f0-4336-9026-92a8d03c0763)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         c081bf34-f1d6-416c-b1a4-5a421bec878d)(content(Whitespace\" \
+         6355b22a-5840-4641-a021-d330b3d5ecd0)(content(Whitespace\" \
          \"))))(Tile((id \
-         7aaa5d75-5f9c-4d0f-a865-4a194ebbe3d5)(label(\"(\"\")\"))(mold((out \
+         0cdc4e39-2a29-4104-940d-63da3a9a0aab)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         54642898-398a-438d-a7af-b594bf32cbf9)(label(t1))(mold((out \
+         16916c72-f9b4-48c2-89a4-0802919498f5)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         1e6a5fbb-0241-49fd-9cc1-2fe7112e417e)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a9929860-1e4a-4956-bcb2-abf4976e7e9d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         db1c4c5f-8a7e-4376-a154-9670e1107673)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         b576e131-0f42-410d-bcf5-b933ab4c1ea2)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         48fcd113-2caa-490e-a35e-1c08ddbee998)(label(r))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         11190eda-cf1a-490a-ae88-d4e4aad2b172)(content(Whitespace\" \
+         \"))))(Tile((id 951e04c3-f55a-4c66-8c2b-ade56a19d82c)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         3f981bd4-c4a4-4e09-9409-c0b7737e2281)(label(r))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         e00757ab-1e06-4ddb-8d22-19a86dd1df88)(label(,))(mold((out \
+         b931491f-3b54-4c46-86bf-845bf2979e94)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         5bba7caf-b544-4b0f-adaf-3c3b807d5640)(content(Whitespace\" \
+         ab5e7840-8f86-44e7-a8a1-93730671a687)(content(Whitespace\" \
          \"))))(Tile((id \
-         9afa29c6-cce5-45b5-ad28-9dc0e37fca8d)(label(n))(mold((out \
+         bbd8c892-419d-4ae4-a085-92657b09181e)(label(n))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         2e660cf8-e8b6-497e-b6fb-70c9b05db353)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c69d7d70-9e2c-4c30-a413-544d458593a3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f91e21a2-2bad-43f9-8984-64328ccdf45e)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         41ba19c8-975e-4cb5-94b1-6f95b2bfd013)(label(Int))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6e4a8bb9-927b-4d47-be83-6359ce38839d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         807c8738-5f19-465c-b972-1cda36875d24)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         82fb2f32-7b66-4725-8247-aafa97639395)(content(Whitespace\" \
+         df72b21b-22d0-4aa3-a126-9d925e25caa1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         74efe653-f068-4c45-a9dc-aff0f14b089b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c00da1d5-a7a6-4bd6-b5a9-1256c851674b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4aa09e24-cbdd-4715-a45d-ba202225dbe4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         93b37ca5-92c8-4e60-936e-5b80c42932ff)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         962b0d81-0e12-4062-a569-95e776b0e548)(content(Whitespace\" \
+         ecab9b29-2d71-439b-9411-1f5c9af22bbc)(content(Whitespace\" \
          \"))))(Tile((id \
-         c0c269c9-98b1-4f60-98f2-57a7e9794e99)(label(take))(mold((out \
+         f85b9f02-90e4-4f80-aec9-a02e661170f1)(label(take))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e83539f2-93f0-4b06-86db-f31888ab7bfb)(label(\"(\"\")\"))(mold((out \
+         5acc3157-0679-4145-87b8-d9cafc2f3f1a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c3cbc3d5-0222-413c-82e5-3eae0fff6a98)(label(t1))(mold((out \
+         ca6daf03-2ea0-4923-a544-c1a193f5370f)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         679f746f-4034-4c11-9c7b-5d4d79b13b5a)(label(,))(mold((out \
+         23a81818-9d6b-4f22-9962-b6acbb58c179)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         17ca3ef3-f372-472f-9c25-5bcef5ee9c61)(content(Whitespace\" \
-         \"))))(Tile((id e83eaaa7-4029-45df-a906-543fdaf5e41f)(label(if then \
+         91cbfa3b-90de-4487-9cf9-4ccb4ee60824)(content(Whitespace\" \
+         \"))))(Tile((id b6cc3836-e9df-40f5-97d4-bf78275cd6fb)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         b232f5b0-6b5f-42a2-8c1a-a46d84cccc71)(content(Whitespace\" \
+         ed154868-9721-4c96-bac1-cf740aae8f17)(content(Whitespace\" \
          \"))))(Tile((id \
-         89f1225b-9fee-47e3-a4bd-bf3ffe80cd68)(label(n))(mold((out \
+         97145ba1-ec73-4ec9-a1e8-5cf9cab186ea)(label(n))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         8c536240-44dc-4cab-a69a-9c73f23cbcac)(content(Whitespace\" \
+         92543358-1d7d-4fdc-85fb-11ad8f76264e)(content(Whitespace\" \
          \"))))(Tile((id \
-         7cefd7bf-16f3-48a0-b385-13db6dd6d744)(label(>=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         ea048aa3-8e4b-4fb3-abf6-9a6737182533)(label(0))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         3553d9ed-5b0a-4032-a6af-d84e8c96830a)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         d0e07d79-c967-40a2-b337-d3ba3dfd9064)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3a64973b-20ff-45b8-b7c3-a0aeaaee9f24)(label(n))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         5275cd3f-b51c-4cfb-8d10-dbd9219cb143)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e56f128d-01fd-4b7b-ba5b-fb26ab8433ff)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f843a25e-cef1-4c4c-b301-436fa3a924a8)(label(length))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9a2b45d3-f0b0-4a18-824d-5486849e6db2)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         0a5aa345-ec32-45a7-b623-e560ad1d638c)(label(t1))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         52c71b07-6996-4552-8a6f-6fc4dba68ac1)(content(Whitespace\" \
-         \"))))(Tile((id \
-         339752e7-3113-4d0f-ac2f-73c10185146d)(label(+))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3c0aff80-f12c-4e2d-9419-f030eeaba74d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         27fb8c4e-7756-49f6-b344-f65ec9056811)(label(n))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         20383673-021a-4977-aaaf-faf151af0676)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6e7c3bdd-c973-41a8-a7a0-cf3491ea72d7)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         86d855b6-ce81-4a22-bdba-2d03491111ac)(label(r))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         999c0395-5334-4414-91d0-25ba5381c0a4)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         71973357-7402-4073-9fea-74c9b743df93)(content(Whitespace\"\\n\"))))(Secondary((id \
-         df6cc612-395e-4fdc-8a40-2c444a654161)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b19f3a87-9888-4315-95db-7bc89d2128d2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82d1533d-9b84-48bb-9edf-8f0ce46a9c3e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         41ca0e37-9dc5-4f3c-bd8b-1a43cf91249d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d5a4a7a4-c01d-4a20-bc2e-82cff5b48494)(content(Whitespace\" \
-         \"))))(Tile((id addcae9a-dc3f-402d-bdfa-e9534bccac68)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ca2e1819-4aca-4ab4-a065-8c00aad6bf19)(content(Whitespace\" \
-         \"))))(Tile((id \
-         603b1e18-3f5b-4d9c-a444-2362c0014f6b)(label(head))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c80d7814-8a9c-41f0-a994-df72ee5e04c5)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         fc891688-4629-4e61-b023-8c80a163c9f6)(label(Student))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         5350150d-dcd1-46bc-89b1-c92caefd7af1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e4960e15-8fe5-4c71-93e1-30caeaa13cc0)(label(students))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c4d62c53-04ee-46e0-8165-bbed80f0e7e6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e5689a61-9b70-490a-bfbe-a97971667cd0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e89baca4-93fa-45b6-aa00-a981695860ff)(label(-))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 25))(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         89dd2c49-1a0c-4c1f-8c4a-2a169776fb0f)(label(2))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         36b18a9a-6c70-4384-ba16-1fc48917c215)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d3514ddd-23a6-44cc-99ee-c29aa854e9ff)(label(==))(mold((out \
+         80545011-1178-4a26-abc1-fa05b01aac70)(label(>=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7c2bb3ed-21ec-434d-9b0c-4b46c0ca9a6c)(content(Whitespace\" \
-         \"))))(Tile((id 0cbbe920-812f-4168-8a34-dcc21b45ed08)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         feee9f20-7702-402c-ba63-8dc69730230d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         04ac9973-97ff-43ee-b963-65f87163a406)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         28ce3153-85f7-4a5d-b0be-b480d2c6f8a9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7dd1ebea-9c9e-4de7-8a48-9e2e9ab3bb8b)(content(Whitespace\" \
+         2401d839-015c-46ae-89ad-ce8e7f9ec4f9)(content(Whitespace\" \
          \"))))(Tile((id \
-         f2c317d8-9c26-4171-95e1-dfc6bde5d5e4)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7d0687e2-6997-4c38-b2d0-a32f9e514111)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         15b7ef53-e14a-4b66-af80-5165f4b97e82)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fc5c726d-1c34-4743-a9e8-8344f567622b)(label(\"\\\"blue\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         cba6151a-8c25-41f6-b810-7847d20c7213)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c4433447-35e8-4623-9fa6-4a23e75d4c34)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6362c6dc-13cb-4b3a-b1d7-6ba11e31d70c)(content(Whitespace\" \
-         \"))))(Tile((id 883a83d3-e6cc-4d15-afe5-92516e8665ae)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         b473acc5-1e21-4f4d-976f-cd2d27879198)(label(Student))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c3b9905f-5d9f-41a5-aa64-054b2dee1b6b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         cf34dd4f-c107-44d8-808c-0eef50547470)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         45524f7b-4568-4f17-89fc-557edeacf0a0)(content(Whitespace\"\\n\"))))(Tile((id \
-         aef7b419-12ca-4788-8e32-7c605db471b4)(label(let = in))(mold((out \
-         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         ec9b4002-d5a6-44d7-bf5c-af278fd1d7bb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d1e2758d-aed7-4455-a4ab-b90f84e1f1ff)(label(distinct))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         9dfe8259-7213-4df9-a3c0-dcbccbb5f984)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         e06b3eab-ee42-48f3-9b97-dcb2bc27f2a4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7b3c1191-4afb-4c9c-8fc9-8327331af367)(content(Whitespace\"\\n\"))))(Secondary((id \
-         218b143d-bc29-4565-987b-187db4a5dbbd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         daec1fea-def0-466e-ac68-03368aab5e0c)(content(Whitespace\" \
-         \"))))(Tile((id 7f44e593-6f6e-4f42-84a3-b9eb136eb908)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         34b2b95d-071e-495d-9e1c-2a6830dd4474)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4adb7d54-f7d4-41e1-b31b-5e099875247a)(label(requires))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         88ffbe69-0bfe-42e0-88d2-1417d07eaf63)(label([]))(mold((out \
+         bbaf4b91-240e-4fc3-b510-73f5482f3871)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         02196f34-a9ab-4529-9f37-3e8493f0bb7e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8be0037c-7aa1-4932-8283-f10f1673e7ad)(content(Whitespace\"\\n\"))))(Secondary((id \
-         56fe8bf1-cb0f-42e4-a976-7e643f1b7339)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cb176689-70de-4165-82e7-000db81c1a90)(content(Whitespace\" \
-         \"))))(Tile((id 679ee17d-cb4c-46c8-b8e4-faef10d4fe46)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         62cf2bda-5881-4aa0-befe-75f2887c3799)(content(Whitespace\" \
+         e9835c79-0601-4153-875e-90df7ddb1e01)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         0bab601d-2eed-4d43-8f59-4b11a7476199)(content(Whitespace\" \
          \"))))(Tile((id \
-         a0151cc9-c315-4a91-be22-fd3cc8b213a6)(label(ensures))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         1751e587-8d42-4514-87df-95b3f983dab6)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         72dcc6e6-7d57-48a8-b8a7-2f1363950f22)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         2f8b0c86-1ac1-41a7-bc0c-ad80ac4731d0)(label(enforced))(mold((out \
+         b108cfca-0824-4026-90d6-fcbe294ccd8a)(label(n))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         62d83427-598a-4c63-bbbc-21c1c64cd317)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5a303a6a-9337-49c4-bb86-3683402cbf39)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c3d1a1bb-0e71-4f3e-805f-6f2607793559)(label(length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         981c16db-63a7-4473-b25e-a4b947344f52)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         121e6af6-90fb-448c-b728-b1a6ec150c3d)(kind Checkbox)(syntax(Tile((id \
-         34e41648-9b4b-45b8-8116-a5ed8eb3707f)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         3e0884db-77cd-4408-8cf8-778bbe2ae76f)(label(true))(mold((out \
+         dc1696fc-4de4-45fc-8420-ab166ed125ce)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         ffb034f5-4ef4-43ea-9558-02648e73538f)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         03d93a38-fa38-4b17-9678-1f95df9a9c44)(label(,))(mold((out \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         1b528f7d-97a2-415d-86da-8f8d27f4ad8b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         256bde2a-cd48-49ae-b869-66a0bed7a12b)(label(+))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         810acf0f-3a1d-4ff4-8f50-e7105a61a4f2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         41d297ae-3937-48ca-87ad-9a1ea0f34bed)(label(n))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         e1f7f419-a1f8-4061-8143-00402055eab6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6e205527-65d5-40f6-a524-724954bb4df6)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a447a75f-6b6b-4b4d-a5d0-68a9b4bd5fb2)(content(Whitespace\" \
+         \"))))(Tile((id 9c7ae40d-0fd2-4037-9a00-e9747f066df1)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         9c96cfc5-2389-4110-9ebd-1f6af49b6847)(label(r))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         36997074-5d0e-4cbc-abae-e64db0385f5f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         4b1d0bff-24c1-4f34-a09e-0fc4da21dc8f)(content(Whitespace\"\\n\"))))(Tile((id \
+         6d57da8c-688f-4b1b-8865-112819495f63)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         5d51800c-5d44-4281-aabd-ca423fbdfc13)(content(Whitespace\"\\n\"))))(Tile((id \
+         301f8428-552e-463b-b010-d4659c33848e)(label(head))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ac29cbdb-0b86-4297-9f1b-29b2d49754a6)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         5b3a8d4f-6330-4440-93de-8c963a919f3d)(label(Student))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         78a428f0-4709-4b96-bf10-ae3d87934afd)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         bdf97743-602e-4d67-9bb6-6de7e02601af)(label(students))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         06eaa467-c31d-41c1-939c-554a0c943e3d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fd3fcc34-b240-4b9d-ba98-6c1018e8d869)(content(Whitespace\" \
+         e58d60fa-2681-463f-b6f3-ab37a61754a5)(content(Whitespace\" \
          \"))))(Tile((id \
-         673a2346-d768-4476-b81f-69283071530d)(label(\"\\\"schema(t2) is equal \
+         b8287d6a-d98b-41d9-83e4-e8f52bbf91e7)(label(-))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 25))(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ec312a29-8162-4273-9303-beaff7b30f1b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c0b37342-63c0-4b92-bff5-fd9a944f39b2)(label(2))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         df500901-9751-438a-914e-78a339c91204)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d6044b59-0720-4465-ae72-7750d93877d0)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6c530dcb-2df2-4d15-b51b-361a685a23b4)(content(Whitespace\" \
+         \"))))(Tile((id 8e1a717e-0c3b-40fd-8134-93fe4dcf57e7)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         cf267e39-60fd-49bc-8ab7-b0166cd33fc6)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         9eca67e0-719b-4761-ab32-baf0b2421aea)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3e74019a-cb11-4565-9169-5fc9168e157f)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ae365bc2-7cec-4c04-a8ad-658dc95201df)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1a88e127-a5cb-4a94-8e26-9f4d110622c8)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8dc81aee-a8ca-4d37-8fe5-23d88d58f9bd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7ddea87b-b19f-41b5-89ce-7996aad1164e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a6ac0676-a283-41c6-9b70-2cd5713c7d4a)(label(\"\\\"blue\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         969465cd-2943-4d46-aeed-f4b4a91da06b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c21b79e0-608d-4b93-bf52-95e5f080b022)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         00b5d2e8-c6c0-4e97-b232-4daf569e6f0e)(content(Whitespace\" \
+         \"))))(Tile((id 2ac6a489-1e86-4d56-a380-95b90ddbcb7e)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         e40929c7-1684-4f2d-838a-907e7040501a)(label(Student))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         65298427-ad2e-4610-8e92-70718b6feba6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d8c1a5c0-5733-4b7d-9376-122b6a6dd7a8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         447bcc5e-3257-49e5-9037-ac8c8f3fdfc9)(content(Whitespace\"\\n\"))))(Tile((id \
+         13a508ba-f52e-4bdb-8899-c59da958a65b)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         8bdc6b85-009f-4b1b-ae30-4a5abb8d5273)(content(Whitespace\" \
+         \"))))(Tile((id \
+         743871fa-c667-4887-b462-2eec24ae6104)(label(distinct))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0af1d96b-78b7-4687-9ea8-edaec79f88b7)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         e5107c1a-b5f5-42f7-bcec-98ca23f1cce7)(content(Whitespace\"\\n\"))))(Tile((id \
+         cb4df675-397c-440b-be0e-efec28fcd0ac)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         be4283ab-c86e-41bf-b3c8-e6540bbd1d04)(content(Whitespace\" \
+         \"))))(Tile((id \
+         21af71d7-b72e-4ab6-a0ba-19971d3f463b)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         9a9bac70-62c6-44f9-9788-96fa039babbc)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         76db43e4-7608-463f-bf56-14c471aaf325)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8b6d70ba-57ca-46a7-a3b1-8fccf659a71d)(label([]))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3a28cf9c-b6fc-4459-9e1e-78f7ae62b9bc)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         cabe3626-23d0-49f9-b699-bd14896eaa74)(content(Whitespace\"\\n\"))))(Tile((id \
+         ca910dfd-a893-4747-8684-d82b7ff86234)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         0e9bd482-4734-4d6e-bd3a-97a04d26e680)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c41c8220-aa0f-4abc-8e15-52233023a2a8)(label(_ensures))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         5299ca40-23db-4005-9283-f73b2df4402d)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         6ddca629-a70d-4ed3-86ec-323eb1117bdd)(content(Whitespace\" \
+         \"))))(Tile((id 92d8ee06-6eac-4295-aa61-658719f09eb6)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         2045b866-2822-4000-a371-1b9fe650b4bc)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         e85ae205-afa1-47ea-8e7e-3c9c4f8ec8e6)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e097b797-c9f5-475d-b9b9-e9eb0201f4f9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         98cddd3d-487d-40cc-ba6d-9e2afa1d2f88)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c0038049-0975-4d76-be2c-b2a3564d41d7)(content(Whitespace\" \
+         \"))))(Projector((id fdcd44af-e300-400a-a50f-2500bcdc5d5c)(kind \
+         Checkbox)(syntax(Tile((id \
+         8229ba01-79d0-4cd9-9cdc-13e3aee61ca9)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ee4b3f5d-3944-451b-8fd2-bf49d532bd36)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
+         e8dc83ee-6380-4b3e-a451-683084f3cf25)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         349b9a30-fa40-4987-ac89-30c6eed5d6f3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         dc3625f2-ae26-40b4-94fc-8419bc118479)(label(\"\\\"schema(t2) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         4355e292-ae6a-4614-bfa5-3dc760ff669b)(content(Whitespace\" \
+         4e2542cc-efef-4890-b205-46e65486269c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         857fc83c-96c9-42c8-b45e-31efefcfb535)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fb2b25e5-f29a-4d8f-898a-964d4b0a09f5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         646d830a-c2cd-4493-95fd-f6d31478a74a)(content(Whitespace\" \
-         \"))))(Tile((id 8b66146d-b3c0-4824-9f81-215b8dbae89e)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         81f508cc-58ec-451b-9e5d-62a89287698e)(content(Whitespace\" \
+         a1267c8f-b5ae-4649-8120-ce7e5e372308)(content(Whitespace\"\\n\"))))(Tile((id \
+         53f0feb2-a81d-4c00-b0fe-e2f08c792988)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         682c20d5-c7f4-403b-b404-2e517630d5a6)(content(Whitespace\" \
          \"))))(Tile((id \
-         7a5ed54d-0d3f-4560-831a-96d5ca7e900a)(label(distinct))(mold((out \
+         cee5beec-5f29-493e-a401-27374a2c4df2)(label(distinct))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         690e721b-fd05-4636-ab2f-158957eda516)(content(Whitespace\" \
+         eb20712c-9c72-4496-9b5f-03023a6e9a84)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b5edfafb-1338-401e-83d5-82464975ba5d)(content(Whitespace\" \
-         \"))))(Tile((id 3740ee0b-3815-432e-94a3-74e60382a5f6)(label(typfun \
+         be442598-1c3a-4dd7-840e-3f095bbdaaba)(content(Whitespace\" \
+         \"))))(Tile((id 6d03174b-ad97-4799-8afb-55862ee611f9)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         59f9b26e-61f3-4987-8faf-11846734b86f)(content(Whitespace\" \
+         fee95ad7-5119-48c5-ab2c-e542b7c26931)(content(Whitespace\" \
          \"))))(Tile((id \
-         a922a754-14b0-49b8-a802-33b8095833ec)(label(row))(mold((out \
+         0b1c4810-a9c9-49c0-9e21-702cec545ae8)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         565a2e63-90ca-469b-ab4a-7f294569201c)(content(Whitespace\" \
-         \")))))))))(Tile((id 724b5d5c-83c6-4971-a4a0-0466118d469c)(label(fun \
+         fcf8842f-1d87-4479-a734-fffaff8bd6f2)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         08aef86a-e334-47bd-a40d-0cbd0f51fc98)(content(Whitespace\" \
+         \"))))(Tile((id 51e565c3-d91c-4b59-ab28-cfb07900ffba)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         4618b436-cf63-4c86-ab04-fdf97a44825d)(content(Whitespace\" \
+         391b83b0-7bfd-4436-84bf-63f002b20101)(content(Whitespace\" \
          \"))))(Tile((id \
-         57a5531b-8f58-4708-89c4-77980a258385)(label(\"(\"\")\"))(mold((out \
+         0c6d63cc-ba98-4e29-9263-0c71171f847c)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         16692162-6efb-4126-8fc3-bc8b2063c342)(label(t))(mold((out \
+         43de5ea5-97ca-42a4-b2d4-8e1b7a61db4f)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         1c38ff71-8846-4cb7-a140-a22660c80f1d)(label(:))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         62886cd3-d854-4b87-b3db-1bcb89646fe9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1572e6e0-7eb0-420e-8c40-a45447420ed1)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         a66e9e88-d0c3-4934-9ae0-912e29bef72b)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         500acc45-1ea8-4fc6-8593-84c7d31347f3)(label(row))(mold((out \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         75acdc21-acef-4361-9200-daf894cfa782)(content(Whitespace\" \
+         \"))))(Tile((id a955d1fd-ca9b-4e2c-9825-e0016918b0cb)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         06a4aa31-4cd0-445d-acca-c1990775cd51)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         5116c3c9-01ca-407a-b8bb-0ed70e9955bf)(content(Whitespace\" \
+         94bb5b93-f6fc-466a-9722-d13d27118eef)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ad1f570e-eaf6-4201-b9ce-78b33e777a47)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c5746fe0-992e-4a5c-a250-32f42a970de1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46bbfd1b-ca44-4b3a-86d6-e597c51a7f82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         02109acc-b2fc-4249-a30d-635dba69d0d3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7b3b6932-dc23-48ba-bcf8-749cf392b922)(content(Whitespace\" \
+         6bc1d1fe-a7bf-49b5-85ac-b522cb23bb33)(content(Whitespace\" \
          \"))))(Tile((id \
-         89e4cdf3-b3c8-415a-a279-4db1b7c91f33)(label(fold_left))(mold((out \
+         3e574ea2-dc22-4e5e-aa50-1cd957bbd93a)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         075182f0-0893-497f-9672-d629b45e35aa)(label(\"(\"\")\"))(mold((out \
+         c352ae30-2773-4580-94cd-b3820e8e2dc9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b6de4cb1-d75e-4064-aa0f-025ef7dbf0c7)(label(t))(mold((out \
+         cae03d32-d6d8-4901-b2b3-da61e176d237)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         b6c47b0a-d000-474e-a4bd-94a1d5a63928)(label(,))(mold((out \
+         e265bd21-82cf-48d7-ba22-a6791521aa23)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6fbd2053-6d28-4e01-9399-41939433c690)(content(Whitespace\" \
-         \"))))(Tile((id 5db3bbf0-2c34-470f-a829-9160d6a00039)(label(fun \
+         1aed3dfe-c422-4a51-b26d-af52419255a4)(content(Whitespace\" \
+         \"))))(Tile((id 40af0202-0e21-4678-b587-0931d74d2fbc)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         1fc194a9-837d-4b07-b175-e46011ccb7cc)(content(Whitespace\" \
+         50c83e7f-4418-49b3-acf2-98c7e8cf413e)(content(Whitespace\" \
          \"))))(Tile((id \
-         beafc6db-a140-4834-8b65-fa5888d881ad)(label(\"(\"\")\"))(mold((out \
+         4479ee37-c60a-4f43-b8b8-814f86a07be7)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         b20a549d-2b5b-4468-93b5-1ba8eb4809cc)(label(acc))(mold((out \
+         5b691bb3-ae92-430b-9600-0b738b248917)(label(acc))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
-         058bcacc-76a3-41f9-9f0a-780e9422cf44)(label(,))(mold((out \
+         28c4d9de-36e7-447f-82f9-9d04f7111de4)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         607e8cd0-793c-404d-beec-4d0f9b6e034c)(label(elem))(mold((out \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         8adc3dc3-cb34-4e6a-9926-067b4715237f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         17f14b44-ecf8-4de1-baf2-dfc418f904a0)(label(elem))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         e24c7912-dc13-4804-a134-c8dcb420fcb2)(content(Whitespace\" \
+         a6694570-9a88-4448-922c-e846a8a2e8cf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         20cc28c7-5597-4ceb-85bd-eca771a88abb)(content(Whitespace\" \
-         \"))))(Tile((id 68987542-5788-4321-aeb0-cf167ab65f98)(label(if then \
+         a5eef1a2-4576-4266-909e-2c4af0e91d8d)(content(Whitespace\" \
+         \"))))(Tile((id be0acf0a-8cd7-4cd9-8c23-2dcb765d7200)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         c50d640c-bfe0-42d2-a7ba-751e9fe35793)(content(Whitespace\" \
+         3bb961a9-0f39-49ab-a6c8-8289f68a379c)(content(Whitespace\" \
          \"))))(Tile((id \
-         754554eb-8a0d-4667-9b2f-41e142aaf146)(label(mem))(mold((out \
+         adb9e068-caac-405c-b5c9-7fd3ab84f44d)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         7a0d44f2-d617-49d5-8cd0-aa61f7a72490)(label(\"(\"\")\"))(mold((out \
+         6e44464c-355a-4665-af7e-e70ff1c4cb30)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8cc1f2f0-0628-43ba-8200-03f73857d955)(label(acc))(mold((out \
+         13238c09-69d0-4f02-be04-cc9958e9809e)(label(acc))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         0ca55101-13fa-44f8-8eaf-f9945c62d3c2)(label(,))(mold((out \
+         c6c8c6e4-b352-4b70-8746-f8191adfc71b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         03a930d8-e6b8-4cdc-a91b-4110a18ba6f8)(label(elem))(mold((out \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c6a431ca-eb99-4d4e-a858-e35abb0efce3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         616f68c4-072a-4582-814f-58181a49ba31)(label(elem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e7bffb6e-5d87-4183-a1cb-7ccb1ec56ba9)(content(Whitespace\" \
+         3abf493c-1240-4777-a0c7-af0bf9728819)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b5482af3-bd71-48f7-825c-caabe9380d5a)(content(Whitespace\" \
+         d3a2e936-2806-42a6-ba5a-f059e9da5d9c)(content(Whitespace\" \
          \"))))(Tile((id \
-         01d066ba-041a-416c-a8a4-bb1a645b69ff)(label(acc))(mold((out \
+         e140a48a-ce8f-4eb8-8042-2fe56b9f14d3)(label(acc))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         bd8d5179-b40a-45ae-b8b8-26b77753eca5)(content(Whitespace\" \
+         e7c3b175-cabf-4efb-b6d0-5d32fed67e2e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ec1cedfe-f05c-4c6f-ae40-0ee998a2d3fb)(content(Whitespace\" \
+         0bfa340c-49b9-486b-ab03-84ea09f39fcf)(content(Whitespace\" \
          \"))))(Tile((id \
-         c5033699-0f6c-4d39-9464-6a7176de19f0)(label(acc))(mold((out \
+         14ba10a7-a591-4b82-8b93-d926f88b30d0)(label(acc))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         2d231135-94d0-46c9-a172-bb77ee53299f)(content(Whitespace\" \
+         3f422182-b4bc-4236-b8df-038eb12205a0)(content(Whitespace\" \
          \"))))(Tile((id \
-         014abc8c-83d6-4384-9adc-8dbde3ccb949)(label(@))(mold((out \
+         bdb4ae33-3bfb-4158-a0e4-bcf0a65ce1ef)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         df2ba097-b77a-4857-bde5-80e3192e7406)(content(Whitespace\" \
-         \"))))(Tile((id a6aa0ee3-23c2-4404-a6b6-da54c68f9eb2)(label([ \
+         8f045285-f31a-4875-b819-da62c92ffcc4)(content(Whitespace\" \
+         \"))))(Tile((id 4b009fd8-ca14-464a-b4b8-7d65be1442ba)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         a9c46569-0450-4ec3-b0d7-e0533d8e84a9)(label(elem))(mold((out \
+         396e1f37-e1e2-486c-a57d-22534bf3cf0f)(label(elem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         cdedd6a9-ba25-448b-ab04-bdec55f81a88)(label(,))(mold((out \
+         aad0ff17-a289-4fe1-9ff0-0f060f1cd766)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         277c820e-d9c5-4b9f-ab5a-0a68597f20bd)(content(Whitespace\" \
+         e55c81c8-e461-4b4c-83e5-4c0f200d65a1)(content(Whitespace\" \
          \"))))(Tile((id \
-         3d38fe1b-b728-4675-8567-49434f83c120)(label([]))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         2e69476b-b1e3-4a5b-bc75-95455a0ccde5)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         248cea78-88a3-4780-b6b1-c4f4271fa9e4)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         955007cd-5d13-4d77-a44f-a233be2f8b66)(label(row))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         765eb745-e972-4a61-a3de-bffa7553ff3a)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0067cdf5-5201-4fc7-b68b-c89202a2eb65)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a478b828-e948-46d0-a1f2-fc84c6d8bebd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8a3d2f74-126f-48b5-a643-a0c7b5f157cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d4f895db-327e-4a3b-b530-42406be74483)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b99f66cc-1441-4192-b169-89c611e8b1fc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82e8790f-d5b3-4794-8045-9e559bf15141)(content(Whitespace\" \
-         \"))))(Tile((id 4927d47b-e332-4216-9193-2822959be162)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         bbe08180-d87d-4cd3-bf87-5e89021a36cb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b20535b2-d130-49bb-8742-c1ad90939efc)(label(distinct))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5a4ab1bd-e245-4bf0-97a1-7e302e6e11d7)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         166f4511-a56c-4f14-b287-5961157ba1f3)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         43393775-2b7a-4913-a022-bf3d1cde3d1e)(label(quiz3))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         54a4dd2a-3a74-4a0d-bc36-a2443f5b3942)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         41372fdd-9bd7-444b-8ec6-609ec7b14999)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Tile((id \
-         3dd003d8-66b0-47ff-86ce-46635e798ab4)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e8285d3c-fb71-4f4f-948e-e36806af5db7)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b79bce4c-7941-4591-b9ed-9392400961a9)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         fb54a1bd-1cda-4ea0-808d-f2614f43b079)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c770f62a-d2a8-4ea1-b8c4-44978bcaf44e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e49bd175-b842-4773-8b3b-7dc2dda5f0c2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4694dd74-6cf7-41be-b0ba-24f7127ae006)(label(select_labels))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0d2d5985-03ff-4063-b1ac-140cc36131fe)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         136a78bc-249a-47d2-a20b-9536f88fd20e)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         66f015a4-df24-4717-912a-75d23db6dd68)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         836989cd-c5cf-471f-90fb-65211d06ee44)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5efb7fd5-dfd0-473b-9cd3-f04a5422842e)(label(`quiz3`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         74764aa7-f343-49e1-9a87-2391b711f283)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2490b9d1-bb8a-468a-992b-176024852036)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5ba21cfe-82ae-47c2-ad5e-b938a5a341aa)(content(Whitespace\" \
-         \"))))(Tile((id 781f797d-b24e-43e1-aa5f-d2e15f674e6b)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         233b22a1-0cc5-4921-b7d6-6ca8ceb2e72e)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6cb0ed47-2273-4ff9-8ce2-778e9589eba8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         61b9d0fd-4646-4bb1-bad1-e43ec9897890)(content(Whitespace\" \
-         \"))))(Tile((id \
-         34595d1a-fc63-4419-8523-900ba85d88cb)(label(8))(mold((out \
+         25135b91-d3db-4ea3-b8fd-f545ff3023bf)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7837a6cf-5392-4aec-926d-cf0c09a2529c)(content(Whitespace\" \
+         19a3e23d-af12-4b9b-acb4-e0cdc3c68b79)(content(Whitespace\" \
          \"))))(Tile((id \
-         19c9df95-4cfa-432d-8cc7-bf4ef06b3962)(label(:))(mold((out \
+         9b654d33-8241-4c6e-bc47-4799235e4144)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f11f5fd7-f39e-4701-aea3-7f3bd921a61d)(content(Whitespace\" \
-         \"))))(Tile((id 8d0d46d8-b310-4731-a1e1-eb1cc9def6ce)(label([ \
+         8d227972-48fe-4667-8e35-17706d1e148b)(content(Whitespace\" \
+         \"))))(Tile((id 134420f5-4424-41be-b17d-eb5e44a36d50)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         f845059e-35b5-4764-9bed-124a68660447)(label(\"(\"\")\"))(mold((out \
+         c2480edd-92d0-467a-bccb-ca0044854852)(label(row))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         9bd1cc23-8ce2-41e1-90cf-ac6f42cf80f5)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         88c6b229-285a-4542-b3ee-c55997f38b13)(content(Whitespace\"\\n\"))))(Tile((id \
+         39096bad-c56e-4a1f-be10-b62e2a1646d6)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         3abadd10-c44f-4e15-a4ba-5efdf2160a68)(content(Whitespace\"\\n\"))))(Tile((id \
+         2f08fad1-9ab2-4d02-9f23-7709a7329b42)(label(distinct))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a55ea4b2-184b-41d6-8dbf-ada8ece2d70e)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         31b26e99-83ee-4f4e-9ff0-5acfd2052e40)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
-         a179781c-8a93-4d19-893e-640c5e2abec1)(label(quiz3))(mold((out \
+         7417cfc5-748e-4c8e-9b63-919e3d34477e)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         aa735230-c416-445f-9e25-ccc34b94b187)(label(=))(mold((out \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2a612e55-17ad-4ffc-9864-7e60f1cdc5ec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d3f1b276-c6df-47c9-9921-1ecf5ea549e7)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2c51f06d-e274-4158-873a-fe378440d13e)(label(Int))(mold((out \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         34a364b2-c8fa-47f1-a326-74c539fc1d58)(content(Whitespace\" \
+         \"))))(Tile((id \
+         06e662b0-26a3-4416-affc-befc5bdd9efc)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Tile((id \
+         70c38a54-641e-4b20-9a8e-341c9fa22c52)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         81791e44-293e-41d6-8d63-362387678d36)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b9ac46b1-de3c-4e98-8e2c-3786bc9cbccc)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         6b0da58b-4888-424d-8b17-5597aaeac9ab)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b934a03c-3f5a-4f77-bf62-b4cd772df76d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5b225d4a-ea04-410e-96b4-57369e7d1d84)(content(Whitespace\" \
+         \"))))(Tile((id \
+         61b1a891-19ae-4563-8fee-f83ff251bd50)(label(select_labels))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5756772e-7a44-4819-9519-5f75c509d916)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         642a6667-17db-4c4d-84a6-14cb0926f12f)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a4502d7c-1f3b-4c83-afc7-ecd00fb2ad65)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         155faa81-1a78-4770-9ca5-7006c7dfbf01)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5418565e-bbfd-4649-a1f2-73b58a7d3772)(label(`quiz3`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         eb5a5d64-b41e-4846-b4fb-8277cb169f94)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7684a50a-785e-486a-a796-a2947772c1bd)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5cee13eb-c014-49c3-b484-eb065ace7104)(content(Whitespace\" \
+         \"))))(Tile((id 754a0623-bb20-4945-96ca-511c2883f80a)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         30eef94d-c8d1-4a40-8cae-a8063c480182)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         60c55566-9b40-4b3e-bdcf-df15029d2bd0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         97f11c86-b587-4d4b-8a66-98d126f9c834)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4ad28c9c-76d5-4968-b570-2e17d1e4819a)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         12d67be4-cf47-4c05-8699-282c1d077f5e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         39030fc1-db25-4ba9-adcc-3513f7e3d02c)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a1889855-5373-4e1a-893b-3ecaa625a540)(content(Whitespace\" \
+         \"))))(Tile((id 4593cc2f-edf9-4770-905f-0f927c72a938)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         338bf2bb-b255-4e72-9d4b-bee36c3e6917)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         204116e6-f4a7-4bb6-970a-ef9c2e0b6f79)(label(quiz3))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b12196df-da4a-4a74-9e43-f2cee4550574)(content(Whitespace\" \
+         \"))))(Tile((id \
+         12b34051-51c2-4631-8be1-16275779d1e9)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         88a01c94-d5f9-4901-9a32-74392c41bfa9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6b405866-d87e-4214-96b0-28c37101793a)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         60919154-7268-483f-ad03-cabce8b275d8)(content(Whitespace\" \
+         cf50055e-8ee8-423c-86cc-b029593c6af2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6f09cae5-546a-44c8-91aa-280a92bc066c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         c6bd083d-ec2a-49bc-ad60-7feac2537865)(content(Whitespace\"\\n\"))))(Tile((id \
-         a8c9eaf0-b94b-4c75-b84e-ba2b7d3ec19c)(label(let = in))(mold((out \
+         7b198839-8d7e-4006-b730-9ac4587398c4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         08aebdb9-4478-4da9-af69-a9e29384d0f2)(content(Whitespace\"\\n\"))))(Tile((id \
+         c06159bd-e2d5-4a6c-87d9-186533fb68ad)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         30276e7f-26db-438c-8a78-c616ce89af8c)(content(Whitespace\" \
+         76d85db1-b534-4e66-bed8-f9d151cfd997)(content(Whitespace\" \
          \"))))(Tile((id \
-         2c00a0be-2f5c-4f1c-8a4e-239f313e092f)(label(drop_column))(mold((out \
+         dd4a0063-67a8-42d6-83c2-b9593273c8be)(label(drop_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ae63a4a0-e9d5-4c40-93e5-ac88f700f55b)(content(Whitespace\" \
+         7f0820db-af9f-4617-b2a5-88964963023f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a6ff6b14-8498-4411-a8c6-94e295ea3ce2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f73a15e4-2f4e-460b-a124-7de4161627dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         15077d7c-972f-4e0b-8eb3-8e18c6522a63)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         54140f74-bc9d-44b0-b3c4-635e369fcb32)(content(Comment\"# omit_labels \
+         81d1c108-cd88-4fbb-951c-883987c32421)(content(Whitespace\"\\n\"))))(Secondary((id \
+         7d3a56d8-4237-4c2b-af45-a61f89440d9b)(content(Comment\"# omit_labels \
          is a primitive operation to drop columns but without row types \
          there's no way to give it a first-class type. This is the idiomatic \
          way to do the operation #\"))))(Secondary((id \
-         711bcc9a-b291-459b-bfb7-13d965b9a91a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         11d04b5b-ec68-4aa2-b762-9af3678c0df3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8abd967-92b1-4110-b9b3-f13ff35ed045)(content(Whitespace\" \
-         \"))))(Tile((id 3a36524c-15a4-43a0-af6b-0961fc48df66)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         928a58fa-0aa2-4b79-aa60-01cc2ec7e113)(content(Whitespace\" \
+         19730faf-623d-409a-a3e3-e4681da874ef)(content(Whitespace\"\\n\"))))(Tile((id \
+         2c7924de-e875-44d6-a378-1c484be31854)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         452f8843-7666-4b34-a239-cbd3cb84d141)(content(Whitespace\" \
          \"))))(Tile((id \
-         8caa3ede-2e47-4b64-ae3c-5c66ec4c6dd7)(label(requires))(mold((out \
+         e51c8be3-970e-4608-8abc-0667b9d01a84)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         ba8fa970-1cf6-44f4-b49a-8a45f1423e3a)(label([ ]))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         c0725497-5080-4a9c-9b20-76cd31e3450e)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         1616e6b0-b73d-4e5f-ad09-46bbdcc14ea7)(content(Whitespace\" \
+         \"))))(Tile((id bb06348a-8e8b-45fb-b137-28f5e3b52e90)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         bc0a85aa-300f-494d-8f29-2b75f33273f7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         103e2b82-1314-4546-82b6-6b8992a2cc4c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         2f85338d-6e73-434a-9124-b6194c3832c4)(label(enforced))(mold((out \
+         4cb73274-6b2a-4c10-91b3-89b2dc7481c3)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         85c6fe36-4cf5-413f-b6b1-8626f384e2ca)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f55b91e6-8fce-4e3e-a56c-d963b052a923)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8961ce6b-dd0e-4175-a1d9-e3693882ed99)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         983fd067-dc77-4254-8b8d-1e5132c48d80)(kind Checkbox)(syntax(Tile((id \
-         8eb00741-fc07-4256-8383-3615c3493504)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         debb2ba8-876e-48e3-b96f-21dc8da26888)(content(Whitespace\" \
+         \"))))(Projector((id cc413930-3be2-44b8-96c0-f7d0d45dccf8)(kind \
+         Checkbox)(syntax(Tile((id \
+         899ded0a-203a-4e4e-9307-5f26e66a5f69)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         c3debb8b-08db-4fe0-bdff-d6c684d56218)(label(false))(mold((out \
+         e9fdc687-9d80-4524-bdce-a69c71cbd089)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         d70ea7f5-ed34-4c3a-9c61-bab01302d7d7)(label(,))(mold((out \
+         140b7828-1983-4cea-b2ae-302e29b41dbf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e517885f-ed44-4814-93db-c8de88fbdfd3)(content(Whitespace\" \
-         \"))))(Tile((id aa0fb305-9faf-41a1-8a69-4fa39e133fe7)(label(\"\\\"c \
+         c0ddf49b-0dbe-4271-a03b-a7922d9ffb98)(content(Whitespace\" \
+         \"))))(Tile((id 781a171d-938d-46ee-9cb0-091c2f2b4956)(label(\"\\\"c \
          is in header(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         09cc923d-1e55-418a-9cd2-a2e33ab88da3)(content(Whitespace\" \
+         6959d0ed-a4af-4b6a-a236-ecf93013909f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7b1311fb-09e3-48f9-8b67-68faaa677b2f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b015f1b1-2347-4ee8-b146-2d8e42a21978)(content(Comment\"# This is \
+         cc4e9467-510d-4b06-b14a-a95e5be26735)(content(Whitespace\"\\n\"))))(Secondary((id \
+         41c1cfc2-76ae-4b23-8990-336c23a8aa82)(content(Comment\"# This is \
          ensured if using omit_labels #\"))))(Secondary((id \
-         6830b526-0b1c-480d-bf9f-e5e8a71413b6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         09c6ed11-a793-4d2e-9ed1-8978f6059e36)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         33b1c1f9-7022-4c52-9dde-4f6de5fe5a83)(content(Whitespace\" \
-         \"))))(Tile((id 6c371a9d-b446-4937-8ad5-e6898dea84b2)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         a08c9d04-59f4-47d1-b263-4dc4dc264ece)(content(Whitespace\" \
+         e5a6d092-1298-4868-9cb7-b8d24af52c70)(content(Whitespace\"\\n\"))))(Tile((id \
+         4a27b3bc-ee77-44f5-8941-cb7178080ed6)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         6c111904-535b-4f74-bab4-456c613525af)(content(Whitespace\" \
          \"))))(Tile((id \
-         dad6208a-0a0f-47e3-869b-8faa6b110222)(label(ensures))(mold((out \
+         27004ea1-d051-44b2-9cb6-8c955217b4a0)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         cbbef743-2fc5-43ea-ac71-1825c69e29af)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         4c5b4c51-6fb1-45e2-8326-ac7a5f5d16af)(content(Whitespace\"\\n\"))))(Secondary((id \
-         23f9573a-6695-447e-9ac4-4f3312b05948)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6f0c119a-05f7-4709-b836-b9883f905fb4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f3e23af8-c4ef-4d96-8a38-f2d0fc3146c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8deb0b1a-6764-4883-af5a-42ba535c5cff)(content(Whitespace\" \
-         \"))))(Tile((id \
-         645f2cae-8fed-497c-91c9-9d9f38de1de0)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0c15616b-0fb4-47b4-b184-c5a3b61069a8)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         39f914a4-e91c-431b-a5e8-035aa02d4481)(content(Whitespace\" \
+         \"))))(Tile((id c514661c-689a-4efc-bf82-8ad7d9a6bee8)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         70b3919e-1651-42ed-b4c1-efb6f482ee8f)(content(Whitespace\"\\n\"))))(Tile((id \
+         7486a97a-c858-49ba-ac45-f88eedfdd7bc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b24a35c2-4980-4340-9b31-5e8e88eee740)(label(enforced))(mold((out \
+         b20e00e6-7b59-4244-9bc4-6771277b40ca)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         2d551d84-a835-4fb3-839e-e199c3f0e960)(label(=))(mold((out \
+         acf3d06e-7295-45d2-9965-b45579d00cbe)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         218cd46b-efdd-4681-9487-fc0e3e6dd5e4)(kind Checkbox)(syntax(Tile((id \
-         9f8efb82-9402-4311-a667-aeb23c0c3ad6)(label(\"(\"\")\"))(mold((out \
+         0adc222d-f2cd-4820-b015-122edb1166de)(kind Checkbox)(syntax(Tile((id \
+         b29ae5c2-6851-4708-a6f4-14068ffec0f0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e64af241-b27c-4d7d-9d32-3b23a45b56e9)(label(false))(mold((out \
+         31f74bd3-a86f-4c17-b4e9-3667569b2787)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         abaa4f3d-b386-431b-a39b-f91dc6a34791)(label(,))(mold((out \
+         2ccdf32c-b078-42bd-a37a-64fc2b5090bc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c22cbb0f-24d3-4bf7-be9e-00258ae1c0eb)(content(Whitespace\" \
+         633517bc-9352-4471-863b-bf7b3535c210)(content(Whitespace\" \
          \"))))(Tile((id \
-         e200c154-b644-4309-be7c-6bc65eaaeddc)(label(\"\\\"nrows(t2) is equal \
+         7f04f37b-c49e-4d5d-936b-53677c6e9f20)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         e0e8b492-fa07-4720-b95b-7ed572e006bb)(label(,))(mold((out \
+         0a95b643-875c-40f0-af94-a6b8ada51201)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8f9bb15d-3516-4b30-b3ec-8e80bae887de)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6814d79c-bdd2-4836-bd98-f775cf5533ea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         270546d5-11da-4e23-88e8-91e56e0763c0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b8406487-d32d-48d0-a452-44d012558c82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e5f2a86-2715-4eea-9b63-43196eb68cb4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a4fa3205-32f4-4aa5-8bfa-070105476552)(label(\"(\"\")\"))(mold((out \
+         82e6260e-566b-4c8b-b7f0-b4f5bc67b7da)(content(Whitespace\"\\n\"))))(Tile((id \
+         5262e0c2-a021-40a0-81a5-eb7648fbb8fc)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b4be23ff-6c78-4f43-96f6-b0c91325f1db)(label(enforced))(mold((out \
+         9351e267-8034-45ae-b09b-e1847802ac21)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         2d326250-d0cb-4132-b148-be9399737769)(label(=))(mold((out \
+         ae031281-e949-485b-b6d6-9debb2d3792b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         1e1a7811-916a-4cd2-ba42-2e6c9f83aa3e)(kind Checkbox)(syntax(Tile((id \
-         5b8d1b4a-da20-4d7d-b30f-f3708797712c)(label(\"(\"\")\"))(mold((out \
+         c6ba89c6-f1d3-429f-92bd-945500161d28)(kind Checkbox)(syntax(Tile((id \
+         02e824a7-8c7f-472a-8835-123c636e72d3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         ce7466d6-dc00-4f1e-9766-1432813e4a40)(label(false))(mold((out \
+         845952c1-baf6-4647-b920-cac79159b5cc)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         cb7a16a0-d21a-43de-aed5-bf35a0bd2331)(label(,))(mold((out \
+         d0cd0d7b-cb80-4bea-b8cf-49cdea2856bb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4a235102-1fd2-4ba8-b803-6689290d01a0)(content(Whitespace\" \
+         2a9d3c2d-e8ca-4e51-84c7-e8cd1dda0ec3)(content(Whitespace\" \
          \"))))(Tile((id \
-         f6e9187b-bc5b-4703-80af-31ddaf707f01)(label(\"\\\"header(t2) is equal \
+         8c4b7d4c-659f-4a97-83a5-56a8de895c0f)(label(\"\\\"header(t2) is equal \
          to removeAll(header(t1), [c])\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         1360124a-34b0-4391-9c1b-1975ea36bde4)(label(,))(mold((out \
+         d596d6b9-9ca5-4553-8159-ab2e2b38c812)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         282cfd36-ae0d-441f-990d-3c321f136c82)(content(Whitespace\" \
+         eef443f4-307d-476c-b464-e1f6bcf01862)(content(Whitespace\" \
          \"))))(Secondary((id \
-         a4962a04-84c5-4485-9576-2eed5f3cc058)(content(Comment\"# This is \
+         6378c73a-d426-44dd-8c4c-faed8d0720bc)(content(Comment\"# This is \
          ensured if using omit_labels #\"))))(Secondary((id \
-         7ca3443b-820b-486b-abc1-a9fa619ff9e2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ab88d715-4367-469c-940d-317ca46a74f1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1345e1c2-b022-4bc8-a90b-b6938ab442ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4de77757-174c-40e3-ab54-ffc0aa211802)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5760ba5e-4949-47f0-ad04-6e76a855a94c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5088e60c-936f-485c-b42e-8a2b2f1252eb)(label(\"(\"\")\"))(mold((out \
+         8a922d37-0fb7-4d44-b08a-2a5b381d21aa)(content(Whitespace\"\\n\"))))(Tile((id \
+         ed520678-0609-4cc4-9d2e-327de5f55067)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         21b2b9bb-1f05-4851-97d7-43cf22724d8a)(label(enforced))(mold((out \
+         862683ec-26d7-443b-a255-a96bc1dd7caa)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         36bc2b4c-ef23-44ed-99fc-8efcfa3651c8)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         bd46c1fd-ba6f-440f-a800-f1a1d443b6ea)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cba9d2f7-ac75-477a-830a-80cff1355ee1)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         b18d745d-61de-4b0d-b2cd-bad59dc14d80)(kind Checkbox)(syntax(Tile((id \
-         b781a0f8-fb82-4773-a64e-2f1f40814600)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         612fcb89-34f8-4560-a04b-926c60e53c77)(content(Whitespace\" \
+         \"))))(Projector((id 0bb9f497-9b37-4b77-9a46-01af57f37527)(kind \
+         Checkbox)(syntax(Tile((id \
+         0d3c80bd-e21c-4062-99f0-2e78e7bba397)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b0d732a8-0fe6-44ed-a406-ff42fde8f4df)(label(false))(mold((out \
+         8c55464d-4fc7-43db-a417-5af5ba769bf9)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         f4a83871-1a33-4fd0-9d23-2043d84e0b5b)(label(,))(mold((out \
+         cec86423-fcea-4035-8342-2840dcd442bd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4a07031b-e3a9-483c-99a1-810b246e7cc4)(content(Whitespace\" \
+         f921a0c9-2eba-4068-aa8e-d4564b95e7b1)(content(Whitespace\" \
          \"))))(Tile((id \
-         e73826b2-85a5-4f88-b45b-141420ed125a)(label(\"\\\"schema(t2) is a \
+         ae80867b-df38-41a4-baed-f3894dedb13f)(label(\"\\\"schema(t2) is a \
          subsequence of schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         bf56e73e-0a41-44cb-a831-7d61c9a0569c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         550ba840-ab00-4a31-a4d6-cb446922c930)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1a3ed48a-ae68-4bb0-8950-5d4557a15019)(content(Whitespace\" \
+         396e142b-e8c6-4571-bd51-7bbe9fad627e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         4f463a9a-35d1-48a8-af5e-b1f9315f61a1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5555fddc-cd7f-4441-8879-6ebdeeae182b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         0d5367ed-d5f9-4803-86be-48d9205bb576)(content(Whitespace\"\\n\"))))(Secondary((id \
-         25ad6838-7247-4a48-8baf-2f990c90bb86)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         eade001b-6f2a-4d91-8bac-27284713867f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae5023a9-e483-4bd0-99b7-77045a60c61b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         51f890ee-c4a1-4331-90af-182fbbedf574)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5eb14b0b-b3c9-442f-b5ff-48ce14c19bc7)(content(Whitespace\" \
-         \"))))(Tile((id 144e943f-b2c5-4360-ad04-aea7d0a81512)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         083efc3a-2a1e-44b0-ba78-693cdaae52fd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ec138d12-51d1-4ae5-a130-225ca6e044ea)(label(drop_column))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         968c9ecb-0a78-47a4-8c5f-96cc54d47458)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         f47bf012-dfed-4ec8-81aa-ff5edfcf3d49)(content(Whitespace\" \
-         \"))))(Tile((id 49722782-1e26-4059-8283-1d064ba13714)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ee757e51-afb5-47e3-84fd-39d833c7fd3c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         abe06a3b-b3a9-4dde-9750-08f1428ae9a4)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         45b561f4-0c36-47e9-8aa4-a26ab0ac2c2d)(label(t))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         736df539-26f1-4b36-bf5f-23844e3aa666)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         84bcd01b-a6c0-41f5-bad1-335c3c72118e)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         046677cc-d1b2-4cfd-ad10-e436b21d3ec2)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         18b4ec21-0c84-4678-9e14-432e7f6e780e)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         03c0cbfc-d3a0-4e2d-a03b-3f56f18b45cd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9b1dd83d-fab2-4791-a627-837f9394b09e)(label(c))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         093facd9-80fe-4ec3-9cc9-695dde9fce45)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         3ee8ca20-0d02-4b3b-9812-eec112a9c9af)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         da150ca7-bb7e-4850-bf1f-40a1de483ff0)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         3b58e097-fb2e-4992-a9c5-e62620d22fc9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         59f08fb8-4688-4034-8178-386755feab1b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         92bad6d1-d303-494b-a7a7-e8f424d4e388)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         90cfc718-19f6-4774-90a0-f24593795e38)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ec3031ff-6c14-4161-9b90-24b3a452755c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         78a16a28-8222-4db0-a7a9-48ebab320577)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e188adfe-3a50-4568-9036-555e32d50cdf)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         c82a2ef9-618d-45b7-9b9f-d858e81ae0e1)(label(t))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e6d222bf-cb35-4846-a2ef-aed3698651a3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3864e24d-3908-40f8-826a-e15b2ae088f2)(content(Whitespace\" \
-         \"))))(Tile((id 04dd914b-38f1-4425-8e13-8fdd67210306)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         75b14719-26b5-4be2-92fe-ba8583b4d498)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ac94920e-aedc-4326-8fb4-402b42be15e2)(label(row))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         42137833-412a-4d31-aacb-2f8804bacfd0)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         aafbca49-8501-427d-a0be-224257fc6815)(content(Whitespace\" \
-         \"))))(Tile((id \
-         69ecad2a-ca5a-4cf5-a4d6-eab2c09f6917)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         1d451701-e77b-4d34-af73-f5c5149989ca)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         61ad9eb3-773d-4293-b2a7-09dc8fa92b16)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c6403616-96f4-4a0c-9529-30be9e08d2af)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fbc4efa9-f751-45b2-9a51-9c4291c55a12)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         58ed002b-9dda-4fbc-ab55-4410d33842c8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         354d2943-0d8b-4a86-b155-46de95a3dc33)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e6d21ac5-dbcf-4d09-8479-1b516bd567ed)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         66a0ef2b-423a-4f17-a74e-d088aff0a9a5)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ac2e92a5-c30d-43be-9dd5-6fdd59531345)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         41ca5c50-9251-4d00-a5cb-3855ba4072a7)(content(Whitespace\" \
-         \"))))(Tile((id 6dff0125-8244-4136-b9fd-44cd92fced0a)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         416a3ef5-fb49-46b9-ae26-9cdd8123ec2e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0171f8fa-2d35-4cdd-9eda-64657ca793f9)(label(entry))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         8dd9e439-ea20-4e9b-a1b4-3723e4dcceff)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         f2135419-8238-4117-b1e6-8a35d49b61d6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cbd7434d-6feb-467e-bee2-09b7c1b2dc10)(label(entry))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a079cde1-1342-4395-857b-f4e265f02295)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         22f71774-d66f-495e-86c5-716e4d1f4758)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         a794121b-8d8d-40b6-b16a-fab705e1c6a4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         903c5797-1a77-4699-bc39-7b51bc70a0ae)(label(!=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4f1fffc8-ab44-4794-b46d-bd221d1c6981)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5b2f6198-f08f-492f-a4c0-57c7fb92465d)(label(c))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5e8cfd3e-e5f9-438d-8572-426034d47650)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6abf409b-d62a-4c6c-ace2-8c7c3b0b36a0)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         91b2aad8-5d79-4af7-9152-c16e27d52425)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7554fe1f-05f4-4e05-8f7b-3de9c9e710c5)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         ef1eeab6-0bb0-4e83-a253-90d803da78a0)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         829cf4dd-2b99-4075-be46-cd94422b5242)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         819c9502-1325-402c-9563-d27c184596c6)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0bfb12ca-1a1a-4c9b-879a-196686ff62d7)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         bdfe7bc8-bbca-4531-a5bd-5f65f2902d93)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c0a9e42e-68d8-4381-ab59-4aa713dfdf87)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de5c9df9-0583-4e0d-9935-991a2fde105c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ea9b656e-b7a2-44db-88e5-6545b3405e45)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ef4c1983-80b8-4c9b-a881-f479c392f32f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e10740c6-c90b-4258-b3b4-de9e68e890ac)(content(Whitespace\" \
-         \"))))(Tile((id f21e3816-ffb7-41ea-bbf4-d59996ff1add)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         9310b28b-65fc-403c-9930-f7af2b0bde39)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a92e4501-372c-40aa-bf69-5634097b42b1)(label(drop_column))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4b016da4-d6ca-4f02-9232-73788500e93b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         e5fd0170-ec74-4e6b-8f39-c85c1c2b5238)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         29c4ad42-c951-46c9-9ef5-55100ce9ca43)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3e79fca7-abed-4144-9f8a-8c0ebdf6ec85)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f1ed48f2-0cd3-4d2b-9579-576d036eadfb)(label(\"\\\"final\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e35a040e-7238-4222-bbc4-239b40cc7972)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ab3e1f6b-e965-47fa-94c6-0078d8ded578)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         013435e1-8b2d-4bf4-b745-c6be6cf8b237)(content(Whitespace\" \
-         \"))))(Tile((id 50a5c834-94d1-4c51-b457-1f2b74d1db7b)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ee1d3a39-58e8-44f1-8e41-dce7308d8498)(content(Whitespace\"\\n\"))))(Secondary((id \
-         81ae5ae0-ebbe-4892-bd84-ff37b4f92620)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d35d3fce-8be5-47aa-9606-44b3674f7664)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f43933a5-9ff8-490b-b7bf-79a0202be0de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e7de283-8de5-41d6-af1e-a4442133e0a5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c9b9c762-85f7-44e4-b86f-6a7897e96715)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         85f89478-d8c5-41bb-adba-6e45a0f345b3)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         eb65b7ac-06c8-45c3-9056-cbadaa27d12d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         46211d40-b7c5-41e9-8e5e-2face50266a7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0dc16ada-dfd9-40ff-97d1-276541e2118b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c6319814-43ba-453e-ba79-28412e91257e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5ae03c4d-8f18-4597-86a1-72714c5ce05e)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         059f03a7-9051-4949-a6f0-1940756860eb)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b06bfcc5-80d2-4579-b1da-7ec530663548)(content(Whitespace\" \
-         \"))))(Tile((id \
-         afc4e8d7-c6a5-4bbb-b7dd-55e9e708a644)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9e9484a2-8a6b-4dbb-a853-918354d30748)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         390b3899-39b6-4df6-95e7-7c6098f7b816)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ddd9abbb-aa5a-4a9f-b3ab-171984b600fd)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ecaa6a7d-c413-4697-978f-60db40871464)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         18551879-e0de-4447-bfd9-2f213208f485)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9b4ca4bb-5667-4e72-af4f-7a8527c6e6d2)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         64a91e95-9f31-46a0-ad8d-82e3fc094d5e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d4a5ff15-504b-4d75-acd1-d407084aab1c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         09f6ef9e-9d6f-4682-ae96-a747264d6bc2)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         497c1b0f-4b35-4112-8c5a-6876f3cd9587)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         326f5008-45fc-4e65-b6d5-da16e4a84bdb)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6f576df2-d2d5-45af-a7f1-9102f29fb124)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         60a47657-3e2e-41ca-8202-ac6ebda124ad)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fd91bec2-d9b1-40c1-a442-4d708ce47fa3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         558de6eb-0e8a-4c45-9950-c6ddddd81df3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c175ea79-ed01-47e3-be85-42e4286db6fe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         092bf440-5474-4a83-b23e-55bb8fcf8519)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f226d6e-dc58-4537-877f-aec17cb9a032)(content(Whitespace\" \
-         \"))))(Tile((id \
-         88c780b4-23e3-4822-9beb-92bcba941c76)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         29106b70-b77b-4dd6-9be7-ba6cff1834e3)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         371c684e-fcb7-437b-8334-b3c0b2d9f1a6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c59e7491-ac9e-4641-99f4-9f7a7fd4c47e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a3db900d-9c3d-4bcb-9e3d-c0fad47ed124)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8f3b7d60-28c8-482d-ba21-0dfc8a6d891d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         58e3af92-7a59-4c48-b812-d94704f0d296)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5054e643-1e43-4ce0-8d5b-4b8c655aa1f9)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b0ff0743-2f83-476e-9719-ce9ed3bf6fc2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         412f26ca-1a12-40d3-a916-49d8b0f00354)(content(Whitespace\" \
-         \"))))(Tile((id \
-         222b1a2c-1432-4498-9a7a-402f3e609955)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a38bea94-3d29-4aaf-b297-605de4501e06)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8f46e70d-2fb9-4da7-a01b-657bc5c51918)(content(Whitespace\" \
-         \"))))(Tile((id \
-         939883e9-1d79-4810-8d49-df35a4b75e48)(label(88))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e0a51aa7-4ffb-4310-a405-0040c62b1a46)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         95e68f82-2e06-4811-a97c-c8555d780fc0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ff5fdcc0-2239-4bee-ac7a-8ca642efe6f9)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ebbec54d-aa93-464e-a22d-42e760940e7f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         529948be-35ed-4667-872f-a492bdf8db44)(content(Whitespace\" \
-         \"))))(Tile((id \
-         22583703-fa86-4956-9a75-c5dda2ddfa54)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         c8384e31-a753-4f36-aeb5-2410e83cfadb)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         df597f0d-0599-48f2-8303-0f9dc929eb67)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cb5902a4-4da8-433f-b543-b009f6d865ec)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9d3dab64-0f93-4de2-9836-8959c64d2dfc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1a7c9de6-cf04-4f18-aa10-7be2909776ef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ca6b6d8f-5565-428f-8fec-14297ca8248c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7cc0a22b-403e-4d77-95fb-e09d15a959c7)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         9666c129-0b13-44d3-8638-13aa13e183f3)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         366ae7bf-d841-455f-9272-777bdd9a7ae3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a3a35442-3409-4178-bcbe-831986513e85)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ab0cdce4-c51f-4294-8f14-b7582baf15b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fb81ff11-a43d-49cc-89ee-2edf86fa4cca)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d4746900-e588-4369-b8e3-b612c515c94f)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         40271c9e-1aaf-47aa-9161-371d012bd287)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f9034f71-f960-444c-91a7-f02bdce9c467)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bb843d30-ff25-4893-ab39-65e49108b48f)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cfb929a4-b879-49c1-abd2-46d0f09304bd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d03faf47-e299-41c4-a933-40c7b8511440)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f47f8b81-933d-45ce-86df-397cbdfc8b12)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a822700e-6067-4c86-83f4-5b3dfc122e6e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ce3efc44-4d49-4217-bd67-aba81e7ace2c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c202d606-5b7d-4534-91ca-c68a5e581003)(label(84))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         32c2c76b-0dec-447e-9fc4-0f0f37fe11ba)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6b6f6284-8904-4080-b97f-2ce1f631336d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         09e80c66-ed87-4bfa-bad6-8e061eb44417)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         609c6562-c91b-4ee4-8cc9-91019cdac258)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         766e04ea-562f-4df3-b334-aec5bbd0a22b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e5a499dd-3f49-48ec-8ee7-1a7ecb2d8677)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3965a6ac-0d93-47a7-a6cf-d4be7653ee03)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ed43983b-e735-4488-9876-c7fb776ae43b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c6260070-9f37-44e5-ad49-2943b50bb93e)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         ba4933b0-8e26-4878-b561-805bacdb0850)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8e3576ba-f336-46ee-895f-e954d3d8ac50)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         83c1d7cb-a5e4-48df-9f9c-d1f6dbd8d08e)(content(Whitespace\" \
-         \"))))(Tile((id 55238c1a-294a-49c7-9b6d-9f7a8fe49bc0)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         67ce0951-e41d-439e-97a5-77d1e4ee0ccb)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         9c0994f3-de81-4477-9123-738fccf346b8)(label(name))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         061ee6d0-59b1-487c-b9a4-f0bdc38ee326)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         a7706f38-8a16-49db-991d-a65d28eed2cd)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         6a7aaa0c-a39e-4fec-8862-e2a00d4e22c0)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6e770e70-c847-4615-9662-1278ab06c226)(content(Whitespace\" \
-         \"))))(Tile((id \
-         89325652-2b0e-4ef2-bc6d-30881741006d)(label(age))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         1842fa94-c117-4d99-9965-e4c6bace8545)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         a61dbb8c-d126-4216-912b-8ea5362ed8fc)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         0a326d1b-e97a-4ea6-887d-67738e0bb173)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e86a193b-d257-476f-b60a-ea7bee48e457)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5682651c-0dcf-4f31-9abb-981a6428d770)(label(quiz1))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         acd44f15-f886-4df0-a0fb-fef104fdbb05)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c3dd3347-de63-491c-85ad-cbc8f9905cac)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         5fdd25d5-2f66-4f1d-9a3e-ddf72f65c282)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9ad4085e-c5af-406d-822e-367d10e38543)(content(Whitespace\" \
-         \"))))(Tile((id \
-         45befcba-9044-4095-ac8b-52aec903d57a)(label(quiz2))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         21df6e6c-1b54-41d3-8f93-fb643a3cb3dc)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6334148a-5ae3-40cc-a508-3d653f353f01)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         881ea2ab-f2bd-4d41-b34c-4aa032edad30)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0bdc51d2-65a4-4a2e-b94c-99264c60ccd8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e503a445-3e65-490f-9dc0-25c615142fa2)(label(midterm))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         340f408b-5b11-4c50-91e1-d4633792569c)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         5e8e9a7c-d9af-4bef-88ef-6ce1525ac97d)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         5cd97a0e-5a82-49a3-a67b-49bb66d02d91)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         08484ceb-a9e0-4c65-828f-8bf5d75d6d8d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9ff3bfb1-aa9f-4277-84f3-19ee4b14c5bf)(label(quiz3))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         97e004c3-4826-4bc1-877c-892fa962d1cc)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         28e4edb4-80da-40e7-b4ee-c61182a690de)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         b6a3576e-acb1-4b1c-a82f-d991c5f42abe)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7e2102ec-39f7-4be6-b74d-f868238b27db)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b5fe69c5-f989-4ead-8314-967bd5f51da6)(label(quiz4))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         c156d663-89b8-4110-9275-7072b8997661)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         08fef7cf-22d8-42c5-99a2-b3002650d121)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         fdbb471e-c55d-4650-b411-c380eaac91f6)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         c7d36fe4-2e12-47ea-be99-d8645473f8cb)(label(\";\"))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
-         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6e0b1a3c-2a7e-4c59-b32d-4c181ef43d67)(content(Whitespace\"\\n\"))))(Secondary((id \
-         05390d88-dc65-402a-913c-27fe6372bcd8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0be493df-dbc3-4775-b33f-25eb44758615)(content(Whitespace\" \
-         \"))))(Tile((id e6cd5a3f-cad3-4b49-8687-fd1e5e2a56c8)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         bff3aab9-7174-4e58-8acf-530a78e65ca3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         1123c67f-f787-4a66-ae74-034f46435ef9)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8a9f08bc-6a01-4c45-9654-8d5adb0023dd)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         6ba040ff-6561-4fda-8a95-41e9bd77d329)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ca537604-9a34-4997-96b2-1b9ad73dbb46)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7d742da2-b5e2-4480-97f3-c22be8bd6b34)(content(Whitespace\" \
-         \"))))(Tile((id \
-         02da1df6-a31d-4414-bc28-859216bebb85)(label(omit_labels))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         394488ba-8e6e-4c0b-8ed2-1d65a9826f38)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         7732f648-1f36-4c39-a715-a2d0d1dc76ce)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         18c4a0d8-ec57-4df1-846e-b906357bb2c8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         064fb7b4-15d8-47c5-a0b6-c3d38ef1deea)(content(Whitespace\" \
-         \"))))(Tile((id \
-         385c06d6-72cf-4313-941f-f8eaef4c38d5)(label(`final`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         cfa9ca02-fe6d-4e41-b5b6-f9e33d504e9a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5c4a1b0d-8c3c-47b3-88f0-c79d491b0f81)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4bb3f638-3949-491d-881a-252a27348b79)(content(Whitespace\" \
-         \"))))(Tile((id 24a10ce1-31a9-4730-aff1-897a9d059a80)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f3172ba0-6f8d-41d5-8e35-907767a53dd0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a11d1dd2-d6c5-4424-b5be-7c218c81d724)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         66c97f32-a2e5-464a-bdba-e5fc74d0acde)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b514fb3d-6f44-4849-8365-f7706419580d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f741fcb1-611a-44c9-8ec7-35722ae07869)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0c50fcdc-c756-4962-9ace-8fabb786c67b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ed31e955-5ec9-4c10-b4ff-4497f7664907)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         467cbe82-af02-4b37-90ca-66fd80e35c6e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3ae346d4-fa1e-4e2a-891b-b5ca4ac31c29)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6729f74f-fb00-434c-8bf2-307a055ed6f6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cdec2726-d45f-48d6-8cbc-42b60d6cc931)(content(Whitespace\" \
-         \"))))(Tile((id \
-         475deb35-2e2e-4109-85b1-8477b3abf2ad)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         21b453a8-6505-461c-bb0e-c3dae4f21584)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         63222ae7-ae11-4806-a55c-c0fb69c327c2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6e27cbde-8750-47c6-9649-e52cff6e86c1)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b1319ac4-bd87-4c0f-92ae-7dd6cc6130dc)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f5802812-6223-4349-8d18-6174c184bd2c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         815f22db-96e3-4ea7-9a36-18ada2c9750b)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c612cd6d-9257-4d69-b2c5-2cd6fa9a3edc)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b197b1c2-49cb-49b3-9f20-a087d3f32c2c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c4aa8e2b-822a-44c8-a9c2-b5916e3f25f9)(label(77))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         71bad182-badf-40c1-b0ec-b960b5e60ed7)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c8e2dafd-bec9-48a0-9154-c0f7a9b2ebd0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b71afb83-4178-452c-be12-5c99eaf0b39f)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6cf00539-cbe3-4297-878a-2e0de54d98e2)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         11b547b5-fe53-4ef6-80a1-1cee32f9ed09)(content(Whitespace\" \
-         \"))))(Tile((id \
-         35a0df43-5a8d-4373-a5fc-222970972a95)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         06c11fc5-c7b8-4d1a-adaa-ff4dbc3ce83e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3a767289-4309-4a38-9bc0-8cf35b4d4120)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fff84faf-b644-4178-b4c0-7b8a24e8cc76)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3d25a1c4-bf40-49a2-9c59-0a0e86781a12)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0b8d99ab-1d9a-412e-868d-4e5e35d4ec0d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8e224dfb-eba9-45b7-bb2f-3c18018a13ed)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ff55fa5c-ac30-47b4-8d27-0244f4114367)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         8b8bf05d-dfa6-4ef7-bafe-13914c1b08a4)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         547914ad-5577-49c6-956a-3d0fe8ff1060)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         953c3275-1253-43f3-87bd-a2c96cc3a6e5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fe0ed9e0-c326-4233-a518-931e0e5fec38)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         35f83dc6-7ee7-482b-be68-4b530d1af709)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a5dae16c-ad78-409e-9bb4-8ff66b3774ea)(content(Whitespace\" \
-         \"))))(Tile((id \
-         56bfe936-56dd-4391-a7dd-624b1e803345)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         937208d6-841b-4f18-a6b1-09159814a66c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         97527bfc-1c03-44ea-811c-7b601917e561)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e45ae1b2-d09c-4c04-b624-1dea9124477a)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d6cb4eb4-842d-404e-8edd-4b35cf22f3dd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9da48264-680d-4ad3-bbbc-f7ead6503d7c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a82f016d-6eff-4a29-b639-b9f1786c49a0)(label(88))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         b9ede92b-904a-49f6-b0f6-bac17bdebdf3)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         977c1a20-9c36-49de-a82e-d5ab74080112)(content(Whitespace\" \
-         \"))))(Tile((id \
-         003b04cc-f590-4162-8645-4c40d3b392fe)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f7c0b1f6-40ff-4291-b82b-256674f28355)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         07a14e17-7510-4d2d-aac4-0ca9de153829)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a645bd0f-a6bb-43a2-bbbc-01dce0ac40d3)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d1c7cf61-6d0c-4513-9442-a4f88880a99a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         701369d9-d0d8-4a85-8111-01f18f183e2c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         afce641a-7609-4a5c-8729-b56701d0c4c5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e6587789-5231-40a8-a8f3-1e3c15ecb1b4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         47f5c86f-2e81-4311-950d-31a803a623b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e60ed55-5775-4488-968d-c02652972ee0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a7d62c77-4f87-403b-9920-3392be1a0e8a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         c12ece35-c5db-4f49-a4a1-4e604ecd4964)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         ce6100e9-2c91-4f27-a0c3-452e0008063c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         87bf09f1-8eb1-4586-b2b9-e3dbcae18e5b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         199717cf-c7ea-4e8c-8971-554c1de0c870)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba659293-ccb5-4bf8-939a-a47c3761c8a5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c9c616ce-52bf-46a4-a2ee-7e1096795cea)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4bbf1f09-4d0c-4f6a-bb52-f2c535dbe993)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f9e20118-722f-42ea-b74e-119e5f3a2ca6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         10ca6a87-6ee2-497e-b109-7ecec5f31e5f)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e4da4beb-a057-4063-adb0-6697036717a0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         eee38c31-6869-4b85-8218-79f9d008be8e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b5dfdd20-0a7f-4496-98c0-77d5c60aa8b7)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         12e45f2b-efcc-4344-bced-612953c34ef1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e73fbe49-7087-4ffb-9092-622abe66c5fe)(content(Whitespace\" \
-         \"))))(Tile((id \
-         df1044ca-268c-4d9a-a86d-625faee94cb7)(label(84))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fa90862a-b076-44b1-9d9c-890ca2a9b0bb)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c4cd88b6-2988-4242-9f6d-def0e6b5f0cf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e4bca556-4954-411d-a990-03bf7d8a21b6)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         362752d0-100f-4d4e-9a69-69e703d9f3cd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7aa51448-e61b-4c8d-809c-d1c2523dc9db)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b24194ff-7646-49c0-bfaa-4cf4c9f56326)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         47e3b6c6-f81d-4619-9e6e-27080867c15b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ad7e82be-7e46-47b3-9477-9d15fa7b76dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c5119915-bc60-4e13-a189-ba443e518b82)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9fcdf8f2-e672-4823-83cc-56c83a001572)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ec549bcb-47e3-47ab-80ae-dc3215f3d233)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f2fb830f-8b86-490e-8185-af2267884b46)(content(Whitespace\" \
-         \"))))(Tile((id 2d6d1634-8796-4293-a31d-4ee610f2ce40)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         ab015dd0-5392-4919-91f8-06d439881133)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         c654e4fa-892b-44b9-8149-3a204a5fbecd)(label(name))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         4605157d-4a53-418e-8bdd-1c1ee26d3972)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         7d76631c-adab-4ab6-afe6-fa9c9d7c6812)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         e776f6d8-18cc-40e4-b1a4-486d8ec0f964)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         25ba782e-0554-4aa2-b5a3-3c09238ee3bf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cc3ce08d-dfa1-48b5-866f-816982217166)(label(age))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         c00ce3ae-4ca6-4cbc-a051-c7d3ab749c35)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         45c48602-f697-4308-8331-4ba063d107f9)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         14f0d76f-83d8-4db4-b7b4-dc8e03d49604)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c44948a8-5b9d-484d-be05-8236a040ed84)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cb73a697-d78b-4c94-8899-4a0df9ed6a76)(label(quiz1))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         8e3d2859-02c2-49f1-8ed2-1e25f4827153)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         0b41a95a-c2d4-4328-a5b7-95d5f6e6bb9e)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         9351a727-6583-4d94-94b6-a4f98fe3ccfe)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d87b6aad-8bbf-489c-8f79-99c0705e1170)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f379ba6a-0b25-4b5d-95d7-98c196589afe)(label(quiz2))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         1b9ded87-3fb0-4679-8bd3-0a578a73974b)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c0432779-377f-4f7a-9c3d-b2c1a1a1ac6d)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         d335cf32-7bdd-4164-bdca-d18a6f5f36ae)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4ea53e0a-98af-4e87-a58a-7a682b071153)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c9ae2515-7eb9-4426-8854-729f75b1383c)(label(midterm))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         5c23cee6-a03f-42ab-868e-c8ddae518386)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         f8212042-ca55-4c9f-92bd-a866bd24ae10)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         bc3f43c5-e649-4205-bb9c-089b5f72ddac)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         29db2ffc-749b-4b5a-b918-bc874e53fbea)(content(Whitespace\" \
-         \"))))(Tile((id \
-         05d74647-c0a8-4e82-b5b8-14b64e3e7b00)(label(quiz3))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         8c2b0942-c4f9-4149-9ee3-02ac6c4ff7ac)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         28e9c5c5-8b0d-44d5-839e-d9db20303570)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         a29f41ef-3713-4d52-9bef-b4c85502579b)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         915c2045-d546-4e8a-841c-1bed336a0336)(content(Whitespace\" \
-         \"))))(Tile((id \
-         add6b0f0-61c3-47ad-b800-d0d87d929c6f)(label(quiz4))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         578e68bc-43ac-4dee-b5e6-0987fa52e4e0)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         119b120f-3823-4a79-be14-95fc9759f244)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b5bbdeeb-bb38-48bd-a669-244eb697f4c1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         22fec3bb-d2f7-4576-86a2-527cde76d0d6)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         d9a7808b-2b82-471c-97a5-08e1405b940a)(content(Whitespace\"\\n\"))))(Tile((id \
-         35f45136-dcdf-4a32-b7cf-ac7a7a9081e0)(label(let = in))(mold((out \
+         076bf58f-4421-4316-933a-58e0984f497b)(content(Whitespace\"\\n\"))))(Tile((id \
+         ba41b350-bcbf-4fab-bb66-78a5ac022da1)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a9863045-c92b-4b16-9683-d15b7c63cdcb)(content(Whitespace\" \
+         b574416f-9b3e-473d-b1a5-d988b8c65973)(content(Whitespace\" \
          \"))))(Tile((id \
-         d042c38b-2fd9-40bb-b5f4-28decb0c05f3)(label(drop_columns))(mold((out \
+         88cd22b3-fa85-44e2-9ed6-bf9fa028808e)(label(drop_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a7cbcb86-6bea-4911-bfc9-990bd8a98228)(content(Whitespace\" \
+         9028c80a-9af2-4873-bc4b-e08e99df39bd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         25c85234-cfc9-4318-831a-5f3742945176)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9e4a206a-206f-49e0-9556-d83351135f14)(content(Whitespace\" \
+         6a179053-10f7-491d-a135-961ed8663e3a)(content(Whitespace\"\\n\"))))(Tile((id \
+         e419bfad-f46d-40fd-93b0-da8167ade2e3)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         b8cd4452-5999-4f50-8307-f5e461aba1c6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9cd73d58-6fe6-4f76-9dc7-a83cda9e7283)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         2998fdc5-fae9-48cb-8e16-d9b30a94193f)(label(t))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f9b3c049-8548-4d28-978a-bbe14f874c26)(content(Whitespace\" \
+         \"))))(Tile((id \
+         74192aa9-4811-4edf-8349-fc56abdca066)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c10ccc24-f76f-4c0e-a131-380c7eca406a)(content(Whitespace\" \
+         \"))))(Tile((id c55b2760-554e-4f01-a4e5-0fdb2258f8fd)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         7176e245-4657-4434-aac2-ce7e4e0d625a)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         a3c9a1d7-6a89-4536-b9bc-3cf531775e62)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         54c42fbf-f6f0-46b5-97a2-8c4f20415e47)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8f0f34fb-dc4a-49cf-a1b1-c72f09db43b1)(label(c))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b7b6bd3a-a01d-4ba8-94a9-af20c9dd0ac2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c1892aa3-53eb-43b4-92f7-a6610b6045fc)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a25133fc-c63a-4b8a-9198-d71086b60b26)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c761ba16-99e0-4764-a619-e49401cdf922)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         42af272e-9bdf-48e7-8c4e-2278f123918a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         c3c28120-8b60-41cf-bfd3-841d7ec073b9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e4148c8a-fb75-49a2-9b28-88180b6a896a)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         50df9dad-c230-4a4f-a8b7-3a98f75b9e94)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         d73ae426-337a-4891-92df-5a3e5a16c27d)(label(t))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         43a60153-992a-446d-a291-5ecde2f98107)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d7fff5e2-e124-4b33-962e-b487694d3ff8)(content(Whitespace\" \
+         \"))))(Tile((id 257d9c92-65da-4bc9-b973-708f50ff59e7)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         5f8d8a8b-3fe0-44f6-a13e-98de53f947ce)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a1f2847c-a620-4436-b0c7-d389547b0f03)(label(row))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         22f59caa-9334-481d-817c-5a715a4adc95)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         a92fadaf-f860-4f7e-aeb9-80eb1810d0c5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d581cc92-c9cd-48ad-89cc-a6143f0595e9)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1c22eaac-d1c1-4d6d-b2f6-52c79acda770)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         055bc6ea-455b-4976-8066-9f07970c723a)(label(row))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         fd772286-9d3e-4915-9e20-f47d59a81a9a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2e73f978-32ba-4021-9c1e-08f5931059d0)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dbd8adab-6005-49a8-a94d-8bc55363abe3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c4ada905-6add-4a6c-9625-98ec9bdd2e03)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ed4da679-9ace-4aa9-ba4e-17173fbe086a)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         cb615c81-089a-4858-876b-62588517f630)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fe70b927-dab7-4f9e-8041-ef05feffc597)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0d49c936-c75a-4879-ab42-954a164cd8e5)(content(Whitespace\" \
+         \"))))(Tile((id 299b0d0a-c98d-43cd-9928-aceb02ad6200)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         5ea298c9-d60b-44c7-ac2e-22b9300d92a9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d198ccf8-3c99-46f1-95cd-3f4de9f1df8e)(label(entry))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         7053035a-08dc-4d26-b77f-4076ca6b3ace)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d95d3461-894a-4c65-98ba-76468e7f57b8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9e29134f-477c-4134-999e-9dd3f00af939)(label(entry))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1c6f435e-ea4c-4639-bdb6-d544db68466c)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         29a835a9-c036-4413-9a85-f39d9f62d5a3)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         44e2a690-c9cc-48db-8a2a-2f2d1f7bcd7b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9fc621ac-9a52-498c-a557-f898cdd6ee85)(label(!=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         255712fb-9424-45e7-93b0-6fa1888be0f4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         59363388-aac9-443a-87b6-8397d825c7a9)(label(c))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         ecc7ee64-736e-4c9e-8e4d-1451d2a34635)(content(Whitespace\" \
+         \"))))(Tile((id \
+         faca80b9-07d1-481e-a4af-7f4f2f7e3bd7)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d4dcab86-8e06-4d8b-a4ce-aa4b7844cd55)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0b3c75d9-3761-4d3d-a1fe-187d597a6be6)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         b25507e8-7bf3-48d8-9d19-c4a897525070)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ba38c220-65bd-458b-9d48-fa8a99fb1adf)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         43e3aa27-7fb5-48a9-b9b8-b8a116f5a9a4)(content(Whitespace\" \
+         \"))))(Tile((id 17c015b8-8108-4ee7-84f3-52300c1a3609)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         364ad0dc-6cf2-48f6-ae27-68d30d0eced1)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         bd158673-cedd-4d58-8fae-fa70872aeb9a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         e6835ee0-845a-44d0-a818-412fa3178778)(content(Whitespace\"\\n\"))))(Tile((id \
+         54b55266-af46-44cd-aee4-2b237d891ae6)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         5a738ffa-01dc-46cf-90e5-021e8b99c362)(content(Whitespace\"\\n\"))))(Tile((id \
+         18a923bf-bc12-42b9-b8eb-21522d3d7041)(label(drop_column))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         57760cdf-5566-4b80-822b-a0848f66349e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         ed560333-976e-48fb-b13a-75fd05811eea)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         db6d022d-13d5-433f-937d-d2cf6fd4bc9b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f597b51a-d716-41ac-b3cc-bd8c7f792bba)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d87df92f-99ba-48ab-9352-f776ff4d98d1)(label(\"\\\"final\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         3376ce82-cfef-455f-a52f-36561ee7255a)(content(Whitespace\"\\n\"))))(Tile((id \
+         ee489cc9-2498-4234-a28b-dc0eee9e17ea)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         58c07beb-ae7a-47cf-9cb5-5a7f63e521cb)(content(Whitespace\" \
+         \"))))(Tile((id e22373bd-19e4-4f8f-a52d-3c5c6be0cfec)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         ee7a5873-0e74-416a-b520-4d331932c38c)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         cd0cd325-5fc1-48aa-b352-085f50351975)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d15bba29-e8c2-4bf6-a8c6-31bb8b22286a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         21b39c72-117f-45f8-9427-7de4e998125c)(content(Whitespace\" \
          \"))))(Secondary((id \
-         25e75374-0a9d-41a4-a724-880b2a18d56f)(content(Whitespace\" \
+         65e7fa3b-1f05-4731-8253-b8ba97d940af)(content(Whitespace\" \
          \"))))(Secondary((id \
-         c624ee2f-699d-4bb0-a9b3-e0ff4597fe45)(content(Comment\"# omit_labels \
+         814dcc16-8573-467e-af44-d88d2f5f52fc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bb1c5c5d-0cc3-4ff3-ac74-f26d3f0e3ee0)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         70948465-cbe2-46a6-92e7-0564ffa29d4c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         896301a3-ef19-415b-aac6-0c5cef665bdf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         28ab40a3-ce0e-4fe0-a070-10ff152e760a)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0cfb1f8a-2cad-4d41-828f-4b114e1c79eb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f296c88d-f8b9-4500-b471-0b833e73c377)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e99994f0-0f39-4c1f-af58-e21a09d997f3)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         00b8ed45-d76e-44de-9405-eba625b68dcb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         63881bf0-81f3-439d-86e2-0527a4e1cee7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         504f1233-e62e-4a8c-80d5-697666c8deef)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         98500c0c-f92d-4346-9429-6d6087b0b20d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         88bf260e-5b8b-4465-ac2e-5035730765b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         551473d8-c476-42bf-a004-cbd9f50f9bb0)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         83d12e66-a60b-4687-9c5b-2b6441291891)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e9bd1fb1-645e-4fd6-aac1-4de2bc8125d4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         774f0b94-eec2-41ed-ac88-4dbb55a9363c)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         88f21917-81d7-4c31-85b5-1fefc77ba19c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         80ca346e-ec3a-4848-a3f6-2d1447ab119d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e1612437-0243-49ce-b5d7-fc35c84a4365)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         6faaf0ba-8a1d-4709-8982-7b756986e440)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8e55b587-c93f-459e-bca9-84b186f4c129)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e549d84f-50fa-478a-a7a8-79618e4e858f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         812445dd-f069-4173-85df-001eeed57604)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         71d5112b-8fff-477d-a9e9-7a3a615ccb09)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         09f8e6e8-edf6-4bbf-ae24-8cfa1cda2214)(content(Whitespace\" \
+         \"))))(Tile((id \
+         374df320-67f0-4cb6-acfa-e2d8e519c11e)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1c655a7e-a91c-4fc3-84e8-4572acee28a4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d2d64cb8-2755-4cb4-91f6-c8a670b59630)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aff73663-b2d3-4150-a57a-5ecb1eb76ace)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         39efae1c-137b-429e-9798-83ce2b212502)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         307dd8ce-4307-4108-8ee6-e956af43d784)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fa3f9873-1088-4df8-b949-90fee2e8fb8c)(label(88))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2b77189d-ca96-4e9e-bfa3-08e2f87ea15c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fbf65312-685e-4ce9-b4d7-6de21013c911)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e8c3f528-c2a8-4c5f-a15f-ca0964cc39db)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8fc48e57-5790-445f-8b84-cb335e9c7714)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d9a12f72-cd39-4774-ac35-7f8116947dec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         47faf895-2398-427b-8af0-7b8d4ed959fe)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         fac49d4f-7a17-445b-915e-56176168c85d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3fdd7ee4-7610-4469-965a-5c5fa8f783d0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7da783da-c69f-460b-b3df-5c99cf54d157)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         726847f5-63b4-4fb7-a364-86e7c9bbc96f)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bb693ab9-2d9b-4789-a185-d11bb0ee97d6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5e699c1a-d77c-44be-b402-dc0f08fba5cb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f96257fb-fa27-4c27-8081-61b49c0b18a3)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bb3552f0-80ea-4c38-8290-45fffe267b90)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1270e82c-8123-453c-8640-66c877cffe39)(content(Whitespace\" \
+         \"))))(Tile((id \
+         969e1c24-91e2-45fe-bde2-e6ed41df85ad)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0a7ffdfc-d0cb-4e83-92e5-0c3debc3739e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bd891b5e-b3d7-475c-9032-6e23efc4c0d2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3e8c4433-a100-4aa0-8274-1b5adaa0b5d3)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7f7d0ed0-eef1-4761-8812-463aab246ef9)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         af04e739-6389-485b-9c9a-a4e5ba5406eb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7e9afcf1-70a3-4404-98f9-df250743595f)(label(84))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         25bcb918-8611-4476-9fa1-b3357cab3d58)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cc3827d2-8771-4334-a787-b89445ada252)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b3a7da82-f43d-474a-a495-a4b5c8cb8deb)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2e93f274-0838-4e77-b12e-3cecff18591b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b8d622b0-c1af-41d3-ba34-23ec0b5049b7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         229b164e-47c5-440c-a5a2-5b1ead29fcb7)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         5ea3cdec-705c-4c1f-9f0d-17bef4b39fd6)(content(Whitespace\"\\n\"))))(Tile((id \
+         a8eb361a-9fb8-416d-b99d-ea34a68113e6)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d54ebc3e-093e-4def-98b2-d1b9f2f9535c)(content(Whitespace\" \
+         \"))))(Tile((id dc7b9808-c3f8-4155-95ba-32a2962855ac)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         b693ad71-26bd-4683-8fb9-44112128871e)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         3111babd-abdf-4a75-8563-36ad8ddff93b)(label(name))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4ba150c7-ede3-42be-92aa-d4666e4412da)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0dae2b79-4453-40d7-8a90-45378063f473)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fdc19f28-333f-4d13-9149-1e708522ef16)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5a8feced-75a7-4e65-84f5-89d26ce9f9b9)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         978d7a62-ef4e-42da-b9d4-0d0f8f87195f)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c3914858-94fd-4b0c-9901-3ccb5cac8458)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9c6cef88-016e-411c-b832-1a86010e4360)(label(age))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a6e54e8d-f420-40be-8230-55d01d27f3d3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         efc123b7-7897-4b84-86ee-97183c78fb44)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         842346b6-8a1c-46e1-8158-2fadfa3eb00c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9c01916a-f323-4eb9-8fba-b54b91d75985)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         b51feea3-2058-4791-bff8-b4b956dca0a7)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8d705d7f-fb2e-4942-a95c-84be72fcec42)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3426ae77-f54a-42bc-9035-ed06014c13cb)(label(quiz1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         972d44b7-149f-40e3-8143-f40598c5677d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8de8da2f-f3f4-43b3-b11c-f676ac83fa29)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         28d4b190-4697-46eb-a7a7-ea2351c7d50e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bd33008b-6b9c-4098-b901-32ff21bfac94)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         41c66637-3944-4ebc-b821-bd4258049791)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ab329741-03ba-436d-ba48-66d338968144)(content(Whitespace\" \
+         \"))))(Tile((id \
+         66cce0a7-c72e-4ecf-93da-0f7d09c94eb9)(label(quiz2))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         cc3a6251-6a12-48ca-bb9a-8bc8a9f542c6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         09eb6ff1-1989-4329-8063-8838b2de5f40)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b64ab5dd-3379-4ad4-b7e1-94793e75bed1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7cc1aad1-5b03-4f5b-882c-c405923bdd24)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         ae08d91d-b06c-479f-b167-036243b07312)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         50e0ac63-acf8-4829-bbfd-0cec5c9c1ff5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         57ac662f-b1de-430c-a7f0-05716dcaeae6)(label(midterm))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9880da96-ecee-4261-8c3b-52be0df087c8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         922d04f5-355f-4d84-8ded-0fe5cae3a6e3)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8e7da8f0-e7ce-4e76-8f1f-ed87d4bfc546)(content(Whitespace\" \
+         \"))))(Tile((id \
+         378d8940-c9a4-4d7f-9917-2575e4cd45bf)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         2352de5e-9437-4d8b-ba01-d9f908974bc5)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8ea67d78-bdd1-435d-82a2-a755434bdc08)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3881392a-fa58-4121-a39f-adb97fb3ba36)(label(quiz3))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f8d3b902-cd01-443b-95a6-2745b3787b70)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0e57cfe3-f74c-4072-b32f-fac8948bbd92)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0812db12-7700-48db-8656-6a42cc4659fb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         30e39789-6d7b-42f5-8cab-7174bc46c0a9)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         b4295421-b89a-4bbd-a954-2ec2b47212b0)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c25beab8-a294-4e03-9d96-475f06aea41c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         26289abe-29a6-47e6-8f67-236d13cdcbe7)(label(quiz4))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         022bf59a-c8fe-453b-9984-37cbb09cbf9b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b4ac448a-6560-4c21-a8dc-1da206a51202)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         84af8fcf-53de-4fa5-8802-fbf151897829)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b61a1b05-a1be-4bf7-845d-df8e12e3b91b)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         6d717e53-0094-4ced-aa3c-bf2d5aa72edf)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         83eab991-069c-464f-8920-de092e16e975)(label(\";\"))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
+         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a7648fc6-fcb4-4b63-9d22-7f11c7d9b9ae)(content(Whitespace\"\\n\"))))(Tile((id \
+         ed1b21a6-ecdf-47ab-a4a1-a50e667f3259)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         232383dc-dee7-4e30-b599-373f3d5662a8)(content(Whitespace\"\\n\"))))(Tile((id \
+         598458bf-007c-4d2c-b976-a37f478dca24)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         271ac07d-8c45-42cb-91ce-001647b4177b)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         b223cea5-8afd-44d9-b511-f544822bc6b9)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         32cd6445-f471-49d6-9e36-9b57a0b902e1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1117be86-5b7a-4291-b79c-3989cb48138c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         045a824a-9bce-4a31-8540-aa0fdf738f51)(label(omit_labels))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6e5e9cc3-f4b2-4bea-98c9-269aea0ac55c)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         ba7432cb-f267-4f42-842b-ce1b6b534539)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8597c0cb-26fa-41af-bb8d-ab8cbd776bfb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7309d5b5-b441-411c-86db-5827f2acfb06)(content(Whitespace\" \
+         \"))))(Tile((id \
+         18889331-166b-434b-9e53-e6444a08c81a)(label(`final`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         6f77a03b-e961-4bfd-8e28-56ebc4f5d52c)(content(Whitespace\"\\n\"))))(Tile((id \
+         6dd502c1-4407-45b0-ab97-a3c83b780ae3)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1a785327-8a61-4dbb-b4f0-05a89fa95000)(content(Whitespace\" \
+         \"))))(Tile((id 0955116c-73c5-41b3-8519-60aefbec0d7c)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         cc41a331-b39a-4ce9-9474-ea1ab3866074)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         9b7fcf70-49d2-4184-a420-0f81b3e844e8)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         29d1397e-1528-40f2-8cb6-0993a48a9b06)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5255eb93-a2cc-4027-b4de-19f3be8f1344)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         478a4576-e78a-4bfd-becc-e96ce07d90f4)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         35360fa9-dcd6-45a2-99ac-a0ba98d0aa4c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bd708e99-1793-4857-9887-64358cfb8365)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         23cd9d97-8d1a-4ca1-8ba7-74db3addfb50)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         900b04df-ec93-416c-9f74-32f5c8bdd69b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6be24f6f-90b3-4c82-abad-8eb8101c8511)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e54b5d3b-5d22-4b89-b316-1759415b3412)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         817fb1b5-5c33-42be-92b6-24746a54b71d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         32db0d10-3c60-4d5a-a182-e30b724485ba)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e27e4483-dbec-4b54-96b0-518bec2812bf)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cefa47da-a2d5-4800-879a-8d03013743e6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ab1305f1-514e-4716-a649-9b2a1e0ea06e)(label(77))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ea2592ef-2462-49e5-813b-f565ce799a5a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         df18c0fb-9b8d-4d8b-a157-6f7c10190f4c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         53f3b0c2-3149-4de0-aa9a-d24312732581)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f99e6f60-b908-4cd2-a982-24431a485daa)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b2e28a13-4712-4b9b-994a-8fa7e506238a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9c8eb1cb-e916-4e4d-a425-ed376bd0357b)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         90d0c9e0-505d-41f7-8773-d3b1a29b5692)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         229d5bb2-7f98-40eb-a9d2-53613675b221)(content(Whitespace\" \
+         \"))))(Tile((id \
+         22008a1e-68ab-4360-89f9-ed09ad6be28c)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         07618de9-d873-4110-b351-2c1e59be55d1)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         12d0284a-96dd-4ec1-a96b-c67a0e50935c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7775dc63-e2c8-4588-be23-fa1ea0bbaa80)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8e82bc93-86aa-4794-8e5f-7fa8deb70e2a)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         93086090-e226-4779-89bd-e8d7701ba021)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9a6b780b-e432-4dae-94b9-3533076680cc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3d346bdf-ed8b-4534-b403-83c994a7eb6f)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         10aaddad-58aa-42c0-95b8-0da8c5df2ae0)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         313b846c-6c84-41cf-ac51-bbd2e2c4fe3c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         45ee27c0-b936-431c-8e74-c836912a9d71)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         264ae0c8-f563-4a6b-a68b-1190c288c715)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b6ebbd1b-34a0-485b-93d8-21e2b6ef90aa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8f4b7857-9b2b-47e0-aec6-aa3a52a3dd08)(label(88))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         a5d810ba-78db-4253-b7cc-9f95886e9f52)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1e071d33-14cb-4d6d-a921-fca8e72b53ef)(content(Whitespace\" \
+         \"))))(Tile((id \
+         249cd0b0-d2d8-4c6d-8214-a81c8fc7fe2b)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8ae9380d-eaff-4fbb-a07c-41dd339d6484)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         685c8bc1-9d78-4e16-90cc-3b7e91d877d3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0623043f-5f8b-468c-b979-966a954d55d5)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         0b75400b-3683-44be-b9c4-77f0488b799c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         41923e4c-2abd-4809-baf4-b4fcdf3e61cc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8d4de7d3-4ac9-4e7c-a280-2268e30f0983)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         dcf15d8b-c7cc-4d03-8189-769e78993cc2)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e9322d2d-71ce-4115-b465-8cd0b4f67089)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d3a633a7-a3ab-40e4-bf88-0b2c258aea01)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9d035096-cd39-40b5-87dd-7dda0ab0b8e5)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d6347589-68bb-4ab8-afda-916d346500e5)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5602b643-73ae-47dd-a64e-faa095a730d8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e1b7da69-54bc-4944-ac56-39c884dccaca)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0eeb33fc-a067-4681-a208-087071a13ef1)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3ac37bb0-747f-4261-bc79-628b7be3ec49)(content(Whitespace\" \
+         \"))))(Tile((id \
+         64bfbd22-25fd-4a68-a9de-0745ed8909e2)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2094d6e6-ad54-463f-83f0-daedb6e7eaa4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e517d4e0-1bcc-4725-b4b5-685015717618)(content(Whitespace\" \
+         \"))))(Tile((id \
+         cd77e258-334f-40a8-a317-4243b10b096a)(label(84))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4badf62d-7005-4aa6-b8d8-45f80a8fbb5d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         69710cb4-0061-408e-8086-07f0479e1d65)(content(Whitespace\" \
+         \"))))(Tile((id \
+         08f51503-2883-4cf8-bb42-c8e38e659815)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d31dd5f4-270b-49b5-a50b-07fe46f6ff43)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f5c1c6e2-650a-410e-aa31-c9786a139599)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2b7703ce-f7da-435a-a5be-6d102eda37d2)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         ccf0716a-7acb-4c56-abf2-849930436564)(content(Whitespace\"\\n\"))))(Tile((id \
+         925c00e1-34ce-4c68-b444-b5bd1cd5fd24)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9a7839c9-6208-4f6f-96fa-161d48f75367)(content(Whitespace\" \
+         \"))))(Tile((id b1abc2e6-0f37-42be-9ac9-28f0e527a466)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         8258d63c-9ecc-4107-99d3-2ebce897ffb2)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         a26f33e6-90cb-45eb-9ea3-1a6f2b419c16)(label(name))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         70cbf186-a8fb-4920-b26a-b2ec2d1be2ab)(content(Whitespace\" \
+         \"))))(Tile((id \
+         438709e8-0078-435f-a10d-77b4381c1bd4)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         00a7f9cd-8575-44d9-8cd7-f02537554d07)(content(Whitespace\" \
+         \"))))(Tile((id \
+         042ac09d-dbf6-4ccd-9cdc-9f848fcba185)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         2cf2d124-6867-4ef6-93e8-70e2528d7750)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a03a4bb1-b66e-470d-a088-43db2f197d5e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b0c23e8c-0eca-422c-b97f-dbd1e5a18d95)(label(age))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7d54c2fc-b572-45ec-b6d4-cddbfde63b59)(content(Whitespace\" \
+         \"))))(Tile((id \
+         5e5e7080-660d-4567-bfa5-a6abaccd6bcb)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5ca07772-2bfd-4701-83f2-131317e9a80d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         376854bc-2e00-46ef-9603-a5050e571bbf)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         aa33f4dc-047f-4c1d-8ed1-5d6d49b4b7e2)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8bbcb1a9-e798-4e4a-8a4e-58168652230f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         da257bc1-3739-4bf0-b4cd-c1b099a1a3f0)(label(quiz1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f028ae36-ce81-4933-9dc9-4cdf4c3f0ab9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         df7c5a3f-7875-41f8-89b0-ff4e167e894f)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5eac1347-cd80-418c-82c4-13cc69ca74a8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         be09ca4e-de3f-49ae-9e55-184bafc665bb)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         d0d33976-72ab-4f63-994c-ac4ae5579c38)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         03d3b733-3168-4816-ab0d-4b48ba602c7d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         42a56cb4-b0ef-4efa-b4d3-9a7e62acc470)(label(quiz2))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         03e9edbf-2379-4692-b1a8-e73b32ab6fb2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b96c57b8-853b-41da-b3bf-26fbef45e608)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4e83dbb2-0efb-4cf0-8ba1-4a042631fc43)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2f5c71e5-c2ce-40fd-bd47-a0ef9492bad1)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         2d64563b-9934-46dc-bb88-94b315effef8)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a8d11ef0-c854-49bd-a434-8bec44e43ce2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         58727fd5-8f08-4f08-8329-25bab52670c1)(label(midterm))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         7058e3d7-c5ce-4794-a0f4-b44752651acb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         b6a307dc-906a-4974-968a-4bc85d1d1a18)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ce788833-0f2f-46eb-b131-6811b26b70f7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7b7e8b57-b4b9-4e16-bfd5-b39a50431dce)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         e1098ca7-3c02-46d7-9382-f34e911fe801)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         920b9f75-952c-477e-a521-fdbad327b793)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4d89f006-8f2e-4dcf-9618-84501a2ff911)(label(quiz3))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ab30840e-38e0-49eb-95c9-5ce10f92d060)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e345fa90-7f09-4df8-bc9e-cdd4e466923a)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         94e25974-2001-48aa-8c59-8f5c4fd371a2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         238bb278-2176-4aed-ad0a-984ec7e70b17)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         28bc7783-9426-4974-abc9-d5c617aaeb0f)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         39ac61f2-6b42-43f3-98bd-7cd1b7d8945b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         561584e5-4234-43d3-af35-31279a258fee)(label(quiz4))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2f8c09e4-191f-4aa6-bf1b-be8d202ba9fc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1fce6bb8-c0d6-424a-9c95-179c4f63dd6f)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a5c18668-e70c-4b8d-8833-d2e22cb8a5b9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ad2a07b7-350c-4de0-a8e9-6763e1bdab49)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         7a0fd320-24fb-4c37-88d0-83580adee8f7)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         6defb3db-b287-44a5-a4e8-6f39e8ae98db)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         13dc8637-26c8-408c-ae75-9027e9eaeeae)(content(Whitespace\"\\n\"))))(Tile((id \
+         40fe2ad6-c2b2-4a25-a1fa-c3e41358a1dc)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         cc622eab-d582-4fa3-8acf-a7b69318cfcc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         60d01a84-78f5-47c8-8d53-e370d8ab9293)(label(drop_columns))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4394eeb4-073e-41e3-8506-49dd7bafecbd)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         126fce47-5a4e-4556-9508-5ae8a6d1d5fc)(content(Whitespace\"\\n\"))))(Secondary((id \
+         f991c1c4-4b8a-46c5-9bd3-851abbc0a7fb)(content(Comment\"# omit_labels \
          is a primitive operation to drop columns but without row types \
          there's no way to give it a first-class type. This is the idiomatic \
          way to do the operation #\"))))(Secondary((id \
-         a6ec1195-5226-4b72-905c-32bf87dee40e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0f33d093-982b-43b5-85ff-965af20d49b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         118f2fcf-34a1-4701-b27c-c33a3c9008a0)(content(Whitespace\" \
-         \"))))(Tile((id 4a77fb15-a7e1-4adf-9f18-b521de3204cb)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         280f2a32-db76-4588-9735-7fef6ea86109)(content(Whitespace\" \
+         c4287c38-d980-4426-9e2a-974854cb08f3)(content(Whitespace\"\\n\"))))(Tile((id \
+         64f63fb3-3e18-4549-9cf9-2a00a3e9d809)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a76e5fbf-dbd4-4d15-9883-f5c481ee3b6a)(content(Whitespace\" \
          \"))))(Tile((id \
-         baa0c3b3-c37b-4ab2-b88b-fcf3bb6de2d7)(label(requires))(mold((out \
+         1787cb8d-cca8-4fae-a986-0d3aa531fae6)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         7351542c-1c1c-42a6-bd08-6db22a072f73)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         ddc24f77-c405-4137-ac69-9b7606adf684)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d00944c5-e935-484c-a3a5-a6b7497cfb93)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         94e4fb26-6892-4b92-b7a6-15c27e721a2b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8cbe47f2-bcee-4c67-aebd-0db88c833afc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         135a2544-75e5-4b0d-a61a-edbcacbf42e5)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ffcc5a6e-957b-4846-8ea3-245a2a773d5e)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b95aaae1-3a8d-4f5c-bb87-92170695511e)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         4f53b1c1-6036-46ba-b070-64a66fa6b96f)(content(Whitespace\" \
+         \"))))(Tile((id f6f12738-8c8f-4941-afde-eeb8cd4c08bc)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a445b230-296b-476c-a85e-4bca6530f297)(content(Whitespace\"\\n\"))))(Tile((id \
+         39594857-2ce1-44c9-8c30-f4499d3b41f6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e2818121-8663-48cb-a15a-6a4f8d321c8e)(label(enforced))(mold((out \
+         bbead117-46b1-4284-b693-19cbde551727)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         dd5fb26c-678b-4359-bb8c-4d65b5d4e329)(label(=))(mold((out \
+         cca1d804-5102-4405-a281-cdfc8c5db61f)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         c6da95e7-ffb8-4786-8fc9-3e44080c3141)(kind Checkbox)(syntax(Tile((id \
-         a49e4511-b6d0-4743-8061-d20f3043ed85)(label(\"(\"\")\"))(mold((out \
+         118767b6-7015-4475-9d25-422820105000)(kind Checkbox)(syntax(Tile((id \
+         6d16b535-7b40-4c7e-acf2-f50a880b822e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         2f608c31-8034-43e7-942a-507e68fe8820)(label(false))(mold((out \
+         d394366a-cf74-4582-812d-c99e138d266d)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         d564a335-b326-4f25-a182-fe0b505c24f2)(label(,))(mold((out \
+         d619f7e2-1b14-4427-996d-d6d3dfdf72fd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2a62021b-abb3-4184-98e4-62e9f3bada9d)(content(Whitespace\" \
-         \"))))(Tile((id 25c3d1fb-a046-4e2c-8c4c-fc40c2c7d17e)(label(\"\\\"for \
+         0e37bb75-b0ea-4687-aaca-9aa51aae8f4a)(content(Whitespace\" \
+         \"))))(Tile((id 76bdf430-4a97-4d80-8d77-582b7e814a5c)(label(\"\\\"for \
          all c in cs, c is in header(t1)\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         dad061b7-ee4b-4d3a-bda6-e90274ba84a9)(label(,))(mold((out \
+         577becf2-4a4e-4fc1-bef9-86db48c9dc3d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         83956bf9-4826-42c7-81ac-aadd9e1b1eb2)(content(Whitespace\" \
+         968bb5af-bea2-4c33-ab7c-666b04a0dc76)(content(Whitespace\" \
          \"))))(Secondary((id \
-         a39dd3f6-cc8f-4230-b195-aa5a28adc0eb)(content(Comment\"# This is \
+         ea14cfba-41f1-4f26-9d58-425014138d92)(content(Comment\"# This is \
          ensured if using omit_labels #\"))))(Secondary((id \
-         ab36a630-f0e5-4c26-83ce-198d62efa367)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0ee753d4-3dc4-4567-8f42-acff5d700ce1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1351eab0-8247-4a99-9868-84d77ba43463)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7575fcaa-a2a9-4eaf-b995-da0695cdca1a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a75dc7d1-24d6-4f2b-a19c-2f0c6e1e064f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7ed9d78b-afee-4580-aa6d-6a2330b2c22d)(label(\"(\"\")\"))(mold((out \
+         2190f82b-56c5-4bf8-940e-994039c33372)(content(Whitespace\"\\n\"))))(Tile((id \
+         3afd2b68-bbc6-4785-831a-60cefde0f2f6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         a9e1af38-3414-4324-8784-dc51de44ad0b)(label(enforced))(mold((out \
+         ec6ba831-acd0-4aa2-bf6f-a2e9828c209e)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fdd15d99-b9a9-46ee-85e8-8c799586d23b)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e7ac0b68-7f89-4e4c-a004-507eb058be0b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         4ab69937-1cb2-4e0d-b62f-99407fa5bc32)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         5f6c29ef-c8e4-44fc-b1b0-a183fa96be83)(kind Checkbox)(syntax(Tile((id \
-         794cb666-f1e7-4a2e-8c9c-800adfc54ad4)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         62cb13d5-e10b-4e50-ac05-df7d2fbde36d)(content(Whitespace\" \
+         \"))))(Projector((id 313fcfc4-f474-4149-a6d3-f16c88e3c69f)(kind \
+         Checkbox)(syntax(Tile((id \
+         f2beb031-ac14-4992-90ae-a8d20f46b57c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         c1d6af72-90bb-44ac-a828-18120f93c96c)(label(false))(mold((out \
+         eede4e4a-ff78-421f-8dae-03e90d442af5)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         85a4c93e-33bb-49d9-bc59-864c81a94d7c)(label(,))(mold((out \
+         c9955501-6868-4969-b07f-f09ada622e39)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3b135736-1fe7-4bf6-8740-ea8c620e5ab9)(content(Whitespace\" \
-         \"))))(Tile((id de7b49ec-5fb2-4e81-9067-c7cadb965ec5)(label(\"\\\"cs \
+         6774bd1a-50c4-4421-8271-655b60601beb)(content(Whitespace\" \
+         \"))))(Tile((id 79d524f3-f356-4d38-87ee-2f42dd71b174)(label(\"\\\"cs \
          has no duplicates\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c4e84042-fa16-48f6-8053-d64ddc299e06)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ed1d1b95-e0a2-4c46-a7e6-69da52b4a1b5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e98af5ba-e3eb-495b-b412-ef8f26cecb10)(content(Whitespace\" \
+         aa99c42c-d939-4f78-bd99-a18b88b915a2)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         625c444c-8e50-4850-b92f-4416a8f97136)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b6278443-1c17-488d-81e6-042d8bf16fb9)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         61c72919-9edb-4d5b-88ce-121e4cb43ae7)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bd2e25a5-1806-43c2-9157-3da6b3a36f1e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         deaf56e2-819f-49ea-831f-6d7ccace82e4)(content(Whitespace\" \
-         \"))))(Tile((id 530036a9-b7ff-4929-8bce-e4589aa07cab)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         96b1b1ef-c2b1-4ea1-bf65-336bccfa4ab3)(content(Whitespace\" \
+         ba3d3ec2-8652-403e-8ae3-f840454ed806)(content(Whitespace\"\\n\"))))(Tile((id \
+         13250222-4f2c-47d7-a719-7322cf7f1492)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         539801da-a6c6-446d-bd42-fda5fcf4c089)(content(Whitespace\" \
          \"))))(Tile((id \
-         5f7bdc19-d50a-49f0-91cc-547744307045)(label(ensures))(mold((out \
+         1345b125-b415-4c29-934e-82f59e1e2531)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         0907da63-7f6d-4596-9dac-edf3e0c6437e)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         c1f16c96-5ffd-444d-af8f-857352ae6829)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f6ef50d0-a8b4-4bf0-a947-5b52d843f360)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ed468fa3-c090-46c4-9c36-2b83d7a5781b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4517011d-72de-4ad8-bb97-ddea966e47ac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         468710ee-449e-4895-baba-8d56c65fb6c0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3c4452a1-6938-4a90-99fb-c6a97a2dfc39)(label(\"(\"\")\"))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0cbe1e13-de3c-482f-b30e-e83b7fdb852b)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         ba022c9e-bc0e-427f-9391-922fe601e15c)(content(Whitespace\" \
+         \"))))(Tile((id d52ba2a9-8910-4995-baa9-b4aa31cdcee6)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         3c0f95a8-191a-40a3-9921-bbc6e1eee914)(content(Whitespace\"\\n\"))))(Tile((id \
+         fd249d01-f175-4842-bf3c-2753a119fe58)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         2c5bb504-1543-4417-8d4c-4c4c06a81f0d)(label(enforced))(mold((out \
+         ddb86569-1211-47a5-b57a-a39bbfe12b60)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         fdf05f01-39f2-476a-b697-2cd6472ac94b)(label(=))(mold((out \
+         ce3a0e49-fb7b-410b-ab37-197fd1e28dc4)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         9d458c39-8e02-4ec2-957c-7b4ddabe97d6)(kind Checkbox)(syntax(Tile((id \
-         bf49c8f3-7e6c-41ca-90be-75f33d4d70cd)(label(\"(\"\")\"))(mold((out \
+         cad65cb9-e720-4b87-8774-255206cdb866)(kind Checkbox)(syntax(Tile((id \
+         8d218594-2604-4c1e-90b6-12cae20b904d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d7274910-b0f9-4855-897b-caaf8a9d6470)(label(false))(mold((out \
+         0f6bb420-326b-4205-9568-e79fe45e6d1c)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         9c3e4dc3-96df-424b-aca8-9ecb409d0082)(label(,))(mold((out \
+         d8cae939-cc98-4947-b962-f8d7928155e7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5af392fe-f130-4b8f-9345-3c2d9ba7cbfe)(content(Whitespace\" \
+         62c77aad-dd61-462f-8892-842a6c11a181)(content(Whitespace\" \
          \"))))(Tile((id \
-         1bec78eb-945c-4d51-976b-7749f9c2ee26)(label(\"\\\"nrows(t2) is equal \
+         f8a19df5-8a84-439f-bd36-5e85206e1c16)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         6461d095-b528-4099-8d87-7c367b58f153)(label(,))(mold((out \
+         6bd22cbe-050e-4837-9c21-7ec044d4584a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         18963d15-5fb1-4d90-8060-71e71559a9bc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         41cc2a3a-0512-47c6-89c1-a9d32c4c5d4a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8805c57e-2c7a-4f3b-bccd-b791385a249e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fe193eb8-3523-495f-ac13-00f1b51df243)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         694d2131-ac9b-4272-a294-c0d71b16a8df)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9fa6a8c3-f76e-4b68-8c25-ea51f6bcfc24)(label(\"(\"\")\"))(mold((out \
+         4fef3a00-d0c5-4cfe-802d-b76e0fd13540)(content(Whitespace\"\\n\"))))(Tile((id \
+         4bdefe90-bedb-4397-b568-0be437073d7a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         e03c5c08-f644-4f4b-a36b-545e2419f63f)(label(enforced))(mold((out \
+         bb748b23-609c-4ac3-83eb-eca6470eec14)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         89c0867a-adc0-4ffe-8cc5-e33db5daa39f)(label(=))(mold((out \
+         9d9b23c6-50f1-40e8-83c0-b5cd34b423e1)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
          39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         9adbf1cb-f285-4842-b7d2-a8515320bea8)(kind Checkbox)(syntax(Tile((id \
-         afb8fad1-8193-4269-9e3c-933ae017da4c)(label(\"(\"\")\"))(mold((out \
+         42622a6a-2447-4602-931a-556a0f9f84b1)(kind Checkbox)(syntax(Tile((id \
+         b7d7c3d6-57fd-4c37-8ed7-08bc713a4438)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         0f5530b1-0be4-4730-ac24-ec8f4e1cc5bf)(label(false))(mold((out \
+         24cf8767-e03d-4f1c-8a46-746922f865ed)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         9ec392fa-22d0-41a5-82ab-2eaa9923ed3c)(label(,))(mold((out \
+         932c267e-dd65-4a5f-9ad1-f530de4aa0d8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6c7f4c5d-28a5-4011-86b7-22f56484bbd3)(content(Whitespace\" \
+         3daa9d54-98d1-4965-9b76-a5da7e7846b1)(content(Whitespace\" \
          \"))))(Tile((id \
-         37972914-adc8-4b99-8af9-361a6ce40b5c)(label(\"\\\"header(t2) is equal \
+         a81d1719-b94d-46e1-b6ff-b4f931949693)(label(\"\\\"header(t2) is equal \
          to removeAll(header(t1), cs)\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Tile((id \
-         4fa12c09-a2dc-4c26-972d-c23c8eea939d)(label(,))(mold((out \
+         406572a4-35eb-47ef-b9f6-c4a15904d68c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8b3a8e48-bbad-4111-a45b-2d20b6f962c4)(content(Whitespace\" \
+         be52dd65-d4c7-47a9-9485-c1a77c665586)(content(Whitespace\" \
          \"))))(Secondary((id \
-         f4ca5e1b-eb23-4c80-b948-66329d71939a)(content(Comment\"# This is \
+         d15cfe31-8a03-4210-9422-f6394eadf081)(content(Comment\"# This is \
          ensured if using omit_labels #\"))))(Secondary((id \
-         0e3d8852-7431-49da-9ba4-86ec288f1b65)(content(Whitespace\"\\n\"))))(Secondary((id \
-         de4e3c32-8e31-4c59-9fa0-5b2c227bab57)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0c86b738-ce7b-4496-a7e2-ab1d058bc109)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         26b5c8d4-6ea4-4925-9d63-3a1b8cc10d21)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cbf230f5-900f-4790-8dd9-58a05b392f35)(content(Whitespace\" \
-         \"))))(Tile((id \
-         6cbf79e7-1691-44e8-9ea8-da548d767eb0)(label(\"(\"\")\"))(mold((out \
+         e9870fc2-08b3-435a-b872-e25b21445a9d)(content(Whitespace\"\\n\"))))(Tile((id \
+         62dadb46-085a-47dd-b9d8-4f5d0a9c5497)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         cb39e837-51df-4271-a5ad-3f27aa0bf5cb)(label(enforced))(mold((out \
+         f3085bfb-7d65-4aac-a4f3-34e63f0c2d1c)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         43bec5f3-4713-43b9-bac2-ec5cff9a7342)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         bf5c9d8f-6cbb-4603-bee5-97fe0edfaba2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6b99d3f4-0d49-465f-90a0-cc80c367a1ff)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         5ed29510-6e2d-4bf5-8518-88785e672168)(kind Checkbox)(syntax(Tile((id \
-         2cb3c0fe-edd0-4425-99ba-f7de169a548d)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5f22460e-fd42-4b42-8ba6-a06a6b54f344)(content(Whitespace\" \
+         \"))))(Projector((id a7c22af7-5fa8-4bcb-a33f-abe9bb7d3d5f)(kind \
+         Checkbox)(syntax(Tile((id \
+         51e2a7d0-6509-4f2d-a89e-0b546fb6c573)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         93be4745-008c-48f9-9965-7360b5ec6d28)(label(false))(mold((out \
+         25e07c8c-89c9-442c-a42d-299af1ea300c)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         6f330d64-3562-4eaf-b7ee-106374e9735d)(label(,))(mold((out \
+         b6ac152b-c761-4025-8cd7-de8c9219ff30)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f86a0847-8ad3-45eb-9a56-8888cf21675f)(content(Whitespace\" \
+         66c06346-1e1c-4590-b187-a4202777bbab)(content(Whitespace\" \
          \"))))(Tile((id \
-         d23b869b-1065-4cd2-8ef6-f037658c69e8)(label(\"\\\"schema(t2) is a \
+         c7a96933-6889-43b8-8acf-e8cb288864d6)(label(\"\\\"schema(t2) is a \
          subsequence of schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         2b5ca50b-92ae-46e8-bf63-18a60a85cf98)(content(Whitespace\"\\n\"))))(Secondary((id \
-         56f3dc5b-165f-4242-b480-62f65a36bad1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8313fa2f-b6e0-4655-a13e-2dd481afb386)(content(Whitespace\" \
+         facf122c-4b8d-4c02-8ec3-14b5b0e464fa)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         b5e0ad31-bfb5-4046-9667-5c40ac9d8dcc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         19ae7cfd-63c9-4ee5-a6f7-b94ab70ae5c0)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         e580b0aa-87cc-42b9-8414-ed0f6f001c27)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ce63aef0-379f-42a4-a3fd-6b32f204e959)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e7e5ae26-deba-4de6-8064-93ac622e8f2f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         094e2463-49b1-4bbf-96d1-5381fd0e3ef4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bf32d58a-eb2a-4506-a549-990aa076e141)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         673cfac1-855f-4454-ad88-be19ba116f3c)(content(Whitespace\" \
-         \"))))(Tile((id 4c3b0b05-fd66-43bc-967d-c2c9b66d2df5)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         47ac42df-7841-477a-9ec5-08c25520fa23)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f5bcb506-d204-4c90-b54e-7b2f89f8adb6)(label(drop_columns))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         e002304a-5e0c-4153-8675-b654be2170de)(content(Whitespace\" \
-         \")))))((Secondary((id \
-         d72d4d70-5e17-496a-853a-09414224b343)(content(Whitespace\" \
-         \"))))(Tile((id 2768de81-87ba-459d-84da-82c88e11539d)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         9fcfad30-c1c2-4c64-bcd3-23029cd3223a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c7ec9e0f-f2d1-48b3-b949-341696845a13)(label(\"(\"\")\"))(mold((out \
-         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0 1))(children(((Tile((id \
-         665ac4e2-ecfb-469d-8403-f08769a7c894)(label(t))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         b6bbd347-4626-48c5-90e8-e50e7fa404fe)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         4e669547-9074-494a-8d21-26ecdd7ba75c)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         b2909d72-9658-4827-be9a-111d8e85b860)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         5233779f-e90e-4514-ac8f-093225afe4c4)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         e127d1af-abf1-4cef-a06e-cc9c93d6173b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4cac9ad9-b5d3-48c6-8d3b-090b782ff2b9)(label(cs))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         d2d4f072-0460-4e26-a271-5463db58faea)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         8192df37-cfef-4cfe-8071-edbd2fd62fec)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         869dec04-4e93-4bf1-acde-6a069d577c97)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         98a85058-badb-49de-82fd-5eacd73f1891)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         b5f22d2f-7d7b-4951-a725-14103a550cc1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4ab40d06-969f-4472-9e33-24183365de13)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         98b6db42-01b6-464d-aee9-a8e9d9f5c3fc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b410fb41-d17e-4d56-8790-eaac11029a01)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         43c826f6-4f09-4c22-9032-442e13a9cfd0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ea8e9fa8-c0da-4038-91ac-ec2ca382eaf1)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         15ebf4cc-49bc-45fb-a321-6a5963fb357e)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         2d5f20d4-d765-429d-8e2d-db6cf3221d91)(label(t))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         93a76b06-686d-4c14-aa0b-78df7801a65a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         4a46445c-794e-492b-8e68-35ad99752728)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         cfffc838-f3f5-4a25-8de6-720f05780681)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c26f8f54-78d7-4192-9206-35f36b59b2a5)(label(row))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         7cc919f6-5978-43df-8685-8446968f1472)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4494d01a-deac-4541-8d9a-7800685b099d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         75391061-7aef-4ff0-8c26-6e8024e9f78f)(label(to_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         227ec0c5-b890-458d-99ce-fb6647bc1386)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         05c19d61-4259-46e6-89aa-4d958cc2a5dc)(label(row))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f4fe5eb0-a05a-4bf7-b66b-05e739d3db89)(content(Whitespace\" \
-         \"))))(Tile((id \
-         600c57b5-8393-4085-ad7d-17fe35c55453)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ab6f3763-0e93-4a92-96bb-3916eb749a53)(content(Whitespace\" \
-         \"))))(Tile((id \
-         21d57995-8388-4426-91c2-d73dc0bc406c)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a2ad1054-fb32-495d-a381-356579d66c2a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         911fdf53-691e-4ba1-bbe8-d021dcf322e5)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         7c108d47-67ba-4c3b-950e-a7e209fc761e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69dd2197-2d30-437b-83f7-3beed18a483d)(content(Whitespace\" \
-         \"))))(Tile((id cc109b6e-3127-4ef8-9b44-5ac50ea45022)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         492ec904-ec6c-4789-b905-61f5291749c4)(content(Whitespace\" \
-         \"))))(Tile((id \
-         94bbce44-16da-42f1-aeba-794d9f8732a8)(label(entry))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Secondary((id \
-         ee405f71-65c2-46cd-ae07-1ea6e48ffd63)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d3273d67-5b1b-4359-983e-6bf57b86e2fa)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9e857359-cddd-47f6-b961-40216f0e26aa)(label(!))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         32653133-c5be-4e40-abd0-6d38ff9b900b)(label(any))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0c68ac22-0e92-4d5d-970b-c40e02ce986b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         8db72808-68f6-4e01-87e0-4c48235cbf74)(label(cs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         25531fa5-93af-40d2-bf12-4ca2a14443fd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         443414e8-30c6-4b13-af87-38d358695173)(content(Whitespace\" \
-         \"))))(Tile((id \
-         e00d5d03-d8d1-4fa7-a231-899b6fd95f65)(label(string_eq))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0553be7d-5d0d-465e-a75b-72bf25ec874d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         fced4060-5c7f-4c57-b07b-2ae1ba43fe1e)(label(entry))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         978a2b8a-4651-48a6-9f94-93a01c5ea728)(label(.))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
-         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         44910bbf-91a9-4b2d-b2bc-bd0ec9b89582)(label(label))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d82ce173-0f7b-4555-9284-576928112d7c)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fdbdb532-0e95-4c6c-93a9-9c4c1b9399bc)(content(Whitespace\" \
-         \"))))(Tile((id \
-         257c38a5-60f3-4466-95f0-b0ec27132338)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         2fc49b16-66a6-472a-ad97-73be47f8bcb6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         98024c94-9be2-40ef-8fce-0079bc42e752)(label(|>))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2fcfbd6e-8f9c-4db9-8c5b-24866e43efce)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a5263070-0d8b-4669-814f-95206354416f)(label(from_lvs))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         1826e804-78d0-4f27-9e0a-dd07483d764a)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         727cd9c3-d309-4883-8c7c-03fc10641877)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         7e1a5456-cf67-40a1-b9f2-7ddd86b2363e)(label(?))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1a178465-9cf9-46f9-815f-32007b823d1b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         94620657-8559-44ca-94d2-cc3105ef88b6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         06efbd9b-fac5-4102-9d7e-2c6ec6a1b100)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4a4c917b-c99e-4a30-b6d8-9258f38d1380)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         da7c869f-7901-4c43-b23b-01939cf69d74)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0fe24904-63ce-41d6-97bf-8c6473dacdd9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8755107d-ad40-4c74-8336-e32018fdfa01)(content(Whitespace\" \
-         \"))))(Tile((id 63333ae5-772f-4764-a605-4e7e4431713a)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         b28ed713-6aed-4e5c-a87a-013d91e3b154)(content(Whitespace\" \
-         \"))))(Tile((id \
-         708e290b-6890-4a73-b304-6d56d626e95a)(label(drop_columns))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         487148f3-ae85-4c67-8b06-c1889b545225)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b5d2476a-91bb-47db-aa9f-48be1a72ceb3)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3723a16d-2f24-45d7-805b-0235b632bd8a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e008b2d1-ca0f-4087-a617-1ff0633a678f)(content(Whitespace\" \
-         \"))))(Tile((id d0cba5f2-ad45-4a39-b62a-ab3f8637f222)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         4583d1c3-5136-48aa-acad-b4ac1d06dd0a)(label(\"\\\"final\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         487ba8ea-7887-4131-9d03-bc8eeddb8bb5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         12d540e4-1c3e-46bc-8f78-5f0400bac3a6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7b94fd11-8dd6-43a3-bd5c-780425a3695d)(label(\"\\\"midterm\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         f33b3cfc-b92b-44fc-b4c9-b7f7507df0f6)(content(Whitespace\" \
-         \"))))(Tile((id \
-         39200731-34c1-4d10-9507-b5461f5e9e23)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         62f22bb7-cddd-47cf-a326-18fe81a7013f)(content(Whitespace\" \
-         \"))))(Tile((id e96c89dd-35d7-4627-804e-c850577fe4a9)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         436cdc9f-0137-4b17-b8ff-7d9ffe00bfb0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a1bb5a3a-8d63-43cd-893e-b8dbfdedc81e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c22a5c42-f707-4498-b492-18f18ed4897d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         500cdb2d-26f5-423d-8661-d695f9de6d84)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ae374fe-9cf3-427e-92e1-999ce867bb7f)(content(Whitespace\" \
-         \"))))(Tile((id \
-         89aa9837-1aad-4107-9128-b5b061ddadb1)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         2f952bef-a2d1-458c-80f0-522c3cb0ebff)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         0450ffa6-59da-4f93-a6e3-5575145049cd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4815e59a-75cf-42c1-ad40-cde1b15d2237)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         de0e69ba-a10b-4be4-adb8-f126085a76cc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f9f60a7e-dbf7-4360-9ecb-23d0dee45dae)(content(Whitespace\" \
-         \"))))(Tile((id \
-         3d4fbcc0-f98b-429a-a106-ad846a35f656)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         03d6bf17-66bf-491d-a357-cd2b412791be)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6812da0c-75e1-4e36-8785-e18fc04d74a2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         09ba6fe1-3341-46e3-9a4c-10ebc65c5c85)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6588d435-9307-4ecc-92f3-23dc2a619439)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         25715550-a3d5-4d50-a34d-f795ffcd26fd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         584df3c2-8399-492f-a04f-cd794acf0452)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         9943b7ef-c3a0-4163-a783-68bb2a53ff5b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         85a0a584-7399-4b1c-99cb-d484cc95560c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         201a0b74-57a1-4687-a3dd-a9732ac83daa)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         320d4e6f-7e89-4402-9471-862c16979f6b)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6a687371-4d0b-4fd8-a1d6-aa5164c86919)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4c2e9f5f-d03b-4401-aeee-55e15f591876)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         c321b6e3-61ac-403d-ba10-3823ee018b52)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b7aad054-edc0-469c-9249-64eda2cd71fb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5d55c861-8cc9-49a8-bb71-ed2a72c8bdaf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         216b2115-e643-4b5d-a6d8-728886482a52)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         57264c65-77d9-4f2f-92f7-61acf07e89d1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a3696ecb-ca06-41da-9471-ad609240bd11)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a588923a-8d5e-4640-aac0-088b320b4874)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         0a65cf36-626a-4d2b-8291-37b606079d9a)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         4ae25780-aaf4-43c1-a69d-f37c2cbc2c54)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4d578ef3-4f16-439d-bda3-efb451cbfe61)(content(Whitespace\" \
-         \"))))(Tile((id \
-         8b5f4ddb-ed12-4afe-bc26-d6baee640a07)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         02e99e24-51eb-4db5-95de-5008edce8dd9)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         329a5e71-7bce-4ca2-aeef-89c24eff3fc7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         41e907dc-ac50-414a-87b7-3f053440ad1c)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f018f933-2272-486d-b891-121e66c68c65)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         79bc38c7-cd4e-49ef-b59b-e8a5e64448ae)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d710d631-d75f-42ad-afd6-be883daa51e5)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         d1d096e4-1eb3-4031-ae2f-d25f7e9d68ab)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c054d781-dc0b-4065-9dce-1b56ee128ba3)(content(Whitespace\" \
-         \"))))(Tile((id \
-         96f65fc8-6711-40cc-ad38-beb6bc47e2ef)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         843b2159-6ce0-40d8-a5ab-40cd20d2ca15)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         edd619e1-bdb3-4c01-8efc-aa52acf6c705)(content(Whitespace\" \
-         \"))))(Tile((id \
-         05c3e184-1bd8-4502-94ac-cee3acf675f9)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         176e69ce-d379-4789-9507-d5620d9ae5bc)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         93cf688c-c788-440a-b821-4d704e0685a1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c2611e81-cb46-4855-abcb-6d794c8b87f2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4291489c-cc3d-4464-bb2d-a57cbb2db8ff)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         10160f0b-c655-4683-ae80-450e4fa1a222)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8e03aa1d-e017-4e20-acfb-421ebddfa63a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f7583654-81c8-412c-97b7-b0738d76ffe8)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         9e896882-8ab9-4d0a-8628-26854802fa44)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         2463933f-faca-4de2-a1b7-6751ef7ca1ad)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c9aa1903-9cbe-4130-b5a3-cf9125f695fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9627644-880e-4d44-b5cd-35e00ff4dfbb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9ecd276f-7e1b-402e-b321-4a44fd38f2a8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b1ed398a-ada5-47ea-ab52-69d0bd67e918)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         45c93848-206a-4ffc-8734-a12ada9607bc)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c0524d09-a734-4996-83e4-5876bb25c9fe)(content(Whitespace\" \
-         \"))))(Tile((id \
-         28a5cfce-111d-49c9-84b7-fba8bc7b8429)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         cfb0a73d-12c0-4269-95fd-10063dbb1fce)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         56c34818-db47-46f4-9262-3dbf53188302)(content(Whitespace\" \
-         \"))))(Tile((id \
-         bc0d5be3-5f53-4071-ae25-fc75879803c2)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         bf8fc9af-4a89-46fb-a77a-8a7b7fc8643d)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69e27fd0-7947-4272-908b-f3a103e0ab46)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5c606b34-4d77-4d6a-9752-e00d63ca2b3d)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f55ce507-ff84-4c3c-ba8d-c27df1cd1a09)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         431be96c-75d8-4092-b1d7-8da8e1fa70a2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         14b55f79-828c-4c79-bb78-8fc512a37df9)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7396cb02-043b-4bfa-b6c1-f4b0f338c319)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3cd9e374-66e2-4c5f-912c-cbbeaa1cba7c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3193cfab-0bfc-4130-97a2-338a820902b3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b0da6ee0-d3c1-4051-a8f5-5051d6d288d9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e9d3bc0-cfbd-46f1-a956-6b3b40522821)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         861a0ae4-eb96-4678-a9c3-9b542c9320b8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         58f8051b-5026-481f-afdb-7cd6f79a40d5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6448cce4-30dc-4592-9270-7e999a57212d)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         63442041-e0d5-4255-935a-3995bc90e3ab)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9868a928-e8a3-4342-afcf-a8c0556c2d10)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         00f78854-0b64-4280-98f1-3ad4ede20214)(content(Whitespace\" \
-         \"))))(Tile((id 01c50f0d-921a-4162-9b21-dab791d1fa90)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         ab1ea202-c567-455c-b7f3-d48681cfbd17)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         8ca8bf90-8453-4023-a3da-9d61d970f119)(label(name))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         d030076d-d020-45b9-a1f2-0237cb78ed53)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         997bdd21-3c70-4edc-bdf6-6b334bafeec4)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         4478eb0f-ff41-4f94-9fa6-47b33674a606)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         23ebfc91-ba0a-45f2-9d80-fb7f84c87d99)(content(Whitespace\" \
-         \"))))(Tile((id \
-         caf82a5c-22cb-4758-8058-83edf492917d)(label(age))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         fbf2f14c-7f27-4bd5-b7b7-a29f9070c197)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d0a6d07c-1e43-48f4-9254-49e8db043485)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         217fcb17-7698-4931-abc8-662eedfba827)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b6699496-12f5-4ff8-8eee-b80b37e7cabe)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b080d89f-75ab-4d56-bc1e-89f3f6323878)(label(quiz1))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         7d7d8efa-5c29-4510-8811-6069f21b775e)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         5141f6b5-2324-4e2b-bfff-9974a31bbf88)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         aa77d5c4-f5e2-4447-995d-f8a06f8a30c2)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         13c243ed-2866-4489-ae32-5bd65f970f01)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2901e1c4-af96-441f-9fea-1ff7fb948672)(label(quiz2))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         6899f36f-7fe3-4bd6-b641-40ceb83f1c42)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         04444be6-32a5-4dda-a10b-5a22487a0351)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         de28780f-683d-4760-850f-749eadc3f8ab)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a8af7dee-3a42-4e9e-a271-d1eaf1b5f07e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c4e6db82-6648-423f-ba09-2c4f9669d670)(label(quiz3))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         1f89f45a-b17d-459f-af07-7d488454f829)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         893c5fc0-ee23-49d5-a03c-cd2cb0bed63b)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         1ff7e1f4-711d-49e8-bce2-aa09814b38ea)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         95410503-7d1d-4c43-ad3d-427d6a118d05)(content(Whitespace\" \
-         \"))))(Tile((id \
-         fa20c27a-cc8e-499b-9c33-93650e487796)(label(quiz4))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         cb15895b-526a-4021-90de-fda808e4a5a9)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         5047eba7-5d38-45ca-a4cd-cf6b9a8246e7)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         51da501f-267f-40fa-9394-a896c0cf1366)(content(Whitespace\" \
-         \")))))))))(Tile((id \
-         ca2c0cca-efc2-49d0-ab3c-0dfa72a477ec)(label(\";\"))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
-         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cd7d3954-fbc4-44d2-b1c5-9b47218964e1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         88887a79-ecb9-41db-8b0d-59f455b00a05)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         736fbfb5-9f64-4ca6-8f45-ec34f340bae6)(content(Whitespace\" \
-         \"))))(Tile((id 0d59f6a4-18d0-44c1-a25c-00b1a6e3940a)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         bf130c7a-e397-44c0-9c96-619bdade3281)(content(Whitespace\" \
-         \"))))(Tile((id \
-         cc1e04e5-4b1f-4002-a074-86dd9ae9965d)(label(map))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         c0361803-0d28-498f-8a65-7e123780a260)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         920d18be-c740-461b-b5fd-bf5d5d0f692c)(label(gradebook))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         52d7f7ef-4ec9-4821-84d4-e1ff2f6b7eba)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7ed9af9d-4f59-4f5d-b4fe-e808ac1ee593)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a067ac01-7aa4-48ea-bc6c-199e0b9fe07a)(label(omit_labels))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         a7c18be7-bf10-4b90-bf2b-b46cfb284c1b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         95b21780-2102-47ad-8544-ae2be97d6b2f)(label(_))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6112e345-c6c4-4fde-9e91-7ea805ea5bcd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         66ed5815-292c-4fdd-a4f6-992b0896b52e)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a25bc304-7e95-487e-90a9-f9bebeb04361)(label(`final`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3ca5bf5a-3bff-46d1-9724-f8b441d539e5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5cebbd60-d8db-4bee-9694-1332d94dc4cf)(content(Whitespace\" \
-         \"))))(Tile((id \
-         ec9de453-5b51-4229-bfda-fde656cddc33)(label(`midterm`))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         09064015-a2e0-4e9a-9025-82a2ba48111b)(content(Whitespace\" \
-         \"))))(Tile((id \
-         4fd986a3-30bc-451e-867b-3d92b7828476)(label(==))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b1df255c-3315-4f2a-b6b1-a983184848da)(content(Whitespace\" \
-         \"))))(Tile((id cd26d111-464f-404b-ab4e-1f78c54bd90f)(label([ \
-         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         56d415cb-4c0e-490c-a97e-0ccc84e2aa19)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9ce36920-999e-4b3c-a742-c11225f50224)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3499c328-9ae7-4ca1-9aa9-75ce11b697dc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         22f87ace-6183-4cdf-97a0-bcc31d6271cb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         097f6098-4d56-45a5-8b10-1569f160d42c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7d57c9ae-b02f-4fe9-84b4-4de795ac10f3)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         6872dcec-ff57-466f-a0bf-02711a09faf5)(label(\"\\\"Bob\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         11708575-fcf9-48fc-b3b0-7accae2f0b59)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e542a937-6207-45bd-bd29-71aba4cb1671)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         44fbc47f-3c4b-4d6a-9831-2c1b39cec45e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         41458434-aa4e-4beb-b34b-52571f90c18d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a8d529fb-24ac-4330-b245-64525d8c1e47)(label(12))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         71d7ceec-6f64-495e-8418-2d7b117588be)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d4f14191-0385-47c4-b055-772a5e09d105)(content(Whitespace\" \
-         \"))))(Tile((id \
-         55610db5-90aa-4b0e-ae6c-441f64957cc2)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         92a7d3b2-50c5-441b-b639-dd80b6ee45c4)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         532cbc88-6ef6-4ddb-b6de-9712cf111cb7)(content(Whitespace\" \
-         \"))))(Tile((id \
-         66cc9bc0-08d3-4a83-8b72-94bd4f0fccf9)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         da8915de-a5ae-436b-b44a-083b4abbde62)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         473cee48-2b80-4a8a-86c6-b96de199c851)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f7d5e0c4-1c6b-410e-b14b-057871f3e19f)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         97bd558a-8159-460a-b67f-97a1b2dac269)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8b54eedd-9a96-4b2a-96e4-a92fbfe22cc0)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d5e480f4-6653-4d2a-94c1-1ba57dee2e9b)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         d4329a40-9686-4e0f-8239-d6f1d4c930d1)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         439ffd8b-ade1-4c20-8f28-7037c5d86af2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1e5b7bf9-ffa1-4acc-a82c-a5bbf1795c34)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         178a5edb-71f2-47e5-9e37-1e5f4567989a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         28ecf10f-c34c-4cdf-adc4-9f777d15a60d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e2c67b4-8eb7-42cd-b942-44788e7c19bd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         15269564-5f02-454f-8acf-7ecdb6d78cc3)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         c91ee40f-f744-4431-9910-603606c65bfe)(label(\"\\\"Alice\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         8202c790-33b3-4fa0-a4b8-a185642e66c5)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c76d4480-f5ed-4e8a-8021-116c701370ea)(content(Whitespace\" \
-         \"))))(Tile((id \
-         843b3c5e-a972-4ce3-98dc-86b398df4eb2)(label(17))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         06602605-3e82-437e-8df0-ed8725583ca6)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7628a9cd-9ce2-45e2-85da-217e6b8ac875)(content(Whitespace\" \
-         \"))))(Tile((id \
-         c3b9f83a-6c3d-4d74-9727-953957ba89c9)(label(6))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         e3449283-2eaa-4766-a3bf-cb197d926ff0)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f670e1e9-f501-4f30-8b58-eaad1f7c6292)(content(Whitespace\" \
-         \"))))(Tile((id \
-         acf85f31-f23d-4392-ac0e-7a11ef3db157)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         52cf58b8-0d9b-4823-b3ef-c10345e1c2fa)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         494c7029-858c-4c3d-b536-fb3a097c9338)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b3b22fbc-3ab9-4b6e-9430-833241ad212d)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         f59be936-ab73-4fae-81f8-8cac6c7d18e8)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5e0f71cb-4d8b-4b94-936d-89a10618745d)(content(Whitespace\" \
-         \"))))(Tile((id \
-         efe012a2-9b25-4649-970b-8751be00a85c)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         b9ae77f3-7cdd-4482-87af-96f2d9f06782)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         66afba33-7693-40f5-a243-16ddbf6de2ba)(content(Whitespace\"\\n\"))))(Secondary((id \
-         33e2e4fc-0818-432d-8a4d-e15b9456799e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9d850523-b613-4f98-b3f7-8f6f691ca2a7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aa618292-a0d4-42ea-9c1f-e8e174afeb6d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f37b275-a294-468c-98ed-58c1655f8914)(content(Whitespace\" \
-         \"))))(Tile((id \
-         7b875fe6-8276-40dc-91b2-5f23b7502cd9)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         ceb5f3a5-5058-4990-b04f-1092bbc7b0f1)(label(\"\\\"Eve\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         315fb6bf-a66f-41a1-8562-d8ee069a3b7f)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         976f99d6-b465-4956-b44c-44a30b16878e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         10147727-0f17-4ea9-896e-a9c10d1277ad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f7f95ccd-e84e-42a7-b7c9-837c8bfce248)(content(Whitespace\" \
-         \"))))(Tile((id \
-         b99ac840-cc22-42d8-8222-dce21598dda9)(label(13))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         923e8c01-e60d-4d2f-9e19-1f7d49881d2e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         62e0a822-6dbe-41a2-b6a0-ba0a2b6dc9d8)(content(Whitespace\" \
-         \"))))(Tile((id \
-         d9c9f115-1e2f-4f0b-87ad-d9938313d16c)(label(7))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         3fd90810-83b9-4916-bb11-e1748238952e)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b4157d1a-2c3e-4812-be41-e7f6ce7ed87a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         dcf35cb4-4551-4db1-b507-72c45b807089)(label(9))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         57939ecc-cf0f-47d9-b6e1-c2fed21056e7)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cc11bc3f-1fc0-4efe-8a83-784fb0f60a23)(content(Whitespace\" \
-         \"))))(Tile((id \
-         9375e659-7347-4357-a19e-a28d68613b03)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         5b2de28b-d8fc-44c9-b348-394df1ace97a)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         814cc6c8-ea14-4f0b-ac5b-90cd31c86d79)(content(Whitespace\" \
-         \"))))(Tile((id \
-         f330394d-c151-4169-a8df-df3ca4242270)(label(8))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         2b84e21c-c085-4263-b34a-bbd255d6dcce)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7a4044e7-1395-4d37-a4aa-d3065a512477)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         54afc4ed-c359-40d2-ad22-142c176e1bb1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         9370f6cf-fe92-49ab-8500-e51bc1433fdd)(content(Whitespace\" \
-         \"))))(Tile((id \
-         0890072f-8f2a-4833-b5c2-25231728f244)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         872dad8a-b8b8-4d32-aefe-d8884e3888bf)(content(Whitespace\" \
-         \"))))(Tile((id 9945b84c-4faf-4ddd-84f4-25aa99e6b12f)(label([ \
-         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
-         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         ae10a4cc-8413-42bc-aa00-2bd75491589f)(label(\"(\"\")\"))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         f7ff71bf-0a5b-41a2-aa45-d771c73bda10)(label(name))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         751f8c92-2164-48de-80ee-f3e5ed4c7f58)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         3e11bf8f-cbf3-43ae-8d2a-06a475da0036)(label(String))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         4ad55eba-35f9-46cc-935e-82cb9cc26fcb)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f385d60b-07ff-4eeb-b9be-f878bab2751c)(content(Whitespace\" \
-         \"))))(Tile((id \
-         21b701a6-b7b5-489a-a196-36adef9a3829)(label(age))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         93859601-1c4a-4bcd-82e1-8b38cdbd4c09)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         fd71153a-c44f-4ec5-b957-78690362303c)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         716e7a7f-6ca9-4499-ac6f-a0b5ab0b5b74)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b5bb977e-9475-4fd3-a109-e134e20a1ed2)(content(Whitespace\" \
-         \"))))(Tile((id \
-         a6d09b2b-2df7-477e-9503-da5781e0c921)(label(quiz1))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         0571a198-24ba-4900-bd89-8176b64f6bed)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6cfd4bb9-05e5-45e8-9218-84074d0e77c7)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         8e6f43da-3a9a-4b8a-9981-b389443fd68d)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9f4ebce6-a3ed-4c75-80af-7308fe3dc636)(content(Whitespace\" \
-         \"))))(Tile((id \
-         939b8795-9a15-41a4-afe1-4f377d5b28c3)(label(quiz2))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         1b069916-2aa7-4af7-87eb-a695b9e44c30)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         e24850da-1703-423e-89a1-d64876b8b468)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         3851f9c8-b430-4c90-bccb-b0008aa8fafc)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a2c687de-f25c-46ce-b212-c14df3f31fee)(content(Whitespace\" \
-         \"))))(Tile((id \
-         27547b55-696e-431a-881b-a311ee9e80e2)(label(quiz3))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         0ee87dac-14ad-4eb5-acfa-c314dc35e964)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         9d348dca-f7e7-4055-b555-610078dc7d6d)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         695550e9-04fa-4a84-8519-d922a808fecd)(label(,))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ca6a1c71-1bb6-43a5-9933-d0dde6ca668a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         5a46dd72-93b2-4e75-a75c-8ec45e1bdc89)(label(quiz4))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
-         866a2867-9af9-45f4-a7ee-49e05e27071d)(label(=))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         b4f51a6a-8458-4cf6-8e24-86399a7140f1)(label(Int))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         f55f96bd-50da-4a5e-b325-272ad410e192)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4528ac27-42a4-4747-ae91-85df943ee5fa)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a71661be-2060-47e2-be0b-62d5c8dad63c)(content(Whitespace\"\\n\"))))(Tile((id \
-         5d993cc0-a3da-4a46-ad0e-600dcd1d476d)(label(let = in))(mold((out \
+         b20cff91-c33b-4596-9277-221bf1aa16d8)(content(Whitespace\"\\n\"))))(Tile((id \
+         c08db618-953b-4125-86db-1c8adf815a6f)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         4004ec4b-aa26-4a38-9e4a-62a7f7f06f54)(content(Whitespace\" \
+         c8238838-1376-4fb1-8e62-52c41e06fc43)(content(Whitespace\" \
          \"))))(Tile((id \
-         63cacc5f-9012-4b63-b6b0-ea0ceaadcfac)(label(tfilter))(mold((out \
+         eb4f0016-7323-4ba5-ae30-b863015a6327)(label(drop_columns))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         914d1572-11fe-452e-a648-6131e44ed347)(content(Whitespace\" \
+         5c0c59b0-b784-4f51-a5b1-d95790b78caa)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3208fab9-0345-4e10-8546-5d5906e69039)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1058ed7e-0d35-4dac-9838-98c22d6f5b3e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1e6ede2a-f301-448e-90fd-27e941ef742f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a246daa9-d2e6-4b1a-8f7f-d16d6d0b4eb3)(content(Whitespace\" \
-         \"))))(Tile((id 4ee9a660-ab29-4712-b04c-0ceca6a391f6)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         6b06b451-d130-4f11-a35c-3a6b6d3b895c)(content(Whitespace\" \
+         53c7f6a0-0514-447d-ba2a-61ebfca3a7e2)(content(Whitespace\"\\n\"))))(Tile((id \
+         8f0bbc5a-0fed-48eb-971a-5e9525f569a7)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         b081f1fb-b65c-4155-bd7a-fbf6a4479d48)(content(Whitespace\" \
          \"))))(Tile((id \
-         173d2576-7564-4178-99bd-a22382b30448)(label(requires))(mold((out \
+         e36aaa02-667f-4479-b246-6790e57ffdcd)(label(\"(\"\")\"))(mold((out \
+         Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0 1))(children(((Tile((id \
+         ef5ea472-850b-4e8d-92c1-3347bd07c76b)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         4ec72c14-8dea-48dc-b73d-97de6e481f59)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         48560207-974f-44b1-a4f9-467b89df6b0d)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         9aca9a70-c24c-4bbf-b5bf-27fa81683617)(label(enforced))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         85125fd1-bea8-4647-8e7b-6e728da7d58b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8e50ceb8-516a-4812-8d09-15fa12f83573)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e83f680e-0ac0-403a-9a5a-a5bb14dac8e8)(content(Whitespace\" \
+         \"))))(Tile((id acc6dcc9-3e12-444b-8817-eb3062e4b796)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         6fe6ee8a-2bd1-49da-a741-4b648a48ca87)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         19ed02bb-fc6e-47c8-a936-16523d338767)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         d6c477fe-46f3-49e4-965b-b27d7dc36ec0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         513f67b6-6423-41ec-90ce-f5a6bf22616f)(label(cs))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         eb274c8e-5c11-4ea7-b240-aa3aea8e6f0c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7a138e1a-eeae-46f9-82a1-dc207f5fac23)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         22f13d19-9b8b-4846-919c-34adb51db970)(content(Whitespace\" \
+         \"))))(Tile((id f53e6d13-61d8-4ebd-bba6-eaacf245cdab)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         587495dd-3078-4e5a-9360-691a3365ae63)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         3eb96e22-b5ee-4d3b-8145-57fd7082ce0a)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ca252c55-b1c9-4938-bc96-d295a6b1ff2c)(content(Whitespace\"\\n\"))))(Tile((id \
+         8115db58-2449-4b73-a338-8d15df4116d0)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         f0dc87dc-14a6-4a97-b321-cc12b7d85b0e)(label(=))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         f9e09270-f857-4a63-b0e0-cdda5789cfec)(kind Checkbox)(syntax(Tile((id \
-         9e485806-2b7d-4d31-832a-70a3c23b361b)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         f07f3a4f-4e1b-44bf-aa7d-64364a7d6337)(label(true))(mold((out \
+         c86b6544-c7a5-4e72-afd6-16f6b786ea21)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         5bf01926-1b42-4449-94d1-8c725269c157)(label(t))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         9ba3e4fe-6f19-49b5-8e07-d26cac1f4b8a)(label(,))(mold((out \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         3734640e-0d58-4d34-9a5d-d8e9173118ca)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         db4da7ec-9c8a-4408-b492-40ffb4270435)(content(Whitespace\" \
+         934ae868-8e4c-4e33-aef6-f3781372145f)(content(Whitespace\" \
+         \"))))(Tile((id 59d092c1-d146-43b1-b194-fa241fa8ccf9)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         da84944a-207d-4d5f-bf92-eca05fc3aa1b)(content(Whitespace\" \
          \"))))(Tile((id \
-         00838ca3-5090-4ab3-a37b-90c471f82c82)(label(\"\\\"schema(r) is equal \
+         f37a7be8-433a-41d2-90d5-450e851d1c8d)(label(row))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         fe8c1803-7f80-4772-ae0f-f1eb18311c9f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         826e29e7-8657-40a3-b10e-17db77bd9176)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ea1b1bb3-d1c7-463d-a845-e741471d3a90)(label(to_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7e5cc779-9fcf-43af-9b3d-d9fdad97edc7)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         b6dbbefe-6b96-49e8-89c6-1b362d5f1e7f)(label(row))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         751d545d-f652-4df5-80dd-1e2f38fb90c9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ab537e07-c426-4e8f-aa66-3bfdc6fdd475)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c4af2c9a-89b4-41f0-93ba-16950f837f0c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f8c8d1c0-0350-4c35-8c4a-5e6a742340f5)(label(filter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         21529944-3544-4237-bbc0-1a6bde9c236a)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         c0935d3c-8239-408e-8364-3b610bdde902)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         833a0656-971f-46eb-8966-5636348a70fa)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         604683d4-4b7d-4430-8018-847e180460b3)(content(Whitespace\" \
+         \"))))(Tile((id e901743b-f806-43c1-a0d4-2fc862115a66)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         cf58ee5a-b9c5-4b5c-a3ff-7b49352b9fe0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fd7d029c-029d-41ea-814d-5f20b59bc01d)(label(entry))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         36fb5f18-4339-49a6-beb7-37206774d54d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         9287e541-770a-4939-a13a-d64cddf5630a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         33e0563b-baaa-4e37-b0ba-a21b7affc64d)(label(!))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6f961547-0402-4bdd-9401-d368ff9840fa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d7475cd5-e9ec-4d45-a938-90dd28bff3d1)(label(any))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         0256a37f-f889-4e1c-9933-5d8967731256)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         f1a45c7c-5f26-4f0c-9eb4-8eda45f9ec61)(label(cs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c8c166f9-90d0-46eb-8851-20c5b1bec37e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ee98e0e5-7aae-452f-8040-8c623646b024)(content(Whitespace\" \
+         \"))))(Tile((id 263959e7-547a-44e0-b4c8-63779c73b8ee)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         a40302c6-94cc-43d1-8403-5b630603bc4a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ec86eb41-8b71-4804-85a3-c3277574dcde)(label(s))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         87787b42-939a-4d48-8d63-518d0f7b740f)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5e402bb9-04dc-4a03-bcdf-2ae479218088)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6256f33f-01d4-48ba-96e8-f2b67b80c259)(label(entry))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         fd07ca4e-a2b6-4af8-8e8d-4acb2f772984)(label(.))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
+         22))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         7b48a64b-27f9-4e35-a52e-0310657fab94)(label(label))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         dcf41a33-d90e-4056-885f-82816a46563c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a0c4fe9e-e941-4e8e-83e9-8a89f231be18)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7bf27382-caf2-4175-98f7-00f4c063258c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6f13978d-ebb1-4414-84c0-cd62a43c3763)(label(s))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         f75be17f-56b9-4439-b42d-be023a83616c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7ce6350d-558a-44a5-86bb-88c305e3c688)(label(|>))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3a28e461-0352-474d-858c-61984156935c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6cfe5c75-53ae-4483-8c41-3872136988ee)(label(from_lvs))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         6d1fa7a0-d1aa-4635-a49e-1097c95f0fc3)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c6dd5d61-856e-4092-879f-23246868609d)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d9c1b195-c10c-4029-9cd0-febf5d5df3db)(content(Whitespace\" \
+         \"))))(Tile((id b5b4bed2-34bb-4f77-b1c9-61374627dc80)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         c54e88b0-dd77-4bec-ba18-253b2013781f)(label(?))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         d4f17b59-9452-4210-bbbf-aaa5036062d9)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         0172a332-ffe7-44de-8f90-d678982a146b)(content(Whitespace\"\\n\"))))(Tile((id \
+         931e29e9-b7ac-4b68-85e5-57bd8be326a5)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         9ab86a9f-7e85-41ba-81f3-b96c898d0970)(content(Whitespace\"\\n\"))))(Tile((id \
+         30abeefb-b5df-49e4-a2e8-c164722f205b)(label(drop_columns))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d7a0edd9-06eb-4d59-a3c8-ef99aeeb6cff)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         561a8a10-2e23-4fbd-b880-b2ddf7484697)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         27d8a2e0-362c-4ff9-9fa5-1f22bcc58147)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2a1f04b8-10d4-42ec-a1bb-9f46d6555d05)(content(Whitespace\" \
+         \"))))(Tile((id fc4d1c21-df62-4866-82ca-9221c2a5e79c)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         06035f47-d4d5-4d06-8145-7cf82c86bdc1)(label(\"\\\"final\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         abd75ea5-6c0a-433b-a86b-b9d023f1ad23)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         da4826df-da24-49dc-85bb-950397462d73)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bfc363aa-fe68-4fb5-800d-ad017dde9c63)(label(\"\\\"midterm\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         5e353e58-8e50-48b4-aabf-94e4d3eb5829)(content(Whitespace\"\\n\"))))(Tile((id \
+         f7a57170-9cdb-489a-9bfa-ca736cdbf81d)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         7862d927-033d-46da-b200-0bb067fee401)(content(Whitespace\" \
+         \"))))(Tile((id 2f660f3d-5f13-44c9-81cf-cb3797c9f61d)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         425bb20d-360a-460b-a4f2-043733cb9056)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         c6efa9a7-e627-47ed-b5ab-c224cd8d7eb5)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         465dbe4b-8821-4994-8a37-c57d25473392)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ee3052ac-c15b-46c8-ba10-85aea4bba403)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         2a933a29-3a8a-489d-b244-8f48c3e1c011)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         bd81c4bc-d8e5-4394-96ba-b0962843aea8)(content(Whitespace\" \
+         \"))))(Tile((id \
+         7c44218d-f86f-4125-a401-29aed727d0da)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         78960444-5766-472c-b89b-6f21e22fabd2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         af04aa78-2552-4e8c-8e8e-847363b53094)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e2c451a1-1863-4814-85c0-e0763fd76064)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b051f402-2412-4c3d-9db7-d79f65ffb476)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5a201976-7fe6-461f-83a4-9522c1ce8062)(content(Whitespace\" \
+         \"))))(Tile((id \
+         bd21ad3f-840e-4c83-b5b4-9d9fe9a2c518)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9a59fd10-c4f3-4ae8-8bd3-212d8e33b4bc)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         64e5f541-1cf3-4f4f-a79a-5ccdec69522d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a58f5bfe-7061-4d5b-984d-804581513b16)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         63732fe1-407c-4960-959d-0a984f36303b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c8e198b9-d6ed-4455-92f2-6b812b139829)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0e2b5402-9d3f-4816-a2c5-ba17a9a4e93f)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         6d686ddb-a85f-4a58-9cad-4f7dd58144c2)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a8334dd9-ee13-4713-a77b-98bdbb8a467f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         72ed33eb-62a4-4a8a-899c-8c3f1c70ee5f)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         e19b11d1-282b-4229-be0a-289fa5f00050)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         266c1535-51ca-4d76-8f41-10679d227f81)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         94137c59-10c8-470b-a0a5-dd62c18b57a0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         396f5804-c157-4aec-8ace-360cb670dcd6)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8a8dac37-a22c-46ea-b36e-c948304185b6)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         322a46ab-2c6e-4e8b-a31c-c67fc4636038)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8d63dbb6-5e03-4da4-a795-22898c19736d)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         2323d5b0-17c7-4d23-b4dd-f8284f7fbff3)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         de9b43ea-84b2-485c-8119-cd36ef51660b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         de852f03-28fe-478f-ac4e-054f76593951)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bce8a352-fca9-49a3-bb76-be293074ad0a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         40eea90a-e25a-4648-a036-9f7996bd06ee)(content(Whitespace\" \
+         \"))))(Tile((id \
+         49864d97-01ca-466f-a4da-0d6f20d7d338)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         1ef3f2de-0d5d-4cd5-b0a7-d4f1c8586f2d)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         407dbaf2-3be8-435e-8c58-4403dcb0246d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1107cb36-0c55-4b7d-9b89-df671a3c35a0)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         49fb695e-30c8-4142-ac8a-774dbd8b9adf)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         89723ec1-0ea1-49f3-8aca-9f3c20632245)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ec8f1668-9916-4c18-b566-3b0012976baf)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         ed8c9c79-be06-4221-bceb-dfa0c70f8a6a)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         7d200714-cb37-4680-98c5-2499b4609705)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0bc50230-0b45-40fb-9616-1b335d3f8ce9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a11b67c5-d3e1-4fd8-a20f-bb415824abb1)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         66b356a2-bc16-43ba-982f-24233060cd67)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c684becc-4428-4450-95e5-cd2e0190cf31)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8fffadae-26de-4805-ad3b-7950ead95b21)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         b6ba85c5-2cdd-438b-94d1-5d0c19a1885b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         37cfe5ac-8d12-4802-b8e9-51fa4869462d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         acff5788-d611-42f8-92ab-bd53b9eeba6c)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         9c682de8-9885-49f5-ae3b-d0947fc34db7)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e757408c-f1ab-4b56-b775-9d419424aa7b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3a835064-4135-4a64-a419-41f17509111b)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ed30c293-8a40-4960-9afb-090cbd35ce74)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         700e71d5-f7fe-44bc-af3a-21db898c4d8c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c333915d-f32d-4eb7-ab95-96d828d6832d)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         ae01294c-2613-4bcc-82bb-8897ac45857d)(content(Whitespace\"\\n\"))))(Tile((id \
+         aea21185-55aa-4c73-ae94-3147a305d940)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5dbec45a-c1ee-42f3-9d93-6f1250936284)(content(Whitespace\" \
+         \"))))(Tile((id 0523d986-5636-4bf6-905c-4d68b2bbaf4b)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         0f449bbe-10c3-4528-af08-a3abbd4b7d06)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         9054839a-ba38-4213-89c9-8940d89f9e17)(label(name))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         06daee63-14c2-4092-b585-be65c578c4a6)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f67f6047-35df-4309-a9f8-2af5c6bfbc05)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         157f5ea2-79f7-4e0d-b96f-b0e25411752f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         8b9399e4-da89-43f4-b18b-4d8a34eb0f16)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         f68700d1-9339-42ad-b906-da3a8795a240)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e47df21c-fb26-450b-b99d-e71f0aeb098e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c87bc553-e65b-4c18-81c3-ef235307b31e)(label(age))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         fcf736e2-d100-46dd-8434-b06c281375ae)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1a76d4a1-e2b3-4dfc-9067-a4884996a0ce)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e3ecb917-d17d-4758-a455-8b302835c2df)(content(Whitespace\" \
+         \"))))(Tile((id \
+         56a02dd0-11a7-48b9-98f7-bd31f053f10d)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         39d63dbd-1ff0-463a-9bd1-6eae1f71fab3)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e408a358-3f09-4ede-98ed-eb38330076a7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3b809b23-fc40-4b11-90b5-5ee93ffa8855)(label(quiz1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         13697d31-0fcf-41a3-84c2-5a5ce9c2fb85)(content(Whitespace\" \
+         \"))))(Tile((id \
+         14883449-7410-4470-9828-87be15bbf1bd)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1c239ec0-6cea-4e6e-8251-4be213d724aa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3ea6c2b8-0144-4370-8b5c-236392a6c9c2)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         7ad21249-80f9-40c4-b2ee-a7be34bf3440)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         99cfa0f2-c5fe-4b4b-af73-fab86a580936)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a261d4c1-5d23-4948-a21d-44ca34feeea2)(label(quiz2))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d7258a95-db6a-48d0-94c3-e132ce295a1b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1548e781-1e59-45dd-99c6-1ae21c6476bf)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a31e98dc-e826-473f-bf6c-30a37108ff1b)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d49e190f-6486-48ed-a803-7ea70785746a)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         d1c58300-6c55-4c69-9b0e-31db16d27380)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         765d923b-6252-4f5b-b16b-bab651ab1818)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ddf34b8c-629c-411a-bf37-efd37bea17a5)(label(quiz3))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         31abbc95-1c00-406c-8534-daca5e0d0ce9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2ed0887e-9ff6-4c05-abb0-c9b9d39a8d79)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         59cea9ae-7642-4785-a016-cc946a71ca35)(content(Whitespace\" \
+         \"))))(Tile((id \
+         affcacfa-fc42-49c7-af0f-4438129cdc22)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         8122f578-8f91-4c41-9b94-aeb62631a44c)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         024fce0f-1648-42a6-8e36-75b8aef75c0d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         233b7863-6fc5-4d2c-9486-4afebbfaa93c)(label(quiz4))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         19f4066b-0c26-4dc1-b4d6-1e80e8e51811)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f8f9e3f1-1ee3-484e-9683-ffc9af5e4b59)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         72b14869-d3a5-4494-89a3-ed5c8a8d70d5)(content(Whitespace\" \
+         \"))))(Tile((id \
+         70470698-55bc-4e43-96ee-6c601f96a549)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         521ee573-70d8-4d86-a4a4-e8793a446d73)(content(Whitespace\" \
+         \")))))))))(Tile((id \
+         1b932005-7674-4ec3-ae68-e82112d3cbd3)(label(\";\"))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
+         35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4aa3d090-93db-46f1-98d6-3a5426f167fa)(content(Whitespace\"\\n\"))))(Tile((id \
+         9903a391-daf7-4589-ae46-8295f075f865)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         f4e515c4-60cd-4c7c-84f3-4ea9e8d3b3fb)(content(Whitespace\"\\n\"))))(Tile((id \
+         f4ea29fd-b76d-4671-aa7b-474c6145f5c8)(label(map))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ec8d98c4-b860-41c4-b6b4-4a3e40ef8584)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         87a3103d-dc05-4f56-a518-58e2a2e72e5f)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         c347af15-9389-4854-bc81-529d3811aac4)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         95256675-25ea-483e-919d-5b1852feba42)(content(Whitespace\" \
+         \"))))(Tile((id \
+         aa0895e3-ed4e-4b60-bd69-e40286e70afe)(label(omit_labels))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e3aa31c0-66a8-499d-9651-b46c419258e6)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         0ce335d3-1742-4040-ab13-1f823f6ba74d)(label(_))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         ff9d5135-1770-4aab-99a2-cd6e8a8ae585)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8c21a6f2-d09b-4237-835d-a70344507357)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d0abd3a0-42b5-4a36-8759-518cbb365465)(label(`final`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         6ef850d6-7766-4683-b325-4f1dbf50e21c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         108b9d22-779b-427c-a4d3-0b42a4d7821c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         84708836-9ae0-4cc6-8dde-1c338cf31b74)(label(`midterm`))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         1e8d8e1a-7fa5-4e40-b5dd-83f0d7ffa9df)(content(Whitespace\"\\n\"))))(Tile((id \
+         3dd213df-5b02-4b61-b8d6-a5163a6feb98)(label(==))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0d2e50fe-d688-491d-99b3-d4cfce07274a)(content(Whitespace\" \
+         \"))))(Tile((id 635f0bfd-e27c-4410-81d5-ba409c976561)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         c8962478-174c-4214-be99-5b91db4ea33e)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         9c5ff625-b726-44b0-b77f-28d3512fe2e0)(label(\"\\\"Bob\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bfbbbc08-8756-4942-8a0c-b360baeffe94)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dc4e31b1-81f0-4d3f-b81c-4f21d1c49ac1)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         c0e77b2d-4e6e-4f97-8460-dc921b19b53f)(content(Whitespace\" \
+         \"))))(Secondary((id \
+         ceec62d0-509e-4929-abca-ade713192fe0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ea25aaa7-fa6f-4b35-b5e9-5fc267c3926c)(label(12))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cc479cfc-b042-4b2e-b6ce-568d19cc647c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6c661739-ba47-433d-89a5-76a09053409d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         730b8ef7-a6c4-45cc-b66f-a1d1c772455e)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d3af6624-664d-45d9-8191-fcf36ce5ea53)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3afbfa77-0c22-4e66-a289-1a987c78c4fa)(content(Whitespace\" \
+         \"))))(Tile((id \
+         36e1a0e3-2da6-44d9-bc81-f8ed730f0ee9)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         42d4906f-c82d-445c-8abb-be1aacc2085a)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9a3f260f-68b2-4cc5-9608-7cbaf2db6955)(content(Whitespace\" \
+         \"))))(Tile((id \
+         9fc0c80c-d2c8-47ce-aff9-431cc83da5ab)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         8c4b5ac9-cc8f-4270-8fd4-207687cc595c)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d35643e7-7598-4d9c-96fd-bcbe328d18fc)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ab5a902a-2bcd-459e-adce-e87ff053b579)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         6c67355e-84a3-4979-b033-55d7e9b723fd)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f7b3b04e-ae99-4eee-a9c5-b74d4cce0a41)(content(Whitespace\" \
+         \"))))(Tile((id \
+         29b1b5e9-ffb6-43d2-9ea8-3287a82e8369)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         eae4afb3-720d-40f5-b7e8-0753ec608637)(label(\"\\\"Alice\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cbeae21a-0962-4bcd-99f3-87f6a30c5d03)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ec73de06-b259-4fe1-8126-83729e8d3251)(content(Whitespace\" \
+         \"))))(Tile((id \
+         473abc19-28da-4150-92cf-2ac3b2ebcb96)(label(17))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         d7776f42-ec17-4ca7-9cba-d572e2a49771)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a2d1d623-6b0f-432c-b323-db237e18f520)(content(Whitespace\" \
+         \"))))(Tile((id \
+         28f5d065-5c80-499e-a070-87c4da5ec7eb)(label(6))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e8178516-8d15-49a5-bfe7-a30f01a29f9e)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6182a05c-feca-4879-98e1-97f45f18f8b1)(content(Whitespace\" \
+         \"))))(Tile((id \
+         30aadf1a-7703-44b1-ac2f-6d7ff6f060a6)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         4bd04f45-f2ed-4488-974c-29486e20ccce)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         478cee3e-f305-406b-886b-e1738554f3cf)(content(Whitespace\" \
+         \"))))(Tile((id \
+         14e268ea-8174-47eb-839d-f9ac91016244)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f05439fb-1548-428c-9d3a-da4e073a9351)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b1c4fab0-4189-4fe5-a5a5-6e6388c9f43d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0ef08da9-e3bf-48b2-86df-1957555f93f1)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Tile((id \
+         058db620-65a5-40aa-a300-f25cfdc55a1b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d3ac2a15-83ad-4f45-9d26-56dd66b57e08)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a9d12cfb-ef80-458f-8f28-7e223148cc28)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         4f4c4ddf-f98f-45fc-8b0e-c41dcbb9f688)(label(\"\\\"Eve\\\"\"))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         12505822-ecb0-4e06-a1ee-2ddc2c3fb9ca)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4c1025b7-bd98-47c5-8c51-704761819847)(content(Whitespace\" \
+         \"))))(Tile((id \
+         40392bd8-6e8a-47e3-abb3-daf40dacc25d)(label(13))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         980f36c3-3da7-45f1-8301-c0ab1245c942)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5640c3b7-916f-4bac-a6cb-df5171e28d32)(content(Whitespace\" \
+         \"))))(Tile((id \
+         fd57b869-beb2-4142-aec4-b3733b952881)(label(7))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         5071a9b9-072e-49fa-bf5e-b643b0d520cf)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         048b6c9d-a57d-4183-8300-7c92217a552d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f8db4703-0b82-47b3-a4a6-0653f5d18758)(label(9))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         e25ed523-d47f-4093-a40c-333f97ac833b)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3356d869-55dc-48ac-807b-be6e22f3bf01)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1956e7b4-e393-406a-bf5d-cff3db81602c)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         bfc8ae14-da7c-4908-b924-ec0b1b45b2eb)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         798bc284-0f61-4ec8-9ec7-d373679e951c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         1ee1c4ed-f896-4b2c-805b-632fa34d4eaf)(label(8))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         582d8bf0-f778-4689-b8f5-4f0094a6394e)(content(Whitespace\"\\n\"))))(Tile((id \
+         06c918c6-15e1-467f-99b6-fb02dd1c8662)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a0c74305-6fd4-4a34-8577-a860e849b8b1)(content(Whitespace\" \
+         \"))))(Tile((id 086b3c38-cf18-48cc-a8da-0b4bc965bf1a)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         7e1799b8-86a4-4548-a9ee-53f68868ced1)(label(\"(\"\")\"))(mold((out \
+         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0 1))(children(((Tile((id \
+         2ceaa308-b34d-4f7b-9ba8-e96ccdb3d36c)(label(name))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8d1dde0f-312d-4563-9eae-ea1e9d11f61a)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d8871943-be41-4671-8d2a-45e96324c7fd)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         568d5da3-83ed-4ed1-8179-1c534d54fb63)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6624e9f1-de97-4c55-a166-9076a620ead8)(label(String))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         77c07ca3-29f5-4496-b273-fff734fbd2d1)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6144c9f3-7062-4b79-a372-9be63fd6d077)(content(Whitespace\" \
+         \"))))(Tile((id \
+         34add6c3-f0f4-44fc-92ad-fe876470a4e4)(label(age))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0dbfca54-1627-4a38-8724-803521d33eae)(content(Whitespace\" \
+         \"))))(Tile((id \
+         ff7f6e57-9da8-4395-a08e-10a4db9c3da3)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         edb9b05f-64ac-4709-87dc-421eb3e3375f)(content(Whitespace\" \
+         \"))))(Tile((id \
+         47d637a2-bca4-4359-a8ab-d5570cd1eadd)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         b67b0892-0b3b-404f-b999-1aafed79cab4)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         4a425508-91bd-47c8-a018-ac7121c1587e)(content(Whitespace\" \
+         \"))))(Tile((id \
+         af0c475e-d2c2-490b-8c12-56a7730d05e3)(label(quiz1))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d4a8aadd-540f-4915-a1b8-3f2c59c15699)(content(Whitespace\" \
+         \"))))(Tile((id \
+         04859d66-ec26-4d68-a113-a516faf31c25)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bafb1edf-6393-4c9c-8da5-f5666ffd0571)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eed785ff-4a62-4357-aea3-d45c60d3d68d)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         0c2540de-cf08-43f1-9312-4d7a4f204831)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a8a4e78f-900a-41f3-b2b3-3d9e39c0ea71)(content(Whitespace\" \
+         \"))))(Tile((id \
+         53ff9dda-7477-4393-9d8f-d115a36f0ba4)(label(quiz2))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d4f1546d-bd86-4f5a-8cce-7dd0398837c9)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f77ff9c0-a7e5-48a5-b487-a512196817ab)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         06729702-1d87-4123-8b59-50bb71f07788)(content(Whitespace\" \
+         \"))))(Tile((id \
+         0aa29f15-4d6c-434d-9a01-dd591bf2d263)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         d5eede45-f042-4b5d-badc-de729360fc52)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         edb9ec5e-0dc9-440b-bb8e-d1713f00da39)(content(Whitespace\" \
+         \"))))(Tile((id \
+         e5de9add-29cd-44eb-8c40-870a92ce5d17)(label(quiz3))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         beba2ebb-d532-4ea7-8ecc-5e3a5bd050a4)(content(Whitespace\" \
+         \"))))(Tile((id \
+         3a2686af-3775-45e7-b1c9-d6a9de784d00)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9678ba30-d9b6-4699-b005-78aeaa57d62c)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c1353467-4643-41e0-b5cd-7bfb9a39d87f)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Tile((id \
+         aeebaca8-2102-4632-be28-9083779ef320)(label(,))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         140f8b3c-bc62-42c7-98e8-6fa2931d53da)(content(Whitespace\" \
+         \"))))(Tile((id \
+         986ef06b-af77-40f3-96b7-e295b537aaee)(label(quiz4))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e8f50eeb-50e1-408c-a18f-1220bb486c18)(content(Whitespace\" \
+         \"))))(Tile((id \
+         f1b03e1c-a494-496d-bb5f-9de10c5aa9db)(label(=))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         046f6374-27f1-41e9-ac56-409c2b7b9552)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6fdf6d3b-a520-4394-ae18-8f0ccef54680)(label(Int))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
+         b27172fb-2697-4e1c-b624-8d89330b4633)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7c9b55ad-e45b-415f-b605-868ee3307934)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         773792d0-aa19-4cd9-9c20-af8843c219ee)(content(Whitespace\"\\n\"))))(Tile((id \
+         ae3c6be1-5c5f-4220-a757-7f55400c1366)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         162007de-e8c1-4421-9ff7-32008f9458eb)(content(Whitespace\" \
+         \"))))(Tile((id \
+         440eff3b-cf6d-451d-8f4f-a01f60082f49)(label(tfilter))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0c7d4e07-fb07-465d-a999-ecb36307ebe2)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         acc16b8b-1e2d-41ff-a98d-2af114a51b37)(content(Whitespace\"\\n\"))))(Tile((id \
+         20c67723-e1e9-4e4f-b15e-fb3bc7e40f18)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         c02150c6-4e8c-4691-a7e9-560ff4678730)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a64f1d8a-b710-4c0f-a5da-5e875835513c)(label(_requires))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a31ab567-00db-4537-96a3-c745292d6544)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         458eb9b3-35bc-4891-b708-81b87b3255fa)(content(Whitespace\" \
+         \"))))(Tile((id 3d9572b9-a642-47a6-be25-88eb65a7a00d)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         f12e5afd-9ae3-405c-889d-8f51febb54f3)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         4e5f212e-eba5-468d-8b96-0111deb704fd)(label(enforced))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ee519fcf-2271-4609-88c9-00ba4ea35cd0)(content(Whitespace\" \
+         \"))))(Tile((id \
+         98fc1b24-6c49-4f5a-aa94-281721f33538)(label(=))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         881e5df9-f366-48ad-a27d-642654025240)(content(Whitespace\" \
+         \"))))(Projector((id d04869fb-dc75-41de-b77a-110420ded1ce)(kind \
+         Checkbox)(syntax(Tile((id \
+         e79feb59-0b30-4fa7-a4da-f0afb9d79153)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Tile((id \
+         36788ebb-c209-47f2-b5d1-23042c218d1e)(label(true))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
+         88490895-036d-4ff1-9d65-03d820a2effe)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         be0d8db6-6cdd-451e-83b0-7ea6de84f1ac)(content(Whitespace\" \
+         \"))))(Tile((id \
+         749d8b94-477e-4f52-ad96-de6d435c24bb)(label(\"\\\"schema(r) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         fb1af0e6-412e-413b-96b1-f486a7dc6000)(content(Whitespace\" \
+         bd3b406d-8cf5-4bb4-a06c-bd63e31c3c51)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3b827199-c432-4b0f-b797-132fe666df30)(content(Whitespace\"\\n\"))))(Secondary((id \
-         eb2cc45a-5786-4501-ab92-97ebe6863824)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5a600bce-821f-4b13-9b49-f418058d9c24)(content(Whitespace\" \
-         \"))))(Tile((id 8e4c732e-8b40-4366-875b-cb5a94895575)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ba45eecf-3a81-40f3-9b57-88cfb04cfce3)(content(Whitespace\" \
+         2451f01d-1cda-489c-bf41-feea9810c95b)(content(Whitespace\"\\n\"))))(Tile((id \
+         b5e89258-f4d8-4b81-a255-f504d747ffe0)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         1d7da2a8-5951-44f7-9ace-76c7c4c8dadc)(content(Whitespace\" \
          \"))))(Tile((id \
-         d3908075-f516-4f9e-a806-3ca1f1205860)(label(ensures))(mold((out \
+         3f160884-6866-4eba-8e14-56344d27fb84)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         010ec461-d45e-47f3-8806-ef94c0afa588)(label([ ]))(mold((out \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         cd580d15-3c1c-40c8-bd69-764e77850d10)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         5a9d449a-db04-4640-ac66-71b5fc78a611)(content(Whitespace\" \
+         \"))))(Tile((id 39d58c56-89c4-434a-905f-26f7baae62f4)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         12859397-9d74-43c8-97cd-9ca97afa3512)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         d8a40f2e-f1d8-43c4-9b25-108872eb3c7a)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
-         b557c4a6-a7e3-449b-ad97-9188f811c57a)(label(enforced))(mold((out \
+         967b8b24-5b64-4651-835f-504ae9feacf2)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6fb3c6dd-7c06-4520-990e-2a5cf5ff7d03)(label(=))(mold((out \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         5630bbc0-b0af-44aa-8683-9e4974b00891)(content(Whitespace\" \
+         \"))))(Tile((id \
+         c9802e62-076c-4ac8-861c-681c2a164aea)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         6c181a1d-6cf1-4b95-bd67-f28d55beaff6)(kind Checkbox)(syntax(Tile((id \
-         d75b58d0-81e0-45d7-90dc-d3e08ada29d0)(label(\"(\"\")\"))(mold((out \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         819bfb87-fb4d-42a7-b6a6-c8b217790167)(content(Whitespace\" \
+         \"))))(Projector((id 949b0611-129b-481d-b1bc-45628022c397)(kind \
+         Checkbox)(syntax(Tile((id \
+         039dd9c9-ff7a-4277-9809-25b7d1984e27)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         b861c0d8-3879-4787-bf04-85bcb1ec79ac)(label(true))(mold((out \
+         1fc3dbd5-9658-4483-a936-0a6d4e443383)(label(true))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))(model\"()\")))(Tile((id \
-         2ced765a-cdf7-4fa3-9c13-20cf9b3a0cf8)(label(,))(mold((out \
+         71c3fbcb-3a3f-4367-a7f5-dc66b5dbe592)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         db230675-768a-4a09-8089-50db6a6bc31b)(content(Whitespace\" \
+         e4772f61-b068-4c5f-abc3-221e8f431d41)(content(Whitespace\" \
          \"))))(Tile((id \
-         3d84a4bf-b34c-44a1-8081-4c36f2c7eee1)(label(\"\\\"schema(t2) is equal \
+         cd7bc024-e388-40c3-aacf-bffa53fd9eec)(label(\"\\\"schema(t2) is equal \
          to schema(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         5013ee98-795c-48e1-9656-e7f5932fd47a)(content(Whitespace\" \
+         8d28cef5-8082-4bd9-8afa-1669d7357ca3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f303f60e-0ef7-4a02-8cfb-5f59bd70f8a3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         4c0b820a-bfa4-4bc3-89ed-7be99ba70930)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ac7fc453-b5bd-42aa-aa3c-b34d8cc24639)(content(Whitespace\" \
-         \"))))(Tile((id d120f20b-d9f3-47fc-a264-625ba65fa315)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         3d837ffb-fc74-447a-bba2-d58413989c6a)(content(Whitespace\" \
+         5125c44c-db0d-4cf8-a8a7-6e30b4f0946e)(content(Whitespace\"\\n\"))))(Tile((id \
+         135108a8-4d35-40e9-a3f2-9ad6e8f02c7e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         543ea9f3-979d-4554-a520-f36e92c9caac)(content(Whitespace\" \
          \"))))(Tile((id \
-         27f14298-6d5d-48d5-9064-306a7bdc1428)(label(tfilter))(mold((out \
+         b0e6acde-598f-4ce2-8771-20dcef0bdd67)(label(tfilter))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7c6df400-e6c6-4821-9e84-3ab9b702a42c)(content(Whitespace\" \
+         ac6ef9ee-6f7d-4778-9433-4702d1e3395b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         de1c88ce-5bb5-4472-bad6-8a603bb01f53)(content(Whitespace\" \
-         \"))))(Tile((id a47ed006-c28e-4f56-9bee-7b9557355541)(label(typfun \
+         1985b2d1-7a4c-461d-aedc-7a9142cf09d6)(content(Whitespace\" \
+         \"))))(Tile((id c4177a5a-0f39-43af-8467-a77eb93a8f0d)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         47710a70-2d45-418a-9ea2-ff35365e6626)(content(Whitespace\" \
+         47182909-4d82-4bb4-98ba-cd49fff058e8)(content(Whitespace\" \
          \"))))(Tile((id \
-         1773c555-6699-405f-99e1-a9aed6fa32f9)(label(r))(mold((out \
+         eadb2ff9-effa-4663-985d-746d6a8c0c29)(label(r))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         2829c778-98a8-4be3-b757-69a5e4d4b4b7)(content(Whitespace\" \
-         \")))))))))(Tile((id d6ca7ab3-b29b-46ec-b4a3-1906d5386f28)(label(fun \
+         f2add5fa-ab1a-4467-9988-721917653960)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         ffe278fe-3b81-4dbd-9c75-2a87a3c5a0c5)(content(Whitespace\" \
+         \"))))(Tile((id 1a21858c-e31e-449e-afb9-b4158ac8183c)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         70bcd690-1f8f-4ca2-862f-9352a454986f)(content(Whitespace\" \
+         af60e549-946d-4e25-a764-4910d99c57a7)(content(Whitespace\" \
          \"))))(Tile((id \
-         79795f30-c42c-4ba0-b0a6-3a4a9f78d0dd)(label(\"(\"\")\"))(mold((out \
+         460da706-5d00-48ea-b904-a0c1e63b9507)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         6894e083-0bfb-48d4-bc40-94c007f22557)(label(t))(mold((out \
+         17633695-d958-4975-8535-2f1d05c8bfd3)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         8805c49b-d1ab-4a6b-a722-a7f294c2f157)(label(:))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         f1e62a64-f96c-4663-9c7c-4ad960a22553)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         4f230407-9cba-44b4-a905-8019ecdbf6af)(label(r))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Tile((id \
-         65331d1d-8af1-4693-bbd0-5ecb24c214b4)(label(,))(mold((out \
-         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f3e39a91-ca0d-45f8-b91e-42b1417c7381)(content(Whitespace\" \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         900897cb-16de-4ade-b1bf-8f62e15b7c5e)(content(Whitespace\" \
          \"))))(Tile((id \
-         d1cedfab-bc01-45b8-9684-f32bf1def953)(label(f))(mold((out \
-         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
-         4b115c66-ec58-4f5a-9a19-bafe2847841b)(label(:))(mold((out \
+         12ae53dc-38ec-41b7-a682-e61fe30baf8c)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b6925b43-8dfd-4fef-b572-80ee15839d00)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2e673e95-b6bc-4157-9c2d-e4d3b329d516)(label(r))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Secondary((id \
-         27a5c406-7624-4af7-be16-3e0828922c65)(content(Whitespace\" \
-         \"))))(Tile((id \
-         962a4f35-912b-4532-acf0-e9c14c5e33d1)(label(->))(mold((out \
-         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
-         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6273d334-87c2-41b8-a5b6-9c552a2d1550)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2f0e376a-681b-41c4-a66a-c66b28eb4f5d)(label(Bool))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0927c607-d2f3-45a4-a375-77c32532396b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         4a311100-1455-4de0-a21e-bdc8912cedca)(content(Whitespace\" \
-         \"))))(Tile((id \
-         2649afbf-e3dc-4713-8de1-fb438c6d42d8)(label(filter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         fff0c74d-04a1-4cad-9cdd-5d48cc719c71)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         71e33601-3eff-48bb-8a6e-d45b27e43136)(label(t))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         6934a52d-0c8f-4608-a797-f914d1bad7fd)(label(,))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7f8aa260-9544-4b36-9e06-ae7c7edd1922)(content(Whitespace\" \
-         \"))))(Tile((id \
-         06c9e91c-6314-4e82-8bf6-e8f55fe1651f)(label(f))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Tile((id \
-         f68e8c9a-5222-460d-8624-3e99de981a39)(label(:))(mold((out \
-         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         3939a509-0ad1-4c96-8b6c-fcb3322b298c)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
-         bb69074c-2fcb-4a08-9808-c93d01839cd0)(label(r))(mold((out \
-         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e9c381b6-8075-4596-93f7-ca80b6009572)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         fd2d4b16-3224-482b-ab23-110d2bcd9d3e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         27895914-fc30-4786-a968-e0c65865851b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e6e25fd1-96fc-49e2-b28c-303a45e15e11)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         71095413-6ff6-45a2-bf95-eda5f818af04)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8003d769-668c-432a-91bc-8e42060e1918)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         510e30b4-c84a-4616-8a07-fb3d016ef92d)(content(Whitespace\" \
-         \"))))(Tile((id 212e7381-fc28-43d7-a738-43b146ec2176)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         4167a900-3b1b-402f-a988-0d7f5a36f51a)(content(Whitespace\" \
-         \"))))(Tile((id \
-         083db227-2e36-4858-9541-c5ad4b097e8a)(label(tfilter))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
-         87057b48-88e4-430b-873a-2385b4b7f840)(label(@< >))(mold((out \
-         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         d87806fd-2fc2-4837-8164-2f98554f21ca)(label(GradebookEntry))(mold((out \
+         74780d37-0618-4811-b7aa-c8b78ea89389)(content(Whitespace\" \
+         \"))))(Tile((id fefafcf6-ff77-4084-bfcd-b802bb54878e)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         11faffd1-7346-4972-a293-9a98f869c993)(label(r))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
-         3f564a65-6bc0-4210-b542-0be49adfc37c)(label(\"(\"\")\"))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         969264fd-d4ea-43e7-aecc-1f999c9b547c)(label(gradebook))(mold((out \
+         25b286a7-9f0b-4db3-8c15-5178b477a96e)(label(,))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         3da613c1-9adb-4b18-b8b9-f663eadd9342)(content(Whitespace\" \
+         \"))))(Tile((id \
+         eeb008fb-603a-477a-bb47-43b378b765ff)(label(f))(mold((out \
+         Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         bfc317c4-33c1-4144-b06a-daeda1b71c87)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6d5a7f5d-d6ac-43de-b867-945977365bee)(label(:))(mold((out \
+         Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e25ac6be-53dc-482f-9465-527cec45b6ef)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a50dd980-ba6e-4614-8b87-cdf15b2693c6)(label(r))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         fab9cfc5-b8ba-4969-ac58-c39f05648577)(content(Whitespace\" \
+         \"))))(Tile((id \
+         d55fcf6c-81b0-4e87-9070-d330befcbe7b)(label(->))(mold((out \
+         Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
+         13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e0e32687-d3ee-45a7-bc65-b6fd260ad32d)(content(Whitespace\" \
+         \"))))(Tile((id \
+         2b0938ca-a353-45cb-bc0e-f0e909f2b6a4)(label(Bool))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         ea2fc26d-340d-44f2-bf70-f03a14dc56e3)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2c1d14cc-45f7-4f89-be83-8cfad452be94)(content(Whitespace\" \
+         \"))))(Tile((id \
+         07e994d9-f1db-465d-a83b-c0085d452248)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6100a297-06c0-481f-8812-954029897c08)(label(,))(mold((out \
+         ea854d6a-c353-461d-9a96-98194d4520e5)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         3cf1467a-b20c-4b5e-ae96-60c03e315ba1)(label(t))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         cdd1758d-1bce-40b7-8bd6-ffffd8c82690)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1fe103e9-dedc-4d13-b488-8cbc40807ca4)(content(Whitespace\" \
-         \"))))(Tile((id eecdcbb8-016c-4e4d-9b7e-570ed46ff6dc)(label(fun \
+         502ae6cd-9ead-4f71-a6d7-9ee46d2cf7ec)(content(Whitespace\" \
+         \"))))(Tile((id \
+         606cae8c-b14f-4b1b-a708-e6b3179b4091)(label(f))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         d7d2c176-e2c5-41c7-8d81-164775d3dcc7)(content(Whitespace\" \
+         \"))))(Tile((id \
+         a7758817-cb5a-4c1c-96d5-5009ad48d8e7)(label(:))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5d9fe69d-4706-46e1-be61-07696cf99faa)(content(Whitespace\" \
+         \"))))(Tile((id 2a86dadf-af9e-44a6-bf07-a8df8ba3c740)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
+         f8382cf5-cd7c-4fc4-bc63-c327784b0a34)(label(r))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         cbe9bcc4-48bf-4749-82f7-4f1d936b58ea)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         22440a3c-1e45-4b62-9658-526c19a490cc)(content(Whitespace\"\\n\"))))(Tile((id \
+         aa1d137e-09f5-4e1c-a9e3-b18072b0bb8d)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         d5f4eb91-4503-4883-ac35-79f55f88027c)(content(Whitespace\"\\n\"))))(Tile((id \
+         4b9692c2-d0c4-498a-a52a-9f7359788825)(label(tfilter))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         f363fe42-9f4b-4a05-8556-b20faaf6c681)(label(@< >))(mold((out \
+         Exp)(in_(Typ))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         31724ae0-c901-4dd6-a012-b5fc27d93a58)(label(GradebookEntry))(mold((out \
+         Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
+         Typ))))))(shards(0))(children()))))))))(Tile((id \
+         b8c7d300-4b82-4dfe-8791-1e575dc70798)(label(\"(\"\")\"))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         1836aeb5-d53b-4362-9807-85b71d5a5266)(label(gradebook))(mold((out \
+         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Tile((id \
+         00c3057b-4151-4c0e-b75e-b90944394719)(label(,))(mold((out \
+         Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b60fa113-146c-4fc7-9f9f-8970562e1f91)(content(Whitespace\" \
+         \"))))(Tile((id 492e3082-1af3-4c75-b0ac-d9499d816b8d)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         5a9aaf7b-e515-438a-b0d8-85e8804628cc)(content(Whitespace\" \
+         1caa2c72-065d-44bb-8acd-f5edb3165170)(content(Whitespace\" \
          \"))))(Tile((id \
-         5de09fe1-e040-4814-add5-156ad8904cf7)(label(s))(mold((out \
+         8455ed1a-9824-4daa-a0b3-28c580ccb3c0)(label(s))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6d22efb1-c149-4b80-ac6e-fb81892c8570)(content(Whitespace\" \
+         37f221fb-a380-45ba-b562-d5c458cce55e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3d1a8e8a-0eaa-4ca3-9184-8589d07170c3)(content(Whitespace\" \
+         a7a4c1d4-9230-4924-998a-74def2a6eb1a)(content(Whitespace\" \
          \"))))(Tile((id \
-         d582253b-48cf-4cfa-86a5-c0c81fe68c49)(label(string_length))(mold((out \
+         33efb60c-615c-438f-b72e-cef9bffaf545)(label(string_length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         24bf53c2-3b03-4122-99a2-22d04d284854)(label(\"(\"\")\"))(mold((out \
+         f02971d8-9c31-4093-8138-0113cbb79fd2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         b50d13e4-726c-40bf-9519-a6f94db02820)(label(s))(mold((out \
+         cb23feaf-a103-44ed-a5b3-7133b6c2ebf8)(label(s))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         d5a7638c-b394-4ec4-8f87-9da94b1b4786)(label(.))(mold((out \
+         42feeb50-ef16-462b-9ad0-84d96e2ede89)(label(.))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 22))(sort Exp))((shape(Concave \
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         b33878e1-123c-4138-abc2-8477190cac6e)(label(name))(mold((out \
+         a4fc6cbe-b469-48e4-8394-4f1b364ef50e)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         0624b96f-2b3f-4905-9de1-63de907af39a)(content(Whitespace\" \
+         c2e2900a-1ab9-43d6-926b-a07ea4662cb7)(content(Whitespace\" \
          \"))))(Tile((id \
-         375e49a9-03cc-4b61-8d46-f8e7f0d620c5)(label(>))(mold((out \
+         8475cf84-7f2f-4c7b-b5f7-f1e780120bbd)(label(>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d38c4ccc-05ac-4215-85f3-a6f60173dde7)(content(Whitespace\" \
+         c15b72d2-996a-423a-ac63-475009c0b421)(content(Whitespace\" \
          \"))))(Tile((id \
-         02208108-01f9-4ee3-8979-a93242a6b5c1)(label(3))(mold((out \
+         41423c6e-fd6b-4a99-9633-0aa1a489f479)(label(3))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         15ac7f5f-a429-4239-a2d0-dcd3c99cc18c)(content(Whitespace\" \
+         1825ef54-577d-4f6e-a560-bd71e9b55827)(content(Whitespace\" \
          \"))))(Tile((id \
-         ed45e412-bb37-40e3-bbbf-02442f5141c4)(label(==))(mold((out \
+         a2de892e-a28e-40fd-b080-51239847015b)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0364ac02-0812-4205-8cc4-53e60549a8af)(content(Whitespace\" \
-         \"))))(Tile((id 3d7a669e-1997-48c6-b001-93721dbff628)(label([ \
+         54ee3cdb-14e8-46e7-a375-ebe86ea8e41f)(content(Whitespace\" \
+         \"))))(Tile((id 901b2df5-8341-4455-9e02-d33d9d38e8ab)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
-         00bb3ec3-800f-404d-80ca-2d338462dc6e)(label(\"(\"\")\"))(mold((out \
+         26bee420-2029-48a0-b434-6b6b8202a37c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
-         ebfe3c07-c987-4c12-b671-d890d68e081e)(label(\"\\\"Alice\\\"\"))(mold((out \
+         c3198c4b-12fa-4470-b4fe-f70a71bc75a2)(label(\"\\\"Alice\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a0d07f69-9ea2-4664-88e4-0893eca76877)(label(,))(mold((out \
+         2326e6f2-bc94-468a-a226-c30ae7ab3207)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7841eb64-3515-4c4b-ad17-923a68b6b692)(content(Whitespace\" \
+         aa22e9b9-406c-4630-bdd9-75c78000bc32)(content(Whitespace\" \
          \"))))(Tile((id \
-         ef78987a-a3dd-44ca-89d8-5486ea39b5a7)(label(17))(mold((out \
+         8f9fb449-5581-435a-becb-491266b66a8c)(label(17))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3c433068-702f-4ec7-8e11-fca046bf8780)(label(,))(mold((out \
+         ffb1b1b3-9480-4e09-92a8-5a636b4d9021)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a660c431-e80b-4f07-8822-d6bbd6f6826d)(content(Whitespace\" \
+         66cda087-687f-4eab-8295-6a35012805dc)(content(Whitespace\" \
          \"))))(Tile((id \
-         773341ed-545a-417e-bb37-013bfa8f2d40)(label(6))(mold((out \
+         4ef5a03b-fb19-41a6-a36f-381ffef353a9)(label(6))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         e8ac9168-63f8-4df0-a20b-78fd95fc882d)(label(,))(mold((out \
+         5f73b2ae-3529-4d90-99c2-3076ae40a52c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         969f7167-5fc5-4323-bdff-a5ae7d2f643b)(content(Whitespace\" \
+         62dcfbca-c24f-49a6-a429-5efc37e0e307)(content(Whitespace\" \
          \"))))(Tile((id \
-         d585ac75-2ea1-4d35-a728-0a782b35f8bc)(label(8))(mold((out \
+         e88c9477-8ab6-4a0f-a970-bedb9af5a0f8)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         a6495831-7844-46a0-b408-79feaa8460a9)(label(,))(mold((out \
+         e5710fc3-ef9f-4558-9a5d-08f6effebcb9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2d1b2ca6-ac9e-4d62-bdb4-e2f312f004a3)(content(Whitespace\" \
+         f84fe41e-ab64-4651-a9e9-70b2f34d330a)(content(Whitespace\" \
          \"))))(Tile((id \
-         af4b2549-d75a-409a-a8eb-85f5e9293021)(label(88))(mold((out \
+         d436c07f-8a56-4d67-adda-4023a7f6e311)(label(88))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         6cfb5130-ae10-4f33-94d1-a58032a6d3c2)(label(,))(mold((out \
+         0dd7dd11-1e51-429e-ab25-c397336c8b55)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         215c8336-d159-46a4-971e-83e4b0aed56f)(content(Whitespace\" \
+         8dd57f5c-7df1-4932-8a7f-86ed9d31e20a)(content(Whitespace\" \
          \"))))(Tile((id \
-         670dcc7d-dd01-439c-b684-04ba42130331)(label(8))(mold((out \
+         a85825f0-440f-406e-ad52-c639dc103990)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         3d356418-7919-422d-bb21-76674a085599)(label(,))(mold((out \
+         045a3ca7-8da8-49c6-830a-e25e97dd509c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         badfa403-8141-44e6-af4e-beaebf929e74)(content(Whitespace\" \
+         7623f41c-6c07-4cc6-aded-720b072805fa)(content(Whitespace\" \
          \"))))(Tile((id \
-         a95b9dd6-24f6-4e7d-b056-11010fc4add9)(label(7))(mold((out \
+         d7320762-753f-4c0a-a460-e7f8400d666c)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
-         74a115ac-e0fa-4136-9ab2-d35995ab59c2)(label(,))(mold((out \
+         11391120-9ba4-478a-99af-26ebb1870585)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9ee5aed9-175e-47c9-b00c-08aa53762d43)(content(Whitespace\" \
+         ed5803e3-6794-4348-bf8d-b9dbf32790a6)(content(Whitespace\" \
          \"))))(Tile((id \
-         e9968982-1141-4640-8e6f-9461a35f9dcf)(label(85))(mold((out \
+         e851303d-dfa8-4423-b0a6-a35ce652e8f1)(label(85))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         9e621bd7-8919-46f3-b76f-2d71f44ce9af)(content(Whitespace\" \
+         860160d9-4468-40de-93a7-5fea2f7601a5)(content(Whitespace\" \
          \"))))(Tile((id \
-         b3cc824f-e407-4d12-9c56-e7f91800ecb8)(label(:))(mold((out \
+         77cc9392-53dd-437f-afc0-f001e4689833)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         efe56099-4231-445d-a8a5-e463b1478c28)(content(Whitespace\" \
-         \"))))(Tile((id 9a79cbc6-c65b-4198-818b-506edf48ce9e)(label([ \
+         2370e06c-de64-4aba-bc70-cc9dbe5a3345)(content(Whitespace\" \
+         \"))))(Tile((id e6c8c42e-affe-4068-b408-302c15a31721)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
-         81f07168-7fd4-46fd-b888-6ee1eb837608)(label(GradebookEntry))(mold((out \
+         24d870da-c8b2-4f59-bddb-477378027dc9)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8880b71d-f8c1-41d0-94df-f871c1839794)(content(Whitespace\" \
+         c4d548af-cc2d-4119-9cb1-e6406f7d5e76)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9945c97d-cf49-4a4a-aaa9-1242c2d75a88)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         8faffbbf-5f52-47c8-bd6c-b2fdeb3a9c18)(content(Whitespace\"\\n\"))))(Tile((id \
-         08998000-3831-4b86-a172-21524685f97b)(label(?))(mold((out \
+         1cccfab5-860d-4071-b494-c78bad1825b6)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         1584a3e9-f2f4-4265-abe5-52be411515b1)(content(Whitespace\"\\n\"))))(Tile((id \
+         1df0cf47-bdfc-415f-b6a3-6851fc08e221)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         5412b7d4-0231-4294-a75e-38fe4f22df90)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
-         let students : [Student] = [\n\
-        \  (\"Bob\", 12, \"blue\"),\n\
-        \  (\"Alice\", 17, \"green\"),\n\
-        \  (\"Eve\", 13, \"red\")\n\
-         ] in\n\
-         type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = [(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")] in\n\
+         type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = [\n\
-        \  (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
-        \  (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
-        \  (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
+         (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
+         (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
+         (\"Eve\", 13, 7, 9, 84, 8, 8, 77)\n\
          ] in\n\
          let select_rows1 =\n\
-        \  let requires = [(enforced=^^check(false), \"for all n in ns, n is \
+         let _requires = [(enforced = ^^check(false), \"for all n in ns, n is \
          in range(nrows(t1))\")] in\n\
-        \  let ensures = [\n\
-        \    (enforced=^^check(true), \"schema(t2) is equal to schema(t1)\"),\n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to length(ns)\")\n\
-        \  ] in\n\
-        \  # We drop rows that are out of bounds #\n\
-        \  let select_rows1 = typfun r -> fun (t1:[r], ns:[Int]) -> map(ns, \
-         nth_opt(t1, _)) |> filter_map(_, fun x ->x) in\n\
-        \  \n\
-        \  test select_rows1@<Student>(students, [2, 0, 2, 1]) == [(\"Eve\", \
-         13, \"red\"), (\"Bob\", 12, \"blue\"), (\"Eve\", 13, \"red\"), \
-         (\"Alice\", 17, \"green\")] : [Student] end\n\
-         in\n\
+         let _ensures = [(enforced=^^check(true), \"schema(t2) is equal to \
+         schema(t1)\"), (enforced = ^^check(false), \"nrows(t2) is equal to \
+         length(ns)\")] in\n\
+         # We drop rows that are out of bounds #\n\
+         let select_rows1 = typfun r -> fun (t1 : [r], ns : [Int]) -> map(ns, \
+         nth_opt(t1, _)) |> filter_map(_, fun x -> x) in\n\
+         test\n\
+         select_rows1@<Student>(students, [2, 0, 2, 1]) == [(\"Eve\", 13, \
+         \"red\"), (\"Bob\", 12, \"blue\"), (\"Eve\", 13, \"red\"), \
+         (\"Alice\", 17, \"green\")] : [Student] end in\n\
          let select_rows2 =\n\
-        \  let requires = [(enforced=^^check(false), \"length(bs) is equal to \
+         let _requires = [(enforced = ^^check(false), \"length(bs) is equal to \
          nrows(t1)\")] in\n\
-        \  let ensures = [\n\
-        \    (enforced=^^check(true), \"schema(t2) is equal to schema(t1)\"),\n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to length(ns)\")\n\
-        \  ] in\n\
-        \  let select_rows2 = typfun r -> fun (t1:[r],bs:[Bool]) -> zip(bs, \
-         t1) |> filter_map(_, fun (b,r) -> if b then Some(r) else None) in\n\
-        \  \n\
-        \  test select_rows2@<Student>(students, [true, false, true]) == \
-         [(\"Bob\", 12, \"blue\"), (\"Eve\", 13, \"red\")] : [Student] end\n\
-         in\n\
+         let _ensures = [(enforced=^^check(true), \"schema(t2) is equal to \
+         schema(t1)\"), (enforced = ^^check(false), \"nrows(t2) is equal to \
+         length(ns)\")] in\n\
+         let select_rows2 = typfun r -> fun (t1 : [r], bs : [Bool]) -> zip(bs, \
+         t1) |> filter_map(_, fun (b, r) -> if b then Some(r) else None) in\n\
+         test\n\
+         select_rows2@<Student>(students, [true, false, true]) == [(\"Bob\", \
+         12, \"blue\"), (\"Eve\", 13, \"red\")] : [Student] end in\n\
          let select_cols1 =\n\
-        \  let requires = [(enforced=^^check(false), \"length(bs) is equal to \
+         let _requires = [(enforced = ^^check(false), \"length(bs) is equal to \
          ncols(t1)\")] in\n\
-        \  let ensures = [\n\
-        \    (enforced=^^check(false), \"header(t2) is a subsequence of \
+         let _ensures = [\n\
+         (enforced=^^check(false), \"header(t2) is a subsequence of \
          header(t1)\"),\n\
-        \    (enforced=^^check(false), \"for all i in range(ncols(t1)), \
+         (enforced=^^check(false), \"for all i in range(ncols(t1)), \
          header(t1)[i] is in header(t2) if and only if bs[i] is equal to \
          true\"),\n\
-        \    (enforced=^^check(false), \"schema(t2) is a subsequence of \
+         (enforced=^^check(false), \"schema(t2) is a subsequence of \
          schema(t1)\"),\n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  \n\
-        \  let select_cols1 = fun (t1:[?], bs:[Bool]) ->\n\
-        \    map(t1,fun r -> to_lvs(r) |> zip(_, bs) |> filter_map(_, fun (e, \
-         b) -> if b then Some(e) else None) |> from_lvs) in\n\
-        \  \n\
-        \  test select_cols1(students, [true, true, false]) == [(name=\"Bob\", \
-         age=12), (name=\"Alice\", age=17), (name=\"Eve\", age=13)] end\n\
-         in\n\
+         (enforced = ^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
+         ] in\n\
+         let select_cols1 =\n\
+         fun (t1 : [?], bs : [Bool]) ->\n\
+         map(t1, fun r -> to_lvs(r) |> zip(_, bs) |> filter_map(_, fun (e, b) \
+         -> if b then Some(e) else None) |> from_lvs) in\n\
+         test\n\
+         select_cols1(students, [true, true, false]) == [(name=\"Bob\", \
+         age=12), (name=\"Alice\", age=17), (name = \"Eve\", age = 13)] end in\n\
          let select_cols2 =\n\
-        \  let requires = [\n\
-        \    (enforced=^^check(false), \"ns has no duplicates\"),\n\
-        \    (enforced=^^check(false), \"for all n in ns, n is in \
-         range(ncols(t1))\")\n\
-        \  ] in\n\
-        \  let ensures = [\n\
-        \    (enforced=^^check(false), \"ncols(t2) is equal to length(ns)\"),\n\
-        \    (enforced=^^check(false), \"for all i in range(length(ns)), \
+         let _requires = [(enforced=^^check(false), \"ns has no duplicates\"), \
+         (enforced = ^^check(false), \"for all n in ns, n is in \
+         range(ncols(t1))\")] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(false), \"ncols(t2) is equal to length(ns)\"),\n\
+         (enforced=^^check(false), \"for all i in range(length(ns)), \
          header(t2)[i] is equal to header(t1)[ns[i]]\"),\n\
-        \    (enforced=^^check(false), \"for all c in header(t2), \
-         schema(t2)[c] is equal to schema(t1)[c]\"),\n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
-        \  ] in\n\
-        \  let select_cols2 = fun (t1:[?], ns:[Int]) ->\n\
-        \    map(t1,fun r -> to_lvs(r) |>(fun entries -> \
-         map(ns,nth_opt(entries,_))) |> filter_map(_,fun (e) -> e) |> \
-         from_lvs) in\n\
-        \  \n\
-        \  test select_cols2(students, [2, 1]) == [(favorite_color=\"blue\", \
-         age=12), (favorite_color=\"green\", age=17), (favorite_color=\"red\", \
-         age=13)] end\n\
+         (enforced=^^check(false), \"for all c in header(t2), schema(t2)[c] is \
+         equal to schema(t1)[c]\"),\n\
+         (enforced = ^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
+         ] in\n\
+         let select_cols2 =\n\
+         fun (t1 : [?], ns : [Int]) ->\n\
+         map(t1, fun r -> to_lvs(r) |> (fun entries -> map(ns, \
+         nth_opt(entries, _))) |> filter_map(_, fun (e) -> e) |> from_lvs) in\n\
+         test\n\
+         select_cols2(students, [2, 1])\n\
+         == [(favorite_color=\"blue\", age=12), (favorite_color=\"green\", \
+         age=17), (favorite_color = \"red\", age = 13)] end in\n\
+         let select_cols_3 =\n\
+         let _requires = [(enforced=^^check(false), \"cs has no duplicates\"), \
+         (enforced = ^^check(false), \"for all c in cs, c is in header(t1)\")] \
          in\n\
-         let select_cols_3 = \n\
-        \  let requires=[\n\
-        \    (enforced=^^check(false), \"cs has no duplicates\"),\n\
-        \    (enforced=^^check(false), \"for all c in cs, c is in header(t1)\")\n\
-        \  ] in\n\
-        \  let ensures=[\n\
-        \    (enforced=^^check(false), \"header(t2) is equal to cs\"),\n\
-        \    (enforced=^^check(false), \"for all c in header(t2), \
-         schema(t2)[c] is equal to schema(t1)[c]\"),\n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
-        \  ] in \n\
-        \  let select_cols3 = fun (t1:[?], cs:[String]) ->\n\
-        \    map(t1,fun r -> to_lvs(r) |>(fun entries -> filter_map(cs, fun c \
-         -> find_opt(entries, fun e -> e.label == c))) |> from_lvs) in\n\
-        \  \n\
-        \  test select_cols3(students, [\"favorite_color\", \"age\"]) == \
-         [(favorite_color=\"blue\", age=12), (favorite_color=\"green\", \
-         age=17), (favorite_color=\"red\", age=13)] end;\n\
-        \  \n\
-        \  # We have label filtering on tuples as a primitive operation but \
+         let _ensures = [\n\
+         (enforced=^^check(false), \"header(t2) is equal to cs\"),\n\
+         (enforced=^^check(false), \"for all c in header(t2), schema(t2)[c] is \
+         equal to schema(t1)[c]\"),\n\
+         (enforced = ^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
+         ] in\n\
+         let select_cols3 =\n\
+         fun (t1 : [?], cs : [String]) ->\n\
+         map(t1, fun r -> to_lvs(r) |> (fun entries -> filter_map(cs, fun c -> \
+         find_opt(entries, fun e -> e.label == c))) |> from_lvs) in\n\
+         test\n\
+         select_cols3(students, [\"favorite_color\", \"age\"])\n\
+         == [(favorite_color=\"blue\", age=12), (favorite_color=\"green\", \
+         age=17), (favorite_color = \"red\", age = 13)] end;\n\
+         # We have label filtering on tuples as a primitive operation but \
          without row types there's no way to give it a first-class type. This \
          is the idiomatic way to do the operation #\n\
-        \  test map(students, select_labels(_, `favorite_color`, `age`)) == \
-         [(favorite_color=\"blue\", age=12), (favorite_color=\"green\", \
-         age=17), (favorite_color=\"red\", age=13)] end\n\
-         in\n\
+         test\n\
+         map(students, select_labels(_, `favorite_color`, `age`))\n\
+         == [(favorite_color=\"blue\", age=12), (favorite_color=\"green\", \
+         age=17), (favorite_color = \"red\", age = 13)] end in\n\
          let head =\n\
-        \  let requires=[\n\
-        \    (enforced=^^check(false), \"if n is non-negative then n is in \
+         let _requires = [\n\
+         (enforced=^^check(false), \"if n is non-negative then n is in \
          range(nrows(t1))\"),\n\
-        \    (enforced=^^check(false), \"if n is negative then - n is in \
+         (enforced = ^^check(false), \"if n is negative then - n is in \
          range(nrows(t1))\")\n\
-        \  ] in\n\
-        \  let ensures=[\n\
-        \    (enforced=^^check(true), \"schema(t2) is equal to schema(t1)\"),\n\
-        \    (enforced=^^check(false), \"if n is non-negative then nrows(t2) \
-         is equal to n\"),\n\
-        \    (enforced=^^check(false), \"if n is negative then nrows(t2) is \
+         ] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(true), \"schema(t2) is equal to schema(t1)\"),\n\
+         (enforced=^^check(false), \"if n is non-negative then nrows(t2) is \
+         equal to n\"),\n\
+         (enforced = ^^check(false), \"if n is negative then nrows(t2) is \
          equal to nrows(t1) + n\")\n\
-        \  ] in\n\
-        \  \n\
-        \  let head = typfun r -> fun (t1:[r], n:Int) ->\n\
-        \    take(t1, if n >=0 then n else length(t1) + n):[r] in\n\
-        \  \n\
-        \  test head@<Student>(students, -2) == [(\"Bob\", 12, \"blue\")] : \
-         [Student] end\n\
-         in\n\
-         let distinct = \n\
-        \  let requires=[] in\n\
-        \  let ensures=[(enforced=^^check(true), \"schema(t2) is equal to \
+         ] in\n\
+         let head = typfun r -> fun (t1 : [r], n : Int) -> take(t1, if n >= 0 \
+         then n else length(t1) + n) : [r] in\n\
+         test\n\
+         head@<Student>(students, - 2) == [(\"Bob\", 12, \"blue\")] : \
+         [Student] end in\n\
+         let distinct =\n\
+         let _requires = [] in\n\
+         let _ensures = [(enforced = ^^check(true), \"schema(t2) is equal to \
          schema(t1)\")] in\n\
-        \  let distinct = typfun row ->fun (t:[row]) ->\n\
-        \    fold_left(t, fun (acc,elem) -> if mem(acc,elem) then acc else acc \
-         @ [elem], []):[row] in\n\
-        \  \n\
-        \  test distinct@<(quiz3=Int)>(map(gradebook, select_labels(_, \
-         `quiz3`))) == [7, 8] : [(quiz3=Int)] end\n\
-         in\n\
+         let distinct = typfun row -> fun (t : [row]) -> fold_left(t, fun \
+         (acc, elem) -> if mem(acc, elem) then acc else acc @ [elem], []) : \
+         [row] in\n\
+         test\n\
+         distinct@<(quiz3 = Int)>(map(gradebook, select_labels(_, `quiz3`))) \
+         == [7, 8] : [(quiz3 = Int)] end in\n\
          let drop_column =\n\
-        \  # omit_labels is a primitive operation to drop columns but without \
+         # omit_labels is a primitive operation to drop columns but without \
          row types there's no way to give it a first-class type. This is the \
          idiomatic way to do the operation #\n\
-        \  let requires=[(enforced=^^check(false), \"c is in header(t1)\")] in \
+         let _requires = [(enforced = ^^check(false), \"c is in header(t1)\")] \
+         in\n\
          # This is ensured if using omit_labels #\n\
-        \  let ensures=[\n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\"),\n\
-        \    (enforced=^^check(false), \"header(t2) is equal to \
+         let _ensures = [\n\
+         (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\"),\n\
+         (enforced=^^check(false), \"header(t2) is equal to \
          removeAll(header(t1), [c])\"), # This is ensured if using omit_labels \
          #\n\
-        \    (enforced=^^check(false), \"schema(t2) is a subsequence of \
+         (enforced = ^^check(false), \"schema(t2) is a subsequence of \
          schema(t1)\")\n\
-        \  ] in\n\
-        \  \n\
-        \  let drop_column = fun (t:[?], c:String) ->\n\
-        \    map(t, fun row -> to_lvs(row) |> filter(_, fun entry -> \
-         entry.label != c) |> from_lvs):[?] in\n\
-        \  \n\
-        \  test drop_column(gradebook, \"final\") == [\n\
-        \    (\"Bob\",   12, 8, 9, 77, 7, 9),\n\
-        \    (\"Alice\", 17, 6, 8, 88, 8, 7),\n\
-        \    (\"Eve\",   13, 7, 9, 84, 8, 8)\n\
-        \  ] : [(name=String, age=Int, quiz1=Int, quiz2=Int, midterm=Int, \
-         quiz3=Int, quiz4=Int)] end;\n\
-        \  test map(gradebook, omit_labels(_, `final`)) == [\n\
-        \    (\"Bob\",   12, 8, 9, 77, 7, 9),\n\
-        \    (\"Alice\", 17, 6, 8, 88, 8, 7),\n\
-        \    (\"Eve\",   13, 7, 9, 84, 8, 8)\n\
-        \  ] : [(name=String, age=Int, quiz1=Int, quiz2=Int, midterm=Int, \
-         quiz3=Int, quiz4=Int)] end\n\
-         in\n\
+         ] in\n\
+         let drop_column =\n\
+         fun (t : [?], c : String) -> map(t, fun row -> to_lvs(row) |> \
+         filter(_, fun entry -> entry.label != c) |> from_lvs) : [?] in\n\
+         test\n\
+         drop_column(gradebook, \"final\")\n\
+         == [(\"Bob\",   12, 8, 9, 77, 7, 9), (\"Alice\", 17, 6, 8, 88, 8, 7), \
+         (\"Eve\", 13, 7, 9, 84, 8, 8)]\n\
+         : [(name = String, age = Int, quiz1 = Int, quiz2 = Int, midterm = \
+         Int, quiz3 = Int, quiz4 = Int)] end;\n\
+         test\n\
+         map(gradebook, omit_labels(_, `final`))\n\
+         == [(\"Bob\",   12, 8, 9, 77, 7, 9), (\"Alice\", 17, 6, 8, 88, 8, 7), \
+         (\"Eve\", 13, 7, 9, 84, 8, 8)]\n\
+         : [(name = String, age = Int, quiz1 = Int, quiz2 = Int, midterm = \
+         Int, quiz3 = Int, quiz4 = Int)] end in\n\
          let drop_columns =\n\
-        \  # omit_labels is a primitive operation to drop columns but without \
+         # omit_labels is a primitive operation to drop columns but without \
          row types there's no way to give it a first-class type. This is the \
          idiomatic way to do the operation #\n\
-        \  let requires=[\n\
-        \    (enforced=^^check(false), \"for all c in cs, c is in \
-         header(t1)\"), # This is ensured if using omit_labels #\n\
-        \    (enforced=^^check(false), \"cs has no duplicates\")\n\
-        \  ] in\n\
-        \  let ensures=[\n\
-        \    (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\"),\n\
-        \    (enforced=^^check(false), \"header(t2) is equal to \
+         let _requires = [\n\
+         (enforced=^^check(false), \"for all c in cs, c is in header(t1)\"), # \
+         This is ensured if using omit_labels #\n\
+         (enforced = ^^check(false), \"cs has no duplicates\")\n\
+         ] in\n\
+         let _ensures = [\n\
+         (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\"),\n\
+         (enforced=^^check(false), \"header(t2) is equal to \
          removeAll(header(t1), cs)\"), # This is ensured if using omit_labels #\n\
-        \    (enforced=^^check(false), \"schema(t2) is a subsequence of \
+         (enforced = ^^check(false), \"schema(t2) is a subsequence of \
          schema(t1)\")\n\
-        \  ] in\n\
-        \  \n\
-        \  let drop_columns = fun (t:[?], cs:[String]) ->\n\
-        \    map(t,fun row -> to_lvs(row) |> filter(_, fun entry -> !any(cs, \
-         string_eq(entry.label, _))) |> from_lvs):[?] in\n\
-        \  \n\
-        \  test drop_columns(gradebook, [\"final\", \"midterm\"]) == [\n\
-        \    (\"Bob\",   12, 8, 9, 7, 9),\n\
-        \    (\"Alice\", 17, 6, 8, 8, 7),\n\
-        \    (\"Eve\",   13, 7, 9, 8, 8)\n\
-        \    \n\
-        \  ] : [(name=String, age=Int, quiz1=Int, quiz2=Int, quiz3=Int, \
-         quiz4=Int)] end;\n\
-        \  test map(gradebook, omit_labels(_, `final`, `midterm`)) == [\n\
-        \    (\"Bob\",   12, 8, 9, 7, 9),\n\
-        \    (\"Alice\", 17, 6, 8, 8, 7),\n\
-        \    (\"Eve\",   13, 7, 9, 8, 8)\n\
-        \  ] : [(name=String, age=Int, quiz1=Int, quiz2=Int, quiz3=Int, \
-         quiz4=Int)] end\n\
-         in\n\
-         let tfilter = \n\
-        \  let requires=[(enforced=^^check(true), \"schema(r) is equal to \
+         ] in\n\
+         let drop_columns =\n\
+         fun (t : [?], cs : [String]) ->\n\
+         map(t, fun row -> to_lvs(row) |> filter(_, fun entry -> ! any(cs, fun \
+         s -> entry.label == s)) |> from_lvs) : [?] in\n\
+         test\n\
+         drop_columns(gradebook, [\"final\", \"midterm\"])\n\
+         == [(\"Bob\",   12, 8, 9, 7, 9), (\"Alice\", 17, 6, 8, 8, 7), \
+         (\"Eve\", 13, 7, 9, 8, 8)]\n\
+         : [(name = String, age = Int, quiz1 = Int, quiz2 = Int, quiz3 = Int, \
+         quiz4 = Int)] end;\n\
+         test\n\
+         map(gradebook, omit_labels(_, `final`, `midterm`))\n\
+         == [(\"Bob\",   12, 8, 9, 7, 9), (\"Alice\", 17, 6, 8, 8, 7), \
+         (\"Eve\", 13, 7, 9, 8, 8)]\n\
+         : [(name = String, age = Int, quiz1 = Int, quiz2 = Int, quiz3 = Int, \
+         quiz4 = Int)] end in\n\
+         let tfilter =\n\
+         let _requires = [(enforced = ^^check(true), \"schema(r) is equal to \
          schema(t1)\")] in\n\
-        \  let ensures=[(enforced=^^check(true), \"schema(t2) is equal to \
+         let _ensures = [(enforced = ^^check(true), \"schema(t2) is equal to \
          schema(t1)\")] in\n\
-        \  let tfilter = typfun r ->fun (t:[r], f: r -> Bool) -> filter(t, \
-         f):[r] in\n\
-        \  \n\
-        \  test tfilter@<GradebookEntry>(gradebook, fun s -> \
-         string_length(s.name) > 3) == [(\"Alice\", 17, 6, 8, 88, 8, 7, 85)] : \
-         [GradebookEntry] end\n\
-         in\n\
-         ?\n";
+         let tfilter = typfun r -> fun (t : [r], f : r -> Bool) -> filter(t, \
+         f) : [r] in\n\
+         test\n\
+         tfilter@<GradebookEntry>(gradebook, fun s -> string_length(s.name) > \
+         3) == [(\"Alice\", 17, 6, 8, 88, 8, 7, 85)] : [GradebookEntry] end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesFlatten.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesFlatten.ml
@@ -1,116 +1,136 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Utilities / Flatten",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id 40bbb6d3-1560-41c5-bac5-ff9386fb0b79)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         edf28e86-b02c-4614-9e0e-e5eadc5a4d47)(content(Whitespace\" \
+         77fd7b0f-5260-4ba2-a740-513b5171ce84)(content(Whitespace\" \
          \"))))(Tile((id \
          7f7c0bb4-7105-41f9-936c-8e2c38137a46)(label(GradebookEntrySeq))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         c72b4829-4fc4-4ea1-86ba-7fc0d048aa77)(content(Whitespace\" \
+         9e6cf527-9f36-4df1-af27-f90a0c99a3a1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d464a98f-60bb-4de4-bf87-696dcd5fb721)(content(Whitespace\" \
+         cd7e26fc-1d23-4546-a77b-c368c7145342)(content(Whitespace\" \
          \"))))(Tile((id \
          c42e8785-8880-4579-912e-c537e9322751)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          ed24f811-fbaf-4fb6-8fc7-2736968a6415)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         546e8844-a56f-46ce-946b-5ca490807376)(content(Whitespace\" \
+         \"))))(Tile((id \
          fef03dd1-97a9-4c7e-9e3c-117a4a714d60)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         de7fe09e-703d-4769-a270-18dbee389f7c)(content(Whitespace\" \
+         \"))))(Tile((id \
          b8b25f12-c759-43e6-ae13-bff24602c786)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          78f82c73-f5fc-48a8-a80b-1f8a94876c95)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5b08b08d-f0c3-4479-9852-9e417456b330)(content(Whitespace\" \
+         67721605-d7fb-4e2c-aa86-345a09983935)(content(Whitespace\" \
          \"))))(Tile((id \
          a8ff5f26-0bbc-4488-96cb-b679e7f1cf7e)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e443f12f-5700-4437-8230-28a73574e3ad)(content(Whitespace\" \
+         \"))))(Tile((id \
          a6d42cd6-cede-4528-8a73-2aa05cc43a9b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2cf42f21-eadb-4b9e-afb1-753288e6df5a)(content(Whitespace\" \
+         \"))))(Tile((id \
          427ee212-61e1-4384-88f4-a8534d801778)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          5d3e0114-094b-4dfa-83bd-434daaf07d21)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6f58cd46-72f2-4b43-8a7d-337dfa0ac0b9)(content(Whitespace\" \
+         6a8c6071-5815-4f18-b5f7-a90c8b469935)(content(Whitespace\" \
          \"))))(Tile((id \
          fb6d8a31-7a1b-4214-8f82-369868b62742)(label(quizzes))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e81e4439-0511-49f4-acd3-6b77ad3bc2eb)(content(Whitespace\" \
+         \"))))(Tile((id \
          88ed8179-527b-49e5-a439-dd0218c7c914)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         cf01e7cf-5314-4dcb-961b-4439c3d0c415)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cca23872-13c9-48b8-8274-c58bbf54cd0a)(content(Whitespace\" \
+         \"))))(Tile((id cf01e7cf-5314-4dcb-961b-4439c3d0c415)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          6d29c216-075c-46c5-9571-c02d1a8e91b6)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          ad0b9ebe-471e-4c94-a75f-1e8eb2ce1846)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f0c1f836-d437-4ee2-80a9-8db915b430c4)(content(Whitespace\" \
+         e4e742c1-8825-4e3e-8f60-80a22c27876e)(content(Whitespace\" \
          \"))))(Tile((id \
          3908b21e-a00a-4ef8-9893-0bd37bf035b3)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4d8c43bd-63f5-4e23-8ffa-ff97772118bd)(content(Whitespace\" \
+         \"))))(Tile((id \
          43e368dd-401a-4f23-994b-39e0bc47c08d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         353e39a7-0b9d-423a-9dd5-7d79f392d1c5)(content(Whitespace\" \
+         \"))))(Tile((id \
          e373934f-89b3-4e35-b41b-c1af7dbf2e1d)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          35a21384-0562-42dd-935a-608d17cc4815)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8688e623-65ce-4b89-bf0f-5078b3c18053)(content(Whitespace\" \
+         10bf8ccf-550c-4332-bfb5-ab139624044d)(content(Whitespace\" \
          \"))))(Tile((id \
          5bc99851-1830-4e43-9a49-65b9c2c61a91)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ca16f098-1396-4e4a-9dd0-5b5fabbaddf9)(content(Whitespace\" \
+         \"))))(Tile((id \
          0be5d324-3a66-4218-bc41-b4f379e50205)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3af4f25b-9d38-4c7f-982f-07f697a5fdf1)(content(Whitespace\" \
+         \"))))(Tile((id \
          2f8d18d7-eabb-4655-b665-515dfde2f230)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         dd0d95a1-61c8-4df1-b557-534551c09a2e)(content(Whitespace\"\\n\"))))(Tile((id \
+         Typ))))))(shards(0))(children()))))))))(Secondary((id \
+         d97cfb69-86dc-4027-b746-2218dbbd4d24)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         fbbcfadc-0b83-4a3c-8253-b4c346f8bde3)(content(Whitespace\"\\n\"))))(Tile((id \
          b038fd74-0c9a-434a-b263-cb9d5f52818f)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         ad8a814d-2119-4aaa-b88d-c28bf0ddfe93)(content(Whitespace\" \
+         d63d8ddd-1228-4744-a7a9-5084390ce12f)(content(Whitespace\" \
          \"))))(Tile((id \
          a3771b00-cfeb-4591-b19b-a193b233e571)(label(gradebookSeq))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ff150720-f4d0-4e11-aec9-b520e9d5a394)(content(Whitespace\" \
+         e10d14ad-f27d-49e8-b900-dc1876af636d)(content(Whitespace\" \
          \"))))(Tile((id \
          b954237a-aa7e-4159-944e-b2be96f755f4)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         557d4b1d-a7ca-49c4-8224-18bfa3cb6167)(content(Whitespace\" \
+         75874144-15e6-4d49-998f-27dcb2d99f61)(content(Whitespace\" \
          \"))))(Tile((id 6e246db1-d02d-4029-ac12-73835982dda8)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          b3231bcf-9fc5-43f0-9a7b-eb963514aeaa)(label(GradebookEntrySeq))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         dd5b8818-c71a-4fb4-82e1-9be149505267)(content(Whitespace\" \
+         b07edda6-68a2-4592-82cf-225bcd66b560)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d4162179-f1a7-4141-b9de-46dc8e221bee)(content(Whitespace\" \
+         78e2ec87-ad20-4f7c-ab4b-3d8b4e2cb178)(content(Whitespace\" \
          \"))))(Projector((id 35c75a8b-bab0-48d3-807c-388d95ddbc0f)(kind \
          Fold)(syntax(Tile((id \
          682a2e3f-6b59-46fb-8327-77b00d27f772)(label(\"(\"\")\"))(mold((out \
@@ -330,23 +350,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          e05eb59c-e91b-4107-8a04-f8e961896d17)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         8a61303f-f5f8-41aa-ac2d-3375f10ab1cd)(content(Whitespace\" \
+         993975df-0b57-445e-a768-d2aa4c38e90a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cea6f975-8b9c-4034-b322-00136f4e806a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3feb8801-1e54-4cfc-b864-227d5bc7b7e9)(content(Whitespace\"\\n\"))))(Tile((id \
+         03791d9f-9636-4cd1-bb9a-0e83b0ca96fd)(content(Whitespace\"\\n\"))))(Tile((id \
          9ec9cbfc-a9bf-4da7-b457-40d5e2805623)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         01125727-b329-4cac-861a-2fb53745a244)(content(Whitespace\" \
+         bfd42717-0082-486f-a6b2-797f1204caef)(content(Whitespace\" \
          \"))))(Tile((id \
-         f869530f-b579-443d-bfb7-89b2d49e9d40)(label(requires))(mold((out \
+         f869530f-b579-443d-bfb7-89b2d49e9d40)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         70152b5a-db14-4364-9c98-caf8c1d6075b)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         7cd23726-5716-40a7-a137-f44616071e52)(content(Whitespace\"\\n\"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         79b1216d-ec5b-4db8-b7a4-57fa418cf675)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         e049082b-e647-4eaa-8dd0-8982991d8079)(content(Whitespace\" \
+         \"))))(Tile((id 70152b5a-db14-4364-9c98-caf8c1d6075b)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         2ad21fd3-ee3f-43c6-b1aa-3345376c1151)(content(Whitespace\"\\n\"))))(Tile((id \
          fa3e566f-791d-4ca4-b60c-c351cebdca0d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -374,7 +395,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c211fb54-c1a8-4572-8b0a-3f924aa80245)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0fc23ee8-8927-4357-99f2-437e94202ad6)(content(Whitespace\"\\n\"))))(Tile((id \
+         eacc6797-8c2d-4d20-b6ec-a1a111905f0a)(content(Whitespace\"\\n\"))))(Tile((id \
          4d89e316-bc13-4713-a882-cac717e70543)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -402,7 +423,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dcb26b7a-5683-4cd9-a5a7-e270bed185b2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e5b1eaec-42dd-4efb-a868-66539bfbe62c)(content(Whitespace\"\\n\"))))(Tile((id \
+         7bbb5108-1ea2-49bb-a3ce-db231adc049f)(content(Whitespace\"\\n\"))))(Tile((id \
          54c4b0bb-b909-48f6-9a6f-d02aa38306fe)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -431,17 +452,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          02a74bc9-dd24-4d9f-9a58-2bb8b3ed7e5d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2e053f51-e95d-427d-8e96-cce370d872f3)(content(Whitespace\"\\n\"))))(Tile((id \
+         d3d6df3d-2355-4a1b-82cd-1aca9c74b5fa)(content(Whitespace\"\\n\"))))(Tile((id \
          049600cd-1450-4ed5-b965-bb4be4f8e802)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         fc71bd55-1de5-4c3a-86cf-4c8e176b65db)(content(Whitespace\"\\n\"))))(Tile((id \
          c8899e32-2fca-4ea4-8c6e-0ab4f9e317fc)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c9f22067-a8a9-40ae-b1d5-062ccb715140)(content(Whitespace\" \
+         \"))))(Tile((id \
          5ded2940-9360-489c-952d-cbede3a0e43b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         7b872501-0a2b-4b98-b586-4c7cac6cad47)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         acecb952-4605-4da0-9360-d43cde593c8f)(content(Whitespace\" \
+         \"))))(Projector((id 7b872501-0a2b-4b98-b586-4c7cac6cad47)(kind \
+         Checkbox)(syntax(Tile((id \
          2dcb63e5-8ce5-414c-bf9b-895cf513e2ec)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -451,29 +477,33 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e123df64-62ce-4da3-80cf-50b382ba047b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5b0c9bb6-3acc-4702-ac4d-cef255ae8c00)(content(Whitespace\" \
-         \"))))(Tile((id 52435fc6-072b-45bb-9d98-7432c9a3eaa1)(label(\"\\\"for \
-         all i in range(nrows(t1)), for all c1 and c2 in cs, \
-         length(getValue(getRow(t1, i), c1)) is equal to \
-         length(getValue(getRow(t1, i), c2))\\\"\"))(mold((out \
-         Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fed739d5-4722-42e6-ae99-fc50416dc3cb)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         34dfdf73-2cc2-4e21-b0f6-309fe4961a75)(content(Whitespace\" \
+         de307dca-ff51-4c1b-8461-493d4ba73e90)(content(Whitespace\"\\n\"))))(Tile((id \
+         52435fc6-072b-45bb-9d98-7432c9a3eaa1)(label(\"\\\"for all i in \
+         range(nrows(t1)), for all c1 and c2 in cs, length(getValue(getRow(t1, \
+         i), c1)) is equal to length(getValue(getRow(t1, i), \
+         c2))\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a9000e0a-45c2-4a73-9aed-50625c07bd94)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         70b50b9d-7a1f-4d10-87d9-fa565d29c5dc)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c6af0bcb-5a87-456c-a053-a9d23516a169)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         bf776162-10b5-4124-9f13-4b7c9103ef16)(content(Whitespace\"\\n\"))))(Tile((id \
+         e032598e-099b-46db-9040-722183d7511a)(content(Whitespace\"\\n\"))))(Tile((id \
          559efcab-9109-4732-afff-f5a553310114)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         478d6617-ff67-42c3-9d4b-4585183c75f7)(content(Whitespace\" \
+         f0a654ff-6fb0-4f63-be68-04dbf55e5332)(content(Whitespace\" \
          \"))))(Tile((id \
-         20da46dd-0a7e-464e-a681-d923ae5d2807)(label(ensures))(mold((out \
+         20da46dd-0a7e-464e-a681-d923ae5d2807)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         6dcea179-d867-46fb-905d-e8ad23c70450)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         20b7f2d8-9159-4770-a72c-b1e8c234d07c)(content(Whitespace\"\\n\"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0308572b-5e0c-4fc8-926a-db574385c991)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         2dc5fd0e-db64-44e5-8fa8-7f5bc318cb3b)(content(Whitespace\" \
+         \"))))(Tile((id 6dcea179-d867-46fb-905d-e8ad23c70450)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ee8473d8-5327-477a-8a0a-6007930411cd)(content(Whitespace\"\\n\"))))(Tile((id \
          455bcac0-0d82-4827-ad23-03d1e3afa901)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -502,17 +532,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6d8c7fac-23bb-42d5-8fb5-f54751245d6d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         970f7a8e-e991-412e-8823-7ac46a726d6a)(content(Whitespace\"\\n\"))))(Tile((id \
+         eacdfb43-01b0-4476-b727-f4bcdd1fb0e5)(content(Whitespace\"\\n\"))))(Tile((id \
          3f91f7f6-9535-4a31-b4c9-f9e0e17bac94)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         308c0beb-d021-4870-b8ab-2777d2b21c4c)(content(Whitespace\"\\n\"))))(Tile((id \
          662361c0-06f8-470e-9c4c-2bcccd0726b2)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         48109696-ec49-49ff-9bde-a16b4836d9f6)(content(Whitespace\" \
+         \"))))(Tile((id \
          98de3cca-6979-40a6-8035-d8f40072379c)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         980b1606-6dd2-4563-9838-17430ae49321)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c6a37ef0-85e5-4ef0-964c-913b5d78ef60)(content(Whitespace\" \
+         \"))))(Projector((id 980b1606-6dd2-4563-9838-17430ae49321)(kind \
+         Checkbox)(syntax(Tile((id \
          e7d177d7-403f-4252-8663-cc611af4dc84)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -522,136 +557,149 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e282f414-7992-475d-8a04-d41566e39f70)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2b8a25ab-5c26-4b47-8133-04ce5bca4744)(content(Whitespace\" \
-         \"))))(Tile((id 8be98757-cd2a-4c23-8588-916f8299cfb6)(label(\"\\\"for \
-         all c in header(t2) :\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
-         Convex)(sort Exp))((shape Convex)(sort \
+         d4841715-f84b-42fe-b0e2-fe9681a9bb70)(content(Whitespace\"\\n\"))))(Tile((id \
+         8be98757-cd2a-4c23-8588-916f8299cfb6)(label(\"\\\"for all c in \
+         header(t2) :\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
+         Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         94b91812-88de-4e29-95d9-e937861a7da9)(content(Whitespace\"\\n\"))))(Tile((id \
+         cb96d440-c558-4434-b1a4-efd165f94319)(content(Whitespace\"\\n\"))))(Tile((id \
          ac727d8a-2cea-44bc-b8f4-8626976dd4cb)(label(++))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6f92f81a-01dd-43fd-a840-dcc0dd5eeee6)(content(Whitespace\" \
+         5ede3017-2b01-490a-b872-367b6098e2f3)(content(Whitespace\" \
          \"))))(Tile((id ed5f890e-2838-4038-94c5-8b0315f349a5)(label(\"\\\"if \
          c is in cs then schema(t2)[c] is equal to the element sort of \
          schema(t1)[c]\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         22accdbf-ab12-48c6-a975-0cc8a602ea23)(content(Whitespace\"\\n\"))))(Tile((id \
+         76736813-add0-4bd6-a2f1-fd25eea2c378)(content(Whitespace\"\\n\"))))(Tile((id \
          e11e11d2-99b2-46a7-ab59-daf17f5ae052)(label(++))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3940f548-e30e-40fc-8748-817534f7c2b6)(content(Whitespace\" \
+         5727344b-c0b3-4e4e-945c-fdfc698b563a)(content(Whitespace\" \
          \"))))(Tile((id \
          b620cf78-8d2f-4c8c-8322-42697da8d5c3)(label(\"\\\"otherwise, \
          schema(t2)[c] is equal to schema(t1)[c]\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d4642881-0f64-472f-8397-448ae7087e55)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a9c36961-770a-4c05-b36c-abc25fa4d861)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b99fb974-db42-48d2-92bd-65e3938eeb83)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         4dc47f46-62fe-4919-a3a1-0bdd35242a81)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         12f579a3-d251-4249-a741-645259b4b193)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         50668dc5-107e-4380-97de-74ab88b23d6c)(content(Whitespace\"\\n\"))))(Tile((id \
+         5ac4fb3b-2914-45a2-874e-25d2025e5708)(content(Whitespace\"\\n\"))))(Tile((id \
          d9aa2a12-6000-45d5-86e1-5fafa0be22ff)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         50d55533-ae19-4016-bc72-e18892dcd756)(content(Whitespace\" \
+         f08cd82e-0598-4c12-b9ac-673b1e8d0253)(content(Whitespace\" \
          \"))))(Tile((id \
          37ee0261-f229-4c2f-a776-e616dd4d0b9f)(label(flatten))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d08845da-7782-4672-8b79-03b2419bc44c)(content(Whitespace\" \
+         367c39c8-7285-4df0-9cd6-6ca45bb8acb8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6cd94bc9-8f7e-4ef1-b783-48a3927ff56e)(content(Whitespace\" \
-         \"))))(Tile((id 2d6b9b71-38e3-406c-9f34-4dbf36c47d85)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         378372f9-c728-497e-8e19-e2b4b590d215)(content(Whitespace\" \
+         94177757-faca-42de-858c-a5b5af80c2d2)(content(Whitespace\"\\n\"))))(Tile((id \
+         2d6b9b71-38e3-406c-9f34-4dbf36c47d85)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         0744e5db-e282-4c7c-b4b1-b61207f25aef)(content(Whitespace\" \
          \"))))(Tile((id \
          851ff363-806f-4c29-ad3c-430cbd2dd9c0)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          b8eb6d4c-1efa-441e-84fd-879094b37ed6)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e03068d6-0d72-4b0a-9379-24d5e08f6954)(content(Whitespace\" \
+         \"))))(Tile((id \
          2942e4b9-4f98-4ec3-8352-8df2fbd3684c)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         b2ff5e21-e563-4a28-8460-da03fa3ffa3a)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6eb4074c-eb78-4111-893f-918acb797fe0)(content(Whitespace\" \
+         \"))))(Tile((id b2ff5e21-e563-4a28-8460-da03fa3ffa3a)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          92acf923-42b3-407d-9276-114bea438533)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          5568ad9c-972b-42f0-a163-51dde9005133)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ea8fbaea-49d7-4304-9240-37ed1daf3aab)(content(Whitespace\" \
+         6a9e9d2d-8f7f-4122-a9c6-5407ff6623de)(content(Whitespace\" \
          \"))))(Tile((id \
          4a4f69e5-4ed0-4db1-b79b-63823ff2d21b)(label(cs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ea49078f-927f-44c4-a98c-8768a746ea2c)(content(Whitespace\" \
+         \"))))(Tile((id \
          b342643e-9ed8-43e4-befc-29dbdd52f52c)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6c9e0cf5-5f20-4f43-8369-14429fe513a0)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         eab77d20-0289-4c28-852b-c82ffdd2a12c)(content(Whitespace\" \
+         \"))))(Tile((id 6c9e0cf5-5f20-4f43-8369-14429fe513a0)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          41e16ec7-c616-4a99-af9e-cadfe1689612)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         80b80947-3359-4ced-bb89-7339dae33870)(content(Whitespace\" \
+         227279a3-a10c-47aa-af85-dce962815fa3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c9da774d-b849-49e5-a1db-6da802022a91)(content(Whitespace\"\\n\"))))(Tile((id \
+         acd73a2f-2901-43e6-89c3-1bba19f2dee7)(content(Whitespace\"\\n\"))))(Tile((id \
          24086b19-726f-4660-a0f3-25d070d72265)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c9996e71-0b72-4047-b1bf-c9662009b7df)(content(Whitespace\" \
+         42319ba8-8d5a-4bc7-a42d-4424a02425a0)(content(Whitespace\" \
          \"))))(Tile((id \
-         dee84752-a05d-4356-bdb6-832952445ff9)(label(select_cols))(mold((out \
+         dee84752-a05d-4356-bdb6-832952445ff9)(label(_select_cols))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d61212f3-b31b-48f6-840b-a202acf94c0e)(content(Whitespace\" \
+         88210591-fcf6-4137-b02b-ebe682218ba9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         aa11c3d3-cdcb-44cb-8a06-1a4d407e7287)(content(Whitespace\" \
-         \"))))(Tile((id 259de074-1127-43f7-a7c5-f3d52c64ab33)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         8a22cee7-653c-45c5-8626-592180e87b43)(content(Whitespace\" \
+         698c8d94-913f-4bab-8dee-6cebcb1c4bbc)(content(Whitespace\"\\n\"))))(Tile((id \
+         259de074-1127-43f7-a7c5-f3d52c64ab33)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         958e3582-1ffc-4bda-9a75-0207fadb221f)(content(Whitespace\" \
          \"))))(Tile((id \
          049b3f80-ae9b-4145-9c38-030e6bb583cf)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          2d70d01b-62d9-4342-a5e5-543fbe168f21)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e0d2fda4-31bd-4110-9fd1-d33dede58996)(content(Whitespace\" \
+         \"))))(Tile((id \
          9e460e6b-c2fd-439a-86a7-874b48b71de3)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8fe93fea-6a77-41f9-991b-176bf342085f)(content(Whitespace\" \
+         \"))))(Tile((id \
          c581e691-1264-4f29-930c-97ea9f09978d)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7210a13a-571f-4e71-bf53-1afdc87a0eb3)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         736929ca-775a-42e8-92c8-05723ff00a9b)(content(Whitespace\" \
+         4dab7919-e621-4528-a17a-0f0690ee0f8c)(content(Whitespace\" \
          \"))))(Tile((id \
          cb73c85a-9a98-4b7d-a767-80ae6b626e64)(label(cs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         24b081c1-035f-4286-ba35-4a2e87b01866)(content(Whitespace\" \
+         \"))))(Tile((id \
          6b34b9f1-4938-412c-9e30-0bbf4e3430f7)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2fba0eb5-f33c-459d-be86-13e4af3c648d)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e56f2cfc-d210-45a8-8b24-5531558dc943)(content(Whitespace\" \
+         \"))))(Tile((id 2fba0eb5-f33c-459d-be86-13e4af3c648d)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          e616649d-05e1-4c4e-be96-3bfa892e6ea0)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         ebcd03f9-b513-408e-a0f9-403d62e7c56b)(content(Whitespace\" \
+         28a7a59e-8e35-403d-8c78-750f356a01f2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d70c9f74-737f-4019-8115-9e944b177283)(content(Whitespace\"\\n\"))))(Tile((id \
+         8041a668-f354-4a13-b1b2-1fe64a94fac0)(content(Whitespace\" \
+         \"))))(Tile((id \
          99e847aa-d8f9-461c-b2d0-228a985772fc)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -661,12 +709,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          61562d4c-6811-448e-b502-7341cc719c50)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         69e98e7d-7836-45f5-a09c-ba3303608896)(content(Whitespace\" \
+         d7c2cfc8-471b-40f7-b03c-0730b4424829)(content(Whitespace\" \
          \"))))(Tile((id \
          d0119f8b-3c55-4b4f-8983-19699b1bcd66)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         059eed23-9af7-434a-b13c-2c9fd07d6e6c)(content(Whitespace\" \
+         c2afba05-361c-4f23-8b98-445d69130328)(content(Whitespace\" \
          \"))))(Tile((id \
          299bace6-26ec-4658-8c26-43be6b385391)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -674,14 +722,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9cf8c167-5580-453a-ad37-9101d2d8d17c)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         380abc43-fb78-465c-b3a8-24a5de3c5302)(content(Whitespace\" \
+         73ed3fee-f3b0-47ad-b008-1a0c78666ec3)(content(Whitespace\" \
          \"))))(Tile((id \
          6f3bd381-0b39-45e3-8c48-d2278f70eb6a)(label(entries))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         80e6edd2-f584-4e75-ae2c-3f5600bcd0cb)(content(Whitespace\" \
+         e4ab5c2e-a3da-408b-b535-c61f714a758e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         67723df6-741a-4e65-b35f-cc4d8581ff35)(content(Whitespace\" \
+         6707a99f-0069-48f6-9846-e62242a0e73d)(content(Whitespace\" \
          \"))))(Tile((id \
          9be292ee-3797-45ac-ab19-b678a26934c6)(label(filter_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -695,19 +743,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b3e63e9d-e8e3-4170-a303-18267119ee6c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ae7540b2-1e3b-4e6b-8f84-61123a4b6501)(content(Whitespace\" \
+         70392704-8fd9-4db6-9f65-ff4e8d0fc2c6)(content(Whitespace\" \
          \"))))(Tile((id 7c76c1b5-9779-4b08-8746-4d72f5286e35)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         485ecf9f-5ef6-4c38-a8ff-e29b6cdb4e31)(content(Whitespace\" \
+         7c9185bf-032f-4d98-a06b-cea8b462576f)(content(Whitespace\" \
          \"))))(Tile((id \
          41fe8089-2a00-4f76-ad20-968a15fe1155)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         201fd79c-cf91-4c5e-a5f5-6a0a47068025)(content(Whitespace\" \
+         f7e1f0bf-4805-464d-832a-b94da1168c23)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f17859d2-fca4-4964-8310-69d424b178ea)(content(Whitespace\" \
+         6197b7ff-e0bb-4704-aa1c-54d6f7331e32)(content(Whitespace\" \
          \"))))(Tile((id \
          0c4e5e49-1f6d-4996-8f09-b33cde67c60f)(label(find_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -721,19 +769,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1c71d98e-6de4-45ca-bbb6-5684d3f092fe)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f465fe59-bb89-4e87-bb3a-63d774794e8f)(content(Whitespace\" \
+         fdc77388-fdd9-4c27-a3de-051e89694720)(content(Whitespace\" \
          \"))))(Tile((id ea98ff91-22af-4dfb-b2f4-d0d882ef9168)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         984a67ec-3e8a-4f7d-88b1-dc0b9f25b6b3)(content(Whitespace\" \
+         0e7a0c36-6f0c-4436-ad05-80d6791323ad)(content(Whitespace\" \
          \"))))(Tile((id \
          1397c210-bbf1-437f-a795-4e142a115d2d)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         35a46844-ca0c-4620-8dcc-9f2726145996)(content(Whitespace\" \
+         1ef17280-4093-4de5-b492-bca0e8c00fe4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7074a3ae-4ab4-4ac1-a52a-722d6a32c4b0)(content(Whitespace\" \
+         2e7b076c-7e07-4bc0-b92a-c7e77a261c84)(content(Whitespace\" \
          \"))))(Tile((id \
          51199f88-432d-4b7a-9a93-68c1b795dfae)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -744,128 +792,77 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9b7e167f-cdf6-4c3b-a675-24c9e3918238)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         dc63a27d-46fb-409f-a97f-30bd63312ea9)(content(Whitespace\" \
+         6aceceb4-8d0e-401a-84e6-42704c3716b6)(content(Whitespace\" \
          \"))))(Tile((id \
          2daacb11-c6ea-4b71-84d2-0fb8fd3229f0)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ef964be6-75dc-4170-bb22-d5a8636ed2a1)(content(Whitespace\" \
+         a401f901-99ba-4ace-8c4e-a8a05461b440)(content(Whitespace\" \
          \"))))(Tile((id \
          888e9197-3c14-4d6f-a473-9ea960e6c0c1)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         49c47ca6-e774-440e-bf25-87ee43a53f83)(content(Whitespace\" \
+         772f58e1-8575-43a0-952f-a027727503e7)(content(Whitespace\" \
          \"))))(Tile((id \
          fd9cf6d1-d509-4fab-9367-9a949ef0924a)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         db1cdf88-3fcc-44d7-a398-db2ec18d30d1)(content(Whitespace\" \
+         4a37cfc6-9c91-411c-8e37-8ed3ca483c67)(content(Whitespace\" \
          \"))))(Tile((id \
          71de39a4-57f7-434f-a82b-54a16f5e4c91)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         7db3eace-4756-4320-a408-eb628fc9bdf6)(content(Whitespace\" \
+         e9d07988-dcec-4668-bb58-7d87cc85ad13)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5115aa28-20ab-4380-94ff-952e50d93dfd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba8ffec6-fe79-4ee2-af05-61c8fffbb23b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27309e63-0342-4d55-9a65-402a51728d9d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9edcb301-846c-49ba-be73-9cd2fdfd1851)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d6569c3a-dc4d-48b7-9e52-5d173b4c72d6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         06de41b9-bb58-4ff1-b04e-180c751a6b73)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e7726f07-5d73-4fa9-bec2-493a7a1d3f56)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         17138ba8-e6ce-4b66-8753-273b2dc78abe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         43c102f5-31d7-4aec-b378-7cdafe85e8bd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         30422979-9d78-4287-b1d0-dc0631134b0a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7cbc969a-ce91-4c13-90e9-2ed75a9d7002)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         608c10c1-b598-4a8c-a158-7f64e641aa42)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6c0cad93-fd88-4c36-8188-8984e3b1dbf0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0192f6d5-65db-40fa-bff0-af707bbd24ed)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d21a0b1a-3730-4d2f-9d2a-235dc5084fdd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61444447-ade4-4ace-84f8-7ba8fbf378ee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a898ac86-f613-493f-a52e-cab4325d3f2c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5264e012-ffd7-473a-ae26-1d9c10d1fc32)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dcb2adcb-86b4-4359-9bf2-dc3f5237bba7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e8624bcb-f97a-436d-8efa-fe7ab328e423)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         09bcf4c2-4388-450b-bd41-f2bde2c6cf79)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dbe5bb31-ff13-48ca-a8b7-73ff6bae4831)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         00c03674-6b99-4581-b1a5-a6a64802d84b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         704c4551-423e-4f5d-9007-7c72f2df7819)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8c53dca-af64-4c72-bfc2-a3780d37a25c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0dd387d8-db41-45e5-a430-6b6221a6aa3d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8a15f652-5231-41a3-9d78-e6bb8d2bf6e2)(content(Whitespace\"\\n\"))))(Tile((id \
+         9e1fc5c9-6e93-4f08-9e05-baa5a72ae097)(content(Whitespace\"\\n\"))))(Tile((id \
          dfc06a3e-9e31-407c-9e67-40f4272c7164)(label(flat_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          1f901ab4-6c91-4d5c-989c-4f178b9f4338)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         6a00bcf7-f027-47ac-b91a-4130f2efbe5d)(content(Whitespace\"\\n\"))))(Tile((id \
          ba89c91b-40de-4de6-a807-25746075a520)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          47d5b607-c05d-4c78-afe4-9228807b4e7c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f7161a79-a1da-4c26-ab90-232367ba99e4)(content(Whitespace\" \
-         \"))))(Tile((id d9fc0b32-4ac8-483f-86ad-74c4dfaafc8e)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         b28a23bd-06d8-4157-8fb5-61bb5b260210)(content(Whitespace\" \
+         e4516144-cc62-49b6-857e-ff88737c35e1)(content(Whitespace\"\\n\"))))(Tile((id \
+         d9fc0b32-4ac8-483f-86ad-74c4dfaafc8e)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         40005501-1341-4727-a25a-88e63a47719f)(content(Whitespace\" \
          \"))))(Tile((id \
          457bc413-cb76-472c-8263-682ba1d11dd2)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6deb7bf0-a3e7-4bbd-9c32-4946c7357b8d)(content(Whitespace\" \
+         e24c25e0-7625-4930-a1b8-a720d6c8405b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         82c103e4-f6e2-4e20-9a91-3943cae058ba)(content(Whitespace\"\\n\"))))(Tile((id \
+         a0473caa-6b7b-45fc-a083-20b55010b779)(content(Whitespace\"\\n\"))))(Tile((id \
          080ca991-b5c0-443c-8f7e-15efdd6c55ae)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c2750175-dcce-4008-a49e-4bc5f03ee5fd)(content(Whitespace\" \
+         1f69dbf6-08cc-443a-945c-af2e7591758d)(content(Whitespace\" \
          \"))))(Tile((id \
          525be726-0104-4afd-bfbe-16a624061d09)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         0b9e1964-b9f7-4287-9ba1-1ab98d75235a)(label(non_seq_entries))(mold((out \
+         0b9e1964-b9f7-4287-9ba1-1ab98d75235a)(label(_non_seq_entries))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
          f97f0639-9a52-4d37-82d3-30d8f0c5146c)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         4d2089d6-f870-4fc2-8b22-e257e12a7ca3)(content(Whitespace\" \
+         7d0d174a-7b14-42cb-8d1c-33451f9e1b10)(content(Whitespace\" \
          \"))))(Tile((id \
          a87cc1ed-d4c1-4b83-88da-0573fea3933f)(label(seq_entries))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         35c8c28c-ccfa-457e-a739-0eca5c349226)(content(Whitespace\" \
+         e7a06d58-65b7-4417-8ae9-6e2ce1ed6dab)(content(Whitespace\" \
          \")))))((Secondary((id \
-         147df20c-284a-4885-ba99-1e8172b9fce8)(content(Whitespace\"\\n\"))))(Tile((id \
+         4ceac88e-07a7-4d70-82c0-5361b2878e3d)(content(Whitespace\" \
+         \"))))(Tile((id \
          7a18646f-4763-4ec9-88dd-cf870a2ba9bd)(label(partition))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -884,46 +881,56 @@ let out : string * Haz3lcore.PersistentSegment.t =
          90c166f5-cb5d-486f-a410-9513614c68f3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         44c11da4-4d3b-4602-94db-26af3ac539e4)(content(Whitespace\" \
+         a7d74f67-e38e-4e7d-a05a-de74f7309cfa)(content(Whitespace\" \
          \"))))(Tile((id a3ce9813-b4c8-4ba7-87bf-1e36a1dc0929)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         c0556e3e-32b8-48ed-9177-1ae4446d0dd9)(content(Whitespace\" \
+         9d3bbac0-4d9f-4fd7-b4e6-aee91bf18555)(content(Whitespace\" \
          \"))))(Tile((id \
          89933a90-8a0d-4fb7-9fda-9710164ccf16)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          2240f83d-bfd1-4086-a936-846ca2ba289a)(label(label))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a2c58171-fb7d-4662-9d44-b39579da01fd)(content(Whitespace\" \
+         \"))))(Tile((id \
          4145a221-0fa4-483c-af40-8c40fbeb1054)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         6c752e46-96cf-4ce2-9c61-648d34befb2a)(content(Whitespace\" \
+         \"))))(Tile((id \
          ff64909d-8097-4abf-ad59-68af403915dd)(label(l))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
          05f45e64-e928-4ae0-85af-92acc0b24761)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         5164ac97-7907-4074-a639-2e5ce7366592)(content(Whitespace\" \
+         1e5e0be1-0e4d-496f-b3a5-a3d3ffdebbd9)(content(Whitespace\" \
          \"))))(Tile((id \
          32095803-ee1e-470d-83f5-de8e69717a83)(label(value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         7e488e7a-5b7f-4fd5-a92d-643576655086)(content(Whitespace\" \
+         \"))))(Tile((id \
          681111ca-666e-4186-a75d-855d42435093)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
-         6d0e38b3-be62-45d0-bb4d-0c141debc777)(label(v))(mold((out \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         f0b586a4-cf45-4e32-893d-482bf46a72b2)(content(Whitespace\" \
+         \"))))(Tile((id \
+         6d0e38b3-be62-45d0-bb4d-0c141debc777)(label(_v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         bc67d427-8c78-48a0-a17e-799bbd345823)(content(Whitespace\" \
+         5a19fe92-bdf0-4b1f-950c-88d0af4dec08)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1685a025-a9b9-4e10-8936-c1b8397f5ef2)(content(Whitespace\" \
+         ff69d30c-63a1-4023-8920-927e1f1a5f2b)(content(Whitespace\" \
          \"))))(Tile((id \
          eae8b135-9cf2-45fb-bb67-5c42565a9047)(label(!))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape(Concave 27))(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3290a362-6206-47e0-8828-6154bf4bbd28)(content(Whitespace\" \
+         \"))))(Tile((id \
          df666996-6609-4b07-81c9-1caf6b14be80)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -936,19 +943,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a23b6438-8f5c-4a80-9017-30f5be8525bb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3a2844a7-20eb-4aa9-8207-32adaaa52d9a)(content(Whitespace\" \
+         8021b66c-7588-46a5-bdbb-edf666bbeb3e)(content(Whitespace\" \
          \"))))(Tile((id \
          091afd4b-59f6-4e47-bca7-1ffca1774cb5)(label(l))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         ab818658-6569-4572-86de-2451a0e571c4)(content(Whitespace\" \
+         b8bd3135-e487-4636-b4dd-340888073dff)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ad0f76ee-6478-4833-9d1c-246aed1dc686)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a6ae9f78-4f06-4164-8ff5-881d1d42c644)(content(Whitespace\"\\n\"))))(Tile((id \
+         fad230ba-979e-4f30-8ca8-7fbac3781940)(content(Whitespace\"\\n\"))))(Tile((id \
          0c25a3f3-e664-405d-88f9-ef8c97cbb69f)(label(case end))(mold((out \
          Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         ccada63f-4db7-454d-ab56-d0a18c73b27d)(content(Whitespace\" \
+         4f199c13-52b7-4c91-84d5-a57c23cda5d0)(content(Whitespace\" \
          \"))))(Tile((id \
          3981ab91-df84-4ca6-ae96-8b2e13954dde)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -962,42 +968,50 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a9d29386-81dd-4cd9-803e-f024b3cfc738)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b12c6497-e434-4762-9e1b-e270d5db021f)(content(Whitespace\" \
+         15ce3876-39f8-42aa-8da7-e8b9a33426bb)(content(Whitespace\" \
          \"))))(Tile((id 216db7e1-6056-42f3-af1e-242c7b3afeef)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         50190b8b-a8e7-4f64-b53d-e8a9aa06ba31)(content(Whitespace\" \
+         cfc870d5-6c67-4564-b9c4-eefae3b108b2)(content(Whitespace\" \
          \"))))(Tile((id \
          d1168860-925e-4eb6-81c1-af7b2db656f1)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          6e63a3a6-6b6a-4d50-8207-9a0a6d735c54)(label(label))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         326d7bb3-eb81-4692-b5ad-fe7db0dfe552)(content(Whitespace\" \
+         \"))))(Tile((id \
          b3cc4daf-94f5-410d-8def-041796dfe6d7)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         2b9d2b6e-9984-468f-b9ba-4a377ad3e853)(content(Whitespace\" \
+         \"))))(Tile((id \
          6a652575-8e63-4464-b954-80e4a99fd428)(label(l))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
          5b091d3b-a2bf-4f7a-91c4-6113193b6876)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         928946cd-7060-4f55-8c6a-ddb3ed5e5731)(content(Whitespace\" \
+         78bce89d-6236-4590-b82d-5109ea5605da)(content(Whitespace\" \
          \"))))(Tile((id \
          8ac50607-a342-4b69-8924-dc26b5490f2c)(label(value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b596d0c6-631d-4b22-ae7c-875116e3f2f2)(content(Whitespace\" \
+         \"))))(Tile((id \
          0412d0e8-2167-43ac-8517-909b6931d267)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         5a7a6303-33ef-4ddb-8e14-e1de9fe41748)(content(Whitespace\" \
+         \"))))(Tile((id \
          8d938872-1ca3-4ca6-8871-7ecebab5067d)(label(vs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         0f355a7d-031c-424e-841d-3b0c65a23155)(content(Whitespace\" \
+         1368929d-5912-4585-b122-5edad8160d4d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         956547b2-3e70-4009-8afe-a507ddedf84d)(content(Whitespace\" \
+         8b2d17df-9c5d-46b4-8d4f-46afa91c87e9)(content(Whitespace\" \
          \"))))(Tile((id \
          72adf03b-6ea5-4081-9895-f300d1f2a827)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1011,19 +1025,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5e434e5e-b94d-4f0a-8f56-8d342b7e9921)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         22395e2b-9486-4b22-80b3-8b2466775cdb)(content(Whitespace\" \
+         992024c7-32ac-4303-8999-02d280c3a9ad)(content(Whitespace\" \
          \"))))(Tile((id 27934a5f-2b53-40c1-a1b0-76ea6351fb42)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         463f1ded-aa59-446e-a730-3715f547005f)(content(Whitespace\" \
+         1899298f-ee27-42fe-937a-504be85714a4)(content(Whitespace\" \
          \"))))(Tile((id \
          66e8266b-7a97-4551-aa16-901a5555b9c3)(label(v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         250aa9e1-5ecb-4244-9ed1-6c1940e81bad)(content(Whitespace\" \
+         ee4b1b72-8a11-4f88-bcd5-ff1b22401ad2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         40b18a78-00b8-401a-8ad0-4192813ea8f4)(content(Whitespace\" \
+         0a0020f4-f3d3-4925-ac9b-30037823433b)(content(Whitespace\" \
          \"))))(Tile((id 750acc75-b5a4-49e5-8dd4-d24e9e838d82)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1032,28 +1046,36 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          b1eb4a6e-70f2-414d-bef7-8fcf5527bec8)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         cb35c0af-c08a-4a91-b066-50bb58fe3c38)(content(Whitespace\" \
+         \"))))(Tile((id \
          881a7e29-4dd7-4c62-84ab-c9e9dc62843b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         dc619aa8-3066-4668-b2ec-a908048131f0)(content(Whitespace\" \
+         \"))))(Tile((id \
          982d4b93-56c4-4385-9682-77eb2665700e)(label(l))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          87812682-482a-4fc3-be7e-af19242ffd5d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         02acd88d-cca9-49b8-b593-f321c2c13963)(content(Whitespace\" \
+         6fe786e7-f10f-4477-8874-ffc14e5d03ff)(content(Whitespace\" \
          \"))))(Tile((id \
          afd943b3-de4c-4c7b-a979-38773eefab2b)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         20ff00a4-be18-414a-b8ae-ae5e93f4c533)(content(Whitespace\" \
+         \"))))(Tile((id \
          81eb7488-35d6-442c-b84b-4b2cf30316c0)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         21e09163-0941-4a0b-b858-6e6da9158c44)(content(Whitespace\" \
+         \"))))(Tile((id \
          f0df1adc-37a5-45e9-aea6-f98aa13d3697)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))))))))))))(Secondary((id \
-         d0771dcd-ee82-42f6-b143-d0134afe333e)(content(Whitespace\"\\n\"))))(Tile((id \
+         4fb276ba-284c-40bd-9503-815e3ed793bf)(content(Whitespace\"\\n\"))))(Tile((id \
          3d28daed-02b6-4dc2-af88-257c83ef76aa)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -1064,12 +1086,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          774472d8-5675-46ca-9a91-aff004ee4167)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d4b38ca5-8a58-4882-9175-136fcd36d0e1)(content(Whitespace\" \
+         f0755416-5880-4bd6-9276-d76c1c8523a8)(content(Whitespace\" \
          \"))))(Tile((id \
          a447946f-0761-4da7-a04d-3ecb55e810f2)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         2f6a9ebe-0a8c-4469-9fca-d623ccaab6e3)(content(Whitespace\"\\n\"))))(Tile((id \
+         ae79ad94-777b-4e87-8e1a-317d9d4345eb)(content(Whitespace\"\\n\"))))(Tile((id \
          4d5fae99-d6a8-4ed1-be95-937495a5aa5d)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -1093,7 +1115,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          be910cc0-dbd9-4642-95d9-b15934dd5bf7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         408aa8a3-ab80-40af-90f3-157bb8045e8d)(content(Whitespace\"\\n\"))))(Tile((id \
+         4c736dae-4e60-486a-a1db-c63d7fd07766)(content(Whitespace\" \
+         \"))))(Tile((id \
          caebe367-e679-423b-9e1e-7d9fdef9cbe2)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1106,11 +1129,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2af58c83-3ae5-411c-adb3-c47b27e49e42)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b7ec4834-7247-4d6d-a463-7eb46075a217)(content(Whitespace\"\\n\"))))(Tile((id \
-         7c9daeef-768b-45cc-9607-a4092a062a47)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         8a1a787c-810c-4913-b408-daf19349d1f5)(content(Whitespace\" \
+         ecd31014-065e-4c57-b0fb-90cdcc9e7511)(content(Whitespace\" \
+         \"))))(Tile((id 7c9daeef-768b-45cc-9607-a4092a062a47)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         e6b29c97-cd2b-414c-af79-6f3287f67edb)(content(Whitespace\" \
          \"))))(Tile((id \
          629763e1-891d-45e9-b833-3c15237737a1)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1121,14 +1145,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          26c1b6ce-a867-4a71-a0c0-1bed0ae28e3f)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         807cb1b9-f2c3-4342-84de-7ab63e88c9ee)(content(Whitespace\" \
+         e78b27c2-5198-4468-aadd-57019dce8f48)(content(Whitespace\" \
          \"))))(Tile((id \
          5390c1f1-f4f7-4c0e-a849-5b8afff86c3a)(label(a))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         09f3b829-1a89-4af5-8b41-17e3437b00e2)(content(Whitespace\" \
+         5bb47582-4d0f-4392-9ca8-79f9ae56c114)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         493a0376-a69f-4ffd-9665-f179aa6c08bd)(content(Whitespace\" \
+         5f8506e4-52f1-440d-8217-19882a5afca6)(content(Whitespace\" \
          \"))))(Tile((id \
          b9457e05-afc7-45bc-be62-b04f20271180)(label(zip))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1142,17 +1166,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9dc5dc5a-0e20-43ab-acbf-93c351ffc6eb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9204d89a-89ee-4734-8414-763b443bba31)(content(Whitespace\" \
+         094d5950-c4a0-4a21-870b-095852d384ce)(content(Whitespace\" \
          \"))))(Tile((id \
          040f1c80-b1ea-4561-951c-e6143d902eca)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d15ceeda-0106-40ba-be3a-3ecf69919aed)(content(Whitespace\" \
+         3fd10570-71fa-4d6f-86a8-b92b6931f946)(content(Whitespace\" \
          \"))))(Tile((id \
          6bd71522-1c8a-42fd-beae-e986d4bb7aba)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b6f55b61-d812-42c8-bd97-0fdadc2aa18b)(content(Whitespace\" \
+         f37441da-e219-46c4-8104-abee728999ab)(content(Whitespace\" \
          \"))))(Tile((id \
          acae41b6-5411-44f6-8efa-cc5f194052e8)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1166,12 +1190,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ee85ee88-d550-4a13-b350-beee55c94350)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d1024989-b2cd-4635-8663-b5a087008c7c)(content(Whitespace\" \
+         e4cd7dbf-a62f-4112-b04f-b43774bc392c)(content(Whitespace\" \
          \"))))(Tile((id 55d35034-5709-4eb1-bb5b-76fb02cef136)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e136989c-91c0-4cb0-ae7f-ac69513ad132)(content(Whitespace\" \
+         663ca882-a0b0-488a-a4c7-03f2c095f940)(content(Whitespace\" \
          \"))))(Tile((id \
          3bc64358-13f1-498e-b928-7e16c0abb455)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1182,24 +1206,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bacb792f-b744-4249-b15b-f9b79ec99bf8)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         3a061d98-f712-4c23-9ed0-f4939e2df83a)(content(Whitespace\" \
+         9ed49344-b4bf-4c78-a327-e7f49d5ee815)(content(Whitespace\" \
          \"))))(Tile((id \
          8b785046-6c63-4880-a55e-5788b1a445a4)(label(b))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         73c82203-c66e-4d7d-b42c-eb403909b3a5)(content(Whitespace\" \
+         78057afd-669b-4350-916e-f175944d5eeb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7c4a7e7f-1e94-46e9-9011-396704691d78)(content(Whitespace\" \
+         75acbb5d-84dd-4ead-a11b-5847b475c6aa)(content(Whitespace\" \
          \"))))(Tile((id \
          6cceb391-736d-414e-a37b-ce6e63866736)(label(a))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f16d74c4-dc13-4846-8b3b-1b33910b6dde)(content(Whitespace\" \
+         669cbe07-ab0d-462c-970c-9c3e5a1e7b7f)(content(Whitespace\" \
          \"))))(Tile((id \
          3f73692d-3af6-4145-b1c8-db65aa3fd366)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ea7307f8-a90d-48f6-97d4-9e6334729800)(content(Whitespace\" \
+         eef2ef56-0afb-463d-8a9c-050597c143c3)(content(Whitespace\" \
          \"))))(Tile((id \
          b634e318-1b8d-4b98-80d0-9226b43beea7)(label(b))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1207,16 +1231,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          06314608-ae82-44d8-85f8-4f9632a66da1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c7bb517e-32db-470d-9698-ddae21c37ae8)(content(Whitespace\"\\n\"))))(Tile((id \
+         516816dc-169f-46f1-ba6b-5b5860e9649b)(content(Whitespace\" \
+         \"))))(Tile((id \
          6b27497f-b0b5-48f1-b558-3fe101372d5d)(label(col1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c77b8720-69b6-424d-b52f-48c450e4783a)(content(Whitespace\" \
+         b51700b9-ada1-45d3-9108-8a8ae2e29326)(content(Whitespace\" \
          \"))))(Tile((id \
          fef980ea-ed93-40cf-87ea-afa45f446bd3)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9aad12df-2f51-4db1-b71e-8b2ea3357f60)(content(Whitespace\" \
+         01c6c2f9-f4b7-4adb-b75f-31ce82c0a838)(content(Whitespace\" \
          \"))))(Tile((id \
          38438750-f620-4d1b-83d7-53cb295c85e4)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1230,20 +1255,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          357cb59c-69ed-425c-ba58-86c92f9b9029)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3afcfc40-7d3b-45cb-b9dd-e78441d48dbc)(content(Whitespace\" \
+         388df8c7-9a99-4739-b080-fe578cbaadd0)(content(Whitespace\" \
          \"))))(Tile((id \
          68efdf01-7ce5-4153-a80d-1e12abe74f8e)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         61e77f79-ba81-4dbb-98f1-8334bd178059)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7e62df47-7f79-4882-b65b-5c023917544f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         9b27b418-7737-446a-9a8a-44f883f2fa98)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c3907e3e-2b45-496f-be41-328e2c38b742)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         94f01105-8488-49a5-ac9b-613f23384e56)(content(Whitespace\"\\n\"))))(Tile((id \
          92f16810-94ac-4107-b939-e5e374df2958)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1a7a9232-a3ee-4ab0-bd54-d54e7923e12d)(content(Whitespace\" \
+         38ed2d48-cb5f-4bee-a54a-be46185b6f66)(content(Whitespace\" \
          \"))))(Tile((id \
          e2d93a66-7118-470d-b291-33f9feffe640)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1257,60 +1279,59 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d81a5da7-3960-4d27-944d-430e7e8ad3db)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8d1a06e3-3386-4932-88ed-61a4e35972a5)(content(Whitespace\" \
+         47faa093-259c-42fc-ba2b-1bfffbea829a)(content(Whitespace\" \
          \"))))(Tile((id c81aa333-3bda-4880-8a02-a3b84c75814f)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         bca7c848-b28f-4544-9530-863b57bf02e6)(content(Whitespace\" \
+         aef70535-b072-4190-8655-1573e4af82e9)(content(Whitespace\" \
          \"))))(Tile((id \
          75552467-c674-41bf-bd40-cd649f277122)(label(rest))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         fe43895c-db08-4c47-b77e-4e7a5b7aa7e8)(content(Whitespace\" \
+         8cb3c439-f708-4f76-af77-ee7328459f55)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2a33ac19-4f53-4353-bdf0-a3b913b5c3f1)(content(Whitespace\" \
+         2fa19c8c-a73d-4169-bc5c-4d29e8a00f76)(content(Whitespace\" \
          \"))))(Tile((id \
          d64300fe-86a0-4079-a8b7-a6391a06b91f)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         ef19bf63-009f-454a-a31f-6ffe9aa1962d)(content(Whitespace\" \
+         ece0728c-6d28-4b25-a77a-15262664385e)(content(Whitespace\" \
          \"))))(Tile((id \
          e1cb837f-99b9-458f-a663-ad41dbed1234)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cc59c4f0-9444-4b5d-91ff-c2d470049ac7)(content(Whitespace\" \
+         83f41702-37ad-4589-aed7-babdb19d353f)(content(Whitespace\" \
          \"))))(Tile((id \
          7c3ed3e4-60fa-4147-8fde-26c40a80f5b5)(label(rest))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e89e8b5c-3af7-41d9-851f-6a62e4929246)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         264e5e4d-bd68-4046-b68d-b4cfe9fb26fd)(content(Whitespace\" \
-         \"))))(Tile((id \
+         947b0d00-d0e4-45fa-bd0e-cc39b52dac66)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         09b465b7-a36a-4917-8a2c-ed956d3a2dfe)(content(Whitespace\"\\n\"))))(Tile((id \
          5f2d04e4-a0cb-447a-b0f0-59425e102b9e)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ed0e5a38-8880-4314-9706-847c477a594c)(content(Whitespace\" \
+         cce9f434-d83c-4902-9051-afa67d88fd8f)(content(Whitespace\" \
          \"))))(Tile((id 1aa32d6f-7fc6-4df8-b290-32ca996ecd41)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          962c9fa1-b03a-48a0-b04b-fc8b10fc193a)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a44c2a1a-e10d-48e7-920b-6960aec4bc78)(content(Whitespace\" \
+         9d671a6f-db2a-4dea-bdc8-821dc6caf134)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8f3c114f-34e1-4d3e-9656-37e2db886356)(content(Whitespace\"\\n\"))))(Tile((id \
+         e0d2e24e-b7b1-4d62-98a4-2b1222c2e4ce)(content(Whitespace\"\\n\"))))(Tile((id \
          9a82e6db-4b7c-46a2-9d97-e3eb8ab99b5e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8263158b-cb0e-4ecd-93f2-c13d34cb5d35)(content(Whitespace\" \
+         b7e1ddea-7742-4baa-b4f0-13d3980d89c9)(content(Whitespace\" \
          \"))))(Tile((id \
          7ff7c929-efc9-4caa-8e74-9d29454593d7)(label(expected))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f15d6fc3-8d0f-4c00-89f5-3801ce191ee9)(content(Whitespace\" \
+         13395e67-9075-4a2e-bddb-ab57d0712bf2)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b1ce4a62-ea26-49b8-a5ed-4de45346f564)(content(Whitespace\" \
+         ea8baf57-833d-46af-a343-6c58115ba524)(content(Whitespace\" \
          \"))))(Projector((id 372eca1b-11ed-458c-9b45-1d91f4f7aee3)(kind \
          Fold)(syntax(Tile((id \
          3aa99562-a6cb-4c6a-bf44-36e6364d31a4)(label(\"(\"\")\"))(mold((out \
@@ -2192,14 +2213,13 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          52951785-a686-44bc-968c-34774579859e)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         46d4b891-db57-444d-a930-836a0b8cc33c)(content(Whitespace\" \
+         8ace1ffa-f5f8-4742-8586-58a86944f2f4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         de6ab109-4668-4c12-9af7-caab1ee292ff)(content(Whitespace\"\\n\"))))(Tile((id \
+         a420fe72-9207-4e5c-baef-1c5f15770695)(content(Whitespace\"\\n\"))))(Tile((id \
          6c05c881-74cc-4fe6-8e0a-f606691c6d07)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         7654e83c-9c48-4687-95c0-d691b64596a8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3e8f927d-8d14-4743-9f5d-3eef77ec470a)(content(Whitespace\"\\n\"))))(Tile((id \
          6006e41d-9681-46b7-8b85-353680fb9997)(label(flatten))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2212,37 +2232,36 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0e940bda-38d7-43d8-adf3-1723691c6962)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         178f2c6e-8ad3-41f4-bfcf-d2547a035063)(content(Whitespace\" \
+         b01786cb-c525-4271-a530-81cec9f615aa)(content(Whitespace\" \
          \"))))(Tile((id 2d105105-01fc-4b0b-b0d4-34a2df76ac49)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          0c3c4b37-5003-472a-94ac-fc217b3c02cf)(label(\"\\\"quizzes\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         a71132f5-9441-4e89-ad5a-e0b58a129c5d)(content(Whitespace\" \
+         191e6976-f67d-4446-b8fe-f7aff53473c8)(content(Whitespace\" \
          \"))))(Tile((id \
          e8e5e6a0-434b-4ec9-b1d6-6f71ecf93911)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         65b9abe1-8372-4735-84e1-9c332bfefcbb)(content(Whitespace\" \
+         ad8abd08-9061-41c4-996c-665f696def2c)(content(Whitespace\" \
          \"))))(Tile((id \
          0dce08d0-ebac-4dc9-94e8-eac3512741c0)(label(expected))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         e939832a-8815-4e40-b731-db028f82a0cb)(content(Whitespace\" \
+         7d08a51b-3e29-4334-b69a-2bfe649042fb)(content(Whitespace\" \
          \")))))))))(Tile((id \
          b0bdecd9-7243-4681-8a1f-0f0027552df4)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e8e39239-2f3c-40f9-8c90-74b749502f4f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         3f14ac31-8614-4709-8b7b-3ec96b384579)(content(Whitespace\"\\n\"))))(Secondary((id \
          f9fb6294-e802-44e9-8414-84b752e3de52)(content(Comment\"# Idiomatic \
          way to do this #\"))))(Secondary((id \
-         7eaf7160-298a-4b9b-ab5e-d465c3a827f9)(content(Whitespace\"\\n\"))))(Tile((id \
+         849d91e7-3f7d-43fa-af0c-564d1decdc98)(content(Whitespace\"\\n\"))))(Tile((id \
          231abe79-1dc1-4ecb-912d-bafc026b4973)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         7ad3312f-4691-43b4-a970-967da81acde2)(content(Whitespace\" \
-         \"))))(Tile((id \
+         080f37d0-2d24-4e1d-ae8f-cfa16598fa69)(content(Whitespace\"\\n\"))))(Tile((id \
          3885f508-5003-40f7-86c3-dc4a35f9bf9b)(label(flat_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2255,19 +2274,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d067a62f-6958-4ee7-9245-af9d88293165)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c96ba72b-5e53-4b32-a624-dc3290c19af1)(content(Whitespace\" \
+         cd90c8b5-484c-4b7c-ae98-45c1e38c56bd)(content(Whitespace\" \
          \"))))(Tile((id 2b477fe3-0e94-4c90-b9dc-dcd0a6cfbdc0)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         6ddb78fa-f2b9-49e2-9ec0-25bc8fde19fb)(content(Whitespace\" \
+         e8918560-85c5-4e7a-8938-d83431c95f5c)(content(Whitespace\" \
          \"))))(Tile((id \
          72cc83a4-20da-4640-86df-8b59f2064d28)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         4c79c2d7-cfc3-4833-bedc-e7d09f64404e)(content(Whitespace\" \
+         5614d519-6312-48e9-ac79-9da430fdd382)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2a4d693e-5dc5-477a-9e5e-645172c49a9f)(content(Whitespace\" \
+         85e31eac-6d8a-462d-b5c5-cd10fe602f02)(content(Whitespace\" \
          \"))))(Tile((id \
          ed26938d-9c5b-464a-bb6f-601afe4c1aae)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2287,95 +2306,108 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6b433b50-15c5-4e9a-8a59-84d4ba8cd6f6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8c0b255b-45da-40aa-8bef-2df2c8350092)(content(Whitespace\" \
+         cccf526f-c8f1-42b9-88b3-b1ed1c3f210e)(content(Whitespace\" \
          \"))))(Tile((id 476830da-67a1-45b1-9e4d-5dd71c2f07ca)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         bf24731c-1cab-4847-8820-6149dc06c915)(content(Whitespace\" \
+         9796e97f-1877-4094-957f-90511ae7c0ff)(content(Whitespace\" \
          \"))))(Tile((id \
          3108ab14-9202-4d83-aa02-257dca9834a7)(label(r'))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         52226f10-dd6b-47d1-b0d6-47ef92b74184)(content(Whitespace\" \
+         f4cd35e7-4456-45d5-8e3a-d386dd30bfef)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7eab1377-1d9c-4209-9065-8567f5cea7cd)(content(Whitespace\" \
+         f0ae7d07-c104-490b-a084-65f9e9af7b2e)(content(Whitespace\" \
          \"))))(Tile((id \
          f88eb5ad-6af5-42c4-9742-11f05e03dfad)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         daca3f4c-ffc6-422e-9678-376e175b9140)(content(Whitespace\" \
+         ed84c923-cabb-4d1c-ad14-055741421058)(content(Whitespace\" \
          \"))))(Tile((id \
          03401e28-7184-4750-9930-c074d4959153)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         042c7e5f-4d13-4c1d-9597-195b14e0ddce)(content(Whitespace\" \
+         e7975014-0dd8-4b62-96da-358eb20a8f2c)(content(Whitespace\" \
          \"))))(Tile((id \
          f3bfbf3d-8bdb-448a-9c8d-068cfd1283c2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          632df4ce-2d91-4033-879f-3e1cd11252ba)(label(quizzes))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9f6c587a-6132-431a-976f-754440f28238)(content(Whitespace\" \
+         \"))))(Tile((id \
          c0d0818c-2a63-424d-87f5-8fd02a8624ed)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6664c170-c2c0-4cf9-ac8d-06040468eedb)(content(Whitespace\" \
+         \"))))(Tile((id \
          2bf5ff9d-2cce-464f-b7a7-65989bc9516b)(label(r'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         62216136-3cad-4d2c-8262-129d098c5944)(content(Whitespace\" \
+         36c308a9-31d2-4105-aa09-092dbe3ea967)(content(Whitespace\" \
          \"))))(Tile((id \
          04dadc6d-1d50-4685-ad6c-af1e145d2fdd)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         03cece8a-ee24-450b-835e-49bf93b64cbd)(content(Whitespace\" \
+         b350eec5-a331-4058-b8ae-4792aeb30ee2)(content(Whitespace\" \
          \"))))(Tile((id \
          83406fb5-bcc0-46af-8cce-780bd8e22f39)(label(expected))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         af595184-1b17-43ce-b499-9fcfe9498163)(content(Whitespace\" \
+         fff07628-8dfb-4684-ba10-2bd770bc7680)(content(Whitespace\" \
          \"))))))))))";
       backup_text =
-        "type GradebookEntrySeq = (name=String, age=Int, quizzes=[Int], \
-         midterm=Int, final=Int)in\n\
+        "type GradebookEntrySeq = (name = String, age = Int, quizzes = [Int], \
+         midterm = Int, final = Int) in\n\
          let gradebookSeq : [GradebookEntrySeq] = ^^fold([\n\
          (\"Bob\",   12, [8, 9, 7, 9], 77, 87),\n\
          (\"Alice\", 17, [6, 8, 8, 7], 88, 85),\n\
          (\"Eve\",   13, [7, 9, 8, 8], 84, 77)\n\
-         ]) in \n\
-         let requires=[\n\
+         ]) in\n\
+         let _requires = [\n\
          (enforced=^^check(false), \"cs has no duplicates\"),\n\
          (enforced=^^check(false), \"for all c in cs, c is in header(t1)\"),\n\
          (enforced=^^check(false), \"for all c in cs, schema(t1)[c] is Seq<X> \
          for some sort X\"),\n\
-         (enforced=^^check(false), \"for all i in range(nrows(t1)), for all c1 \
-         and c2 in cs, length(getValue(getRow(t1, i), c1)) is equal to \
-         length(getValue(getRow(t1, i), c2))\")\n\
+         (\n\
+         enforced = ^^check(false),\n\
+         \"for all i in range(nrows(t1)), for all c1 and c2 in cs, \
+         length(getValue(getRow(t1, i), c1)) is equal to \
+         length(getValue(getRow(t1, i), c2))\"\n\
+         )\n\
          ] in\n\
-         let ensures=[\n\
+         let _ensures = [\n\
          (enforced=^^check(false), \"header(t2) is equal to header(t1)\"),\n\
-         (enforced=^^check(false), \"for all c in header(t2) :\"\n\
+         (\n\
+         enforced = ^^check(false),\n\
+         \"for all c in header(t2) :\"\n\
          ++ \"if c is in cs then schema(t2)[c] is equal to the element sort of \
          schema(t1)[c]\"\n\
-         ++ \"otherwise, schema(t2)[c] is equal to schema(t1)[c]\")\n\
+         ++ \"otherwise, schema(t2)[c] is equal to schema(t1)[c]\"\n\
+         )\n\
          ] in\n\
-         let flatten = fun (t1:[?], cs:[String]) ->\n\
-         let select_cols = fun (r:?, cs:[String]) ->\n\
-         to_lvs(r) |> (fun entries -> filter_map(cs, fun c -> \
-         find_opt(entries, fun e -> e.label == c))) |> from_lvs \
-         in                          \n\
-         flat_map(t1, fun r ->\n\
-         let (non_seq_entries, seq_entries) =\n\
-         partition(to_lvs(r), fun (label=l, value=v) -> !mem(cs, l)) in\n\n\
-         case map(seq_entries, fun (label=l, value=vs) -> map(vs, fun v -> \
-         [(label=l, value=v)]))\n\
+         let flatten =\n\
+         fun (t1 : [?], cs : [String]) ->\n\
+         let _select_cols =\n\
+         fun (r : ?, cs : [String]) -> to_lvs(r) |> (fun entries -> \
+         filter_map(cs, fun c -> find_opt(entries, fun e -> e.label == c))) |> \
+         from_lvs in\n\
+         flat_map(\n\
+         t1,\n\
+         fun r ->\n\
+         let (_non_seq_entries, seq_entries) = partition(to_lvs(r), fun (label \
+         = l, value = _v) -> ! mem(cs, l)) in\n\
+         case map(seq_entries, fun (label = l, value = vs) -> map(vs, fun v -> \
+         [(label = l, value = v)]))\n\
          | [] => []\n\
-         | (col1 :: cols) =>\n\
-         fold_left(cols,\n\
-         fun (acc, a) -> zip(acc, a) |> map(_, fun (a, b) -> a @ b),\n\
-         col1) |> map(_, from_lvs) \n\
-         end |> map(_, fun rest -> r ... rest)\n\
-         ) : [?] in\n\
+         | (col1 :: cols) => fold_left(cols, fun (acc, a) -> zip(acc, a) |> \
+         map(_, fun (a, b) -> a @ b), col1) |> map(_, from_lvs)\n\
+         end\n\
+         |> map(_, fun rest -> r ... rest)\n\
+         )\n\
+         : [?] in\n\
          let expected = ^^fold([\n\
          (name=\"Bob\", age=12, quizzes=8, midterm=77, final=87),\n\
          (name=\"Bob\", age=12, quizzes=9, midterm=77, final=87),\n\
@@ -2390,8 +2422,11 @@ let out : string * Haz3lcore.PersistentSegment.t =
          (name=\"Eve\", age=13, quizzes=8, midterm=84, final=77), \n\
          (name=\"Eve\", age=13, quizzes=8, midterm=84, final=77)\n\
          ]) in\n\
-         test flatten(gradebookSeq, [\"quizzes\"]) == expected end;\n\
+         test\n\
+         flatten(gradebookSeq, [\"quizzes\"]) == expected end;\n\
          # Idiomatic way to do this #\n\
-         test flat_map(gradebookSeq, fun r -> map(r.quizzes, fun r' -> r ... \
-         (quizzes=r'))) == expected end";
+         test\n\
+         flat_map(gradebookSeq, fun r -> map(r.quizzes, fun r' -> r ... \
+         (quizzes = r'))) == expected end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesfind.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesfind.ml
@@ -1,87 +1,98 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Utilities / find",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id 30b7fdee-15ea-4435-bf4c-67163d0a40e6)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         9ce40a5d-8fd6-466e-95cf-42a2e2c2de95)(content(Whitespace\" \
+         1d42fec2-33d5-4ce1-a4a8-51210851d2f7)(content(Whitespace\" \
          \"))))(Tile((id \
          f3ae6925-3f51-4a88-abe2-8754c4b29834)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         9cebb3a6-d0ef-4c93-946f-88374f619119)(content(Whitespace\" \
+         81674e5e-6fa7-4f62-aa82-c50aa9cef3eb)(content(Whitespace\" \
          \")))))((Secondary((id \
-         cef38437-69eb-4dd7-8e22-14d1c83c00b3)(content(Whitespace\" \
+         62f93cd5-2d6e-4df9-855c-f0efaf95f134)(content(Whitespace\" \
          \"))))(Tile((id \
          5e19dab3-67de-4d91-8639-a255fba1a3e6)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          0f8d3995-e3bc-4294-9a52-96bad65a2924)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         92bf55d3-4496-41b8-aab6-aea01674a3c6)(content(Whitespace\" \
+         \"))))(Tile((id \
          4e9d3e6e-9f16-4b03-a3a9-8cc7184b26b3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0561e85c-f66d-4faa-994d-2f6e39206aa9)(content(Whitespace\" \
+         \"))))(Tile((id \
          57a95d9b-89a0-4b37-9be2-2c086c836b3b)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b7bbab9f-44af-4c57-9331-e64615bab2cf)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ada8a60f-d685-4eba-a68a-6b56e9f2f20a)(content(Whitespace\" \
+         21433b15-706d-4753-9df5-788b14e3b3d7)(content(Whitespace\" \
          \"))))(Tile((id \
          c44d570b-9001-4409-8912-91554065f00f)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b8b496ea-4555-4bf5-866a-8744709c4c59)(content(Whitespace\" \
+         \"))))(Tile((id \
          37f0b319-eaf4-4ba1-8016-ac4f6956f5af)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e025e6eb-525f-485b-a1a9-5895e7a77ea0)(content(Whitespace\" \
+         \"))))(Tile((id \
          eae4aefd-85d9-4670-83f2-c9cb791c6cc3)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          177cbd49-737a-4bf6-b490-c5dbbde464b1)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5fac1207-1d9e-49dd-a5be-a7ffce4157ae)(content(Whitespace\" \
+         c608adf8-2976-4c80-a9c3-6d6e674f67c0)(content(Whitespace\" \
          \"))))(Tile((id \
          b53ac139-429d-46a1-a288-5556de23b8bb)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0c52330b-776a-426c-9c83-04857f6f17be)(content(Whitespace\" \
+         \"))))(Tile((id \
          28292eac-524c-49f6-84da-835f6bccac85)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6950a26b-0386-44a4-bb9b-63cb255d7b9b)(content(Whitespace\" \
+         \"))))(Tile((id \
          d22800a9-2fe0-4870-91c5-7e64565a76b0)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1ecdcc9e-a633-46e2-a249-bf7b8290a55d)(content(Whitespace\" \
+         bb530147-0003-4d8f-8658-dcfb2e4989f3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         09d4f349-4079-49e2-adb0-61efcbbdafc6)(content(Whitespace\"\\n\"))))(Tile((id \
+         eed68021-25af-471c-8d63-6667cdd5be8b)(content(Whitespace\"\\n\"))))(Tile((id \
          8f659a3c-58a0-4628-a8c4-b41aa200447a)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         87c5afbb-e2fd-4bf5-a30d-b898ce0ba380)(content(Whitespace\" \
+         d87202b2-03f2-4a58-b866-3545e2ed486f)(content(Whitespace\" \
          \"))))(Tile((id \
          4cf995b9-b561-4fdd-8f63-ddefa328c039)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6b604537-9ed6-49ff-a9e7-03b0e61d2cbd)(content(Whitespace\" \
+         e523d0c5-17ec-4ef6-b585-32b4c4315c69)(content(Whitespace\" \
          \"))))(Tile((id \
          13cb89db-cee6-4ce8-ab85-18ae9c1ffa4f)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         09c3a314-94cf-4df7-96f4-1bcd8e953c53)(content(Whitespace\" \
+         c0bb8a90-d3fe-4863-9aba-1bcf3a5e0a2c)(content(Whitespace\" \
          \"))))(Tile((id 6ae68242-c994-4006-9101-22015fafe858)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          0fcdb1b5-c301-438a-b1bc-9719c9f796d5)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         99820a0c-25f1-46e2-ba9b-8bc0949ea1ef)(content(Whitespace\" \
+         2dcc1332-f2dc-439a-9cd3-a8885a87d060)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e7d566d1-741a-4a6f-b941-aef0ac4f27c7)(content(Whitespace\" \
+         9114d339-5a12-41f7-8cba-484737c015bc)(content(Whitespace\" \
          \"))))(Projector((id a22775a3-0547-46ed-acf2-aa8cfcdfb8c2)(kind \
          Fold)(syntax(Tile((id \
          8b5f7c9a-445c-4c3c-b2ab-030c14005330)(label(\"(\"\")\"))(mold((out \
@@ -167,25 +178,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          1d18ddd4-614f-4bdb-bebe-55b2971289dc)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         7ec2b335-9ec1-4461-a3fe-6e5c9aced963)(content(Whitespace\" \
+         c2e69a8f-3a21-415e-ba5a-10fb508a9b8e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         bb7fb2e0-ed71-4b3b-b7f3-4960912a116d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ac8da229-8fd7-4259-8957-a83e9a1ad29d)(content(Whitespace\"\\n\"))))(Tile((id \
+         4622e8c3-d494-480e-bcd3-74224668da88)(content(Whitespace\"\\n\"))))(Secondary((id \
+         e2593c54-2676-4ecb-a3cb-38934d7c6e44)(content(Whitespace\"\\n\"))))(Tile((id \
          dd5bc079-442d-4dcc-847d-d2079d6c3d97)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         47bd2ce4-08f5-4f28-b425-b402740c287a)(content(Whitespace\" \
+         6ec51485-3132-4b49-8da5-26c706b27d45)(content(Whitespace\" \
          \"))))(Tile((id \
-         1c5bdb8d-ae59-4cb7-84c7-975314808267)(label(requires))(mold((out \
+         1c5bdb8d-ae59-4cb7-84c7-975314808267)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b4a0ac0c-5121-4636-b5bb-14a5b876ce39)(content(Whitespace\" \
+         6682ca43-5957-4ea5-a13f-5050e45f80b9)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f73fd2b2-1c03-41ab-a560-1933d98b4df7)(content(Whitespace\" \
+         f46c82d3-0e5b-4fb3-a39c-49f17a002c2e)(content(Whitespace\" \
          \"))))(Tile((id 563d798f-331a-4cc9-8881-bda93f800f13)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         40b70e3d-7509-4507-b5e7-1c4d83ff90d4)(content(Whitespace\"\\n\"))))(Tile((id \
+         19587928-f0ef-475d-9c4b-d76c61727a49)(content(Whitespace\"\\n\"))))(Tile((id \
          2809ca9f-1ae6-4c22-b1af-9e097682ab7b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -213,17 +224,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d0efa9e1-6059-4af7-b7bd-5f91578cb397)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b8f06113-59b3-4ef9-87a8-3a8d65beec21)(content(Whitespace\"\\n\"))))(Tile((id \
+         2571ac5d-489c-42a4-81aa-999e1b0bc9da)(content(Whitespace\"\\n\"))))(Tile((id \
          141c5c6f-43bb-41e0-92ec-3746c872185e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          a8629ab3-6588-4d39-8f2d-bdac1ee95ae9)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7f19d390-4735-495f-9eae-76eaeb595be0)(content(Whitespace\" \
+         \"))))(Tile((id \
          e21d667c-e8db-4ea5-aa67-93703360af08)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         e49570f6-8f94-4a5e-bffa-b1e3e4d8efa4)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         03bf3395-41b6-4a8d-a318-08502a8381a5)(content(Whitespace\" \
+         \"))))(Projector((id e49570f6-8f94-4a5e-bffa-b1e3e4d8efa4)(kind \
+         Checkbox)(syntax(Tile((id \
          dc9cba25-01c4-4007-b06f-5f399c8f42e2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -233,30 +248,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ee467d51-d43a-41a9-b5cb-ec06f9ac05da)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b1ba15f9-9d26-4f68-8274-9c2cb10d007d)(content(Whitespace\" \
+         f2f5ea05-07af-4ec9-aa60-532910fd37b3)(content(Whitespace\" \
          \"))))(Tile((id f60ede34-872a-45f8-bcdc-c506f3b0ca8c)(label(\"\\\"for \
          all c in header(r), schema(r)[c] == schema(t)[c]\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         93a985f0-edb8-42af-b7c1-6605ef7e8f1b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         19bcb542-464f-42a0-842b-3cff045d4d98)(content(Whitespace\" \
+         6b0668de-8bcf-4407-95e9-ba569b238f94)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         d0144b47-15ab-4d04-9b73-f8aa6dd9a590)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         814cfe7c-8204-46f1-94e2-cbfca47a5472)(content(Whitespace\"\\n\"))))(Tile((id \
+         25ece718-3819-4b09-8fa2-d78b5dba9652)(content(Whitespace\"\\n\"))))(Tile((id \
          cca45f3a-46f8-4b3a-80db-77179d24da6e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         2cf43a47-7598-44b0-8e4e-b94e86d2c0cf)(content(Whitespace\" \
+         d5b39a1c-237a-4255-983a-4be04023a444)(content(Whitespace\" \
          \"))))(Tile((id \
-         6a1cbf25-0b62-4ac3-9a42-96e712978fdb)(label(ensures))(mold((out \
+         6a1cbf25-0b62-4ac3-9a42-96e712978fdb)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2d7f0a96-87bd-49e2-a8e8-159d1ef95840)(content(Whitespace\" \
+         a0f7dd88-ff77-4d40-bdd8-86fbfacb20f2)(content(Whitespace\" \
          \")))))((Secondary((id \
-         64a97dbf-f6e6-4b6c-b4b0-af4f30d24fa8)(content(Whitespace\" \
+         9157f722-2fcb-4705-b480-de764845327c)(content(Whitespace\" \
          \"))))(Tile((id 001993ba-935d-4b7a-b9fb-5fcecaeede63)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         cffa27bd-0706-45b1-8056-a792859c0cdf)(content(Whitespace\"\\n\"))))(Tile((id \
+         9783df73-a633-4e08-9e7c-349bf0977158)(content(Whitespace\"\\n\"))))(Tile((id \
          7be5f958-f2c9-42de-913d-1347beb05e29)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -285,17 +300,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c90ccc97-112d-42fb-94cb-7954283a954c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d38d544b-ca4b-4d41-b63b-f56d8aaa1565)(content(Whitespace\"\\n\"))))(Tile((id \
+         df8a7ac8-0121-4896-9b37-2692bfe0896d)(content(Whitespace\"\\n\"))))(Tile((id \
          afea2cb5-aa5b-4ec0-9788-a47435fe29af)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          4c233d6c-4f56-40d2-b824-224ff64ddf0d)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         67320045-5014-4d06-b9d6-1cbb48c5eac1)(content(Whitespace\" \
+         \"))))(Tile((id \
          43dee4c9-a0ad-4f44-83a0-227fcd987241)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         0abed003-e008-435f-9157-7e47b66738b9)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9f306869-a927-4079-b08a-7c7df77d70a5)(content(Whitespace\" \
+         \"))))(Projector((id 0abed003-e008-435f-9157-7e47b66738b9)(kind \
+         Checkbox)(syntax(Tile((id \
          b513b97a-6227-4a47-aa00-a326024bb302)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -305,108 +324,117 @@ let out : string * Haz3lcore.PersistentSegment.t =
          41811419-214b-4041-a425-c802e3d762dd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         06f4a084-cb07-4220-9104-a59e815811c2)(content(Whitespace\" \
+         f5ee643d-97ee-4f3b-a4db-c96fecd273bb)(content(Whitespace\" \
          \"))))(Tile((id ea3a0a1e-676c-4c4b-b716-2d2cbef53706)(label(\"\\\"if \
          Some(n), then getRow(t, n) matches r on all fields in \
          header(r)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         cf1f08c0-d6af-48e6-a82f-0d865c285c34)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         148c7861-d453-4d5c-a234-92b60fbd8233)(content(Whitespace\" \
+         d41bf706-6321-4106-99c5-0a8b1af36928)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         75442839-c0b4-4712-9067-fb5b8e42fc7a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b23154bf-0dcb-4085-bc34-f03ff09a5337)(content(Whitespace\"\\n\"))))(Tile((id \
+         6d273777-6c3d-4ce1-92f1-3e6d4c800beb)(content(Whitespace\"\\n\"))))(Tile((id \
          a23ddef6-42f3-48d5-a6cc-f2ea81cf379a)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         5df747eb-0499-4a06-8231-5c7ce9f723b1)(content(Whitespace\" \
+         c946fa9b-148e-4aa8-9573-c50000f2f394)(content(Whitespace\" \
          \"))))(Tile((id \
          a970ec07-4b7c-4acb-85d5-8ae34eea181e)(label(find))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b268cd09-3186-463e-9de2-39036fa8963d)(content(Whitespace\" \
+         def9ef88-dade-454d-a35e-46813171f436)(content(Whitespace\" \
          \")))))((Secondary((id \
-         077e10bf-c687-4152-9911-10cd45f91e89)(content(Whitespace\" \
-         \"))))(Tile((id ae18f887-67a4-4e2d-ab86-b9c09614a77b)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         5feade7c-ea4f-4b97-80b8-8c256c6a0851)(content(Whitespace\" \
+         0306d6d2-b109-4dd3-bb30-ff08ff6a1261)(content(Whitespace\"\\n\"))))(Tile((id \
+         ae18f887-67a4-4e2d-ab86-b9c09614a77b)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         8d76886f-56db-4b2e-ae2d-9fadc628a070)(content(Whitespace\" \
          \"))))(Tile((id \
          97e6b572-eac3-483b-8eb8-7842e168196d)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          4d352f6a-d202-4915-b101-0077266d47fe)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b5a86f70-ae2c-40a3-99c5-36e3c3a3fcc8)(content(Whitespace\" \
+         \"))))(Tile((id \
          52545c75-4ffb-4b12-9aaf-26e020e467f2)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         c7a603c3-86b0-48a0-8d5a-052ae12ad7a0)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5001e791-55c6-413d-ad43-b95554bcfc4e)(content(Whitespace\" \
+         \"))))(Tile((id c7a603c3-86b0-48a0-8d5a-052ae12ad7a0)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          71fde39c-f59f-402f-ab59-581e850a7276)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          b342da3e-9500-419d-978f-5449abfdb5dd)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         a19b805d-84d1-43a8-8362-828dc62c6afc)(content(Whitespace\" \
+         952d909a-a5b5-4ca0-9e0a-2096b306564b)(content(Whitespace\" \
          \"))))(Tile((id \
          bbed1606-9fdd-4d69-9904-dc3a108e3226)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         16d9790b-f567-4335-bd5c-8bec11ed99d5)(content(Whitespace\" \
+         \"))))(Tile((id \
          22597e31-9685-4d50-81ab-10215a77cccf)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b9830d9d-4ab5-43ed-ba88-a1076ad21e2d)(content(Whitespace\" \
+         \"))))(Tile((id \
          75dfff2a-f8d0-4d5f-885e-a882d6e5f15b)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         91b6dcf9-8d73-4c16-8f27-bb387cac49b8)(content(Whitespace\" \
+         1ba98b2a-15d0-4a80-a52f-ffa6e7b45146)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e2fbf59a-75af-44b6-82b3-a81326f35263)(content(Whitespace\"\\n\"))))(Tile((id \
+         97769746-752b-43e3-858d-163795c7fe56)(content(Whitespace\"\\n\"))))(Tile((id \
          98796cfd-132b-480d-a986-87a7bc32ca8c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         45a1fb13-6778-40f1-a671-74807a64b6c4)(content(Whitespace\" \
+         23021da6-542d-49ad-8c8d-9f32ee2cee73)(content(Whitespace\" \
          \"))))(Tile((id \
          286304f7-a55e-43d5-9f29-f31ca248e6c2)(label(is_match))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c417f5d7-edf9-4490-b15f-9d19a32ab3c5)(content(Whitespace\" \
+         812c70ff-7c0b-42e2-a558-74f1fd9be35e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ff7ca367-01b0-48be-adbc-85864c055413)(content(Whitespace\" \
-         \"))))(Tile((id b4a81f13-349d-4a0a-955b-2090a85df77b)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         55b7184e-1762-4fe8-9f18-4455e62a1a7b)(content(Whitespace\" \
+         ecc1ec1a-e7ef-43ed-abce-3480ce7bb8c7)(content(Whitespace\"\\n\"))))(Tile((id \
+         b4a81f13-349d-4a0a-955b-2090a85df77b)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         c99e7b0c-5400-41aa-8d53-220cafc50c2b)(content(Whitespace\" \
          \"))))(Tile((id \
          2db34c48-e216-4948-b11f-1abdc95ad8f2)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          4b3bea0f-4671-4e67-8aa7-a4345b10360d)(label(row))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         8bf25fa3-0854-4dc7-845a-957b3477ea43)(content(Whitespace\" \
+         \"))))(Tile((id \
          7dd5e6a0-c580-450c-a1be-e71583d77b86)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         355d314a-6e64-4f5c-8fc7-8609e3b14a17)(content(Whitespace\" \
+         \"))))(Tile((id \
          6b919b84-1848-477b-a177-ce5bc1fd71c7)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         a501431a-6981-4e4f-b351-053bf55db485)(content(Whitespace\" \
+         041a4734-3622-4798-bf04-fdd5cc8a88ab)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2afb973d-5aa9-4ab9-b87e-0ff0ad27a5ac)(content(Whitespace\"\\n\"))))(Tile((id \
+         23b88b5f-4c25-475e-a89c-bd0873584b6d)(content(Whitespace\"\\n\"))))(Tile((id \
          6817f62b-cbfe-4973-bfb3-94ec36a53e54)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e7cc7485-ec11-41f8-b5e0-0a6b6a28fb1a)(content(Whitespace\" \
+         a0fcb67c-4a19-4604-af1f-a9f7d72f9651)(content(Whitespace\" \
          \"))))(Tile((id \
          c211968a-33b9-479b-8afd-e4dfcd5eb80e)(label(row_entries))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0e760338-f317-4293-b68a-5e63a5172dea)(content(Whitespace\" \
+         0d6ed6c8-ff41-47df-9377-a6dc8d9da2f1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2e33d099-c2d6-4ea3-bde6-eb67439d7c7a)(content(Whitespace\" \
+         6a5e1a6c-acc2-4420-80b3-9d8e472c6cfe)(content(Whitespace\" \
          \"))))(Tile((id \
          13f812a3-4fc4-4770-8972-d383d685279c)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -417,20 +445,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          99d4c541-f0bc-4a47-8d9e-c5a5dd9afeee)(label(row))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         467d87b0-b734-4b3d-8f2d-14b030af3b5d)(content(Whitespace\" \
+         70e234ff-6804-435b-a544-3522289dda26)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         783543fe-53dd-49bb-a204-540b97f63407)(content(Whitespace\"\\n\"))))(Tile((id \
+         1b8c8b68-59e6-4f50-b0fa-895fa7b034b0)(content(Whitespace\"\\n\"))))(Tile((id \
          752c056f-bd8f-41fb-b205-d578b23f742a)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         049e61ae-b19f-41b4-8930-9db88e043496)(content(Whitespace\" \
+         ec736914-9550-46cd-922a-e0c43964c1e0)(content(Whitespace\" \
          \"))))(Tile((id \
          fe30a4b7-3b89-4770-849b-c6db657115ef)(label(r_entries))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2335905c-e938-4a47-ae54-3395a4a3cde0)(content(Whitespace\" \
+         d225d4a7-6fde-483f-b79a-62877f19ae2b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         495b3f35-c976-49eb-bafd-5a325352767a)(content(Whitespace\" \
+         01246be9-4da4-4982-a32f-f0740edfea41)(content(Whitespace\" \
          \"))))(Tile((id \
          63e1b599-686d-476b-ad20-bd783b30d9bb)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -441,38 +469,38 @@ let out : string * Haz3lcore.PersistentSegment.t =
          53fd343f-876a-44fb-bf98-bacf34f45692)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9e08f8d7-e5a6-4bc7-af80-d0cb8cf31de5)(content(Whitespace\" \
+         8ed6cd23-6e6b-47ab-90d8-2ac2f7d9c376)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a56ac225-fc31-4b90-b8c2-e8566ae5e873)(content(Whitespace\"\\n\"))))(Tile((id \
+         cf9a6b13-1cc7-4a40-86bf-eb4ee2798aaa)(content(Whitespace\"\\n\"))))(Tile((id \
          033cbaeb-6d49-4eaa-8010-b0bb69613161)(label(all))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          b4095aee-44bc-4cbc-bd7a-4dc4208c1972)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         62bbe023-c982-4134-bb26-aa889a705fed)(content(Whitespace\"\\n\"))))(Tile((id \
          3686027c-f5e2-4c46-9d89-72c76f947cb7)(label(r_entries))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          9f93162e-75d8-4b9d-bd44-d78d69ba2ec8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4123b255-e166-4378-aff0-1ecd57747aa3)(content(Whitespace\" \
-         \"))))(Tile((id b3ed90a3-e2e7-4407-b5fc-8563a4fa0a14)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         134fd747-e56a-4a49-81ec-c3a3c0153ce2)(content(Whitespace\" \
+         1649b6d6-034b-4541-96b9-2516c200423f)(content(Whitespace\"\\n\"))))(Tile((id \
+         b3ed90a3-e2e7-4407-b5fc-8563a4fa0a14)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         42040eb2-c56b-4c4e-b3db-13b01961da7d)(content(Whitespace\" \
          \"))))(Tile((id \
          2156c4b6-64c5-407d-a6d2-7458bddf96da)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c3e69a35-9de2-42ac-8352-5553c89b92bd)(content(Whitespace\" \
+         0489131b-cf3f-49f8-8008-1affcb0dbff7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ed5993cb-4073-4493-818b-076d63a6cc65)(content(Whitespace\"\\n\"))))(Tile((id \
+         c8e04fc3-c0b4-473b-afbb-251e97f21f0c)(content(Whitespace\"\\n\"))))(Tile((id \
          549c7572-296d-45a4-903f-76fdc3641d3c)(label(case end))(mold((out \
          Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         b05477bf-ae99-4855-a757-358c216e8393)(content(Whitespace\" \
+         5aeadebf-dfbe-48a8-88ed-8eec1e35e225)(content(Whitespace\" \
          \"))))(Tile((id \
          772b6e01-a6db-4555-a00f-013b973e2de0)(label(find_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -486,19 +514,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f05b0482-81cb-4be2-9b6a-6a1491af9a99)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4b543aa3-efdb-4733-aa50-9ed3ac1adbb7)(content(Whitespace\" \
+         93c8b73f-f015-437a-ab02-ce8c999b1755)(content(Whitespace\" \
          \"))))(Tile((id 85740c22-66b5-417e-b788-c4f847fec3b3)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         8cbd1cd5-633d-4a36-9e74-0a09d7332e3b)(content(Whitespace\" \
+         2038f757-61c4-4e59-badc-effde11a90fe)(content(Whitespace\" \
          \"))))(Tile((id \
          2c0e3117-7e1b-4972-9246-bbccb9fa23be)(label(e'))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         02a3a12e-63d8-4242-bb64-2f0cc41774cb)(content(Whitespace\" \
+         91960227-0e45-451c-b19a-27735038425f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a1cc50f8-a9f1-49fb-bd0e-0c5d96287eb1)(content(Whitespace\" \
+         71b9d067-f892-4b21-9bb7-96c074acb953)(content(Whitespace\" \
          \"))))(Tile((id \
          afeb04a6-8d78-4d0e-a725-d508083fc5a7)(label(e'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -509,12 +537,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f96e738d-f3ae-41ee-831c-136bc4035e87)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         957c2d71-252b-4959-bd68-0a35422534aa)(content(Whitespace\" \
+         dffbde63-5d01-4bc6-8781-9cca06c36a2c)(content(Whitespace\" \
          \"))))(Tile((id \
          ddbfd355-e2f0-4227-b783-953784344683)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8e2e3505-4dae-4217-981f-df29dd8c37c5)(content(Whitespace\" \
+         8d2494d7-a417-46cb-9016-f4ad856874c6)(content(Whitespace\" \
          \"))))(Tile((id \
          e6ffad17-63b0-4826-b13b-ef38a28c1591)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -525,7 +553,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8fe2bf8b-e32e-4156-85b1-5477afd4706a)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c5c2c26e-eb87-490e-b21d-8190c2e7c4fe)(content(Whitespace\"\\n\"))))(Tile((id \
+         f8b46650-77c2-4889-bf9b-023e13b45fe0)(content(Whitespace\"\\n\"))))(Tile((id \
          fc92dfe2-3540-4009-9a2e-9055cd4e8310)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -542,7 +570,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          8bc40c81-738e-4b75-9926-e1b55f858719)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cc3433f7-461e-4249-a385-963cc2688977)(content(Whitespace\" \
+         1a81f5e0-fbc4-4406-b14e-b6e93c44c558)(content(Whitespace\" \
          \"))))(Tile((id \
          4188eb99-0142-466e-9c75-e2211b2ef6f7)(label(e'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -553,12 +581,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ccaf0cd0-512a-4e2c-acef-0c19f7051035)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         7a09bb4d-8824-4573-88f3-e8a781e16a8e)(content(Whitespace\" \
+         99974d02-f09e-4db5-8fe3-a2364825837d)(content(Whitespace\" \
          \"))))(Tile((id \
          8c556642-00d2-46b9-ad0f-7859aafd7d69)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ba64db4f-e7cf-44b8-af33-65200b6144fc)(content(Whitespace\" \
+         81ef5075-908b-45c1-9f99-ef6f35f58163)(content(Whitespace\" \
          \"))))(Tile((id \
          45cab771-e114-4896-8bcb-e7bc0858878b)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -569,7 +597,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          89ec2d2c-a7ed-4a06-95ec-ca024abf1289)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c4dccdf6-b769-47ef-828d-b441b311b4ee)(content(Whitespace\"\\n\"))))(Tile((id \
+         5787feb1-0c2d-41fe-9af4-54fd3965daad)(content(Whitespace\"\\n\"))))(Tile((id \
          85be25a7-e8f6-4e16-a466-54901c468243)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -580,27 +608,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          70d1127d-0536-44e1-8460-396b5f1c74c9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0ad0356f-6fe5-49b3-9224-7bd335225ce3)(content(Whitespace\" \
+         e06ef63d-b3a6-4130-82be-d83353d7cec8)(content(Whitespace\" \
          \"))))(Tile((id \
          44806aaa-7345-4701-91c9-93371604dd0d)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         17c03380-baf8-4800-8699-09c43428f4b1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         84cb76ba-2898-485e-a1d2-9475267a94e0)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         9f185cb1-14a6-442a-b189-9c7dc8998a3e)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ce6b2294-2359-48f6-879b-87003d11d2c8)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         67e7e395-50ff-496d-aec9-d5d9caf15039)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         5ea51640-fe54-4de7-942c-127874892112)(content(Whitespace\"\\n\"))))(Tile((id \
          690faf2c-9c59-489b-bc81-f2844c60a67a)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fd1581e6-952e-48fb-adb9-dafe8ba6e006)(content(Whitespace\" \
+         74a4aeb2-722a-444e-bd12-e92b840b7d55)(content(Whitespace\" \
          \"))))(Tile((id \
          06d84967-2682-4a81-ab5e-a92494f53adb)(label(Bool))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         c0a7db63-c53b-4f2a-af9f-4633b504395f)(content(Whitespace\" \
+         c4f063bb-84a6-4503-bfbe-66b7083ce559)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         91ee4a25-6ede-47c2-9ac8-5af3456dea99)(content(Whitespace\"\\n\"))))(Tile((id \
+         91490277-8576-45f6-875e-2f8142cd20e2)(content(Whitespace\"\\n\"))))(Tile((id \
          202b7f99-b3c9-4cff-9aad-c80ad392c694)(label(find_index))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -613,32 +639,36 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ae8507cb-18d4-4841-9db8-41275b22fe32)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7036f3a8-fd5b-4ab1-8681-992dbc75be64)(content(Whitespace\" \
+         fc254e22-75e1-4c49-bd30-f177e2d29f4e)(content(Whitespace\" \
          \"))))(Tile((id \
          ae2429fe-1a33-4c2e-a5c6-f380de169034)(label(is_match))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         695a3cfc-6d51-4f28-aae4-f36013af47d7)(content(Whitespace\" \
+         0c80cf8b-9d33-4c7a-8acf-9fe8afbbe1e9)(content(Whitespace\" \
          \"))))(Tile((id \
          0bad1973-1979-4507-a8f2-24843a05de61)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         cd7dfc56-051c-49ef-a2c4-995fb929c7cf)(content(Whitespace\" \
+         8d278295-5f88-4862-94ad-96b61377cf3a)(content(Whitespace\" \
          \"))))(Tile((id \
          3f8f0d83-97d4-4542-9c36-11236315410b)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          6f80d6a1-460b-461a-937f-806d916d41fa)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape(Concave 33))(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         021d5f28-7c0d-4110-992b-61ab72976dee)(content(Whitespace\" \
+         \"))))(Tile((id \
          cd41f9fc-bd8a-440d-b141-24c88a41a95f)(label(None))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         d7f96f9f-6035-4dea-b8de-f3d65a6db43c)(content(Whitespace\" \
+         4418ac4b-ff30-4df0-9aae-b20745878e06)(content(Whitespace\" \
          \"))))(Tile((id \
          af953080-d28e-4c1d-ad1b-ebd3d1787bb0)(label(+))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 12))(sort Typ))((shape(Concave \
-         12))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         12))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f2fd91a0-4480-49d1-a013-90aae8bac7b3)(content(Whitespace\" \
+         \"))))(Tile((id \
          b8bb1429-8095-499f-9873-b000cadbf92c)(label(Some))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
@@ -648,14 +678,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          919758e1-8a23-4966-bde7-81ae6624b561)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         cc0d0432-c5a5-4aa7-906d-05feb2349b4f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a4980fd1-7d51-46df-b1aa-9ab697668812)(content(Whitespace\"\\n\"))))(Secondary((id \
-         83291a35-916d-4605-b9f7-18e44c4da91e)(content(Whitespace\"\\n\"))))(Tile((id \
+         d1b5c9de-5bdd-4591-b9ff-5616ae38fcb5)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         516901f5-0aae-4960-8e38-08f61943986c)(content(Whitespace\"\\n\"))))(Secondary((id \
+         ec31fc12-ba19-4650-ba21-eb8f4e21d4ac)(content(Whitespace\"\\n\"))))(Tile((id \
          ec9f3218-8de6-44ee-a459-a86a688eb310)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         c0c879c1-f958-45f1-9158-299a12af3f33)(content(Whitespace\" \
-         \"))))(Tile((id \
+         686c9f6f-573d-4bc2-bb4e-cf6a852aca2c)(content(Whitespace\"\\n\"))))(Tile((id \
          8943f392-4ed9-4cce-996c-656d6f91a746)(label(find))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -668,26 +698,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1d477de1-d572-43b7-8d74-db9d99e625c4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bf396e64-6955-4a17-a9be-ed766e914809)(content(Whitespace\" \
+         2fc43699-944f-4b8a-91b7-cb3598b30b7d)(content(Whitespace\" \
          \"))))(Tile((id \
          846f816b-b025-4e8f-9bb5-3e76a4972c95)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          c88fb6b6-4db0-495c-a81f-ea1113040ad7)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ef375ab8-2cd1-451c-82cb-e301dff5fa3b)(content(Whitespace\" \
+         \"))))(Tile((id \
          db6034ac-5d6a-42af-84fe-83bea33f7b5d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fca79b9a-ab84-49ab-b9a7-c3fa40ede700)(content(Whitespace\" \
+         \"))))(Tile((id \
          c3b20a1f-69f5-4d32-a0a0-deb124b01587)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         0a7f036b-d354-4ca0-bc42-d569d74a0f35)(content(Whitespace\" \
+         33b80bac-0a4b-4966-8811-a40f8aabd408)(content(Whitespace\" \
          \"))))(Tile((id \
          76ec1167-1bff-41ff-b0ac-7c2dac31d390)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c44e84f2-a202-4329-916b-b14db021b1d2)(content(Whitespace\" \
+         a7166cfa-d57e-4675-af06-9a43448c0042)(content(Whitespace\" \
          \"))))(Tile((id \
          fdb20916-238f-4630-b356-909bb415a80e)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -698,21 +732,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          66f31b22-3f83-4f03-aaee-17a23420a03e)(label(2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f6392cc5-d4d7-4b18-9cb4-6bb7e4c5e466)(content(Whitespace\" \
+         da2b28e8-4a58-49b8-80ac-5aed91ef34aa)(content(Whitespace\" \
          \")))))))))(Tile((id \
          1d257419-1aa6-4038-9ca1-d554a1c9b16e)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8a395a5f-945c-451c-9e1f-5a7a65e70083)(content(Whitespace\"\\n\"))))(Secondary((id \
+         5ac7cc46-94fb-459f-843d-dd1f7cc65153)(content(Whitespace\"\\n\"))))(Secondary((id \
          a00af839-cd49-4afb-bc7a-3157a42775bb)(content(Comment\"# Idiomatic \
          way to do this is type safe but requires the user to project the \
          labels manually #\"))))(Secondary((id \
-         332de44d-69f6-4062-8d23-afa92a72b706)(content(Whitespace\"\\n\"))))(Tile((id \
+         268c9cda-e365-4e1d-af0e-997da8a2f1bc)(content(Whitespace\"\\n\"))))(Tile((id \
          cb22b110-4990-4f62-ae7b-adf3bb8841ef)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         eb1a9553-2435-417a-b891-8e2a36fb8802)(content(Whitespace\" \
-         \"))))(Tile((id \
+         4f407649-64fb-45e0-8d8c-bc94214c9cf6)(content(Whitespace\"\\n\"))))(Tile((id \
          d481cd22-e8c0-45d2-af8e-fffdedd651c6)(label(find_index))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -725,29 +758,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6f376075-260b-467c-a0a8-6ebbfa8a5a9c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3c274a4a-c863-4aeb-817f-c39658100739)(content(Whitespace\" \
+         f8c7051e-9d79-4366-87ed-3cab52364d86)(content(Whitespace\" \
          \"))))(Tile((id a8b7e957-602e-4647-86e1-738c2c9eefe3)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         c1faf9f3-fed6-4069-973b-5461f652088a)(content(Whitespace\" \
+         2f9270c6-d30e-44f7-a942-2237c18ceb67)(content(Whitespace\" \
          \"))))(Tile((id \
          034eb2f0-67dc-452b-b7b2-c0c83928aedf)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         99344399-2eba-4d36-936f-ada6c88df21d)(content(Whitespace\" \
+         47c1c0cf-f669-4f26-99b7-1ff38050fdeb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0d679487-0fd7-4b95-a876-0150f105205e)(content(Whitespace\" \
+         d878882e-345c-4f7b-bf8a-5d367ac252c6)(content(Whitespace\" \
          \"))))(Tile((id \
          9b918b14-b267-4be6-a482-98faabac0dfd)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         8db01baa-4f15-43d3-87de-548ace5a3380)(content(Whitespace\" \
+         5743bdba-9d73-4c4b-b9f5-ad5939602821)(content(Whitespace\" \
          \"))))(Tile((id \
          fe32b032-4103-4ffe-b371-b8ba09ec5150)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b95c8c86-66ae-4770-818e-89dbc78573b8)(content(Whitespace\" \
+         b6ee2cc1-4492-4f8c-a23c-188dd18235c1)(content(Whitespace\" \
          \"))))(Tile((id \
          0490690c-8825-4a33-9d7d-997e0e6125c0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -755,31 +788,35 @@ let out : string * Haz3lcore.PersistentSegment.t =
          66127883-32dc-415e-85b4-ea031381bf4e)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c14e7cb5-946b-4e28-8359-0a2f2dceffec)(content(Whitespace\" \
+         6f5176a7-31cd-4624-9dee-40197cac0e85)(content(Whitespace\" \
          \"))))(Tile((id \
          8e735631-e7e6-425e-b317-c27ecfc62e62)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e13eff14-3278-4c2f-8939-66ee66204aaf)(content(Whitespace\" \
+         8c4ffdbb-700d-4ad7-8b4c-2abdd9386c24)(content(Whitespace\" \
          \"))))(Tile((id \
          c6cc911d-27ce-44e8-9290-67dedf78601b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          5f6ad5f2-5a0d-47ab-97ba-9fb7ea2e2cc2)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         dbf7c0af-4c5b-4943-8c92-4d19234845f3)(content(Whitespace\" \
+         \"))))(Tile((id \
          97b19079-b958-4f41-a972-e503c204e3bd)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cadee05a-81d4-4ba4-8663-ad1773a65e6f)(content(Whitespace\" \
+         \"))))(Tile((id \
          920560cd-56fc-47e6-bbba-6353f7570e71)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         316ead2d-587f-463b-b5a1-17a8524c3770)(content(Whitespace\" \
+         464ea9db-ea72-4a27-a2db-867d0b2859df)(content(Whitespace\" \
          \"))))(Tile((id \
          a1a0e915-edfb-40a4-97ee-395213d1562f)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         77a8aaa4-6593-49c6-8765-ea77e6235ae0)(content(Whitespace\" \
+         4de76fbb-98f0-47a5-8dff-ee1adbd74768)(content(Whitespace\" \
          \"))))(Tile((id \
          17ff99cb-91e6-482b-958c-17bd809bcfd8)(label(Some))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -790,41 +827,48 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7fa0852b-1773-4d0e-9346-cb538949e4f2)(label(2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c1c270fe-b90e-4f1f-abd7-50600dbd0c21)(content(Whitespace\" \
+         3f82101b-f587-4cea-beca-cc6a8239f04b)(content(Whitespace\" \
          \"))))))))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
          let students : [Student] = ^^fold([\n\
          (\"Bob\", 12, \"blue\"),\n\
          (\"Alice\", 17, \"green\"),\n\
          (\"Eve\", 13, \"red\")\n\
          ]) in\n\n\
-         let requires = [\n\
+         let _requires = [\n\
          (enforced=^^check(false), \"for all c in header(r), c is in \
          header(t)\"),\n\
-         (enforced=^^check(false), \"for all c in header(r), schema(r)[c] == \
+         (enforced = ^^check(false), \"for all c in header(r), schema(r)[c] == \
          schema(t)[c]\")\n\
          ] in\n\
-         let ensures = [\n\
+         let _ensures = [\n\
          (enforced=^^check(false), \"result is None or Some(n) where n in \
          range(nrows(t))\"),\n\
-         (enforced=^^check(false), \"if Some(n), then getRow(t, n) matches r \
+         (enforced = ^^check(false), \"if Some(n), then getRow(t, n) matches r \
          on all fields in header(r)\")\n\
          ] in\n\
-         let find = fun (t:[?], r:?) ->\n\
-         let is_match = fun (row:?) ->\n\
+         let find =\n\
+         fun (t : [?], r : ?) ->\n\
+         let is_match =\n\
+         fun (row : ?) ->\n\
          let row_entries = to_lvs(row) in\n\
          let r_entries = to_lvs(r) in\n\
-         all(r_entries, fun e ->\n\
+         all(\n\
+         r_entries,\n\
+         fun e ->\n\
          case find_opt(row_entries, fun e' -> e'.label == e.label)\n\
          | Some(e') => e'.value == e.value\n\
-         | None => false \n\
-         end) : Bool in\n\
-         find_index(t, is_match) : (+None +Some(Int))\n\
-         in\n\n\
-         test find(students, (age=13)) == Some(2) end;\n\
+         | None => false\n\
+         end\n\
+         )\n\
+         : Bool in\n\
+         find_index(t, is_match) : (+ None + Some(Int)) in\n\n\
+         test\n\
+         find(students, (age = 13)) == Some(2) end;\n\
          # Idiomatic way to do this is type safe but requires the user to \
          project the labels manually #\n\
-         test find_index(students, fun r -> r == (r ... (age=13))) == Some(2) \
-         end";
+         test\n\
+         find_index(students, fun r -> r == (r ... (age = 13))) == Some(2) end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesgroupByRetentive.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesgroupByRetentive.ml
@@ -6,93 +6,100 @@ let out : string * Haz3lcore.PersistentSegment.t =
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         6b0387d5-79c7-4f2a-bff5-a7dfa25ed7fc)(content(Whitespace\" \
+         b9d17167-606d-4efd-8b5b-7b0bee7fb394)(content(Whitespace\" \
          \"))))(Tile((id \
          aa1a0db1-c61e-4594-89e2-6ee4be76c7c0)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         e77df420-6954-4ff2-a5f6-de9e40cfdab4)(content(Whitespace\" \
+         1e0494bf-3757-4804-9572-38ebde963bff)(content(Whitespace\" \
          \")))))((Secondary((id \
-         fe27199f-05ca-44d2-aa71-8bce5ed9896f)(content(Whitespace\" \
+         4294a53b-2c72-4ac9-ab1d-69ff19b68c76)(content(Whitespace\" \
          \"))))(Tile((id \
          0c144a8f-77ce-4410-a8d0-0c85400fa71f)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          52feecb7-e589-4e69-aea2-c24bc649e7c1)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         61a68216-ad1e-49f4-be62-77f2bab56131)(content(Whitespace\" \
+         \"))))(Tile((id \
          b6023386-260b-40a6-a00c-3396655b5c15)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         83ac8ca3-2f91-4c76-819b-28229a75a607)(content(Whitespace\" \
+         \"))))(Tile((id \
          c1ca0ff3-15a7-4f51-9729-b283c7b4f60c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          8da3eac9-80bb-47f0-84ee-4a7f75d5c4d7)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         722e7530-78fd-47fa-86ee-cbc88a86aab6)(content(Whitespace\" \
+         746d293a-efe0-4645-8981-5b0c9d6008b9)(content(Whitespace\" \
          \"))))(Tile((id \
          6d731dfd-2f42-4c10-a791-03e3f648f827)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         98b398a5-9c7c-476d-a0e5-b3986ef530d3)(content(Whitespace\" \
+         \"))))(Tile((id \
          7346d1d3-34d0-4031-8099-e87efea90b8d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f93120d0-5d0d-47c8-a4e7-484d4f2a422e)(content(Whitespace\" \
+         \"))))(Tile((id \
          2249c78d-99f4-4d6f-b5a7-abb654db1d3f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          78617bfc-600a-4c7f-b841-450bbaa67650)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ad3ceb97-f159-4c52-8ed6-620ab896aa8e)(content(Whitespace\" \
+         4103cdbd-2338-4c2e-9366-a7d53dc822cd)(content(Whitespace\" \
          \"))))(Tile((id \
          4afa00a7-f958-4278-abd9-8585d952a9f4)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e28b1add-bd23-4cea-9ff7-a2d0e19e3e7c)(content(Whitespace\" \
+         \"))))(Tile((id \
          db4f3a9b-f3da-4877-9e1d-32db7803bde4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0e72a625-2da4-4b1f-8a04-8d0ebb3918cc)(content(Whitespace\" \
+         \"))))(Tile((id \
          ea413540-59c3-4f2c-8b87-1cef5b7d4a0c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         8c251f9f-2772-41f8-b9d3-494c67d2aba1)(content(Whitespace\" \
+         c4069299-55a5-4de5-93df-622528bfba46)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3eff469d-67a9-414f-bd59-7f36b145e284)(content(Whitespace\"\\n\"))))(Tile((id \
+         60111373-19b8-4e98-87ea-755b3ca0503b)(content(Whitespace\"\\n\"))))(Tile((id \
          9a6d5e56-33e3-4dbc-8e5f-ef7a2d060d1c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a3f6bbf3-baa1-4481-ab79-92a1073e39a3)(content(Whitespace\" \
+         0a017673-e1b0-4df4-8cd9-89fbb6545c86)(content(Whitespace\" \
          \"))))(Tile((id \
          b0f3bea5-4f0e-452e-8deb-e51b03983fc0)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9d124e5a-0fbe-457b-b326-b02c6f40febb)(content(Whitespace\" \
+         dffd6e03-30c9-40fc-8faa-a86ff9d5b7d6)(content(Whitespace\" \
          \"))))(Tile((id \
          96fe3789-3575-43eb-9747-075b8fb6d1e0)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         648108f9-dbb8-4ef9-8b4d-2bab5c8bb248)(content(Whitespace\" \
+         d88d4e2e-408c-449c-ab7c-000874d71e9e)(content(Whitespace\" \
          \"))))(Tile((id 2488c81d-999d-4b21-9e40-834c68d2cf94)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          cf4813d2-ab4e-4900-8d42-3677df068333)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         bdb1fb3a-5599-4d72-929d-44ba6909fb92)(content(Whitespace\" \
+         29a081ed-3f26-4a8c-b9ac-da893a4a7fbb)(content(Whitespace\" \
          \")))))((Secondary((id \
-         be9bcb6f-2d60-4f85-837c-65d7656b99f8)(content(Whitespace\" \
+         67712093-b267-4290-8574-4756d9f259d4)(content(Whitespace\" \
          \"))))(Tile((id \
          ff2714c4-bda0-4b9b-a2f3-45f22e4f07e4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          53ebc806-59fd-4e1f-aa34-29c15c767199)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         e60e7e9d-8234-460c-ac1c-b95beaee95aa)(content(Whitespace\"\\n\"))))(Secondary((id \
-         65c95185-a1d7-47e1-a25e-a57b3e8671ac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         718f90dd-e2fb-4789-823b-ce19d19c9c9a)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0 1))(children(((Tile((id \
          a2111496-2a42-4a84-aa69-5915be1311bf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -118,10 +125,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          84b937d3-3831-4b97-8337-1219b75c0d8d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3bbd1e71-aa24-47b5-859c-d7d3262bb1b2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6d7c5b2e-aa54-4061-953e-c43e0462b220)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e98cceab-b05e-4b68-9ae9-30fba0374352)(content(Whitespace\" \
+         1d78c0dd-b616-4aad-a775-8393f282d39b)(content(Whitespace\" \
          \"))))(Tile((id \
          be9cfd82-59ec-4194-aa45-9611d0c89bcd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -148,10 +152,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3c1db267-fb27-4711-a27a-3da614623ca2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         91177f9a-d8fd-417d-97ad-6a59bf4e0f0d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0d2c2e04-c315-47d1-9f03-a59c09bbd594)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         19959210-aadd-4bd3-86bd-5afc204d6e27)(content(Whitespace\" \
+         0082a052-e4bb-4522-b756-bd43dc491b20)(content(Whitespace\" \
          \"))))(Tile((id \
          9e2c2d61-8746-44da-a802-330204c25d82)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -162,7 +163,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          462e6f0e-bf42-46d0-8a07-be8e6019e1ad)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3af7b069-9981-4b44-8e38-f3f409bf6c4e)(content(Whitespace\" \
+         61274be5-0554-4942-90ce-ec94bd10ca17)(content(Whitespace\" \
          \"))))(Tile((id \
          5e7e2211-232e-42dd-94dc-0cdcdd8f570b)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -170,33 +171,34 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c946369c-721d-42b2-b3cc-72f23a3c69f0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a6717c85-8c5d-451b-8b71-fd39e6a88a48)(content(Whitespace\" \
+         38e2a2dc-5dfd-47eb-af2c-fce4987ee726)(content(Whitespace\" \
          \"))))(Tile((id \
          e55f5a5e-d999-424b-b39c-158cfed9d28f)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         be860acf-8872-4045-9f39-d7fafb9fcaa3)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         9d432b0c-8bc4-42b5-984f-56de7722d596)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         31cca858-0caa-465f-8d74-3119743ca2cb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b71ff4e2-e4f0-41a6-8ce3-7ca547598084)(content(Whitespace\"\\n\"))))(Tile((id \
+         a212ab4a-fa5b-4c1e-9bb2-44fa9faeb0d7)(content(Whitespace\"\\n\"))))(Tile((id \
          c15ecad5-980a-44b6-91b5-f282249ecc4d)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         2219c3b9-b3f5-4ba9-bc53-2a5cea2a93b2)(content(Whitespace\" \
+         30c05863-4c56-4852-85f3-eed8bd76cac4)(content(Whitespace\" \
          \"))))(Tile((id \
          edfb3007-049b-4864-8af5-32de8e3b9d79)(label(expected))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         37cc0b0c-40d7-4ff5-9b22-46cab1081e03)(content(Whitespace\" \
+         b41aeb10-13b5-4f5a-ae22-4f56b3e6acb3)(content(Whitespace\" \
          \")))))((Secondary((id \
-         df40dbd1-3849-4913-875b-3369cdd639e2)(content(Whitespace\" \
+         aa9b9d27-aff7-478a-a52d-e947dc86b8e2)(content(Whitespace\" \
          \"))))(Tile((id \
          33c5be00-564a-48fa-a615-4b180b073306)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         143592f8-668e-440b-8502-ae211e5335e8)(content(Whitespace\"\\n\"))))(Tile((id \
          4f4acde8-7ee8-43ce-8fe5-cc5d564eb7c4)(label([ ]))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         5af6ff82-40c6-42fe-a8b8-a1f587115c09)(content(Whitespace\"\\n\"))))(Tile((id \
          90d7ff04-1146-4596-bee6-a03ea4587b4e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -266,8 +268,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ac1594ad-8813-4274-81cf-0d000aa11ba6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         813d78f7-cf51-4c3e-bca9-f00d84aab7cc)(content(Whitespace\" \
-         \"))))(Tile((id \
+         cd604917-b442-4a3b-a080-a7773c613296)(content(Whitespace\"\\n\"))))(Tile((id \
          3e625569-941d-40b9-92c6-ef827cdbe4fe)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -337,120 +338,127 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0f949f8d-a936-498b-9486-9b8a22c9784b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         96198ee0-5858-4c13-add4-a6eeb5597fbb)(content(Whitespace\" \
-         \"))))(Tile((id \
+         7073bc9e-dd0e-4594-bb22-c9ea13495dcf)(content(Whitespace\"\\n\"))))(Tile((id \
          9f7d4b17-cce8-4afb-b407-12c1b0ead939)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          9f581b3a-2929-4f05-85dd-854a085b5c58)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c6610107-a8fe-47ee-9ae4-02af70657c8f)(content(Whitespace\" \
+         \"))))(Tile((id \
          8d610bd8-83e7-497f-9320-b623caf599c8)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a86a3c8f-cb54-4eb0-b87a-dca6b7705a8c)(content(Whitespace\" \
+         \"))))(Tile((id \
          d54dce73-0cbf-421e-954e-39f933e187cb)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          d8930486-f190-4eab-8183-a1f09886068b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e6bea874-8b71-482c-841b-ef85946dac28)(content(Whitespace\" \
+         01a5a967-0d0f-4062-9dd3-cce000f51ee6)(content(Whitespace\" \
          \"))))(Tile((id \
          5f546a72-1a10-437b-8502-20028f30e9dd)(label(groups))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         91e71640-53e7-40d6-af98-373df61bf9e0)(content(Whitespace\" \
+         \"))))(Tile((id \
          34b6ad72-0dae-4e76-899f-e39ed1738577)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         95f5f2a0-468a-43ec-944b-353a980773e5)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         9f26dd83-dd35-4cee-ad30-fd66a67bd43c)(content(Whitespace\" \
+         \"))))(Tile((id 95f5f2a0-468a-43ec-944b-353a980773e5)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          7e8b5446-31f0-4001-b267-8af994e79eb8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          dd6ed094-f7c9-49b4-8f4e-af59ab4a619b)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         0da2a8f2-15a6-4806-8b24-41745d30f80e)(content(Whitespace\" \
+         \"))))(Tile((id \
          ad950297-662e-4da4-8bd1-5c30a401b8b0)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         20a62b81-6282-411c-a1f4-1891fe145e16)(content(Whitespace\" \
+         \"))))(Tile((id \
          d63cb69e-61a4-4d04-82e5-970d652f3e3a)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          be152d76-1d7b-4b7f-a79c-4a4bf66588dd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5e999dab-9558-4e92-9b91-d5ac6104bcd8)(content(Whitespace\" \
+         b4945662-472d-4250-8745-cb8ae08b0920)(content(Whitespace\" \
          \"))))(Tile((id \
          01085fe7-bbb2-40a6-8f71-171ddfb39d18)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         d3bdc9ac-cda8-452a-a1c9-9a62a1c03e14)(content(Whitespace\" \
+         \"))))(Tile((id \
          f5c68080-043a-4282-86f4-8d97d1d8d2d0)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         e835ba61-a7fa-444a-86ad-7e1a923af91c)(content(Whitespace\" \
+         \"))))(Tile((id \
          4b9ca1a6-f6b6-442e-a615-af47663bd5a0)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          3ae4ebcd-019d-4dd0-bbb6-4ca44cb99cc2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c69769f7-a7c3-4173-b868-009b2160a997)(content(Whitespace\" \
+         a4651052-2999-40ac-99e6-43dfbca0e797)(content(Whitespace\" \
          \"))))(Tile((id \
          12bdc58f-f72d-4812-943a-2637ad80559d)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3e2c4744-af57-4292-8db1-e2d7a216a2cf)(content(Whitespace\" \
+         \"))))(Tile((id \
          0d8c98db-a1ba-4411-b116-58a97392b1ed)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         6af5e17f-ff80-4bef-88dc-d43df185cb9d)(content(Whitespace\" \
+         \"))))(Tile((id \
          017948c7-7343-4a56-b166-34a6e1f291aa)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))))))))))))(Secondary((id \
-         54079d53-0321-4847-82a0-9a41c1258a56)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
+         ed7ac206-ee7c-46b5-bc4a-676d355889ae)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         cb26a19a-1ab7-4977-be62-6b18067eaf8f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         82483139-1c68-4251-bbbd-03c274195bf6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         541532c5-d50f-48bb-8e85-9e0d75a94a93)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8db10eae-b227-4c14-ba7b-2fb72f3df800)(content(Whitespace\"\\n\"))))(Secondary((id \
+         159d71e7-7e42-42e2-b300-d0b08b2535c1)(content(Whitespace\"\\n\"))))(Secondary((id \
+         4539aa95-3dbe-4672-8a17-bba3d7dcf763)(content(Whitespace\"\\n\"))))(Secondary((id \
          a04c584c-3b5b-4573-bb14-80bd85e2203c)(content(Comment\"# This way \
          closely follows the TableAPI by taking a string column name but \
          provides no static guarantees #\"))))(Secondary((id \
-         b205f3a1-65f2-4a05-9f62-9b6651851e98)(content(Whitespace\"\\n\"))))(Tile((id \
+         c671d623-a711-48f4-9bd7-b1faed5705a3)(content(Whitespace\"\\n\"))))(Tile((id \
          a29d0335-b442-4089-99fb-f0cae627b0cf)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8fdfc770-2d32-4f07-b498-a8747254b970)(content(Whitespace\" \
+         a48ba325-13e0-48d8-80a4-8d561bb54540)(content(Whitespace\" \
          \"))))(Tile((id \
          4a5deeff-27c3-4119-b61f-d151b0475744)(label(v1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9619262d-396c-42d5-adb6-ac56c5ac4608)(content(Whitespace\" \
+         e3c95169-f810-44aa-a8bf-f75987d9b87f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         abd29fec-86d1-44dc-b461-54139b5c8343)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ba13f2ae-aeec-48f2-add6-3ef839249463)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4c8ad656-c611-42e6-9e4a-2ace81104d08)(content(Whitespace\" \
-         \"))))(Tile((id dc5f3135-ec04-49c7-bd82-ea2c56df080e)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         bfe700c8-9a5c-466e-a70e-e8ad92392f21)(content(Whitespace\" \
+         76f39b1c-ad72-459c-a71a-b6c8382d345b)(content(Whitespace\"\\n\"))))(Tile((id \
+         dc5f3135-ec04-49c7-bd82-ea2c56df080e)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         44df0c32-1f96-4eb6-97ad-c706e87ed0d8)(content(Whitespace\" \
          \"))))(Tile((id \
-         5213356a-06d4-41bd-8fd3-f5bafef4cdd6)(label(requires))(mold((out \
+         5213356a-06d4-41bd-8fd3-f5bafef4cdd6)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         4d0f0fcb-7e87-4bfd-a752-68f09c4689d5)(content(Whitespace\" \
+         673b896a-6261-440b-a3d0-24a83910aa7f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d0ffaec3-891c-4244-8345-1f06adaf6e7a)(content(Whitespace\" \
+         fc089871-0766-40fc-b438-2c326b0b874d)(content(Whitespace\" \
          \"))))(Tile((id 7895c037-c34f-4924-9664-f153d2743976)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2e49b986-3047-45c0-a269-53de25cba008)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b9b2b790-4537-4062-b93b-155be421f9d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bb4080a0-463c-48a1-94cc-e3ebf3680978)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b1f82d23-c1ad-4146-8643-7689eefb9d76)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         41835f90-e40d-4463-9aa3-0719aad31f34)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          f198b465-0fcc-4e21-8b9c-11d4541e3bf6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -477,24 +485,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c487784f-d712-4a27-a662-0ed3bb72d3b0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         42e8721a-7fd2-4614-b004-d016fe53be31)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b8bf3346-b91b-43fd-80b2-c7f3bc4238a2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cdf00bd7-9791-43df-abdd-0ee7ac816688)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         56e76788-7e4e-46c5-ad9f-c2e1a5a203de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         659a5613-e8c0-496d-bae9-8d8d96ab3d8d)(content(Whitespace\" \
+         dc8a4400-8487-461e-bc0b-2236ddd7623e)(content(Whitespace\" \
          \"))))(Tile((id \
          10d299c2-3888-42dd-96d6-0bc9414f8350)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          b34e9776-018c-4f8a-a544-b1101f84c22b)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2930b201-89a6-40e6-91d4-be96a3dd7b7d)(content(Whitespace\" \
+         \"))))(Tile((id \
          97c7af07-c23b-4e47-9739-c4f96bc040d8)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         94da5534-fc0c-402e-8191-9ff073038dfb)(content(Whitespace\" \
+         \"))))(Tile((id \
          e314c9ff-7e85-4b61-9330-50a5e8daea5b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -504,47 +509,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          daf2aec4-8d67-4e2b-b1b1-2177e75b1ee4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d4e66ce4-b834-4d11-aa6c-021f2b87e1bc)(content(Whitespace\" \
+         1d16fc2b-53d2-474b-b5a6-a4141c159d40)(content(Whitespace\" \
          \"))))(Tile((id \
          1e713cf0-40d8-4c0b-8141-7a4a9d7f7ab5)(label(\"\\\"schema(t1)[c] is a \
          categorical sort\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1dcb738b-d346-4c5a-a376-9824024e6d92)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2252a528-4ad7-45d5-8bee-612a81b312a1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         643386d9-b1bd-4969-af3b-317658b856b3)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         3c54cac1-0fcf-4ab9-859e-d5c41d192f35)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         30514810-6602-4d65-b09d-54257581b37b)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         20310ef5-b8f2-48ba-a2af-9551aa3e5e5c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         73ade6f0-9ef8-41cc-8803-24cf8c7a40b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c8383d8-eada-468f-94c8-20004a5d0078)(content(Whitespace\" \
-         \"))))(Tile((id 76b9472b-b807-4251-98de-8ce9ceadf556)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         3a693753-916a-4ef6-a985-b9b036ddf9b4)(content(Whitespace\" \
+         72f826ca-daee-46b6-ae3b-586a33b26519)(content(Whitespace\"\\n\"))))(Tile((id \
+         76b9472b-b807-4251-98de-8ce9ceadf556)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         df80f6c1-3d4a-48fa-94b9-1e87f6e74706)(content(Whitespace\" \
          \"))))(Tile((id \
-         745fea3f-5ea3-4e54-8c93-e2685def0f32)(label(ensures))(mold((out \
+         745fea3f-5ea3-4e54-8c93-e2685def0f32)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         017daf52-3e64-4a0d-806b-e79307d3eda2)(content(Whitespace\" \
+         f2f9b501-9149-4efe-bcd5-0afc10ebadba)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d50fa2ee-bb8d-44ae-bda8-d254e4d9d079)(content(Whitespace\" \
+         6aa800d9-dec0-43c8-8c39-a96c76a19c47)(content(Whitespace\" \
          \"))))(Tile((id 4e83fd93-a5db-4d50-865b-93f9a0e599d2)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         03e09c79-a5de-4259-ac6b-cfca7120de8e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2d42e39a-5365-479c-9828-c6b69f54cc23)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         63828677-095d-4dd2-a6e6-55030f5ecced)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46933b94-7e3c-4531-881c-7e9480c76dea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6dac6d6d-a907-44cc-8ed8-9923b8dc5263)(content(Whitespace\" \
-         \"))))(Tile((id \
+         49201a65-6616-4ef1-a8cc-8ab795a1173c)(content(Whitespace\"\\n\"))))(Tile((id \
          98762de0-f3fc-4e54-853f-8b39383c61f4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -572,15 +560,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2c82966f-d497-4323-9f22-3df7cec83b4e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bf8701a8-c314-42bb-b258-2d02bb9bab82)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3c1da876-a6a4-4426-a5aa-4d23e56e4021)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         211ab904-efe9-442a-a330-7db19f4b1f81)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         12dbcf2c-d3a7-4028-897b-cea154f0484e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         10082ca8-1844-4e32-8495-d346e1f73aa3)(content(Whitespace\" \
-         \"))))(Tile((id \
+         5e5b6c14-911e-4573-9325-f9db00086089)(content(Whitespace\"\\n\"))))(Tile((id \
          4b9f9192-2064-49f6-8179-d2308ff3a777)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -608,15 +588,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ad52d3ac-0e74-43d2-a244-76dbc7ada5ae)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2412f79c-a339-4262-b626-e8578acb0e10)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e1f1fb9c-56d6-4f49-956d-f8bc89181fd4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3c532cd2-0dcf-4ded-bf2e-f1b30424f69f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         42d91708-fa5a-47b9-9461-564001992bf5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4aa77add-c585-41bb-9b4a-aaf54432aeeb)(content(Whitespace\" \
-         \"))))(Tile((id \
+         1d8983ea-d85e-4b64-a7fa-2fe63a7c0822)(content(Whitespace\"\\n\"))))(Tile((id \
          e6226e57-678d-4bf3-9e15-56d4f792d8d9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -644,15 +616,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d912e6c6-a1fb-4a4d-aeb5-4e9041abc12c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         290219d3-537a-493a-a5b0-9561d7b6e4b0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         401156d1-ea1d-43e6-a837-d672634b8ec3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         322ec3fe-d780-4a9e-8bbc-c184b9a2ba45)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8f42eee9-be10-42fd-9dc9-513a742c62fb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a331efce-f3b9-465f-9ed4-8ce9d3994053)(content(Whitespace\" \
-         \"))))(Tile((id \
+         8ffed97f-5323-42df-a38b-2ce39dcd0e69)(content(Whitespace\"\\n\"))))(Tile((id \
          7434aea8-87a7-4a68-b34c-4b71a22d85c2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -680,15 +644,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8849d1f0-baa0-4c35-9816-bb6be3407df2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f52768c8-933a-4060-8430-131df97779d8)(content(Whitespace\"\\n\"))))(Secondary((id \
-         30826ef5-dffc-4244-8058-9de03b87f014)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e64fb391-2387-4a29-bb81-a11520880b0f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e062672c-98fa-40f1-bf9b-c97cf4e8a467)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aaa82768-288c-43cc-9ab4-ce1b60d7c0ec)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e5f3a08d-07f4-459d-8e17-8aed6f140152)(content(Whitespace\"\\n\"))))(Tile((id \
          e8d28f24-c42d-47d1-bced-3cc5a1806686)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -716,24 +672,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a58f4470-f4d1-4d81-9579-0c8260d01f1d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6b0a32d3-6645-4fb6-a850-fffa32c36a14)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1b919933-54e5-44aa-9a94-6b4385044ec6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         35c0e6da-4b38-46d9-82ec-13f70a0ca212)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d126cbd-e7c7-4b3d-8aec-a36ead4a9214)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         39f2a88b-6c1d-469a-b074-ffbdbe8e4de8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         b954a5f1-3059-42f3-9918-850087784f79)(content(Whitespace\"\\n\"))))(Tile((id \
          6a061b5f-14a6-4dc1-9f74-9ce7a68a6292)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          e9540683-f64b-443d-88fc-cb74e8729f2b)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         18918960-21ed-4318-9e94-41d091fc6f0b)(content(Whitespace\" \
+         \"))))(Tile((id \
          3621b41d-5b7e-4e35-afa0-219ba9109593)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         beefea88-1662-43f7-8a2b-7abfb45c0d5d)(content(Whitespace\" \
+         \"))))(Tile((id \
          8d871960-e8e3-431c-9760-cddff7c6639f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -743,143 +695,125 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bad54c85-f2f9-4e7b-9eb8-14e93a5aaeb4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3ec47573-3946-4676-9920-212043c499ed)(content(Whitespace\" \
+         ddbac2a9-5f6f-4904-99f4-bb46b3fbe619)(content(Whitespace\" \
          \"))))(Tile((id \
          8454dc70-1667-4c97-aa63-92f6caa4caa4)(label(\"\\\"nrows(t2) == \
          length(removeDuplicates(getColumn(t1, c)))\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         250de0aa-6a1a-4026-82e1-a62e730822e1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e1ab694c-bc31-4c3b-b369-527ef26190dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e390ec00-2e1c-462d-bb05-d214bc969327)(content(Whitespace\" \
+         28b13874-248c-41d1-825e-77f76e107415)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         548dd16b-c506-4046-b239-787ae2da19bc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1f1e4516-f479-4114-a2f6-4633a0fe91c1)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         6e0af931-a6db-486e-ba53-5d1c89ebfe05)(content(Whitespace\"\\n\"))))(Secondary((id \
-         69d543a3-9954-4065-9150-a1cea0bd031c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         58ff8649-ef33-4fac-bf9b-f6acaf7be511)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d02eaf1c-99e7-44b9-b841-e4fe1da8fccb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         af1b500a-7fa1-4517-8562-3ec3f514090f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8a684b04-7910-45e7-89e4-d776148f824a)(content(Whitespace\" \
-         \"))))(Tile((id 86123782-51ef-40ca-8be7-3b15ba327998)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         322cf60d-1203-4368-88aa-2cf47048ed72)(content(Whitespace\" \
+         9e40f5d1-6061-4360-8cd3-f70e59a9b352)(content(Whitespace\"\\n\"))))(Tile((id \
+         86123782-51ef-40ca-8be7-3b15ba327998)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         df716b0e-c271-4cce-bc5b-2567673a14ec)(content(Whitespace\" \
          \"))))(Tile((id \
          a591bb9a-4090-4d93-89ff-6e78f56ee2dc)(label(group_by_retentive))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c88c2ed1-0fdc-42c6-a3eb-0eca8c427ea6)(content(Whitespace\" \
+         9fe3c4ff-0438-4dfd-a11c-5597bec79a09)(content(Whitespace\" \
          \")))))((Secondary((id \
-         19b1a8c4-fe18-4993-9dab-6694d545fa88)(content(Whitespace\" \
-         \"))))(Tile((id 85287f44-4a5e-44ab-9a07-94d52eea0a36)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         b5493ecf-556a-44d7-9827-eb294c9b57ad)(content(Whitespace\" \
+         30a9a4fa-00a9-4665-b801-4ec9926a6c49)(content(Whitespace\"\\n\"))))(Tile((id \
+         85287f44-4a5e-44ab-9a07-94d52eea0a36)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         f869d3c7-0158-4223-80d2-2c8cfa3cbfc8)(content(Whitespace\" \
          \"))))(Tile((id \
          cc672d3e-51ad-4108-8b53-9b33099e136d)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          5d20a262-4622-47a5-8d57-a8400b5ee023)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4bbe030b-065f-4ab6-8bb4-132066c9bdd0)(content(Whitespace\" \
+         \"))))(Tile((id \
          074738ea-bb57-463f-9402-cda62d6b2248)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         b7f7c87c-e9b5-4413-b5ec-9cf0f4427bad)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fc16c40a-0104-46db-b6b7-7a5597962c1e)(content(Whitespace\" \
+         \"))))(Tile((id b7f7c87c-e9b5-4413-b5ec-9cf0f4427bad)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          d77f833e-320a-460d-b817-39ae7d30b240)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          c020d9b8-01e2-4c63-9104-00484fac8a33)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         46dce191-d208-4e45-a1b4-1b1502737bb9)(content(Whitespace\" \
+         b8931a64-8751-4eff-bc86-7a2a221f2a64)(content(Whitespace\" \
          \"))))(Tile((id \
          6ae1dc6d-990e-4b1b-9bbb-06f230207cb9)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         568d8ed2-8d56-451b-a575-0f97798ec5cf)(content(Whitespace\" \
+         \"))))(Tile((id \
          2dba7f26-16dd-489e-83c6-87d44de86584)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3ec0a8cc-1e10-46e9-8c3d-b583936b43ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          80a8465f-c751-4a35-83e0-8f7b53dfc215)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d1d66e3d-650c-4481-ba1a-c468e766d5b9)(content(Whitespace\" \
+         f9387773-a054-4339-b4af-eb16167d9f6b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cbc45985-3865-4b67-961b-2c73857c9396)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cb6401e6-2f42-478c-b175-f3af686cc13d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e288897-fa45-401e-8989-b0a8099e3c2a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         891a5076-9560-4c7c-9970-e40c505bf8db)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d6a8522-cc34-45e2-937b-6803c7971e89)(content(Whitespace\" \
-         \"))))(Tile((id 3bb21f74-c4a8-46b1-bc23-76808ee8133c)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         b0d8a84d-6d0d-4df9-bc58-0f470fd415b0)(content(Whitespace\" \
+         af48b4ad-e863-453c-8695-059e766781fc)(content(Whitespace\"\\n\"))))(Tile((id \
+         3bb21f74-c4a8-46b1-bc23-76808ee8133c)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         6e09d542-8d73-4da4-bf6e-d17cb26d1df5)(content(Whitespace\" \
          \"))))(Tile((id \
          7bce25ab-b906-4c96-b39b-40bdd2bbec2f)(label(get_value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         36d0122b-aaaa-41a2-87e5-77df0b26a856)(content(Whitespace\" \
+         e890004f-76ef-4bdf-9e39-9f01c1cdda2b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         48ff0b87-62e9-4ce8-bf63-41f047697b41)(content(Whitespace\" \
+         00909ddb-3f10-4e17-bf7b-98da56baaf72)(content(Whitespace\" \
          \"))))(Tile((id 06934a38-1f71-487e-8242-593ac5aa8d4e)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         c8c5c1c9-13a3-4e84-8549-8e3508ff7cef)(content(Whitespace\" \
+         92f13bc5-137c-4fca-872b-28c9937f1d4e)(content(Whitespace\" \
          \"))))(Tile((id \
          877e0210-cc30-465c-b449-d5bad30cd8d5)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          0cc32b48-f5df-4df9-9538-a16bee5211b5)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ca7064b6-f481-4829-a926-348aff7bd76e)(content(Whitespace\" \
+         \"))))(Tile((id \
          1342ca0a-7110-4e63-ba4e-8681a524e2d0)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         30091e87-e49b-49f4-adf1-d5d24feb950d)(content(Whitespace\" \
+         \"))))(Tile((id \
          d2dfb608-2b91-448f-b73b-642d9a3227e8)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ce0332d6-2fae-40cd-97ac-79fec4ddd198)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         1be499bd-12a6-4b48-b252-d11e10e6a1d9)(content(Whitespace\" \
+         a73bc7fb-d5c2-4c2d-8cc6-8ee748190f80)(content(Whitespace\" \
          \"))))(Tile((id \
          e5ff5874-cee0-4f86-ae4f-d737c5b1b979)(label(label))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         63ef7f92-6355-403f-9e28-f9be7cfc652d)(content(Whitespace\" \
+         \"))))(Tile((id \
          9017b1cc-d12d-469a-8830-249c87b856f7)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         483d4782-9753-413d-984e-3996f6439188)(content(Whitespace\" \
+         \"))))(Tile((id \
          19b2bb73-d426-4525-95fa-95903402ae58)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         12eb35d6-7ff1-48af-a65d-fd43509cb429)(content(Whitespace\" \
+         2fd7b56e-585a-4ecd-ac15-1b07805df506)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c2fdf084-f1a0-41ca-8828-ed6ae24545fc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e0b6efb5-197e-446e-a469-dcffcb2daae7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5bf77064-7a9f-45b4-81b6-b4dcdf037dd9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fafe0796-db82-42d6-a527-3b60fe21564a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4ffebfee-070f-461a-93db-1bcbbe0786e3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bc1fe2b6-59b7-476a-8459-8a5508e2ed5d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         633f4f18-f59d-40ee-80a7-be60d7259aec)(content(Whitespace\" \
+         71b63c0c-1772-457b-bda1-72bbadf0008f)(content(Whitespace\" \
          \"))))(Tile((id \
          f675200d-7660-46b9-a778-44ff9dc9cac3)(label(find_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -899,19 +833,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dc1f8460-7a47-44bc-b2a3-41bcdd932c1c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f6f170b0-1d79-4b0e-8210-ba326d955adb)(content(Whitespace\" \
+         3c2e1712-ea8b-4eec-be9b-0523dbdc1cf3)(content(Whitespace\" \
          \"))))(Tile((id 12992c80-2239-4ece-b824-a6357d873e10)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a80ba012-607a-4759-951a-35705d712e67)(content(Whitespace\" \
+         9d128d3d-7199-4664-99c9-3dd4e7c421c6)(content(Whitespace\" \
          \"))))(Tile((id \
          42a4f225-3bbe-4836-9abe-00c51c7a1654)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a17249ae-1435-4311-a7cf-4226b3b5572d)(content(Whitespace\" \
+         0faa0dac-e41b-4b6b-8d32-679162c1642d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         98c7b1d7-c85e-4aa8-b0f5-e8b8c3757cb5)(content(Whitespace\" \
+         e372a384-f15b-4ef7-8bd4-2fc61816901b)(content(Whitespace\" \
          \"))))(Tile((id \
          d1d8c946-9f50-4651-b9a9-5e3f828f7278)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -922,22 +856,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d1244fc9-f789-4155-93ef-db25c61e4fba)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         de588776-88a5-437d-9892-16572adc55a8)(content(Whitespace\" \
+         0d7ad870-746e-458c-a97b-e6be102a1e3a)(content(Whitespace\" \
          \"))))(Tile((id \
          cde94013-4bb0-4118-af04-b5229a9e2936)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0691ef54-046d-4112-85a4-e91b41a32574)(content(Whitespace\" \
+         535b23e3-ea6c-4532-8cfa-f95a8f9ad2f3)(content(Whitespace\" \
          \"))))(Tile((id \
          cb076072-0b52-40dc-b010-16a5a59b2578)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         32c22947-c92c-42b3-aced-db84bd658636)(content(Whitespace\" \
+         fff4aaa5-966d-45cf-b814-6e213444ff87)(content(Whitespace\" \
          \"))))(Tile((id \
          e564b0e5-be98-4f08-bc2b-4ebec16610e6)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4b721add-a6eb-455b-aa49-0b146a8910d8)(content(Whitespace\" \
+         c3e24a3d-24ef-4330-ba5a-ba69e46a5a28)(content(Whitespace\" \
          \"))))(Tile((id \
          d427a2d3-0377-411c-a33b-41bb292d21df)(label(option_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -951,19 +885,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8144abe0-406d-4e35-b33d-93afca80edbf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8ee9e783-c88d-40d2-8b20-937e488ce7e0)(content(Whitespace\" \
+         6fa50551-8c1a-449a-9eb5-8df147607adc)(content(Whitespace\" \
          \"))))(Tile((id bec79a05-5952-4107-8f47-c7bab32e2a1f)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         c0504270-007c-4074-a144-0b15f4f6fa77)(content(Whitespace\" \
+         f7045134-eb8d-4eda-8623-b946ec20562e)(content(Whitespace\" \
          \"))))(Tile((id \
          55d7ebb4-a226-4a63-aedc-8a056617517c)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         12a67ef3-732a-4c1a-b76f-12396dc2463d)(content(Whitespace\" \
+         1bb51249-10cc-4732-acf3-f54c8b7674fe)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         94e1ef3c-f34d-4a14-ab28-159af227f016)(content(Whitespace\" \
+         f2c76bf8-26f5-4e0e-b41d-2fa44faab0c9)(content(Whitespace\" \
          \"))))(Tile((id \
          87c05f35-c2a6-4553-bc5b-7885afded1e5)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -974,72 +908,47 @@ let out : string * Haz3lcore.PersistentSegment.t =
          88074e4d-f5c3-44de-879b-a1368eb868ed)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         cc57ff0d-4fb2-44f1-9db7-b8c26e76eca6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e6909320-5386-4830-815e-191e3a962e8f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5cea570c-6744-4ba8-b418-8f996db07f26)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7efb99b7-1c71-4c96-a5bf-5b2abb548a7d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         13692299-0613-4de1-b864-56255327574c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         60a5d03b-6e26-470e-830f-57ca0d350288)(content(Whitespace\" \
+         9b636cf6-2382-4337-b4c0-fa2d81a53236)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         402af5d4-1deb-4ed3-9176-da24f1d44255)(content(Whitespace\"\\n\"))))(Secondary((id \
-         7ac9dd7e-8917-4c05-9f58-5a7ab9954b28)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c6225ca2-e60c-4f7e-a996-4b306fd85729)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d6291da3-02db-475d-9ceb-564c004c5876)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         77f8ce56-7b23-434e-b6ff-150ba2e04303)(content(Whitespace\" \
-         \"))))(Tile((id 822ee242-269e-41ed-a8b2-3a5f0eb51e10)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         830cc87c-83d7-40ab-aad1-669a4f2621ef)(content(Whitespace\" \
+         193c2520-2e10-4cb4-80db-268bcb1ffeed)(content(Whitespace\"\\n\"))))(Tile((id \
+         822ee242-269e-41ed-a8b2-3a5f0eb51e10)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         cbe42d2c-91c6-4329-85d6-876066687f3b)(content(Whitespace\" \
          \"))))(Tile((id \
          ce0799ca-f0ff-4a9b-b81d-57d38c74087d)(label(remove_duplicates))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         6d28f963-e3f6-4e73-a398-eaca1383c797)(content(Whitespace\" \
+         a655f37d-d111-467a-b09a-97ef56197570)(content(Whitespace\" \
          \")))))((Secondary((id \
-         772d1d4b-6c70-4e20-8b90-5c699e6e737d)(content(Whitespace\" \
+         c8e69a2f-6cc1-4949-92a4-4e8e0de85ac5)(content(Whitespace\" \
          \"))))(Tile((id 3e452f3a-fae4-4326-b918-1bf1721a2a77)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         ab1b87ac-129f-4140-aa86-edf0af977527)(content(Whitespace\" \
+         c712a6a8-4094-4a6c-ab96-2142803144f4)(content(Whitespace\" \
          \"))))(Tile((id \
          a6ec6f17-ca05-4c9c-8069-99dc129b28ea)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          930f5bb3-992d-478c-a3b1-f28b9ac01024)(label(xs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         30e3f35e-11ab-49c5-bdac-06ee094d074e)(content(Whitespace\" \
+         \"))))(Tile((id \
          1c14e465-3810-47e3-8fb3-eda705bde231)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         e2ef95aa-7431-4e5f-bb06-903e7340f484)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b3c02473-dbdc-4dce-8ef8-df16a2b7606e)(content(Whitespace\" \
+         \"))))(Tile((id e2ef95aa-7431-4e5f-bb06-903e7340f484)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          29900909-ca6e-4e9f-be76-36b7f8c68722)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         96c323e4-4bd7-4cb6-a71f-a73556d2533e)(content(Whitespace\" \
+         d72f477d-da6c-4cf5-bb5a-96a9e77b27be)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d7c9a9db-3748-46e8-82c6-1960fc12bcab)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ef8f3e38-fdd8-48fc-964a-cc2f5bc4000e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ffa71cdf-5224-45fd-9a86-e63447d8a603)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         80989d40-095d-4e73-b6e1-b8cf03501870)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         82b36b8e-aa19-41aa-8147-70ba58907f4c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         327c2f6a-2e55-4f7e-a247-90bc54c3adda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f1e9689-87cd-4d80-967f-3f9271bf3f35)(content(Whitespace\" \
+         e85cf8a9-ce11-42ac-a9f9-834a89213e12)(content(Whitespace\" \
          \"))))(Tile((id \
          d9b562d1-55a2-49fb-aa2e-8555db32ee22)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1053,27 +962,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f491acbf-41c5-4a9f-ae03-6cf803e4fa21)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9e80e525-0242-4d81-b5fb-4131cbaa1e15)(content(Whitespace\"\\n\"))))(Secondary((id \
-         772eba5f-368a-472b-83de-400758cafa4a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7c50b117-46e8-4b81-872d-ef32e7c3faad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4bd66567-4294-4f9a-860f-b9e4bf08fe19)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9afbd68e-efc0-4bdc-8441-a8b6def94279)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4cd9fda5-cb78-49cd-b052-c56401097eeb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         12fbc66e-e688-4648-8a04-5cf2430055f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7eef2605-3aa5-4826-95ea-258c60142fd5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7d3b73d9-ac79-4c34-a422-911aaea6d233)(content(Whitespace\" \
+         70f372fc-3da9-403b-a8f3-f65aa6150155)(content(Whitespace\" \
          \"))))(Tile((id 3b51a2dc-9c24-447f-87e3-4c7824f64dff)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         dd622a37-a310-4167-b40b-1c2fb78af1d0)(content(Whitespace\" \
+         72b59cd4-fb44-4861-9f61-659a8d989346)(content(Whitespace\" \
          \"))))(Tile((id \
          fda2d1ce-a533-4125-8b59-6007f9d77aeb)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1084,42 +978,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c734558d-bcb2-40f4-b138-ee98c990e7f6)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         33123797-4b68-4ea2-b115-ee84251c3435)(content(Whitespace\" \
+         45533044-4e3f-40b7-8ad9-44afb67a20f6)(content(Whitespace\" \
          \"))))(Tile((id \
          055768c2-859e-4d2c-bf20-99cbcabbdc44)(label(x))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         88a5f7e0-a7a8-4133-898e-830e5717b1f1)(content(Whitespace\" \
+         f2ca33cd-fc70-43bb-a15a-6bcc4005fa3e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         300b7789-302c-4023-b0d1-84e823f4a12f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f8be3bf2-666d-49c4-b560-3199c48dd032)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ba889b56-4b37-43aa-9019-16b8d6b592b0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fe279548-1000-4e21-87da-afaca610e080)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3526c153-cbd1-43de-9826-a33f8a3f190d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         02b5f692-a423-45ff-8263-e45f5a8c72c2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cbdd7c06-1fe5-4bcc-9b9a-a0c45bb5bf67)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a996c4e1-572a-482d-a6a5-42dfb6a3b62a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f480bb78-4251-4855-951e-8626ad8e1341)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ac565ef-2f0e-4832-a94e-820742300658)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a0bb3f2c-4cc3-419a-be8e-f1eee29e6f83)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aba412cb-2472-4268-b354-dcc73646399a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ccf3ffe-9826-49f4-89fb-a919b5bbbc43)(content(Whitespace\" \
+         7376ec07-d88a-45ff-a502-ccc80b54e070)(content(Whitespace\" \
          \"))))(Tile((id 9cab7184-6a27-4c74-890a-fa7a1c38505f)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         c93e9fd2-359f-4cba-b563-fad3ca189f8f)(content(Whitespace\" \
+         cefe4d1a-2744-4242-9946-963758fc708d)(content(Whitespace\" \
          \"))))(Tile((id \
          9a3fb400-814f-4c7c-b395-cef34fa5ac78)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1133,31 +1004,31 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e76416c3-d3a6-4dc1-a67a-454713b39e92)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cdd74259-919a-4f4f-8580-227e89365eb8)(content(Whitespace\" \
+         0f6cf139-1f4d-4b65-9459-21ce0424fac1)(content(Whitespace\" \
          \"))))(Tile((id \
          01a44edc-b2b8-47a4-ae56-8cff824bd336)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6402518b-95b6-43af-8897-7aa63666bf36)(content(Whitespace\" \
+         7cbe0313-ab78-47c9-8181-6a63303d878a)(content(Whitespace\" \
          \")))))((Secondary((id \
-         9e3c41de-f9dd-4a23-956d-03408b091ab3)(content(Whitespace\" \
+         bb4f626f-e118-4939-ab9c-2a40b86923b7)(content(Whitespace\" \
          \"))))(Tile((id \
          4324090e-cbd7-4949-b4d8-bd057daf4562)(label(seen))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         1de52712-2773-4101-812d-1b0779c0d8be)(content(Whitespace\" \
+         40e7ae29-f6c3-47fc-b41e-888625c78641)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3804bbcf-363b-415d-b016-a78d6cfcb3e3)(content(Whitespace\" \
+         fbf5c3f4-b000-45b1-a65c-b8708a7a743d)(content(Whitespace\" \
          \"))))(Tile((id \
          9e6a8908-5d80-4279-81cf-bf7fcc8f2ca4)(label(seen))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         ea801998-c2d5-43df-9581-050026a46664)(content(Whitespace\" \
+         a73a4102-af5a-4388-919c-94e9fa505016)(content(Whitespace\" \
          \"))))(Tile((id \
          63431ac9-62cb-488d-bf7e-7f1cc0b4eab0)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b074b951-f173-41bf-85ab-4aea2907e2d3)(content(Whitespace\" \
+         1627c07d-3ca3-45a5-872f-49c9d2605949)(content(Whitespace\" \
          \"))))(Tile((id 2f4ff022-82b1-4742-8dad-7bb5ab8baeb2)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1167,81 +1038,62 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6dd8c7b0-501a-4ac9-9416-fc761a1e5353)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ded9d806-9b5e-45c1-bd03-8fbf0732181f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5923a0a6-a905-401a-a664-2bd93d0622de)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         edbdf542-86c0-45d6-b748-7820d779d182)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         26ad0f23-82ed-47b3-89b5-14580cb39dea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9d7be0a-de01-4c5b-908f-3c87a594ee74)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f6164f54-bd87-40d5-92d2-14c0252fbb3c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a53f5b82-d160-45b5-979a-058254cb64a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cbbcc049-41d8-4101-bc22-abcfebc17dee)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         07ddd69c-1608-4fac-bb8f-1bc8e7a95605)(content(Whitespace\" \
+         773e36d7-b008-40fe-a8f7-10c559f689b7)(content(Whitespace\" \
          \"))))(Tile((id \
          13108503-8985-4727-b583-42545d93dd52)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         52d5e3a9-a927-4e2a-850c-82fae7f8d883)(content(Whitespace\" \
+         254c835d-9d77-421b-9063-f74d417f1f9e)(content(Whitespace\" \
          \"))))(Tile((id \
          8b460ace-f18a-4cef-905b-8eae2638bcbc)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6e76d740-9380-4749-83fc-e3202c54365f)(content(Whitespace\" \
+         86538fa2-0428-4958-9eb4-9c2d7b5bf0d6)(content(Whitespace\" \
          \"))))(Tile((id f4b09d7f-f346-493f-ba3a-422171166ddb)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          33d0686e-3dde-42ea-b6ee-8fbde0082c7e)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1a667c2c-e16b-4a2b-877a-11754f61ebc9)(content(Whitespace\" \
+         ffe56be3-b0d6-4018-bc0b-6fe3ef9c4f68)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         57058a50-ad29-419a-a7f4-bb83809ff96d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bf918b43-4520-46f1-89a5-c804dae3aa1a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         591699e1-f38c-4c1d-85ac-cc4f926a4657)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9f665f2b-8571-4e8f-ba00-9d73e1a94228)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         90da8c59-8ec8-4615-a984-96a315ac26f6)(content(Whitespace\" \
-         \"))))(Tile((id 1cfc3da4-d086-4caf-bdb4-c1e80f97c516)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         0d7dc3d5-315b-4579-80ae-1c028a395095)(content(Whitespace\" \
+         d7845a69-35c9-492b-859c-cedb28c609c2)(content(Whitespace\"\\n\"))))(Tile((id \
+         1cfc3da4-d086-4caf-bdb4-c1e80f97c516)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         7deb9b39-5740-4393-9349-87e270a8e28a)(content(Whitespace\" \
          \"))))(Tile((id \
          7cdf2f25-7387-4024-ab60-0f3654c99e60)(label(get_key))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d426bd7b-1c9d-4e46-b95d-3ddf4b3cfd8e)(content(Whitespace\" \
+         fe0ce34d-dfe1-4343-b845-dac774404738)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4c7cfdb4-f3ca-4bd7-a9be-712656feba6a)(content(Whitespace\" \
+         c5a90dd8-63c4-4680-8d08-8f3abbe04988)(content(Whitespace\" \
          \"))))(Tile((id 6e5aa119-20ec-4149-9bf9-2f483c2575c9)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         476d09e7-35c7-4457-bf30-3ffa3487add2)(content(Whitespace\" \
+         82cbf0b1-7e3c-4128-b154-d76abb2250a8)(content(Whitespace\" \
          \"))))(Tile((id \
          abbab3b2-7bf6-46a6-9abc-fcf4a4613676)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          d293ed27-691f-4127-ab5f-8bfcd1dbcf61)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         98f739f4-278b-4cc2-994f-bb1589b3b301)(content(Whitespace\" \
+         \"))))(Tile((id \
          81a230e6-6564-468f-8829-ea072957ca2d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b047b68a-e242-49b4-a690-2ccc25b37992)(content(Whitespace\" \
+         \"))))(Tile((id \
          da416fb8-5fe0-4e29-a37f-e90f8f3b00d6)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         316596a1-a13b-437c-b52a-cde263dc8700)(content(Whitespace\" \
+         974001fa-13e8-4ce7-a6f5-5fd9b9b5459e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8941637a-aa67-4bbb-9730-3112d963b2d6)(content(Whitespace\" \
+         31c94a78-d972-4141-9b9b-1f776da946f0)(content(Whitespace\" \
          \"))))(Tile((id \
          ff741637-b823-43e8-b1a3-14c71b96014b)(label(get_value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1255,44 +1107,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b02011fa-b5be-4b9f-8e6e-9aad86a9e121)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dc370d99-50b6-4122-9414-9f3c4aa30a35)(content(Whitespace\" \
+         2776633c-b193-4f64-99e5-c36f5ad9c761)(content(Whitespace\" \
          \"))))(Tile((id \
          eb540f09-2783-47cd-a726-c7bdcd8a1b1e)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         681ff9a8-e824-4b33-8257-8e320502ab6c)(content(Whitespace\" \
+         7c989701-9ad5-4276-9112-8f0e34c32028)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1dd8bc41-1cf1-401c-8fc6-4e0e6ba11679)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b33f4780-9cbb-466d-a034-674c7c246d9c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8bb33dc9-26d4-4edf-8b67-146e5c3f0dba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6bad8d7b-389a-439e-a155-9a1f12d5ceae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ce27890-aec5-4b7c-a28e-c483c8d31710)(content(Whitespace\" \
-         \"))))(Tile((id cf6b5b36-a610-4bdf-9aa7-f74f4dbf8151)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         22447c85-6233-48e1-9518-50830b5e3566)(content(Whitespace\" \
+         a91b73b1-9903-4311-86a6-b63b5cf846cc)(content(Whitespace\"\\n\"))))(Tile((id \
+         cf6b5b36-a610-4bdf-9aa7-f74f4dbf8151)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         ec0466f7-9914-4c7a-ad38-828e68406809)(content(Whitespace\" \
          \"))))(Tile((id \
          2ada4fe0-332b-442c-af4b-ac346795b294)(label(keys))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8d4d930f-9366-449a-8609-2a015d371d1a)(content(Whitespace\" \
+         373f185a-ea0e-4a98-be59-be9732181fd8)(content(Whitespace\" \
          \")))))((Secondary((id \
-         83153f23-7cc5-4869-b9ff-70023b00dd54)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1d7e5dd9-9ca7-4c7d-acd9-3f545cb6faa1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         02b1826a-0add-4c30-9051-41d16759b8a7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ed0ba6bb-fafb-49fd-be6c-f91447cb918b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ee3f6734-deed-45ab-907a-7f31eefe7520)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         05afab70-ccf7-4008-b5bc-967c79351349)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f04c38d0-1059-42d9-909f-425d73dee439)(content(Whitespace\" \
+         b884b9b6-fba1-45d3-9405-7f3e66ddf809)(content(Whitespace\" \
          \"))))(Tile((id \
          2bdc5cf5-8f5d-4eda-a601-f624e634d2be)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1306,28 +1139,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          39f0457f-dbc7-4461-9570-1330a8566aeb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         89ee71d7-f855-4f46-a526-284d957265d1)(content(Whitespace\" \
+         68b0d273-55a3-4bdc-bd18-b1a1598bd498)(content(Whitespace\" \
          \"))))(Tile((id \
          369d4f41-4aaf-4e20-af23-ee7df6967449)(label(get_key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7372b2c6-fe0c-44d0-a3cc-d1804e202fad)(content(Whitespace\"\\n\"))))(Secondary((id \
-         01b473e5-47df-4d2f-8ea7-dc31b5a0b5e5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b732f523-d3ca-4b64-a4c3-3b152ab9dbe3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         61d2cd23-f2f1-4297-b500-9c119b88bb82)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8c01fddf-a5c1-4145-b800-1af8c51effe8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         10986ea5-ca78-459e-92d6-dc09562caeda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         98bd9088-59e0-40ab-89b2-8714ff37a8ea)(content(Whitespace\" \
+         e512dee9-192c-4a2b-a9e0-171fa7c53c48)(content(Whitespace\" \
          \"))))(Tile((id \
          12f10f2a-f4cf-48a0-b7e5-137ce4697e8c)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         75f80dcd-1ae3-43eb-9651-8003d2f051bc)(content(Whitespace\" \
+         2403b7a5-30cf-4ffe-9e47-997e879b0765)(content(Whitespace\" \
          \"))))(Tile((id \
          ef96d566-074d-4dd3-be58-88017a1d6fd8)(label(filter_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1341,176 +1163,101 @@ let out : string * Haz3lcore.PersistentSegment.t =
          faa1b51c-31bc-48d8-9ca9-ec5ebe788680)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         41b5cee5-f6da-44ab-8094-f9f6fbe76a7b)(content(Whitespace\" \
+         1a153c33-dc39-488a-8c86-8aa33f347bd0)(content(Whitespace\" \
          \"))))(Tile((id facd9946-ae9a-4533-8ba3-a9409980a6f7)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         ff3c4e65-192d-4847-829a-77cd7ced4902)(content(Whitespace\" \
+         3c4cd215-2b5a-4439-8970-072d1c3d4306)(content(Whitespace\" \
          \"))))(Tile((id \
          679e36b8-0592-4dd5-a9a7-feb7c82e876e)(label(opt))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         bacdf7a0-372b-4ef8-b924-cf84d22ed083)(content(Whitespace\" \
+         45040c5f-3c2c-4658-ad9e-9e1370640717)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         666d41a3-a8b2-45d7-a9d4-76d107e8f162)(content(Whitespace\" \
+         3b249eea-ab9a-43cc-9ace-0a76df2f0978)(content(Whitespace\" \
          \"))))(Tile((id \
          cfa599b2-f0aa-446d-b95d-84ef1904a3bd)(label(opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b1095917-2ae5-4424-947a-cb4f26662530)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f9e9efd7-dcd4-43ed-809f-d4a02e46faf0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         40b9e79e-d0d5-4d47-82d5-6d6ac3a0b1a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7267d820-a405-4bbc-92cc-e8d66aa76b11)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b0d67621-080e-4581-b2df-f6e528adbad3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3e1bba34-50ef-4978-943b-1d01272b384c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1663e10-9bb8-4948-ab07-13b34c2bb655)(content(Whitespace\" \
+         580ca62e-b33b-46af-a529-57ba7b602350)(content(Whitespace\" \
          \"))))(Tile((id \
          18d06470-c410-4ef8-8552-952b177f6a11)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0d1df01a-c37f-4a26-b7ec-ecb86aca3d2e)(content(Whitespace\" \
+         f7d19f8d-abcf-4a02-81db-566f3cc041e4)(content(Whitespace\" \
          \"))))(Tile((id \
          9efff330-c90e-4d58-a639-4987d4c86896)(label(remove_duplicates))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         fc9afd83-ae76-4832-a97b-77bc3e36269a)(content(Whitespace\" \
+         3ef0539b-e357-4785-b1ae-a70b0b72d91c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         002123ae-60b9-4b82-b33e-b1c603b979f0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8e08713a-88c5-4bd6-8182-e730e084bd19)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         221a558e-d4e0-46cc-8f1e-05588c07879d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6ebdbcaf-2afc-4863-ad2c-fce32497abdf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4a2a5f2a-f444-4527-b578-0f681e8b3d4a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d28a2185-1a34-4fc6-aa68-1ea40906237d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b94305f4-8b3f-4eaf-8c84-033f4340d7d0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e86f7d0f-03d4-45ee-aae7-8c93cfe68f26)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c9c6b640-6f41-4a30-aa6e-1d1afcd1f1fb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         88a82b91-1bc1-42a1-b52c-8a2ff477ca5b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ed1346aa-d1cf-483b-a563-16ff8fadabad)(content(Whitespace\"\\n\"))))(Tile((id \
          e25ceb99-605f-4f71-acf7-a1e8a165b44a)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          61d5031d-b459-4c53-9f89-9596d553f00f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         bbd656ee-79da-4b27-ab00-723adca13d5c)(content(Whitespace\"\\n\"))))(Tile((id \
          61df1906-55d9-4560-aae2-a6f9dfcbdca7)(label(keys))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          ced68281-bfbe-4481-a195-4b2cac1f1099)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0a635403-7358-4dfb-9709-a9a5434c8fab)(content(Whitespace\" \
-         \"))))(Tile((id c9b27097-cf51-4397-9c83-fc483da5921b)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         8eb442a9-f09c-430f-88b6-4a98c8326343)(content(Whitespace\" \
+         87f15e80-dc75-4c89-9968-760e5d54b58b)(content(Whitespace\"\\n\"))))(Tile((id \
+         c9b27097-cf51-4397-9c83-fc483da5921b)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ba6a441b-bdee-4ea1-836a-083e9eae9825)(content(Whitespace\" \
          \"))))(Tile((id \
          70e33d12-fe43-4d38-87d7-018e91b7b198)(label(k))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         71058be8-c79d-462d-9a6a-84e697940543)(content(Whitespace\" \
+         6bac3b08-e5fc-4714-a902-f9d5eadab34c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         23efa553-ca28-433d-9d6c-a25dda14a497)(content(Whitespace\"\\n\"))))(Secondary((id \
-         766bb3c2-7151-4d59-83ad-556bac10580c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         381d3190-5b03-4b08-9443-45d5a3d486e6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f655ff56-dd4f-4445-9e61-c99ca0f928c0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f597ca15-133d-483a-a8da-3fcc3a5b3f27)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f6d35720-25f1-4f26-8add-615dd15026a8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0cf9b45c-acd3-44c5-8eba-ca3cc9303b9d)(content(Whitespace\" \
-         \"))))(Tile((id 2774c0c3-7899-4d6c-af3a-bcbc337cd703)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         ac8872f2-c4f9-40b6-ae56-9b2a52b06053)(content(Whitespace\" \
+         eea30ee8-bd5e-4d6c-84b8-f04ccb0f5390)(content(Whitespace\"\\n\"))))(Tile((id \
+         2774c0c3-7899-4d6c-af3a-bcbc337cd703)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         7d990346-fce8-4ec9-af2d-7b246d144b64)(content(Whitespace\" \
          \"))))(Tile((id \
          ecb67d0a-2658-446d-beb4-e8f6d29a1cc6)(label(rows))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d53a3c2a-a4fe-43fd-a0a8-53713b0b5b5d)(content(Whitespace\" \
+         b5baafc3-0e4b-42e6-9214-221e4e151d77)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6c4511c1-44fe-4f65-9fcc-66ec196e6cc1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6294b887-d0e3-4ef9-b0f7-428ef94e1961)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5ab4b10e-31a5-4ea5-8677-974207d25976)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b9c4181f-2f7a-455e-b6ba-85d826459274)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f5d2665f-400b-47b6-93de-c6e66e7e7507)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         07ea3773-c243-40bb-8397-b82c8191aae3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         04c48c19-b9d4-41cd-9379-664469755a86)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8513aed-32a3-4411-af72-52e822af1577)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32b4bcf9-fbbf-4f9c-abfb-11a6a5dd45de)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ef78de82-78f9-45cf-ac85-83f2a4fa1cfd)(content(Whitespace\"\\n\"))))(Tile((id \
          727f6e29-e791-426d-ae05-a986c9f90640)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          0e912e21-148a-42a6-9b76-75ee7e1116b7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         6e0aa56e-b0e3-4ff3-b5d8-f8c6df351889)(content(Whitespace\"\\n\"))))(Tile((id \
          b5215009-ccb3-4cd9-b79f-a178373f5a11)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          09d24cf7-4857-4d7e-997d-ddbfb67fe3b5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         47a87048-95d4-4580-b1e0-caa0e6af2d23)(content(Whitespace\" \
-         \"))))(Tile((id 2f9e7ea7-78b1-47ec-b854-f4319955adac)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         8a71a6f2-b368-44a9-b2b2-55e3f3d35aaf)(content(Whitespace\" \
+         2c838bb2-1458-4c34-a7d6-df8d2ced8dcb)(content(Whitespace\"\\n\"))))(Tile((id \
+         2f9e7ea7-78b1-47ec-b854-f4319955adac)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ea34665f-77df-48d0-a449-3c8ef4d3fcea)(content(Whitespace\" \
          \"))))(Tile((id \
          b77ed21c-8d3f-4e57-b741-554aab2b759f)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         65f9c445-a799-45c4-8bf7-59ed0aa80efd)(content(Whitespace\" \
+         cd9c05ee-1240-46c5-a789-a60c779b16ff)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7c40eacd-2d3e-47dd-b704-2b21762c886f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         beed665c-f6d1-4f37-8131-b46fc0f1de81)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         443b98ce-ab76-4896-b83e-a84224371248)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         40c0eea7-4570-456a-bcd7-02941ad2b43c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e5148078-831d-4eec-90f3-eeaed7d107b8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4f7a404b-5592-437f-94c3-2a4c8bb07dd2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6e5ab91d-633d-4d7a-b03a-51b9a946fe47)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         3b893400-0cfe-49d3-a774-fa29483cf364)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a640d4d6-0f64-4d56-bf93-3d72657e86ad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7092fde6-2d6a-449c-9349-f9f4c4c18551)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         54671348-e2c4-48fe-8ce8-0348d9c59727)(content(Whitespace\" \
-         \"))))(Tile((id f7cd4a7e-db9b-4447-bddc-9804e7824eca)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         9239f5d1-ad40-4f45-a891-b624e2d8c890)(content(Whitespace\" \
+         440dd346-bcbd-437a-93aa-24be1976b10f)(content(Whitespace\"\\n\"))))(Tile((id \
+         f7cd4a7e-db9b-4447-bddc-9804e7824eca)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         e4ae485c-f5fb-477b-9478-78e1d1cd17bb)(content(Whitespace\" \
          \"))))(Tile((id \
          69136ca2-d45f-45c5-8c53-57f2934855a9)(label(get_key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1521,30 +1268,10 @@ let out : string * Haz3lcore.PersistentSegment.t =
          64eec9bb-d23e-4570-8b45-b096edbe76e0)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         8bcbf910-261f-413e-b7ef-3f8f0194c17d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c57cca33-d852-4ea1-8747-c873b298c035)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d0f37078-1056-478b-895a-eba3ed950f2a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5f41d095-e557-44ed-a072-1558878e3c14)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ccf58a51-1a8a-470c-9d96-9676d8ca30a3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         91aa12a8-1e35-4026-a5bc-160226c642df)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         84dd1e60-95b4-45aa-88de-e287c39ef34a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4e1f2462-a899-4e0c-9d3f-d5d3c6d76d98)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7f752949-baf5-4b78-ad40-8395784beaa8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5c49a6b9-1385-4749-90a8-259f42fe64ef)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         80afbbf7-fd7b-4656-b919-057afb755d73)(content(Whitespace\" \
-         \"))))(Tile((id a220b60f-5e6c-4bfa-b214-a2e253c7dfdf)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         a92d2794-1ce4-46f0-8a9e-9cdc77de95c2)(content(Whitespace\"\\n\"))))(Tile((id \
+         a220b60f-5e6c-4bfa-b214-a2e253c7dfdf)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          a94e3048-f38c-4f27-9857-12d896fd4bd2)(content(Whitespace\" \
          \"))))(Tile((id \
          4f6fabeb-61c7-4b69-8d46-423c59b3beee)(label(Some))(mold((out \
@@ -1558,45 +1285,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          c6d9b98f-b748-4459-aa60-bbcf3d6eb591)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5ec7ad5e-64fe-427e-8a2b-db447df57c18)(content(Whitespace\" \
+         d74db9d3-33e6-4cfb-b060-13dc5ade7e5f)(content(Whitespace\" \
          \"))))(Tile((id \
          4ab07905-df37-48aa-9e38-4a4662b1f953)(label(k'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         a1e87ee7-15b2-43de-ba2e-a65ac52919e1)(content(Whitespace\" \
+         11afd568-bbe1-4ac0-87c7-015430ffda46)(content(Whitespace\" \
          \"))))(Tile((id \
          184d9486-a6e7-49cf-bed4-abcda9a9e981)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ab28678a-6217-4ff0-9731-87517ffcfd87)(content(Whitespace\" \
+         e00eccb8-2ce3-492a-9915-b15048d9dcac)(content(Whitespace\" \
          \"))))(Tile((id \
          28ef72e7-d72b-4502-a344-97014b035733)(label(k))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         5e9759ba-fc02-4460-9ebf-9e58cca2a4fa)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b9dcb58a-e0d4-4841-a50c-b53da88b9baf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4cba50f5-c0d2-4cb6-904a-21b5e6fd3b3d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         834dcfe1-3f5c-4abc-a1e5-480f312e28c9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f3a6c76f-a38e-48f3-9f41-6ed37a57bae0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         df08f6f7-a7bd-4a43-ae5e-0475986dbfda)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         56a89b29-5f41-48b8-9178-979e92c9b22d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1be14ee5-207a-4682-836b-6af23666debf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0f2345b4-ac3d-4edf-adee-ad1f651da8da)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1fb912fd-5aff-41a5-96f2-05f93b90b0cc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d07658fd-a76d-410e-9609-a650e3b7d75e)(content(Whitespace\" \
-         \"))))(Tile((id b5c65380-53b9-4720-aeed-1ed14ca542a0)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         af38c5cc-3888-4934-879e-afc9a5121e3e)(content(Whitespace\"\\n\"))))(Tile((id \
+         b5c65380-53b9-4720-aeed-1ed14ca542a0)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          37ca88ae-2fe8-4c46-a9bd-23459f3d7449)(content(Whitespace\" \
          \"))))(Tile((id \
          7f0ab6ab-8834-43f9-b53d-b6a54ab1dd6b)(label(None))(mold((out \
@@ -1604,111 +1311,74 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          23e61aa1-85c4-4205-b8e9-440a87944b9e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1e44fa45-9a01-47c0-8456-0e79e606e81f)(content(Whitespace\" \
+         f9bbe290-aae4-4baa-b81a-05a418c026c4)(content(Whitespace\" \
          \"))))(Tile((id \
          541ce636-c132-4205-afeb-bbeea9ace661)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         047c60cb-5666-4cea-aad7-953061d268dc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         99295e6a-4d38-44e3-9a12-428b4223a17b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         19a80929-2d41-449a-ae04-6fd3fe160dd6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1d9a3981-b3c5-4a38-8473-b2232bc65174)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         49e9bb0b-486b-4afe-bf43-9ea8a9841f08)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         68610be4-38c0-45f8-ad71-f04a8d9200f9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         977ff000-cefd-4efb-ac12-8c9ee3a2d4f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0af8ca70-b35f-4b42-836d-c3b7eb7c94f9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         46081bab-93aa-4178-a70e-d1cb814a0916)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cd390c13-e7b2-4606-9382-b06617a09c8d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6dee7701-167c-49f6-a965-ed2186db91fb)(content(Whitespace\" \
-         \"))))))))))))))(Secondary((id \
-         0b79809f-e11c-4147-8006-0334913cba15)(content(Whitespace\" \
+         d4b9d691-6767-44d0-8275-60d993831750)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         6968f505-7d23-4f45-8ba4-e3c8a3e8d98e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         9e828a5d-ce82-4b2a-92c4-4d5af6a41ef7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4ad98191-a6e2-4eb3-adcd-50ba3373ed4d)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5617a8d6-265a-4db3-ab47-2ee7f2298e15)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         308d1a1b-6569-4a0d-ac72-2be7f3a78698)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         134a38c3-7b8a-44fa-a56e-121a5ff643e8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7da08181-2ace-4ee2-a796-8cc7b7283f42)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5e79c064-f078-4a49-b3b6-2ee30b2e8d2c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2773d547-fc82-443a-bb69-ac0bfd8b3651)(content(Whitespace\" \
-         \"))))(Tile((id \
+         abd0b2a7-c685-4fc2-aad3-9b194d05cead)(content(Whitespace\"\\n\"))))(Tile((id \
          10104c79-39b8-4e45-9745-884c6bce8e6f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          60dd28cc-63b2-4610-a4f0-30f957eb59e0)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         4d61727c-fbea-4d72-90eb-295bd9cbe48a)(content(Whitespace\" \
+         \"))))(Tile((id \
          336afe53-113e-4a67-93f9-98ef5f4e3a81)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4e164963-48a6-4fb6-9f5e-d62df8a015ef)(content(Whitespace\" \
+         \"))))(Tile((id \
          54c06ef2-e854-498c-b648-b59de909a3be)(label(k))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5e1db809-0f1e-4a48-b7ab-b4584a7af43f)(content(Whitespace\" \
+         8d6b7413-74aa-491d-8e9d-f5ce9d55102f)(content(Whitespace\" \
          \"))))(Tile((id \
          95b410a3-7e78-4a98-b152-b9177705a85f)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         33d26c82-e74c-4d0d-bafd-2ca63785e6b1)(content(Whitespace\" \
+         d5341545-91a8-4b21-9df9-1af8fda8377e)(content(Whitespace\" \
          \"))))(Tile((id \
          caac7a41-d83b-47d5-bc9a-ec5db1850208)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          d25bad6a-38b7-4933-8971-28de87ba0ec5)(label(groups))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         acf51035-5437-4873-9774-7da047915df2)(content(Whitespace\" \
+         \"))))(Tile((id \
          651a9914-4fed-42f9-ad52-e2a545f3be50)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         50a3e4eb-ecbb-4830-9fa2-3450a0f5e277)(content(Whitespace\" \
+         \"))))(Tile((id \
          ea8fdbe9-5b39-441f-ae8f-299952d1870e)(label(rows))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         2fb4a538-e4cf-4900-83eb-a1fd06659ac6)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         f04e0501-fb33-4c2f-bca7-3b49f06a3540)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         b9e5395b-b64e-4e28-8d30-0cc5de3c29c8)(content(Whitespace\"\\n\"))))(Tile((id \
          cb121e1a-6ad9-41da-ba3d-44940e95b5cd)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a2b3e1c2-2a0b-4914-88ca-bf4feac47d32)(content(Whitespace\" \
+         9401b715-70fb-4c4c-8e9a-e20bf45e54df)(content(Whitespace\" \
          \"))))(Tile((id e89c5c3c-f8ae-466c-9046-08fe010db35b)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          6a18ff49-055c-4143-aae9-330f15bf5d09)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         94e2b35b-473b-4dea-9421-51a2661f8dcd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         186dcfc3-7001-4881-8427-71a25331c2e1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8bc73339-ec53-47e1-9857-a7d7db21f7f7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         47ab04c6-eeb4-40ca-9634-143ca69fcd66)(content(Whitespace\" \
+         9b1b9730-4f06-44bb-8846-d47e7a0c52cf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         70168621-7827-43ed-9766-a3511b54bc6c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2a3622db-0fa4-4e1e-838c-cf375e7efee8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         87b59001-1f73-4466-b032-bab05e1e508c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f917d1e4-c1eb-426f-8ab8-8fa8afff084f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         63b130ae-8264-44d2-a6de-6194e657c55c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7dd8ec14-87ef-42fe-a2b0-bcc961635899)(content(Whitespace\" \
-         \"))))(Tile((id dfdc720e-c5fd-443c-87de-3f06c0537621)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         af42c0f7-9007-4f3f-9f64-b2d8031d8d20)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ec213966-9b11-4204-8c39-9af5dbbce75c)(content(Whitespace\"\\n\"))))(Tile((id \
+         dfdc720e-c5fd-443c-87de-3f06c0537621)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         20e12c94-7f8a-4a20-ae0f-369920708cbd)(content(Whitespace\"\\n\"))))(Tile((id \
          8a8015fb-1851-4907-9e98-5301edc695b9)(label(group_by_retentive))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1721,67 +1391,56 @@ let out : string * Haz3lcore.PersistentSegment.t =
          03f950ea-0714-4b0e-9250-4e1f2cea8333)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6372e2a8-7d3d-4ce4-85b1-7f5aaeda0623)(content(Whitespace\" \
+         fbc70df9-f448-47a6-9229-9e195485a9b8)(content(Whitespace\" \
          \"))))(Tile((id \
          d3acfdc5-6040-4a67-a496-7e6598bee665)(label(\"\\\"favorite_color\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         7153e503-f46c-4c97-968e-4141cd03ea5e)(content(Whitespace\" \
+         e77879ab-f818-488a-8031-209f1ab3a508)(content(Whitespace\" \
          \"))))(Tile((id \
          6dfcb236-c12f-4b70-acd1-19c76a2525a4)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6d732972-b7c2-4718-b580-e7d247248730)(content(Whitespace\" \
+         062928e5-6d6d-46f3-b0f8-3667c091eb36)(content(Whitespace\" \
          \"))))(Tile((id \
          af98056d-9097-457e-95b0-b8aa66122c5e)(label(expected))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b820cca5-ca35-4fc2-bd72-89d18ddb89c3)(content(Whitespace\" \
+         f7fcfc6f-1120-4b30-8c84-c9f86781c9f9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6d9da18b-2cc9-4752-bdcb-9de80ff7d837)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         9f8b5387-b077-4f9f-8e58-642f64ddc3b2)(content(Whitespace\"\\n\"))))(Secondary((id \
+         e7637ab5-512e-4098-8a48-1d4896f97213)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5bec6ee0-536a-4953-85ac-25a6b1eee745)(content(Whitespace\"\\n\"))))(Secondary((id \
          731f3cec-bcc5-46e8-adca-8bd85234d7a7)(content(Comment\"# This is the \
          more idiomatic way and takes a function to project out the group \
          #\"))))(Secondary((id \
-         922c3472-deda-41a5-b198-68db79686cbe)(content(Whitespace\"\\n\"))))(Tile((id \
+         84a512fb-632a-49ff-ad23-e4bc0ea1b6d4)(content(Whitespace\"\\n\"))))(Tile((id \
          258401f1-327f-448d-a83a-31da4b9f541d)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         21a556f8-b222-4092-a805-703738e2fac4)(content(Whitespace\" \
+         8a69857d-9504-46d9-86cd-f14c62f180c0)(content(Whitespace\" \
          \"))))(Tile((id \
          f332fe2b-0734-4d7f-bacd-e346817f0565)(label(v2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d3ea246e-c641-4158-b55c-2d6af45b6f7c)(content(Whitespace\" \
+         97603480-7ef9-4b6a-b324-19a9a9aebb77)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d21feabe-5fe5-48e0-8490-c3c95568c79c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         1979c4ae-0f04-49b3-874e-27c7896ea657)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d3a25ba4-bbd5-4166-a2ad-624f616716eb)(content(Whitespace\" \
-         \"))))(Tile((id 53e0d307-ea3d-4fcb-8582-58fe9e606088)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         a4d14346-2e15-4e1c-848c-3bfaac84f97f)(content(Whitespace\" \
+         44c40443-ce78-4cf7-bdff-f4f41fd7c36c)(content(Whitespace\"\\n\"))))(Tile((id \
+         53e0d307-ea3d-4fcb-8582-58fe9e606088)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         a26e3730-0917-456b-b80b-490ac3e262ce)(content(Whitespace\" \
          \"))))(Tile((id \
-         bd1007f4-6f00-4730-a09a-9390852742f5)(label(requires))(mold((out \
+         bd1007f4-6f00-4730-a09a-9390852742f5)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f646ae76-8e01-4e38-bd5b-77814ff46134)(content(Whitespace\" \
+         7b03f438-f4d3-42a5-b286-98b309b64ff4)(content(Whitespace\" \
          \")))))((Secondary((id \
-         54d78fb3-031f-4117-8404-19bc606aa050)(content(Whitespace\" \
+         8f4190f0-d2e7-408c-aeb0-87108dd2ea4c)(content(Whitespace\" \
          \"))))(Tile((id 3e4ea34c-9adc-4070-b62a-73e3593a112d)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         f1823bc7-974b-4eb8-909f-7ea879e61803)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c21f880e-4e63-4dca-ae0b-fd958faf3e2a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fac5db7d-6aa9-48d0-bd7a-fecccb7c6097)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f8445905-7813-4afc-b102-db25b9aabf34)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         beeac3d2-bbb6-4e6a-9da6-8260637ef3bc)(content(Whitespace\" \
-         \"))))(Tile((id \
+         6df0f100-fabb-4461-a817-c523d0565ce5)(content(Whitespace\"\\n\"))))(Tile((id \
          2825ff52-5062-46a8-9401-aff823cf2d55)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1808,24 +1467,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b8396bd8-15d6-4a4a-aecb-610ae8abc955)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d903c671-c0c9-45d3-b24e-e59479c055fe)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c305a6fa-cba4-4ac3-96b8-33d9c5656939)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b29320b9-876f-44de-a722-5028d4166a10)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bf565418-578a-4104-bcaa-8cbbd412fe75)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         245147dd-dbbb-488c-b6a6-194fea49f081)(content(Whitespace\" \
-         \"))))(Tile((id \
+         bdd24ef1-1b51-4dba-81cf-ecffee7f2238)(content(Whitespace\"\\n\"))))(Tile((id \
          a51a7de1-11c2-4a8c-8974-e3f2051a8ae9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          68282207-0698-4d0e-bc77-942342c4bab5)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         bbd825a9-23ef-4d93-87eb-899b2567c904)(content(Whitespace\" \
+         \"))))(Tile((id \
          7cee9dbf-2755-4030-97d2-993991ff8bde)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         53c31dce-a1df-444d-93b1-394259996f9e)(content(Whitespace\" \
+         \"))))(Tile((id \
          17b25e92-50f6-4358-a0cb-3b47c9924ab9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1835,51 +1490,34 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4243c1bd-0d46-41da-a1eb-44fc58f3d312)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         17e58098-ec5b-41d6-9077-0bb27eaa60ec)(content(Whitespace\" \
+         c50e14a4-66c4-4a93-ab3c-abd3bba85779)(content(Whitespace\" \
          \"))))(Tile((id \
          f43f56fb-9be5-4f5d-b5a5-72fcddb1e9d4)(label(\"\\\"schema(t1)[c] is a \
          categorical sort\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         2064df34-2e39-42ff-9fc2-6e01ad1929a0)(content(Whitespace\" \
-         \"))))(Secondary((id \
+         0a977976-801d-4317-8599-ad60f1e0e431)(content(Whitespace\"\\n\"))))(Secondary((id \
          aa5247b7-02cf-4511-ba48-884cf79fd07a)(content(Comment\"# Verifies \
          it's a string column #\"))))(Secondary((id \
-         d6e08a8f-975b-4353-9aec-cd1c1051b883)(content(Whitespace\"\\n\"))))(Secondary((id \
-         56485cdb-a5a4-4f44-8cfa-57c9988f5e4f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e92ebe87-f96d-4a47-bd3b-028f8086f42b)(content(Whitespace\" \
+         bc742c14-e3be-4621-a125-ebda81eea7f7)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         bed39310-37ab-4219-9adc-5457db17d7b8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         41c03adb-ac3b-43f8-83c0-15b16dc4015c)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         30aae443-f04c-421a-a92f-f89fe58dbfa5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         52a22547-c45d-41f2-b084-f69fd1c50f71)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1784c6e1-f284-4dfe-b505-4d0242359568)(content(Whitespace\" \
-         \"))))(Tile((id 9045189d-0217-40d2-ad3e-aafcec5e4192)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         1de3edf4-77f1-4da0-b5bc-9426b814e710)(content(Whitespace\" \
+         5b08f517-7566-4372-b3b5-085227e436bf)(content(Whitespace\"\\n\"))))(Tile((id \
+         9045189d-0217-40d2-ad3e-aafcec5e4192)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         50d9d6ef-43dc-409a-a9ec-e47759d06f40)(content(Whitespace\" \
          \"))))(Tile((id \
-         410436b8-c1cc-4997-bd89-7d0d57bc4acd)(label(ensures))(mold((out \
+         410436b8-c1cc-4997-bd89-7d0d57bc4acd)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         873d2df2-8450-4abb-8758-159a0b0cf2c4)(content(Whitespace\" \
+         1a938014-1450-44dc-b302-8f97e84bf835)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a7ad194e-22d1-4056-9f37-96668787da1e)(content(Whitespace\" \
+         df1457e2-9998-44f5-bda3-53bacb51eec8)(content(Whitespace\" \
          \"))))(Tile((id 97664ce7-b3a5-43f3-b7a4-ad3f9e01d29f)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         2a1cbe7d-a53f-4fcb-b11a-c86133c8e784)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a75fbb98-0854-48c6-ab36-de54e84b2fac)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6eb2f283-ce5d-48c5-9b25-5d724ccd24ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5561fa36-53a2-4d6a-a6a6-43fce5cbcedd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9132a0c1-5e40-4d17-98ec-ba4bb44045e9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         0f3d322c-25c3-46ca-96e7-6e9ad10346c5)(content(Whitespace\"\\n\"))))(Tile((id \
          7c361fcb-5f33-4ee2-bc9d-23aeb6c5feaf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1907,15 +1545,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f07b820d-9f7d-4778-a3ce-d8a81e227163)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1fce013d-112f-4c39-b0c1-fde59c539aa1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e340f633-ed8f-4c3c-a3d4-8af978a9071c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ae9ce2ee-2983-418b-a8f8-8798723d566a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bbd3acb8-2e19-452b-9992-939e1eb54415)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d2d1a3cf-c4c0-4d59-a7f2-43a19402cde9)(content(Whitespace\" \
-         \"))))(Tile((id \
+         34d97df7-b068-4615-b4c8-b71f2410af7c)(content(Whitespace\"\\n\"))))(Tile((id \
          99ccc7e5-f126-42d6-a114-8c83c97ed0d6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1943,15 +1573,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1529a23c-4943-42ff-b765-d2e46ffd69aa)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cc3e751b-d37c-4906-b150-986c0660e545)(content(Whitespace\"\\n\"))))(Secondary((id \
-         2fbfd71c-8e04-4cd3-b77d-0f4c8fda5b4a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f8559dec-8d0d-4327-ae96-aef588a7ce8d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         85e711d4-bea2-49e5-b0d8-07b6e2cbca9d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5828c9d7-629c-4bd1-85f3-d3e1a9858f50)(content(Whitespace\" \
-         \"))))(Tile((id \
+         a4dbd29b-6763-466a-a792-3dd31cdaf23f)(content(Whitespace\"\\n\"))))(Tile((id \
          661ba29a-b98b-4bea-9c36-eaf368140ce4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1979,15 +1601,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9c9838e4-2a65-44fb-82d2-0e32130df2ad)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69d22c6d-0b8d-4335-9ec2-ee6cd8087ce9)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e6ac9427-c7d1-4859-90a8-3f5a463b75f5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         121b9da7-a381-4d47-a9a4-b919b16d45e0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2a3b78f2-5dee-4232-a664-9134eaab1a29)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         13cc5fce-5a5d-441e-95bc-5f123cab978d)(content(Whitespace\" \
-         \"))))(Tile((id \
+         aebbe259-4b94-4844-ad3f-e576cab62cc7)(content(Whitespace\"\\n\"))))(Tile((id \
          cd6e89d6-02f8-495a-92e5-bf07bc1690cb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2015,15 +1629,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f3078843-5d65-495a-8c5f-f6daa8766b9f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ec16bf20-b24d-4371-a6d7-e379ac1604f4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fe10ce86-7512-4757-9bd4-59d0a731502d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a7720018-b40e-40e9-8f96-d3c660fefebf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         bfbf9685-4924-499e-a49a-5b9e5d1193ba)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         06185a90-9398-47f1-a93b-98ea0e2edb39)(content(Whitespace\" \
-         \"))))(Tile((id \
+         3b968afa-ab6c-4592-a05a-7fce0f4956b4)(content(Whitespace\"\\n\"))))(Tile((id \
          7dc51b13-c525-468c-b5b6-fc5515b2c9d3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2051,24 +1657,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          50a3bca2-a3bc-48c7-b7ff-d9284dfe21a0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0a8fdc24-cd1e-4744-8521-3e968c7c996c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c8474666-b316-4624-bfa2-04e574286ab3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         11aebedc-09db-4723-b8e7-100715b520d9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a7de793a-3396-4938-990c-3b3ef2a88afb)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b7e4d4d-7575-4fd9-bc16-18b452c58ad0)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e8f5d8d8-739e-4f6d-8684-c416d718cd00)(content(Whitespace\"\\n\"))))(Tile((id \
          4e065abf-04b5-42ed-bcdf-99dea16017e0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          efa084be-209a-453d-bade-f1adb32b269a)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ca4d094d-3abc-48b7-bbb3-2c1efcf9889d)(content(Whitespace\" \
+         \"))))(Tile((id \
          56f54ec4-0f73-45c5-ac2f-edc136516d54)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b268ecb5-71fc-493e-a4c1-01d39500be19)(content(Whitespace\" \
+         \"))))(Tile((id \
          c2cf409d-92a4-488b-8132-aabef3de6142)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -2078,67 +1680,54 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d8b9bec3-01e5-4e4f-9903-99f7fd636387)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ed2402c5-5465-4773-9129-aa65e1c6fabe)(content(Whitespace\" \
+         78daa4ce-a7ae-4f2a-ac0c-6a91123ee5e8)(content(Whitespace\" \
          \"))))(Tile((id \
          fcf9824b-233d-4590-a1d8-9b0072fa60fc)(label(\"\\\"nrows(t2) == \
          length(removeDuplicates(getColumn(t1, c)))\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         cdcd4351-fa81-47f7-a66e-d1ad045728ea)(content(Whitespace\"\\n\"))))(Secondary((id \
-         0bd20605-1657-454c-895e-ec7f94d21b48)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ccab8fb-184d-4a01-9b6c-737178b2c05d)(content(Whitespace\" \
+         a39b202e-8593-4aab-922e-efbc8628b5fa)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         5e9fc297-c93b-4005-9f2d-2599a4eb2b00)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         317e289c-09b8-4fad-b1b6-60e64f27c2f0)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         d97953b9-7bac-420d-9c18-afc0735fa122)(content(Whitespace\"\\n\"))))(Secondary((id \
-         83bd409a-767e-4cae-9a63-20556e48988b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f4724e8d-3b45-4f6d-8b37-f0f0f774c064)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ca324928-9a48-45a1-8d47-2de1726d2421)(content(Whitespace\"\\n\"))))(Secondary((id \
-         64210aac-1da4-48d1-ad28-021380530565)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         27b8b3c3-62f5-4d08-a519-a6570311459e)(content(Whitespace\" \
-         \"))))(Tile((id a63e9a23-34f7-436b-be46-b2206ef1a85f)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         e6ee508a-3812-49d5-b8fa-2e5524e4c417)(content(Whitespace\" \
+         4b10f03f-1109-401c-97ae-eb9c5f268e61)(content(Whitespace\"\\n\"))))(Tile((id \
+         a63e9a23-34f7-436b-be46-b2206ef1a85f)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         74be7d4b-351f-4c23-8e85-2662de818a8b)(content(Whitespace\" \
          \"))))(Tile((id \
          12ad1e9d-577b-4614-8ea0-6b7a8c460a57)(label(group_by_retentive))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         344cd873-7015-456f-bb52-b62cd87e23b1)(content(Whitespace\" \
+         6afd9892-876f-4172-a03c-4cea1e10bd5e)(content(Whitespace\" \
          \"))))(Tile((id \
          a18bc2e3-9c4b-4009-aebc-451a01b21ac7)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b79a5045-857c-49a3-8a76-a0de13eaeadd)(content(Whitespace\" \
+         590d0bbf-2f75-46e0-b791-60bf08e9a025)(content(Whitespace\" \
          \"))))(Tile((id ea4c2e72-8c0e-4bfa-a271-6d4b47e05e56)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         c7da2ccd-d318-435d-9697-1ca1a7b0a8f0)(content(Whitespace\" \
+         5601081e-40db-4c03-a744-6f49b84a339b)(content(Whitespace\" \
          \"))))(Tile((id \
          cfdf6962-f850-461c-8d6e-0ac7e2f9076e)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         9883f8a7-84f4-41c4-b9af-ec7683f7625a)(content(Whitespace\" \
+         6384cf6c-e057-48fa-a40a-ec8126b62642)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e11eec1e-851b-4909-8c8b-be5fb8b9edb2)(content(Whitespace\" \
+         2f4b915a-354a-447d-b633-31b543b06609)(content(Whitespace\" \
          \"))))(Tile((id 30742532-20db-4ada-8121-e594dc715171)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         30181581-b843-4816-b792-4b875338507e)(content(Whitespace\" \
+         a7b77c3a-9992-4ffa-8ac6-1d0685bb0acf)(content(Whitespace\" \
          \"))))(Tile((id \
          cd76a395-1669-4b87-8fd1-74bc6d204d40)(label(key))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         0371b681-a229-4e5e-b3a8-580cfa34dffe)(content(Whitespace\" \
+         10deb960-198d-4280-a9d5-f5ba1cc834a9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         eb083490-cf42-4faf-bf80-b3d3a772164b)(content(Whitespace\" \
+         a2481452-a128-413c-8749-de92b92eb73c)(content(Whitespace\" \
          \"))))(Tile((id \
          4301b0f8-8d5e-4760-b986-86152152c6d6)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -2152,7 +1741,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9144cb52-e054-4140-8da1-fcd974702c21)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         01859e1f-7541-4b67-949c-0ee6544ae001)(content(Whitespace\" \
+         18cf4645-1fbd-4f71-a7b6-51406dc66213)(content(Whitespace\" \
          \"))))(Tile((id \
          4acb3d01-b33c-4af2-b22d-9dea78dc7b85)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -2160,22 +1749,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d97904f8-e221-4b20-a760-8b527a686884)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         a7ba69ba-aa8d-4ae8-9e65-e412e6ee63d2)(content(Whitespace\" \
+         00122072-273c-4f74-a463-937d22b61e47)(content(Whitespace\" \
          \"))))(Tile((id \
          36cd2181-85e5-438d-bd41-d9bf13347e97)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dd32f15c-90c8-4905-ae45-a6cd23d22e5b)(content(Whitespace\" \
+         f65a9ad2-116a-4826-b94c-ed22cabdd22b)(content(Whitespace\" \
          \"))))(Tile((id \
          e3dc737d-fd12-498a-9c90-1e1639af9dbc)(label(key))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         ee40dab8-41fe-4c3c-a46c-1ec158efcda1)(content(Whitespace\" \
+         c637a7ad-d460-4e1e-8671-a52c71c7c3e6)(content(Whitespace\" \
          \"))))(Tile((id \
          ccaee32f-1ca9-4798-8adb-9313d9f78973)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b34a6d13-0a2a-4d89-bcd6-8020474aa1a2)(content(Whitespace\" \
+         a8a75ed5-ba7c-43ba-86f5-c9b3904206b7)(content(Whitespace\" \
          \"))))(Tile((id 7eea049f-4e11-4f55-9f73-cf6a02fdc888)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -2184,71 +1773,66 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          68c37d8f-ca54-4653-860e-38447a1dab4b)(label(key))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9a0cafe1-6f36-42bf-a751-8d3a91f1e56a)(content(Whitespace\" \
+         \"))))(Tile((id \
          8b231aa5-0271-4962-a759-0ce46ac6e220)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6da1a753-ea60-4a7d-bd6e-9e9c35e6bc0f)(content(Whitespace\" \
+         \"))))(Tile((id \
          c689b079-9d85-4597-9bd7-cc0a51281ecf)(label(key))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          fedbad7c-5ed4-467f-ad78-9b80544035a7)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         283da6e7-b6dc-4f48-b547-a41cf8b24f02)(content(Whitespace\" \
+         71c5a1cc-77a1-483c-9363-13515fc90390)(content(Whitespace\" \
          \"))))(Tile((id \
          e74a612b-1d83-4d8f-b686-0439afe11562)(label(groups))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         4296bff4-9045-4666-bd2d-904b31378d46)(content(Whitespace\" \
+         \"))))(Tile((id \
          ba80b6dd-5d71-4aa3-a8f5-bc4f1bfc2529)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         6abfcaf2-1c10-4171-b478-5bb32b9d29e3)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f32a17ff-734e-4656-9c45-455d9eef20c4)(content(Whitespace\" \
+         \"))))(Tile((id 6abfcaf2-1c10-4171-b478-5bb32b9d29e3)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          32a9bb9a-2b19-4934-8646-4ed7bdaed8ef)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         2bd366b4-845f-4c2e-968d-d4c72b4b0465)(content(Whitespace\" \
+         55d770b2-5a41-4fa7-98d9-ac56e446c391)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d1481ac3-123f-422d-a3ee-f46b55990923)(content(Whitespace\"\\n\"))))(Secondary((id \
-         be7576ec-39b2-4dd5-b3dd-2118f46e1ab7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2a85b093-3bdf-42e2-b63a-0d042b638986)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         452b7cff-5710-4b14-96ec-65aa651596c7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9914f719-18e3-45e2-ad95-41541aa6ee0e)(content(Whitespace\" \
-         \"))))(Tile((id 97a79642-272a-489b-9190-5782c8a64f29)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         cbc9e56d-282e-43d6-84e6-591f8d99ad44)(content(Whitespace\" \
+         458b5d0c-5f55-4d20-8a72-0a861bb5442c)(content(Whitespace\"\\n\"))))(Tile((id \
+         97a79642-272a-489b-9190-5782c8a64f29)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         22baad72-ea64-477c-8adb-362cb910e961)(content(Whitespace\" \
          \"))))(Tile((id \
          54b5cf0e-6c8e-48bd-aab0-09976ae9d1f7)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         4388908d-3b59-4eb6-be97-d0d50516426d)(content(Whitespace\" \
+         2ef64fa9-4174-4409-b9ed-bfa387ff4e24)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         10fbc889-03c6-4a19-b67d-e0ede8826a8f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e0a45818-9ff6-49bd-8e10-c5cb70d1567d)(content(Whitespace\" \
-         \"))))(Tile((id bd81076c-d9be-4db4-b1d1-76c4909695cf)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         614d6a46-9a1a-40d5-ae79-7383bf9f5b20)(content(Whitespace\" \
+         346a08b1-24e9-4bef-bace-ebc334a7bb46)(content(Whitespace\"\\n\"))))(Tile((id \
+         bd81076c-d9be-4db4-b1d1-76c4909695cf)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         02902e7d-6c2a-43af-95f1-4534b1e7c752)(content(Whitespace\" \
          \"))))(Tile((id \
          37247d7f-1462-4f48-b86b-b8a8d064e9a0)(label(key))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         78fe8c27-0862-4977-ad4d-e34c10495957)(content(Whitespace\" \
+         ca58bbb4-5d36-4225-9878-31ee9ff42aaa)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         cc5d81bc-4a07-4d26-af9d-1c26cdc04dd1)(content(Whitespace\" \
-         \"))))(Tile((id 3970417d-2032-4b8b-a2a1-35a390a5c64b)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ab193929-ddf3-452c-b393-57163556c12b)(content(Whitespace\" \
+         737b739e-eb83-437c-914f-73f6822f5ebf)(content(Whitespace\"\\n\"))))(Tile((id \
+         3970417d-2032-4b8b-a2a1-35a390a5c64b)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         bcd835b8-ec31-4b1a-b031-370cad6062ca)(content(Whitespace\" \
          \"))))(Tile((id \
          54219127-e98a-4201-92c1-ba5fdee11362)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -2259,49 +1843,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3daa7e8d-0af1-4731-b64e-3bd4fc1d3440)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         318d0ade-9934-4bf9-8b8c-2385c02a15bf)(content(Whitespace\" \
+         2043938a-aec5-477c-8675-22dcd02afe07)(content(Whitespace\" \
          \"))))(Tile((id \
          89be6bdb-50fc-4eaa-9cf4-48a677fe078f)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         4d35b287-5772-47f7-89c2-db9b5fdbb5f3)(content(Whitespace\" \
+         743aa127-d131-4f44-8aa5-1c13d0a55c5e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         95394c8b-d0ff-4346-9b69-f7247d5aa5c2)(content(Whitespace\"\\n\"))))(Secondary((id \
-         937487fa-c3bb-4363-8454-5fc9b39b516c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9350b9f0-5094-4966-9119-24e19e1a01c6)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7fe6903f-ba44-479d-958e-56a86d6822e4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         9b87a377-499f-4f4b-82e6-b112195b8e9d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2da795b4-e058-40dc-bcec-f42e84e98aa3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7ece9c46-5532-42d4-b56f-86dbc2517537)(content(Whitespace\" \
-         \"))))(Tile((id 596a225e-4316-49be-be3f-d586bc72a9fe)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ca64dc9a-03be-4d3d-a769-1932bed44b22)(content(Whitespace\" \
+         df73fa93-7fc7-4aeb-819c-766449c8004c)(content(Whitespace\"\\n\"))))(Tile((id \
+         596a225e-4316-49be-be3f-d586bc72a9fe)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         a50641b7-a087-40b3-bdc4-3e09b26f60d9)(content(Whitespace\" \
          \"))))(Tile((id \
          cd78bb3d-f394-4db1-b6e3-2e9f82fce547)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c60f04b2-56cc-49ac-b692-2093b950937b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         388f3ead-7fca-4542-8f28-e25c8c2eec46)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6f73eee2-5dc6-4631-bf79-09210ba92149)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         34db0d7b-ebe5-474f-bcd7-ac33e65ae5bf)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f8b2b513-3805-4b4d-9877-93f1206fa2fa)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         43a0a325-3ab7-42e8-b16f-fd4e25b9a48c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e31b2ca6-b5f2-4823-af5c-fa41d10e1e03)(content(Whitespace\" \
-         \"))))(Tile((id c7575adb-4ff4-44e0-b9f2-97c6a4b843f7)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         54f10dae-d612-4a48-99fe-6ce26f0dc8df)(content(Whitespace\"\\n\"))))(Tile((id \
+         c7575adb-4ff4-44e0-b9f2-97c6a4b843f7)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          e75a2433-3548-42fc-878c-4e8d2083c643)(content(Whitespace\" \
          \"))))(Tile((id \
          45e7ebf8-66c1-4379-bc5f-4e1fb4d603de)(label([]))(mold((out \
@@ -2309,27 +1870,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          2c5209cb-a74b-403e-978e-df3034d97466)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         945bf243-bf2b-410b-8b17-7a2d969f1e8b)(content(Whitespace\" \
+         eedb55fb-92f2-4616-adfa-a030a16426db)(content(Whitespace\" \
          \"))))(Tile((id \
          2030b900-2d82-4bf1-ac4e-f6cc4c084d42)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         dd776adb-a8f7-45db-8666-46b0cfa5fbf6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         73e50a4c-8496-4be9-af81-1bff138ed6dd)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6cd5f9ab-b640-4fad-8ddd-8013939b635c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         dd2c69bc-a82c-4bd2-91ae-ec07a0a8e2ea)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1a1d937-11f1-4c79-8de3-0b71d0d5260b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0e27c204-1226-42a9-b568-7a3b49c45b42)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ec709b25-e848-4d64-ac5c-a9357ad5b6e1)(content(Whitespace\" \
-         \"))))(Tile((id 559000b2-0dc4-43a4-b2c9-79d8be9f6d40)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         5d1b3070-2909-4572-afdb-dbb2110e32e7)(content(Whitespace\"\\n\"))))(Tile((id \
+         559000b2-0dc4-43a4-b2c9-79d8be9f6d40)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          ece57d26-2835-4d81-9ccc-b8ccc534e199)(content(Whitespace\" \
          \"))))(Tile((id \
          c6feac33-a8f4-4e9d-9318-bb20f9f64cac)(label(x))(mold((out \
@@ -2343,36 +1892,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          72a05b8b-c23b-4093-9d64-de7d85d9dd37)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4dddd35e-6927-413a-a23c-0683f0338439)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0ab9d936-9ea2-46fd-8e22-84d640fb4dbc)(content(Whitespace\"\\n\"))))(Secondary((id \
-         44fb9189-036f-4e99-afc7-381e6a1c1b01)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2c96b405-6f7a-433b-a992-3f0013bcaeae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a5d56b74-8fee-452b-9cb7-7ca5567eadb8)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4394ff34-a582-474e-a29f-ade58e96f51b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         f818e052-b226-431c-ba3b-f826a9a62dc9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         0e865372-3ae4-4f81-921b-d0d9c7274b6c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ed0ba93a-5607-40c1-b780-1968faa9ecc2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         897e4d6f-4e67-448c-8664-7b6de9d42e97)(content(Whitespace\" \
-         \"))))(Tile((id 5a0bce03-6802-4f55-9e92-4c93a52091ea)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         4b699224-e7dd-46a0-bc9c-bae7954af53e)(content(Whitespace\" \
+         bbd0f648-19aa-4c1f-b6b0-7cf8e1399f23)(content(Whitespace\"\\n\"))))(Tile((id \
+         5a0bce03-6802-4f55-9e92-4c93a52091ea)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         b8d9c7b7-0499-4769-b873-97b8ab68530f)(content(Whitespace\" \
          \"))))(Tile((id \
          92a95345-ced3-4b99-9435-20710678ced3)(label(key))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d19ac317-8f1c-474c-a91f-c74fb058d679)(content(Whitespace\" \
+         98c13f0c-2293-456d-afc1-f5d6de59dee4)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2ca6a885-0d90-422c-b8be-fa850a573ee6)(content(Whitespace\" \
+         5c743180-2963-432e-a37c-afe008ab4f24)(content(Whitespace\" \
          \"))))(Tile((id \
          bd7c0e15-56a5-4a77-bd7a-1a96e37d0cd2)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2383,36 +1914,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7d21b8fe-a01c-4b30-a4d6-385685d90af7)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         f88a0554-f1f0-4ed0-a482-507d50c12c0b)(content(Whitespace\" \
+         1524c947-f3d8-41df-a08c-d5752e87454c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         83f66931-58f9-4751-882f-9c97e9631ad3)(content(Whitespace\"\\n\"))))(Secondary((id \
-         ec254ee7-47e9-4881-bb4c-8e04e572f6c2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c21c3755-1bb7-4f12-8143-babf88ae130c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d1817859-2dce-4b06-98ce-ee5f75996519)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         645a6023-e328-4087-a0d6-2b25d613e3d4)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         66578b9c-2f9f-4749-bb3f-46f697f86952)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         fd0cabdf-dcf4-4bca-ae12-ac03446aa56f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         6cf57187-2d3a-49fd-b922-16f109169f30)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5628ba6f-0111-4861-a711-2b76c7f524f7)(content(Whitespace\" \
-         \"))))(Tile((id 8b39b95a-9e8f-474a-a28d-b1acad24a763)(label(let = \
-         in))(mold((out Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
-         2))(children(((Secondary((id \
-         17c78fc1-2c92-47b0-908c-ece792f9e020)(content(Whitespace\" \
+         a45daea6-4e99-4524-b991-c5f7daa7bea3)(content(Whitespace\"\\n\"))))(Tile((id \
+         8b39b95a-9e8f-474a-a28d-b1acad24a763)(label(let = in))(mold((out \
+         Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
+         16e6980d-4c75-483c-911c-acfd1cbdb94c)(content(Whitespace\" \
          \"))))(Tile((id \
          9bfca49b-6ac9-461a-a8ee-2e5ff7d9eb34)(label(grouped))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f8c19a10-0f03-42e4-b4cd-2c82b5ae4da0)(content(Whitespace\" \
+         d7d3190f-c346-4eca-9711-228b48abed14)(content(Whitespace\" \
          \")))))((Secondary((id \
-         778c10d1-4d57-4381-84ad-fb45f1a6402e)(content(Whitespace\" \
+         b4fe14af-77fb-4e4d-8841-d5b877176093)(content(Whitespace\" \
          \"))))(Tile((id \
          4fb75b14-5ac6-464e-bd4a-4d400991834f)(label(group_by_retentive))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2438,33 +1953,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          41079392-d8aa-4e3e-a966-48a8bdb13a30)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b558df7b-f50d-4df4-a8e3-e88e26f733c5)(content(Whitespace\" \
+         48629d1a-e668-4e6c-a8f2-cc38a904e050)(content(Whitespace\" \
          \"))))(Tile((id \
          f431a333-5484-444f-96e6-00504eab1124)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e69a201b-19ac-4688-a99a-c018687b4187)(content(Whitespace\" \
+         80d4a9a9-5f9c-4cdf-ad8f-85092768bb78)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         68cc2cdc-9b1f-4d04-99a2-a80a62034553)(content(Whitespace\"\\n\"))))(Secondary((id \
-         37790295-27b3-4ce7-9239-61cc8a79902e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1054f198-10af-4c6b-8777-22f1dfb38663)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b238578b-e780-4301-8d8b-8235be49851b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4910a401-942b-4039-8b3e-a8734a171d64)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b1fd4400-1e34-4ff9-ad87-1bb6c4bf288a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a8b607c1-f57a-411f-8b19-a951c3138b75)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d3f0fea5-f79e-47e1-8fe0-affb501cfad1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         abff1f3b-eeef-4047-a26b-212f96668555)(content(Whitespace\" \
-         \"))))(Tile((id 5288f58d-9ca9-4451-9524-9a2cb38e1a33)(label(case \
-         end))(mold((out Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ad723258-253f-4b54-8d33-d46a01fde652)(content(Whitespace\" \
+         4829d29e-285f-4cac-8b46-86c3b74a75c2)(content(Whitespace\"\\n\"))))(Tile((id \
+         5288f58d-9ca9-4451-9524-9a2cb38e1a33)(label(case end))(mold((out \
+         Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         78faa99b-885c-43fb-ae1f-d1df624e9a8f)(content(Whitespace\" \
          \"))))(Tile((id \
          3b63ecc7-3e81-47b5-ad01-043fe7a8eaba)(label(find_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2478,19 +1978,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          16406640-b57d-4e31-a592-9d5a84387457)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8eec5a60-5ce8-430a-a088-0ec02335cb9a)(content(Whitespace\" \
+         8a8c7bb8-5ad8-4ebf-bc39-c4f625127d56)(content(Whitespace\" \
          \"))))(Tile((id 5cb02c08-8575-4113-9c3f-58d8178f23d6)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         b622c8b7-4054-4f97-96de-35901eef4418)(content(Whitespace\" \
+         c1da9709-3d4f-4f20-b3b9-5a1d833bbb48)(content(Whitespace\" \
          \"))))(Tile((id \
          bdc95ffc-b219-4be5-a182-452d360d98fc)(label(g))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         747f56a3-8bb6-4050-803f-9720cef425be)(content(Whitespace\" \
+         43ba09a1-1b0c-46d8-a122-6f9131ae3256)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3a133ecc-ce04-4500-9453-4f45c6e4d067)(content(Whitespace\" \
+         3b2ba6f3-00c4-45e5-8176-6cfb2281014b)(content(Whitespace\" \
          \"))))(Tile((id \
          452a8f02-880e-411f-a05a-afaa523e527a)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2501,38 +2001,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          369e3045-3d76-4271-bb9f-d0dd2b9db804)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         3dd63590-339f-489c-8cba-5b4e9b5b67a2)(content(Whitespace\" \
+         bf7cccbe-93a9-436c-8711-6ef35468fac2)(content(Whitespace\" \
          \"))))(Tile((id \
          dfeaed2d-59e8-4288-9f80-4706c40c1ddb)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ae8b31aa-3fda-487c-a38f-5d4ef31f428c)(content(Whitespace\" \
+         322b32a1-92e5-4fbc-a7b7-ca58cdfac6d6)(content(Whitespace\" \
          \"))))(Tile((id \
          62788e60-11b8-40d7-9ded-35335102a370)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ad6474a3-c4ab-4471-b9a0-a06b9452c079)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e5b00790-618d-4296-bc1c-26b52f6f183a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         5dbb71a2-3abf-4d8b-802a-10e2e292dfb2)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c1c8b85d-c11f-4cb3-8185-a88726941382)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         8cab26e6-3aa1-4f59-88c5-a318354d9805)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1b10819c-4de0-49a9-8ac0-7299b9856454)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         b28dc652-4f65-4a5a-b1a2-e8ab209a52a9)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         01503738-013f-41e8-936a-cc18cdc2f101)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4eabf3c9-963d-4233-8246-7b9e88195bc7)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         16fb9e46-0453-426e-b3ea-41e2f72edfab)(content(Whitespace\" \
-         \"))))(Tile((id 26932cb2-42d9-4173-a379-cd551049bf34)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         176390ca-e7b4-4d1a-8566-ffd46c5c5475)(content(Whitespace\"\\n\"))))(Tile((id \
+         26932cb2-42d9-4173-a379-cd551049bf34)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          d5f47a23-d537-4df1-908c-d2b4c834cafb)(content(Whitespace\" \
          \"))))(Tile((id \
          aa621e8d-152e-43e3-8a37-49a560e87dbd)(label(Some))(mold((out \
@@ -2546,7 +2028,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          30f382c1-5d75-471d-8534-aa9fbe2525c8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ccd79c4e-d0d2-40af-a362-b1f1217992f7)(content(Whitespace\" \
+         f4565d1a-1207-48ee-91d3-5cc8b663b713)(content(Whitespace\" \
          \"))))(Tile((id \
          8581f228-8229-45b3-848b-e09b463f752e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2556,10 +2038,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          e95f4c76-6aad-447d-9117-653930b60001)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6f614941-4e6b-4b16-a6a2-898e15fc3d42)(content(Whitespace\" \
+         \"))))(Tile((id \
          3ba588fd-a57a-4379-baf4-96329b69c1ca)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b0c0a361-c39f-4210-8862-cf7c6870ca03)(content(Whitespace\" \
+         \"))))(Tile((id \
          98dc1341-e657-4136-a645-e68fd3366bea)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2569,22 +2055,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9848ab05-a347-4f03-b552-16ae4dec5f5b)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9609bc88-98fe-4e03-a8fd-811a75615729)(content(Whitespace\" \
+         45c4811a-29c3-402f-81fd-0daa9349462d)(content(Whitespace\" \
          \"))))(Tile((id \
          4cb5ce8c-132b-4c55-b6e3-bf09c3eac906)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         466c95e2-79e3-449b-82f9-aec6cbba8c8b)(content(Whitespace\" \
+         f9cb0876-4e0b-4894-a0c0-36ede261c103)(content(Whitespace\" \
          \"))))(Tile((id \
          5a8dc015-6810-4e0f-b169-a4fd36005fd6)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          f472f02c-5d0c-4c93-af4f-2bf46ceb276d)(label(groups))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         fcaa9e91-dabb-467b-b8bf-afc6ea90a6e1)(content(Whitespace\" \
+         \"))))(Tile((id \
          64aded18-a6a4-4b50-ba7a-a41b8db2e6c8)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2c9073c7-55cf-4f65-9a8b-f7916faef5bb)(content(Whitespace\" \
+         \"))))(Tile((id \
          95e26c34-213f-41be-b739-60706344f733)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2594,24 +2084,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7c1d6bb8-4426-4ffc-8fc0-7c9b639f7296)(label(groups))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         ba103368-e48e-4456-a5b9-a9d958b1f29b)(content(Whitespace\" \
+         89e62850-224e-4749-8c38-e4ca5cd436c5)(content(Whitespace\" \
          \"))))(Tile((id \
          36d42157-3031-46d9-a125-b8df5eec7210)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2d66ff75-f060-466a-9832-3ccc0dd643d6)(content(Whitespace\" \
+         6ee106e5-74d9-47b1-abd5-ff0d83eb166f)(content(Whitespace\" \
          \"))))(Tile((id cea98c70-ca25-4eaa-94d8-c5d59c76d742)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          91add2d9-ac85-48dd-9566-6a978640f308)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         cf10670f-3f22-40c6-883f-94359fe4c5ef)(content(Whitespace\" \
+         85784f08-8acc-450e-a351-770ac9f05292)(content(Whitespace\" \
          \"))))(Tile((id \
          fe6cc0c5-2424-44ff-b067-28a40703a38b)(label(::))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
          29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a7791a9c-0e5b-493b-9e43-0c2885e7ffd5)(content(Whitespace\" \
+         065d40a6-7638-49d5-9eb4-8449372ac037)(content(Whitespace\" \
          \"))))(Tile((id \
          4ae5971f-aae8-4603-aac3-4c63b083a163)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2625,19 +2115,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4572f41b-5368-4be3-8993-e200c69b2165)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         939fc173-14ac-4bd5-ac28-66347d9d507d)(content(Whitespace\" \
+         57636102-4138-4428-83c0-d0df4060b9a7)(content(Whitespace\" \
          \"))))(Tile((id a51d0e11-32d3-4bc3-a8be-c78aba2fd522)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         1bd020ac-da59-4472-8e14-adbd9fbaa56a)(content(Whitespace\" \
+         0eabbcc0-af08-44cd-976e-cfd934c93ebc)(content(Whitespace\" \
          \"))))(Tile((id \
          d09cc44b-c1d5-463a-8776-acf174cd3bbc)(label(g))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         d3803f7d-736c-4392-9287-282077164faf)(content(Whitespace\" \
+         3ffe3b21-696b-4020-a412-3c9f78ac5761)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4e72d95e-1d2b-4050-b443-08d7cf5604e2)(content(Whitespace\" \
+         e74c9014-76f7-4ddb-9691-f16165fb908b)(content(Whitespace\" \
          \"))))(Tile((id \
          0282a9b5-ed31-4fcc-8482-397187df2be5)(label(g))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2648,36 +2138,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d610e9ae-ae87-4d9b-a266-8761126bbaee)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         7bda0c8f-7fdf-4c8c-96ac-36db5cd32736)(content(Whitespace\" \
+         5c13c09e-7677-4336-ad49-5377ccdaf36e)(content(Whitespace\" \
          \"))))(Tile((id \
          9d6ab8c7-a120-47b8-84af-8abb51d60836)(label(!=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         81845997-20ce-47a3-9fbe-04edfdac1194)(content(Whitespace\" \
+         9e69d502-d3ca-45f0-9787-8c0fec608aa6)(content(Whitespace\" \
          \"))))(Tile((id \
          712a4353-8aec-4534-a76b-fe15dfeb982a)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6d37ef82-a0df-4a5b-93e0-b67deb05def4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         6a5d2e5b-4eee-4586-9d7b-975c5703d01d)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         18c39ece-9107-41bc-8716-2274d25b728a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d634867b-8797-468d-9bd5-5646886bc724)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a5d1d9f3-a8b7-4ff0-b3bf-ec383003868a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         4c05c2dd-abe4-4806-ba16-3491202f30ae)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ff38ae89-fa4d-45d0-ada6-80ace85d3af3)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         845d3f15-308e-4866-a6bd-8dce8fb1a679)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         a34ac137-2d8a-4475-80d9-2eebdfe6a076)(content(Whitespace\" \
-         \"))))(Tile((id 9435b5b9-4378-4fd7-982e-77a1ea9cfac3)(label(| \
-         =>))(mold((out Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort \
-         Exp))((shape(Concave 46))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
+         e472181e-db7c-4057-9765-20ec1996b642)(content(Whitespace\"\\n\"))))(Tile((id \
+         9435b5b9-4378-4fd7-982e-77a1ea9cfac3)(label(| =>))(mold((out \
+         Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
+         46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
          acd5d379-617d-409d-a0ba-e02fea7d07da)(content(Whitespace\" \
          \"))))(Tile((id \
          3d7f08dc-8031-4181-9ef7-252b27b30d93)(label(None))(mold((out \
@@ -2685,7 +2159,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          307315e3-3c08-49d1-8d1c-dc381c262adf)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3ec48281-b968-46e1-9aa2-dda8bf14f29b)(content(Whitespace\" \
+         82b9ab64-65ad-4191-b3d0-22f815a8966c)(content(Whitespace\" \
          \"))))(Tile((id \
          1498f265-d269-4791-b741-1d5e90c77714)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2695,94 +2169,61 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0 1))(children(((Tile((id \
          6bc29cd6-a011-4d7d-8030-11b2aaae1140)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         ead6bd07-91a6-4054-becc-bc45cd90d081)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb95fad7-35e6-4461-9e7d-4c52b60f9e3a)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         cc1bbeb5-6c02-4557-bf99-d11c8135693d)(content(Whitespace\" \
+         \"))))(Tile((id \
          8fc2f763-1e54-40d8-a45a-62762077e249)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fbc84338-b2cd-45ac-9310-c5758958668b)(content(Whitespace\" \
+         47701245-f30d-4d30-bf80-5d0194a2afe8)(content(Whitespace\" \
          \"))))(Tile((id \
          72ac9918-99f4-4cbb-a111-84740c21041a)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         480207c2-2103-4241-b419-78f5fcd615ba)(content(Whitespace\" \
+         7b8fbb60-4444-4b9d-bf88-dbfcc4a8a2d6)(content(Whitespace\" \
          \"))))(Tile((id \
          2f9e13cb-4afe-4676-88a6-b0c759da29e9)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          aad7fa65-fced-4aaf-a39d-d2558d5d7769)(label(groups))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         97e23d60-468e-4a33-977b-68a834aa75ed)(content(Whitespace\" \
+         \"))))(Tile((id \
          675140ed-d935-4a4c-9318-7fe73181b697)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         e16131d3-d5ad-45dd-a4d2-f9310ff45658)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4087d587-975b-4183-b99a-b0d01ffd6e98)(content(Whitespace\" \
+         \"))))(Tile((id e16131d3-d5ad-45dd-a4d2-f9310ff45658)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          68e8b839-a739-428a-ae95-80c70c0e99f9)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         dc1b9e98-69d5-4221-9e41-083d70547c81)(content(Whitespace\" \
+         f182d3c2-a662-49f2-a0ef-9151238bf0bf)(content(Whitespace\" \
          \"))))(Tile((id \
          8cab89ff-1d70-4af9-87e2-6cd8e5147ed3)(label(::))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 29))(sort Exp))((shape(Concave \
          29))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b9e9d499-cc4f-45b9-8d5d-89b88410329e)(content(Whitespace\" \
+         4b8f0899-7a90-4fbf-98c4-5c31f8a8cd89)(content(Whitespace\" \
          \"))))(Tile((id \
          b38e16d2-58e7-48e6-9a6c-ea79bb4a212b)(label(grouped))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         5bd61ced-cecc-4ab8-9363-ff34fbbdd525)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c8ec0304-36c8-408e-9764-4c5de9a185e1)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2570ab3a-09a2-4f40-afc5-33b930f99107)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         aef05776-a0a4-4d89-b5be-5b206fe0612a)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ad965537-edb9-4e23-9b18-4c67cd6c2b69)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d05f1ae7-404a-490a-8e7c-0944e00cbd1f)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2f07a75c-e549-4689-87b2-43efac950549)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         71077ee4-bb90-4a8a-83a9-8296af1db6db)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         32565e42-9f77-4367-b8dd-4e5702c77b50)(content(Whitespace\" \
+         fbdf1ab8-3dec-441d-9301-df9514e8b563)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         856fbbf8-cc03-418a-ac8a-93b7d06d5262)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         24482f5f-c603-403b-b1f5-2361c2108527)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         76aeeffd-d563-4f65-a443-407090d1c822)(content(Whitespace\"\\n\"))))(Secondary((id \
-         cf754096-4a8d-4b89-97cd-d4a987116dbe)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c7279ff8-8311-4b15-ad29-b7c6636ddc7e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ef67c808-9b2f-493b-bb09-51d3be814bbc)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         cc28589b-f4ec-4e44-94d6-25e435ae3634)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2efebc04-b617-4daf-9210-99d40f449d3b)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         2b57db94-f06f-4e85-8610-4e7fd23d8218)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         af4d535a-bbb6-496a-b3f3-b23c03e96a15)(content(Whitespace\"\\n\"))))(Secondary((id \
-         69b444f8-6f92-49b2-9a2d-d74356defbad)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         1ea64f07-f4e6-4a0d-ac14-6b4c654d8258)(content(Whitespace\" \
-         \")))))))))(Secondary((id \
-         8066dee6-e813-4d89-8d68-b3dabc73f43b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e909ee8d-3093-4175-a09e-eae95478c3f0)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         7981f6c7-4c21-4759-9b11-67e4858c717c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         ccfd95a0-fc46-44cb-ae89-4f6bf436e26c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         86ce25fb-7510-49be-81f7-8069e5f1c04c)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         719b4279-4ad6-4756-898f-c0a7889a3d19)(content(Whitespace\" \
-         \"))))(Tile((id 9ff4ef30-8d9a-4927-a853-ddc5724e59f7)(label(test \
-         end))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         0f6cce16-1295-4453-9ad0-80ee182eab66)(content(Whitespace\" \
-         \"))))(Tile((id \
+         84e68123-e0e1-4574-ba49-b683951afcf3)(content(Whitespace\"\\n\"))))(Tile((id \
+         9ff4ef30-8d9a-4927-a853-ddc5724e59f7)(label(test end))(mold((out \
+         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
+         Exp))))))(shards(0 1))(children(((Secondary((id \
+         08f6e4dd-b75c-4a31-929c-cc662f856873)(content(Whitespace\"\\n\"))))(Tile((id \
          6c4197e0-1cd7-4ac2-abd0-7de3cc22378f)(label(group_by_retentive))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -2807,19 +2248,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          612d1c93-0142-4050-a5ea-3552ffed6d15)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9d3df76e-9af7-4140-8de9-c3b0e59aac16)(content(Whitespace\" \
+         08b8be17-42a9-47c2-a5c3-89a83952cc3e)(content(Whitespace\" \
          \"))))(Tile((id e5f7c562-6ac9-45f0-a5cf-523f5591f13b)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e99376ea-c05f-46ff-8047-41b9658fa2ae)(content(Whitespace\" \
+         ec7f018a-f8e8-4f31-b4a2-7cad4ee72f3a)(content(Whitespace\" \
          \"))))(Tile((id \
          b7ac5e1c-be77-4403-95a9-126426045434)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5cdaf759-18ce-46da-9988-9d5b42e6c20b)(content(Whitespace\" \
+         21a2b075-2c77-4da3-835f-9d5795232e7e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         a0918c76-1ccd-4411-8a97-ebd11304af98)(content(Whitespace\" \
+         6933e860-9a40-4850-b4b4-230c721eaf65)(content(Whitespace\" \
          \"))))(Tile((id \
          82cace6c-6964-4a57-a378-f2d28b9e0abd)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -2830,119 +2271,116 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f597b4de-9c6b-49f9-a836-d57d283559d2)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d423582e-9b0b-4c70-adc1-db6f0db325b8)(content(Whitespace\" \
+         9db8f508-fc4a-45de-99e7-a4b2fc7bb3ac)(content(Whitespace\" \
          \"))))(Tile((id \
          18b20237-b6c0-4a18-80bc-3fc608c477da)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5223d031-350b-4179-b2a6-ef365da09776)(content(Whitespace\" \
+         432c7c85-1d86-4383-8d58-eceaa8602876)(content(Whitespace\" \
          \"))))(Tile((id \
          8e5b3eb1-e830-4fe5-b390-ba9b62fa714e)(label(expected))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         4832045e-fc82-4479-8afc-983e6d4841d1)(content(Whitespace\" \
+         06be127f-b1e9-409f-b83e-aac365514a52)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         22efb4d7-023b-4aae-9c19-4064f02e2a15)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         6518e202-0186-4a93-96f0-159008b63572)(content(Whitespace\" \
-         \"))))(Tile((id \
+         7d7c76a1-289e-43c2-b662-52c8e10c8942)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         f35f84a0-85fa-46ad-a2ca-00528d8ecbb5)(content(Whitespace\"\\n\"))))(Tile((id \
          c69c5493-299a-4e72-be6a-9314339a3ca7)(label(?))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Secondary((id \
-         d4975b7e-f63b-44cd-9402-5d96e3b3b0c2)(content(Whitespace\"\\n\")))))";
+         Exp))))))(shards(0))(children()))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
-         let students : [Student] = ([\n\
-        \  (\"Bob\", 12, \"blue\"),\n\
-        \  (\"Alice\", 17, \"green\"),\n\
-        \  (\"Eve\", 13, \"red\")\n\
-         ]) in\n\
-         let expected = ([(key=\"blue\", groups=[(name=\"Bob\", age=12, \
-         favorite_color=\"blue\")]), (key=\"green\", groups=[(name=\"Alice\", \
-         age=17, favorite_color=\"green\")]), (key=\"red\", \
-         groups=[(name=\"Eve\", age=13, favorite_color=\"red\")])]) in\n\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
+         let students : [Student] = ([(\"Bob\", 12, \"blue\"), (\"Alice\", 17, \
+         \"green\"), (\"Eve\", 13, \"red\")]) in\n\
+         let expected = (\n\
+         [\n\
+         (key=\"blue\", groups=[(name=\"Bob\", age=12, \
+         favorite_color=\"blue\")]),\n\
+         (key=\"green\", groups=[(name=\"Alice\", age=17, \
+         favorite_color=\"green\")]),\n\
+         (key = \"red\", groups = [(name = \"Eve\", age = 13, favorite_color = \
+         \"red\")])\n\
+         ]\n\
+         ) in\n\n\
          # This way closely follows the TableAPI by taking a string column \
          name but provides no static guarantees #\n\
          let v1 =\n\
-        \  let requires = [\n\
-        \    (enforced=(false), \"c is in header(t1)\"),\n\
-        \    (enforced=(false), \"schema(t1)[c] is a categorical sort\")\n\
-        \  ] in\n\
-        \  let ensures = [\n\
-        \    (enforced=(false), \"header(t2) == [key, groups]\"),\n\
-        \    (enforced=(false), \"schema(t2)[key] == schema(t1)[c]\"),\n\
-        \    (enforced=(false), \"schema(t2)[groups] == Table\"),\n\
-        \    (enforced=(false), \"getColumn(t2, key) has no duplicates\"),\n\
-        \    (enforced=(false), \"for all t in getColumn(t2, groups), \
-         schema(t) == schema(t1)\"),\n\
-        \    (enforced=(false), \"nrows(t2) == \
+         let _requires = [(enforced=(false), \"c is in header(t1)\"), \
+         (enforced = (false), \"schema(t1)[c] is a categorical sort\")] in\n\
+         let _ensures = [\n\
+         (enforced=(false), \"header(t2) == [key, groups]\"),\n\
+         (enforced=(false), \"schema(t2)[key] == schema(t1)[c]\"),\n\
+         (enforced=(false), \"schema(t2)[groups] == Table\"),\n\
+         (enforced=(false), \"getColumn(t2, key) has no duplicates\"),\n\
+         (enforced=(false), \"for all t in getColumn(t2, groups), schema(t) == \
+         schema(t1)\"),\n\
+         (enforced = (false), \"nrows(t2) == \
          length(removeDuplicates(getColumn(t1, c)))\")\n\
-        \  ] in\n\
-        \  \n\
-        \  let group_by_retentive = fun (t1:[?], c:String) ->\n\
-        \    let get_value = fun (r:?, label:String) ->\n\
-        \      find_opt(to_lvs(r), fun e -> e.label == label) |> option_map(_, \
-         fun e -> e.value) \n\
-        \    in\n\
-        \    let remove_duplicates = fun (xs:[?]) ->\n\
-        \      fold_left(xs,\n\
-        \        fun (seen, x) ->  \n\
-        \          if mem(seen, x) then seen else seen @ [x],\n\
-        \        []) : [?] in\n\
-        \    let get_key = fun (r:?) -> get_value(r, c) in\n\
-        \    let keys =\n\
-        \      map(t1, get_key)\n\
-        \      |> filter_map(_, fun opt -> opt)\n\
-        \      |> remove_duplicates in\n\
-        \    \n\
-        \    map(keys, fun k ->\n\
-        \      let rows =\n\
-        \        filter(t1, fun r ->\n\
-        \          case get_key(r)\n\
-        \          | Some(k') => k' == k\n\
-        \          | None => false\n\
-        \          end) in\n\
-        \      (key=k) ... (groups=rows)) : [?] \n\
-        \  in\n\
-        \  \n\
-        \  test group_by_retentive(students, \"favorite_color\") == expected end\n\
-         in\n\
+         ] in\n\
+         let group_by_retentive =\n\
+         fun (t1 : [?], c : String) ->\n\
+         let get_value = fun (r : ?, label : String) -> find_opt(to_lvs(r), \
+         fun e -> e.label == label) |> option_map(_, fun e -> e.value) in\n\
+         let remove_duplicates = fun (xs : [?]) -> fold_left(xs, fun (seen, x) \
+         -> if mem(seen, x) then seen else seen @ [x], []) : [?] in\n\
+         let get_key = fun (r : ?) -> get_value(r, c) in\n\
+         let keys = map(t1, get_key) |> filter_map(_, fun opt -> opt) |> \
+         remove_duplicates in\n\
+         map(\n\
+         keys,\n\
+         fun k ->\n\
+         let rows =\n\
+         filter(\n\
+         t1,\n\
+         fun r ->\n\
+         case get_key(r)\n\
+         | Some(k') => k' == k\n\
+         | None => false\n\
+         end\n\
+         ) in\n\
+         (key = k) ... (groups = rows)\n\
+         )\n\
+         : [?] in\n\
+         test\n\
+         group_by_retentive(students, \"favorite_color\") == expected end in\n\
          # This is the more idiomatic way and takes a function to project out \
          the group #\n\
          let v2 =\n\
-        \  let requires = [\n\
-        \    (enforced=(true), \"c is in header(t1)\"),\n\
-        \    (enforced=(true), \"schema(t1)[c] is a categorical sort\") # \
-         Verifies it's a string column #\n\
-        \  ] in\n\
-        \  let ensures = [\n\
-        \    (enforced=(true), \"header(t2) == [key, groups]\"),\n\
-        \    (enforced=(true), \"schema(t2)[key] == schema(t1)[c]\"),\n\
-        \    (enforced=(true), \"schema(t2)[groups] == Table\"),\n\
-        \    (enforced=(false), \"getColumn(t2, key) has no duplicates\"),\n\
-        \    (enforced=(true), \"for all t in getColumn(t2, groups), schema(t) \
-         == schema(t1)\"),\n\
-        \    (enforced=(false), \"nrows(t2) == \
+         let _requires = [\n\
+         (enforced=(true), \"c is in header(t1)\"),\n\
+         (enforced = (true), \"schema(t1)[c] is a categorical sort\")\n\
+         # Verifies it's a string column #\n\
+         ] in\n\
+         let _ensures = [\n\
+         (enforced=(true), \"header(t2) == [key, groups]\"),\n\
+         (enforced=(true), \"schema(t2)[key] == schema(t1)[c]\"),\n\
+         (enforced=(true), \"schema(t2)[groups] == Table\"),\n\
+         (enforced=(false), \"getColumn(t2, key) has no duplicates\"),\n\
+         (enforced=(true), \"for all t in getColumn(t2, groups), schema(t) == \
+         schema(t1)\"),\n\
+         (enforced = (false), \"nrows(t2) == \
          length(removeDuplicates(getColumn(t1, c)))\")\n\
-        \  ] in\n\
-        \  \n\
-        \  let group_by_retentive : poly row -> poly key -> ([row], (row -> \
-         key)) -> [(key=key, groups=[row])] =\n\
-        \    typfun row ->  typfun key -> fun (t1, c) ->\n\
-        \      case t1\n\
-        \      | [] => []\n\
-        \      | x::xs => \n\
-        \        let key = c(x) in\n\
-        \        let grouped = group_by_retentive@<row>@<key>(xs, c) in\n\
-        \        case find_opt(grouped, fun g -> g.key == key) \n\
-        \        | Some(g) => ((key=g.key) ... (groups=g.groups @ [x])) :: \
+         ] in\n\
+         let group_by_retentive : poly row -> poly key -> ([row], (row -> \
+         key)) -> [(key = key, groups = [row])] =\n\
+         typfun row ->\n\
+         typfun key ->\n\
+         fun (t1, c) ->\n\
+         case t1\n\
+         | [] => []\n\
+         | x::xs =>\n\
+         let key = c(x) in\n\
+         let grouped = group_by_retentive@<row>@<key>(xs, c) in\n\
+         case find_opt(grouped, fun g -> g.key == key)\n\
+         | Some(g) => ((key = g.key) ... (groups = g.groups @ [x])) :: \
          filter(grouped, fun g -> g.key != key)\n\
-        \        | None => ((key=key) ... (groups=[x])) :: grouped\n\
-        \        end\n\
-        \      end\n\
-        \  in\n\
-        \  \n\
-        \  test group_by_retentive@<Student>@<String>(students, fun r -> \
-         r.favorite_color) == expected end\n\
-         in ?\n";
+         | None => ((key = key) ... (groups = [x])) :: grouped\n\
+         end\n\
+         end in\n\
+         test\n\
+         group_by_retentive@<Student>@<String>(students, fun r -> \
+         r.favorite_color) == expected end in\n\
+         ?";
       refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesgroupBySubtractive.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesgroupBySubtractive.ml
@@ -1,87 +1,98 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Utilities / groupBySubtractive",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id 18e87e1b-eb7d-4b85-9453-2c970f25add8)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         42e2f639-3cd1-457e-9b40-66a6e0033ff8)(content(Whitespace\" \
+         f2dd504f-57eb-405d-8824-be6fbf7783a3)(content(Whitespace\" \
          \"))))(Tile((id \
          ec8b854f-da74-4225-9d7e-36793c6f5c88)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         edb62f04-f4dc-47be-b786-f97198676345)(content(Whitespace\" \
+         7b4b9de7-43ba-48e0-b656-babaf0d11f2f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a970320e-6cfc-4a06-8ab0-54d744d589da)(content(Whitespace\" \
+         cb618982-61dd-41ba-85c8-e04056fde6de)(content(Whitespace\" \
          \"))))(Tile((id \
          3c62b110-a43c-4566-a26b-0fd7cb5900d0)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          59008701-77a8-41b6-a9dc-a3c0ba624649)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1cdcef90-9731-481d-9173-17154d9cd4b6)(content(Whitespace\" \
+         \"))))(Tile((id \
          ff6f5597-915d-4240-8365-6ecfa84e444c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5f428cc2-f219-4da8-9bde-0a4dd3e5e0f7)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb08cc12-0b48-476d-a991-ae231206f9f9)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e7eaed3c-049b-4b3c-8f86-f9e993ce83b9)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9f2ca4f8-ff7f-41c4-be2e-49502770dc32)(content(Whitespace\" \
+         d4f14192-ce5d-4274-8a56-486e28f95fd5)(content(Whitespace\" \
          \"))))(Tile((id \
          85ed21c7-6b65-4b27-ad44-85d8209cc2fb)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         924b24d2-b832-4d2c-aab3-1c3bb5acd0af)(content(Whitespace\" \
+         \"))))(Tile((id \
          6d5f1162-02f5-4fc9-a48b-563a69732234)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         961f0693-392b-4b84-a4b3-95a39c85890d)(content(Whitespace\" \
+         \"))))(Tile((id \
          8069cb28-580e-4d4c-b4b2-c8a9d80ff3fa)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          652bccea-89d5-409f-b836-b0dea28ebf2a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5420a5d9-1a79-4fdd-a3ff-b54682b68151)(content(Whitespace\" \
+         6eb67505-df8c-434f-a06f-552386e9927a)(content(Whitespace\" \
          \"))))(Tile((id \
          7796adf6-ac9a-4eeb-a4fc-fab64d7d5e76)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         095df411-88db-4d12-837c-e2ae534b8047)(content(Whitespace\" \
+         \"))))(Tile((id \
          d8e8c97e-141c-47a3-bcce-2785dc2666f3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         755b6a44-f6af-4a20-9242-b0f064237203)(content(Whitespace\" \
+         \"))))(Tile((id \
          d579a6fc-650e-4a21-8a2c-82ca6714ff25)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         aa50806c-3150-40bb-8b1d-36fa7d79fd56)(content(Whitespace\" \
+         8e5d1fff-22a6-463f-949e-401ae0c3fbd1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         dbfc8fba-5931-415a-b3c6-52ddb7436db4)(content(Whitespace\"\\n\"))))(Tile((id \
+         f6409e62-0275-46fb-8ed7-905fdbbd370b)(content(Whitespace\"\\n\"))))(Tile((id \
          3f2c8437-4c67-43da-92f9-6f79b6ffacca)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         6d208989-fdc2-40a2-9744-4391a0bd8a99)(content(Whitespace\" \
+         58be23ff-5594-478d-aca1-0da60f20fa93)(content(Whitespace\" \
          \"))))(Tile((id \
          6a645a70-1856-41e0-a85b-c0edeb074f0f)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c9abdb40-3ac6-4ac7-807d-32501abeb402)(content(Whitespace\" \
+         dc7c3264-c72a-46c5-add3-8a62be07d0d0)(content(Whitespace\" \
          \"))))(Tile((id \
          46e15f96-b4b6-4d19-8751-c224e5f4ddbe)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a457c9fb-ed83-4683-805e-3a92bacdbee4)(content(Whitespace\" \
+         da2a8393-f1e7-4f92-82b7-2a6c2c8ffce6)(content(Whitespace\" \
          \"))))(Tile((id e370db3e-b5ad-4021-b044-bbdef67e909f)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          384e94e5-177d-461e-ab90-b71a508b0415)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c7a61352-f520-4631-834c-bc382d99867c)(content(Whitespace\" \
+         199ae86e-e0b8-4cbc-bc8e-54c1959651f7)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6a95ae90-671c-4451-b746-3881b0462e20)(content(Whitespace\" \
+         1d152614-c60f-47ae-9ae2-16a2bf82db6a)(content(Whitespace\" \
          \"))))(Projector((id b9d1cd89-6dfa-4c3a-ae8f-9a5fd8dd83a8)(kind \
          Fold)(syntax(Tile((id \
          b9d6b250-177f-482e-9993-3965ccd564ec)(label(\"(\"\")\"))(mold((out \
@@ -167,25 +178,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          89ee406e-4ee7-4fa2-a263-3c026eedc628)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         857e4987-7dbd-4114-a250-86fc84c17077)(content(Whitespace\" \
+         e0ac9d3a-2441-4cee-a3b2-89ee6306acf6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6d37b8c1-7524-4c10-8fad-00675a5cc174)(content(Whitespace\"\\n\"))))(Secondary((id \
-         c57bef7d-a7cf-4bc1-9b38-f15e9e576788)(content(Whitespace\"\\n\"))))(Tile((id \
+         1cf601e3-5d64-46f5-a22f-c3d8916a24f3)(content(Whitespace\"\\n\"))))(Secondary((id \
+         137fe1a1-bfd5-4b4a-9576-c7284618f137)(content(Whitespace\"\\n\"))))(Tile((id \
          2e6a8e31-4740-4086-88bf-6817c87c5112)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         85501bc8-732b-4513-acf4-f9ad682d5b39)(content(Whitespace\" \
+         72ebb211-2258-40ba-938e-4aaf443fee2b)(content(Whitespace\" \
          \"))))(Tile((id \
-         33a319cc-b23a-4a2a-8936-7a02c4006e17)(label(requires))(mold((out \
+         33a319cc-b23a-4a2a-8936-7a02c4006e17)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         af7bf530-dc28-4891-80ef-6f8aa1bf76cb)(content(Whitespace\" \
+         0476ee38-3bf6-4f88-a9dd-74adee9735ec)(content(Whitespace\" \
          \")))))((Secondary((id \
-         e46ac812-0d45-402d-9c0f-63810c8cdf85)(content(Whitespace\" \
+         d23f606c-0764-41c3-ac19-83cc6aa3954f)(content(Whitespace\" \
          \"))))(Tile((id 67da95c7-b3e8-4071-b998-872c69bf8bac)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         fee22b57-7a58-47bf-a01b-4f5a0e2dc7b4)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          2f28ec0c-8060-40d7-9ecd-d56b9d8581ea)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -213,17 +223,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          57f2b6f2-cfa3-4cd2-a29b-7f9bbfeafc6c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2ff64541-bea4-4a89-bcfe-eb2aebb7659f)(content(Whitespace\"\\n\"))))(Tile((id \
+         37b6b7f5-6f90-43f5-bc90-67b8e8119325)(content(Whitespace\" \
+         \"))))(Tile((id \
          8566a64f-182a-4244-bc8d-b538a5633d1d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          02541992-1af9-45e7-991a-c992ab44d8cb)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         146dee14-9255-4ec5-a9bc-769080f3bb87)(content(Whitespace\" \
+         \"))))(Tile((id \
          d2cf4ec7-de3a-420d-8621-c7ed955dac3e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         c44c27e8-d2a7-471e-b5a3-a9327ab383f2)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fa5b718f-a039-401e-8f31-8d35417497db)(content(Whitespace\" \
+         \"))))(Projector((id c44c27e8-d2a7-471e-b5a3-a9327ab383f2)(kind \
+         Checkbox)(syntax(Tile((id \
          a8d43cbd-3632-4439-99b7-24a06d113060)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -233,31 +248,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0dee2241-b08d-46e5-b8f0-7a2f63ede513)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7361e87e-b404-42cf-a696-f15397174b70)(content(Whitespace\" \
+         0189ed6b-5348-4762-a1dc-7f4e12f21cc2)(content(Whitespace\" \
          \"))))(Tile((id \
          082a334c-4cb5-4df0-ab7e-e9baf8a1aae4)(label(\"\\\"schema(t1)[c] is a \
          categorical sort\\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ecb47686-e50a-4342-8106-c12473c50ebd)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         821f3ff4-a449-4844-8186-58c156e12de2)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         8d047bd0-10d6-4cbb-9e6c-96f35c6dba0f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         91bff259-d185-4818-87dc-0d8d319b3a56)(content(Whitespace\"\\n\"))))(Tile((id \
+         1a613986-c014-4311-ae31-1860749b9a87)(content(Whitespace\"\\n\"))))(Tile((id \
          52a83bf5-33a7-4f7c-a95d-ee52a91157d2)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         b74c4982-244c-4f9d-ae87-3851045b4df1)(content(Whitespace\" \
+         72644608-b595-47a5-8fc5-8d12a9862b0c)(content(Whitespace\" \
          \"))))(Tile((id \
-         e40ced1c-da4e-4268-92bd-2e710a0200d3)(label(ensures))(mold((out \
+         e40ced1c-da4e-4268-92bd-2e710a0200d3)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         07fcd689-aa03-4c5a-88db-4f30e9e77cf3)(content(Whitespace\" \
+         a1d2ddb3-f4a4-4498-b15c-e26e758fb318)(content(Whitespace\" \
          \")))))((Secondary((id \
-         78962918-71ca-4c3c-ad14-aab92b62d6d9)(content(Whitespace\" \
+         44effd19-aec0-46f1-b3a7-9f9da9ad3a90)(content(Whitespace\" \
          \"))))(Tile((id 050336c7-bd04-4c6e-9f52-47f6f7cf935d)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         49c3dbbe-992f-42cc-8f3d-8ccc8bdf97ea)(content(Whitespace\"\\n\"))))(Tile((id \
+         f6384597-1aa3-44fb-9f89-b215988d98cd)(content(Whitespace\"\\n\"))))(Tile((id \
          6849fa12-4d4c-4c0e-acdd-066828b199b4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -286,7 +300,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6c3506b9-e8d2-4f48-b350-8a20c3a0633f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         09bb8f33-4850-4189-9e45-bbe169899aab)(content(Whitespace\"\\n\"))))(Tile((id \
+         9331cc79-532e-4464-8e61-bbc48b58c44b)(content(Whitespace\"\\n\"))))(Tile((id \
          1f03b499-8a95-4dd1-b2f0-9add79074048)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -315,7 +329,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          46eada35-ddbe-40de-84a3-0e994059700d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         95fe74a5-3240-4af7-8013-6367b4551301)(content(Whitespace\"\\n\"))))(Tile((id \
+         7c846c94-1a67-4982-beaa-409681462f0f)(content(Whitespace\"\\n\"))))(Tile((id \
          2a56b9e8-c638-40cb-8934-166a704c926f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -344,7 +358,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5b001cca-e578-45eb-9bdc-a5e39c62d191)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         afe4f332-8b54-4f6b-8995-ac0f932000e3)(content(Whitespace\"\\n\"))))(Tile((id \
+         78041371-c153-4fed-9e4c-f23475723e5a)(content(Whitespace\"\\n\"))))(Tile((id \
          b91aa1c1-2346-427a-b6ad-8a5b834d1893)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -373,7 +387,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9302549c-7cab-4aaf-b792-5f0669b99abd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3728b31c-4bfa-4028-bd8f-dac74358b3c9)(content(Whitespace\"\\n\"))))(Tile((id \
+         57a318b3-82ed-411a-9e34-c4540d02ad34)(content(Whitespace\"\\n\"))))(Tile((id \
          1c1ccf1c-7697-4122-9f65-05b931af71f8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -402,7 +416,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9601b361-7f5e-4136-8c40-2157c7caa598)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bf98d171-44fe-4b3f-b5e1-03049a00d143)(content(Whitespace\"\\n\"))))(Tile((id \
+         b0602e3d-9496-408a-a99d-9749a334e54a)(content(Whitespace\"\\n\"))))(Tile((id \
          8efcfe7e-6328-4795-bb5c-1ab58de575d1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -431,17 +445,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          38c320c6-a6d7-4569-a907-9e1f7423d5ae)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b8222618-cb00-4ccd-a85c-5a8cc78a281b)(content(Whitespace\"\\n\"))))(Tile((id \
+         0ae7cc6a-b576-4d4b-bc18-1a8f23d6e71b)(content(Whitespace\"\\n\"))))(Tile((id \
          c1f21adc-dfa8-4c9a-8c16-144b81dd47f7)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          02fbc59e-ac03-4143-a772-700ecd948542)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         550c954c-2fd2-46a5-abd5-f78442f02994)(content(Whitespace\" \
+         \"))))(Tile((id \
          7687a557-e34a-403d-9c36-75ae97fe7524)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         065e3cd2-a89d-4f94-bcb8-c174f9e869fb)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3309fe5c-b551-4239-8c01-e33484ca1087)(content(Whitespace\" \
+         \"))))(Projector((id 065e3cd2-a89d-4f94-bcb8-c174f9e869fb)(kind \
+         Checkbox)(syntax(Tile((id \
          04e4ad5e-3709-44d5-924c-e1f38e04f049)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -451,39 +469,39 @@ let out : string * Haz3lcore.PersistentSegment.t =
          53b3295d-6113-40ea-b80e-a9d023d2135d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fbb6d17d-02a9-49c7-b718-45a1d92749d0)(content(Whitespace\" \
+         2e1f254a-7532-4c5d-9432-1ff512a8baaf)(content(Whitespace\" \
          \"))))(Tile((id \
          98f569e7-83a0-424f-9407-55aca6ac9daa)(label(\"\\\"nrows(t2) == \
          length(removeDuplicates(getColumn(t1, c)))\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         21d31f2b-fe16-489f-a554-6cb1e6a81a63)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         24590f69-3e8d-43d0-a59a-2290fbdfa506)(content(Whitespace\" \
+         34688d64-942d-493b-a55c-f388caafea66)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         6c42309b-f81e-4a39-98ee-f62548ce3d35)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         59b5c073-bdf7-4288-8673-3205adee844e)(content(Whitespace\"\\n\"))))(Secondary((id \
-         774d1e3b-92fa-4c0d-aaf5-37534b933d91)(content(Whitespace\"\\n\"))))(Tile((id \
+         fbfe0fca-3430-4ed9-abb6-10c2116cf056)(content(Whitespace\"\\n\"))))(Secondary((id \
+         8328f9ae-65b8-4bef-89a4-c1da7534e829)(content(Whitespace\"\\n\"))))(Tile((id \
          93a57d67-5f00-4145-9db6-6e5fd05b7bfe)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1bc5046b-77af-4cba-902e-3b8d5edfc624)(content(Whitespace\" \
+         1d66b4f2-5d5e-40c9-b149-924182e8926c)(content(Whitespace\" \
          \"))))(Tile((id \
          13f43c4a-8729-4fb1-8ec7-cbbb8f5335e8)(label(group_by_subtractive))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5c3094f6-6a7e-4197-b059-8d943db4c171)(content(Whitespace\" \
+         c1d1e033-58c1-492f-9f50-0b4ee3a57c45)(content(Whitespace\" \
          \")))))((Secondary((id \
-         43d18ad9-bf3a-4735-a545-7534c57db8d6)(content(Whitespace\"\\n\"))))(Tile((id \
+         403507ab-5437-4f10-8f88-6869b1e9eb06)(content(Whitespace\"\\n\"))))(Tile((id \
          456aa59c-3196-4b18-ac86-f803be1fc746)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         fa921338-0a62-45a0-9c4a-1aa8cfe324e5)(content(Whitespace\" \
+         b5ed8d2c-e322-4cf9-aa4d-ba5c79f5b21a)(content(Whitespace\" \
          \"))))(Tile((id \
          a6c9fa88-1bb4-4e1b-a0f5-eb617321cc69)(label(get_value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e62993a6-2af2-44bf-aaa3-dab5f50b9336)(content(Whitespace\" \
+         97d433ec-3825-44ba-8b12-123d2d148526)(content(Whitespace\" \
          \")))))((Secondary((id \
-         6fc86ed4-eae5-4922-8d9e-246019e34094)(content(Whitespace\" \
+         bb09b1fe-2d60-452b-ae68-62ceab51b3b4)(content(Whitespace\" \
          \"))))(Projector((id 50cee923-d991-406e-90db-97abb3cfadac)(kind \
          Fold)(syntax(Tile((id \
          69f68a40-0b22-42eb-926e-db8328d9e1d1)(label(\"(\"\")\"))(mold((out \
@@ -617,44 +635,48 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         44106f03-1c14-4c9c-981c-5fb4906a8796)(content(Whitespace\" \
+         11dbc22a-5ff6-4f83-8955-d5a4d30bfbd2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9b80aa69-2ec8-4291-875a-feccde682ff7)(content(Whitespace\"\\n\"))))(Tile((id \
+         7b094c9d-08c4-4b01-95dc-18b092c6cf19)(content(Whitespace\"\\n\"))))(Tile((id \
          30daed64-13d8-43ed-adaa-74ea04d9e3d5)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         6a247e6b-57cb-41aa-a954-6b45b29e0ea5)(content(Whitespace\" \
+         69694b40-32de-4373-862c-45174eabd950)(content(Whitespace\" \
          \"))))(Tile((id \
          bd209e34-1d0f-482d-8bab-8e0580710ae2)(label(remove_duplicates))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         55e5905d-c62e-40c2-9fb1-63549398ddb7)(content(Whitespace\" \
+         042ac780-1696-49df-82cc-ded3e8e6cdbf)(content(Whitespace\" \
          \")))))((Secondary((id \
-         828e502f-aecc-4de1-b77e-71b0e3e255bb)(content(Whitespace\" \
+         d7608f6e-1cc7-4768-81f5-88917c7d18e7)(content(Whitespace\" \
          \"))))(Tile((id 9b29e907-f12b-4a39-a44d-31f5557d9dfa)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         210b2341-be0b-4032-b47d-00451084d772)(content(Whitespace\" \
+         206b22be-e2d5-40ce-860c-1bc5b73bce46)(content(Whitespace\" \
          \"))))(Tile((id \
          76b12ca0-ee77-417b-80a4-fcdafd55682e)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          a7a415b1-a5d3-4760-9ae6-7c4f8984b1bb)(label(xs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6355bc06-761c-4e37-886f-a25db6238db0)(content(Whitespace\" \
+         \"))))(Tile((id \
          eefd4fbe-4992-448b-80ce-5c8d1bedd085)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         85707b41-59e6-41c2-95b5-93178dad2e73)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f7b5b0b8-754e-4b33-ba6d-f34231bab005)(content(Whitespace\" \
+         \"))))(Tile((id 85707b41-59e6-41c2-95b5-93178dad2e73)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          1b4c9f87-ac8e-48e4-867b-57bfe824d624)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         dd1dca45-1f05-430c-9159-f669fc9d809e)(content(Whitespace\" \
+         a9434d69-b95b-447d-a961-f035f087448c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8d8ee8de-119d-4479-8489-10cbcd84c6cd)(content(Whitespace\"\\n\"))))(Tile((id \
+         9db06ad3-0daf-4e4a-9fa6-b24866cb6701)(content(Whitespace\" \
+         \"))))(Tile((id \
          28ee1e34-35b1-4a0a-bdec-0ba1f2538ae5)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -667,11 +689,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e3bed25c-4396-410d-b7a2-0f961a718fe1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f0a90b7a-990a-452b-994d-7de85cbf584c)(content(Whitespace\"\\n\"))))(Tile((id \
-         119bece7-89d5-4da9-967a-34a5e8aceba8)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         aa9cf3f2-1239-4138-b8c4-f044cc5b1b24)(content(Whitespace\" \
+         3b4db327-9242-45d7-b244-7f5c0654ad7f)(content(Whitespace\" \
+         \"))))(Tile((id 119bece7-89d5-4da9-967a-34a5e8aceba8)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         f587ca46-484a-4e66-b6de-988d7e2cd370)(content(Whitespace\" \
          \"))))(Tile((id \
          a2fcc49b-b7b9-4a6e-990f-684ec81f5851)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -682,18 +705,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          07a53c42-e668-47ce-8755-9e389f3488ac)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         eec82dc8-0365-4696-a8e7-0aba15d07722)(content(Whitespace\" \
+         ae767a95-fd76-4290-b53c-3fae2ffcfe64)(content(Whitespace\" \
          \"))))(Tile((id \
          1b6810a1-cd00-4e47-b415-25f44cf5521d)(label(x))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         cb0cc28d-826c-4421-8b01-d2d76695366e)(content(Whitespace\" \
+         449988a1-9f2b-4e77-ab4a-d7bc2ced6485)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4e2acda6-2e0d-488f-955d-fe4820a55621)(content(Whitespace\"\\n\"))))(Tile((id \
-         95ac029e-89d6-4ea7-a3e8-9a0211720418)(label(if then else))(mold((out \
-         Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         36))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         9f5b8bfb-b389-447e-aacc-d518049602ab)(content(Whitespace\" \
+         914dc0d6-48d5-4716-bbd3-4394be545d49)(content(Whitespace\" \
+         \"))))(Tile((id 95ac029e-89d6-4ea7-a3e8-9a0211720418)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         e57b9bd3-9ddf-4911-844f-3277c70a5d73)(content(Whitespace\" \
          \"))))(Tile((id \
          48fcb714-73e7-4c11-8e43-bedd711cc8cc)(label(mem))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -707,31 +731,31 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4342e8c7-70b4-46be-9fc3-345459a51fc7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c86ab382-e436-4b51-9f78-537e7907a380)(content(Whitespace\" \
+         5195fc9e-77ee-49a4-abad-1ccbb4f79d28)(content(Whitespace\" \
          \"))))(Tile((id \
          269d0cf7-a1ae-4ec5-99cb-3489f1994761)(label(x))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         281aefdb-1ae3-4e2f-a218-1a1faca05668)(content(Whitespace\" \
+         5c2e559e-58ed-4f2a-96b6-8722ce8362bc)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f32c7347-bef2-4e94-b987-c5cd1e95342b)(content(Whitespace\" \
+         9de1cc37-094b-4e9b-9469-993d13fa8c86)(content(Whitespace\" \
          \"))))(Tile((id \
          6372424b-02c2-43c6-a9cc-5597de257999)(label(seen))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         74907c1f-d6b3-4b4f-ac9f-5d3f21a27c3e)(content(Whitespace\" \
+         2661ebc7-b95c-4e9f-b76d-02aa048e1639)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4eef7e93-7841-49ad-9d48-5dcbe471e7db)(content(Whitespace\" \
+         5aab0f91-3176-4df6-81da-c894ae2029e8)(content(Whitespace\" \
          \"))))(Tile((id \
          1d53f5f1-d47b-4cf1-852f-4536b7a4bbc9)(label(seen))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         b2cbb3e1-7359-438b-9351-f6b7f8bf3353)(content(Whitespace\" \
+         c3063963-ea6d-422d-9dea-c6c42b7a5f9d)(content(Whitespace\" \
          \"))))(Tile((id \
          2fbdc32f-23d4-456c-8532-0e61d8ecc205)(label(@))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         db865d9b-5812-4c34-829d-a85f89407071)(content(Whitespace\" \
+         65566cdd-f4eb-451a-aeca-9c7aee6af9c9)(content(Whitespace\" \
          \"))))(Tile((id dbbba10d-1b36-4beb-b3a4-536bd6e1fab4)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -741,91 +765,107 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f720dbed-44f7-4d9e-8d54-87313225eb2b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         dd3e7cae-6fd6-4032-8492-405410e83522)(content(Whitespace\"\\n\"))))(Tile((id \
+         cfb6ed79-13d7-4bc7-8916-d67963cad456)(content(Whitespace\" \
+         \"))))(Tile((id \
          9c078946-ac61-423b-bf8a-e4e527fad3ee)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         bb855c95-98ca-4cad-bb91-94e932b10da7)(content(Whitespace\" \
+         0fa4bc7c-792a-4a1b-b8aa-d6c3db5b9744)(content(Whitespace\" \
          \"))))(Tile((id \
          c972ad6e-7c0c-474a-a5ce-727b75007565)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         474840fc-7467-4d3e-bb0f-ee14d71df640)(content(Whitespace\" \
+         4daf20fa-c175-45ac-95a6-eaf7a3c8bd64)(content(Whitespace\" \
          \"))))(Tile((id 4748d6a9-530b-4fa0-82bb-60d359f6aece)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          01acc63d-eabb-4662-87a9-f5f65cf46cfe)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         b543883e-edae-414a-bc8b-1420c9566610)(content(Whitespace\" \
+         30145987-0902-4110-b265-34b66aaece22)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c91018bc-ba97-4907-90c1-8e4abde173a0)(content(Whitespace\"\\n\"))))(Tile((id \
+         3357981f-36a0-48c6-ae83-832e1b9978b1)(content(Whitespace\"\\n\"))))(Tile((id \
          93b50e4e-3e7c-428a-adc8-eb9d31752d86)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ed40ecab-bc3e-41bb-94d4-9a8ea8732982)(content(Whitespace\" \
+         9026dfac-3e21-47e6-81d8-be16979465e0)(content(Whitespace\" \
          \"))))(Tile((id \
          d571ab96-86f7-4478-81a3-f5dfc9ab16a8)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          a4f53b89-28f5-4708-beb9-5c51ca1e4c71)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4357f7cb-7f3a-48e2-b6ab-6ee9d725587e)(content(Whitespace\" \
+         \"))))(Tile((id \
          babe6f30-2060-4937-bac6-fadd6d33d67e)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         fb10fe77-4d09-4146-8048-5feee553d1b7)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c2fab23e-01fd-4798-aa4c-904684fa1f22)(content(Whitespace\" \
+         \"))))(Tile((id fb10fe77-4d09-4146-8048-5feee553d1b7)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          18c0e79c-1952-4b70-ada8-b175f68fdcc6)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          66d3b744-4b25-4352-90af-d1ab7b7d2ea4)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         d025163c-01c3-4f44-96e8-248d4edf782d)(content(Whitespace\" \
+         8e49ef98-74b7-4f11-a679-e1d6bc14e23f)(content(Whitespace\" \
          \"))))(Tile((id \
          561dcee0-abe4-4c0a-a7d7-4f7dd6768bef)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         1ed2d89f-db2c-49c9-9876-14e8a439fc80)(content(Whitespace\" \
+         \"))))(Tile((id \
          2c850fcd-6c97-4b97-9678-f5dc98141a54)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bae351a2-fd54-445d-95cf-81d90b994d49)(content(Whitespace\" \
+         \"))))(Tile((id \
          e5036c65-d107-48b3-94a8-26358fcfbd1a)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7995952a-91a6-4dbb-a086-d93cfb1b34b9)(content(Whitespace\" \
+         2d287552-7526-4448-acde-b8c331975978)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c3383f2e-5ef2-4137-9de1-a1f5dfa3fb5c)(content(Whitespace\"\\n\"))))(Tile((id \
+         3bdfb7d6-00f1-4400-8d8a-b371984f9f61)(content(Whitespace\"\\n\"))))(Tile((id \
          cdb52a83-8dc5-4b86-9191-0de86bde39f0)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8ad7e35e-4d02-4991-a7e7-bfe77d82c48c)(content(Whitespace\" \
+         171d55ed-0aec-4a28-8231-764e995c77da)(content(Whitespace\" \
          \"))))(Tile((id \
          91c37271-78f5-4a2d-beed-148cbeacdfbb)(label(get_key))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0ac023c1-cb7b-42a3-b607-949adf4ce781)(content(Whitespace\" \
-         \")))))((Tile((id a7aae3b8-73dc-4a5f-825c-4ebf0fdf4a0e)(label(fun \
+         18ae9f72-3c9b-4254-9a82-26e50f41c5a4)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         2163a952-932a-4c89-9623-b2a80bf0d381)(content(Whitespace\" \
+         \"))))(Tile((id a7aae3b8-73dc-4a5f-825c-4ebf0fdf4a0e)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         95d5024e-6f21-4b13-a602-7e75619763a6)(content(Whitespace\" \
+         6a98ea17-20e9-4e07-87f2-0b5d25679523)(content(Whitespace\" \
          \"))))(Tile((id \
          c53ac1a2-f832-4b53-b2b2-a0fbb916123f)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          aa42140f-7459-4bf1-8b3e-4da599e12f6d)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         f9330c10-a3b4-4df9-884d-3641ae0b9ea9)(content(Whitespace\" \
+         \"))))(Tile((id \
          f6576b4b-246c-4a6b-a78b-d330c7aa24e8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         502f418f-d2d8-4622-8e2a-1adc0bf02691)(content(Whitespace\" \
+         \"))))(Tile((id \
          3beb5e33-9536-47ba-b7bc-0fbd8a32399a)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c3fcb590-a2e5-48e1-9ccb-8c9d1bcbd4a5)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         e315d1c8-882f-498f-a623-861cee6802b8)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         7808a2f2-1df2-4cc8-af88-68c9191c60e0)(content(Whitespace\" \
+         \"))))(Tile((id \
          b9dea33d-300c-4767-957c-342c585049a1)(label(get_value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -837,25 +877,27 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          4d01f351-5999-487e-91dd-549349ab14a9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b4d86b7a-ecef-4df1-ad74-926f8dec480a)(content(Whitespace\" \
+         \"))))(Tile((id \
          52198df6-e923-4a54-8b42-87f561382e9a)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4d881df9-4f98-44c9-8c88-c43c45329997)(content(Whitespace\" \
+         b5ad80cc-4a3b-4b14-963f-4822de9faf67)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8e207edc-154e-435a-b89a-4440ef7aa5eb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         09640c0f-76fd-425d-8999-3db20d0046c0)(content(Whitespace\"\\n\"))))(Tile((id \
+         151e9b6a-2efc-4c2e-b7e3-fd46b68abe5a)(content(Whitespace\"\\n\"))))(Tile((id \
          c021150d-5bf7-47e9-9eed-ebab392234d6)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         7a33d205-d2f6-4183-852b-935d2c5ebfff)(content(Whitespace\" \
+         f11a47e8-1784-4212-bb68-0d614a68c59f)(content(Whitespace\" \
          \"))))(Tile((id \
          693c74f1-e841-46a3-abf3-6caff8fb378c)(label(keys))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8faf8758-f391-4d78-a75c-143edb0f11de)(content(Whitespace\" \
+         a5a5c363-063e-48c2-90d5-52e25cc1a6fe)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8ebce5cd-0d8a-461c-b471-e5373f0c6247)(content(Whitespace\"\\n\"))))(Tile((id \
+         dea80ce8-626f-463e-9b39-86a734884bc4)(content(Whitespace\" \
+         \"))))(Tile((id \
          dcabbad0-5c10-4328-aedc-adbc62ca99f2)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -867,14 +909,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          9858ea2f-7c9c-42fc-b249-f66ee39ccbf6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2c2607a7-fd79-48a5-8adc-ad6d8c6dc017)(content(Whitespace\" \
+         \"))))(Tile((id \
          58e23e60-b45c-468d-a8a3-d572324a71cb)(label(get_key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         667357fc-684f-476a-90b3-221b063dc9c9)(content(Whitespace\"\\n\"))))(Tile((id \
+         aea78f4c-cf20-41f7-85f0-907a8b6558da)(content(Whitespace\" \
+         \"))))(Tile((id \
          86bbc081-95e4-4eb6-9b6d-0e2587214ba6)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         685fab39-3524-412f-87f9-9b18db4675d5)(content(Whitespace\" \
+         \"))))(Tile((id \
          b682616c-1465-43a8-9df9-278b6ceb83bb)(label(filter_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -886,93 +933,102 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          7d954e4b-deff-4cdd-855b-0937e21538c1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         f5f73b8b-d5f8-477c-b5f5-84263fa9c45e)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         abf93830-134b-41d6-a07b-9c412022b79a)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         652569ff-cd0b-4c43-bf34-a8ea76c02378)(content(Whitespace\" \
+         \"))))(Tile((id f5f73b8b-d5f8-477c-b5f5-84263fa9c45e)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         352dbc72-c7c5-4859-96ce-ae0b86e6fc13)(content(Whitespace\" \
          \"))))(Tile((id \
          65e1752e-6356-4e77-beb9-e8d47ed61242)(label(opt))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1ec938fc-4143-4685-8b52-aace4176d0aa)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         572b694b-61e2-4841-bffe-89ae53bf3c3c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5840df5d-0b94-40df-a63b-b614c6c46a75)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb0ea6c6-ac08-4ab7-98b6-7b2229678c35)(label(opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ed6a73fc-b75c-4b5d-ad12-a944656de270)(content(Whitespace\"\\n\"))))(Tile((id \
+         1c3d1829-534f-4473-af47-a0d68d80a8bf)(content(Whitespace\" \
+         \"))))(Tile((id \
          6face37c-150a-414f-9855-4a957c3ccc69)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         1f17a675-0a64-4687-a93e-6f4c826fa6f9)(content(Whitespace\" \
+         \"))))(Tile((id \
          38074e05-5696-4b21-b982-5f22b6fb00af)(label(remove_duplicates))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         58c17113-096b-4707-b67f-03a431c8685e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         c9f983e0-6360-4124-8b98-ef71f80f4053)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         669bc4d2-5f73-43a0-b96a-8cfe041166e5)(content(Whitespace\"\\n\"))))(Secondary((id \
-         b2aa1ba4-c04b-4268-97a6-fa99a46dd239)(content(Whitespace\"\\n\"))))(Tile((id \
+         57a8e38a-6478-4c96-8630-42122dd6e8e3)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         d4f4a8b3-a1be-4b23-a419-724df55ed5c8)(content(Whitespace\"\\n\"))))(Tile((id \
          bf2bec80-4d82-4390-85b4-707f54e84850)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          beaaad69-4d9b-43a5-a00e-d98477b8a54b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         9939ec83-4ee9-4251-b6e0-6d81395bb0a7)(content(Whitespace\"\\n\"))))(Tile((id \
          ada9f03a-021d-4d83-91ec-c1b180721a14)(label(keys))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          6e098730-bf6f-4e81-b0cd-5a3e50ce736e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         838a5275-0755-48d5-b0ed-5081c2a28955)(content(Whitespace\"\\n\"))))(Tile((id \
          07b044fd-79fd-4a86-9ebc-7347e56c3a2f)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         fa9e28ef-d823-468f-a4cd-b6c5b460de49)(content(Whitespace\" \
+         d763ea1d-1b31-4a8b-a11c-ff222f47004a)(content(Whitespace\" \
          \"))))(Tile((id \
          c3367d6d-16ae-4f46-af45-2700fcd7f143)(label(k))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2c83b672-504c-4312-9786-4f6e0d8ce45d)(content(Whitespace\" \
+         4e78225f-ddd7-4d61-8627-4fd850ee6133)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0134d458-eaff-4e53-af13-3579b769e163)(content(Whitespace\"\\n\"))))(Tile((id \
+         236ace88-69aa-4f4c-aa1f-cb18b04b0f4e)(content(Whitespace\"\\n\"))))(Tile((id \
          cb3b5669-07f8-49ab-96e7-5773e5cbee80)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         b545be2b-9bbf-4a2f-82b4-b4d98512b897)(content(Whitespace\" \
+         2c41273e-7c0f-42a4-99ef-f8d168a6a0a9)(content(Whitespace\" \
          \"))))(Tile((id \
          c839404a-115c-4791-ac81-346a301c2953)(label(rows))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         36f6d98f-4e5b-4aaf-8fdb-733e27527606)(content(Whitespace\" \
+         4516449b-2ef7-4ee6-a6f6-c329b41238bb)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ca3dc640-8a63-4154-a246-4654e2e416d2)(content(Whitespace\"\\n\"))))(Tile((id \
+         0c56f54a-9b55-41eb-8382-954080a0a0ef)(content(Whitespace\"\\n\"))))(Tile((id \
          27c46b0c-e6da-4fa0-ba38-557b409aec05)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          d1989e87-d115-47c2-80f6-f9b44ed0c1fb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ca503a55-c550-4f47-86be-81ca38fbb9ea)(content(Whitespace\"\\n\"))))(Tile((id \
          8cbd228e-db96-42e8-8a03-db04ad8a9aec)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          b39355ef-1bab-4fdf-b97a-2e1e6723ac99)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4c03bd74-23be-43dc-9723-488f026c19e7)(content(Whitespace\"\\n\"))))(Tile((id \
          3bfca413-ab08-4765-9b6d-8105a6dbb79b)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         00eb6a1a-23bf-402e-9735-0630059d9d2d)(content(Whitespace\" \
+         0aeec17f-0c5d-40b0-92b9-8d16bc3ad643)(content(Whitespace\" \
          \"))))(Tile((id \
          49e37e2a-ebe0-4374-a793-39ecb3369c13)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         2f307b46-6c92-4b0c-bb2e-206d24e14dc8)(content(Whitespace\" \
+         7f5a4580-57c9-448b-88d8-23a2e45b6349)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         aeac8fe8-e0c5-476c-bf53-03c97b2b3857)(content(Whitespace\"\\n\"))))(Tile((id \
+         86626c24-cd36-447e-b0d1-c72e59b8819d)(content(Whitespace\"\\n\"))))(Tile((id \
          0f68547a-02c2-4c89-b62a-3cf787a71113)(label(case end))(mold((out \
          Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         3350e753-6aff-448d-8490-ae9d1bc5099c)(content(Whitespace\" \
+         4fbac36e-2cf2-4b4e-8088-f0aba9e218ac)(content(Whitespace\" \
          \"))))(Tile((id \
          6fed4b38-91e9-49df-aa9a-f368cda94393)(label(get_key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -983,7 +1039,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dd20fc41-47f0-4c09-85ce-47a42a4c8a08)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         73a3a7c0-5550-48db-812b-52d8f6ad71a5)(content(Whitespace\"\\n\"))))(Tile((id \
+         186fee0c-502d-413e-9c2b-b097350eddfe)(content(Whitespace\"\\n\"))))(Tile((id \
          3b8dd441-1a3f-48b3-ae56-9e0aa009d700)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -997,19 +1053,23 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
          9955a69e-668a-4bb1-8527-fb658c14b2eb)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         \")))))))))(Secondary((id \
+         6cbed944-0aa8-40c2-9ac1-57ba674d1d57)(content(Whitespace\" \
+         \"))))(Tile((id \
          216454d5-b8a4-40ff-8747-f1d5aabf1cb9)(label(k'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         0f648823-f63b-46a3-8733-17010f8baed3)(content(Whitespace\" \
+         bd6bda6c-80a4-410e-96e6-d15ea3acf8b5)(content(Whitespace\" \
          \"))))(Tile((id \
          f924823c-224a-4aab-907a-ca002fabda6a)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5c89568f-17bf-4f41-bdc3-653bc11a3386)(content(Whitespace\" \
+         \"))))(Tile((id \
          d27b7081-70e6-4d80-998a-757591fcab9b)(label(k))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         eaf35cf4-138b-4153-982c-d382c0b135f9)(content(Whitespace\"\\n\"))))(Tile((id \
+         21da4049-1751-4900-90d4-cf03927ecca2)(content(Whitespace\"\\n\"))))(Tile((id \
          918efb3a-7527-4d3b-be61-0be7ca8239ba)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1017,17 +1077,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
          960acd2e-9530-4a2d-b0c1-2e927a74c41f)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         \")))))))))(Secondary((id \
+         aacb25da-6387-4c9e-9067-189bfaa869ca)(content(Whitespace\" \
+         \"))))(Tile((id \
          a0539c45-fd80-4491-ab4e-d365f29a875a)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         482de5e9-2bba-4257-870c-4b1d871ce514)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         d8148b89-c8e8-450c-aa06-ee858f412829)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         1c42f457-ef21-47e8-b971-b5706d4757d3)(content(Whitespace\"\\n\"))))(Tile((id \
+         52f7e915-ab98-471c-9239-1b877327d4ff)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         51a41301-dbe0-4fdf-a567-75c4a20e105d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         7f2a0721-3f9e-4b86-8d4a-c45f77e31a20)(content(Whitespace\"\\n\"))))(Tile((id \
          cc7cc58c-aa72-4522-8d1f-6adc3aa3354c)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         453c4ced-fa4b-495e-b34c-4e0fefd6bb2b)(content(Whitespace\" \
+         \"))))(Tile((id \
          5dfad288-cc0d-4f22-a77a-321ca092eac7)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1039,18 +1102,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          d74df76f-e216-45eb-af78-97888bbb1fc7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         0c8d29f1-13b4-4205-8683-22e5108b7c98)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         4fb8df7c-5e21-4fc2-9b69-ee26f6167413)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8541533c-a785-49d2-bc98-cd0e6c0ad52d)(content(Whitespace\" \
+         \"))))(Tile((id 0c8d29f1-13b4-4205-8683-22e5108b7c98)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         d0dace51-410e-45e2-a5f4-8f61501634eb)(content(Whitespace\" \
          \"))))(Tile((id \
          a80b0c16-675f-4942-9db2-579d27c486a5)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f341557a-2b55-4a55-9802-35704cd250fd)(content(Whitespace\" \
+         df5497ee-1995-43a0-9b5d-af465d14ece1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2f424c36-3b56-4026-8fe4-5eadbae0b732)(content(Whitespace\"\\n\"))))(Tile((id \
+         0deadf37-be39-4959-b73c-4852d7cdc465)(content(Whitespace\" \
+         \"))))(Tile((id \
          4efc03ac-793f-4ea0-8413-cc48e1b82d76)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1060,10 +1126,13 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b2900598-36fe-414c-825b-8cf485b0640a)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6377db58-234d-4435-9b55-36913ac96adf)(content(Whitespace\"\\n\"))))(Tile((id \
+         97eb3c93-1de2-4210-ac7a-7bc01a78ac27)(content(Whitespace\" \
+         \"))))(Tile((id \
          5de272a2-5163-4e80-8bcf-5b855c7f3fa3)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         742c7f63-11d0-4f38-8a0f-183b972caa82)(content(Whitespace\" \
+         \"))))(Tile((id \
          3b1f9a76-fc54-4344-bc73-9b13cef56823)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1075,17 +1144,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          68168da4-b4ee-4711-8124-3e82e2c59087)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         b8ae7e77-070c-40db-8bf6-d01460ee97c3)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a703aa78-0cd5-4027-a8fe-6760e6b68ac1)(content(Whitespace\" \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2f6aa0d9-6b07-46aa-adac-d1fbd1d429e0)(content(Whitespace\" \
+         \"))))(Tile((id b8ae7e77-070c-40db-8bf6-d01460ee97c3)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         fc1d1b4c-02fb-451f-96e5-1af5ed3b450b)(content(Whitespace\" \
          \"))))(Tile((id \
          a590469d-229b-4579-875a-97a271aaf7ee)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ae2b7401-0e0a-401e-8b9e-1c71c78291a5)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         bed1ce6f-16eb-4f8e-a5f8-eec189dd4cff)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         802a3473-f9cb-4416-993f-b5fef004dc6f)(content(Whitespace\" \
+         \"))))(Tile((id \
          9486a7fc-4952-4481-8e3d-aefc6a441c55)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1094,67 +1167,84 @@ let out : string * Haz3lcore.PersistentSegment.t =
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
          82d283a9-49ee-4c65-81ea-f1c9e82401ac)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f4b51821-8cfa-44b9-b38f-375e8a5ae889)(content(Whitespace\" \
+         \"))))(Tile((id \
          0586223a-7fd5-4b6a-a079-17483c90e320)(label(!=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f35bf4bf-7d1b-4178-b44c-92801d54f985)(content(Whitespace\" \
+         \"))))(Tile((id \
          d01854bc-720c-42b2-afba-91b81b3131b5)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         c5b0131d-7795-41d4-8909-64361d8dd92b)(content(Whitespace\"\\n\"))))(Tile((id \
+         057837b7-0eca-48c9-a3bf-686ee178ce12)(content(Whitespace\" \
+         \"))))(Tile((id \
          5ca46890-0ba7-4799-bafe-82c90a00d7cf)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d9ba83b1-a4a1-400c-b257-c30c0e8b2e8a)(content(Whitespace\" \
+         \"))))(Tile((id \
          3024c8e0-0254-405e-af7e-4ed2f76b8123)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         50ffba31-ebba-4d1c-b246-df904ac3128e)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         e50c379d-5f5d-4784-92f7-8d5055f07dc7)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ddb5d886-ac4e-4aa0-8c0d-491d0e1ff888)(content(Whitespace\"\\n\"))))(Tile((id \
+         52be7735-3d92-42ee-93d2-8a1958303cd4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         2f89ee5a-62d8-455b-a351-5a4f7ca04078)(content(Whitespace\"\\n\"))))(Tile((id \
          541960df-a0e3-4401-8e22-0b75616e9008)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          341e2091-eecf-41da-90de-0f9d5270103d)(label(key))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         42122f4a-62d5-4f1a-91e3-42c97745baf3)(content(Whitespace\" \
+         \"))))(Tile((id \
          2f85af11-c9fe-4a32-b3e2-6333cd2817c8)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d6790afc-2fa6-4e87-8020-068556392335)(content(Whitespace\" \
+         \"))))(Tile((id \
          764ffd29-7e6a-45a9-98d3-6a2f92fa7ff4)(label(k))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4511cea7-81a5-4172-a04f-b17253d258c4)(content(Whitespace\" \
+         186e0384-d0b7-4032-b479-399466716b0e)(content(Whitespace\" \
          \"))))(Tile((id \
          3ae56168-b005-4ad0-b494-02d5e34cf902)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
-         28))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         04ad6684-d625-48ee-8e56-a902fbba461e)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb2c818e-0298-4800-ab24-bf05c52f22cd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          89441d53-75bf-4038-bed0-fc89eb07e8d0)(label(groups))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a2a1659c-acc9-424e-b8bf-9085c159f23b)(content(Whitespace\" \
+         \"))))(Tile((id \
          ee6c0183-d65a-4817-9437-98a4a9f746bf)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f3cd5f9a-eaf4-4bd5-9b67-e9d2f3389ddd)(content(Whitespace\" \
+         \"))))(Tile((id \
          4f8ee2eb-c79c-41c9-8866-4e735cb990cb)(label(rows))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         54fb8a54-8ccb-4e64-a3b0-2b5dd728f77b)(content(Whitespace\" \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         197f4ced-23ac-4244-8403-5a4ad504146e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         40a00f9b-d4cb-40ad-b2af-ffad7ca9020c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1ce13e2c-daff-478b-acc7-f6bb28a3ccfa)(content(Whitespace\"\\n\"))))(Tile((id \
+         86e8aced-cf3a-4ae2-add7-96c3c739e867)(content(Whitespace\"\\n\"))))(Tile((id \
          e3be32ab-6a71-4b9d-b9c6-db55e555a288)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         98b399ca-60f8-43b0-868e-e0b9e17b07e6)(content(Whitespace\" \
+         b020ead9-73ea-4cd1-97ec-91eaa4ada18e)(content(Whitespace\" \
          \"))))(Tile((id \
          571b5b10-b918-4a11-adc9-d99b7502f4a1)(label(expected))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8db246ac-0295-4bfb-a914-eccb3f1739b8)(content(Whitespace\" \
+         8588a7e0-944c-49e4-b375-8700a1029112)(content(Whitespace\" \
          \")))))((Secondary((id \
-         b4f995c4-2123-4d1e-b215-a7716c1cddc4)(content(Whitespace\" \
+         1bdbad24-b502-45b5-9540-d282aba60ba1)(content(Whitespace\" \
          \"))))(Projector((id 47ad8d71-44e2-4e6c-bab9-fa9cfd709e6a)(kind \
          Fold)(syntax(Tile((id \
          eb07387a-af9e-45b0-87be-dd928a2c5725)(label(\"(\"\")\"))(mold((out \
@@ -1330,15 +1420,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
          b7c604ff-7fab-42c8-bc90-d07af0a87579)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         51577cd2-896b-4927-8dd4-f1d7bc25f2ac)(content(Whitespace\" \
+         396fee0f-80a2-48c0-a806-a8949005a5d4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         852e9118-ad42-4242-9d39-ec780be0cd5f)(content(Whitespace\"\\n\"))))(Secondary((id \
-         d2e905c9-9273-4239-a4e9-69f0972e1b07)(content(Whitespace\"\\n\"))))(Tile((id \
+         62ce8fda-a35d-4b76-8d6c-8a2186369630)(content(Whitespace\"\\n\"))))(Secondary((id \
+         43c9814e-53b3-4f61-8132-cfeb6d2d7c6e)(content(Whitespace\"\\n\"))))(Tile((id \
          bdb6bad7-7499-4ba9-b0e3-97cb96317e92)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         c6621410-9506-4d7c-b378-6b1d8d5046f6)(content(Whitespace\" \
-         \"))))(Tile((id \
+         e35585eb-24b7-425d-96b0-9147153fcf74)(content(Whitespace\"\\n\"))))(Tile((id \
          ab8e8b2d-68e6-49cc-85fa-fb313b9e6920)(label(group_by_subtractive))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1351,35 +1440,34 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ea66c091-e4f6-4327-a973-b9f89ab67ff7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         03bef32c-1c54-44b3-8d86-1325ac85851c)(content(Whitespace\" \
+         ac62e578-4d35-499b-8aee-f28f5faed4c9)(content(Whitespace\" \
          \"))))(Tile((id \
          8f6f24d5-022f-4455-8bd9-b139e757d0c8)(label(\"\\\"favorite_color\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         983599d1-ae6d-4e1b-9f0a-0a3593a1905c)(content(Whitespace\" \
+         d941cab5-6bf8-4fb7-8f9c-65fc32b6a4e5)(content(Whitespace\" \
          \"))))(Tile((id \
          0fc0469b-8c25-4e5d-8110-eb711cbc5b3a)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         67978266-bd22-437b-943f-e48bc78e9664)(content(Whitespace\" \
+         98a23a2a-b13d-4f47-a6a4-d8bcd71adf2d)(content(Whitespace\" \
          \"))))(Tile((id \
          77f4d5cb-8b6d-44f8-81ba-d7f27736e6e8)(label(expected))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d40c5ed2-e7a2-4196-9e18-7884acadebbd)(content(Whitespace\" \
+         e63150f2-0756-469c-80e1-04f08a4a42df)(content(Whitespace\" \
          \"))))))))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
          let students : [Student] = ^^fold([\n\
          (\"Bob\", 12, \"blue\"),\n\
          (\"Alice\", 17, \"green\"),\n\
          (\"Eve\", 13, \"red\")\n\
          ]) in\n\n\
-         let requires = [\n\
-         (enforced=^^check(false), \"c is in header(t1)\"),\n\
-         (enforced=^^check(false), \"schema(t1)[c] is a categorical sort\")\n\
-         ] in\n\
-         let ensures = [\n\
+         let _requires = [(enforced=^^check(false), \"c is in header(t1)\"), \
+         (enforced = ^^check(false), \"schema(t1)[c] is a categorical sort\")] \
+         in\n\
+         let _ensures = [\n\
          (enforced=^^check(false), \"header(t2) == [key, groups]\"),\n\
          (enforced=^^check(false), \"schema(t2)[key] == schema(t1)[c]\"),\n\
          (enforced=^^check(false), \"schema(t2)[groups] == Table\"),\n\
@@ -1388,43 +1476,41 @@ let out : string * Haz3lcore.PersistentSegment.t =
          header(t) == removeAll(header(t1), [c])\"),\n\
          (enforced=^^check(false), \"for all t in getColumn(t2, groups), \
          schema(t) is a subsequence of schema(t1)\"),\n\
-         (enforced=^^check(false), \"nrows(t2) == \
+         (enforced = ^^check(false), \"nrows(t2) == \
          length(removeDuplicates(getColumn(t1, c)))\")\n\
          ] in\n\n\
          let group_by_subtractive =\n\
          let get_value = ^^fold(fun (r:?, label:String) ->\n\
          find_opt(to_lvs(r), fun e -> e.label == label) |> option_map(_, fun e \
          -> e.value)) in\n\
-         let remove_duplicates = fun (xs:[?]) ->\n\
-         fold_left(xs,\n\
-         fun (seen, x) ->\n\
-         if mem(seen, x) then seen else seen @ [x],\n\
-         []) : [?] in\n\
-         fun (t1:[?], c:String) ->\n\
-         let get_key =fun (r:?) ->get_value(r,c) in\n\n\
-         let keys =\n\
-         map(t1,get_key)\n\
-         |>filter_map(_,fun opt ->opt)\n\
-         |>remove_duplicates \n\
-         in\n\n\
-         map(keys,fun k ->\n\
+         let remove_duplicates = fun (xs : [?]) -> fold_left(xs, fun (seen, x) \
+         -> if mem(seen, x) then seen else seen @ [x], []) : [?] in\n\
+         fun (t1 : [?], c : String) ->\n\
+         let get_key = fun (r : ?) -> get_value(r, c) in\n\
+         let keys = map(t1, get_key) |> filter_map(_, fun opt -> opt) |> \
+         remove_duplicates in\n\
+         map(\n\
+         keys,\n\
+         fun k ->\n\
          let rows =\n\
-         filter(t1,fun r ->\n\
+         filter(\n\
+         t1,\n\
+         fun r ->\n\
          case get_key(r)\n\
-         |Some(k') =>k' ==k\n\
-         |None =>false \n\
-         end)\n\
-         |>map(_,fun r ->\n\
-         to_lvs(r)\n\
-         |>filter(_,fun e ->e.label!=c)\n\
-         |>from_lvs) \n\
-         in\n\
-         (key=k) ...(groups=rows)) in\n\
+         |Some(k') => k' == k\n\
+         |None => false\n\
+         end\n\
+         )\n\
+         |> map(_, fun r -> to_lvs(r) |> filter(_, fun e -> e.label != c) |> \
+         from_lvs) in\n\
+         (key = k) ... (groups = rows)\n\
+         ) in\n\
          let expected = ^^fold([\n\
          (key=\"blue\", groups=[(name=\"Bob\", age=12)]),\n\
          (key=\"green\", groups=[(name=\"Alice\", age=17)]),\n\
          (key=\"red\", groups=[(name=\"Eve\", age=13)])\n\
          ]) in\n\n\
-         test group_by_subtractive(students, \"favorite_color\") == expected \
-         end";
+         test\n\
+         group_by_subtractive(students, \"favorite_color\") == expected end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesgroupJoin.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesgroupJoin.ml
@@ -1,157 +1,188 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Utilities / groupJoin",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id 763498f6-75ce-4734-8815-96be723bdb9e)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         83631372-8143-41d8-ab6b-5ccbd63db154)(content(Whitespace\" \
+         b89164dd-fd39-461a-8026-283c79b4c69b)(content(Whitespace\" \
          \"))))(Tile((id \
          0a9b92f2-2ac2-40c7-8fab-c463d8d21d8a)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         2d3d034c-3a58-4f50-ada3-205052272f70)(content(Whitespace\" \
+         79a310a2-68a3-4dfc-83bb-5765af1dd937)(content(Whitespace\" \
          \")))))((Secondary((id \
-         05fdd27d-9620-456d-82ea-fd0d29aecd91)(content(Whitespace\" \
+         86dd94fd-a5b2-43b1-8614-30675aef010f)(content(Whitespace\" \
          \"))))(Tile((id \
          7ae732e8-25a7-4fa4-aed4-3a8f8b0c8467)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          0b7138b1-969c-45c3-8019-cb673fe5fd58)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e09557ed-25cc-4d73-9461-27648e46849e)(content(Whitespace\" \
+         \"))))(Tile((id \
          44dda58e-f945-49be-b4f5-b044534aec14)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         859efa48-7071-41cf-a6cf-fc3545cd194b)(content(Whitespace\" \
+         \"))))(Tile((id \
          46be0663-d6f4-4d4a-b6c9-bb98b86c8c39)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          39ddde0a-d616-4cc2-b0b6-44148623b0f7)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c9d84a5c-c274-42d6-b4b7-11be6c9d0c94)(content(Whitespace\" \
+         9d8678d4-e514-42bd-939c-ed517e339c58)(content(Whitespace\" \
          \"))))(Tile((id \
          8abef15c-3726-4c8e-8865-c5820f44af37)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f8f1b552-f1ca-4c91-8df6-7dd9b4d855fa)(content(Whitespace\" \
+         \"))))(Tile((id \
          2a1226e7-32e0-49b3-abc3-e52488759034)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b8cb9483-b143-4640-a6db-54bea9d2496c)(content(Whitespace\" \
+         \"))))(Tile((id \
          500b6766-cbeb-4cf0-b8cc-67e48052e1e3)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6075b83c-f283-428e-99b4-cca7cb735b79)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ca1e370f-e409-4511-aeb7-1a1ff3d1e15a)(content(Whitespace\" \
+         24dabee5-7d71-4e2e-b649-975f897ede85)(content(Whitespace\" \
          \"))))(Tile((id \
          ab227856-ba4c-44d8-927b-4438ad617a29)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0fd2346a-12b2-46af-9f66-4cb612263de8)(content(Whitespace\" \
+         \"))))(Tile((id \
          4bc8b482-b171-4e9b-b0e9-1e4ddb339d3b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7c831c26-c6ab-453b-aed3-e339df083e9e)(content(Whitespace\" \
+         \"))))(Tile((id \
          3db827cb-7a86-46bd-bd1a-013473f56965)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c13232d5-730e-4c2c-8bc0-2a06dfd5276f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4628c44f-314d-4644-854f-5a0b709f646f)(content(Whitespace\" \
+         df75c44c-3555-4f2d-927b-7ca4098ebb5c)(content(Whitespace\" \
          \"))))(Tile((id \
          fcf4b672-a78c-4790-955b-16721f605270)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9c4a9076-2333-4b1f-afdb-2a9f52d2104b)(content(Whitespace\" \
+         \"))))(Tile((id \
          c5cc54c8-26c4-4b67-8810-692449189622)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c44ab0e3-fd9a-4f19-a628-4d5a2a0eaf88)(content(Whitespace\" \
+         \"))))(Tile((id \
          47affa82-2bac-4386-b89b-d99db9f412a8)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e87bd824-b4a1-4537-912e-0b7bd53deb2b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         be091118-fd87-49e1-85b1-fa44d9a20be6)(content(Whitespace\" \
+         6d349eba-bc99-49e5-9634-7c4f3a5d29d5)(content(Whitespace\" \
          \"))))(Tile((id \
          77e9f3e6-1c1c-4d8b-976f-b43c691e71e3)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c811f247-2abe-41b6-9fcb-e189e2cdd89c)(content(Whitespace\" \
+         \"))))(Tile((id \
          84dbcb92-443f-4e95-9d6a-a05d2b853f7c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         61b79b52-8625-40b9-bae1-3330040db3d8)(content(Whitespace\" \
+         \"))))(Tile((id \
          9c42d932-cfdc-414b-ba0d-532a78436878)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          662a60b9-7e8f-4803-8037-3e72a6d1d10d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f9bb3530-a52f-4a0f-a727-a5d6e2b93278)(content(Whitespace\" \
+         68cc9b2f-8482-4106-b1c5-179b07d644dd)(content(Whitespace\" \
          \"))))(Tile((id \
          c5320711-7b0c-4ca4-82d5-c2f3cac1bc41)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         1e07ffcd-7a32-4158-9a86-547fa1579325)(content(Whitespace\" \
+         \"))))(Tile((id \
          c5668367-d65d-48a0-bfe1-7a24eb47ac9a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b4182339-0cf4-45c5-8f10-87cdafb87dbe)(content(Whitespace\" \
+         \"))))(Tile((id \
          11a2a4a4-dd7c-4468-9752-a0f480b7d532)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          cb967b22-0eb2-4cb3-b921-356c03db37f8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         163cb744-866f-4eea-bac8-faac34de23b1)(content(Whitespace\" \
+         d55e2acb-b012-4b0b-b3ec-87b03752e76a)(content(Whitespace\" \
          \"))))(Tile((id \
          b20b8261-97cb-4543-b190-33277feb383c)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         11001bbd-76d8-456e-95a2-3657057fd489)(content(Whitespace\" \
+         \"))))(Tile((id \
          67a420be-208e-4e2a-9542-e2c52f994e89)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5c92165c-4942-456f-a29e-46130d9b4aee)(content(Whitespace\" \
+         \"))))(Tile((id \
          e20dfe26-d435-45d1-912f-c3e5c3f6fec7)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          cb82c659-477e-4208-aedc-ad9c8d3581e0)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b554ded4-6b62-470d-bc0a-3575a7ded9ec)(content(Whitespace\" \
+         4a20ecac-b49c-471e-8d3d-c5fdafaa1feb)(content(Whitespace\" \
          \"))))(Tile((id \
          da7c65df-0915-458d-b3dc-f414324e7727)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0b2c8b32-8208-42c3-93fb-65d42bbf2c50)(content(Whitespace\" \
+         \"))))(Tile((id \
          f97f7a7f-9d83-486a-801d-4d521c2bff6b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0880546d-2cc1-4201-876d-d888d37a24d5)(content(Whitespace\" \
+         \"))))(Tile((id \
          b6845e22-94df-4250-a092-e7aa1246f880)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         4d06c416-28f5-468d-97df-7c9239d8eec0)(content(Whitespace\" \
+         534b81a0-cf91-4ab9-90ab-07295ec2ce61)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         102eccae-981b-425c-8f5b-f56c6498588d)(content(Whitespace\"\\n\"))))(Tile((id \
+         db96885f-945d-412b-abf8-10b949db5835)(content(Whitespace\"\\n\"))))(Tile((id \
          30f6a4b9-305a-49ed-b596-21b65c8e661a)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         67b0e5cf-62d5-4f2c-be3f-845564d1ba18)(content(Whitespace\" \
+         ceb04a48-179d-44ff-aaf1-b972917ff522)(content(Whitespace\" \
          \"))))(Tile((id \
          598af32c-3795-42c0-b1d1-479bb784fddb)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c64762d0-f62b-4578-9ff3-e8a7aab36c68)(content(Whitespace\" \
+         6ec51954-eb74-42ca-b865-c0b892c6377a)(content(Whitespace\" \
          \"))))(Tile((id \
          1f803245-e5c2-4942-9f48-f298db859e7a)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c1ec1b8b-9bc4-4efc-95c9-c7356a473d99)(content(Whitespace\" \
+         d868358e-2dec-442d-9df8-1dd9aff5dbcf)(content(Whitespace\" \
          \"))))(Tile((id fafcb358-e775-4802-855b-7b3ab0ce10a9)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          9f2d118f-bc11-433c-8025-947fdfbeca46)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e642c1d1-ccc1-4c2a-91af-6db5ab10cdd8)(content(Whitespace\" \
+         9e404725-810d-4f36-9180-ed321742d967)(content(Whitespace\" \
          \")))))((Secondary((id \
-         c27e3faa-d6e6-4872-b05e-d0ee73ee5b2c)(content(Whitespace\" \
+         edaecfab-347b-4943-9a74-295d1502fb66)(content(Whitespace\" \
          \"))))(Projector((id 074fa8aa-cd46-414d-a040-5499ff22e7c9)(kind \
          Fold)(syntax(Tile((id \
          14781ccf-6b1a-45cf-9af1-b9e51e7df0ea)(label(\"(\"\")\"))(mold((out \
@@ -365,87 +396,99 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          aca73bb3-8bb4-4dc5-899e-361efa24ddaa)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         ce88aec5-9db8-45b9-b149-c71e1e2e2926)(content(Whitespace\" \
+         26d86c67-bd38-4a65-ab13-fb35a5678749)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1f0aa2c4-13f0-4fea-8a74-e09a1a9d4757)(content(Whitespace\"\\n\"))))(Tile((id \
+         7898c828-0531-4b58-b72f-5ad50cdccee3)(content(Whitespace\"\\n\"))))(Tile((id \
          4734767a-b3aa-486e-b5e8-401f141f92a6)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         f86abac3-331f-4474-b0e5-8db9b09b858f)(content(Whitespace\" \
+         da3c2fae-1ad8-4609-92d1-6ef3256c86d3)(content(Whitespace\" \
          \"))))(Tile((id \
          1dcb2ec3-2645-4f26-ad62-6e5b9513d9f9)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         67ffc9f7-7945-4ad4-b9cc-ad4b19100e97)(content(Whitespace\" \
+         09cf5018-d564-4b51-9d37-db147175ac1b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         69dabd13-7606-4828-a6c3-3f1e572653e5)(content(Whitespace\" \
+         252b6ad0-8530-4143-ad75-097ed83c7e7d)(content(Whitespace\" \
          \"))))(Tile((id \
          d3b661c0-578e-45af-b083-0650c7d4bb1d)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          8cfff310-981e-4c15-a8e2-a38722633be7)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d9ee6246-7bed-4bdc-8b7b-b3122a75e9bd)(content(Whitespace\" \
+         \"))))(Tile((id \
          d3a1311e-44f2-48a2-ba60-94fb4f9195d4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         09b6b0e2-cebf-46f4-a35d-be6ad5619f20)(content(Whitespace\" \
+         \"))))(Tile((id \
          76827cbc-db7c-4a4e-9e51-c7473ef8fbf1)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          f9ecd4f5-34dd-4138-bd31-e1a2786c4e78)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9ba148db-aa37-44c5-9c9a-af3911145a2f)(content(Whitespace\" \
+         403296eb-33de-40dd-9bf5-c5127fbcecb4)(content(Whitespace\" \
          \"))))(Tile((id \
          0d36d2b0-f5b2-4eae-9f4d-bfc23bf65657)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d7fb7607-9c7c-4578-9c5e-ae581414c04c)(content(Whitespace\" \
+         \"))))(Tile((id \
          1c29da51-219c-42b8-936a-5045e7991fa6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         18562624-42a3-4c2e-84a3-ed36453507b7)(content(Whitespace\" \
+         \"))))(Tile((id \
          1794c8c9-23e1-4b00-a4fd-ceaa874030c5)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c1577b25-8b77-4e5c-a233-e4b04fdf779e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         96727d1d-b6dd-4c30-a3b6-5d69f1978534)(content(Whitespace\" \
+         380babc0-cf0a-4044-8361-efcdc747f6d8)(content(Whitespace\" \
          \"))))(Tile((id \
          a0d7a9cc-b51f-4aec-9886-cf342edc0349)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         87992370-6cc8-40e1-9455-7c8bd8e3d3d3)(content(Whitespace\" \
+         \"))))(Tile((id \
          c2cd8088-6430-453e-9f2a-15d679b5b88a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bf4229dd-2376-4c51-817f-e973639860b2)(content(Whitespace\" \
+         \"))))(Tile((id \
          17df8179-9cfd-4fcd-9301-9e29027c245a)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d02c950c-70b5-4195-b4a4-45474b8ee9a4)(content(Whitespace\" \
+         d53fa882-e5e7-42ad-a64c-49e74dbef22a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         22c8dbce-b6f8-46f0-b74c-1cc69b0e1d4c)(content(Whitespace\"\\n\"))))(Tile((id \
+         cc3f4358-08cc-42ef-875b-fcacc1e529a9)(content(Whitespace\"\\n\"))))(Tile((id \
          8825b9cd-2919-4326-9e4c-713d5e1b6ba7)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         d76c0de1-fbd9-4e4c-8e08-498b65c78273)(content(Whitespace\" \
+         2c30ec79-8e97-47b4-a810-3ffff715313e)(content(Whitespace\" \
          \"))))(Tile((id \
          8dd1f5db-fe67-4536-82fc-17c33b9c154d)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         87754e2c-06db-49fd-afb2-e0649e44edf0)(content(Whitespace\" \
+         f7e60989-8b0e-4af5-a56d-28df6430c48b)(content(Whitespace\" \
          \"))))(Tile((id \
          ff73b7a0-e6c7-48cb-9458-f2b2b3222da8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3b89eae7-c544-415d-a502-53310f6e6521)(content(Whitespace\" \
+         81032f78-f8b2-45e0-b883-5f59f5944417)(content(Whitespace\" \
          \"))))(Tile((id 438e246d-14c2-4bda-bd8e-647e0e89e01c)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          2c3048a8-ee5b-4760-ab85-9048efec6914)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         01f68db4-43a5-418e-83db-cd3231e8ae5e)(content(Whitespace\" \
+         7cd47666-4b5f-4ca5-bef5-5d0e6a115c8e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         d25883c5-01e2-4a10-b154-8ff5cf056acf)(content(Whitespace\" \
+         7de8d0ab-8927-4ca1-869f-0a9bcfae7e59)(content(Whitespace\" \
          \"))))(Projector((id c20f09c1-1567-4da5-85d7-fc320b43d8e9)(kind \
          Fold)(syntax(Tile((id \
          102f16d4-d3e5-448f-8abf-9eb737684c1d)(label(\"(\"\")\"))(mold((out \
@@ -531,36 +574,43 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          c0961505-c7aa-48dd-adca-b39c3b72d067)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         04bb6e4a-e12e-4f71-b17d-ecc88ff27df0)(content(Whitespace\" \
+         2bfbccb8-6adc-4343-bd73-c3cb2e5b9911)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d4511399-9647-4ff1-a1bd-8f89370fe7b4)(content(Whitespace\"\\n\"))))(Secondary((id \
-         a64d6db4-b84e-400d-a9c8-99e013e0ffb6)(content(Whitespace\"\\n\"))))(Tile((id \
+         18853d16-eebc-4527-b25f-99486651376a)(content(Whitespace\"\\n\"))))(Secondary((id \
+         ffc8f30e-6ccb-44ba-a3a5-ea8c57c199eb)(content(Whitespace\"\\n\"))))(Tile((id \
          1e8e35dc-5743-4d21-8060-35afefd7e492)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         6e529114-28dd-469b-895a-45a2baa8fdac)(content(Whitespace\" \
+         e30274e6-043e-4b81-bc28-6d401e0a4f88)(content(Whitespace\" \
          \"))))(Tile((id \
-         9240225f-cf1a-4130-b3d7-1d73839f227d)(label(requires))(mold((out \
+         9240225f-cf1a-4130-b3d7-1d73839f227d)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         e5da5e0c-194e-4718-837d-7c6cce82c484)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         3be6475a-cb62-4b01-b36f-b541f647c257)(content(Whitespace\" \
+         \"))))(Tile((id \
          2c51922f-1c62-43f9-afa8-2c2dc4dc298c)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         bd744a9e-745b-472d-80ab-058e42a9aad9)(content(Whitespace\" \
+         148eb569-d754-47c7-a8b8-c527a418e689)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c19b121f-b5f4-494b-afc1-665e54545e38)(content(Whitespace\"\\n\"))))(Tile((id \
+         2adf996d-fd0f-4b5b-b7af-be08859a5b51)(content(Whitespace\"\\n\"))))(Tile((id \
          5213e45d-d667-4a1c-85d7-c39f4626693e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         9b6e259d-7b78-49f7-8f4d-bcc014493303)(content(Whitespace\" \
+         251c66f1-2594-468e-994a-020458adc85e)(content(Whitespace\" \
          \"))))(Tile((id \
-         8a5b21c6-97cc-4f60-b200-4b9593e083e2)(label(ensures))(mold((out \
+         8a5b21c6-97cc-4f60-b200-4b9593e083e2)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         ce4ae38d-98fa-468e-90f0-e5f9d0e9eeee)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         6445f099-1482-42bc-8170-ba7b2b228b72)(content(Whitespace\"\\n\"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         31e58e01-4c40-4758-a451-6284a623e880)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         5492dbb9-ba39-412d-a63c-171c86ef4b7e)(content(Whitespace\" \
+         \"))))(Tile((id ce4ae38d-98fa-468e-90f0-e5f9d0e9eeee)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         3e3dc429-1934-4341-a372-9d1a799ebe1c)(content(Whitespace\"\\n\"))))(Tile((id \
          f8732838-5503-42d2-a538-f45a0b15c219)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -589,7 +639,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          729c91ba-862e-42ff-a47c-8f8e86112e90)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         06703848-43f8-4025-b7c5-a54f7ee4fb8a)(content(Whitespace\"\\n\"))))(Tile((id \
+         6a0b812a-5643-4cf0-ba94-51d5dca7ba46)(content(Whitespace\"\\n\"))))(Tile((id \
          3d6b6b7e-e309-4585-85d9-76f8190668eb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -618,7 +668,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e7f33616-e639-4f0e-aa48-b9299ecb9580)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         62f9c559-def0-4284-8bb0-f274183f958e)(content(Whitespace\"\\n\"))))(Tile((id \
+         0eec3714-90c3-4d7c-9d2f-6e523b35937b)(content(Whitespace\"\\n\"))))(Tile((id \
          b216c215-c7d5-4c22-b719-084149d17ed3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -647,7 +697,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          60c39806-9f69-4881-82fa-3a843d107c6d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f9a72d37-f167-4912-95d4-42e50d2cd5e0)(content(Whitespace\"\\n\"))))(Tile((id \
+         9c933faa-8c1c-461c-8922-b99a883a6e6f)(content(Whitespace\"\\n\"))))(Tile((id \
          d24d8168-20cd-4d63-8ce8-8333baf1d236)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -676,17 +726,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          be63dddd-0538-41a9-94b3-539a4715a202)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6bfea94f-2ca7-4d1b-a985-ce8932729e2e)(content(Whitespace\"\\n\"))))(Tile((id \
+         db2b157e-a747-416a-9651-b1418d97d60a)(content(Whitespace\"\\n\"))))(Tile((id \
          e65907eb-7df8-4310-98ae-49722de5018f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          cfda7462-6303-4b67-97e2-a4a7d6d3959a)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         351a59d3-524d-44a1-9ea5-c379a3ce086a)(content(Whitespace\" \
+         \"))))(Tile((id \
          570e7b9e-b5ec-45c4-91d6-6940b86e1342)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         af508caa-6455-422a-84d7-99449bcd71a8)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         db572bfe-4aa5-4362-ad36-db497f91fa4a)(content(Whitespace\" \
+         \"))))(Projector((id af508caa-6455-422a-84d7-99449bcd71a8)(kind \
+         Checkbox)(syntax(Tile((id \
          bbcfd818-5aae-4e80-aa2e-35f32619177d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -696,78 +750,78 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4af25274-7ed0-4077-8446-dbaaef72e5fe)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e290ff59-ad5f-4132-a83d-956eae518f0d)(content(Whitespace\" \
+         954d258d-1da6-4bc0-bea9-7cda58546ee0)(content(Whitespace\" \
          \"))))(Tile((id \
          ddabb1d0-8c49-4345-a824-7a6e8ad6f1ac)(label(\"\\\"nrows(t4) == \
          nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         afea94d3-61c3-4aeb-8810-23df9f52958e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         58d548cf-3089-4e35-8e7f-7d61b583dbb9)(content(Whitespace\" \
+         f46e5dbd-93de-47b2-b8da-c36c219a0d37)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         7720d0ac-6307-4c34-b169-cb9a76221c16)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9545838b-c8a9-49c7-b64a-397625578130)(content(Whitespace\"\\n\"))))(Tile((id \
+         0f64b4e9-372c-4939-a378-8de788b9fb4b)(content(Whitespace\"\\n\"))))(Tile((id \
          a83bb3e0-cb56-467c-981c-560881aa0ebb)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         0d20ffed-9628-4357-ab31-59f195d6912b)(content(Whitespace\" \
+         28c88f9b-998f-4f51-b706-d916042e1f7a)(content(Whitespace\" \
          \"))))(Tile((id \
          c6e48db4-0377-49a1-9119-aaddee3e0df7)(label(group_join))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         99b9b7e6-0704-459e-b031-0a0bfd94e411)(content(Whitespace\" \
+         8f6d83e2-9f7a-4fad-9be0-911442c012bf)(content(Whitespace\" \
          \"))))(Tile((id \
          44b9fa51-4f85-4297-888b-cba23fd12ade)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bb45ba58-bcaa-46c4-bfac-ca09e8c6fc92)(content(Whitespace\" \
+         3eaf3fb3-719b-412c-9880-2da2ececb947)(content(Whitespace\" \
          \"))))(Tile((id 3e6550d8-dcfe-4c26-99f6-d325c3a6ce8d)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         499d3f37-3818-4625-85d4-45780225460f)(content(Whitespace\" \
+         5316a5ce-8ba9-4512-be78-abedfef1fe19)(content(Whitespace\" \
          \"))))(Tile((id \
          ba2b66b2-706b-4b7c-a1fe-d8e49fff319e)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         a5d0a28c-a8f8-4fd8-b8c1-2c945bd3ec97)(content(Whitespace\" \
+         a1475645-0aa7-43ff-b887-776f01bc34ac)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d6aa4dc5-cbad-44aa-89ef-41e5bbdd37d5)(content(Whitespace\" \
+         6f53008e-6ad0-4eb7-9503-931dccf53197)(content(Whitespace\" \
          \"))))(Tile((id 7304ca39-7841-4c01-84af-b29015d96450)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         e6817bc0-acc0-429a-b718-2663f8271ddd)(content(Whitespace\" \
+         2849ce70-4634-4a40-ae49-cf1fe9f492e2)(content(Whitespace\" \
          \"))))(Tile((id \
          1008ac76-9b49-4626-bf66-199087dafe3a)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         7605810e-0730-47b0-a116-0c6adb5f6e77)(content(Whitespace\" \
+         468a72ba-ae7a-4c7d-9532-841de6153bea)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1332863f-694d-4e29-acc3-87f45dbd2292)(content(Whitespace\" \
+         6d2ae1b4-e579-41c4-a03a-f222554361b7)(content(Whitespace\" \
          \"))))(Tile((id ab93effa-c9e0-4d68-90c6-d21d064d8437)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         09c02e5c-d2a8-4e84-a5be-7329ba8c14a0)(content(Whitespace\" \
+         deaf3816-f922-4bc0-a61d-552df349d67e)(content(Whitespace\" \
          \"))))(Tile((id \
          601863bc-f18f-45f3-800e-79cbef5339b0)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         e8212306-e995-4877-a882-e6832b1cac24)(content(Whitespace\" \
+         86d2baa8-02a3-475b-955c-1ed28df9e0e9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ce9cf7ef-7887-4c2f-8662-44a2e9c0c1e5)(content(Whitespace\" \
+         db5dcdaf-cf9d-4a73-8988-bd6beea17455)(content(Whitespace\" \
          \"))))(Tile((id ce4382ec-e12c-4db2-b26c-5cba135f2aff)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         bb5db730-e3d9-4a56-8be1-6186d44d3e77)(content(Whitespace\" \
+         6f95d95f-90e0-4c3a-b10d-8f85c5bfb9aa)(content(Whitespace\" \
          \"))))(Tile((id \
          510192e0-bd55-4148-bf9c-a16ae6fa63ad)(label(k))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         8265394b-2449-4bb5-9a9d-f62f4e11aa04)(content(Whitespace\" \
+         e11abc04-f234-483d-9801-91a58a4c6043)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d1b72a2c-bdd8-4bf8-ac44-a788af60deba)(content(Whitespace\" \
+         15cecec9-8e77-410f-982b-7de4d7417aca)(content(Whitespace\" \
          \"))))(Tile((id \
          4f29fa3c-b542-4638-b6fa-ce105a061bd8)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -780,27 +834,28 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          6b31a98a-c900-47ec-85a7-8547a2fe44de)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         262fbc4c-5d7d-4cf4-9aa7-a7b25bfba20a)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         85086d3c-6665-4dc1-ac0a-43346a6684fd)(content(Whitespace\" \
+         \"))))(Tile((id 262fbc4c-5d7d-4cf4-9aa7-a7b25bfba20a)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          6d74511e-19f4-4770-8366-b01f4ff5781a)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          bdfdc8c7-4d83-4d3c-8a3f-7859c0a1860c)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7af6259e-a6b2-4b2b-9f31-432adc85825b)(content(Whitespace\" \
+         2bc90193-f1b3-438a-9300-fe4a60c1bcb4)(content(Whitespace\" \
          \"))))(Tile((id \
          cb6987a6-6b3c-434e-8c6d-a50b010be765)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         68eb1faf-ca6f-40cd-a547-419315cddc8e)(content(Whitespace\" \
+         01143e87-49ad-43ef-bf08-0e0c03785126)(content(Whitespace\" \
          \"))))(Tile((id \
          ff490051-0a16-4162-ad0f-7d700ae0cd9b)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d57255bb-f1b2-44d5-9f2d-e9b6b34ed104)(content(Whitespace\" \
+         3409271e-b27a-495d-8331-440755a6aef3)(content(Whitespace\" \
          \"))))(Tile((id \
          894dc1d4-b4a0-4630-94c9-7753b7fc437d)(label(k))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -808,17 +863,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          94d53c64-6af4-4c32-8173-f441a4aa9d38)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f3c49fd7-3d7d-416e-a7b3-e52994feffa9)(content(Whitespace\" \
+         f14417c3-685c-4cc9-8b51-64a74a6ac75a)(content(Whitespace\" \
          \"))))(Tile((id \
          20b0a0d6-00e2-4a96-83cc-2e8c0e70ab08)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         2cafbb13-87d2-4864-800d-df6e0229d879)(content(Whitespace\" \
+         a733005c-f98d-4cdf-b12b-8e6d73564851)(content(Whitespace\" \
          \"))))(Tile((id \
          23a8836a-cb7a-4333-88b5-b81ec891fe4b)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e5e41df4-fe84-4ea5-9cf4-a05258764e60)(content(Whitespace\" \
+         92c13749-2153-4ce0-a5bb-bb593b58f893)(content(Whitespace\" \
          \"))))(Tile((id \
          2a50dc04-a497-45fc-8fe8-b78f6d863716)(label(k))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -826,7 +881,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9951bf24-a53c-4d61-8a3f-b20945170f38)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         23a648c2-eea4-4897-81fb-e0603c7b5054)(content(Whitespace\" \
+         c97c535e-c934-440e-8ea0-312b85c630cf)(content(Whitespace\" \
          \"))))(Tile((id \
          14dcc1af-6486-4a32-8c98-d29e071b7039)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -836,145 +891,153 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          849a9618-e8bb-442a-9373-55e3a5919d40)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         5acd3b6e-ade5-4a15-8457-634a9bddf853)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         887beef6-1336-4b88-85f1-69e1f17ea6ca)(content(Whitespace\" \
+         \"))))(Tile((id 5acd3b6e-ade5-4a15-8457-634a9bddf853)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          2fc66965-1be8-450a-8f4d-21fa12fe7c8c)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         f63fa8d3-8ab9-40b7-b4bc-270cf766faa2)(content(Whitespace\" \
+         ceb769ea-6d6d-4a4b-944a-f0bca0eea7ae)(content(Whitespace\" \
          \"))))(Tile((id \
          47ba8df4-aa36-4314-8a70-1486b7e295dc)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f12a0da4-5ef3-40fe-bbb5-9a28cb2ba4aa)(content(Whitespace\" \
+         557fb578-284a-4c63-a8d6-583e84d01980)(content(Whitespace\" \
          \"))))(Tile((id \
          ba3da1d4-2784-4153-9e32-5cebee343c2c)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7644c855-2aef-4098-b58a-49f4183b5a8a)(content(Whitespace\" \
+         e4284ea0-3e73-4194-8362-504bbc620385)(content(Whitespace\" \
          \"))))(Tile((id \
          89e62366-3b0a-4b36-b5a3-2f5f4f3b3712)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a87cc659-8a93-4d34-bd33-df696fe384af)(content(Whitespace\" \
+         2bb6dcfa-6f99-4760-80b2-cb4edfdbc12a)(content(Whitespace\" \
          \"))))(Tile((id 485b0dd6-1134-472a-846b-6acb1f40e0b2)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          df0a90a0-dc4e-45f8-b2d2-80b055b82e6f)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0ff48376-3abf-45f6-9b54-aec8f0febf64)(content(Whitespace\" \
+         5e74ceed-0e4f-48a3-9f2b-6efc74cd7625)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3e237d65-2e49-4a33-8ead-5b6d3bd03aa0)(content(Whitespace\"\\n\"))))(Tile((id \
+         8e2cb5c7-3d22-4bdb-b5da-9193eb19439f)(content(Whitespace\"\\n\"))))(Tile((id \
          bb633495-acce-4c35-891c-69024078b32c)(label(typfun ->))(mold((out \
          Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         0013d542-c696-4d79-8558-0518faecf202)(content(Whitespace\" \
+         5e6616f0-4fca-4a2c-a677-12b4f56be29a)(content(Whitespace\" \
          \"))))(Tile((id \
          e1cf2527-4508-4c1d-815f-928baa21e4b7)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         b1eba4b4-30f1-4528-8c70-da98738c0860)(content(Whitespace\" \
+         4ea94d10-dbbb-4ffe-b9e7-24aed870568d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         866260ca-30c9-4a61-84c2-1eb5cf241574)(content(Whitespace\" \
-         \"))))(Tile((id bdcd40ae-12fa-4bb7-b3df-00f6c29d89dd)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         260eacf0-af72-4fdf-93f3-95d43ebc4ade)(content(Whitespace\" \
+         ddb6c31a-a1fa-45d3-a21d-d195f8c25877)(content(Whitespace\"\\n\"))))(Tile((id \
+         bdcd40ae-12fa-4bb7-b3df-00f6c29d89dd)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         9ee01294-8594-4ad3-b45d-67a41bb61b5f)(content(Whitespace\" \
          \"))))(Tile((id \
          0102da8b-ec5f-402b-be86-231ed30fba4c)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         5c986809-6537-4733-b565-91605431939c)(content(Whitespace\" \
+         1b843738-bb0b-436e-949e-72f6ab8ffeba)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         14ca0c25-873f-4e70-8adf-306bc8ebb4f1)(content(Whitespace\" \
-         \"))))(Tile((id d795efd8-1455-40cd-b75b-8b9ee8086798)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         1e2e81cb-9ada-45bb-b780-f2ba6099f8cf)(content(Whitespace\" \
+         b7dc3e4c-421b-4633-a679-7b138dcf3b76)(content(Whitespace\"\\n\"))))(Tile((id \
+         d795efd8-1455-40cd-b75b-8b9ee8086798)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         a9249b6a-db00-46db-be20-fd446bb84465)(content(Whitespace\" \
          \"))))(Tile((id \
          40910926-77f2-4750-ae0f-47b63491a9b6)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         c9bb5c56-3f6f-40fa-b6d2-5bbdfb8c6536)(content(Whitespace\" \
+         4e9381e0-3f73-4708-a106-f245e8fe7cdc)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         4cad77f7-94b9-4dfd-8e2b-1d0465827bd3)(content(Whitespace\" \
-         \"))))(Tile((id 4c3e6316-1c25-4414-a86b-742a36b7dfc4)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         b197f346-133d-4fae-9e7f-ce2fffb95dda)(content(Whitespace\" \
+         15c7b834-bc5a-4653-aa6d-2a0339b67df2)(content(Whitespace\"\\n\"))))(Tile((id \
+         4c3e6316-1c25-4414-a86b-742a36b7dfc4)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         5be8592f-7477-47e2-a5da-35ec6db7536a)(content(Whitespace\" \
          \"))))(Tile((id \
          1d19877f-0d25-4f0f-af06-0056980fb119)(label(k))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         7e989df0-27ad-4629-9b21-cd208d412e3c)(content(Whitespace\" \
+         9396b2fe-c91e-46db-b3c0-ee188096490f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3da4bf37-afe5-4901-86b2-ef618bf240f4)(content(Whitespace\"\\n\"))))(Tile((id \
+         9379cae7-c0c8-4ed0-86b8-ed2c7d0bb12c)(content(Whitespace\"\\n\"))))(Tile((id \
          f720e4f7-638d-400c-b67b-ea4858d6bb5d)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         be82c1c3-d5fb-48a5-a4e6-cf5e2c86a77e)(content(Whitespace\" \
+         71531275-bbd3-47a4-b3e9-96b005860b08)(content(Whitespace\" \
          \"))))(Tile((id \
          bc646ab8-f404-4991-a570-b7f52cabe0b7)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          ba887efc-935b-44dc-822d-303320e11a43)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         478bf000-cddf-4d26-8e3e-cb1d0dfe62f4)(content(Whitespace\" \
+         \"))))(Tile((id \
          e3820d52-5d76-4929-a559-ecef34dc61b2)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         f8e4308c-1c4a-4c20-a2fd-40c31e2df505)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         bdbc214d-c6b0-4374-9b8f-5f997f13d70a)(content(Whitespace\" \
+         \"))))(Tile((id f8e4308c-1c4a-4c20-a2fd-40c31e2df505)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          51aa5393-b6bb-468b-aaa2-b8b01b6ada5d)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          c06a27d6-439c-4637-bb4a-ac40b51402d8)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         7e83c0c4-c438-453e-ad6b-69b3bb3ef2e6)(content(Whitespace\" \
+         36509ccb-e84a-48f5-8aee-d425b4f03876)(content(Whitespace\" \
          \"))))(Tile((id \
          6104c4a5-5f5b-4690-86a9-1e2731fe9044)(label(t2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0a7fd488-49dd-4907-bd0b-07d3cad5c277)(content(Whitespace\" \
+         \"))))(Tile((id \
          ff915411-7473-4402-9537-ff806381da51)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         1491553e-d419-4f80-b72c-2ff19461acd9)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         773777b3-c513-4747-8f64-1a30670851d1)(content(Whitespace\" \
+         \"))))(Tile((id 1491553e-d419-4f80-b72c-2ff19461acd9)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          c813f73b-c18e-468b-a74f-ce3a2f155604)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          6f369d86-9456-4e5d-8be4-ac8790b6e30a)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         20f9be83-42f1-4faa-a726-ab4bfb1db562)(content(Whitespace\" \
+         51f93d02-20e1-4022-a884-ed83bd728083)(content(Whitespace\" \
          \"))))(Tile((id \
          ab403abb-682c-4a53-a486-8ba9ecd10502)(label(get_key1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         026ef325-a6c6-447c-9af4-7a5b6cb4ea4a)(content(Whitespace\" \
+         \"))))(Tile((id \
          61e39846-dd91-451e-a5cb-3d7d86b48890)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         009e9b18-2fbe-4599-b252-bfbd3e191bef)(content(Whitespace\" \
+         \"))))(Tile((id \
          c4c0fb32-0aff-419a-ab0f-63f018c1d63a)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          b26edc63-36f1-4aa9-9ace-4f5d0c364d37)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         1cdf3e59-8948-4815-b64a-48f33c4b49c9)(content(Whitespace\" \
+         925cc220-f66e-41ac-8561-ddc87aaed6f0)(content(Whitespace\" \
          \"))))(Tile((id \
          9a50ed8b-174d-4bcf-b8b7-29fe363ee0ab)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         77592049-7a0a-405c-84ab-b2da5e38c5e1)(content(Whitespace\" \
+         fa2ae85f-5de3-481d-9a09-6d969b77d3a7)(content(Whitespace\" \
          \"))))(Tile((id \
          c90c906e-4bdc-4722-95fe-feb8a7badca8)(label(k))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -982,26 +1045,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8e616bdf-24fd-45c4-8b0d-f3f0284d6165)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         562a5e5e-caba-4993-8b61-258bd5027799)(content(Whitespace\" \
+         831f5a3d-e31e-4c0f-bc36-eb824f128530)(content(Whitespace\" \
          \"))))(Tile((id \
          a9aef3f7-cee7-413a-9550-8a32bda57592)(label(get_key2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ba8f3ab6-0795-4159-a768-1f03c9d2469c)(content(Whitespace\" \
+         \"))))(Tile((id \
          4a8ac39f-fefe-4873-a974-ca164440bd9e)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f015834d-a15c-4d8b-b98d-51e6b88616d7)(content(Whitespace\" \
+         \"))))(Tile((id \
          921fc192-0c9f-4645-b23f-2d4136ca78dc)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          25cd15f4-071e-48f3-870f-0ef1d0d49ab8)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         f4f4f7a7-638f-4c00-bb5d-7f622477595d)(content(Whitespace\" \
+         06a33055-08df-47d2-970f-226b8ddafac9)(content(Whitespace\" \
          \"))))(Tile((id \
          1b084fd8-b108-4096-8eee-4402d22b37cf)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ded02cc9-6225-4985-8e31-a4b9ea09b398)(content(Whitespace\" \
+         2546d0ae-5541-4b41-8f88-a5392e366517)(content(Whitespace\" \
          \"))))(Tile((id \
          7adc79d4-f319-4ffa-879e-39e96ac7ec16)(label(k))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -1009,14 +1076,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a895fea0-ff2f-48fc-8adc-0b1d932ef1bf)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         9759e9d8-ddcd-4758-88d7-1bbc34c273fb)(content(Whitespace\" \
+         7cebe239-8d0a-4f99-b8a5-63626d833f87)(content(Whitespace\" \
          \"))))(Tile((id \
          1cdb0341-2305-46c9-95f3-b7629c40f874)(label(aggregate))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         01acd89d-08e5-4d53-a9af-3498515ade46)(content(Whitespace\" \
+         \"))))(Tile((id \
          4d786459-8ee2-481b-85fd-0d44f1acc10c)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         399719b5-791c-47c9-bd50-98b1ad63ab80)(content(Whitespace\" \
+         \"))))(Tile((id \
          42b08d1d-e4a9-4dc6-b5b0-956835457559)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1028,83 +1099,88 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          386a75a2-01d2-4184-abed-cd551678fd55)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         af44d768-9e11-410e-b1cd-0a21c19a52b5)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5efc1e3e-c0b2-4560-b25b-9eafb6881deb)(content(Whitespace\" \
+         \"))))(Tile((id af44d768-9e11-410e-b1cd-0a21c19a52b5)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          ff8779dc-417e-4c8c-a494-4a939f57c37a)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e874f3ac-8138-4be5-83eb-0d18b400e573)(content(Whitespace\" \
+         decb10c8-64f8-412f-94b5-28910f67d10b)(content(Whitespace\" \
          \"))))(Tile((id \
          bd85a23b-5688-4f90-9475-f90606edd4ea)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4f65c412-5386-45ba-954a-f374c7de5b9c)(content(Whitespace\" \
+         37c546ee-3503-4bf9-92ba-305d43c40ba5)(content(Whitespace\" \
          \"))))(Tile((id \
          3c609f32-06bf-4d3a-b76c-ff2fb2e9e466)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         3517d2ed-f84c-48f2-abb4-dd68c551ad4e)(content(Whitespace\" \
+         a2431fbb-c4f8-4b66-b9d4-c34e03424826)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         89692074-19c3-4b03-b35f-1d1f52a353ef)(content(Whitespace\"\\n\"))))(Tile((id \
+         0a285c31-14da-413a-aefa-6a0110b88be2)(content(Whitespace\"\\n\"))))(Tile((id \
          873217c2-1670-44d6-9166-fbf12e7cfb7b)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          9e8558e7-7f95-4d72-a981-ce2dae0e86f3)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         63eda2a0-b3d7-4fa4-9cbc-8ddf95819e03)(content(Whitespace\"\\n\"))))(Tile((id \
          2b6d94f9-c022-4c9f-92f1-a229f1d125e2)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          44942017-ea05-4614-aa8b-f1664159fd89)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7df86bcb-8c65-4c60-beb0-a28d22b81630)(content(Whitespace\" \
-         \"))))(Tile((id 37c22f03-c643-473d-9944-0496743dabdc)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         cba8e872-df1d-4d9d-b1f4-8d0667754bb4)(content(Whitespace\" \
+         57d4242d-1f2a-4db6-803f-009bf7b866a8)(content(Whitespace\"\\n\"))))(Tile((id \
+         37c22f03-c643-473d-9944-0496743dabdc)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         5f315984-c9c1-4afe-8879-66926bbf75d7)(content(Whitespace\" \
          \"))))(Tile((id \
          3fb35473-fa8f-4f21-89e3-3c2974e85977)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          a744a32f-6bd3-4b1f-89ad-f44c40ff4d16)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         15071629-5677-4c3d-b0ca-c2bcd1628c8f)(content(Whitespace\" \
+         \"))))(Tile((id \
          7c409e11-9ac6-4e8a-920c-e42249f4a9b9)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         54f04003-8b65-4525-92d8-2fd049e1df08)(content(Whitespace\" \
+         \"))))(Tile((id \
          13fec0da-6983-48df-a771-6a23b2b41f99)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         147cfe6a-7bd2-4344-8ea1-3141a734efbb)(content(Whitespace\" \
+         fb3b7769-41cf-4ebd-bf68-73e74d6c4ee2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         631f766b-b344-4111-8b52-3d1792d55ab9)(content(Whitespace\"\\n\"))))(Tile((id \
+         a6b88e5c-fbd7-4486-9416-63ac41c5157b)(content(Whitespace\"\\n\"))))(Tile((id \
          e47edaca-000b-4fe8-ac8e-a1e2c186b856)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         f9b826cd-b3e3-4e43-95d9-1147023ecfc3)(content(Whitespace\" \
+         9da9c4c3-07c3-443b-a809-cdab50cd505c)(content(Whitespace\" \
          \"))))(Tile((id \
          db3ac9e8-b60d-4791-b975-4b15733ca769)(label(t2'))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         acce8104-85c1-4072-a816-1a30d94d4a58)(content(Whitespace\" \
+         174257da-7cfe-4e29-adc6-22ee360043db)(content(Whitespace\" \
          \"))))(Tile((id \
          82295eda-b74c-47f9-9adf-f7df4d6cd448)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9adae8a7-73d9-49b8-a48a-03ee2e3308e5)(content(Whitespace\" \
+         a788f121-1415-4c1a-8c78-0fec737a5795)(content(Whitespace\" \
          \"))))(Tile((id e62d636a-5fd8-416b-8477-c8cfec4a0218)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          9a651d12-45cd-4e21-a634-b71e22a6ca95)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         6dc56bde-df7f-45e1-b8d4-5bc6e686ed21)(content(Whitespace\" \
+         50c891fb-3eb8-44e1-b7d8-b79712cba751)(content(Whitespace\" \
          \")))))((Secondary((id \
-         a0630c28-ce6a-4f8d-a2a6-b48e2ff54288)(content(Whitespace\" \
+         887be148-d610-47ad-b022-eacce0aa86ec)(content(Whitespace\" \
          \"))))(Tile((id \
          f3cc365d-6c90-4df0-93e6-b89441a396dc)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1118,25 +1194,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5e23e074-17ad-41a2-9461-c15ebb38d86b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b9c9597e-6637-4fec-b8fa-40b9280c35f4)(content(Whitespace\" \
+         9b12d1e8-559c-4aa9-a87d-b543576b56f7)(content(Whitespace\" \
          \"))))(Tile((id c31a94bd-096e-42d0-a84b-4f38276a83d1)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a2776a05-7856-4ce4-9d53-995a4b4c461f)(content(Whitespace\" \
+         e5d54be8-41f8-493b-aecd-c71e249be595)(content(Whitespace\" \
          \"))))(Tile((id \
          a44e90bf-ecf4-4ab4-8d2d-2986d4bcfa13)(label(r'))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ff75e76f-6409-4e2b-b2ec-71369fb3441a)(content(Whitespace\" \
+         \"))))(Tile((id \
          a77d6a52-7036-41df-972d-f60da27841c1)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         716019c9-a169-42d1-bdf6-c243f452b227)(content(Whitespace\" \
+         \"))))(Tile((id \
          30eaea86-d87d-4e60-8325-fe94a53c591d)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         eca0db1e-79ae-46b0-b381-8576df8a0da7)(content(Whitespace\" \
+         af25ce2b-06db-49cd-a687-dbbd10aa074d)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c882bda4-dc89-4e55-ab5b-8de3e1cdee87)(content(Whitespace\" \
+         4dca9e68-165a-4a8a-9b8f-00caec4c25ce)(content(Whitespace\" \
          \"))))(Tile((id \
          9ddc89a7-9fbe-42f6-a1f4-e95ec9a0e4e6)(label(get_key1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1147,12 +1227,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ebf0fed1-ae7a-44b8-b1e8-3abaf45c02ab)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         090f5022-0260-45f0-be00-6664caaeb27a)(content(Whitespace\" \
+         a61fe9a3-569f-4839-82aa-3ef5978183c7)(content(Whitespace\" \
          \"))))(Tile((id \
          9e179c7c-273f-4feb-ad98-69e5aab52baf)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         72ef546f-2f70-4e03-bc8c-cfb2f77fb042)(content(Whitespace\" \
+         5eacf499-8109-498e-8a03-1bddb96e85d7)(content(Whitespace\" \
          \"))))(Tile((id \
          007188f9-b7cd-46d3-849e-a9efd5cb4ffb)(label(get_key2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1163,9 +1243,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4fcd94ce-3153-4a24-a6bc-9d26e0b8ed55)(label(r'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         9acf59a9-3ace-4ccf-91b0-31f29aa078ce)(content(Whitespace\" \
+         9a4ce11a-876f-4099-8a58-94c8c77af571)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         213a527f-9416-4540-b7c4-2ce32adeb144)(content(Whitespace\"\\n\"))))(Tile((id \
+         793eb4a1-e90c-4e1d-b4db-a2c5043e6192)(content(Whitespace\"\\n\"))))(Tile((id \
          29ec867f-091d-4c4e-9a6d-af549c92225f)(label(aggregate))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1178,48 +1258,49 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6a333650-dc6e-4ac5-9c6e-67f619302cbe)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         707453d4-62c6-43aa-9d7e-2de1ffbc569a)(content(Whitespace\" \
+         8172446b-bc38-4688-b532-f39c186ab918)(content(Whitespace\" \
          \"))))(Tile((id \
          9ba4a4c0-22a2-4f51-b453-c7b3f4b4d0b4)(label(t2'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d00bd93c-b1e8-44f0-8037-daae23835412)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         3e2cb909-5606-4801-9aed-630542b4d011)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         a7619e1d-6ed0-43d6-a365-9e6efe1d450f)(content(Whitespace\"\\n\"))))(Tile((id \
          e7afba4e-d499-4716-884d-5b1d99614a68)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         d8768c72-4f73-427a-ba64-da9456cbd36a)(content(Whitespace\" \
+         954da542-0c43-4ca4-9c16-db408b1636f6)(content(Whitespace\" \
          \"))))(Tile((id 1829f9cb-c140-4c14-b635-4ece7a367a22)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          77d92dbf-ec13-41e8-961d-5a5545bc6493)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7967fb33-b84e-4d5d-9670-ac0a1e4039cc)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         95d2708d-d0f9-4201-8a3f-ae0b1cf1adf6)(content(Whitespace\"\\n\"))))(Tile((id \
+         90c6f560-84e8-4f0f-bc65-02a873e55695)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         33e9fc48-ce8d-4089-b653-5f9f0d8006e9)(content(Whitespace\"\\n\"))))(Tile((id \
          c9b1fa67-7207-4749-a53a-efc688423307)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         5e2c50c9-ac61-4194-bd43-be5a374fa1e3)(content(Whitespace\" \
+         c2a46527-ff09-495a-b55d-7d47c3b717aa)(content(Whitespace\" \
          \"))))(Tile((id \
          a2bb243f-c908-45bf-8f6b-544a7ce324ab)(label(average))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8e977579-74bb-4e20-b8fb-eb9f2cafa9c3)(content(Whitespace\" \
+         d9808866-f1d6-45bc-8064-e46743cb10e6)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0deadb40-e2f3-4540-9235-99cef621f4fd)(content(Whitespace\" \
+         c93aeb9d-90e6-4405-9136-27ec0197ab6d)(content(Whitespace\" \
          \"))))(Tile((id b345b8f6-02cb-445d-a902-6f2658276a39)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         7a11727d-9523-452b-b453-e905ea95a575)(content(Whitespace\" \
+         e83b4983-4778-498e-9492-9dfef47302ca)(content(Whitespace\" \
          \"))))(Tile((id \
          3ecf50d4-57a9-4170-8081-7aa64911309b)(label(ns))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b6ce1c05-8e69-4a3d-a687-d0a04f73502e)(content(Whitespace\" \
+         4e18003c-b911-46cb-85b2-113bec286f7e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d378fe4e-18a1-4e57-8972-cfc59909b8ec)(content(Whitespace\" \
+         75442498-2da5-45e6-8015-d090b596ec9d)(content(Whitespace\" \
          \"))))(Tile((id \
          f867d51b-1629-42ca-a3e6-7369f049a6d0)(label(fold_left))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1233,7 +1314,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          364c89f5-f7e1-4cc3-b681-8b9758868656)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8ebbdea1-31dc-4f58-8ec5-77ffddd54292)(content(Whitespace\" \
+         c94bcbd3-9d4a-4c3d-b6b3-344b7577ad36)(content(Whitespace\" \
          \"))))(Tile((id \
          29a63aa3-9db2-4fef-8ccc-bb2377b5725f)(label(int_plus))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1241,17 +1322,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1598a80b-4962-42f1-9c7c-58ce609a9f0e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7c8f3320-7d69-478d-b04c-97407fa2bbdd)(content(Whitespace\" \
+         32754cf9-0ef9-4a3a-807b-8a5b3040d283)(content(Whitespace\" \
          \"))))(Tile((id \
          f1ba915d-3b6b-4f53-8257-26223528ad3a)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         86da4547-edc3-49f3-852a-e90cf2826d3f)(content(Whitespace\" \
+         a6ddad46-1fbd-414e-a71c-110a32ec4aae)(content(Whitespace\" \
          \"))))(Tile((id \
          b1c7ab41-43f3-4bd3-ba1c-c67f491f3e3d)(label(/))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 27))(sort Exp))((shape(Concave \
          27))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         990d20eb-5975-47fd-b89d-3c0fc3952174)(content(Whitespace\" \
+         517eb69c-8537-4474-96a2-623746d1da90)(content(Whitespace\" \
          \"))))(Tile((id \
          6a95fb5f-7c47-4782-912a-18d942009fbf)(label(length))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1262,14 +1343,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ca2cee5b-0c74-432e-90f0-96e2b0f16bbc)(label(ns))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6cb09ea8-95dd-4b1d-a55e-072ae8a7efd6)(content(Whitespace\" \
+         9b068189-89f4-44e1-aea6-90ba3fdc554c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         52d46783-2081-424d-be67-52e78b7756d6)(content(Whitespace\"\\n\"))))(Secondary((id \
-         bdf41a60-24bd-4b8b-9136-86835adee030)(content(Whitespace\"\\n\"))))(Tile((id \
+         987c2708-6bd3-4bae-a9f1-0b2a3fb01952)(content(Whitespace\"\\n\"))))(Secondary((id \
+         8e19a112-8d6e-4f8c-8131-0b6825526b1e)(content(Whitespace\"\\n\"))))(Tile((id \
          220f7e37-d1e4-46a3-8a65-b98379cbc124)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         4d29b649-120a-45c0-b3aa-edcb57c0256f)(content(Whitespace\"\\n\"))))(Tile((id \
+         3cf64de4-b3a0-4607-a324-f27de78a3b82)(content(Whitespace\"\\n\"))))(Tile((id \
          a7fc4b7e-b9bb-47db-aa56-483a092a8bc2)(label(group_join))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1372,7 +1453,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fb96e407-0951-4e85-94fa-83d098c66b1d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9b17ac19-f78b-48dd-a32b-02c22eebdeb4)(content(Whitespace\" \
+         09634c0a-816b-4d18-9439-2d594d9ff9e9)(content(Whitespace\" \
          \"))))(Tile((id \
          cf8c659a-b8ec-459e-9672-f5ff0f954104)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1380,19 +1461,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5f5f0a4b-e18e-4b82-a693-a932e33612bc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         29d12550-7ff7-4114-8bb4-320d924d1445)(content(Whitespace\" \
+         84491538-3661-4337-b338-9ff8d6831fde)(content(Whitespace\" \
          \"))))(Tile((id f1e84f8a-8923-48b9-bcf3-6eafa816e4a0)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         9261f7f0-06c5-46b1-8c9d-0c2c29f0ecf5)(content(Whitespace\" \
+         f0c9c752-65e9-48b0-a57f-525d06f05bde)(content(Whitespace\" \
          \"))))(Tile((id \
          e3ed2545-1404-4e91-99bb-ed59fa31387c)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         991d45c2-735f-4d5e-9d63-9a25b711f58d)(content(Whitespace\" \
+         2a5db2e9-4e73-4647-b704-347f1fa24690)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c83374bd-77f8-4483-8ffe-c6ddaf10391d)(content(Whitespace\" \
+         f32e7cc4-889a-442e-9608-1ab92110b19b)(content(Whitespace\" \
          \"))))(Tile((id \
          0e3f4bc3-742f-46c4-ba8d-8fa5f09988a4)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1406,18 +1487,20 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8bdc14e2-63c5-4741-baf6-8751a2076805)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ef0b1e68-12b8-41c1-b5f3-d4d2a72cf5da)(content(Whitespace\" \
+         cb77f9dd-8772-449b-99f7-d2a84d2c47c3)(content(Whitespace\" \
          \"))))(Tile((id af131e53-2b0f-448e-be7a-9156eb91a94d)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         bfdab9b9-f342-4ff6-8983-516955325da1)(content(Whitespace\" \
+         4a82d8f7-8031-4139-80b4-45a7d54ddd17)(content(Whitespace\" \
          \"))))(Tile((id \
          a20fd6e5-dd5d-400b-8da2-8ee232dd90a9)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e2a9f285-9b9a-4722-997d-c3127c3248b0)(content(Whitespace\" \
-         \")))))))))(Tile((id \
+         346116fe-3098-426d-9077-a093bef390a4)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         3de64f71-d811-40e9-bdf1-52094a2b7fbe)(content(Whitespace\" \
+         \"))))(Tile((id \
          4f6fcfc7-6951-4f00-a232-a63692b4baee)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1430,12 +1513,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          cf856fd8-59e6-46fa-97a7-d033f239cdf5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         04746b60-3d94-4d93-8da3-35bd375a648d)(content(Whitespace\" \
+         1ac7afad-ec71-48b7-8135-5fd4bba22e48)(content(Whitespace\" \
          \"))))(Tile((id 860c7554-df53-454b-a72c-1226977f0567)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         23235e84-6b94-47a0-9f94-56de2bf9e4c7)(content(Whitespace\" \
+         aa4abe32-4bff-48bf-b6d6-9831dd3ca204)(content(Whitespace\" \
          \"))))(Tile((id \
          90de7709-6696-457e-8fe4-8c912ecc6c91)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1446,34 +1529,38 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c722988d-d450-471b-8704-dc0010463d75)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         fe96ef6b-3131-40e8-8ac2-d90160504c11)(content(Whitespace\" \
+         b71736e9-d2b5-4b40-9730-24b49aabccec)(content(Whitespace\" \
          \"))))(Tile((id \
          19ec9ea3-06d9-4164-acbf-45924edf4a86)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         50c6f340-aa54-42dd-b3eb-743d66f14f6e)(content(Whitespace\" \
+         8fb3a023-ce13-46cb-b1ba-ab2b94c25289)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0762343c-2d07-4a4d-81d9-f10317b673a5)(content(Whitespace\" \
+         101d2d06-f9c3-47cb-9a05-571d14f06281)(content(Whitespace\" \
          \"))))(Tile((id \
          0a5a742c-cf90-4e51-93f5-f59a3ec07986)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         df1954cb-b2b5-4a46-b788-75a5798a70ad)(content(Whitespace\" \
+         98e7b100-e9c6-42c5-908d-dcc145bbb916)(content(Whitespace\" \
          \"))))(Tile((id \
          47dd4a7b-db5f-4229-8741-219163b1803e)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a1b5dd6b-f986-48e2-8d0b-82eeb3c05ddc)(content(Whitespace\" \
+         efd33363-8b30-4a8a-8809-d8a094dcdcf3)(content(Whitespace\" \
          \"))))(Tile((id \
          6469e79c-2bdc-4b22-bc38-b4c98a380a34)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          0130103e-4551-4edd-b226-8068dd9988ba)(label(average))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         3340989a-98bc-40ac-9d8d-48afc7ca05da)(content(Whitespace\" \
+         \"))))(Tile((id \
          c738b417-64d0-4538-9f3f-0d4566488a79)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a4a92775-5174-4694-b9a1-3fac7259aab9)(content(Whitespace\" \
+         \"))))(Tile((id \
          a3488428-a627-4b0c-a222-3eb6d377f027)(label(average))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1489,15 +1576,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aaf7db4d-7e59-41f2-89f7-6ed35cf06572)(label(final))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         db7c2d05-3b72-4a18-bdee-5c815e9e8f03)(content(Whitespace\"\\n\"))))(Tile((id \
+         91991a48-efad-42f6-8ae9-cc315475a16d)(content(Whitespace\"\\n\"))))(Tile((id \
          66d13cc0-7180-4c7f-8bc2-615b9eb7daed)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9805df54-010f-453f-889c-fe04ce455cc3)(content(Whitespace\" \
+         24809236-715c-496d-8a13-0e123c675362)(content(Whitespace\" \
          \"))))(Tile((id 2e5a2df5-b415-43aa-98b9-e5cd001cb9a1)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         8346e337-0267-4d29-a46a-b1d952c5c7cf)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          2bd5c91c-f815-45dc-9915-9262fb53439f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1531,7 +1617,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          64afb3ba-0027-43fd-87fd-6edb0b0a30e7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4459f296-49ce-4807-874f-66d085618d06)(content(Whitespace\"\\n\"))))(Tile((id \
+         0bc7567c-887e-4c7c-a43f-ed3ac9bb511d)(content(Whitespace\" \
+         \"))))(Tile((id \
          df24a9fc-5edc-45c9-b8e8-32e9de4c7fe2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1565,7 +1652,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ed95ba1c-3519-47a4-9b0c-128835ba2761)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e87ad3eb-db42-43eb-b481-ab401871629b)(content(Whitespace\"\\n\"))))(Tile((id \
+         a6efaa86-d6b0-41bb-953f-581b61645013)(content(Whitespace\" \
+         \"))))(Tile((id \
          6baa2e02-c8ed-4bc2-b422-cd7793822efd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1575,7 +1663,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ec5eb1f5-746b-46b8-9de2-5de6cf5d1ed7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fea123cf-10b6-4e2d-8270-1bbc894ad042)(content(Whitespace\" \
+         b40f8f08-783a-4c31-92ab-140d586ca62a)(content(Whitespace\" \
          \"))))(Tile((id \
          4c950fbf-3d58-4760-b6b0-66452344ba80)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1583,7 +1671,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          85707168-be71-4204-ae8f-9fb9112bd8e1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8072cb91-d078-4490-8133-05b4f74a0f92)(content(Whitespace\" \
+         962b76cb-9a11-4cd4-8a82-1f9dcd2100f2)(content(Whitespace\" \
          \"))))(Tile((id \
          ff9715a9-df23-4301-9ec5-3c6560020698)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1591,18 +1679,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          215b8a45-fc6f-4b29-aff0-2a5b1d1bb790)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d1dbb8dd-b12b-46b5-887d-0efd8e3ea847)(content(Whitespace\" \
+         f74b9d26-1523-470e-8146-9381a3f48c36)(content(Whitespace\" \
          \"))))(Tile((id \
          1ada7bd6-49a9-4de5-bbd3-7b8f847332e8)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fe26a2e6-9da9-4f33-99be-c0020b9f7c37)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         f7f8390e-7cb3-4903-b7a2-ca4d74bbd5c8)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         85257040-5edf-422f-b20b-892ccc77212c)(content(Whitespace\"\\n\"))))(Tile((id \
          fac4c15b-b0ca-4eb2-b7c8-6ddb02855037)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3e82d166-ad00-4a01-88a4-0d3326100a7a)(content(Whitespace\" \
+         2e94506d-5403-42e3-94b8-5ba3a261c619)(content(Whitespace\" \
          \"))))(Tile((id 44ff0f0e-2b38-4839-a3f2-979ad1a7723e)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1611,98 +1697,120 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          fbf57ee8-b384-44b2-b3f5-a0a98d699c96)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e94df407-70e3-4034-be47-ff9cfa4bdaad)(content(Whitespace\" \
+         \"))))(Tile((id \
          c6d9c17f-95a4-4ab0-a98a-1ef703ca789f)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         93900b96-f0ed-4ca3-9918-cacbe21dd955)(content(Whitespace\" \
+         \"))))(Tile((id \
          759aa291-4a49-400e-93f1-534d021ec248)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          9f52b3cb-dc23-4ed0-888e-f6c58a28a577)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ccabcd01-55a8-4c10-93d2-48d1c99cadfd)(content(Whitespace\" \
+         23251183-87a3-452d-92f2-c399d1c52b39)(content(Whitespace\" \
          \"))))(Tile((id \
          1db24341-e940-4af0-aaa2-856e1918e82f)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f6735a6a-d442-4d37-a7ec-a8122dc3db99)(content(Whitespace\" \
+         \"))))(Tile((id \
          8418ffbd-1238-42e7-b97b-96dbdb5ef360)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e2a2a7bf-b931-441b-9c7f-b5a6bdab063a)(content(Whitespace\" \
+         \"))))(Tile((id \
          9fd6d9da-4ca5-4930-bd05-ffd9ebf1ac5f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          7da0a80d-e068-4d8e-9967-921da6c686e1)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         95ddf2db-e323-44b3-92a1-1ef3f7559e07)(content(Whitespace\" \
+         b479c914-be09-484b-a9f6-0ef30d7ac4fa)(content(Whitespace\" \
          \"))))(Tile((id \
          ec07850b-e124-4835-b7e8-7db21136cb5a)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         be354f6f-15ca-4174-adda-9d3dc8a64ccd)(content(Whitespace\" \
+         \"))))(Tile((id \
          389e5603-85e7-4e3b-82ee-7c5ce6bee6b9)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         2345acdb-d948-45f7-aa6d-bea85a2b0ff3)(content(Whitespace\" \
+         \"))))(Tile((id \
          0a6d7eb1-5505-4cf8-b7da-37e68ba94a8c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          260e65fd-ad11-4771-aea9-771fd4228a61)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9adc7ab7-33b8-4020-a2ee-98ac74fb6b1c)(content(Whitespace\" \
+         cf1547f0-7249-42b8-a4b4-49d3f2c61de3)(content(Whitespace\" \
          \"))))(Tile((id \
          ce60973d-3e6b-4a85-ba62-eb34a28a7d85)(label(average))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f7270040-c90d-41fd-9317-aa6e97ba97d1)(content(Whitespace\" \
+         \"))))(Tile((id \
          b0397986-cea5-413b-a42d-ad8fbc685a75)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         44d0369a-2288-4f2d-9ad1-7abf84a4aeaa)(content(Whitespace\" \
+         \"))))(Tile((id \
          8b884658-1d91-4cd9-b48f-be0b9aedcbc0)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         3b126846-dbd8-4ef3-bec4-4813b3fb173f)(content(Whitespace\"\\n\"))))))))))";
+         90dca125-1416-40da-8e92-ab16067416e9)(content(Whitespace\" \
+         \"))))))))))";
       backup_text =
-        "type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+        "type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = ^^fold([\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
          (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
          ]) in\n\
-         type Student = (name=String, age=Int, favorite_color=String) in\n\
+         type Student = (name = String, age = Int, favorite_color = String) in\n\
          let students : [Student] = ^^fold([\n\
          (\"Bob\", 12, \"blue\"),\n\
          (\"Alice\", 17, \"green\"),\n\
          (\"Eve\", 13, \"red\")\n\
          ]) in\n\n\
-         let requires=[] in\n\
-         let ensures=[\n\
+         let _requires = [] in\n\
+         let _ensures = [\n\
          (enforced=^^check(true), \"schema(r1) == schema(t1)\"),\n\
          (enforced=^^check(true), \"schema(r2) == schema(t2)\"),\n\
          (enforced=^^check(true), \"schema(r3) == schema(t1)\"),\n\
          (enforced=^^check(true), \"schema(r3) == schema(t1)\"),\n\
-         (enforced=^^check(false), \"nrows(t4) == nrows(t1)\")\n\
+         (enforced = ^^check(false), \"nrows(t4) == nrows(t1)\")\n\
          ] in\n\
-         let group_join : poly r1 -> poly r2 -> poly r3 -> poly k -> \
-         ([r1],[r2], r1 -> k, r2 -> k, (r1,[r2]) -> r3) -> [r3] =\n\
-         typfun r1 -> typfun r2 -> typfun r3 -> typfun k ->\n\
-         fun (t1:[r1], t2:[r2], get_key1:(r1 -> k), get_key2:(r2 -> k), \
-         aggregate:((r1,[r2]) -> r3)) ->\n\
-         map(t1, fun (r:r1) ->\n\
-         let t2' : [r2] = filter(t2, fun r':r2 -> get_key1(r) == get_key2(r')) \
-         in\n\
-         aggregate(r, t2')) : [r3]\n\
-         in\n\
+         let group_join : poly r1 -> poly r2 -> poly r3 -> poly k -> ([r1], \
+         [r2], r1 -> k, r2 -> k, (r1, [r2]) -> r3) -> [r3] =\n\
+         typfun r1 ->\n\
+         typfun r2 ->\n\
+         typfun r3 ->\n\
+         typfun k ->\n\
+         fun (t1 : [r1], t2 : [r2], get_key1 : (r1 -> k), get_key2 : (r2 -> \
+         k), aggregate : ((r1, [r2]) -> r3)) ->\n\
+         map(\n\
+         t1,\n\
+         fun (r : r1) ->\n\
+         let t2' : [r2] = filter(t2, fun r' : r2 -> get_key1(r) == \
+         get_key2(r')) in\n\
+         aggregate(r, t2')\n\
+         )\n\
+         : [r3] in\n\
          let average = fun ns -> fold_left(ns, int_plus, 0) / length(ns) in\n\n\
          test\n\
          group_join@<^^fold(Student)>@<^^fold(GradebookEntry)>@<^^fold((name=String, \
          age=Int, favorite_color=String, average=Int))>@<String>(students, \
-         gradebook, fun r -> r.name, fun r ->r.name, fun (r, t) -> r ... \
-         (average=average(t.final)))\n\
-         == [\n\
-         (\"Bob\", 12, \"blue\", 87),\n\
-         (\"Alice\", 17, \"green\", 85),\n\
-         (\"Eve\", 13, \"red\", 77)\n\
-         ] : [(name=String, age=Int, favorite_color=String, average=Int)]\n\
-         end";
+         gradebook, fun r -> r.name, fun r -> r.name, fun (r, t) -> r ... \
+         (average = average(t.final)))\n\
+         == [(\"Bob\", 12, \"blue\", 87), (\"Alice\", 17, \"green\", 85), \
+         (\"Eve\", 13, \"red\", 77)]\n\
+         : [(name = String, age = Int, favorite_color = String, average = \
+         Int)] end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesjoin.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesjoin.ml
@@ -1,157 +1,188 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Utilities / join",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id c207c6ec-834b-4aec-8da1-2667b7e1ca3e)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         da91f436-e5ff-4a0c-a37a-e42ec8bc3553)(content(Whitespace\" \
+         d149f0a6-0efe-4c9a-9e40-1ac2f6cfefa8)(content(Whitespace\" \
          \"))))(Tile((id \
          43e7d3ed-442e-4f37-84e5-a2d97de013ea)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         49180a39-933c-45a5-bb14-fa5b65b428da)(content(Whitespace\" \
+         d06b0a78-efa9-43c8-95d7-15d1fc375d42)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f6ff7327-4782-444e-927b-0af1e56eab36)(content(Whitespace\" \
+         e4aea869-e364-43bd-bffe-dc587e5d9822)(content(Whitespace\" \
          \"))))(Tile((id \
          4c792dfe-5873-4360-9d51-e7df91837ba1)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          c6296017-dd61-46d9-acf0-6140feb8c3f4)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b36a3b82-d353-4cfd-a125-dcf575dc6b11)(content(Whitespace\" \
+         \"))))(Tile((id \
          7103868e-51ff-4776-96f8-2ba3aaa6b71e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         84daae37-a7a6-4ef8-81bc-fdfa7d6e3364)(content(Whitespace\" \
+         \"))))(Tile((id \
          21e33391-8b24-4933-8307-48913c4f56e8)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ff32b83a-8f7b-47cd-b839-c426322b9d3f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f1e722e1-7bbb-4937-988d-074e490b8c58)(content(Whitespace\" \
+         9c7fce4a-6577-425a-bfd1-7cae5d030696)(content(Whitespace\" \
          \"))))(Tile((id \
          6b321226-5abc-4c38-8163-314b71cb85ae)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2379ad77-955c-426a-a4e1-e33045cbc758)(content(Whitespace\" \
+         \"))))(Tile((id \
          697ff076-7160-41e2-b768-0bee53d827bd)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         378de5fb-d532-45b3-ac37-6ced923503a9)(content(Whitespace\" \
+         \"))))(Tile((id \
          01c60a83-3205-454d-99e7-cb25f253dff4)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          1c231a82-a336-4731-a9ab-f8d4bd5acefd)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2140a8d6-a39a-4f22-b359-1b35f477d670)(content(Whitespace\" \
+         bc8a2c78-1ebb-439c-8df9-be58b72caf2f)(content(Whitespace\" \
          \"))))(Tile((id \
          c8250304-3552-460d-a780-f95d07ab1712)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         88233359-d36a-4376-b710-eb7d8373807f)(content(Whitespace\" \
+         \"))))(Tile((id \
          733aeebd-9803-42e9-938d-98ffa3e2d952)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6f3b9327-9092-4f9b-9af0-4d1c6ef7b363)(content(Whitespace\" \
+         \"))))(Tile((id \
          a197ff0f-0d3e-4c0e-be2f-ba23ba505471)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          17d5e7a0-dad8-42b5-9251-cefc7a43c4b2)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         12dc2a3f-ac68-4c4f-bef2-0739231461f0)(content(Whitespace\" \
+         04d5b3ed-9bee-4821-bc89-16c2d3f2b62c)(content(Whitespace\" \
          \"))))(Tile((id \
          ce435ae3-e508-4616-9e14-336f22876432)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e0e0b681-694a-4a64-ba17-a16788214e50)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a8d1b51-0267-47f1-aade-6092a7fc55e3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         81f4f3a5-3b60-428f-8a47-9ca2c37b657c)(content(Whitespace\" \
+         \"))))(Tile((id \
          a57d4609-18ad-4c44-b1b0-01b8cefd9af2)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6651fe7c-aef4-4efd-ac35-8956361804fe)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         665fe17d-1cc7-489e-a06e-1cac1f7466cd)(content(Whitespace\" \
+         0442d6b6-193e-45d1-a0c1-6f54366536c6)(content(Whitespace\" \
          \"))))(Tile((id \
          8a2624fa-1bfe-4679-b70d-86cf49cd9f9b)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         25873b9a-82e4-4706-96c1-22c5c794ef01)(content(Whitespace\" \
+         \"))))(Tile((id \
          562c5413-b4bc-465b-b201-49ee4e2accd4)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         dbed0695-0a1f-47f7-8175-4a10481e4ffa)(content(Whitespace\" \
+         \"))))(Tile((id \
          1dfb0677-4cb0-44e4-8727-444ee37e4b65)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ba163e9a-86d1-46d9-8045-72210a3a4d49)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         43ba7fd9-7869-4a1b-9fd6-c913322bd10b)(content(Whitespace\" \
+         bfd946bd-1799-4bd9-ac43-2f986a3cefb1)(content(Whitespace\" \
          \"))))(Tile((id \
          a4b69587-3e26-4499-85eb-3283087ccfc6)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bab9827a-04f7-449d-a502-63531d69c00f)(content(Whitespace\" \
+         \"))))(Tile((id \
          c6badffc-68a1-43bc-a17c-c132df052968)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c358647f-613e-47ed-a702-945c78645abc)(content(Whitespace\" \
+         \"))))(Tile((id \
          c0a5ff4d-6658-4596-a2bf-07eb7523dbf1)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          575b177c-2df8-4090-aaab-286a7a99c8b8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8494aec2-df0c-4747-9746-88e6ef963579)(content(Whitespace\" \
+         8aea9975-13e3-4a0f-bee0-cc8b402bcc2d)(content(Whitespace\" \
          \"))))(Tile((id \
          18104154-6670-4fbf-9fb8-27a7db5ee59d)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         be9fdb6e-02c3-4982-9486-5f5cafafa4b4)(content(Whitespace\" \
+         \"))))(Tile((id \
          88850735-9f65-4321-930a-f1b10693c696)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b9a95771-ef17-423f-ba17-bd38e26e8d0d)(content(Whitespace\" \
+         \"))))(Tile((id \
          260ea961-87fc-4b6f-aeca-4ab98816158e)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          dc7311f9-6264-4721-b1e5-61104b7eed8f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2e203d58-fb2b-4234-b752-91691d90c79c)(content(Whitespace\" \
+         bbfeab29-9cc3-42f2-a9b4-73049158f2c3)(content(Whitespace\" \
          \"))))(Tile((id \
          a0d4a86f-4575-4c40-a55f-163f003319d3)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         c7db3451-bfd7-4d9a-bf1c-62e82e572fdc)(content(Whitespace\" \
+         \"))))(Tile((id \
          f3fe21bd-4876-4d12-8119-614bd42d7b71)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9f38be36-e220-4542-955b-f78c1f3354da)(content(Whitespace\" \
+         \"))))(Tile((id \
          abf10b0c-9ff7-4750-b926-64c2018783d5)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         42e51995-2769-4870-8c0e-b8072cf5eaa8)(content(Whitespace\" \
+         ed244d5e-101e-4141-8f9a-b96e87e857c7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7b4410ff-a4b7-4385-a962-e87a16fbbdf6)(content(Whitespace\"\\n\"))))(Tile((id \
+         bb1aaef8-fe3c-4b1c-a46a-a831059af45e)(content(Whitespace\"\\n\"))))(Tile((id \
          79d478ed-2f23-4ff2-8d46-d91307c39055)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         5457d730-e269-4f8b-bd97-3855330f33d9)(content(Whitespace\" \
+         f041c19c-a7ed-4ace-b1fc-91569413b3fd)(content(Whitespace\" \
          \"))))(Tile((id \
          1dfa9df4-e350-414c-aafa-02af4cd37911)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         664993ea-2096-4fde-b2fc-5538cbd55abe)(content(Whitespace\" \
+         b9095a44-77b9-44db-93b8-fc9d239258d9)(content(Whitespace\" \
          \"))))(Tile((id \
          1cac7f81-f3a4-4a28-b3bd-4cd794357138)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fc26dd29-6909-479d-a093-e8057ca85994)(content(Whitespace\" \
+         e00e0d65-e311-44be-b7fc-e92359b2eb28)(content(Whitespace\" \
          \"))))(Tile((id d05ac7b7-a680-42ad-acbb-48510e1e1461)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          6f339eb2-8763-4447-a237-e42455fe65a1)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         420e257c-67bf-4f7f-acc6-980347e1d3ef)(content(Whitespace\" \
+         ccaa8c79-cae8-4a52-84dc-88bc3b8ec925)(content(Whitespace\" \
          \")))))((Secondary((id \
-         09d0ee84-9d14-4f26-a25b-8a08a51f4ac2)(content(Whitespace\" \
+         59926d75-d198-4924-8e85-d39f7dfc7311)(content(Whitespace\" \
          \"))))(Projector((id 3764a13a-9fb7-414b-b410-78e633b64e53)(kind \
          Fold)(syntax(Tile((id \
          06af9086-e938-4ab0-8cc5-2d4f85e8e013)(label(\"(\"\")\"))(mold((out \
@@ -365,87 +396,99 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          916fa5fe-23ac-41e5-ba9e-98135e6c5dfd)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         f65ca1b3-85c1-48cb-ac5f-89bac0acc37b)(content(Whitespace\" \
+         20be20c6-1d45-4efe-851e-849bc2ecc467)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         59fd5fe8-d3cb-49b0-85c6-dad334b09a91)(content(Whitespace\"\\n\"))))(Tile((id \
+         d9ba0285-a848-45de-8255-9d116a619bee)(content(Whitespace\"\\n\"))))(Tile((id \
          ad39de51-7faa-43ab-ad11-3b531a611e2a)(label(type = in))(mold((out \
          Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         dec3225a-51a6-4f2d-9670-73b497566de0)(content(Whitespace\" \
+         b86e2d2d-1b8c-428a-b30e-c92c14a72328)(content(Whitespace\" \
          \"))))(Tile((id \
          5ade42fe-9693-4055-ba4f-96080e6ffabc)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         3ae8382d-d3ec-4253-aad3-af8231fd4751)(content(Whitespace\" \
+         ddfae682-6879-45da-a813-11c5fc6e379b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7c0d2989-c258-46f0-975e-ab58ebd7a501)(content(Whitespace\" \
+         307bbacb-c1d6-4b3c-9e5a-6d9463c308dc)(content(Whitespace\" \
          \"))))(Tile((id \
          1d09305e-15ef-42af-b786-fc3c74e55851)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          86a13c42-92fb-4f4f-97a0-3abeb726796b)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         697057de-4903-4c4c-ade9-76df5fbcb250)(content(Whitespace\" \
+         \"))))(Tile((id \
          7eae8212-8845-42a9-9619-484bf16061dd)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         de85cc9a-d09f-40a1-b5d9-5a51b8b2721c)(content(Whitespace\" \
+         \"))))(Tile((id \
          fc960f8b-408c-45dd-83fd-6a0fec0ee58d)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          4360db69-6d9d-432a-9c52-e0f42eb6d399)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         96a70723-65b3-4506-a384-ac77e5c3fd8c)(content(Whitespace\" \
+         019f9b7f-b6c4-41f9-96de-374e97f707c8)(content(Whitespace\" \
          \"))))(Tile((id \
          de9fe61a-c368-4670-a20d-85747467e3b6)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0c2006d2-f52f-4c5d-a7e5-59d9c47d48e3)(content(Whitespace\" \
+         \"))))(Tile((id \
          1053796b-c06a-425f-b3ac-e212d4436328)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f4958e3f-f3e0-4782-afa5-270174e27ece)(content(Whitespace\" \
+         \"))))(Tile((id \
          b6b57b17-5f47-45dc-9fa7-e24cda4310d8)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          96aae775-0f0c-4ccb-a5ba-f50173c04c7e)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8c13fbaf-acba-495a-8ef2-2f4f205364b4)(content(Whitespace\" \
+         5046ef6d-30bb-4c4c-a7d8-8df4636d4a5c)(content(Whitespace\" \
          \"))))(Tile((id \
          e524d546-ba22-486f-b7b8-3a78cf1fb983)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5363bc9f-a110-4509-b227-8681220678e3)(content(Whitespace\" \
+         \"))))(Tile((id \
          c1e347f3-b3d2-4f59-943e-21ed1f509a99)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         758cc5c2-365f-4b9f-b4dc-4d0ebcfb7fd6)(content(Whitespace\" \
+         \"))))(Tile((id \
          177b7532-cbc2-4465-9b55-6c2595a47776)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         73e2457a-f541-4212-9097-accd2e4589d8)(content(Whitespace\" \
+         8cfdb2ce-1332-4875-b0de-5e2107f054e4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         059ab19f-bf3c-406b-8f82-65b5d9ab7daa)(content(Whitespace\"\\n\"))))(Tile((id \
+         339110fe-5278-4c8f-8cc2-e65c948f9945)(content(Whitespace\"\\n\"))))(Tile((id \
          c59217a8-a549-41bf-ab8f-b3a537cb29eb)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         561752b1-8aab-46f3-9b2c-16784a4f79af)(content(Whitespace\" \
+         e2ca45c3-7761-43c4-9fbb-7f00cec282b9)(content(Whitespace\" \
          \"))))(Tile((id \
          fe1badbb-1f29-444a-bc39-3f063fc0fd7c)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b8cbce51-c8ec-4979-b2f5-f13e617222fe)(content(Whitespace\" \
+         e9029d20-8725-4daa-a09f-f39cb66d19b7)(content(Whitespace\" \
          \"))))(Tile((id \
          0467ddb7-ff7e-462e-a76c-00db8fc5cc01)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         54aeefc8-5bac-446a-b35d-a88389e9cfaa)(content(Whitespace\" \
+         3c3f2f36-b4ad-4e42-9788-676dd1a5468e)(content(Whitespace\" \
          \"))))(Tile((id b7dd799a-7861-4e8a-b8d2-662ec39fb18d)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          2aa68410-dafa-4b61-a136-b530ce6aa62b)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         aada3afd-6b86-4e4b-9d2c-255fb701b49d)(content(Whitespace\" \
+         2038b943-c931-4f81-91e1-3e8128cf456f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ecb28492-f761-4fe5-a6a8-c7e1b5e2fc77)(content(Whitespace\" \
+         582a2d86-ffb2-4604-8886-be5d7eac86b8)(content(Whitespace\" \
          \"))))(Projector((id c215a931-6621-4efb-8ed5-b626521d2515)(kind \
          Fold)(syntax(Tile((id \
          768dac85-2b18-40fe-ab68-9ac99749fc5c)(label(\"(\"\")\"))(mold((out \
@@ -531,36 +574,43 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          7ea52402-4e7f-4465-8432-d450f886a373)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         e0fc26ef-fdc4-4f7f-9cd5-9d43ee693ce4)(content(Whitespace\" \
+         7a0f7d1c-0ea6-4bb5-8d1a-bb39cca58cde)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6244df0e-042f-47ec-859a-b702bd2020a1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         9730477d-f4c8-4d28-b4ff-cb14376ab861)(content(Whitespace\"\\n\"))))(Tile((id \
+         81165fff-c060-45a9-9253-0b179bb07f14)(content(Whitespace\"\\n\"))))(Secondary((id \
+         5df86be8-81a0-45a0-8062-fe15adad4720)(content(Whitespace\"\\n\"))))(Tile((id \
          599ba328-3b53-47ad-a2ac-3f5287dfed7e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         35094d28-9577-4c81-ae18-2dab4f7e18cd)(content(Whitespace\" \
+         5732ff64-ad00-4696-8d3a-2317bc8576cc)(content(Whitespace\" \
          \"))))(Tile((id \
-         be9ae4f1-346a-464b-85cd-ee675013f331)(label(requires))(mold((out \
+         be9ae4f1-346a-464b-85cd-ee675013f331)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         80085198-b252-4d99-8d0b-dbe0c1669af2)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         73b029b2-f386-4ce5-9c76-a47ad0a23a8e)(content(Whitespace\" \
+         \"))))(Tile((id \
          af569ad5-7efd-4ae6-90c9-13d0d8b22d51)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         2bff734b-372e-499d-a644-ed2f05ede95b)(content(Whitespace\" \
+         f4909b1f-4d1e-4a1a-a8ee-a6f93b77bc82)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         295b8c87-e497-488f-9bad-d8919852685f)(content(Whitespace\"\\n\"))))(Tile((id \
+         08d3f9bb-4c57-45a3-9f61-7f07da378710)(content(Whitespace\"\\n\"))))(Tile((id \
          a1c3fd08-fb5c-423a-825a-dc1a2b5eaaff)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         6c17703a-0a21-4622-8336-265251f0309b)(content(Whitespace\" \
+         66aaa57b-59c3-4d23-999a-45ca512dac66)(content(Whitespace\" \
          \"))))(Tile((id \
-         8dae4301-281a-48a2-9c10-c51f82a608c2)(label(ensures))(mold((out \
+         8dae4301-281a-48a2-9c10-c51f82a608c2)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         8a4b6bd6-9c9d-4e67-a880-5a2b611208f9)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         cf32e271-05fa-4734-ad7e-38b90685efee)(content(Whitespace\"\\n\"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a55d4a9b-8e04-4ccb-ab74-2a667546d427)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         ac556be4-9ce4-4b33-aa88-12a415732c0e)(content(Whitespace\" \
+         \"))))(Tile((id 8a4b6bd6-9c9d-4e67-a880-5a2b611208f9)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         976642a2-6ba5-484d-ae87-84611ae5cb21)(content(Whitespace\"\\n\"))))(Tile((id \
          cf7e5939-77a2-427e-a686-4225d9407081)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -589,7 +639,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          503644c1-b291-425f-8292-9ad5b2e0e8b0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ad774b0a-9b60-467b-9216-db22935462ba)(content(Whitespace\"\\n\"))))(Tile((id \
+         19623e90-189d-48e9-ac9e-ba6d59d104e6)(content(Whitespace\"\\n\"))))(Tile((id \
          716c8e0a-7b86-49ad-bbcf-3bccec309791)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -618,7 +668,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a74e7c2f-91c6-4752-8be3-37c390606573)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0b770cf0-a0f4-4578-a79e-130f3f024b6f)(content(Whitespace\"\\n\"))))(Tile((id \
+         d6ae5257-90e3-4a56-9247-8bcf0f9954ba)(content(Whitespace\"\\n\"))))(Tile((id \
          a3dba26c-4006-410e-b22c-7daa2f558e53)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -647,7 +697,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bde7516c-af79-4d60-b72f-6403f3eb288d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fdfb6bdf-8af3-48bb-a023-19004d1a6473)(content(Whitespace\"\\n\"))))(Tile((id \
+         e57131ae-3e7b-4317-983b-00ee0c36179f)(content(Whitespace\"\\n\"))))(Tile((id \
          ff7ef679-d43e-44b8-be61-259d651e4720)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -676,17 +726,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          55fd9867-8bca-40ab-ab3e-d1627dadc48a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         22d02788-57d6-4db2-8a71-1a78419ed8de)(content(Whitespace\"\\n\"))))(Tile((id \
+         11b98cf3-f553-4d48-a4d5-71faf2f80c3f)(content(Whitespace\"\\n\"))))(Tile((id \
          0b8b0482-e24c-424b-82a5-d53f97083fbb)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          7b39da2d-68e6-4b93-9c75-acf88a3d3c68)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6afa514a-44e5-42da-873e-3dd52f4f744d)(content(Whitespace\" \
+         \"))))(Tile((id \
          42d29490-affc-49f5-9d59-539cbb807bd3)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         c20b2bb3-342f-4453-abb5-9ea2ab21fea3)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         82c5c5ed-fe0d-441a-930f-2dab0530cfc1)(content(Whitespace\" \
+         \"))))(Projector((id c20b2bb3-342f-4453-abb5-9ea2ab21fea3)(kind \
+         Checkbox)(syntax(Tile((id \
          f56328a6-cd93-455e-85ac-759306cc9b37)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -696,78 +750,78 @@ let out : string * Haz3lcore.PersistentSegment.t =
          656c91a7-cf2e-43df-8add-f850da617f4b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a4dab81d-f142-4c80-8171-9980fde81669)(content(Whitespace\" \
+         ff9e6133-f1b2-4020-9cc3-d790f72646ea)(content(Whitespace\" \
          \"))))(Tile((id \
          7c965cdb-85c8-458c-a5c8-9fc30cddffbc)(label(\"\\\"schema(t3) == \
          schema(r5)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3c3791e7-85ce-4c72-b6e1-00991894f00e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ad505dde-0f79-417c-9094-4fa98bf1302f)(content(Whitespace\" \
+         ceaa9db4-53ec-48cf-a007-a31c86bfc6c4)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         85111d5b-ecf2-42b4-8dcb-078cf8c99fa5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7d4373d9-d6fd-4379-bab5-8f5338172b5e)(content(Whitespace\"\\n\"))))(Tile((id \
+         52fad517-c082-4dec-8377-fab91a988305)(content(Whitespace\"\\n\"))))(Tile((id \
          e669573a-513e-4f61-8104-338d55eeb48a)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         66723716-82e4-40d9-8d25-f9437926db42)(content(Whitespace\" \
+         098f53da-568e-4798-871a-be81a1389948)(content(Whitespace\" \
          \"))))(Tile((id \
          23ce9e80-af07-408b-8517-89f2f92c418c)(label(join))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f499e867-0a1c-46fc-8186-329205cca872)(content(Whitespace\" \
+         8b1b5d0d-ab35-4587-9fb7-abffc8fb0b5b)(content(Whitespace\" \
          \"))))(Tile((id \
          799d0869-8ad1-441e-934e-701517302298)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c7853c6a-d72b-4680-bb25-da208a8e6c05)(content(Whitespace\" \
+         d9c12927-13ed-4d00-a775-08a0503b239a)(content(Whitespace\" \
          \"))))(Tile((id 84e7bcdb-f9e9-4441-83ea-64dfa03c3a7d)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         b2655433-2b21-4860-a80c-26771be85372)(content(Whitespace\" \
+         26512db3-e21d-4aee-949a-0840b5c4534c)(content(Whitespace\" \
          \"))))(Tile((id \
          3e67a38a-113b-45cd-b5ab-18ab5ff65da0)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         d034c29c-e98a-4ae2-90e6-7acb0e03bb42)(content(Whitespace\" \
+         0eb5d2dc-5d59-4a74-8ff2-69b34c50db1c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3aedf90b-d400-4f78-83c9-45b4dc8e152d)(content(Whitespace\" \
+         28698017-3d4f-4773-a4b8-aca2014c6160)(content(Whitespace\" \
          \"))))(Tile((id f65e3e87-f54f-4518-a7fa-65eede69c7b5)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         68c82463-63ab-4539-9b8f-b692b1d6e38f)(content(Whitespace\" \
+         67edc6b1-3d3f-48e2-9100-accdeee740bb)(content(Whitespace\" \
          \"))))(Tile((id \
          56a15bc1-1487-466b-8676-8db64adc218a)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         d3582c7f-1035-453a-86ce-fc26ef356c41)(content(Whitespace\" \
+         bf86d25c-d837-4ba9-8364-52b15163444a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d4c0491a-541b-4276-bec3-3977a5064fdd)(content(Whitespace\" \
+         718c9e47-9a6e-4a94-93de-ba3ed280a27e)(content(Whitespace\" \
          \"))))(Tile((id b5b5c2c8-5d1d-4ab5-85c0-080ce45ee89d)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         ed337298-c6fb-485f-a95a-1dd6ba55d29b)(content(Whitespace\" \
+         56ce41b0-a707-4a6d-8e9c-5df230d5bf07)(content(Whitespace\" \
          \"))))(Tile((id \
          05c3ccc8-9d84-4d2b-9e48-370daf5d8792)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         c449a28b-300a-42a0-8606-83381a66edaf)(content(Whitespace\" \
+         a63644e2-02a8-4430-9ebf-67d5f020f85a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9688f5de-b581-4f97-b07f-2e80eddef093)(content(Whitespace\" \
+         31629402-6388-4d4c-9f22-91516f267b3f)(content(Whitespace\" \
          \"))))(Tile((id 598b0f8d-449e-4897-8f13-2280d5230096)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         ede90ed3-5110-4c2d-a92f-82337ae980b3)(content(Whitespace\" \
+         be40f59b-bb84-4271-ab83-ab41cd323237)(content(Whitespace\" \
          \"))))(Tile((id \
          9cfad9f8-1396-458e-ad71-e4bef0f4b963)(label(k))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         2886650e-f125-401e-999e-9a9d13b69be9)(content(Whitespace\" \
+         54c57521-464a-4e9d-bb5e-16562250bc37)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         80ce9b6e-6ff1-4757-bfdb-a7d8c3784893)(content(Whitespace\" \
+         13fb37a2-e6b2-4ca1-836b-b278d53e99ba)(content(Whitespace\" \
          \"))))(Tile((id \
          b69e8909-861d-4352-a13a-5cd73b39bdb3)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -780,27 +834,28 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          67d4b2cc-a66f-4248-ad3d-d9f6ea99b2c6)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         48fa243c-6379-4b0f-b20b-ad6862bd895c)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         86564d81-3e1e-4aa5-a4e7-68f98a2b2146)(content(Whitespace\" \
+         \"))))(Tile((id 48fa243c-6379-4b0f-b20b-ad6862bd895c)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          f5977c0b-3b6e-4fc5-8a8b-2f6ac33b4f75)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          570ed206-5e69-488f-8550-26a84f1843ea)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3f1470ef-ead1-4016-a954-7983856a3048)(content(Whitespace\" \
+         f10f7dda-9950-44f6-b5da-688b1d5beb49)(content(Whitespace\" \
          \"))))(Tile((id \
          6bfcd7ee-08a6-4b64-8e31-e3ca18e418b1)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         ac9328b4-b8ca-43a4-b8d3-7bea761cf965)(content(Whitespace\" \
+         14dced00-fc46-4906-9d8b-83e11e171dca)(content(Whitespace\" \
          \"))))(Tile((id \
          a9d20b67-789f-41c8-aa45-6c2cdbe392c4)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         65c53095-1342-486e-a402-4d3d8bfe1c1f)(content(Whitespace\" \
+         f67548bb-a8af-4825-a693-4ebd8ddf7008)(content(Whitespace\" \
          \"))))(Tile((id \
          47b1f664-cd2c-404c-9e9f-b5b7b2da085b)(label(k))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -808,17 +863,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aebdbe41-449d-47f3-a552-7c6e5401e0e3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c0ff9b0f-ae8c-4ca9-8e37-6d3a1e01375d)(content(Whitespace\" \
+         26904415-cde1-41f2-aaaf-6958cadf571c)(content(Whitespace\" \
          \"))))(Tile((id \
          8792f058-dcba-49c9-a314-bb2f46428775)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         9fb8a977-b81b-444c-9f22-9023894ca0d2)(content(Whitespace\" \
+         63be03ac-649e-4eb9-91c7-9500c8205975)(content(Whitespace\" \
          \"))))(Tile((id \
          9b5eb473-a7c5-4eba-8c21-7043efff1295)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f8ff073b-3e08-46b8-95ef-a4aced2418df)(content(Whitespace\" \
+         b39893e4-d965-4095-b7fd-7090f4c0fe75)(content(Whitespace\" \
          \"))))(Tile((id \
          4c1a8a9a-c9c0-447c-8c8c-9c40a457d28e)(label(k))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -826,7 +881,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d3416037-7cc9-4c18-998d-38be1343d06f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         eaa46f99-d7ef-4467-85ca-abe0b5856f85)(content(Whitespace\" \
+         84e9d62f-cc95-43a5-8928-4ccca0767ec4)(content(Whitespace\" \
          \"))))(Tile((id \
          e6002667-b750-4502-82c4-91d6bc9b9579)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -836,142 +891,151 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          32d2e751-709d-460b-a6d0-bea0f5f2b93f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         02261996-8c27-4327-a4a8-7d1d1fdbe8db)(content(Whitespace\" \
+         \"))))(Tile((id \
          ec2d1762-27aa-48a2-9096-8ba678735ae7)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         98998174-02a2-47bd-8445-4dbdbc57df07)(content(Whitespace\" \
+         cbd60cf2-8ab0-4d48-944e-d97e0287c27b)(content(Whitespace\" \
          \"))))(Tile((id \
          ebf7fce4-1be6-42b9-b9b6-776d7dd4314a)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         87f1bf86-7f4e-4a5a-8f53-1dec50e8246c)(content(Whitespace\" \
+         b4189564-3b71-41a6-9fd4-c89919bed508)(content(Whitespace\" \
          \"))))(Tile((id \
          8a6cbbb8-d816-4c95-bcc7-8995658d6919)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         c52154b6-2521-4a13-986a-d0ea091e344e)(content(Whitespace\" \
+         4030b906-4234-4413-a1fb-7f8780947e43)(content(Whitespace\" \
          \"))))(Tile((id \
          5e37117c-d9b7-4844-8c62-e24e3d806131)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c3cf8e2b-2875-44e2-88e2-3db414307653)(content(Whitespace\" \
+         9a9dca8f-4c79-47aa-9db6-690e75edb107)(content(Whitespace\" \
          \"))))(Tile((id 16323284-efeb-4872-bf78-321e5b431f97)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          34a313bc-6db3-44c3-885b-2efbdbe4bb33)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         9683acc8-bb22-4fae-a5b4-c08a7474e4e0)(content(Whitespace\" \
+         54f4ff09-73c6-4d8f-9e7f-a99fd30b1176)(content(Whitespace\" \
          \")))))((Secondary((id \
-         73cabbf1-b747-483a-b49c-348a399e20a2)(content(Whitespace\"\\n\"))))(Tile((id \
+         591c9353-e5c0-46d3-8978-15c3d7ea43b4)(content(Whitespace\"\\n\"))))(Tile((id \
          055442c0-80f7-4ed1-a604-6dcbde5f3b9e)(label(typfun ->))(mold((out \
          Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         79b08533-3443-49b9-b023-59431f2e377f)(content(Whitespace\" \
+         6eccc7d8-04ff-4657-9815-2ed56470fcd1)(content(Whitespace\" \
          \"))))(Tile((id \
          0eb81b69-1f81-49f2-a397-67f6112ef202)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         1b45f538-57a8-4c90-afe9-77a001994047)(content(Whitespace\" \
+         69f96636-0388-481a-b826-3c45a1b22ed8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2d78a5ec-8999-45e4-90ad-d16198d9c8d9)(content(Whitespace\" \
-         \"))))(Tile((id d358bdf5-1ad9-4046-ad48-f039ecab8878)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         9589aac6-640f-4608-b428-70191bc3ce41)(content(Whitespace\" \
+         5d7ae5fc-9d56-4282-ba78-440a197bf82c)(content(Whitespace\"\\n\"))))(Tile((id \
+         d358bdf5-1ad9-4046-ad48-f039ecab8878)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         b61f0ed2-0146-48be-8f1a-04d40e7b7ea8)(content(Whitespace\" \
          \"))))(Tile((id \
          b11a39b1-d415-4de1-ba8c-07ebe4814887)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         e3dc9077-e9b6-47e1-bd8a-c56fe0a128cf)(content(Whitespace\" \
+         be5f1370-9424-4c51-95af-cdc7e62eed62)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7405c27b-bc26-4e98-a779-174b8bbb0a1f)(content(Whitespace\" \
-         \"))))(Tile((id 33a810a5-267d-4aad-a29e-b3cd7fade858)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         99239c6f-03a2-44c0-b003-502b795dee21)(content(Whitespace\" \
+         769dea29-bc6c-4dec-b658-2e483a6639e3)(content(Whitespace\"\\n\"))))(Tile((id \
+         33a810a5-267d-4aad-a29e-b3cd7fade858)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         2e416965-9798-40bd-a64d-54e8f9c85b65)(content(Whitespace\" \
          \"))))(Tile((id \
          056baf02-90db-4fe3-b6e0-341245276906)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         25fea02d-2f40-457d-91f2-aba30c4f7b4e)(content(Whitespace\" \
+         80345d2f-cfe7-4344-ba9c-9813ee584156)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b03e6756-abf5-4e71-8873-07eae4be36d6)(content(Whitespace\" \
-         \"))))(Tile((id b8ff5792-bef1-4daf-b8be-2429888bcebd)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         99d94264-364f-49bf-956c-d35bc59bb437)(content(Whitespace\" \
+         f9a8763d-6fe0-492b-a6a4-d2e8367eacc1)(content(Whitespace\"\\n\"))))(Tile((id \
+         b8ff5792-bef1-4daf-b8be-2429888bcebd)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         9fdd02ba-5b97-4db8-99c1-2a73c03df276)(content(Whitespace\" \
          \"))))(Tile((id \
          fc9c08c2-7cae-4b44-86fd-65e27b773ea9)(label(k))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         8be3b655-1582-4964-8396-60580944b1fd)(content(Whitespace\" \
+         c6aac6ce-b7af-463f-b906-1210deebcb63)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8adcd7ff-6bb0-4aee-bd98-f4ee81a742de)(content(Whitespace\"\\n\"))))(Tile((id \
+         7130691c-2726-4803-a6e6-3a58a80169b8)(content(Whitespace\"\\n\"))))(Tile((id \
          36aeecf9-b136-4947-8484-430291fff8e0)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         6d477f18-ba1e-4b1f-91e7-97075bff860a)(content(Whitespace\" \
+         5b540fc0-7e7f-497b-aca8-92283548ca01)(content(Whitespace\" \
          \"))))(Tile((id \
          72ebaa02-a29c-4fe0-a362-c83121ad6acb)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          fc460951-9075-4f6c-bdc9-cb8ac05bd4be)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         ca8ac038-96d1-435e-ad6b-c5c20641a6f6)(content(Whitespace\" \
+         \"))))(Tile((id \
          eabd3c88-7cb1-4c77-8944-f0cb9c76b02e)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         b8756b56-999f-4ee5-bff6-9b33d433705a)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3a520267-e394-45f1-a85d-6d57c032d33b)(content(Whitespace\" \
+         \"))))(Tile((id b8756b56-999f-4ee5-bff6-9b33d433705a)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          c3716679-85d8-48a9-b630-c45dc8d2eebe)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          5c5e9612-a86f-47d6-a26e-e9c5e192404c)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         e8a7564b-fa1a-4d79-91db-42a4cef834fa)(content(Whitespace\" \
+         44a6c317-5863-45d3-b862-0349c27fbfc8)(content(Whitespace\" \
          \"))))(Tile((id \
          d769a4da-f8f1-4922-8391-714db1f36cb6)(label(t2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         62577565-1bd3-4241-baec-cfa9eba9045f)(content(Whitespace\" \
+         \"))))(Tile((id \
          49311754-506a-46df-bb65-4719dd962743)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         0c5e5869-3211-41c9-bc4c-5300f6602819)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b22a6d3f-1d1a-481a-9a31-11feb50858bf)(content(Whitespace\" \
+         \"))))(Tile((id 0c5e5869-3211-41c9-bc4c-5300f6602819)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          d5118703-db4d-439d-af96-c6fc91ee0917)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          c3642c2d-d3d2-4796-bc11-14fe4eade655)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         181d1819-7161-4f0d-89d7-37976894216f)(content(Whitespace\" \
+         bdfbdcf4-0171-464f-9f2c-5686a3acbb79)(content(Whitespace\" \
          \"))))(Tile((id \
          f433ddea-098e-4ce9-a691-693f9cf2c772)(label(get_key1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         602a2f2e-df67-4e7c-81de-2d5ff7da0541)(content(Whitespace\" \
+         \"))))(Tile((id \
          6d22a29f-bae4-4a1a-9802-ec89a7b0d84f)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e4091733-8044-4048-a07a-f46a7295904a)(content(Whitespace\" \
+         \"))))(Tile((id \
          cd93c5bc-faca-41a9-b75d-6e943eef911f)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          0149595a-5e49-4fff-9976-960bad25100b)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         9c11efc0-cc94-44a6-b6e6-fac1b7e4daab)(content(Whitespace\" \
+         1e10c600-4e17-4d66-8271-63b8a034228a)(content(Whitespace\" \
          \"))))(Tile((id \
          33a9ebf8-56cb-4416-8984-4f0879e5d646)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4992ccf2-7f13-43c0-91ba-480a5018f554)(content(Whitespace\" \
+         940248a7-5d82-4236-805d-959b959c8732)(content(Whitespace\" \
          \"))))(Tile((id \
          8dc9a635-801e-4f54-b160-51f59ffe27a2)(label(k))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -979,26 +1043,30 @@ let out : string * Haz3lcore.PersistentSegment.t =
          071b043f-b88d-4a26-b70f-d338f326b6fd)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         d8c93f68-e38a-4a0e-b192-f7311c537775)(content(Whitespace\" \
+         db74586d-14d3-473d-9123-5d9a0e0e2363)(content(Whitespace\" \
          \"))))(Tile((id \
          c6379dcb-535d-46a7-a78b-5188804032f2)(label(get_key2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         a18605ac-a661-4b44-bb08-8b83a6cb56c3)(content(Whitespace\" \
+         \"))))(Tile((id \
          7407b2b7-148b-43f7-9154-e3e972ffbc02)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         512b9f76-2073-44b5-8aa8-8ed3d2c3cfc7)(content(Whitespace\" \
+         \"))))(Tile((id \
          eb38b235-1a7a-40f0-a345-734212ce6260)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          7568a59f-a6a3-43e8-a261-34cd7880cbee)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         0ed60db1-147e-471c-a615-a1b90848944f)(content(Whitespace\" \
+         6a84aefa-ae1a-40f5-bcda-c2d4b53aedf0)(content(Whitespace\" \
          \"))))(Tile((id \
          83479a84-4136-4873-9b52-b2724e697d50)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2e3b7924-4cf7-49c8-89bb-386be623da72)(content(Whitespace\" \
+         e403ebde-309a-4e72-856c-7fcf0a809691)(content(Whitespace\" \
          \"))))(Tile((id \
          f27b2b85-13fa-48bf-b493-89b0e80fa6a6)(label(k))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -1006,14 +1074,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          edb7157b-77de-463d-9e91-c8eef7e1dfa5)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         c228bb3e-03d7-4834-b94d-4a08b2da167f)(content(Whitespace\" \
+         c9c75da0-53ce-43b1-b2e4-b19509bd5d42)(content(Whitespace\" \
          \"))))(Tile((id \
          813f5f99-fa0d-4107-94c6-bfeed90581b0)(label(combine))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         d898f7e7-cdaf-433a-9d2c-5d2c185b4461)(content(Whitespace\" \
+         \"))))(Tile((id \
          05529bf6-385b-4ed4-922f-6f939df525f9)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a14732a7-4ef6-40ca-920c-94f391641724)(content(Whitespace\" \
+         \"))))(Tile((id \
          f58f7110-36c4-4f53-af6a-7dce1bfa8573)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1025,80 +1097,86 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          67d84472-a55a-4aac-bffd-119578f1ef77)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c010c750-eb52-4ea4-af06-93a23846b1ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          f0cde9a3-fa01-4f5f-83ed-d6b29fb26047)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         01620c5b-1523-44fe-a6ba-69385fe53228)(content(Whitespace\" \
+         2dd6f0d3-761c-4a6d-aac8-68967dde76e8)(content(Whitespace\" \
          \"))))(Tile((id \
          427545ca-eb05-46a1-9142-bcabdb54ac01)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8e44fcc3-a13b-48df-b7fd-65f50fe789a4)(content(Whitespace\" \
+         23960622-fd46-4a5a-b86b-cd3f29890d5e)(content(Whitespace\" \
          \"))))(Tile((id \
          97f71f44-e86f-4c7d-9729-1e8a6b1b18e0)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         ce79daaf-69e6-4b76-ba2b-c90e2794dcf9)(content(Whitespace\" \
+         3bb9c5d2-1653-4ee7-88c1-559541cfb9e6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6c0753fb-a468-40d7-a446-1095386d8eda)(content(Whitespace\"\\n\"))))(Tile((id \
+         d2f4ffbe-0312-4127-8411-82c74bd89679)(content(Whitespace\"\\n\"))))(Tile((id \
          0bd55943-c6f8-4d63-9909-cb008c73ab31)(label(flat_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          e3a92022-65fa-4e49-a169-51878339a27b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         af278c82-4fb4-4ac9-94df-c1ff40d4a9fd)(content(Whitespace\"\\n\"))))(Tile((id \
          d2fe7f6a-6414-4244-a4b4-efa739e5397d)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          305f41f7-26cd-45e6-bb65-4ddb7c5b1e9f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1eeb4452-d4c1-40b5-b7cb-6e98e2683707)(content(Whitespace\" \
-         \"))))(Tile((id 4e39d56e-b589-401e-8c0f-7e62f2941cfe)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ae744fb2-0bfb-4a66-8837-564ef575af79)(content(Whitespace\" \
+         3d747283-ed37-47dd-86ae-9abc0997efa1)(content(Whitespace\"\\n\"))))(Tile((id \
+         4e39d56e-b589-401e-8c0f-7e62f2941cfe)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         5b4628fb-fedb-4243-b663-d7a6e2443be4)(content(Whitespace\" \
          \"))))(Tile((id \
          82cbed87-f8bc-4904-b6be-fc24cb5d4e53)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          b7f669a8-6857-47ef-b4e7-c30a11872411)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         7d71ad35-2a11-4716-90fa-bcc0e460b0b6)(content(Whitespace\" \
+         \"))))(Tile((id \
          6728e343-5628-49b0-aad5-3b2280a91454)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c7120795-a548-4ff5-b983-df6649bdb162)(content(Whitespace\" \
+         \"))))(Tile((id \
          43587041-d666-449c-9ffe-bb910a814b8e)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         ef1145b7-6c1a-4b65-841e-fe7739a97b9c)(content(Whitespace\" \
+         7881c61d-da5a-4a0d-85d7-b454e74b06e2)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6b61665c-06cb-455a-b80f-f93faaee6a76)(content(Whitespace\"\\n\"))))(Tile((id \
+         6d1395ec-3bb3-4bce-9d57-c224174fd3f0)(content(Whitespace\"\\n\"))))(Tile((id \
          35d2a935-67c2-434c-b872-6bc60e5c4c24)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8fe890a6-0398-4c7a-a44e-acefd4c53fcb)(content(Whitespace\" \
+         d5ffcca6-4d24-4e30-bef7-aff16efb1801)(content(Whitespace\" \
          \"))))(Tile((id \
          15a65c5f-f91b-493a-b374-7b77861a3d49)(label(t2'))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a482952a-c926-49fa-8178-b847b846edff)(content(Whitespace\" \
+         0376b08b-4363-4a8b-b22c-a180bb8c3918)(content(Whitespace\" \
          \"))))(Tile((id \
          746ec451-62cc-4acc-b3a8-9a38e75582ab)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         fc90b66b-a3d4-4f3f-85ea-412b61f20631)(content(Whitespace\" \
+         e78fbb29-24c7-44e9-88f1-9256238f72e9)(content(Whitespace\" \
          \"))))(Tile((id b5b5aa4c-4a0d-4926-98b6-0b153c8137fd)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          2329b740-68c7-4016-b542-fd531df0b7c0)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         223ef3b8-5e9d-4a09-86b7-a53de359add3)(content(Whitespace\" \
+         d1701a8e-d015-4637-ab21-7db54990f2a6)(content(Whitespace\" \
          \")))))((Secondary((id \
-         fe18c881-aba4-48e9-b3f1-503105caf47a)(content(Whitespace\" \
+         174d8179-3f72-45c7-a572-89230b190262)(content(Whitespace\" \
          \"))))(Tile((id \
          a7017693-e6e7-4a5f-9446-d1e24506afb3)(label(filter))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1112,25 +1190,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9e33e669-d600-4801-ae14-0abc657e7f47)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         74072dbb-f324-47e3-8ea8-3a9f92eca59d)(content(Whitespace\" \
+         b9c915e2-df0e-495b-960b-31ac305fb4de)(content(Whitespace\" \
          \"))))(Tile((id 75e93ed0-51e9-456c-899b-c75cc81c4f35)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         d7236c4a-2760-4d6f-b64b-6ace540e782c)(content(Whitespace\" \
+         bcff4d93-f099-41ec-ac11-8a8d745f0a80)(content(Whitespace\" \
          \"))))(Tile((id \
          d88d187a-1010-406d-ba97-af94668f5433)(label(r'))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4db04180-76cb-4f20-804d-38620f44f601)(content(Whitespace\" \
+         \"))))(Tile((id \
          7a1647a3-932b-4e9c-8cd5-e7b6de3308af)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fbd635b0-f88f-4d14-aa89-6d5450507c2c)(content(Whitespace\" \
+         \"))))(Tile((id \
          4d32fc79-f26e-4ab0-a7f2-cd7df22e9823)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         3c7d3a02-63ef-47f7-a7ea-bac8824564c2)(content(Whitespace\" \
+         ec5ea922-0308-4e0b-9162-e7bffb7d3952)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         73bc47a9-c4ec-4484-ba67-15289e0ecc76)(content(Whitespace\" \
+         1698e47c-bf73-4f31-a410-900d235ff6de)(content(Whitespace\" \
          \"))))(Tile((id \
          43f2c818-556c-4513-9799-aff0747dfab1)(label(get_key1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1141,12 +1223,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          81b35dfc-16bd-41fd-bff4-ea9828949e9b)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         500ba231-a1db-41b0-a3db-dbd1172551b0)(content(Whitespace\" \
+         47448fe1-deab-4939-b839-a7c8c6dacf8f)(content(Whitespace\" \
          \"))))(Tile((id \
          081a04ac-4e34-42df-9a4e-13a70d7e0893)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         68a225f8-6836-49ff-adfc-0280fc5fe16a)(content(Whitespace\" \
+         974bc443-298f-4404-b297-94eb11e938ee)(content(Whitespace\" \
          \"))))(Tile((id \
          4c9df4c3-099b-4aed-b34a-bd7ee6763912)(label(get_key2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1157,9 +1239,9 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4c5e7e71-0aac-449c-902c-028caef3f5a0)(label(r'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         24392f68-226e-46fa-a37d-334c63c9a260)(content(Whitespace\" \
+         11aeb4de-ab6c-41bc-a79a-526df5f5a9e3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         754914e5-8db2-4c69-86e6-6a08d141b7e5)(content(Whitespace\"\\n\"))))(Tile((id \
+         43a4af50-f815-4ad4-8902-60f44e9e8daf)(content(Whitespace\"\\n\"))))(Tile((id \
          2fa8108c-0e34-43e5-863a-acfdd4796638)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1172,25 +1254,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bde39b90-3023-470f-93aa-5dfc3188bd83)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e9d3a990-8961-4c4a-886e-23ed5dacee50)(content(Whitespace\" \
+         64889e81-a9e1-42b2-8518-7762cd5bee05)(content(Whitespace\" \
          \"))))(Tile((id 77249213-39d3-464a-9c9e-2a713a2b4d51)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e028bbee-898d-457e-8dce-edb8d4b7192c)(content(Whitespace\" \
+         85948502-0ba1-442f-b97f-1ed20d43dbcd)(content(Whitespace\" \
          \"))))(Tile((id \
          d9b1053d-d720-4dd2-ba28-d9a46900e8c7)(label(r'))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         aba05008-0ece-49d1-b830-459819c9955e)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a3a8ca9-0e49-4541-94ac-9f610d9ed660)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6c9ab084-1b95-4179-8f30-75293bf91277)(content(Whitespace\" \
+         \"))))(Tile((id \
          9e996b11-8e56-48ee-997b-31c3672fc6d0)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         4db3ed94-9907-4807-94e8-12e341b3f4f1)(content(Whitespace\" \
+         f1d39b35-3dc0-48a8-88e0-3a9b186bf153)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         374b5ff2-a431-4210-967b-54884a6b4064)(content(Whitespace\" \
+         05eba243-1e20-437d-9779-c4a14e657389)(content(Whitespace\" \
          \"))))(Tile((id \
          22d38ef9-558a-484d-99cc-1bc93335f753)(label(combine))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1204,30 +1290,31 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e6f96933-312a-4b29-8376-1f88e196f79d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e01bc92a-3d68-473a-8d29-2adc69764a5e)(content(Whitespace\" \
+         6b280608-74a5-4fed-9edc-9fba311bd4fd)(content(Whitespace\" \
          \"))))(Tile((id \
          d90b800f-b278-42e0-b2d2-c2a7bb950583)(label(r'))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         e3977578-5900-447b-b2a5-22ff5c97f080)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         58a72ccb-07ca-4d1d-bcd9-2787b5f76c80)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c2ddb064-3c76-4c11-96c7-413dca6ed64d)(content(Whitespace\"\\n\"))))(Tile((id \
          a8ab2fd9-e6cd-4e10-bb89-1aa4a56de830)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         5285dc5f-1e98-4538-a502-8d8116086780)(content(Whitespace\" \
+         0194ed38-fb97-4c3d-b3e2-81d8b71ae482)(content(Whitespace\" \
          \"))))(Tile((id bdce5930-7d71-43da-92ac-9ecdace026db)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          d0924a56-0bd2-4cff-9fc8-2795273d9236)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e37f238d-c2ae-4837-8332-4c4d5f3aa7c7)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         780c88a8-d1e1-450e-b8b5-15bbd13baad1)(content(Whitespace\"\\n\"))))(Secondary((id \
-         41ff9c40-406a-46ec-a912-37f2ba4e19b9)(content(Whitespace\"\\n\"))))(Tile((id \
+         156e9291-65ac-4a17-99b6-f17b3d5e8e3c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         b75cabfa-4701-4b75-8489-8d6c3ab1b3a0)(content(Whitespace\"\\n\"))))(Secondary((id \
+         131861ff-3218-43fc-a7d7-95ba49406ff9)(content(Whitespace\"\\n\"))))(Tile((id \
          b8f490a8-36cf-4a44-8805-92435219ae10)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         ddca86a0-207a-4094-800b-009d1018951b)(content(Whitespace\"\\n\"))))(Tile((id \
+         8062e48e-bdd1-4489-b3c1-e9cfffa70823)(content(Whitespace\"\\n\"))))(Tile((id \
          90ea1ede-f06e-4a3b-8496-cd57b511e2c2)(label(join))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1251,52 +1338,68 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          0d0709de-7d88-424b-a8c2-c679955f3b7f)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         82f1b5af-6722-4b96-8ca8-c01622614904)(content(Whitespace\" \
+         \"))))(Tile((id \
          b5315735-6f5a-4e27-888e-0eb3fc2de868)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c7226197-b3a7-48a7-bcd8-8a2afc681d7a)(content(Whitespace\" \
+         \"))))(Tile((id \
          50ad0962-8e8b-4cc6-adeb-f83ea3b6756c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d1072d57-d0ee-4fa7-be11-24e5ddfc8390)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7b5d546c-396e-4b5d-975c-e876623fd874)(content(Whitespace\" \
+         b5e19963-f0c5-4cc8-baf6-b9c9997a631c)(content(Whitespace\" \
          \"))))(Tile((id \
          5676e774-bc48-468e-824c-87a1e60d1812)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d12424b9-7b30-4ff1-8e95-0ef4600d919c)(content(Whitespace\" \
+         \"))))(Tile((id \
          e6df6972-98b0-4b57-946a-5ed167805ef5)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         025d6949-52eb-4fba-a1b2-58aff2b7e868)(content(Whitespace\" \
+         \"))))(Tile((id \
          55684d94-cc99-4c4f-8172-830d30022ff7)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          0e89b860-b254-4635-83da-356a1ea901dd)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         cec5ab51-9eb0-48ad-a73a-fe7778a5dcae)(content(Whitespace\" \
+         2536aac1-f12f-4ec8-a21f-26b96af412ab)(content(Whitespace\" \
          \"))))(Tile((id \
          7996a54e-48e1-44a0-8772-3668c4749eda)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         b6108a19-dcd3-4956-8027-9997c18d50e9)(content(Whitespace\" \
+         \"))))(Tile((id \
          d4be2c0c-9cc9-4047-8d90-8933454f259a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3760a0f6-8fba-41c4-8680-602fc44b9f65)(content(Whitespace\" \
+         \"))))(Tile((id \
          3f9fc255-cf7f-49b1-9f29-4a6756ad098b)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          74babc95-010a-4874-88c8-6c5650f1d934)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6b672820-9273-4db0-86f5-8fd0f8fce5d2)(content(Whitespace\" \
+         827e5f4a-2ffd-417b-ae12-d626663f943b)(content(Whitespace\" \
          \"))))(Tile((id \
          3c15f92c-144b-4d5b-ac29-4249631e22b6)(label(grade))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d7fc5fce-bcaa-4cb2-afa2-c993139fa953)(content(Whitespace\" \
+         \"))))(Tile((id \
          de7e7494-8270-4b24-ac21-d8c41b707150)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         63592817-5310-4b1d-949c-c514c125f041)(content(Whitespace\" \
+         \"))))(Tile((id \
          0a51df24-c2d3-460d-80b2-b34a1e50d2ff)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
@@ -1308,15 +1411,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          213d003c-1ca8-43f2-8786-c32014c75a95)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         0d72a4cd-4e44-4443-9922-6af1c588053f)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          5a237ea1-667f-4a14-be40-603a7678c86f)(label(students))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          975774d1-50c2-4303-9d8d-02934fc57754)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7226e6b6-946d-42ef-9c20-55de29ebecb6)(content(Whitespace\" \
+         c2bfb621-5d6b-4f5d-b8ce-005e3f97dbb2)(content(Whitespace\" \
          \"))))(Tile((id \
          cf450a96-f484-4f08-82ec-37082708e70c)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1324,18 +1426,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6f42539e-8029-4626-b431-529e2db16d35)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e322051e-c2fe-4d29-a8a4-fbb2a24f8e31)(content(Whitespace\"\\n\"))))(Tile((id \
-         4ec5924b-1861-47ba-b1bf-0ff95f130e22)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         87962367-c557-4021-a6b3-ffc16f4d8737)(content(Whitespace\" \
+         7f37bdc5-36cd-4638-83a7-19476137259e)(content(Whitespace\" \
+         \"))))(Tile((id 4ec5924b-1861-47ba-b1bf-0ff95f130e22)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         90cf7f49-aee3-4946-ab3b-5c4ff97ca7a2)(content(Whitespace\" \
          \"))))(Tile((id \
          a3b96e36-e704-45c8-a2ac-909a26fb6863)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         60aec1d7-77ca-4030-aae9-205a15944e90)(content(Whitespace\" \
+         7698b776-bee9-4e3f-8656-03447c8cfabd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         685aab44-f05c-4e75-b32b-60c6e2cf3f4f)(content(Whitespace\" \
+         729c473b-5ca5-4d3e-b9e1-c47a9799b251)(content(Whitespace\" \
          \"))))(Tile((id \
          a86f2a23-a2e5-46a6-a263-1a9c2bec920f)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1349,18 +1452,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3706af4a-bec5-4db4-979a-22aefe15f690)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4775565f-a184-4272-b2ad-cb76c60faa4e)(content(Whitespace\"\\n\"))))(Tile((id \
-         475f5af6-1ba3-486a-b8e8-f037dbdc9c31)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         95617e86-3df7-4494-989c-dec9e0b77c1f)(content(Whitespace\" \
+         af0e0634-471d-4daa-afae-93ad0edb3eef)(content(Whitespace\" \
+         \"))))(Tile((id 475f5af6-1ba3-486a-b8e8-f037dbdc9c31)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         e5436544-c112-4bec-9159-b5258ffcb789)(content(Whitespace\" \
          \"))))(Tile((id \
          a2818fa6-7bfb-483f-aaba-162deb822396)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         245444cd-ea4f-473a-82f0-7679aacf4585)(content(Whitespace\" \
+         8b4de2a3-1ec6-4bf9-b6c9-ff023bbe4982)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ef948218-10ad-476e-93b5-45a004c9d26e)(content(Whitespace\" \
+         63717bba-bd6e-4ede-99bb-6f593e96b0ea)(content(Whitespace\" \
          \"))))(Tile((id \
          972004d5-dfb0-401f-99ac-1dfc4dea2260)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1374,11 +1478,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aae38666-8342-452d-9f34-bfd2792f58fc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         21081a08-14ec-49f3-a872-7c6822cf17c4)(content(Whitespace\"\\n\"))))(Tile((id \
-         5c595b53-012d-4b11-988c-9f243a16ffa9)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         24546774-4885-479c-a477-f9f399cf043e)(content(Whitespace\" \
+         1378915a-954c-4eb6-b103-8311899f6c3c)(content(Whitespace\" \
+         \"))))(Tile((id 5c595b53-012d-4b11-988c-9f243a16ffa9)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         c4f99d30-63e9-44eb-ab7a-b2d91e4c7ffe)(content(Whitespace\" \
          \"))))(Tile((id \
          035ecdb7-6678-428c-8812-fa0893777b0a)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1388,33 +1493,39 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          6a3649a7-7fe5-4f16-b98b-fafbe5a0f786)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         e34c8898-4ba1-408d-af98-f4c668bf1cc1)(content(Whitespace\" \
+         \"))))(Tile((id \
          ebeaeed3-bb9c-49ae-b428-0387745725a9)(label(r2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         ba1cf0d8-c67f-4edc-8cb1-0e3713c150a3)(content(Whitespace\" \
+         4231282c-d508-433c-976f-e51a26141c1c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         aba40695-3e03-4c31-81a7-f508196c3678)(content(Whitespace\" \
+         f5e8e6f5-e68e-4b66-842a-f5a81525dee9)(content(Whitespace\" \
          \"))))(Tile((id \
          71989fb1-4df3-459f-948b-7c6f37d88ffa)(label(r1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         073164b2-e921-4d10-b3e7-5944f6164c09)(content(Whitespace\" \
+         9a7b3ff9-cba4-480a-9b19-2e310fc8a367)(content(Whitespace\" \
          \"))))(Tile((id \
          d99fc76e-4a73-419f-8437-226bd0e9d629)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2bd9b1d7-8464-4dbd-9d9c-7babeac02994)(content(Whitespace\" \
+         bb3c84b2-1821-4a22-abc7-a06faea55bce)(content(Whitespace\" \
          \"))))(Tile((id \
          8d90cb02-714c-4b4d-8aeb-931ee5631ad1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          15875331-99d8-4583-a22d-1be192783aaf)(label(grade))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         802bffe4-5252-464a-98ec-e940e336a391)(content(Whitespace\" \
+         \"))))(Tile((id \
          695a1755-5a2f-4d9b-8dd9-78a6dc975ff8)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5529601f-66c3-4016-9f7c-85c6db1bfb14)(content(Whitespace\" \
+         \"))))(Tile((id \
          e3175874-0d00-429b-a1f4-f790a225ea0f)(label(r2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1423,18 +1534,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
          ce55612e-b630-411e-9df5-90481f1406c8)(label(final))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d8587026-e5f7-49f2-b9e4-57faa9b36560)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         ed46abb6-7ae8-44e5-a483-1e87a4d80e12)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         db3c29c2-71b2-42c6-892a-5eae657a812f)(content(Whitespace\"\\n\"))))(Tile((id \
          22fc312f-d7ae-418a-9cb3-80ca5dae669a)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         11b7fcd1-380c-4001-aba0-9cddd510b98e)(content(Whitespace\" \
+         6c7e76bc-cd25-4860-a3a4-541f7291b2e3)(content(Whitespace\" \
          \"))))(Tile((id 809e551a-c9f2-4a76-b8cc-2ceb3dab7bb4)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         65341021-664e-4534-86a7-ce2855228a68)(content(Whitespace\"\\n\"))))(Tile((id \
+         3240454f-737c-4d74-9821-8d106ae858c5)(content(Whitespace\"\\n\"))))(Tile((id \
          27df5a5a-b25d-42be-8b74-dc5de3401cf0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1492,7 +1601,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          ae31d5ba-c67a-4f82-9b88-b6e3484828c7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         41765d62-b6e7-40c1-b673-0a1ceb3bdd9b)(content(Whitespace\"\\n\"))))(Tile((id \
+         eca4fbec-80b3-4bf1-b314-9073cead5a72)(content(Whitespace\"\\n\"))))(Tile((id \
          9c3cdc13-50ec-4d64-bc6d-e5c1002a3828)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1550,106 +1659,127 @@ let out : string * Haz3lcore.PersistentSegment.t =
          be26b955-4e6a-41f5-8f13-e96dd323731e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c9dca5dd-1d67-4120-9427-be25d12a60f5)(content(Whitespace\"\\n\"))))(Tile((id \
+         22537c08-d0d4-49cd-bccc-7e068637168a)(content(Whitespace\"\\n\"))))(Tile((id \
          bbe6dd2e-04b6-450a-b3d6-691653f35684)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          193d9698-cc2d-4033-9ea8-0d95866e1bee)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9b18e25f-1cf4-48a0-9fee-450c2c89bd7a)(content(Whitespace\" \
+         \"))))(Tile((id \
          fd235cbf-1440-4ece-93d5-a58808a7615b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         59788c87-2f61-44f1-a561-51d08fd2c051)(content(Whitespace\" \
+         \"))))(Tile((id \
          06271e70-76c4-467b-9144-5cddb143fc35)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          436b645e-e491-4c1e-bbe3-f608e7f4e0b9)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         045c44fa-3511-4964-8755-5d24239a4e3a)(content(Whitespace\" \
+         a2a6b3cc-5f1c-4b9b-9499-39b3401c5005)(content(Whitespace\" \
          \"))))(Tile((id \
          c964dc67-4833-4c36-961e-ee24469fcdfb)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c160b484-29ac-49ae-9533-98d49b29085c)(content(Whitespace\" \
+         \"))))(Tile((id \
          de203407-e8f9-4ccf-b4cd-3f45d85b0633)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         99245570-b603-43ca-a383-78376cee27eb)(content(Whitespace\" \
+         \"))))(Tile((id \
          fe2b90fa-c925-4f0f-b952-1ffdba06ab6f)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          04280137-9b98-4adc-aeb1-4f35723720f0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6261de9e-5af0-4287-8e87-579c8481e86d)(content(Whitespace\" \
+         7c71d04b-d7f6-41d1-8dc9-a51025483e7b)(content(Whitespace\" \
          \"))))(Tile((id \
          e13c14e6-3e02-430d-88fc-9453ce2575c8)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c2ab967f-0fce-4a3a-9009-10f1eefd70ac)(content(Whitespace\" \
+         \"))))(Tile((id \
          5e2bf80a-8f93-4439-b68a-4b15d2c5b84f)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         0ab3605c-d40e-4de6-95ab-9899a8de0a2c)(content(Whitespace\" \
+         \"))))(Tile((id \
          afbf9490-40e7-4542-a367-2f4555423328)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          6379609a-4ae4-4836-b12b-03c89e3a52cf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ed44ff6e-bdfd-4779-ad44-78ba988483f3)(content(Whitespace\" \
+         246b8cc5-e5cb-44f8-a8dc-5e4e18cd8c0a)(content(Whitespace\" \
          \"))))(Tile((id \
          00fd2513-30f1-4dc4-8a9b-f04a451b8297)(label(grade))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a7e6ab75-312b-4629-931d-d3ec89b0eebb)(content(Whitespace\" \
+         \"))))(Tile((id \
          996172af-ffe7-4dbc-ac53-c8118d24e511)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         20886489-a055-4c1a-aa53-8cc0f1a7bc23)(content(Whitespace\" \
+         \"))))(Tile((id \
          0c8354cd-4fac-4b76-a38a-4e2c7d585da4)(label(77))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         5c9043d8-abe8-40fc-a5f3-6235d72d2231)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         0989c9d1-6bc6-4b28-9f45-dcb9a7854c95)(content(Whitespace\"\\n\"))))))))))";
+         483b1b8c-da7e-43b6-8275-84cecb1ab0c4)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         51a3d3f2-bbd6-45c1-9c7c-c7caea9ccb6d)(content(Whitespace\" \
+         \"))))))))))";
       backup_text =
-        "type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+        "type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = ^^fold([\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
          (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
          ]) in\n\
-         type Student = (name=String, age=Int, favorite_color=String) in\n\
+         type Student = (name = String, age = Int, favorite_color = String) in\n\
          let students : [Student] = ^^fold([\n\
          (\"Bob\", 12, \"blue\"),\n\
          (\"Alice\", 17, \"green\"),\n\
          (\"Eve\", 13, \"red\")\n\
          ]) in\n\n\
-         let requires=[] in\n\
-         let ensures=[\n\
+         let _requires = [] in\n\
+         let _ensures = [\n\
          (enforced=^^check(true), \"schema(r1) == schema(t1)\"),\n\
          (enforced=^^check(true), \"schema(r2) == schema(t2)\"),\n\
          (enforced=^^check(true), \"schema(r3) == schema(t1)\"),\n\
          (enforced=^^check(true), \"schema(r4) == schema(t2)\"),\n\
-         (enforced=^^check(true), \"schema(t3) == schema(r5)\")\n\
+         (enforced = ^^check(true), \"schema(t3) == schema(r5)\")\n\
          ] in\n\
-         let join : poly r1 -> poly r2 -> poly r3 -> poly k -> ([r1],[r2], r1 \
-         -> k, r2 -> k, (r1,r2) -> r3) -> [r3] =\n\
-         typfun r1 -> typfun r2 -> typfun r3 -> typfun k ->\n\
-         fun (t1:[r1], t2:[r2], get_key1:(r1 -> k), get_key2:(r2 -> k), \
-         combine:((r1,r2) -> r3)) ->\n\
-         flat_map(t1, fun (r:r1) ->\n\
-         let t2' : [r2] = filter(t2, fun r':r2 -> get_key1(r) == get_key2(r')) \
-         in\n\
-         map(t2', fun r':r2 -> combine(r, r'))) : [r3]\n\
-         in\n\n\
+         let join : poly r1 -> poly r2 -> poly r3 -> poly k -> ([r1], [r2], r1 \
+         -> k, r2 -> k, (r1, r2) -> r3) -> [r3] =\n\
+         typfun r1 ->\n\
+         typfun r2 ->\n\
+         typfun r3 ->\n\
+         typfun k ->\n\
+         fun (t1 : [r1], t2 : [r2], get_key1 : (r1 -> k), get_key2 : (r2 -> \
+         k), combine : ((r1, r2) -> r3)) ->\n\
+         flat_map(\n\
+         t1,\n\
+         fun (r : r1) ->\n\
+         let t2' : [r2] = filter(t2, fun r' : r2 -> get_key1(r) == \
+         get_key2(r')) in\n\
+         map(t2', fun r' : r2 -> combine(r, r'))\n\
+         )\n\
+         : [r3] in\n\n\
          test\n\
-         join@<Student>@<GradebookEntry>@<(name=String, age=Int, \
-         favorite_color=String, grade=Int)>@<String>(\n\
-         students, gradebook,\n\
-         fun r -> r.name,\n\
-         fun r -> r.name,\n\
-         fun (r1,r2) -> r1 ... (grade=r2.final)\n\
-         ) == [\n\
+         join@<Student>@<GradebookEntry>@<(name = String, age = Int, \
+         favorite_color = String, grade = Int)>@<String>(students, gradebook, \
+         fun r -> r.name, fun r -> r.name, fun (r1, r2) -> r1 ... (grade = \
+         r2.final))\n\
+         == [\n\
          (name=\"Bob\", age=12, favorite_color=\"blue\", grade=87),\n\
          (name=\"Alice\", age=17, favorite_color=\"green\", grade=85),\n\
-         (name=\"Eve\", age=13, favorite_color=\"red\", grade=77)\n\
-         ]\n\
-         end";
+         (name = \"Eve\", age = 13, favorite_color = \"red\", grade = 77)\n\
+         ] end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesrenameColumns.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesrenameColumns.ml
@@ -1,87 +1,98 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Utilities / renameColumns",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id 6b2a0bd5-505a-4e90-8856-88708117b1f5)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         940d5658-4fa1-4d52-be10-5954afd1c9cf)(content(Whitespace\" \
+         568e5e7f-a97f-4950-8521-29501468c18e)(content(Whitespace\" \
          \"))))(Tile((id \
          da6dd0fc-89e3-4386-849f-01449717caa4)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         3db59d6f-c1e4-43ae-b12d-11d9a5433f74)(content(Whitespace\" \
+         e992025a-e319-4084-92a9-d8edda299720)(content(Whitespace\" \
          \")))))((Secondary((id \
-         980557c8-2c32-4f1b-b038-98967916185c)(content(Whitespace\" \
+         de7a27f0-0f32-43d4-969e-b835e58caffa)(content(Whitespace\" \
          \"))))(Tile((id \
          df353660-4b7f-499e-8399-4a925800b2e7)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          957f9520-f472-4792-aa7b-653cb0fa7b9b)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         03d7fc9d-5cbd-4855-9deb-056b26f2af23)(content(Whitespace\" \
+         \"))))(Tile((id \
          fdcfd9e0-5df9-47d6-81f0-9bc7f920722d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         cd4b2afc-3784-4d8c-992b-0d727cd8f91f)(content(Whitespace\" \
+         \"))))(Tile((id \
          2dbecfe7-e692-4246-89a8-8f14cc60717b)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          ae414ad4-f148-4ba2-a051-5a2cd722e416)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4f918430-6a60-4c23-90ae-36c813fb385c)(content(Whitespace\" \
+         39b51dc7-d28d-4281-a960-718ccb5043e5)(content(Whitespace\" \
          \"))))(Tile((id \
          0387095d-cbe6-49f1-8280-3eb12591ccba)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         9fecbc4a-8c7b-4723-a9fc-3d5a01f066c1)(content(Whitespace\" \
+         \"))))(Tile((id \
          f6eddd76-c39a-48e6-b73a-570ac7feb995)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c419b931-6d3b-455b-971b-614ff36fb96f)(content(Whitespace\" \
+         \"))))(Tile((id \
          fba8d0ff-f93a-45ca-a3cd-2993016eb7a9)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          81f05f11-860a-4080-951c-1ebba5913c34)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         8f61cda3-3ab0-447d-a43c-9675c9e1579d)(content(Whitespace\" \
+         0d7ca238-26fc-45fe-8117-baec89e95dcf)(content(Whitespace\" \
          \"))))(Tile((id \
          3a42eae9-f731-42a6-b069-e019fc87ca71)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e759f12c-e557-45b2-8486-d70a330777bd)(content(Whitespace\" \
+         \"))))(Tile((id \
          2635d9d0-eddd-46b3-a591-ab2d2d629c29)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0edfeeb1-ef74-45d5-9738-cf7d8e16d7af)(content(Whitespace\" \
+         \"))))(Tile((id \
          847df91c-e285-4fc4-a2ab-55fcd3513d86)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         0af09f23-7df4-48f1-84e1-7f5d9c2f811e)(content(Whitespace\" \
+         84a0ed97-8243-4010-99ab-e663bbbb7b0b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f3024893-82f5-47c9-bb66-f16e04c5e915)(content(Whitespace\"\\n\"))))(Tile((id \
+         de836284-2879-4ea4-b7f6-37c8d53109b9)(content(Whitespace\"\\n\"))))(Tile((id \
          3362609e-4de4-4fb0-87ff-986ed3b08328)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         51100348-e1e8-4025-a7bc-dbe74012615a)(content(Whitespace\" \
+         90feda6a-ce05-492a-9c4a-d68f68e5ecc6)(content(Whitespace\" \
          \"))))(Tile((id \
          02ccc010-b756-4f5f-ad1a-1660efe8a5df)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         e5d23794-2cd2-4252-8adb-6e70168abd53)(content(Whitespace\" \
+         57f211f3-044b-44d8-a1e2-606dcc1a61ec)(content(Whitespace\" \
          \"))))(Tile((id \
          495dd6be-09e8-4f9e-b0cb-e617383a75dc)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9364ab7c-505d-419e-8326-90dfc42d150b)(content(Whitespace\" \
+         4e074d39-96ed-4be5-94f0-09cb530e021f)(content(Whitespace\" \
          \"))))(Tile((id b1c329c8-6248-4861-a19a-b9ad6ffb0eed)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          9d45821d-de3a-4b1c-b024-76e84ed3811d)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         b9a52e04-26df-4194-8bf2-bcc7ae57be63)(content(Whitespace\" \
+         f97db4fe-0a84-4294-8f9a-e9f0ddd88c29)(content(Whitespace\" \
          \")))))((Secondary((id \
-         95b95114-5120-43a5-9f76-cad5f0df0e13)(content(Whitespace\" \
+         6ab273db-1f8d-4561-ab35-cf1067ebc485)(content(Whitespace\" \
          \"))))(Projector((id f2c4b7d2-4959-43ce-b65b-0064c729b445)(kind \
          Fold)(syntax(Tile((id \
          d18be506-40ad-4611-adfe-1e5ffb718ebb)(label(\"(\"\")\"))(mold((out \
@@ -167,25 +178,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          c3d7aef1-8d44-4ba7-b096-21833b66521c)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         366f5ee8-f9d7-4a88-a43e-21cf4c5b71f0)(content(Whitespace\" \
+         4f58bc5f-77b5-4e66-858e-870323afc608)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2fbb1036-39fe-4f3c-bdc6-40197c56b629)(content(Whitespace\"\\n\"))))(Secondary((id \
-         3fd8c3d9-b6f1-468d-9b73-1bf71ce387ea)(content(Whitespace\"\\n\"))))(Tile((id \
+         96cca2c4-273e-4f00-83b3-b4b031e5c65b)(content(Whitespace\"\\n\"))))(Secondary((id \
+         98881da9-ceed-4567-aa86-db50972300e9)(content(Whitespace\"\\n\"))))(Tile((id \
          7c0ef256-5b08-42f0-aeb2-2e3ae398ded1)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c7ff13d0-24af-4070-be77-4f813dd61369)(content(Whitespace\" \
+         765118f0-bd81-4140-bedf-bc2873595994)(content(Whitespace\" \
          \"))))(Tile((id \
-         4c2f3738-5629-4f00-97c9-ef65e4a6dd50)(label(requires))(mold((out \
+         4c2f3738-5629-4f00-97c9-ef65e4a6dd50)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         f74efe79-4a17-4b66-9296-b3c95c475e1c)(content(Whitespace\" \
+         2214d652-068a-4cfb-be0c-ad85db227c5b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         0ca88fa5-3fdd-4344-8fea-3afd52f3112c)(content(Whitespace\" \
+         b3be451f-6688-470c-a188-120584b0761d)(content(Whitespace\" \
          \"))))(Tile((id b939e41f-6018-49cd-9dd1-0ae0e6a1b749)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         200a11c7-64c5-4579-b124-431131f6bb11)(content(Whitespace\"\\n\"))))(Tile((id \
+         51e5d61c-5bad-489c-9c3a-e786d7ac0730)(content(Whitespace\"\\n\"))))(Tile((id \
          5841e800-970c-4de5-a5ac-dde858a4c52f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -213,7 +224,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          16dbcb19-4c12-449c-8b46-51debb4a76a1)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2e272651-0770-4f4f-96dd-475b613add42)(content(Whitespace\"\\n\"))))(Tile((id \
+         7f63290f-acd9-4949-990d-b9dd8c361890)(content(Whitespace\"\\n\"))))(Tile((id \
          f8ac489c-89d4-4610-b4ba-fbeaf4690283)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -241,17 +252,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          34e51924-30f0-44b5-8968-efd1e6a142f3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         08c2840b-5321-4508-83ec-6589c3415e32)(content(Whitespace\"\\n\"))))(Tile((id \
+         9f96ae37-5bfe-417c-8d93-5434a97e0cbf)(content(Whitespace\"\\n\"))))(Tile((id \
          3f136f8b-22c0-4063-9980-3e38678c6d35)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          5bbe9ff7-3fee-461d-aaec-0a640d708d6e)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         29c2d028-5162-4126-816d-9a50682db565)(content(Whitespace\" \
+         \"))))(Tile((id \
          425a4c1a-a03e-49b0-9f8a-96f6360d6ce6)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         78746efb-6703-426a-acb7-ff925735ec72)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2af4fef4-d795-4aa3-9c62-83620c9c3281)(content(Whitespace\" \
+         \"))))(Projector((id 78746efb-6703-426a-acb7-ff925735ec72)(kind \
+         Checkbox)(syntax(Tile((id \
          44d869d6-b56d-459c-99cf-61a43ec81557)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -261,32 +276,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b17e5c61-ef59-4b41-825a-aa1fd7a7e1d5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2c2efa6b-39ad-41dc-b32f-1d3741854c0c)(content(Whitespace\" \
+         4068cade-1ffc-4a31-8544-2b334f751f7d)(content(Whitespace\" \
          \"))))(Tile((id \
          02e90333-586c-4cb9-91d0-cc0908cb5c07)(label(\"\\\"concat(removeAll(header(t1), \
          [c1 | (c1, _) in ccs]), [c2 | (_, c2) in ccs]) has no \
          duplicates\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e9923e6b-8318-46d7-b8af-5a65554ec66d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         971170e2-3ef1-4110-9a19-a2323168194c)(content(Whitespace\" \
+         940f1dfc-e61b-403f-9b6e-a6a27b53fe2e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         3d42f919-d73e-4ebc-b382-9db1ad7a5cf4)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c8391059-e747-4d17-b9f6-6a8f21159008)(content(Whitespace\"\\n\"))))(Tile((id \
+         8059b3e0-c318-40b5-8ce1-3080bbaba446)(content(Whitespace\"\\n\"))))(Tile((id \
          50cbee3a-5c5a-412e-9ba3-42a28ed33182)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         2485c16d-d790-40fb-9e8d-6d70d37e4378)(content(Whitespace\" \
+         125fd6da-93dd-429e-8202-d89947e48426)(content(Whitespace\" \
          \"))))(Tile((id \
-         56ecf002-03c1-4ca2-afa8-fcf361381908)(label(ensures))(mold((out \
+         56ecf002-03c1-4ca2-afa8-fcf361381908)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         06a934d0-7077-4e31-ad34-d15ed04afc2b)(content(Whitespace\" \
+         4d83788f-4abc-4a2e-baed-7fcadee925f2)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ac7a84c3-025e-4e62-971f-0b1e2c65a1bf)(content(Whitespace\" \
+         04ff6b9d-1784-4ad4-a310-ce54039e5e82)(content(Whitespace\" \
          \"))))(Tile((id 3cb76ed2-63a5-445c-96f7-0afd7d275628)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         49bda8a9-e46b-4f82-818c-771deedd2f76)(content(Whitespace\"\\n\"))))(Tile((id \
+         7d72df99-e158-4d32-95de-cd9a96ec6f8b)(content(Whitespace\"\\n\"))))(Tile((id \
          5082356f-3bfb-4c8c-a923-e472a1eaa872)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -316,7 +331,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b5041e39-c9c2-483b-925b-4f83860515d7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a06cbf24-8e02-4345-be62-6cb405577e14)(content(Whitespace\"\\n\"))))(Tile((id \
+         cef39e25-b9ea-4093-a157-7bc4b009a215)(content(Whitespace\"\\n\"))))(Tile((id \
          af50be8e-32e9-4656-ad0e-31b872bd39cd)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -345,7 +360,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          be3bca01-422a-4402-904d-29c0c55db9f7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         ed141cb9-9560-46aa-b33e-5aa5e3bcf843)(content(Whitespace\"\\n\"))))(Tile((id \
+         93be4250-458a-4fce-adec-e8d81cc92a46)(content(Whitespace\"\\n\"))))(Tile((id \
          8cfb992d-bd4d-4c8f-b63f-e9a71a13a02f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -374,17 +389,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fe708ae2-517d-4357-ab6e-49eb351bb0bc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         83d3d3f2-cc07-457a-a6b1-0ff7a477a87c)(content(Whitespace\"\\n\"))))(Tile((id \
+         689b86b9-d2ce-4c9e-ba38-380a1ff549f1)(content(Whitespace\"\\n\"))))(Tile((id \
          c4837b7e-bf30-4818-b0b6-2f9e5cf8b35b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          3fcb986d-70e6-4427-88f8-c2cc56a3bcb0)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         235b250f-ee58-410c-bd24-fe19ed4b26c7)(content(Whitespace\" \
+         \"))))(Tile((id \
          32da0ffd-2ba3-4a9b-8f68-e6fca0cc059e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         ba26c82c-1332-489d-9b46-5291d30655fa)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         f434010e-9830-49c6-b529-5b3ed2d5ea92)(content(Whitespace\" \
+         \"))))(Projector((id ba26c82c-1332-489d-9b46-5291d30655fa)(kind \
+         Checkbox)(syntax(Tile((id \
          1d0396c6-e692-4b9c-b535-606d499ae065)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -394,62 +413,68 @@ let out : string * Haz3lcore.PersistentSegment.t =
          5be9bf3d-2a4c-4cb4-8e0b-e881b7f33c49)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         10af6fa3-b3aa-4903-93c5-d34999ef313d)(content(Whitespace\" \
+         ddafcf12-1334-4e06-b56b-6b213798064f)(content(Whitespace\" \
          \"))))(Tile((id \
          868ccd1e-2342-4eff-8206-46ae6d2e761f)(label(\"\\\"nrows(t2) == \
          nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         d60ed0b7-77b1-4d7b-92df-400630efb8a8)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         98ca0d52-f396-4077-b383-ac6cffad2653)(content(Whitespace\" \
+         b147451a-a9a4-4a58-9147-36a7aa4002ca)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         3875dd67-2a46-4fb8-83c9-8cfdf466e538)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ccf117f4-5907-445d-abae-2edc6f9cdf1c)(content(Whitespace\"\\n\"))))(Secondary((id \
-         f7b9d3d9-74c9-4ee3-a8b5-caa543e41383)(content(Whitespace\"\\n\"))))(Tile((id \
+         d13dbc98-25ed-4509-9a94-dce6bc5beee2)(content(Whitespace\"\\n\"))))(Secondary((id \
+         f75a2d2f-36dd-436b-aa5e-02617202d7a6)(content(Whitespace\"\\n\"))))(Tile((id \
          631598fd-258b-4ce0-a755-0f69e3e4c23b)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3958eb9c-be13-4b86-9c5e-fe6b01e3bfdb)(content(Whitespace\" \
+         70561a90-799b-4737-9ff1-e9d61a25445e)(content(Whitespace\" \
          \"))))(Tile((id \
          9f261edf-cc64-472c-b769-4f048a445512)(label(rename_columns))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         92289490-c1d5-463a-81dd-077ac803d20a)(content(Whitespace\" \
+         b92d64d1-aaae-4c20-9823-937735954a7b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3fd51c70-38ec-4e13-b485-0a0b65f2a698)(content(Whitespace\"\\n\"))))(Tile((id \
+         fe853889-63e9-4d13-aa8d-823d56224e3d)(content(Whitespace\"\\n\"))))(Tile((id \
          71e33e55-c3ae-43db-819a-1b9aed648995)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         e7e921e9-40a3-436a-98e6-5e05d268300c)(content(Whitespace\" \
+         7f8016ec-2c5c-4614-b752-095720134533)(content(Whitespace\" \
          \"))))(Tile((id \
          647c5bb6-d230-412b-b870-7f8d17785d66)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          b72762fc-7fa8-4b74-a57c-f17b8836e60d)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         05774bfd-34ea-4984-a0df-60857636a236)(content(Whitespace\" \
+         \"))))(Tile((id \
          f77c7eb9-bf5a-4535-ade0-12eca5946f75)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         dd80aac3-6380-4e9f-ae07-c9b0b906d52e)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a5dfd208-b699-4fa0-8ae3-6ab7b3881e5a)(content(Whitespace\" \
+         \"))))(Tile((id dd80aac3-6380-4e9f-ae07-c9b0b906d52e)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          9bc6682a-cda3-4002-9f1f-6759da9c25bf)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          506e31ae-3559-4551-ab91-2ab75f681511)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ede27cbe-f906-4738-a108-0fb8f846e8bc)(content(Whitespace\" \
+         c393d33a-da6f-4c45-9c7a-936b849bf61c)(content(Whitespace\" \
          \"))))(Tile((id \
          5ef65ce2-55da-4188-a7ec-10c835b97f1b)(label(ccs))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         27b24659-b3fc-49a5-a9b8-0357823c9b4d)(content(Whitespace\" \
+         \"))))(Tile((id \
          eb916637-9ede-47c6-94fc-4ba88af7b179)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2f7b0888-03d2-4e92-bc42-dd8088dafa88)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         175bc882-f405-4403-81a3-73d68be5c9d1)(content(Whitespace\" \
+         \"))))(Tile((id 2f7b0888-03d2-4e92-bc42-dd8088dafa88)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          5513a83d-91cc-4528-9570-8de8dc224990)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
@@ -459,39 +484,39 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0d148908-5bb7-470f-9923-927300032aac)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bbaf7aaf-baee-4529-aecc-a255335baa21)(content(Whitespace\" \
+         acc03ee9-b209-4309-897d-3d00e6602364)(content(Whitespace\" \
          \"))))(Tile((id \
          5b2665e4-8ea0-4275-bc80-743424640a15)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         afe3adcb-1972-4fb9-b69d-fc9e1acf65e5)(content(Whitespace\" \
+         9b486c1e-1c90-4a13-8375-50f4afc871a3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         87689169-9fcf-422a-b2b0-9b573169cd0c)(content(Whitespace\"\\n\"))))(Tile((id \
+         aa422b27-6ac1-431d-aefe-37daa1992984)(content(Whitespace\"\\n\"))))(Tile((id \
          1809b564-89c1-4307-96c0-c8f25140af08)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          8f84fc38-fd84-4bc2-9f58-70c6e3fbddbf)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         854d37db-9a4d-4442-bb78-715b871daac5)(content(Whitespace\"\\n\"))))(Tile((id \
          e526ff44-91dc-4463-8d43-359a870af98c)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          6073fd1e-be63-4fb4-90ee-bbffb2401b7c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         55a9e543-5cbc-471b-a7b4-1cc4cac8162d)(content(Whitespace\" \
-         \"))))(Tile((id 2b2c8bda-792d-412c-941a-a76766fa97c0)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         5b0ce0aa-595b-4dce-9d60-d439bd69948f)(content(Whitespace\" \
+         10cd2de4-0dd0-46e1-9215-0741c3fce8b9)(content(Whitespace\"\\n\"))))(Tile((id \
+         2b2c8bda-792d-412c-941a-a76766fa97c0)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         de497678-fb25-4114-9166-ee9f523e0f58)(content(Whitespace\" \
          \"))))(Tile((id \
          65cd87de-2df3-430e-ae5f-0d4939bc03d7)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         a719b040-8a4a-4f4b-98a8-67e8855c8c36)(content(Whitespace\" \
+         24ab0ef3-b2be-41ee-a9f1-cacaa880b061)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         95a4dd7d-3d54-468c-998e-077f74cc6beb)(content(Whitespace\"\\n\"))))(Tile((id \
+         d772b7a8-6348-4bf7-82a0-2f043e52a057)(content(Whitespace\"\\n\"))))(Tile((id \
          ba7f4dd8-0f96-4a90-9d27-d3eefbc0772a)(label(to_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -501,64 +526,72 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d9305aa4-5782-4855-9259-831608c53ad7)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         a3e97c2f-70ab-4bda-b87f-ddb830d3b38a)(content(Whitespace\"\\n\"))))(Tile((id \
+         2beaa38a-85e0-4d09-aee9-fd5e8557a58c)(content(Whitespace\"\\n\"))))(Tile((id \
          c831bc46-b599-4244-b748-65c346d1040d)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         841e72f1-aee7-4be3-8481-294888245c84)(content(Whitespace\" \
+         65830b3d-3a5d-48f6-b3c3-a712ec5ed392)(content(Whitespace\" \
          \"))))(Tile((id \
          20a06d18-a6e6-439b-a039-6062334c57a3)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          eca4e1e5-8ccd-4480-acc5-152cc0200a41)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         5ac16bfc-40fa-45ca-80fe-cdb233ffb175)(content(Whitespace\"\\n\"))))(Tile((id \
          39f819ac-d220-4f33-9033-2a4c69416112)(label(_))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          942e9160-3523-44fe-a698-32d0b1210bef)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1e2e06c2-a27d-49d5-b138-6cb63869cacc)(content(Whitespace\" \
-         \"))))(Tile((id e6eee3a3-5357-4659-9f77-4c2abee73a21)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         070b8aa8-a4b3-4edc-b8e5-f90157802ff4)(content(Whitespace\" \
+         10e834a1-c945-470c-bcab-974b75145dc7)(content(Whitespace\"\\n\"))))(Tile((id \
+         e6eee3a3-5357-4659-9f77-4c2abee73a21)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e14b3fb8-9987-4eee-b892-0352ad3acc6f)(content(Whitespace\" \
          \"))))(Tile((id \
          fdf9152f-df02-4535-ad92-b74715df32bc)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          d7846862-10c4-42a2-b852-c7f7b3a5f18a)(label(label))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         b87ed3c2-4810-4050-b4e4-db9604d79a74)(content(Whitespace\" \
+         \"))))(Tile((id \
          e3b4d3de-bcde-42f7-a158-b9c8fd867561)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         33534c8e-ec0f-4f09-bcd7-2cdaf38b7ca2)(content(Whitespace\" \
+         \"))))(Tile((id \
          17cc9834-56a4-431a-af35-a32b8962fb7a)(label(l))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
          69512113-d7a1-4249-8731-57fdc3f22935)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         ecdca662-cd46-462e-b934-f7be822cae8a)(content(Whitespace\" \
+         e3918dff-05a1-42ca-a9b3-0702a31a32dd)(content(Whitespace\" \
          \"))))(Tile((id \
          31cc4307-ca7f-4741-ae87-f27f5bed61ce)(label(value))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         edb7561e-5ac8-45ff-b9bc-a9bab24eadf6)(content(Whitespace\" \
+         \"))))(Tile((id \
          ebc2f90f-06d1-4ab9-99ac-1418170a9394)(label(=))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 39))(sort Pat))((shape(Concave \
-         39))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         39))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         9633a651-56c9-47d0-a49d-b59d5a77539f)(content(Whitespace\" \
+         \"))))(Tile((id \
          d30aa63a-6cdd-4b48-92be-da72658510bd)(label(v))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         456a19c5-671d-411c-a2e6-3ea537f0c8e3)(content(Whitespace\" \
+         5373eb47-433e-4468-8a73-bad28200c9ad)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c8f0388a-553f-4dff-ad7b-1d34339c8fe1)(content(Whitespace\"\\n\"))))(Tile((id \
+         f907dcb4-67d3-45f3-bd6b-5ffc52f51ea6)(content(Whitespace\"\\n\"))))(Tile((id \
          82144b40-b96a-475b-9422-0de94d0e6cf7)(label(case end))(mold((out \
          Exp)(in_(Rul))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         367a816e-b48c-4484-ae66-1c06394b841d)(content(Whitespace\" \
+         b71b1807-00af-4d55-8270-5789b4339c92)(content(Whitespace\" \
          \"))))(Tile((id \
          9c84f400-6b18-45cc-accd-f1dde0319ede)(label(find_opt))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -572,12 +605,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          db04e4ed-04a7-4c3e-b363-930b88e6872f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         aae08b43-a4b3-4fd1-850f-7546b020d7c8)(content(Whitespace\" \
+         27f58c99-0a3f-4249-854a-bbfffc66775a)(content(Whitespace\" \
          \"))))(Tile((id 71fa4fe5-9217-477e-a673-5b05d826cf6f)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         5c9e21c8-d82a-479d-8661-bc9fffe7def3)(content(Whitespace\" \
+         8e2441d2-3c5e-4032-9043-350c6ff0f975)(content(Whitespace\" \
          \"))))(Tile((id \
          bdfdc4cb-b59d-4408-83f3-5a6adf83aa34)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -588,29 +621,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          27ecb478-fdc0-498b-94f3-b07e0254e11c)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         73980f7b-688a-4585-80b2-06c7925d1a32)(content(Whitespace\" \
+         27992012-5ff5-4809-b611-b75e1e66711e)(content(Whitespace\" \
          \"))))(Tile((id \
          4af80ab1-e987-48ff-b20f-3dc836697e97)(label(_))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         92dffcef-ff61-4006-a1c6-7fc2af1af96c)(content(Whitespace\" \
+         7234a9a6-f328-47fa-8d93-ebe47e3a9748)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9a32f4d8-a309-40fd-bdd7-6ced7df08298)(content(Whitespace\" \
+         7413d53e-764e-45f1-9153-7cf726304d91)(content(Whitespace\" \
          \"))))(Tile((id \
          7efbc13a-2b47-4ee5-9b1f-fe1d9f65e9c6)(label(from))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         55816477-ac78-461c-b594-5df1cc7e93e7)(content(Whitespace\" \
+         429f0379-556e-47cc-b12e-ae14203928cc)(content(Whitespace\" \
          \"))))(Tile((id \
          80a570c8-87ce-4ed8-b982-32fa7e2def90)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         944fb081-07e7-41c0-b5db-1f1bb969cf87)(content(Whitespace\" \
+         97f20571-0a55-4593-9998-ef91bef36133)(content(Whitespace\" \
          \"))))(Tile((id \
          3bb657b0-a917-4acd-8fb8-0fe757aa35e2)(label(l))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         16f1f8ef-d81d-4cc2-950c-ee35a7c8284a)(content(Whitespace\"\\n\"))))(Tile((id \
+         5cc7090b-7c01-4bde-98eb-f78af1f71baa)(content(Whitespace\"\\n\"))))(Tile((id \
          57b1c3f4-10ff-4571-8711-75c3e6fea4ac)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -638,35 +671,43 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))))))))))))(Secondary((id \
          57e7bcaa-b47b-448e-9d5e-c5eba1acf2a0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b7f5ed92-c026-428b-a0f2-b6b7fa89b4ef)(content(Whitespace\" \
+         2b7e2fac-bd29-4e1b-a23e-78cee0257435)(content(Whitespace\" \
          \"))))(Tile((id \
          c28d1a12-9a76-4675-8a56-9b0d0603299c)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          18865e21-203b-4042-b676-2341a6dadb07)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         09a07feb-6fce-40df-ac1d-53b4cb0c07c6)(content(Whitespace\" \
+         \"))))(Tile((id \
          8774075a-2743-47a9-8131-f3ecc81fe0ca)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         900c3569-f97d-4969-8e8e-35dd0eb7994b)(content(Whitespace\" \
+         \"))))(Tile((id \
          b75b8bed-f2fb-463a-a11d-6b8680821e60)(label(to))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          15eb0cd1-081a-4e13-a0c3-b1e3969cf16a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d97233dc-cf39-4c14-be7c-fa4664d9e1b3)(content(Whitespace\" \
+         d42c9219-0825-4470-8a03-c453f5099258)(content(Whitespace\" \
          \"))))(Tile((id \
          2ec7ab34-5b0d-4bf1-9d4b-fa5f40a6a5cd)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         cc9cc0a0-2aa2-41a2-8930-781780d2f617)(content(Whitespace\" \
+         \"))))(Tile((id \
          21d22030-71fc-44d3-ad47-53a72e751a3e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5e745b1f-7cdd-4ee0-b22e-ddd17593a236)(content(Whitespace\" \
+         \"))))(Tile((id \
          7222259c-e0a7-445e-911d-16b5be2e11f6)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         020dae74-1697-416e-a867-bd4116df1307)(content(Whitespace\"\\n\"))))(Tile((id \
+         0b13f0d6-140a-467d-a361-ddb3a8bf8a63)(content(Whitespace\"\\n\"))))(Tile((id \
          3e0f6ac6-92b5-4554-a232-3a8ca32d6833)(label(| =>))(mold((out \
          Rul)(in_(Pat))(nibs(((shape(Concave 46))(sort Exp))((shape(Concave \
          46))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
@@ -677,72 +718,79 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Secondary((id \
          14633791-976e-45fa-b0a2-09f2e5fb2d3a)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d6249aa3-9358-45a2-8065-7073fd05d43e)(content(Whitespace\" \
+         7a93ed90-83a2-4000-bd2d-995762a9fe98)(content(Whitespace\" \
          \"))))(Tile((id \
          f662c7a6-3caf-4329-b40b-fbe947216bb0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          cd7e1857-b5b9-49bc-b90b-c0600458ff2e)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         caa1136c-0c13-4ac1-a683-1a6392a74d69)(content(Whitespace\" \
+         \"))))(Tile((id \
          7380fcb2-2cc3-4dde-9af7-a07fea07c078)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         43b1dc5b-be9e-4fdf-bee1-b8604579195e)(content(Whitespace\" \
+         \"))))(Tile((id \
          cb2e81ad-b4cb-4126-807a-3c4bf276d543)(label(l))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          58375513-e549-4d2f-9bed-d21a3a65641c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         db8e3d57-055a-4095-8098-3dc6f7a5e9ee)(content(Whitespace\" \
+         49726579-4c36-4eb1-96ca-87864f8283b2)(content(Whitespace\" \
          \"))))(Tile((id \
          2407795b-5b26-4f04-8ff7-35ee0e63178b)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a7f815ab-495e-415d-bb9c-58949c3a085b)(content(Whitespace\" \
+         \"))))(Tile((id \
          74067069-c4bb-4b6a-b25b-a76a473d0175)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         15414689-75cc-4535-99d7-eaf6f9e0adef)(content(Whitespace\" \
+         \"))))(Tile((id \
          662e3abb-9316-45ae-bb45-6913d4a78dd0)(label(v))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         e3560fad-9981-4f11-bb3f-e16a52b099c5)(content(Whitespace\" \
-         \"))))(Secondary((id \
-         5cc40f1f-e4cc-43c1-b10b-53ff9d2005dd)(content(Whitespace\"\\n\"))))))))))))))(Secondary((id \
-         b3501e5b-ec81-45ef-9040-d0404a1dd971)(content(Whitespace\"\\n\"))))(Tile((id \
+         38da5790-7b0d-4c7c-8857-253def0abd2f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         23dc1297-ab34-4b2f-bf94-efffb3052ac9)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         76b1d372-3f2b-4eb0-8834-4a6601b24fa1)(content(Whitespace\"\\n\"))))(Tile((id \
          80a6c7aa-07e7-4e25-a0e0-28e31588d665)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b8a5a9f3-df0d-45ec-b47d-111c6e5386a5)(content(Whitespace\" \
+         d17cdb2c-65eb-4d91-aa03-81757770b192)(content(Whitespace\" \
          \"))))(Tile((id \
          3373d0b7-d65e-4074-8580-7a379235f06b)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         1b38724c-6492-48d3-8ef2-d6611850490b)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         da1db4c9-e699-41dd-998a-18a84a26e52b)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         435d3564-9b97-4955-a6c9-6428dce50cb0)(content(Whitespace\"\\n\"))))(Tile((id \
          d852f996-6993-4eb2-aaa8-9afc6149b48a)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         736dc3f3-f700-4957-8010-5e085007d213)(content(Whitespace\" \
+         a5ed01ce-401d-492f-a3e5-9ee5eea06c04)(content(Whitespace\" \
          \"))))(Tile((id a5894ed2-b01e-4130-b685-ff757a91f873)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          68faefb7-71b0-4ba9-a9d1-3c6e561354f6)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         63923bcd-8010-403d-9549-e8e95acfaadb)(content(Whitespace\" \
+         453d0b7a-f2ec-41f6-98ac-db0a082bd048)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         17015735-bda7-4152-af2a-97ba5eca9616)(content(Whitespace\"\\n\"))))(Tile((id \
+         19211dd5-b2d9-4127-a2aa-ba387d6520f8)(content(Whitespace\"\\n\"))))(Tile((id \
          faff2f7c-5a72-428b-8f50-89c7e467d1d0)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         d0d4be3c-6a16-4122-b4b5-fdfbec62a0cb)(content(Whitespace\" \
+         92bcb20e-9001-4dba-b807-0f1f27cbdb37)(content(Whitespace\" \
          \"))))(Tile((id \
          1df80f0a-430f-4f68-9089-c7a98b472f83)(label(expected))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         de294af3-9070-4055-b83d-561b82996c6a)(content(Whitespace\" \
+         f3f7ced0-9b24-426f-9d00-c6c3661874fa)(content(Whitespace\" \
          \")))))((Secondary((id \
-         f27c87d3-b463-4743-bc42-d837876e33d2)(content(Whitespace\" \
+         ea167752-7a3b-4313-a4b8-0b1531fa418a)(content(Whitespace\" \
          \"))))(Projector((id 2cc30c49-26e6-435b-98cd-503f6b25037e)(kind \
          Fold)(syntax(Tile((id \
          d7a10c93-222d-41d8-9d14-9605b851972e)(label(\"(\"\")\"))(mold((out \
@@ -882,14 +930,13 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          fa1aa88b-6015-4247-8691-c39d58094846)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         b553586f-18c0-44a1-8193-71cf384ce873)(content(Whitespace\" \
+         bf384cca-8dd1-42a8-a40e-e6b51b034a19)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ce6174cc-b82f-4772-aedd-d11e0ca5da16)(content(Whitespace\"\\n\"))))(Tile((id \
+         73f86cca-6f8d-4272-8892-d4e30ba0ec72)(content(Whitespace\"\\n\"))))(Tile((id \
          d00ec10b-e58e-4c9f-b5c1-9193e045c09e)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         fa2a6116-58b2-49e9-9576-2d9b0944964f)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c734fc19-6edc-40e0-8657-1ce7640046b2)(content(Whitespace\"\\n\"))))(Tile((id \
          b0ad513b-fc98-4e7c-ab4b-59de08372eda)(label(rename_columns))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -902,7 +949,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          41f3cd67-d650-4d9f-a7e2-36b0ebebbb25)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         52aafb15-b916-4ba8-ae0d-841d423c2bad)(content(Whitespace\" \
+         a1f1246c-b7be-4634-a473-3ae000e7d9ff)(content(Whitespace\" \
          \"))))(Tile((id 0d976127-05dd-4adc-86c1-f336678ca759)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -924,7 +971,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aeb7f143-71cf-4801-ace1-6a61d9ba1bb2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a1a9f671-4fa7-41f9-ac2f-d761faccd5b6)(content(Whitespace\" \
+         640d2e31-48fa-4def-bcd0-59a43ce6f5b6)(content(Whitespace\" \
          \"))))(Tile((id \
          40d10be7-8ecf-4202-a9a1-cc8d4b530cce)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -935,31 +982,31 @@ let out : string * Haz3lcore.PersistentSegment.t =
          bc6671e9-8cb2-46a6-a4c4-f9fa24274465)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d9237d00-d7af-471e-9331-e80fe35dfbbd)(content(Whitespace\" \
+         bc6147f2-ab78-434f-8b50-3e222a281d09)(content(Whitespace\" \
          \"))))(Tile((id \
          b09fbf61-6e98-42d3-9b5a-43a972998110)(label(\"\\\"first \
          name\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         4de38b47-08ff-4916-9fff-2ca45eeff055)(content(Whitespace\" \
+         bf608cbe-a837-483f-b224-47ad361ea691)(content(Whitespace\" \
          \"))))(Tile((id \
          c228f957-0581-4c6b-b6ea-edf14dd89d58)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         59f4460b-829b-4e48-92f0-1ec20ff58750)(content(Whitespace\" \
+         e190e5b9-59ef-41cd-bfd3-04efbb31ef08)(content(Whitespace\" \
          \"))))(Tile((id \
          995d0d4d-2c72-44cb-8a65-02df39ca7578)(label(expected))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         c6a5d5c2-34a2-4f24-9230-97630ec47ea7)(content(Whitespace\" \
+         aa69eac6-5f4c-423c-91cd-569fad45067a)(content(Whitespace\" \
          \")))))))))(Tile((id \
          c691223f-911a-492d-9569-7f40cd45a469)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f9230236-282c-4b80-8d67-a26c0eb029e4)(content(Whitespace\"\\n\"))))(Secondary((id \
+         23c89d3b-9f82-4772-bc23-ca84cbce91a9)(content(Whitespace\"\\n\"))))(Secondary((id \
          dfecb2aa-781e-4e70-a899-576fefc56011)(content(Comment\"# Idiomatic \
          way to do this which gives better type feedback#\"))))(Secondary((id \
-         63692dda-8a29-475a-9b04-0bdcb4aadd77)(content(Whitespace\"\\n\"))))(Tile((id \
+         8422fa47-d703-4930-a954-8ea7497953c5)(content(Whitespace\"\\n\"))))(Tile((id \
          506b0ffa-f8bf-4060-9c64-6166ad44acfd)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -972,29 +1019,34 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b0b27c54-96cd-4d8e-b36d-e8c00f7f1242)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         977571eb-d6e0-4930-8c4f-0941455d02a7)(content(Whitespace\" \
+         4281e98c-5c2d-4422-becc-f8a1ea952efe)(content(Whitespace\" \
          \"))))(Tile((id d159e56a-59cf-4625-b584-6696e5091f47)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         fb91662a-957a-4aa2-a960-a3d3948d24aa)(content(Whitespace\" \
+         28df2e9c-b654-42f8-ad00-b7c0c0ac878f)(content(Whitespace\" \
          \"))))(Tile((id \
          eca0bb42-1fa6-49d1-abea-0b6092f55a0a)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         09b8920e-a808-441b-a424-7831dcded844)(content(Whitespace\" \
+         2101e6c7-eb77-42ca-b638-af0ca1b58ebb)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         fd1fc566-9f5c-45e6-9d39-d8e3b5d4326d)(content(Whitespace\" \
+         16a468ac-0532-4dc2-8bc1-bfb80119c5f1)(content(Whitespace\" \
          \"))))(Tile((id \
          2edbf1d0-5a18-4937-a66d-3fe7c18b662a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          54bc32de-ec8c-4b80-80e6-c298faa6cd20)(label(\"`first \
          name`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2f43243f-aa85-4455-adee-cf22b0ccc256)(content(Whitespace\" \
+         \"))))(Tile((id \
          d713723a-990c-4b91-8965-c39a309a2aa7)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         19c5d1e5-ab44-43c9-a469-3f3ac64fe230)(content(Whitespace\" \
+         \"))))(Tile((id \
          7c63b27b-3f8a-4956-a1b8-2b6c3b5cd737)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1007,14 +1059,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          51b30a25-db87-4623-94a2-3f0600b01ba3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         04e2b4a2-fec5-4949-a09c-3f1984585801)(content(Whitespace\" \
+         34c08533-4692-41ec-b83e-0f6fa7b2055f)(content(Whitespace\" \
          \"))))(Tile((id \
          68e1013b-74bb-43cc-b827-b832116a940b)(label(\"`preferred \
          color`\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
-         Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))((shape Convex)(sort \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         fa8db140-2d95-44bd-93db-a51c6d6e7d08)(content(Whitespace\" \
+         \"))))(Tile((id \
          25a51c47-a262-4c38-8f97-0be93c6efe9b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b488963b-3b32-4b7a-9f72-22f119b02333)(content(Whitespace\" \
+         \"))))(Tile((id \
          6ce991a9-dfb8-4875-b820-202e9725bbae)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1024,12 +1081,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          34a02c0a-d2d9-42f7-85c0-fb9b30eaeb89)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         36f5acbc-4bce-477f-aee6-f974bbbe820f)(content(Whitespace\" \
+         e1d1eea3-5b47-44ab-bcd7-1223c2512322)(content(Whitespace\" \
          \"))))(Tile((id \
          bc505c2f-ff89-4424-b06e-0b0137308b06)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c921df7b-7007-4c41-ac5b-ca1276ed8019)(content(Whitespace\" \
+         93861edc-56b8-4d11-92af-733999bae714)(content(Whitespace\" \
          \"))))(Tile((id \
          dc745f1e-1e4e-4ebf-b251-f4c01de5f67c)(label(omit_labels))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1042,57 +1099,70 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          d532a5e6-97fa-4b70-9df6-067e35a75263)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         11ea6966-1dee-49a4-bb26-61472cc00ea1)(content(Whitespace\" \
+         \"))))(Tile((id \
          ed84e2eb-cfc7-4856-9c01-4b9041564aca)(label(`favorite_color`))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          217dc526-009d-46fb-8b9f-14d0b7333183)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ae462216-9e05-4a77-b7bb-23ecc934ddfe)(content(Whitespace\" \
+         \"))))(Tile((id \
          02feb45f-7f5e-47a4-9b0e-645557dfd515)(label(`name`))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
          let students : [Student] = ^^fold([\n\
          (\"Bob\", 12, \"blue\"),\n\
          (\"Alice\", 17, \"green\"),\n\
          (\"Eve\", 13, \"red\")\n\
          ]) in\n\n\
-         let requires = [\n\
+         let _requires = [\n\
          (enforced=^^check(false), \"for all (c1, _) in ccs, c1 is in \
          header(t1)\"),\n\
          (enforced=^^check(false), \"[c1 | (c1, _) in ccs] has no duplicates\"),\n\
-         (enforced=^^check(false), \"concat(removeAll(header(t1), [c1 | (c1, \
+         (enforced = ^^check(false), \"concat(removeAll(header(t1), [c1 | (c1, \
          _) in ccs]), [c2 | (_, c2) in ccs]) has no duplicates\")\n\
          ] in\n\
-         let ensures = [\n\
+         let _ensures = [\n\
          (enforced=^^check(false), \"header(t2) is equal to header(t1) with \
          all c1 replaced with c2 for (c1, c2) in ccs\"),\n\
          (enforced=^^check(false), \"for all c in header(t2), if c == c2 for \
          some (c1, c2) in ccs, then schema(t2)[c] == schema(t1)[c1]\"),\n\
          (enforced=^^check(false), \"otherwise, schema(t2)[c] == \
          schema(t1)[c]\"),\n\
-         (enforced=^^check(false), \"nrows(t2) == nrows(t1)\")\n\
+         (enforced = ^^check(false), \"nrows(t2) == nrows(t1)\")\n\
          ] in\n\n\
          let rename_columns =\n\
-         fun (t1:[?], ccs:[(String, String)]) ->\n\
-         map(t1, fun r ->\n\
+         fun (t1 : [?], ccs : [(String, String)]) ->\n\
+         map(\n\
+         t1,\n\
+         fun r ->\n\
          to_lvs(r)\n\
-         |> map(_, fun (label=l, value=v) ->\n\
+         |> map(\n\
+         _,\n\
+         fun (label = l, value = v) ->\n\
          case find_opt(ccs, fun (from, _) -> from == l)\n\
-         | Some((_, to)) => (label=to, value=v)\n\
-         | None => (label=l, value=v) \n\
-         end)\n\
-         |> from_lvs) : [?] in\n\
+         | Some((_, to)) => (label = to, value = v)\n\
+         | None => (label = l, value = v)\n\
+         end\n\
+         )\n\
+         |> from_lvs\n\
+         )\n\
+         : [?] in\n\
          let expected = ^^fold([\n\
          (`first name`=\"Bob\", age=12, `preferred color`=\"blue\"),\n\
          (`first name`=\"Alice\", age=17, `preferred color`=\"green\"),\n\
          (`first name`=\"Eve\", age=13, `preferred color`=\"red\")\n\
          ]) in\n\
-         test rename_columns(students, [(\"favorite_color\", \"preferred \
-         color\"), (\"name\", \"first name\")]) == expected end;\n\
+         test\n\
+         rename_columns(students, [(\"favorite_color\", \"preferred color\"), \
+         (\"name\", \"first name\")]) == expected end;\n\
          # Idiomatic way to do this which gives better type feedback#\n\
-         map(students, fun r -> (`first name`=r.name, `preferred \
-         color`=r.favorite_color) ... omit_labels(r,`favorite_color`,`name`))";
+         map(students, fun r -> (`first name` = r.name, `preferred color` = \
+         r.favorite_color) ... omit_labels(r, `favorite_color`, `name`))";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesselect.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesselect.ml
@@ -1,87 +1,98 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Utilities / select",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id 1ab95a51-37ce-4326-8aae-893f4d3b6ed9)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         9e40e647-ec01-4eb5-a3a9-6d3c687fe8aa)(content(Whitespace\" \
+         cf429839-9e07-4187-8753-761901fb10d5)(content(Whitespace\" \
          \"))))(Tile((id \
          5ec8b8c1-ac12-4ad4-b18f-69a14fdee20d)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         aa03f438-e7da-4d14-a305-75773aaa90b9)(content(Whitespace\" \
+         41db1780-8bde-47e6-8eb1-4b9ac36bb551)(content(Whitespace\" \
          \")))))((Secondary((id \
-         74066bfc-d727-4b82-bb18-ac1e87b6ed13)(content(Whitespace\" \
+         1953f844-5410-4f8b-a977-6a963b4e89e9)(content(Whitespace\" \
          \"))))(Tile((id \
          4c890dc8-d09d-4fc2-bf34-47ae399bd3ba)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          b0647388-8ee2-46b0-b60d-629942d2c733)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         89f90713-07c3-4003-a47b-bd33bc4420cf)(content(Whitespace\" \
+         \"))))(Tile((id \
          54ae1949-4eb3-4e91-9fee-f4cf926183d8)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d82da07e-fedf-4071-b999-df24da5505e2)(content(Whitespace\" \
+         \"))))(Tile((id \
          12e2a4af-e80d-484e-9b2e-ce89f7d8b46c)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bb1cc974-d771-4e99-a2e4-5d2c3f6c356f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bdcfddef-e042-4f50-af78-2bcfabac5145)(content(Whitespace\" \
+         9aa3bfb8-0d08-4acb-94ad-31c5ac53e1b3)(content(Whitespace\" \
          \"))))(Tile((id \
          309e8c53-f644-4e11-b042-7fd2403534b7)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         2863f662-ae41-4472-97f0-a1b655da13ce)(content(Whitespace\" \
+         \"))))(Tile((id \
          91c100ef-3d00-4f89-897f-1fecb888b16e)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7dd8709e-2b7b-4b6e-ad79-85a336204986)(content(Whitespace\" \
+         \"))))(Tile((id \
          4dfb6c21-698e-4ab1-a471-5df5c450eb69)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          45b1f5be-9bdf-4fe4-a19d-99ee68754857)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b25385ff-3477-4bc6-bf3f-ac7e3512ae8e)(content(Whitespace\" \
+         955c1129-fb7e-4f5a-bdb2-06483421d54f)(content(Whitespace\" \
          \"))))(Tile((id \
          3f9850f4-f515-4a45-866d-484df6e7bf35)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         708b5236-70ea-4b86-9284-a8d11e2e8a8b)(content(Whitespace\" \
+         \"))))(Tile((id \
          6fbf1d9f-60eb-4342-b5ae-c4f18cdfc95a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         13d0ebf9-fd49-4af0-a520-d182ca0c62bd)(content(Whitespace\" \
+         \"))))(Tile((id \
          7d092b8c-678e-4880-b341-726b7c6dffe0)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         04ab2e21-5141-4859-98f2-6a3f596d78c4)(content(Whitespace\" \
+         13c29cca-7217-469c-a181-87f83816459c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         45c0949a-ccd3-4f0c-ad10-08c467f92e35)(content(Whitespace\"\\n\"))))(Tile((id \
+         2d0a8860-21eb-4b98-a63f-bda3cfba4bc8)(content(Whitespace\"\\n\"))))(Tile((id \
          7d328ee7-e80a-494f-862f-f75dec595187)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8166baa4-0cf8-4e12-a18d-51927ed101fb)(content(Whitespace\" \
+         638187f5-d676-4d0b-a7e5-e601c3d22c31)(content(Whitespace\" \
          \"))))(Tile((id \
          9775c945-fcbe-4c57-88d8-f8dd438f26cd)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         0cdde627-87df-485c-9e27-b8d701f9672a)(content(Whitespace\" \
+         3ba1bc7c-bb2a-4821-8f9d-dd585097db70)(content(Whitespace\" \
          \"))))(Tile((id \
          c6d9da3b-96d5-4ff1-83fd-c32cf16566c1)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         dc87a213-0c3d-4476-bc1a-accbe5bc91cd)(content(Whitespace\" \
+         57dbde96-2b31-427a-958d-825488dd3a02)(content(Whitespace\" \
          \"))))(Tile((id b665e2f8-9bfd-446a-8fdd-ee3eaed0fc6d)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          81d6bb4d-fc49-4fac-8d1f-58a8c0fd3aa5)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f0c242a4-fece-400c-b76b-d4891d7bf254)(content(Whitespace\" \
+         74fafe46-abd0-446e-97f2-e0d0da1afcb1)(content(Whitespace\" \
          \")))))((Secondary((id \
-         617c00d1-65e7-4277-aba5-aa572f893c8c)(content(Whitespace\" \
+         74debde9-ee32-4005-8893-ae073b455ca3)(content(Whitespace\" \
          \"))))(Projector((id 334ad5d6-a5d7-4323-988d-e5074cb054aa)(kind \
          Fold)(syntax(Tile((id \
          a0290a76-fa77-4c2c-8338-10e194d22899)(label(\"(\"\")\"))(mold((out \
@@ -167,36 +178,43 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          3b1bcc42-4941-43f4-af84-c16a2eb8d6f1)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         3dd66862-25a8-409b-96eb-69ae226dd852)(content(Whitespace\" \
+         e658e4b6-8b7e-44dd-b4a8-f1dffcd945ed)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ecf74700-df15-4f92-918c-f3283b9ae3eb)(content(Whitespace\"\\n\"))))(Secondary((id \
-         fda41228-1f7a-43d7-8ddf-469bbdd3e757)(content(Whitespace\"\\n\"))))(Tile((id \
+         54140999-dc58-47e9-b23f-74d0f8ed9304)(content(Whitespace\"\\n\"))))(Secondary((id \
+         690dbe12-52ce-4783-8225-e658b1e917db)(content(Whitespace\"\\n\"))))(Tile((id \
          4e9bd54c-2e38-4056-8c36-2870f736faef)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         3a3653ff-1743-4ee6-8acd-d9e5d23d77b6)(content(Whitespace\" \
+         beb1217c-c700-45ad-85be-0ad5398b0ddb)(content(Whitespace\" \
          \"))))(Tile((id \
-         e09a3648-9aa6-419a-9f26-db6f8bbeed21)(label(requires))(mold((out \
+         e09a3648-9aa6-419a-9f26-db6f8bbeed21)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6f08203d-0c3e-4c57-b064-0148da3161c3)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         49a41a6c-5739-469b-ab3c-66d1cc1a1af8)(content(Whitespace\" \
+         \"))))(Tile((id \
          4ef3b339-d8d1-4025-bb44-2bf971ae9af9)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         2de3d000-5bb0-4b10-8105-b0640890e8ac)(content(Whitespace\" \
+         96e9fcda-67d5-439b-b8d9-c49c2eb8c720)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         792adeb6-e0a1-4908-acd9-029ed4261f83)(content(Whitespace\"\\n\"))))(Tile((id \
+         b3e49507-69e6-483f-90fd-c4d5720386f7)(content(Whitespace\"\\n\"))))(Tile((id \
          4ba81e79-9f4d-44e5-b5b3-50b0fc44c12e)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         2d5c4d4f-4375-4334-aef5-ecb68fcb8826)(content(Whitespace\" \
+         d5094d63-4e03-4d5d-b9cf-c4441c022eb0)(content(Whitespace\" \
          \"))))(Tile((id \
-         a57d712f-5603-40f0-b613-6ccfe3a403ad)(label(ensures))(mold((out \
+         a57d712f-5603-40f0-b613-6ccfe3a403ad)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         8139d81c-b5b5-4a10-a9b6-9e776d2917f1)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         15fe50fc-33dd-462f-aa66-846b343a4cc9)(content(Whitespace\"\\n\"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         35ed2f9a-b489-4175-9906-db272fdbdb4f)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         f6a1d381-be3d-41d8-a3e3-7e0c3ef11cf7)(content(Whitespace\" \
+         \"))))(Tile((id 8139d81c-b5b5-4a10-a9b6-9e776d2917f1)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         dc0fa216-2f58-4f17-8559-9d6e4d013e0f)(content(Whitespace\"\\n\"))))(Tile((id \
          86f6b4a7-46a0-49ae-bd3e-327d97fbd457)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -225,7 +243,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          055535ed-7f6a-47fa-b64e-cc4d18817abb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         66ec8d15-364f-4cf4-87b4-edc75230dd10)(content(Whitespace\"\\n\"))))(Tile((id \
+         489b5fe0-8485-4baf-bf4d-265484c68fdc)(content(Whitespace\"\\n\"))))(Tile((id \
          65f6bb02-cd8f-46d2-a843-700b8231d9d1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -253,7 +271,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          80949c9d-fe19-4393-90b1-b0d80c435fa0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7df5f505-12d3-47c5-9bd7-b506638d8c87)(content(Whitespace\"\\n\"))))(Tile((id \
+         22f19785-9bbd-46e2-8243-4cba9f2c17af)(content(Whitespace\"\\n\"))))(Tile((id \
          c27c34d8-0281-460b-9ae4-f3b2ada0bb3b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -282,17 +300,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          44206c17-c6da-4b2a-b31d-a73080b80ae3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         39b8e004-4762-4633-a396-95a36b64ba65)(content(Whitespace\"\\n\"))))(Tile((id \
+         ff73f163-d095-4f2a-867f-844c06e7021f)(content(Whitespace\"\\n\"))))(Tile((id \
          9c69141d-c2f2-4f52-afb4-6a9c1eaf5516)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          a197835a-ec17-4844-a9bb-cdb528b6bf63)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c914cfc4-82c0-4961-9bd6-9bab1e5593b5)(content(Whitespace\" \
+         \"))))(Tile((id \
          b8333eb8-6c8e-4476-b1f4-9fcaa09c2b71)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         7bd80770-5d9d-43b4-a7e5-8eb5422b3495)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2d641a44-be83-4020-b31b-6ecfd1eddb66)(content(Whitespace\" \
+         \"))))(Projector((id 7bd80770-5d9d-43b4-a7e5-8eb5422b3495)(kind \
+         Checkbox)(syntax(Tile((id \
          02997f43-8508-4c6f-8de7-3a9622331639)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -302,82 +324,91 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3272b43b-5d1a-4899-8469-2e896280ef4a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         1a307920-8d45-426f-9784-507cc0127b50)(content(Whitespace\" \
+         f716abaf-f95a-4792-8423-318df699b335)(content(Whitespace\" \
          \"))))(Tile((id \
          fa7a70bc-cfec-443a-b73a-44cd8d0a8018)(label(\"\\\"nrows(t2) == \
          nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         25917094-e692-4370-90b6-b53f16811766)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         c0857389-79f9-4624-afaf-40b3d74a8b54)(content(Whitespace\" \
+         a854f058-b486-40b2-b955-7def0f1dd566)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         31970202-4240-4cbd-a7c7-f42b637895bd)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         84b1ac10-0eff-41ba-8dfd-418d6f5a5c1b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         e7e1e985-6eaf-41dc-931c-075b40994d6e)(content(Whitespace\"\\n\"))))(Tile((id \
+         d9833af5-0aac-4546-96fe-9c1c2efb5906)(content(Whitespace\"\\n\"))))(Secondary((id \
+         5c815606-b14c-4a2e-987d-2defb8998dd7)(content(Whitespace\"\\n\"))))(Tile((id \
          1925e353-7adc-4db8-b61e-1d3c520e2141)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         e57a3f79-bd7c-4e90-b925-0b14d2d415fe)(content(Whitespace\" \
+         e1096343-53a4-4dd1-9281-bb5dc73096c3)(content(Whitespace\" \
          \"))))(Tile((id \
          6e9ff8bd-1b90-4e95-ba23-23abab791a7d)(label(select))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         c5b7f61b-9194-4905-ad7e-dbc813e157f2)(content(Whitespace\" \
+         d1ce782b-5300-4c99-be8d-1bb8b95186f4)(content(Whitespace\" \
          \")))))((Secondary((id \
-         fdd0185f-343e-4c14-840a-07e3a972c6a9)(content(Whitespace\"\\n\"))))(Tile((id \
-         eb15e0e6-3b75-4c1e-8c30-f963bbbfef80)(label(typfun ->))(mold((out \
-         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a5810e88-a933-419f-ad40-bd45c1b56720)(content(Whitespace\" \
+         cd87ae77-39cb-41da-a8d9-03b7eb135642)(content(Whitespace\" \
+         \"))))(Tile((id eb15e0e6-3b75-4c1e-8c30-f963bbbfef80)(label(typfun \
+         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         a8883c9b-710b-4f13-be08-35e8c411f77e)(content(Whitespace\" \
          \"))))(Tile((id \
          a441f20e-d105-4658-ab3b-f408da7f121f)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         0c114b3f-d729-416d-b613-9c26f3170efd)(content(Whitespace\" \
+         7f3ba29d-69f1-4148-8edd-46a5450ba4df)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         426537b5-546c-4076-9bc7-b52895b7fef8)(content(Whitespace\" \
+         ba9a0394-a4eb-4650-a6e8-3f365a4cae61)(content(Whitespace\" \
          \"))))(Tile((id 07f7b54a-e4b6-4aba-a56e-64b8519fb46f)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         1999864a-916c-4110-971e-16f0f042ea71)(content(Whitespace\" \
+         911450fa-3567-45f8-9731-71dfd17a59e7)(content(Whitespace\" \
          \"))))(Tile((id \
          b588152e-4cd9-4a9a-8733-8e75857cc4c9)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         cfc5f47b-8f86-4a5e-8d28-9a4eaaaaa66f)(content(Whitespace\" \
+         734c10a9-cb80-40b3-add8-7435efc60994)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7a608934-76f9-452e-a866-a17ed0ca0d74)(content(Whitespace\"\\n\"))))(Tile((id \
-         130a206e-eaae-4f38-bf3d-c886069ac78b)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         e3b585d7-be3d-4680-beb1-2716dabc3eb2)(content(Whitespace\" \
+         0e1d37ee-ee44-4adb-86bf-dcf48b33d761)(content(Whitespace\" \
+         \"))))(Tile((id 130a206e-eaae-4f38-bf3d-c886069ac78b)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         a2f3577b-9cdb-44a7-b0e9-c096ac1cccbc)(content(Whitespace\" \
          \"))))(Tile((id \
          a8c79ee8-83a0-447b-a949-a6fc1e736d3f)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          81b1f9bc-0a40-459e-9ed3-8390acb041ce)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         01c5bbf7-ee60-4717-9e59-0af5fbc52619)(content(Whitespace\" \
+         \"))))(Tile((id \
          22e8df24-867f-4100-9850-05f856e24cbb)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         24c53c0e-ec80-42a4-8a1d-dc5bad18cb3e)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         97b114fa-d418-4a3a-970e-673cf280f2d9)(content(Whitespace\" \
+         \"))))(Tile((id 24c53c0e-ec80-42a4-8a1d-dc5bad18cb3e)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          d8bd8b30-b56b-47f0-b1a7-0ecf406c9c10)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          beba81a2-2828-4ef0-ade4-f8ab7fcdd1c0)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         4bc9a843-3d09-4182-b809-a95f26a88aad)(content(Whitespace\" \
+         34ce6ae9-76d7-4d82-a002-36c226679aab)(content(Whitespace\" \
          \"))))(Tile((id \
          a2055dac-14ba-4b36-a7a3-18d821bb2298)(label(f))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         53b93f3f-8c98-4d2c-a191-7293451a556e)(content(Whitespace\" \
+         \"))))(Tile((id \
          3b2590bd-6f39-4db1-b993-320af9446fbe)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         547bafca-d8b6-40c1-b60e-7fcbdf5fd29d)(content(Whitespace\" \
+         \"))))(Tile((id \
          270b1de3-6191-4fc5-9a46-3ec1bfd0b322)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
@@ -389,23 +420,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          c26084a6-bf96-4e31-aac8-6fb19bbce18d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7434759b-d0f4-4def-adfc-b0e3b75270af)(content(Whitespace\" \
+         \"))))(Tile((id \
          0ece515e-9ea6-4150-be18-11066ff7999d)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         040565b3-2eb1-4620-a71b-d97182275655)(content(Whitespace\" \
+         6d114cc1-5ec2-4cf4-bf96-ce06a5556a90)(content(Whitespace\" \
          \"))))(Tile((id \
          0fbff750-5fd5-4a80-ba1b-e39b4dc84f8f)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0f1d56f9-3c1a-4bdd-bf9b-fca9e837cda5)(content(Whitespace\" \
+         cd0ba728-38a5-458c-ac4b-222378ffc83f)(content(Whitespace\" \
          \"))))(Tile((id \
          7918767e-4932-4c89-9742-3c5c9a01810c)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         3e99681b-7276-4421-965a-788426b86f8d)(content(Whitespace\" \
+         9d7b7e9a-4934-4ef5-9f33-d10c54ca23c6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d1fcda25-a8cf-455a-9fc0-a911dfd4df2e)(content(Whitespace\"\\n\"))))(Tile((id \
+         75e10596-4759-4437-a7b3-9b2e34c776fc)(content(Whitespace\" \
+         \"))))(Tile((id \
          733caba1-a481-4a44-927d-a3515410154e)(label(mapi))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -418,12 +452,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2bb6a551-dbb5-46cc-a018-2027d4e1f949)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a6ec8959-6d2b-48a8-b767-40e273cc6d2c)(content(Whitespace\" \
+         2a6e9d77-b10d-4492-a83b-db465887420d)(content(Whitespace\" \
          \"))))(Tile((id ae881f1c-4ecb-4dfe-a0a2-d618feb40c69)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         f55cdd52-a467-42aa-967d-e1587c4a99ce)(content(Whitespace\" \
+         43375569-f802-4a68-b9a0-a584b3d6dafc)(content(Whitespace\" \
          \"))))(Tile((id \
          474768fa-1009-4527-9d90-13cb398a96ec)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -433,13 +467,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          7dac3931-20dc-4171-b7ee-e7f3bb0c1075)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         1698b0c1-914e-4bb2-b931-06a03dabc9f9)(content(Whitespace\" \
+         \"))))(Tile((id \
          55d06321-1b84-48e9-baee-f9a9dcd6a5f4)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         2485b760-aefa-491b-9950-a9e83ba96e23)(content(Whitespace\" \
+         e546519b-ee61-445a-bf74-862742828a82)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         9dc8aa08-05d7-4673-bd28-43da2c732c33)(content(Whitespace\" \
+         897b5973-4ef7-4300-8eaa-52bafed10650)(content(Whitespace\" \
          \"))))(Tile((id \
          4d5f9fcd-b200-49ff-899e-c97592aae48b)(label(f))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -452,29 +488,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          764d0b64-f126-43b8-b2b2-e20bc45be188)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b22a5ffd-7584-48f1-92eb-5e342b5de4d3)(content(Whitespace\" \
+         \"))))(Tile((id \
          d427355a-524c-4d93-baeb-c6f5f7545679)(label(i))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         d5591531-75db-4ee8-a037-05879486ca2a)(content(Whitespace\" \
+         a664dd23-e85a-4d5e-b6f4-4e1fe1bf5847)(content(Whitespace\" \
          \"))))(Tile((id \
          f920e75a-233c-477b-a27e-eab432e45ab9)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         cbe574d6-44d6-437a-b42d-f199ff447478)(content(Whitespace\" \
+         023d3564-2d7a-4cec-88b6-4038e36656d5)(content(Whitespace\" \
          \"))))(Tile((id dca94259-0561-4bbb-bc0c-b6d45ffa543a)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          135ae642-fa91-4c1b-8d92-a27fb40a2721)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         2ccfdf16-f742-4e8e-b063-f6d6c16f1772)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         86df5ddd-f764-4e13-9cbc-d186d7c5d771)(content(Whitespace\"\\n\"))))(Secondary((id \
-         939cff48-fb09-44fc-85a9-cc96bba934b3)(content(Whitespace\"\\n\"))))(Tile((id \
+         5aad9de6-19ed-4e31-93b4-373196e61337)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         14c79777-6309-40d2-be9c-91804d8a4967)(content(Whitespace\"\\n\"))))(Secondary((id \
+         7d62984a-87a1-4b95-bd65-3039139258f3)(content(Whitespace\"\\n\"))))(Tile((id \
          07bc5f2c-774b-4119-abf9-e3a789e78f4b)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         48e623f0-892e-48a3-b969-4edd47741f13)(content(Whitespace\"\\n\"))))(Tile((id \
+         9023f089-0854-46a6-8684-7a843066b77b)(content(Whitespace\"\\n\"))))(Tile((id \
          31d813fb-1575-4a68-9bdd-6126b91191dc)(label(select))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -541,12 +580,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          af8bd66c-3d90-4105-92f3-9c92bf2ee84d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b4763b1d-9752-45fa-a1f7-451f007b1b54)(content(Whitespace\" \
+         1355ec59-03b5-4d82-afba-2fab9dd9a551)(content(Whitespace\" \
          \"))))(Tile((id 9d63691e-0a5e-42d3-88be-6879cd0e1a18)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         94f2ec10-91a1-42e7-a207-d82faafdd813)(content(Whitespace\" \
+         71bd1ef9-c173-4e22-a3a2-81896260cee8)(content(Whitespace\" \
          \"))))(Tile((id \
          f889da8e-df50-4665-ae24-ce8cf732e5c8)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -556,37 +595,47 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          964ad31e-77ff-4194-ade8-6d4429364e7b)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         efefdc32-657c-43c1-ab76-dafb7de1bfcd)(content(Whitespace\" \
+         \"))))(Tile((id \
          2115c1c0-1e56-45bd-8110-2824c84b6445)(label(i))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         1c82cefa-54a4-43f1-aa97-bc5d457b5e7f)(content(Whitespace\" \
+         c6cc1c28-d0a8-4cea-acac-4a02f865b855)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5bed8a67-90f1-48cd-a9a1-b9b8f08ab43a)(content(Whitespace\" \
+         9a52aa3f-75ed-410b-9124-44c1b99cefc4)(content(Whitespace\" \
          \"))))(Tile((id \
          bb559fc5-4376-4f11-b4d6-21102cc54137)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          0d2a1886-0733-44f9-a914-6dde867c2ddf)(label(id))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         6eb5d421-fa42-4744-a0d7-9d7b4619bf81)(content(Whitespace\" \
+         \"))))(Tile((id \
          cf75d305-c723-4cb9-80d3-b279f07ed507)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4eecc9ae-ce77-41bf-b77f-45721ac8c420)(content(Whitespace\" \
+         \"))))(Tile((id \
          dc85eea6-c64b-45e7-9dbe-f4f7264c3113)(label(i))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          b2ce24d0-6dc8-4762-b0c8-65b29d7a8080)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         bcef865f-00a8-467c-8b44-74c1f55a3ffa)(content(Whitespace\" \
+         8743bd31-1d91-490b-a7a8-3585b453c46e)(content(Whitespace\" \
          \"))))(Tile((id \
          4dfb9644-df5c-4d9b-94f8-9360c4e74b22)(label(color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         7fbc9a74-c6cd-4f8b-99d5-987b3888477b)(content(Whitespace\" \
+         \"))))(Tile((id \
          6b1d4542-1a74-4f3e-b1f7-9ecb1c47f8fa)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         84dfa8d4-5719-43d1-8480-7ef2062d4db9)(content(Whitespace\" \
+         \"))))(Tile((id \
          100ea1da-7114-4735-87db-e89d78046713)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -599,14 +648,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b8dc3de8-4530-4ed3-a809-08061e743d62)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0c35e5ff-447c-42a8-9175-0b621fde07d9)(content(Whitespace\" \
+         b32fff01-cb47-45eb-9c77-61bbbd3ec47f)(content(Whitespace\" \
          \"))))(Tile((id \
          87eab94d-393f-4683-873d-08ceda68eaa1)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         cc69f9e3-953e-43d4-94e3-3d68c8401f91)(content(Whitespace\" \
+         \"))))(Tile((id \
          d7bc01c0-edf3-44a5-8b70-73dabe41af6c)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a4f2b22a-68fb-46c8-80aa-7abdb7ebe7d2)(content(Whitespace\" \
+         \"))))(Tile((id \
          d85dcbae-976d-4455-9e11-397c5a426ed9)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -616,15 +669,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          c311b82b-fb60-436c-9b9a-6ef877cf117e)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         b14998ae-28ae-4cf2-94b5-646e88442631)(content(Whitespace\"\\n\"))))(Tile((id \
+         400179c4-95ca-467e-86ea-270b5572aae7)(content(Whitespace\"\\n\"))))(Tile((id \
          d68ee97b-0f64-496a-85b2-731e44d83669)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         81964789-645d-4810-8062-6c047d7dbc5f)(content(Whitespace\" \
+         a26de99b-90fc-46c5-91ca-9d57254380cc)(content(Whitespace\" \
          \"))))(Tile((id 7026ebbe-cd9f-4ec2-accc-3852f7fe076a)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         85da62bc-96aa-4277-a381-1ced3ede271e)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          314d9592-d2ca-4e77-9bd9-d4c3a2f2a127)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -668,7 +720,8 @@ let out : string * Haz3lcore.PersistentSegment.t =
          990f708e-549c-4c0e-b6e0-4a45b95aca18)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e64ecbbf-36e4-461c-bd57-55228caba0e9)(content(Whitespace\"\\n\"))))(Tile((id \
+         ec2e9ac9-ecf8-4960-ac02-fbe1484dbba0)(content(Whitespace\" \
+         \"))))(Tile((id \
          93dee744-4963-4dc3-9448-8e7ad0223522)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -712,75 +765,82 @@ let out : string * Haz3lcore.PersistentSegment.t =
          41fe8de2-13da-4c31-8d6c-87e82e60396c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         decbafc7-2d09-40ac-8524-18f19129926a)(content(Whitespace\"\\n\"))))(Tile((id \
+         116c6794-6409-49a0-be47-5cca8c21bf94)(content(Whitespace\" \
+         \"))))(Tile((id \
          ffbfe12f-da47-44b9-8a5a-6470b6d3b285)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          054f0415-7778-461f-9fd3-1154d4c41ee2)(label(id))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9d221322-3f0e-479c-b13f-511f9b72081c)(content(Whitespace\" \
+         \"))))(Tile((id \
          e3764205-3b6f-4d60-88cd-67345a1b47bd)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         39a14dd2-16d6-400e-82a6-08b3f0fab808)(content(Whitespace\" \
+         \"))))(Tile((id \
          51b6e9a2-b115-40c4-b985-3aa2fe28d82b)(label(2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          8514dd57-43c4-4e22-a345-4291a7dfd8c3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         96f1166a-b9f7-47ec-b8e0-2b8e6a44dc17)(content(Whitespace\" \
+         0fed7bd8-01c3-4bde-8978-344e82d4cee1)(content(Whitespace\" \
          \"))))(Tile((id \
          5fd98972-59ff-4040-be72-3eccea7d5a2c)(label(color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8359d63a-af6e-4e98-a6ca-75d74852e96d)(content(Whitespace\" \
+         \"))))(Tile((id \
          9539e308-e381-4e4b-ad25-b4c54b0f39e9)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         fa3806a6-2467-47b7-a9d9-76ddf91a5b74)(content(Whitespace\" \
+         \"))))(Tile((id \
          04b45faa-76db-4934-9a99-5039011cc2e4)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          4eacc495-9ce9-4f86-905c-e97e8f904e32)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         33cf8c44-310f-4c69-95b6-460111e40411)(content(Whitespace\" \
+         51e802bc-3a5b-412d-b2b9-26896c307d78)(content(Whitespace\" \
          \"))))(Tile((id \
          95a6f9e9-d1fd-44e0-9ddc-b0e67e91189f)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         e49e1528-0f17-4c4a-b229-cea802efbe4c)(content(Whitespace\" \
+         \"))))(Tile((id \
          3b6880c5-c157-4a63-a9d8-3cd2e1c0725e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         8c734524-8747-49cd-80c6-fc4cde9aeade)(content(Whitespace\" \
+         \"))))(Tile((id \
          d9695827-9d81-4e42-9e3d-ba653aa91674)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         b5feb0b5-366d-4bf7-9641-48bedd803d13)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         b1c61084-913a-4ef5-8d7b-19e6bb08ebfd)(content(Whitespace\"\\n\"))))))))))";
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         ffafbd21-c5f8-4936-95f5-7ca2acc48894)(content(Whitespace\" \
+         \"))))))))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
          let students : [Student] = ^^fold([\n\
          (\"Bob\", 12, \"blue\"),\n\
          (\"Alice\", 17, \"green\"),\n\
          (\"Eve\", 13, \"red\")\n\
          ]) in\n\n\
-         let requires=[] in\n\
-         let ensures=[\n\
+         let _requires = [] in\n\
+         let _ensures = [\n\
          (enforced=^^check(true), \"schema(r1) == schema(t1)\"),\n\
          (enforced=^^check(false), \"n is in range(nrows(t1))\"),\n\
          (enforced=^^check(true), \"schema(t2) == schema(r2)\"),\n\
-         (enforced=^^check(false), \"nrows(t2) == nrows(t1)\")\n\
+         (enforced = ^^check(false), \"nrows(t2) == nrows(t1)\")\n\
          ] in\n\n\
-         let select =\n\
-         typfun r1 -> typfun r2 ->\n\
-         fun (t1:[r1], f:((r1,Int) -> r2)) ->\n\
-         mapi(t1, fun (i,r) -> f(r,i)) : [r2]\n\
-         in\n\n\
+         let select = typfun r1 -> typfun r2 -> fun (t1 : [r1], f : ((r1, Int) \
+         -> r2)) -> mapi(t1, fun (i, r) -> f(r, i)) : [r2] in\n\n\
          test\n\
          select@<Student>@<^^fold((id=Int, color=String, age=Int))>(students, \
-         fun (r,i) -> (id=i, color=r.favorite_color, age=r.age))\n\
-         == [\n\
-         (id=0, color=\"blue\", age=12),\n\
-         (id=1, color=\"green\", age=17),\n\
-         (id=2, color=\"red\", age=13)\n\
-         ]\n\
-         end";
+         fun (r, i) -> (id = i, color = r.favorite_color, age = r.age))\n\
+         == [(id=0, color=\"blue\", age=12), (id=1, color=\"green\", age=17), \
+         (id = 2, color = \"red\", age = 13)] end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesselectMany.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesselectMany.ml
@@ -1,157 +1,188 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Utilities / selectMany",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id b2bb07c1-4589-4781-a911-025550ca47eb)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         0931a2fb-b66b-412b-b99c-630fb8f77a2f)(content(Whitespace\" \
+         47ea2b25-6aa6-492b-8525-e5e931d31a15)(content(Whitespace\" \
          \"))))(Tile((id \
          1f1efb5a-5a32-47c2-86bc-ff28f77c97c6)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         4280d207-3228-4c8e-8e48-70053481dc6e)(content(Whitespace\" \
+         35e10f53-cc30-4c08-a464-68d35dea5139)(content(Whitespace\" \
          \")))))((Secondary((id \
-         8c69b45a-77ef-4d37-b4a6-0f4e71f3bf5d)(content(Whitespace\" \
+         498a7c4f-e69e-4a50-a756-9a5f71debf29)(content(Whitespace\" \
          \"))))(Tile((id \
          dea64ddd-28ce-4452-8d29-dbb2857e5bcf)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          c16e3feb-b09b-4fc3-98d4-3ce22aa83498)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         df133246-defa-44e9-acd4-7a1344a60ba3)(content(Whitespace\" \
+         \"))))(Tile((id \
          0df8bf69-ef87-4032-b1a8-7dc59e51a6ab)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         eb98fc01-424e-4c6f-954a-14ef084cde10)(content(Whitespace\" \
+         \"))))(Tile((id \
          9afd41fc-6721-49c6-813a-f35d1db9251a)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          32184c83-98d7-4d2a-872c-1c580c596889)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         e0cd5c19-d105-4c06-9a33-8f097b5b15df)(content(Whitespace\" \
+         5d24f49b-2a99-4b47-bb99-4f7bd620b64b)(content(Whitespace\" \
          \"))))(Tile((id \
          8f6e87fd-49d1-401f-8ece-f7f49e0114da)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         bf9ee54b-0193-4bc1-883b-6dd510a7305c)(content(Whitespace\" \
+         \"))))(Tile((id \
          78e82658-1b55-4a74-95d2-cb678dba0651)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         96b7272a-f08c-486d-8685-17e1abc8940f)(content(Whitespace\" \
+         \"))))(Tile((id \
          37c0c2ff-2e09-455d-8e99-8aebfb4c8855)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          25de2920-6755-49af-927c-21ff6ddd6ed8)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         336a0fa0-4869-4114-b9ab-7c16ec6cd1df)(content(Whitespace\" \
+         31f098b2-e8de-4ba8-b941-1ff323b87f15)(content(Whitespace\" \
          \"))))(Tile((id \
          ffe94a7a-6cfe-499d-922a-fcd430f518ff)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         37668a89-e9f2-4f3a-9f33-890a73a5d490)(content(Whitespace\" \
+         \"))))(Tile((id \
          b99eb54d-f3a8-4638-a14b-49814e2a91b6)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ffdce061-33b8-47e4-bf30-4b756d28d5ee)(content(Whitespace\" \
+         \"))))(Tile((id \
          943e80c3-0940-4ccf-958e-f15783b730d7)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          c3ec9cc9-0a87-4276-8972-a146789502bc)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         70f769ed-9023-40d1-b066-eaad1c7d7ba3)(content(Whitespace\" \
+         d3bd1649-8d46-4429-a1ed-2aeba56123fd)(content(Whitespace\" \
          \"))))(Tile((id \
          9c96c0bc-66d2-44d1-b9cf-110ce31801ac)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         6869cc33-a434-4094-832c-d964002a45dd)(content(Whitespace\" \
+         \"))))(Tile((id \
          4f17fe43-de04-40e3-af94-f0af8561ba80)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c7910de2-92d3-48ab-85e0-b90b0b5d80ce)(content(Whitespace\" \
+         \"))))(Tile((id \
          77be9e26-9c36-4315-bbd5-e9eeb80c877b)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          bbdc4750-d612-4784-9355-f3ca5c49ccee)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         4d30d968-1d0b-42c1-b7f3-b9ebc61d2508)(content(Whitespace\" \
+         3642fec5-8a03-490f-a91c-ff04e1a5dc35)(content(Whitespace\" \
          \"))))(Tile((id \
          80b17f67-5dc8-47c4-aba5-85c5f72c1b72)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         a01e43bf-4be1-4de0-a83d-ca85b4d85454)(content(Whitespace\" \
+         \"))))(Tile((id \
          2b46682e-96da-4ac7-8567-74f35b5ce567)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7fc780f4-c565-4a16-8464-35d0f88f627b)(content(Whitespace\" \
+         \"))))(Tile((id \
          581b7551-a6a1-4de2-8ce2-633828281552)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d42bd327-da81-403a-8b51-facd8b63cd4f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         bc83eb10-ade3-454c-a111-bd7d84c61b1e)(content(Whitespace\" \
+         a97ce17f-768d-419f-bccc-f07f94e6e4c1)(content(Whitespace\" \
          \"))))(Tile((id \
          2a6df80e-7e34-4cd6-91dc-fd9d38563e26)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0f1dfca4-8437-4654-b3c6-b961c7a6cd12)(content(Whitespace\" \
+         \"))))(Tile((id \
          db11fbbc-9301-4f79-9b1f-d9e59e4bff27)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         516ed1f4-a3c7-47e3-9b1c-d700eac6647f)(content(Whitespace\" \
+         \"))))(Tile((id \
          af5b2133-5c16-4220-8f20-e02098596c0d)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d1ad3921-faba-41b8-adf1-1a5045c51717)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         61f7c320-d89c-46d0-b659-212b1792d0c4)(content(Whitespace\" \
+         15e7a814-637c-4db6-8ce7-d0f2f6e1d699)(content(Whitespace\" \
          \"))))(Tile((id \
          1f59408c-c1c2-47ad-b2f3-62cf92b0b35c)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         84c88f57-2e5b-4c49-8582-dc0285a40154)(content(Whitespace\" \
+         \"))))(Tile((id \
          a9499055-cd46-491f-8341-51d5e520f1bc)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         b116d471-9138-4fcb-b15b-826f87e7f08c)(content(Whitespace\" \
+         \"))))(Tile((id \
          50bba909-4cab-40cf-a2b7-014abd31cc58)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          d84a0a47-abf2-4e19-b9c3-e84dcf29a047)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f6a84d5c-8bc5-4aa2-8b39-e24d1d2a4882)(content(Whitespace\" \
+         6565316e-fbfe-4977-a52e-776d02f3a23b)(content(Whitespace\" \
          \"))))(Tile((id \
          7e1df862-daeb-4f5d-86ad-ab8bd83c1241)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         e14dc7d1-4758-4769-bbad-98b800466164)(content(Whitespace\" \
+         \"))))(Tile((id \
          620a8be8-d9cd-473a-84d1-2120cb221801)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         8e9b4b15-0b54-4931-a2b3-f6e67482dc32)(content(Whitespace\" \
+         \"))))(Tile((id \
          6e264658-f723-4693-a6bc-1a7c53ecbee1)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         b64148c0-3718-4083-b724-e86288b53be3)(content(Whitespace\" \
+         0a7d3fdf-65df-482e-9af8-429cd4245b98)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5ce6b55e-de8d-472c-9157-30920f6eb25b)(content(Whitespace\"\\n\"))))(Tile((id \
+         2e2bfd70-858d-412e-9b27-419735b8e7aa)(content(Whitespace\"\\n\"))))(Tile((id \
          23340507-8c3f-436b-8241-95efebc890b3)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1c8db87c-91dc-4fce-a9f0-9a5fca573471)(content(Whitespace\" \
+         fc0291d2-95c9-495b-8f51-73c895a55c8a)(content(Whitespace\" \
          \"))))(Tile((id \
          92c9c624-e55c-458c-a12b-15ce9d914351)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         22c63781-6106-46fd-a1f3-d5d73529a0fb)(content(Whitespace\" \
+         49fc76ab-fff2-49fd-89da-e1b2b7bb971b)(content(Whitespace\" \
          \"))))(Tile((id \
          4f5b3828-9d6c-4d93-9792-fd0e497fbf15)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7e8a546a-50d2-47f3-b683-055ac48c6f8d)(content(Whitespace\" \
+         536b5208-3ea3-4d5b-a7a9-c1f797154f00)(content(Whitespace\" \
          \"))))(Tile((id caec708f-041d-45f1-a606-b48d34d0f823)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          6589a9cd-3e28-4c21-8f6e-c021f30c18f5)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         f922a67d-dc4d-40c0-bcef-817c0ce6817c)(content(Whitespace\" \
+         6db3882e-7f19-4161-a4f7-0a179ce87f7d)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4aa45b07-6ac6-49ba-a046-951737d18549)(content(Whitespace\" \
+         415d4521-944b-456b-879d-e81984cbcfac)(content(Whitespace\" \
          \"))))(Projector((id 48b5e7ef-76d0-41d7-824b-7a36821a860c)(kind \
          Fold)(syntax(Tile((id \
          eaf98bb5-d077-4a07-9c74-b7669b694209)(label(\"(\"\")\"))(mold((out \
@@ -365,35 +396,42 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          557e10b8-fc2e-4804-aa00-bba17a77766c)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         c3e31f04-934e-433d-ad1c-488b5e2770bc)(content(Whitespace\" \
+         a565a251-b940-4194-a30b-9206c77f4ed9)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         539bd7ed-b786-4c69-81dd-b66ddeb19958)(content(Whitespace\"\\n\"))))(Tile((id \
+         fbf46104-8bd4-4f01-809d-66ae2f73d33c)(content(Whitespace\"\\n\"))))(Tile((id \
          e1b162c5-471a-4e98-ac89-9c74f414464f)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         2dd1daff-b8af-47ad-8a9b-93f6df907727)(content(Whitespace\" \
+         778e3bea-9164-4f40-9196-42800de2a92b)(content(Whitespace\" \
          \"))))(Tile((id \
-         511e29b6-278d-4d46-a18a-f9026f6ee3a4)(label(requires))(mold((out \
+         511e29b6-278d-4d46-a18a-f9026f6ee3a4)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0cb68270-4013-44cc-8574-e2fbe1bb6215)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         bb69f5d4-45dd-4355-90de-5d92abe78700)(content(Whitespace\" \
+         \"))))(Tile((id \
          46d517bd-d794-415b-a1b4-20ab6a3c29dc)(label([]))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         0383facd-dc37-417a-938a-ff4a70b0e6c1)(content(Whitespace\" \
+         1dee1627-520e-4d89-8b27-ef398bda8a16)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1c8b9fa0-e4f0-43c7-bb52-fd1ca827a28b)(content(Whitespace\"\\n\"))))(Tile((id \
+         04c3a0ad-7c8a-48c7-a449-80a987a85fef)(content(Whitespace\"\\n\"))))(Tile((id \
          7781bba8-85c0-4500-a34a-c194d7ccb383)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         7bfa1b51-c809-4e8e-a51c-e2fc49bf8164)(content(Whitespace\" \
+         5e516bfd-45b2-437e-a9bf-ae1af9bf7607)(content(Whitespace\" \
          \"))))(Tile((id \
-         ca6ffe4d-774b-46ed-a6f7-ace2983d415f)(label(ensures))(mold((out \
+         ca6ffe4d-774b-46ed-a6f7-ace2983d415f)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         7540a93a-ddbf-4991-ad69-4085350d09d1)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         19d9c478-fb2c-4499-ad0f-97486da0babd)(content(Whitespace\"\\n\"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         bf19b6c9-ad23-43d2-9dba-4067b1cdb743)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         2554c75c-b6ef-4cb2-b580-bcc1b035e250)(content(Whitespace\" \
+         \"))))(Tile((id 7540a93a-ddbf-4991-ad69-4085350d09d1)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         222ee1b6-5197-4e7c-95d2-791f5f27a018)(content(Whitespace\"\\n\"))))(Tile((id \
          9b670724-2072-4cf7-bb85-cc4c142ccf1f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -422,7 +460,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          6f7ec455-47c0-4623-adb8-fced125c45c0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2aedbd83-2434-4d4b-bb97-f507aba51fa9)(content(Whitespace\"\\n\"))))(Tile((id \
+         c07cc124-4ee6-4879-b6ff-92ce1ba06195)(content(Whitespace\"\\n\"))))(Tile((id \
          13e17e11-4bf1-43ad-9582-fa0272b99032)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -450,7 +488,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dca6c614-524a-48fc-888e-48b098bad5e2)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e9eb7cef-2d05-4869-ba0f-f447a79ee770)(content(Whitespace\"\\n\"))))(Tile((id \
+         31dddd61-25d6-4d67-a135-104f92070780)(content(Whitespace\"\\n\"))))(Tile((id \
          ad7ad062-775d-4a1d-a5d2-52a5f7f78834)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -479,7 +517,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4b27fb05-6b51-4654-96f5-07341a700201)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b8c1bcb1-2d12-4142-a8d5-f904e63c6ac2)(content(Whitespace\"\\n\"))))(Tile((id \
+         bde3498c-2df5-40d6-a48e-cb8365591d36)(content(Whitespace\"\\n\"))))(Tile((id \
          e7ed94e0-0760-4688-a0b7-21bd7547431d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -508,17 +546,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d52278e2-a937-4790-bab2-573faab9b298)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c6be6eb0-bead-4567-bde0-4e4af13d467a)(content(Whitespace\"\\n\"))))(Tile((id \
+         7e2c7910-f724-4e61-91be-775cce74a296)(content(Whitespace\"\\n\"))))(Tile((id \
          75108c20-48e1-4c46-ae10-87862d87aa0b)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          dc0eb91b-c532-41eb-8f3c-1ca50b91d055)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         318ae203-21b2-4e7d-b2ab-eb2862086353)(content(Whitespace\" \
+         \"))))(Tile((id \
          49a7312b-0b86-47a4-82cc-d575f5f4daff)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         76399219-44c4-4a6a-b3b5-3e197d2db450)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         848806cc-2c64-4398-b6c7-bb3d51e1fb18)(content(Whitespace\" \
+         \"))))(Projector((id 76399219-44c4-4a6a-b3b5-3e197d2db450)(kind \
+         Checkbox)(syntax(Tile((id \
          44c4431f-a0b0-4679-90fd-1e21b613a577)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -528,66 +570,66 @@ let out : string * Haz3lcore.PersistentSegment.t =
          865d895e-4b87-4a1b-a067-f0566e6227b5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5bd26941-a076-4ed1-b89a-96e4e0078d9c)(content(Whitespace\" \
+         a395cf4e-6378-4cc5-baa8-a2a0e504deec)(content(Whitespace\" \
          \"))))(Tile((id \
          3c68a60c-e682-4a83-abba-a9d0e0a4a02e)(label(\"\\\"schema(t2) == \
          schema(r4)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         4d72e475-023f-4ce8-b55c-bcd9ad8f53ee)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         a593c94a-eb69-4bf9-b433-637612dcbb2d)(content(Whitespace\" \
+         6e956427-5826-44e7-85df-47c501243ec0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         7d59e872-6252-409e-8b03-9fc6aa2dc4f6)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         5a9d430f-f3e9-409d-b842-bdae85c0fabe)(content(Whitespace\"\\n\"))))(Tile((id \
+         b4bafbe7-a6e9-4cc5-9ba8-87a57309a4b2)(content(Whitespace\"\\n\"))))(Tile((id \
          2043025d-9579-449e-a875-bcdb58c6743c)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         0a551658-29d0-41cc-8b3b-176a78faef40)(content(Whitespace\" \
+         0cd91555-1332-44be-b619-0630d7c07a99)(content(Whitespace\" \
          \"))))(Tile((id \
          e26cad38-7878-40d7-a539-aaa038bbd8ab)(label(select_many))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         7d7582dd-c45a-41d4-a19f-b189e607b4e6)(content(Whitespace\" \
+         f68dd730-6405-476b-84af-38d69bef5c9e)(content(Whitespace\" \
          \"))))(Tile((id \
          075bb8f5-4e2c-4cbb-9908-97ce73a4c4ee)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         39b29a49-7529-449a-8190-efb6b4e70288)(content(Whitespace\" \
+         67a18432-e2cc-411e-b739-959c4dd53f9c)(content(Whitespace\" \
          \"))))(Tile((id 91752ad0-15c0-421e-8a5d-86d156eb9170)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         a42232fc-9bba-4987-904c-584d3d2d32bd)(content(Whitespace\" \
+         218cd69e-2a4f-4c0e-8694-44797e8224d3)(content(Whitespace\" \
          \"))))(Tile((id \
          56335cfc-174a-4893-9a79-4c2a76897706)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         ecd8b81d-a7e9-4a76-b427-101f982584e1)(content(Whitespace\" \
+         78be0ddd-f40c-46b6-aa31-50a3ed00f019)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         c8704723-8dcb-48e5-ba9d-4e0d2e6b15b3)(content(Whitespace\" \
+         f161d403-6340-48e0-8430-152909dd6810)(content(Whitespace\" \
          \"))))(Tile((id 2dd707f5-fe45-402d-920a-7ecca657e0b4)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         a839f843-2b97-4bf6-9adb-9cf7558bbb01)(content(Whitespace\" \
+         e9633717-378c-4aff-9aa7-d5264f321548)(content(Whitespace\" \
          \"))))(Tile((id \
          d19a819c-dfd8-4e81-98bd-7c904ed3be85)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         b51b76ae-08e5-44a8-8bf2-330cb6de5ff4)(content(Whitespace\" \
+         6e23810e-2fd8-4beb-ad84-45408fde4240)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         ebd99340-7f9f-4337-8e3b-61c1662d6c1a)(content(Whitespace\" \
+         4446472b-1ea3-44fe-ad6a-3936cdf484bf)(content(Whitespace\" \
          \"))))(Tile((id 2e496f18-5faf-4b1a-a4e7-83f7dde478b3)(label(poly \
          ->))(mold((out Typ)(in_(TPat))(nibs(((shape Convex)(sort \
          Typ))((shape(Concave 37))(sort Typ))))))(shards(0 \
          1))(children(((Secondary((id \
-         c6626e49-4aca-4fe2-af67-d784aa303265)(content(Whitespace\" \
+         f43e86d4-94e5-40e6-9bcf-2ad2cf6b3b5e)(content(Whitespace\" \
          \"))))(Tile((id \
          8718f49b-a74d-4136-a494-aac20c587773)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         a5ff3b6e-dcf8-47ef-bc24-55dfac00e5b0)(content(Whitespace\" \
+         1dfe7bb9-8b37-4ef3-9202-3ab09d5e9209)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6bbb6917-9744-431c-95d8-ea88e4f51417)(content(Whitespace\" \
+         8c726843-e5b0-448f-a043-696a76f187d7)(content(Whitespace\" \
          \"))))(Tile((id \
          192c0cca-234e-4b31-b655-5d3c0e0a6999)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -601,7 +643,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2821d4b6-2568-4eca-9531-35d7a6ff4223)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c0e9887f-cd30-482c-b7d9-7e5ed959a5f5)(content(Whitespace\" \
+         b2bcc8f2-f689-4b0c-9c1c-573e9ef07c71)(content(Whitespace\" \
          \"))))(Tile((id \
          075e9919-42e7-4305-af4d-5f23b9a3b5ed)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -611,16 +653,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          2896264f-c790-4fba-a548-5d249d6c8535)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         a39023b9-584f-4408-8ff9-0120814c5cf2)(content(Whitespace\" \
+         \"))))(Tile((id \
          6420c4bd-3686-4f25-98d9-b19f211b94ed)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e068d59d-f32a-48c9-9045-de6a3afc7f10)(content(Whitespace\" \
+         4ed67bfa-f702-462d-987e-1eea76c78fcf)(content(Whitespace\" \
          \"))))(Tile((id \
          dbef1416-4a84-4efa-a0ca-b633a692a8d6)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         53dbb8b9-9c2f-42f8-988a-48c7dd35bce6)(content(Whitespace\" \
+         8a1d138a-aec8-42cd-a065-b24ab56e5118)(content(Whitespace\" \
          \"))))(Tile((id e887d67e-84f7-4539-8ef3-9c7f6a1786fd)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -630,7 +674,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0f65f5b9-c2cd-4323-85f9-3abfbf8e7c2a)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         7c5ab7ec-4d80-4b05-930e-8ea01f477081)(content(Whitespace\" \
+         f16ff4c8-a4a9-46fc-8b3f-21732d81475a)(content(Whitespace\" \
          \"))))(Tile((id \
          e33aa8d4-a1f2-42b1-9092-79faeb22c1e3)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
@@ -640,101 +684,108 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          1decd7e7-fba0-4537-8ac9-76c1b0c71e27)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f9c67411-75a1-4d44-9a6f-e98a4d14b6be)(content(Whitespace\" \
+         \"))))(Tile((id \
          d218cbf2-7311-4f84-ab67-1ccd8ef0d4d2)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         93813cd8-7070-4314-ae1b-febe50bd0ede)(content(Whitespace\" \
+         d0ac6d34-5ba2-4d55-b27c-0ccb65630792)(content(Whitespace\" \
          \"))))(Tile((id \
          241f1936-c475-4c0f-8df6-f0f6bb7cc731)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9fd66de7-31aa-427d-98c5-28e66bc715b0)(content(Whitespace\" \
+         99bfb3f4-9f7f-444a-9e01-d8795cccb232)(content(Whitespace\" \
          \"))))(Tile((id \
          8492b9c3-b40d-42ec-8769-6715671b98ec)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1d7bc52a-d424-48ea-960e-0b1fcfca6e36)(content(Whitespace\" \
+         4bb9b1b9-7aab-42c1-8017-c2f89487983b)(content(Whitespace\" \
          \"))))(Tile((id \
          0f3c2f93-7ef5-4afc-ad43-5a10ddaf7146)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         0f6c63d0-26a0-4aac-9e7e-c694d0d1ed5e)(content(Whitespace\" \
+         43f4840c-54de-4733-8e74-9552eb0c86b9)(content(Whitespace\" \
          \"))))(Tile((id 83d0f257-a2c9-49e7-b963-b9b77c91d468)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          fed2ec71-6c92-4c41-962b-d560e34196da)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         5518f811-0a8f-4c9c-9877-3320f35ae411)(content(Whitespace\" \
+         a0fd4bbd-284d-41a6-b6a4-08ec0be4286e)(content(Whitespace\" \
          \")))))((Secondary((id \
-         177cf3e8-6af3-44ed-bca3-e81f819e953b)(content(Whitespace\"\\n\"))))(Tile((id \
+         f6a689da-f546-481b-9283-8fdf068b6e02)(content(Whitespace\"\\n\"))))(Tile((id \
          8443bf5f-635d-4db6-9ea0-7769c744e4b2)(label(typfun ->))(mold((out \
          Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         43d908cb-fc88-4eb3-9c05-eeb04436c386)(content(Whitespace\" \
+         fe8647f6-b3fe-48f3-86a7-86f852165b71)(content(Whitespace\" \
          \"))))(Tile((id \
          c7146f41-94ba-4d27-b002-3cde4b7ba993)(label(r1))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         1556af2b-5c27-46bb-a572-385f72f6547b)(content(Whitespace\" \
+         49af4e6c-5980-4b1d-a037-f737108e1853)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         bd727c8d-559f-412e-abe4-66640e1a0b75)(content(Whitespace\" \
-         \"))))(Tile((id b85184ea-868e-4e3a-a560-ed454871779e)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ca07d6a5-680e-4a35-a8b3-f6f19c2fe9ec)(content(Whitespace\" \
+         88598d47-8fd7-488b-bb5e-87ca590625ed)(content(Whitespace\"\\n\"))))(Tile((id \
+         b85184ea-868e-4e3a-a560-ed454871779e)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ea66a170-2d7c-4347-813d-d729357481ae)(content(Whitespace\" \
          \"))))(Tile((id \
          bcb13dc0-bdad-4b2e-bc3f-e42f82ce6c6d)(label(r2))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         f75013b2-4954-4997-90fe-4a40c778163b)(content(Whitespace\" \
+         f0f00a9a-8872-4b68-a988-cf8a5020c337)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6cf4bc51-d62b-47b2-874a-cb409ba3d8be)(content(Whitespace\" \
-         \"))))(Tile((id 7e0388cf-1ab3-4a6c-ba39-f00e85a39f2d)(label(typfun \
-         ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         1ed5c679-acf1-488f-bb16-5da4cb9ca261)(content(Whitespace\" \
+         f59e45bb-e74f-4dd4-b327-60e720daf4bb)(content(Whitespace\"\\n\"))))(Tile((id \
+         7e0388cf-1ab3-4a6c-ba39-f00e85a39f2d)(label(typfun ->))(mold((out \
+         Exp)(in_(TPat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         e34b9a34-9d05-4923-ac02-6d7353ab21b5)(content(Whitespace\" \
          \"))))(Tile((id \
          a4b56a87-099a-42cb-b6fe-7f53ae0fb192)(label(r3))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         5fa3edc4-d43f-43fa-9b21-e70815543126)(content(Whitespace\" \
+         97a65c60-e79b-466e-823e-1b525cdaf12f)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         20ae10d3-7e8c-4bd8-bfd5-228de57023d1)(content(Whitespace\"\\n\"))))(Tile((id \
+         46514baa-595d-436c-9b5e-653b76639d05)(content(Whitespace\"\\n\"))))(Tile((id \
          9a0f30b4-a07b-45ac-9626-955a4f06acaa)(label(fun ->))(mold((out \
          Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         ddc86df7-7ec8-475f-a4e3-b52cdb3f20a2)(content(Whitespace\" \
+         9e44c474-c7ef-46f3-94e6-1bb6cf3b4e0d)(content(Whitespace\" \
          \"))))(Tile((id \
          caef6636-5887-43b7-b988-e6486ac19a9b)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          eb039f6a-dcd5-4927-bca2-e54bfcbbe254)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         9ef325ae-2ecb-4b83-88fc-c2054aa90e2b)(content(Whitespace\" \
+         \"))))(Tile((id \
          4454fa8a-44a2-403f-827b-e3b733b38227)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         61dd1984-622b-407c-ac06-7350a9812044)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c9600d9d-7b98-4d29-8e48-f0b39fdc861c)(content(Whitespace\" \
+         \"))))(Tile((id 61dd1984-622b-407c-ac06-7350a9812044)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          7cb3a2af-e84c-40a6-ac6a-e9acc6bca40d)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          96503c65-2e03-4123-b935-6ec194162d15)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         b3896891-f0d7-474c-859e-2eeda90dc368)(content(Whitespace\" \
+         7bf4eabd-ce1a-4fb8-8ac4-6200a107779b)(content(Whitespace\" \
          \"))))(Tile((id \
          dfe93add-43d9-4d1a-a1c7-f83cc82d5019)(label(project))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6fc8095d-477a-4b60-b2ec-674d6f410c96)(content(Whitespace\" \
+         \"))))(Tile((id \
          55d61a14-cba8-4d0b-870f-f622cc3e5650)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         5c1f6731-a522-4d34-93a4-6d7b5d18c635)(content(Whitespace\" \
+         \"))))(Tile((id \
          979289f2-0622-4fc6-88f0-e9e651a2369a)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
@@ -746,16 +797,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          cb3c5a47-0091-4de4-a3e1-d633c5424d77)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9e19c6f8-4106-4b39-b0d7-3de1f682d2d1)(content(Whitespace\" \
+         \"))))(Tile((id \
          fe7ff6d7-8d17-4dae-9450-0ba2dde10599)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         28cbc4a1-190b-4f45-8433-16f9d3b862d9)(content(Whitespace\" \
+         d76f4b28-2345-4387-85b8-ea297f0dc0f0)(content(Whitespace\" \
          \"))))(Tile((id \
          75f27514-8ea3-4013-9e27-2e2b5d625b91)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         b3d2e5b5-1de8-4ab7-860b-d630e0a3743c)(content(Whitespace\" \
+         88a7a3da-e468-46cf-b506-59f507f55cbc)(content(Whitespace\" \
          \"))))(Tile((id 5848d782-3cb6-430e-b21e-cb4706c89724)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -765,14 +818,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3bef114e-d9ed-4344-a8ce-f9ab2d5a8061)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         a4dd1396-7e9a-44f2-88fa-ffdf224a8da8)(content(Whitespace\" \
+         9b059ba5-8ac1-480c-a420-97a19df4aca4)(content(Whitespace\" \
          \"))))(Tile((id \
          9aa01d99-42a5-4d1a-81a1-6b4de44afbbd)(label(result))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         4e01b52b-b309-49ec-8c9a-dd65ea6d8d28)(content(Whitespace\" \
+         \"))))(Tile((id \
          336be2e1-1f74-493d-98cb-dce37a2004b8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         981fd73f-5d2f-45db-b0bc-cdf8aaef7723)(content(Whitespace\" \
+         \"))))(Tile((id \
          362f8334-7c0a-4b2f-933f-972333b1c9a5)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
@@ -784,23 +841,25 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          467bc077-5e55-432c-867a-1f7af4f12442)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         47cddc89-1dda-4325-9d76-29594c47df63)(content(Whitespace\" \
+         \"))))(Tile((id \
          f8f9eef6-a7b5-450b-9583-a0363e2f7739)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7a012f3f-de86-4233-a7c2-5198a776056b)(content(Whitespace\" \
+         8f9aaa68-723f-48c9-a7ab-8cf2616f9ae0)(content(Whitespace\" \
          \"))))(Tile((id \
          95241c7f-0f1e-476b-9724-17db2d196cd4)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         a1c70522-bac2-4179-91e0-c96cfbeb71b3)(content(Whitespace\" \
+         55a4bc21-582b-4195-8bca-5b9728c9eb17)(content(Whitespace\" \
          \"))))(Tile((id \
          5241449c-8c0f-4cc8-84cf-6cea327b9a72)(label(r3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         92edda2d-cb55-4264-b47c-9535d17f73b3)(content(Whitespace\" \
+         8565c1ae-1435-4027-bcbd-f066d0b94d3b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         461126d8-66ee-4373-aaad-1272f223a5ac)(content(Whitespace\"\\n\"))))(Tile((id \
+         48186c5d-e172-466f-85c9-831dd1068aa1)(content(Whitespace\"\\n\"))))(Tile((id \
          2b7776cd-e163-4f35-9ef2-5efb01c97a20)(label(enumerate))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -810,11 +869,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8edf8b49-3a67-432b-b7e8-9b52163e1f44)(label(t1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3b36ae04-0a30-4a16-adc8-f3104b0cd085)(content(Whitespace\"\\n\"))))(Tile((id \
+         ed0ffc69-51b0-40de-b69f-f0e15a78b65c)(content(Whitespace\" \
+         \"))))(Tile((id \
          3437cbc3-171a-4c83-b5e9-d4bab0626269)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         85146f2a-9902-4371-9a66-1e505e6c179e)(content(Whitespace\" \
+         6aaa44a2-5e8f-4107-abc9-80ee86d5f95d)(content(Whitespace\" \
          \"))))(Tile((id \
          0c72ebf6-5b5d-4d98-aedd-4e0281122dd6)(label(flat_map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -828,12 +888,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          eb9609be-0543-44ef-8112-e7301804ea6e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4175d510-7263-4c66-aa3a-62377a8283aa)(content(Whitespace\" \
+         3cfaa8f4-282a-4e6b-bd24-7921b6c96e12)(content(Whitespace\" \
          \"))))(Tile((id 030afa6c-10be-4fcf-92cd-fd7a4b2c19e2)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         a661e094-e58e-46b2-bd9c-46b8011a77d2)(content(Whitespace\" \
+         3a32b1fb-acd4-48b1-a51f-3c8e40862077)(content(Whitespace\" \
          \"))))(Tile((id \
          1e2ac2b3-161e-4bb0-b3c3-9abc01275add)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -843,13 +903,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          c89a553f-da54-4013-a945-e12e6330289e)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         97a9d3b4-dabe-42a6-9ecb-b641bd4e2fcd)(content(Whitespace\" \
+         \"))))(Tile((id \
          c0ba537f-0f45-4008-b6d9-96141eb653f9)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))))))(Tile((id \
+         Pat))))))(shards(0))(children()))))))))(Secondary((id \
+         6e8e97c4-4e09-421f-880e-27e664b2d185)(content(Whitespace\" \
+         \"))))(Tile((id \
          9ab68ec9-cc43-491b-97bb-431a740e7d96)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         f1bad987-6d16-4954-9a8d-c00eb6726833)(content(Whitespace\" \
+         \"))))(Tile((id \
          4db42198-228c-496f-ac2e-8ba6cf7cc592)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
@@ -858,13 +924,16 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0))(children())))(Tile((id \
          9d5f6465-1eaf-4437-9466-7d1c0cf195bc)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
-         44))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         179301d6-cff9-4db0-bce2-4b49635fd22a)(content(Whitespace\" \
+         \"))))(Tile((id \
          2e8c2c2b-7417-4396-8114-62fa7fbea9d3)(label(r1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         7df4b441-913f-458f-a69e-30d9ddb6ff53)(content(Whitespace\" \
+         5461d3f5-0f4b-4087-bac0-d776ffef1215)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         df116189-7a9c-4185-86c9-206f28f69338)(content(Whitespace\"\\n\"))))(Tile((id \
+         3888fafc-2012-4b71-b605-df8dc50a25a2)(content(Whitespace\" \
+         \"))))(Tile((id \
          31b3b21f-d6cc-4643-b15e-dc47d353c08d)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -889,25 +958,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          32a950d5-c42e-4dec-b7c0-9ee2deee15b8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fe7523d2-4595-4dc9-a183-a201bbe4f98b)(content(Whitespace\" \
+         f4fdacf8-68f5-4f14-bfd9-ebe994c2a56e)(content(Whitespace\" \
          \"))))(Tile((id 9187726b-7248-43bf-8265-0582efeac30c)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         5b4c87c1-6f1b-42aa-9edf-c5ad8a1184c2)(content(Whitespace\" \
+         541ed6e5-a160-47f3-b0f7-d9c3f3baf579)(content(Whitespace\" \
          \"))))(Tile((id \
          581abea9-be0f-4a87-8512-879b7e287181)(label(r2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         701cabfc-3e6d-41f8-a2c5-ccc13894b13d)(content(Whitespace\" \
+         \"))))(Tile((id \
          7da08faa-49e9-42fc-8d92-bfe4c3ea3bb0)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         46ddd0bd-b53d-4d2f-9ac2-a1aa3d1b11f0)(content(Whitespace\" \
+         \"))))(Tile((id \
          515851ad-7c73-4c63-8347-15bcce753ed4)(label(r2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         d8839e1a-f73a-4512-a527-4866eeced44a)(content(Whitespace\" \
+         36accabe-9b14-485a-826b-e5837084f026)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         42a9804c-475f-4b58-a917-1e78d75ed154)(content(Whitespace\" \
+         e56ef3f3-0b2b-451b-8b86-7cd8e957632d)(content(Whitespace\" \
          \"))))(Tile((id \
          5c6a19fc-ae2f-48f1-a304-fd010e1eae5e)(label(result))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -920,16 +993,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children())))(Tile((id \
          e02a9dbb-ed36-4b11-a1bc-77fa6727571a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
-         44))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ab0b7bca-f7bf-4f31-a21f-60f5fcee1fcd)(content(Whitespace\" \
+         \"))))(Tile((id \
          b0f1a849-e2ec-4fe1-a9f8-819aa7101d79)(label(r2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))))))))))))(Secondary((id \
-         989adb30-53c9-4cf3-89b5-99ad3e35c9ac)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         3a868499-b1d9-4783-8ca1-7213ca62ce6d)(content(Whitespace\"\\n\"))))(Tile((id \
+         52397d0f-69fb-4284-a084-58b22d87074d)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         5485ecaa-dad3-4ca3-aac4-1b76025b943a)(content(Whitespace\"\\n\"))))(Tile((id \
          a8668733-d0ca-4041-aca9-b62166c98391)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         988bca07-a9d8-438c-8ef0-71a7acd250fe)(content(Whitespace\"\\n\"))))(Tile((id \
+         3dc7ef70-c94c-4ed4-8414-f2aac99f64ac)(content(Whitespace\"\\n\"))))(Tile((id \
          0ed6016a-0fcb-4fd6-a914-3b4a10040a48)(label(select_many))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -953,28 +1029,32 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          74e0f00f-0504-470d-89a6-aab5bd708722)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         098c94bd-449e-4c77-af66-44442e5efbd8)(content(Whitespace\" \
+         \"))))(Tile((id \
          9636997e-12ca-4055-854d-6ea2018ce4f1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         0074bec0-cb17-4b00-afc2-e84a21428c62)(content(Whitespace\" \
+         \"))))(Tile((id \
          c5edba54-8890-449c-b151-a31e2bce4c6c)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Tile((id \
          7dd1dc13-b41d-4e71-b0ca-1a8106c47786)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape(Concave 23))(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         574b4fc8-8e62-4ad6-b5c6-6f94d0642f9f)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          d04c85ca-c311-4bb4-a2cb-adeb298ae76d)(label(gradebook))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          18bb3db5-b048-49b9-ae32-3b0da2bcd83e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d60e7a7b-2ae0-4cc9-86c2-e30dc4672483)(content(Whitespace\"\\n\"))))(Tile((id \
-         f01faa2a-6b26-4a9b-99d0-8ff187200eaa)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         a0b3c2ae-e38d-4c97-8003-69f5839027bd)(content(Whitespace\" \
+         23ff2996-01be-47da-8e47-c36ff6fd1d54)(content(Whitespace\" \
+         \"))))(Tile((id f01faa2a-6b26-4a9b-99d0-8ff187200eaa)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         2ef75066-a387-4e9e-a4d2-8534788d7d4a)(content(Whitespace\" \
          \"))))(Tile((id \
          7951bed0-13bb-4724-8342-6960189b3741)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -984,64 +1064,68 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Pat))))))(shards(0))(children())))(Tile((id \
          b909d5b4-9129-4624-a230-3c16b766b8a0)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         a4a64d8c-01f6-4ccf-9917-08e8b073e937)(content(Whitespace\" \
+         \"))))(Tile((id \
          a30ec91a-a278-4877-a5cb-5ff34c42d842)(label(i))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         c857716d-d515-49f4-a8da-db4e2e011e58)(content(Whitespace\" \
+         a1500dc8-b910-4d1a-89b7-97c7d61c3257)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         8c8e01c6-ef11-46be-9827-68c4e0c5484f)(content(Whitespace\"\\n\"))))(Tile((id \
-         54117a6c-7e82-43db-a557-85d8ea359b22)(label(if then else))(mold((out \
-         Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         36))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         897a1ce0-e5c2-4138-a5a8-c31685a65ddc)(content(Whitespace\" \
+         75d22286-58f9-44bb-bf37-ea461f48e5ef)(content(Whitespace\" \
+         \"))))(Tile((id 54117a6c-7e82-43db-a557-85d8ea359b22)(label(if then \
+         else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
+         2))(children(((Secondary((id \
+         3466ca06-a195-4fb0-9c13-68b5e774363e)(content(Whitespace\" \
          \"))))(Tile((id \
          71ccf489-0441-4f27-a30a-df2a950e4ae4)(label(i))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         199f7c84-7910-43fa-93d8-0b45e0ea654c)(content(Whitespace\" \
+         a7b5571a-cc37-496e-a77c-2882cccd0488)(content(Whitespace\" \
          \"))))(Tile((id \
          46040f19-6bf4-411b-9b72-1bbdabe55984)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3f95fa47-986d-41c4-b1c4-eae6188bcc42)(content(Whitespace\" \
+         94da7a82-3504-42cd-82cd-7851b7af9ee1)(content(Whitespace\" \
          \"))))(Tile((id \
          8b2898a1-4417-4316-8add-efa69205d5a0)(label(0))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         616ec88e-88cb-4081-b39e-c5b004b0542d)(content(Whitespace\" \
+         f7a0c848-80b0-4b0a-9988-9d45dd283d59)(content(Whitespace\" \
          \")))))((Secondary((id \
-         55869f53-b6f2-46e0-831d-2c17eac7932a)(content(Whitespace\" \
+         e5b571f0-85d5-446b-83d5-54aefe1b491a)(content(Whitespace\" \
          \"))))(Tile((id 3f586ef7-eade-4026-a1d1-17857ade2d9a)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          0e35cf8b-6d2f-4b04-8d04-4a3def2912da)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         9566af20-8726-46aa-8829-8f34ff82ec6f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         d7e9c432-2e74-4822-bb04-56cc5fb3b835)(content(Whitespace\" \
+         1d06fa09-918b-4a0f-a601-14af6f38a88c)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         074cd230-498b-4070-af5d-ce42d0f28862)(content(Whitespace\" \
          \"))))(Tile((id 1f1f1896-356d-45e5-8053-136bdbdd237b)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         d30f2604-226c-4979-9c5d-e9ee30eeeb2d)(content(Whitespace\" \
+         0c506829-4833-44ab-bac8-5223058d9fa4)(content(Whitespace\" \
          \"))))(Tile((id \
          6907ab9e-01de-495d-aa30-e74e5692e0e8)(label(i))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         e0bcad1c-06cb-465b-bf6c-54429b98c487)(content(Whitespace\" \
+         27d27ac4-6a2b-4c2d-a52b-f22e5d0723da)(content(Whitespace\" \
          \"))))(Tile((id \
          666492f8-2c6c-47f1-953d-a291fec3f61e)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9a9a9fcc-72e5-4420-a74a-30eea8c80387)(content(Whitespace\" \
+         9003a67c-8917-4919-9c95-b3fcd2e7b1ff)(content(Whitespace\" \
          \"))))(Tile((id \
          f913643e-b104-4c52-b8de-b4b5a7764b21)(label(1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         6e92bd5e-34e4-43d7-97f4-5af63e7cdf9c)(content(Whitespace\" \
+         c1300ce1-a624-4bb5-8fcd-0ae0ebe3ce22)(content(Whitespace\" \
          \")))))((Secondary((id \
-         98414260-0419-4787-9ceb-6a0af3a6e570)(content(Whitespace\" \
+         011f0ba3-aa59-4fec-a7a6-0b464dbb52b7)(content(Whitespace\" \
          \"))))(Tile((id 3116bd2a-d5c6-4394-a0b8-eb2a5d029224)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1051,13 +1135,14 @@ let out : string * Haz3lcore.PersistentSegment.t =
          3609d6f0-b8c2-4b33-a121-92d812476ea6)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a588b1cf-069f-48d2-a01e-04ffc3126d2c)(content(Whitespace\" \
+         7d0e73eb-e560-4002-bade-229a04a805ab)(content(Whitespace\" \
          \"))))(Tile((id \
          ec39135f-16e6-4ae4-928b-ededaa4b4a85)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         93a18715-ce45-481b-b5e1-3a30787b0b78)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         4eee9ab1-fcc0-4473-8455-2c0ed66f6ba3)(content(Whitespace\" \
+         836ca930-25c8-4641-8502-c0082f7f1086)(content(Whitespace\" \
+         \")))))))))(Secondary((id \
+         8c8e0d5b-4bef-45bd-b2d4-f35af033a2e1)(content(Whitespace\" \
          \"))))(Tile((id 706d3595-4efe-4735-9ec3-b6e0b29cbf47)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1067,7 +1152,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f55f45fd-3a42-4027-b6f2-aed0a559f8ce)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         097752bf-be6e-4644-a652-af65b68a0e44)(content(Whitespace\" \
+         4572c9e4-f9f4-4189-b1f2-79ac65f5ea17)(content(Whitespace\" \
          \"))))(Tile((id \
          439cae70-0f68-4348-ab94-4393aefa7182)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1075,7 +1160,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e595b0f2-ba16-4ee5-b49b-982edef6ac1d)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         33e3c036-95fc-41f9-9416-cbe89375967b)(content(Whitespace\" \
+         bfd68d0a-4624-4184-a415-dc4801694851)(content(Whitespace\" \
          \"))))(Tile((id \
          abd201bf-4ff7-4302-8950-281ee104d5bb)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1083,37 +1168,44 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0e6672ca-48e8-423b-9e64-598ce31bc914)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f04a5ed3-29c3-4430-8b92-84e076d6504a)(content(Whitespace\"\\n\"))))(Tile((id \
-         bce53d89-6863-498a-a398-c3388c979bee)(label(fun ->))(mold((out \
-         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
-         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         d4b810cf-5688-4401-9017-9d6417269a5e)(content(Whitespace\" \
+         3c014b57-4125-448a-aa85-67d48256cb1c)(content(Whitespace\" \
+         \"))))(Tile((id bce53d89-6863-498a-a398-c3388c979bee)(label(fun \
+         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
+         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
+         1))(children(((Secondary((id \
+         36fed1ed-97d2-4c85-921d-58333a1d3ed8)(content(Whitespace\" \
          \"))))(Tile((id \
          6c21e6da-47a4-4401-a0e6-6a8d62e5d181)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
-         a16ba6b9-ad1d-4c4f-9169-baf247296094)(label(r1))(mold((out \
+         a16ba6b9-ad1d-4c4f-9169-baf247296094)(label(_r1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Tile((id \
          871c2c9e-6af9-4abb-a879-e85e6a530477)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
-         44))(sort Pat))))))(shards(0))(children())))(Tile((id \
+         44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
+         c705a182-9747-4c10-a88f-f9fa531913a2)(content(Whitespace\" \
+         \"))))(Tile((id \
          afc3e4b2-2100-441a-bf18-4cfe185fa373)(label(r2))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children()))))))))(Secondary((id \
-         acab02c4-a769-4ba2-a7f1-1175e31faac1)(content(Whitespace\" \
+         75ba7fb1-2c7a-45a7-a0e6-b05b7c37994c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         46007542-01fb-47e2-988b-2e7df030bb88)(content(Whitespace\" \
+         6e0fc848-1605-4bd8-b65b-64049d02d3ea)(content(Whitespace\" \
          \"))))(Tile((id \
          d56a2880-920a-441a-a993-dab55930940e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          0942248f-fe9c-4257-b14d-bdc9c9166758)(label(midterm))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f065fa01-76b1-4ae1-b657-6e8a076866a0)(content(Whitespace\" \
+         \"))))(Tile((id \
          8a2d1467-5026-4271-bced-206731213c87)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a490dffc-81d6-4b43-9ba2-45d52bfb6a12)(content(Whitespace\" \
+         \"))))(Tile((id \
          32744d39-1f11-4e6f-84f6-621fb39c768f)(label(r2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1122,14 +1214,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          22))(sort Exp))))))(shards(0))(children())))(Tile((id \
          c823e1ab-126f-41db-847d-bfd618af2193)(label(midterm))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         fd137e85-74cf-4a58-a0c0-5620755d8eee)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         98dd2113-a9fc-4929-9cc3-33a4167177d5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         87a5e267-7812-4ca0-8573-51718fe2c0b1)(content(Whitespace\"\\n\"))))(Tile((id \
          c76a47ba-c53d-4aaa-95c4-d6da0cbc00c9)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8574ea49-982f-48fa-9fd7-822d2681102c)(content(Whitespace\" \
+         69d7ec3b-4be4-42af-a2ea-8e01f26ed0fb)(content(Whitespace\" \
          \"))))(Tile((id f0e4ecf3-df35-403a-98fc-2a141f2e7642)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1139,7 +1229,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aaf2549b-72b7-4083-bc79-46c8b1859a1a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e9334cd3-c6b4-41d4-9643-a0d9fdce2930)(content(Whitespace\" \
+         f50a417f-fb8a-4d47-91e2-8c480c647cf1)(content(Whitespace\" \
          \"))))(Tile((id \
          228393b8-7b12-45e5-b9ed-74784ea01b2e)(label(88))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1147,7 +1237,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          868e8f7a-bf27-4b5e-a475-c3f6059d636f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         42af2395-c288-4878-982d-dacaf8e887d8)(content(Whitespace\" \
+         ed453acc-3a23-4413-bbc8-f89485db9752)(content(Whitespace\" \
          \"))))(Tile((id \
          cfb7e530-f1cc-4ea6-a141-06edd287f841)(label(88))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1155,7 +1245,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b26606a4-a674-4865-b30c-7bf869f29a67)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         20ac6afd-afbe-4a7d-be79-8656a179eaca)(content(Whitespace\" \
+         3e8d29b1-6ab1-4808-9511-2ef693321831)(content(Whitespace\" \
          \"))))(Tile((id \
          90781bde-dc8b-4d62-8fdb-3b6f5b54d1b8)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1163,7 +1253,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9acc0572-dedc-4403-8c2a-d4cb4b9b3fdf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         33497969-5d1b-4261-89e7-20b09a1d7a88)(content(Whitespace\" \
+         ff0dc1f6-08e3-4568-aa82-12d2863dfd7d)(content(Whitespace\" \
          \"))))(Tile((id \
          67d0c8e1-0d1b-44e2-a27e-ac0e7573db17)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -1171,17 +1261,17 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d8091ba5-2c76-47cc-83cd-086b6cbb2fff)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         811b8b0d-9643-442a-881f-633b580f85f6)(content(Whitespace\" \
+         acc4892a-59eb-4827-a11c-bc678a2bec01)(content(Whitespace\" \
          \"))))(Tile((id \
          629d020b-82e8-4c48-b0bb-af29bfb32f06)(label(84))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         ac331a95-709c-4b22-bc79-bfc5fb8324e6)(content(Whitespace\" \
+         90915a85-038a-4cf1-abaf-14ea2fedb73a)(content(Whitespace\" \
          \"))))(Tile((id \
          8717df68-0156-4942-979b-cb5b4ef2a2fc)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         90e8aca1-7291-45f9-8a61-9717bd89d7c3)(content(Whitespace\" \
+         24dcfcf0-1ca7-47a0-ba51-4ac0b507709b)(content(Whitespace\" \
          \"))))(Tile((id df48fd4b-e186-4104-9e55-b4d58f061194)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
@@ -1190,48 +1280,48 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Typ))))))(shards(0 1))(children(((Tile((id \
          573bb8de-acea-4de8-9d6f-20cb353f7a95)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         468e7dae-8d97-481c-9d1d-e92ee55f4c02)(content(Whitespace\" \
+         \"))))(Tile((id \
          6ea0b510-4a5d-41b4-85a8-4fbbe8a4aa4c)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9e36a9f5-00b2-40ce-b083-2951040b9a8d)(content(Whitespace\" \
+         \"))))(Tile((id \
          9dc098e2-f56f-4496-99d1-42f6d383a827)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         a79a5a62-b44f-4470-a160-f80c833be0a0)(content(Whitespace\"\\n\"))))(Secondary((id \
-         221d0be1-801b-4f92-aeb5-ea7f3d915f87)(content(Whitespace\" \
+         e41b6ed3-68c7-489e-b7dd-ba72c74a7a7d)(content(Whitespace\" \
          \"))))))))))";
       backup_text =
-        "type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+        "type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = ^^fold([\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
          (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
          ]) in\n\
-         let requires=[] in\n\
-         let ensures=[\n\
+         let _requires = [] in\n\
+         let _ensures = [\n\
          (enforced=^^check(true), \"schema(r1) == schema(t1)\"),\n\
          (enforced=^^check(false), \"n is in range(nrows(t1))\"),\n\
          (enforced=^^check(true), \"schema(r2) == schema(t1)\"),\n\
          (enforced=^^check(true), \"schema(r3) == schema(t2)\"),\n\
-         (enforced=^^check(true), \"schema(t2) == schema(r4)\")\n\
+         (enforced = ^^check(true), \"schema(t2) == schema(r4)\")\n\
          ] in\n\
-         let select_many : poly r1 -> poly r2 -> poly r3 -> ([r1], (r1,Int) -> \
-         [r2], (r1,r2) -> r3) -> [r3] =\n\
-         typfun r1 -> typfun r2 -> typfun r3 ->\n\
-         fun (t1:[r1], project:((r1,Int) -> [r2]), result:((r1,r2) -> r3)) ->\n\
-         enumerate(t1)\n\
-         |> flat_map(_, fun (i,r):(Int,r1) ->\n\
-         map(project(r,i), fun r2:r2 -> result(r,r2)))\n\
-         in\n\
+         let select_many : poly r1 -> poly r2 -> poly r3 -> ([r1], (r1, Int) \
+         -> [r2], (r1, r2) -> r3) -> [r3] =\n\
+         typfun r1 ->\n\
+         typfun r2 ->\n\
+         typfun r3 ->\n\
+         fun (t1 : [r1], project : ((r1, Int) -> [r2]), result : ((r1, r2) -> \
+         r3)) ->\n\
+         enumerate(t1) |> flat_map(_, fun (i, r) : (Int, r1) -> \
+         map(project(r,i), fun r2 : r2 -> result(r, r2))) in\n\
          test\n\
-         select_many@<GradebookEntry>@<GradebookEntry>@<(midterm=Int)>(\n\
-         gradebook,\n\
-         fun (r,i) ->\n\
-         if i == 0 then [r]\n\
-         else if i == 1 then [r, r]\n\
-         else [r, r, r],\n\
-         fun (r1,r2) -> (midterm=r2.midterm)\n\
-         ) == [77, 88, 88, 84, 84, 84] : [(midterm=Int)]\n\
-        \ end";
+         select_many@<GradebookEntry>@<GradebookEntry>@<(midterm = \
+         Int)>(gradebook, fun (r, i) -> if i == 0 then [r] else if i == 1 then \
+         [r, r] else [r, r, r], fun (_r1, r2) -> (midterm = r2.midterm))\n\
+         == [77, 88, 88, 84, 84, 84] : [(midterm = Int)] end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiestransformColumn.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiestransformColumn.ml
@@ -1,87 +1,98 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Utilities / transformColumn",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id 68e42863-b4d5-4245-bf36-b795c62f2941)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         a3ae68ee-1ce6-4cec-aeb4-cc446ca60b27)(content(Whitespace\" \
+         c8959aff-eb1d-48da-9073-66bda7bf8103)(content(Whitespace\" \
          \"))))(Tile((id \
          f8ea3023-c7f7-4c54-b23d-15f4fffb5bd3)(label(Student))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         e4cfaf36-3c5b-4526-9975-c6933f897cfe)(content(Whitespace\" \
+         7b758de6-8b1f-4834-85c3-8306e83d893b)(content(Whitespace\" \
          \")))))((Secondary((id \
-         63bf73f9-ad0e-4c96-9c5a-185d4e1e2fe5)(content(Whitespace\" \
+         9b94b0fc-60c8-48c1-a939-8ad9b13601ba)(content(Whitespace\" \
          \"))))(Tile((id \
          0a713b60-56b5-43bf-ba49-22fc64f8587f)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          15a0c0b1-769a-49a6-b649-5d503bddc7d4)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         08c7dd23-ca8a-40fd-ae76-3aff3f99f186)(content(Whitespace\" \
+         \"))))(Tile((id \
          8692b567-1fa9-4ce0-84c1-00bb2dce8849)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c2205c94-9c9c-45aa-86fd-9d9966c96e98)(content(Whitespace\" \
+         \"))))(Tile((id \
          57f28fca-6611-47c9-b9df-6035ff803123)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          fd2f7940-e990-4d3d-b406-67410320b998)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         be031322-6905-47b3-b181-7c704553936a)(content(Whitespace\" \
+         125a6ede-29cf-4ce5-b37a-ab24d9499d02)(content(Whitespace\" \
          \"))))(Tile((id \
          1ab3b93c-939d-4b18-ab15-09a41f98d111)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         8f5c6462-037e-4b72-950a-91a36b3cbb5d)(content(Whitespace\" \
+         \"))))(Tile((id \
          afb06760-158a-40c2-ab9c-f2f4487cd36a)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         1b634c8f-c00a-436a-acb8-1328c3c3e626)(content(Whitespace\" \
+         \"))))(Tile((id \
          a8ababb0-3083-4d77-8cb9-0d4f9ed7fbfa)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          a890e0a0-b77d-4b24-9e0b-40e03d1d502d)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f076542a-d0f5-464b-b4d5-3f2a97ae7111)(content(Whitespace\" \
+         29cc72e6-d5f2-4b72-a499-6ba5dee4087f)(content(Whitespace\" \
          \"))))(Tile((id \
          61c4866a-011f-435d-b4bb-33939b49b219)(label(favorite_color))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         5e730636-38d2-4f3b-a7a4-451957702fd0)(content(Whitespace\" \
+         \"))))(Tile((id \
          e9955eea-7fc4-4ad7-8d5a-98587c658d84)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         3b132c01-fe6c-49dc-991b-f96a68734a7d)(content(Whitespace\" \
+         \"))))(Tile((id \
          0489f748-04a1-4c67-bd52-655838bc2afa)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         412003f6-1a7d-44f9-b292-3b20551c9941)(content(Whitespace\" \
+         9390953b-4fbf-4e02-aac2-2d624e460399)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1f50b935-4cf6-4dd9-bb0e-f79ab0b1fcbb)(content(Whitespace\"\\n\"))))(Tile((id \
+         3f27f8eb-984b-4699-b3ab-dee179293b91)(content(Whitespace\"\\n\"))))(Tile((id \
          a997df70-8e6c-4f86-8c66-879515f9f950)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c1271a84-3a71-4ee5-bdf8-32490f609df7)(content(Whitespace\" \
+         ac682cac-6ee9-4f9f-bce7-4ab5deae9cd9)(content(Whitespace\" \
          \"))))(Tile((id \
          1a1a7849-2721-4f98-9e71-5d0bfa1ab71f)(label(students))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         807077d0-c50b-4426-851d-e3af467c7088)(content(Whitespace\" \
+         04da04c9-d320-4c56-945d-0f0b684b5ce3)(content(Whitespace\" \
          \"))))(Tile((id \
          644326b4-ee33-465a-ac2a-b2014b6c0245)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         cd813d0b-15bf-425d-bc86-7fa73a7bd949)(content(Whitespace\" \
+         75003a6f-e062-4c4a-89fb-cd65f8955acf)(content(Whitespace\" \
          \"))))(Tile((id c53708d0-464d-4a14-bf8c-a54015a55a0d)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          b30fa48d-e9ca-4303-beb5-53db36414ef7)(label(Student))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         753c2070-5544-466d-81ff-79cef7cfd737)(content(Whitespace\" \
+         90b135d6-bcda-4589-86fc-29434cceeb03)(content(Whitespace\" \
          \")))))((Secondary((id \
-         05ebd873-06dd-48f6-b7c1-36d08ade5b92)(content(Whitespace\" \
+         ff8c6914-d9be-404d-9810-bf27d2a5ed10)(content(Whitespace\" \
          \"))))(Projector((id a78542e4-1ea2-4ef2-a95d-89f44d13a5df)(kind \
          Fold)(syntax(Tile((id \
          739db7fe-21bd-4b7e-b50b-0d1773ba7eb4)(label(\"(\"\")\"))(mold((out \
@@ -167,31 +178,38 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          fee0cd37-fb86-4cff-a078-1426d9c9a2e0)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         5af11cfb-5173-4b8e-b727-ed060ac58d84)(content(Whitespace\" \
+         c60f888d-c272-49f4-ae5a-33a76fc040c3)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         2dcee4ed-0b69-4db3-99d8-ecd226b11b8b)(content(Whitespace\"\\n\"))))(Secondary((id \
-         01283e0b-a882-4707-aca7-49efbfaa4f8b)(content(Whitespace\"\\n\"))))(Tile((id \
+         6e53cd20-6dc3-4293-a916-6076ab7cd215)(content(Whitespace\"\\n\"))))(Secondary((id \
+         38e156de-aef0-445a-a751-e7572ad08a1d)(content(Whitespace\"\\n\"))))(Tile((id \
          3d32eeef-b8c4-4cc9-9c3d-ef9b164c1184)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         db17db72-59cc-4599-a934-3ea3d07ae745)(content(Whitespace\" \
+         c68ed8b6-fc85-436a-9685-6010df0bdb83)(content(Whitespace\" \
          \"))))(Tile((id \
-         cad03cb9-351e-40bd-9ae9-bf905a1a658c)(label(requires))(mold((out \
+         cad03cb9-351e-40bd-9ae9-bf905a1a658c)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         0bfd99da-b8d1-480e-88f3-72cc40220aea)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         36b9a0df-92da-4d8b-87a8-9d2ba11c655b)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         7beb9b44-6fd1-4478-bf76-925b4cdfff20)(content(Whitespace\" \
+         \"))))(Tile((id 0bfd99da-b8d1-480e-88f3-72cc40220aea)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          3dc35018-dbe1-48a3-8d9d-e471a3d5e871)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          1e46b1ce-4273-4d5c-a803-564e5e08726b)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         692d8ccd-dffb-41a1-9684-dd50fe6fb278)(content(Whitespace\" \
+         \"))))(Tile((id \
          afb81da0-cff2-46f4-9170-0d5c5f949366)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         f5261743-da32-4c0f-8439-11f8fd307408)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d96fca70-6992-4598-be29-8c66f9ee00d7)(content(Whitespace\" \
+         \"))))(Projector((id f5261743-da32-4c0f-8439-11f8fd307408)(kind \
+         Checkbox)(syntax(Tile((id \
          2377d3cb-f0f0-490f-836d-55df6d24d232)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -201,26 +219,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d2564720-3ecf-482d-853a-c02af4c2e41b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         16d539f6-770c-4503-9a38-40149e1d27a4)(content(Whitespace\" \
+         8839bdfd-2dfd-4f64-83e8-0e2e4dc13605)(content(Whitespace\" \
          \"))))(Tile((id 332ccc24-84a3-4953-9cff-99f39a5d1666)(label(\"\\\"c \
          is in header(t1) \\\"\"))(mold((out Exp)(in_())(nibs(((shape \
          Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         0e2ebf60-c55e-44ca-8fb2-ca1fc933af70)(content(Whitespace\" \
+         b7ecdd44-85c2-4e64-8f8d-bda8c0ac4ec1)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         3de451f1-a7f9-4755-a5dc-c19c713daae0)(content(Whitespace\"\\n\"))))(Tile((id \
+         2be3ce15-2cfa-438b-afeb-ee1977c908c2)(content(Whitespace\"\\n\"))))(Tile((id \
          a1c27f5b-0e8f-4fca-a823-b906493dd70f)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         a73c5204-733c-4c81-bab6-bd867d158d92)(content(Whitespace\" \
+         d66c5ad4-24ea-4c1f-92c9-b7b12e43c72e)(content(Whitespace\" \
          \"))))(Tile((id \
-         dba2d49e-a988-4b49-a36c-0199e76bd422)(label(ensures))(mold((out \
+         dba2d49e-a988-4b49-a36c-0199e76bd422)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children()))))((Tile((id \
-         f27c5b36-f99c-4658-838a-35be90886889)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Secondary((id \
-         ac357e51-5c53-4b3e-b469-16e3dc116080)(content(Whitespace\"\\n\"))))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         6435e348-4687-4bdb-b2ec-4e3579f3a4dc)(content(Whitespace\" \
+         \")))))((Secondary((id \
+         0cffb763-6e8d-40d1-b665-08a8a58b3de8)(content(Whitespace\" \
+         \"))))(Tile((id f27c5b36-f99c-4658-838a-35be90886889)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         ce84d3dc-97b2-4aa4-9c59-42f43d84a25d)(content(Whitespace\"\\n\"))))(Tile((id \
          c1f27631-025b-4420-add4-bc804f55519a)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -248,7 +269,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          660040f0-bc80-43ac-8969-af26d01e9b87)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5c7efebc-ba3d-43e6-bb4a-29fec3f7f1ce)(content(Whitespace\"\\n\"))))(Tile((id \
+         210c878d-bc5e-47b8-a87b-32d19de98356)(content(Whitespace\"\\n\"))))(Tile((id \
          21c51900-7cea-48e0-9217-88eaf3974a50)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -277,7 +298,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1cd0ff19-02c2-448e-a49d-e876cc796733)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8418593e-ec54-45a6-9d22-a11122cc6046)(content(Whitespace\"\\n\"))))(Tile((id \
+         255901d7-f697-40d4-8c56-4856b6ece8d7)(content(Whitespace\"\\n\"))))(Tile((id \
          d8df1217-ce22-4325-900d-816aa2440db4)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -306,7 +327,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          0e40d47c-458d-425d-b445-efcd71ee631c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3bab0417-8b56-4b6a-8ab8-4b54b2782734)(content(Whitespace\"\\n\"))))(Tile((id \
+         5af774a4-7994-4ce1-ac99-c1080e709bbc)(content(Whitespace\"\\n\"))))(Tile((id \
          d88557b9-75a6-4391-99a3-e7341b6f81d0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -335,17 +356,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4ac03301-337f-4536-8e12-f0412d19cdbf)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         df7e1774-8be4-4f98-b0d7-d2f8f4785ebd)(content(Whitespace\"\\n\"))))(Tile((id \
+         ae08eb45-ed07-4cd8-90da-28bd235a345b)(content(Whitespace\"\\n\"))))(Tile((id \
          d3147523-a1af-4d5c-acfc-0ba35361ea88)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          7957bcbc-cc2e-44aa-9d67-ae77371332b2)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c1d6c7f6-f085-486c-89fa-b427e73006a5)(content(Whitespace\" \
+         \"))))(Tile((id \
          ab7bc5ff-4247-4e5c-a756-734c77c1b460)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         e7f0317f-db17-4243-929c-a73ecc4f8e17)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         39ede7ad-0622-4ea4-80f0-37aa3e880b2d)(content(Whitespace\" \
+         \"))))(Projector((id e7f0317f-db17-4243-929c-a73ecc4f8e17)(kind \
+         Checkbox)(syntax(Tile((id \
          bff19e19-55d1-4bba-9c05-751db080dfc1)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -355,92 +380,102 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b4c4a4b8-b66e-4b86-8b53-34d8d0ca4083)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c33d85cc-56cd-4a4e-820d-9d53bcb39f03)(content(Whitespace\" \
+         bbd4daa6-3ddf-43b6-a71c-66e569e3d0e1)(content(Whitespace\" \
          \"))))(Tile((id \
          c187753c-3ed5-4c75-98a2-c6c718dd2cd2)(label(\"\\\"nrows(t2) is equal \
          to nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         71947ee4-40bf-43a3-9ab3-70d89bdd1bc5)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         b1ccc4bd-f4a1-4194-bdd0-bd66f4921809)(content(Whitespace\" \
+         885385d8-83c8-421d-98d3-401296968338)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         a0ecb16f-5278-4622-a661-e8be79b5c88b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         1c0f89b0-851c-476a-b062-a41dbdc3da12)(content(Whitespace\"\\n\"))))(Tile((id \
+         2f2d3530-dfcf-4024-b843-32a97a59e4d3)(content(Whitespace\"\\n\"))))(Tile((id \
          4bd77294-2200-4913-8e58-00a91daabeee)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         c950cbe0-b3eb-44be-ae6b-c226d9f2c164)(content(Whitespace\" \
+         3728b742-03bd-40b6-84cc-549f0d2c9d90)(content(Whitespace\" \
          \"))))(Tile((id \
          c44806b3-c8a8-488c-9ab5-bb4cc691e504)(label(transform_column))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         9f8aa993-013c-40a6-816c-9bdcca1b0b87)(content(Whitespace\" \
+         d7fe315f-e0d2-40f5-b74c-72fb4f6afbca)(content(Whitespace\" \
          \")))))((Secondary((id \
-         7e685346-7753-4142-85bb-0b1abc6ea095)(content(Whitespace\" \
-         \"))))(Tile((id b9e66b51-dc32-4873-970e-2761712b3140)(label(fun \
-         ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
-         Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
-         1))(children(((Secondary((id \
-         ac192789-a1d8-4fe2-8909-d669dc1f2e2f)(content(Whitespace\" \
+         ced60d4c-3884-482d-818e-b757344fac18)(content(Whitespace\"\\n\"))))(Tile((id \
+         b9e66b51-dc32-4873-970e-2761712b3140)(label(fun ->))(mold((out \
+         Exp)(in_(Pat))(nibs(((shape Convex)(sort Exp))((shape(Concave \
+         37))(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         8241b939-a486-4721-a776-e9cf41362aa1)(content(Whitespace\" \
          \"))))(Tile((id \
          c91378b3-adec-4c8f-a3fc-6b65a2a6ab5c)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          f4ab7a98-8413-44db-822e-64cfe5ffa9be)(label(t))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         233ccaec-6292-4a40-8808-833bcde083e4)(content(Whitespace\" \
+         \"))))(Tile((id \
          1c4f3700-c753-40ed-9957-1e87849f7953)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         d05af610-e50d-4c27-b8ed-0ce3291cfae3)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         9b79d4cf-5a76-49b4-8908-a76f096059eb)(content(Whitespace\" \
+         \"))))(Tile((id d05af610-e50d-4c27-b8ed-0ce3291cfae3)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          be3bb2fb-8cdb-4c5d-a884-9b25e8642af5)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          1fd70654-26f4-478b-96c6-bdbb0bf227fb)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         6dd466f6-d338-4a7a-ac56-f9b89b95b144)(content(Whitespace\" \
+         289fbc8f-61c9-4c51-95ef-32517b183d76)(content(Whitespace\" \
          \"))))(Tile((id \
          bf397cf4-93e4-4093-b3c9-1423129e0290)(label(c))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         49faeca9-946f-46c5-b928-306f701427a0)(content(Whitespace\" \
+         \"))))(Tile((id \
          70d45339-81f1-4a08-b264-aa5e34e75fe1)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         e9cafefa-5e0b-4ffa-ae2e-366a9bcfe64b)(content(Whitespace\" \
+         \"))))(Tile((id \
          1015682d-26cc-44c9-85d9-a831de70d8ea)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          6b70e3ed-d027-4c78-a269-06faedf421ee)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         f63b807c-413b-4389-a292-f08b10a2ad5f)(content(Whitespace\" \
+         172a3a3d-175c-475a-a8b8-8df0afd519c8)(content(Whitespace\" \
          \"))))(Tile((id \
          be8b8e81-9f1b-472f-b3d1-3523016702cd)(label(f))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         0c5957e7-dedb-4c2e-95c1-26352d761180)(content(Whitespace\" \
+         \"))))(Tile((id \
          ee121246-94b2-4e79-a537-ffd54e775699)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         c2b1517c-1f16-42bb-8cc7-76f2da1cf708)(content(Whitespace\" \
+         \"))))(Tile((id \
          a60f77f7-0738-465c-add7-8c78591f9e51)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          fc7ac6e4-a91c-4406-a378-8f52ea1ba26b)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         d33b7721-6573-4162-924f-20d0ed9cae22)(content(Whitespace\" \
+         eda9bf4a-8cf4-4eb8-818e-555553f256ad)(content(Whitespace\" \
          \"))))(Tile((id \
          325dcf59-3dee-4578-9758-53fc35d8b53d)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f7865196-e579-4294-ae6a-0d605ca932d3)(content(Whitespace\" \
+         0993836b-57ed-4222-8854-39511c157bb3)(content(Whitespace\" \
          \"))))(Tile((id \
          a7458322-d4f3-4a9d-b8ab-92c20f645125)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         f8a9923c-03cf-4d08-a28d-1479fa0f4109)(content(Whitespace\" \
+         89e05650-35fa-45bb-894b-b25f4e8d85fa)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         e5321b56-200b-4617-a81f-07c408e4248c)(content(Whitespace\"\\n\"))))(Tile((id \
+         72e1b7e7-9aaf-4c29-98f2-4447a2997bd4)(content(Whitespace\"\\n\"))))(Tile((id \
          827f006d-f9ac-48e6-bfd2-1ec5c2aa7a6f)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -453,19 +488,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          d676ef29-9f68-4a00-b4ef-00cea3de86a8)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7ce06464-1f8d-4022-984d-3ac9f470f949)(content(Whitespace\" \
+         94cfd3c1-c35d-40ee-987b-a161d9ae90dd)(content(Whitespace\" \
          \"))))(Tile((id b1927cd4-0dc7-4b77-8d9a-1a0032a91685)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         901b532f-39a8-4cd7-85db-e4c03758dedc)(content(Whitespace\" \
+         e7b9d78d-133e-4b71-adca-0b7c487e2beb)(content(Whitespace\" \
          \"))))(Tile((id \
          2c7808f0-760a-480c-9789-aebfcffe784b)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         869a0065-ac7a-4f78-b789-6e2c122ea35d)(content(Whitespace\" \
+         cdd8bebc-b705-4e1a-9049-166709b2dd8c)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         7349a7bc-d138-4e2c-92cb-6d84980214ad)(content(Whitespace\" \
+         58f863a6-8f1c-4709-b994-b93abfe6621f)(content(Whitespace\" \
          \"))))(Tile((id \
          c007ae4d-b34e-460d-94ed-3edba0f9e4b8)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -485,24 +520,24 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e9badf04-051b-482c-a425-eb876da2154e)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fe7620cd-7641-4e1b-a7d6-e91b504f7aae)(content(Whitespace\" \
+         597f8d49-be79-45ce-b586-363f8ae826a6)(content(Whitespace\" \
          \"))))(Tile((id 0d8a8958-ef60-4ec0-bc1a-d4660cf1e2bb)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         058a147c-8c26-4020-81c9-c447c8713428)(content(Whitespace\" \
+         31a3dd5d-c6a9-452d-96de-a69633324774)(content(Whitespace\" \
          \"))))(Tile((id \
          a6416a57-79c2-4239-b01e-e901853de017)(label(e))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         4c149f2a-2796-4797-9f8a-2af94d22b9d9)(content(Whitespace\" \
+         4eeb1553-a706-449a-8604-27eccb9b71d7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         f1544eba-cea9-448c-9e6c-8684a9fd6d9e)(content(Whitespace\" \
+         dca14899-fa95-4048-b381-538e968e76f0)(content(Whitespace\" \
          \"))))(Tile((id 1ec85fa3-d927-4029-9514-34b18bcc5a87)(label(if then \
          else))(mold((out Exp)(in_(Exp Exp))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 36))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         13488f81-faa6-47c8-8933-01071211e902)(content(Whitespace\" \
+         4a71440d-25a2-437a-bcdf-49b3d908ba50)(content(Whitespace\" \
          \"))))(Tile((id \
          72ca98f5-61a3-4031-9c1c-439d14b17444)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -513,29 +548,33 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e6025a71-e989-407c-b406-f5cf33540895)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         bc622c68-bb4f-47a5-ab12-64585475a798)(content(Whitespace\" \
+         3345b1a5-95b6-4e16-8c88-4d270b92c06e)(content(Whitespace\" \
          \"))))(Tile((id \
          df35f586-134a-4721-b263-780b9dbad566)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a8c49a3d-9e4d-403b-82ad-02a2c1d00e9c)(content(Whitespace\" \
+         8b02cf2f-9213-4770-9f6c-2ac262b940c9)(content(Whitespace\" \
          \"))))(Tile((id \
          b0ace867-b345-43e6-8cd9-da84ae63b41d)(label(c))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         6e95ab60-3db1-4e74-8ba6-8ce7fe129048)(content(Whitespace\" \
+         efb0d8c2-a736-4a50-9d6d-99c11035ce65)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3110317a-1a0b-4814-9b52-965aad22e84a)(content(Whitespace\" \
+         de6931cf-fcd9-4e8a-a93f-d91f5873c682)(content(Whitespace\" \
          \"))))(Tile((id \
          6e5b2e21-a178-4b01-bd9d-0115278f9580)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          bdeb1568-5c65-4aa2-93ac-8ffd8ddbecb0)(label(label))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         33225dd5-881c-4f6e-abcd-50216435fd2f)(content(Whitespace\" \
+         \"))))(Tile((id \
          2fdd1ef7-e916-4266-8dfb-40d8948d5759)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4d941b89-8712-42cc-bbc1-2845a907ffe9)(content(Whitespace\" \
+         \"))))(Tile((id \
          0933d99e-d9fb-4bcb-b102-47bd1d81d9df)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -548,14 +587,18 @@ let out : string * Haz3lcore.PersistentSegment.t =
          637f9e61-de31-4565-99e7-860ba78cca7a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         68b616b1-684d-45a0-aa64-24badf31dad6)(content(Whitespace\" \
+         94741465-1110-4636-be87-2a903655d7fc)(content(Whitespace\" \
          \"))))(Tile((id \
          55d91420-0b99-4a00-9c10-b7f6bbaa3c4c)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         289dbea8-7afd-4f64-99f7-cfd5c133a1ad)(content(Whitespace\" \
+         \"))))(Tile((id \
          2ac7417b-7931-4b0d-9909-f2d9cdebb60a)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         ce9b8800-44a7-404b-81f6-1930e54db5b0)(content(Whitespace\" \
+         \"))))(Tile((id \
          6182a565-5935-4110-95f8-299263d157f5)(label(f))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -571,54 +614,54 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9edef964-42a5-48c0-85ec-9980c0ec7e64)(label(value))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         992e302c-6785-4255-803b-3859870467f0)(content(Whitespace\" \
+         a01a664b-22c0-4aab-b7e1-0d174a9652a7)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         760aa598-2720-4b1d-9672-3faed65c0625)(content(Whitespace\" \
+         7a046016-5c70-401b-ac36-423d3eaa7719)(content(Whitespace\" \
          \"))))(Tile((id \
          cecc536b-da44-461f-be2a-7e783f48f86d)(label(e))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         603cc915-5f98-4601-9b3d-b69bc115f6bf)(content(Whitespace\" \
+         041a4bf6-b3e1-4383-8266-fcf60d629b97)(content(Whitespace\" \
          \"))))(Tile((id \
          aae12fe8-35cc-4e27-8480-3a8f42adcba9)(label(|>))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         574513bf-ab22-4e90-bfbf-eb47624a0b5b)(content(Whitespace\" \
+         f4a9d356-03c9-43b1-9873-d9c485bf2fe4)(content(Whitespace\" \
          \"))))(Tile((id \
          b8398fec-0eaa-4c04-bf7a-bc299c422bfb)(label(from_lvs))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         3cd2f601-3684-4ad6-9c29-5b011a4eca7a)(content(Whitespace\" \
+         06a7ebc5-03ac-469e-a2bf-57eeac2a2222)(content(Whitespace\" \
          \"))))(Tile((id \
          2fdbac55-2c00-4f6d-a5cf-5a0bcdec9e09)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         16e393a9-630d-41a2-bfd8-d65c5a9fd89a)(content(Whitespace\" \
+         1a238f39-ac51-46bc-9a2b-5d9547919b98)(content(Whitespace\" \
          \"))))(Tile((id 7e7f43b0-582f-4720-b1bc-ac987a9f38a3)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          b219f94a-a00d-4eed-922f-d75cf2f60632)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1a9fdd22-49cb-42ed-a295-8bd7f8ab6cac)(content(Whitespace\" \
+         944b02cb-6b11-4c83-8067-0d259aa404e8)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         09943d5a-3661-4a05-b129-4c20acad3e6a)(content(Whitespace\"\\n\"))))(Secondary((id \
-         77ec1da5-9c47-4a47-ba14-c2c0541061b9)(content(Whitespace\"\\n\"))))(Tile((id \
+         3ccae208-4343-40be-9b17-cc456ba9c86f)(content(Whitespace\"\\n\"))))(Secondary((id \
+         85e77a93-11b4-468b-86ac-77d766193b9f)(content(Whitespace\"\\n\"))))(Tile((id \
          48ad9663-fddf-4f65-a434-2716c4af00ea)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         8efba29d-1ccd-489e-bbff-1d47ae399ca0)(content(Whitespace\" \
+         0ba60628-6125-44ca-bea3-8d195767bf07)(content(Whitespace\" \
          \"))))(Tile((id \
          24e3e184-f092-4701-bc39-a7794d85ab8b)(label(expected))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b9f4d71b-3226-432c-87c8-a0cae6228142)(content(Whitespace\" \
+         5ad348f1-aa36-4541-a4d0-d2fae39bff63)(content(Whitespace\" \
          \")))))((Secondary((id \
-         4c97200d-442a-480c-82bf-3b11c54a3a37)(content(Whitespace\" \
+         ff16f0bc-278f-4b7c-a9f3-207ec5352e0f)(content(Whitespace\" \
          \"))))(Tile((id 3b0c07fe-dab9-4489-b8f1-ead1f76f2b87)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         89bb3030-b243-44ce-be74-ba16e0745bc5)(content(Whitespace\"\\n\"))))(Tile((id \
+         7c553333-e2fe-4564-aac0-f4d9172b1f45)(content(Whitespace\"\\n\"))))(Tile((id \
          8bef0d74-68ae-40fe-b6a2-a6ffdd08f221)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -662,7 +705,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          861f276d-912b-45c0-a5c9-96b546c91307)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6a27e3c9-f9df-4aba-a2ab-845ea039bddb)(content(Whitespace\"\\n\"))))(Tile((id \
+         fee9004b-0789-48d4-93e1-cbdcfc675a7b)(content(Whitespace\"\\n\"))))(Tile((id \
          0868b53e-b954-4494-827c-9970a9f592ab)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -706,56 +749,66 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2b0edd0c-e631-485f-93ba-d11691776c75)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a1ffee43-56f6-42ab-aa3e-4e746508e245)(content(Whitespace\"\\n\"))))(Tile((id \
+         6a9103fb-53f2-45dd-be98-db2482ef7f4b)(content(Whitespace\"\\n\"))))(Tile((id \
          320ead75-ebe4-4e51-935e-c009f0fee19d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          c4e4b908-7ea3-4f5c-be6c-811d255e9218)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         2e441b16-045e-4307-aceb-2f80a7c9807b)(content(Whitespace\" \
+         \"))))(Tile((id \
          dfdada6d-978c-4748-8125-d01a4a835359)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
-         c8b8b564-ec50-4395-982b-ce4a3fc8b59f)(label(\"\\\"Eve \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d0916635-7e43-4c5a-8d1b-dc8158b4c696)(content(Whitespace\" \
+         \"))))(Tile((id c8b8b564-ec50-4395-982b-ce4a3fc8b59f)(label(\"\\\"Eve \
          Smith\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort Exp))))))(shards(0))(children())))(Tile((id \
          72ddb72a-ed40-42ea-8839-23738a93c5fd)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb90bb26-0cdd-41fc-9ef6-7c27b04f4fc6)(content(Whitespace\" \
+         3ecbb9cb-2509-4f0f-b57f-4de21af7d3c2)(content(Whitespace\" \
          \"))))(Tile((id \
          8bccd71c-1e7a-471f-b6fd-6baf1b2fc632)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a4617556-130f-4adb-9405-33c8a3469f76)(content(Whitespace\" \
+         \"))))(Tile((id \
          181cc502-f72a-4d42-bcb9-06c0f0a65cc9)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         2b7d0392-81bf-497d-8e64-8c368062030a)(content(Whitespace\" \
+         \"))))(Tile((id \
          f960dba9-aec9-4c32-ad60-b8b4c7bbdd98)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          f0a734e0-3e3a-4d16-a9fa-fa1edd662984)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9c26fab1-069b-45e9-8210-d80ed2a6394d)(content(Whitespace\" \
+         6e365ae6-2f16-4db8-80f6-a80fb2e799dc)(content(Whitespace\" \
          \"))))(Tile((id \
          ff3f8544-aedf-40ac-aa26-b181566575cc)(label(favorite_color))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         9e58e4bd-60b6-49c9-a574-3279e796abf7)(content(Whitespace\" \
+         \"))))(Tile((id \
          8d1ac136-8041-4a67-9e61-d345ed02068d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         20280892-79b4-45e5-88f9-054447e76dfa)(content(Whitespace\" \
+         \"))))(Tile((id \
          34ff9e17-af13-4039-885e-099b2bc8a804)(label(\"\\\"red\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         022c0364-4e00-4083-93fb-bdba59c93ae3)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         2c9ba52c-8d78-47cf-8a6d-d6262ac68d48)(content(Whitespace\" \
+         809b1b03-5b48-4046-840a-7f726027e97e)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         fdce0dec-0406-4987-aceb-a3e6b893b733)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         db4b1e12-d07b-4350-a969-7cf2a9e02fbc)(content(Whitespace\"\\n\"))))(Tile((id \
+         42bcb2de-7fff-470b-bc2e-e60b26fbfb4c)(content(Whitespace\"\\n\"))))(Tile((id \
          719ee323-49a9-4d47-b3c6-ec350dafefd7)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         09107fdf-08b4-490c-aa72-504cb68915f0)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ddb20fab-3749-4665-b70e-0ffb00975dd1)(content(Whitespace\"\\n\"))))(Tile((id \
          8634d05d-128a-4abd-82b0-4ecdb3be1496)(label(transform_column))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -768,7 +821,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b9d71a39-f548-4805-8a91-652ed774bb8c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         15d56fe1-800c-4da1-b262-04ce39da7c55)(content(Whitespace\" \
+         09f66172-c3a5-4e1f-9336-91b2ca9bb7a7)(content(Whitespace\" \
          \"))))(Tile((id \
          88a220e2-78ce-4217-83d0-742930ebb3b5)(label(\"\\\"name\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -776,57 +829,56 @@ let out : string * Haz3lcore.PersistentSegment.t =
          36fb6417-ad06-4372-8096-f5f3f0e00548)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         abacf753-5742-4d8c-a981-9a71f6c5e863)(content(Whitespace\" \
+         cc43df52-78a4-4ca9-9e15-e8817ad0f7b3)(content(Whitespace\" \
          \"))))(Tile((id ebd98fc0-b578-4ed6-ad8a-531acf5297c2)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         64af18e2-d256-44af-be71-dc7f9d80ddbb)(content(Whitespace\" \
+         d03feea9-36c0-42bd-b9ef-0552ac63c60b)(content(Whitespace\" \
          \"))))(Tile((id \
          fce5d9f0-b398-49f0-934d-a65d3e4ca3cb)(label(n))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         1c104ca2-e6da-4c8b-a694-f704f6c12fea)(content(Whitespace\" \
+         15650af4-602e-49fd-b5ed-35e69ed77a92)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         68515c04-b6b6-4688-9822-be4461be3e60)(content(Whitespace\" \
+         b4403846-ffc4-47e8-8886-2ebc45c1e408)(content(Whitespace\" \
          \"))))(Tile((id \
          b8a250ad-4f3f-4ecf-9d4b-473d2e7fbd15)(label(n))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f1ad9f30-0bde-4b40-8f26-73628668390e)(content(Whitespace\" \
+         9a05c379-8d8b-4c67-accc-a6fb1a258519)(content(Whitespace\" \
          \"))))(Tile((id \
          3f995c9d-a9af-4797-ae6c-0304a408a1cb)(label(++))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         99288c9a-d2b4-4eb0-8a37-b651f538dfdf)(content(Whitespace\" \
+         dc150e02-18af-43ce-a48d-1088d5d6b721)(content(Whitespace\" \
          \"))))(Tile((id 2d876c63-195a-487a-9e8a-8821f897e2c7)(label(\"\\\" \
          Smith\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6fbe5c36-76eb-453d-b789-5426f95a1ad8)(content(Whitespace\" \
+         b82d93fb-ac22-4bec-ab55-8101825ca3c2)(content(Whitespace\" \
          \"))))(Tile((id \
          1c506150-b650-49a2-93ef-c3c08589003c)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c5f9ca84-28a3-4ac1-a58f-974677cce5f1)(content(Whitespace\" \
+         662bc858-35de-40e6-ba40-70c11c31f227)(content(Whitespace\" \
          \"))))(Tile((id \
          31df0909-a3ba-4f21-b84c-9d9021d244f5)(label(expected))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         f5a8dc9a-6717-4271-8bc1-99be94b66c83)(content(Whitespace\" \
+         c79cd13b-5e52-4394-be38-30599c208532)(content(Whitespace\" \
          \")))))))))(Tile((id \
          d81cd9dc-2ad4-4bf5-8e18-1249caaa7cc7)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         45cda725-338f-4a9a-916f-8cf6d5c81ba4)(content(Whitespace\"\\n\"))))(Secondary((id \
+         2d2f9bc1-ab2f-4a80-b2d8-bdbb5fa65cbe)(content(Whitespace\"\\n\"))))(Secondary((id \
          bf327b57-66da-4597-b3a8-f5f7d6f94f9a)(content(Comment\"# Idiomatic \
          way to do this #\"))))(Secondary((id \
-         10814474-e9eb-40f5-98a3-054608bedce8)(content(Whitespace\"\\n\"))))(Tile((id \
+         0d75c293-723e-4e1e-a737-18e769410528)(content(Whitespace\"\\n\"))))(Tile((id \
          1094bfb4-55b7-4515-a1e3-abb1390d4d0c)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         7e89aeac-c845-48a3-b616-146b38d138e5)(content(Whitespace\" \
-         \"))))(Tile((id \
+         ec875aa6-2f7c-4d54-9ab5-6d5b3030144f)(content(Whitespace\"\\n\"))))(Tile((id \
          624a947f-8af5-45c5-a433-9809378b47be)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -839,39 +891,43 @@ let out : string * Haz3lcore.PersistentSegment.t =
          1a98bbe8-bd2e-4635-9767-14968069b482)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         852c6ef2-f738-4116-a730-c89bc1de647f)(content(Whitespace\" \
+         bcb05f70-31fd-4e5b-bc01-c4a0c764c2fb)(content(Whitespace\" \
          \"))))(Tile((id 2e59278c-78e7-435f-9328-c25acd92e534)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         14827501-96b3-4de0-8e97-0435b7ee8700)(content(Whitespace\" \
+         53502f66-39df-4b80-9152-cb153ed38ca4)(content(Whitespace\" \
          \"))))(Tile((id \
          cd84919e-a70f-4229-992d-989083715399)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         8506ad86-a526-4903-afc4-9341431fd0f9)(content(Whitespace\" \
+         11a94138-6e8c-467d-8fb0-f6e28017cced)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d691da4f-e96b-41c0-baeb-4b6177267acf)(content(Whitespace\" \
+         f5542e8d-28ab-4228-b104-53701db440a4)(content(Whitespace\" \
          \"))))(Tile((id \
          305bff28-c2bb-487e-bc93-24bc8603a93f)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         5ca3ebb6-fd59-40b2-9033-6ce46698e7e0)(content(Whitespace\" \
+         22f84394-a57c-4945-9900-b1eb1275e76d)(content(Whitespace\" \
          \"))))(Tile((id \
          06b6ef4e-3263-48c7-ad56-2ea87e2b17a6)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3ec923ec-cbfb-417c-946f-156559a0f09c)(content(Whitespace\" \
+         d4d04176-fca1-4054-a855-3f949830cc27)(content(Whitespace\" \
          \"))))(Tile((id \
          95674641-354c-464d-b422-bffc91001a12)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          56a8e4a2-275a-49d0-8a65-cfbcada7039b)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         257a0867-9de8-40a6-aaeb-06aae2fa6890)(content(Whitespace\" \
+         \"))))(Tile((id \
          2f953a22-6498-411c-b7f6-ad35812e8fd0)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         04e6a78f-ba86-466c-8cd0-f4b999112476)(content(Whitespace\" \
+         \"))))(Tile((id \
          c1f48970-5fff-4b71-a0d3-705b1ab96d94)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -881,56 +937,61 @@ let out : string * Haz3lcore.PersistentSegment.t =
          13d80e43-c0c3-4030-8292-4257851f1dae)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         28a5a5f0-eac5-4f67-a115-f722fb39fcaf)(content(Whitespace\" \
+         a52f7b78-1d2e-401f-a6be-fbf5490e0b2d)(content(Whitespace\" \
          \"))))(Tile((id \
          591a1711-e421-42cc-8aff-555e76773522)(label(++))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 30))(sort Exp))((shape(Concave \
          30))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         fbc1620f-f6a7-4db8-ba27-ac5b6a7f91f2)(content(Whitespace\" \
+         0739b777-31f5-4578-a3dd-977b92dab218)(content(Whitespace\" \
          \"))))(Tile((id 3b69d96c-544f-4bb6-a827-499fceba7697)(label(\"\\\" \
          Smith\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         6aafd275-007a-4f7a-8b56-fa129c08d5e8)(content(Whitespace\" \
+         9f8faebf-db41-43b3-96a2-4b54387c244d)(content(Whitespace\" \
          \"))))(Tile((id \
          5b9541a4-00cf-47f5-ad7b-47eba2717eec)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         c72a6aa8-c4a5-49dd-b3dd-a60ca3dbb905)(content(Whitespace\" \
+         9cef9c9f-7e90-4902-b293-11a6ea778fa3)(content(Whitespace\" \
          \"))))(Tile((id \
          32e5b55d-118e-4a32-8dce-58eca688d554)(label(expected))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         d7b6e535-3bfb-4ae6-ad83-4d05cf4d1fbc)(content(Whitespace\" \
+         d28d4617-2ab8-4593-af31-63d9ff56901c)(content(Whitespace\" \
          \"))))))))))";
       backup_text =
-        "type Student = (name=String, age=Int, favorite_color=String) in\n\
+        "type Student = (name = String, age = Int, favorite_color = String) in\n\
          let students : [Student] = ^^fold([\n\
          (\"Bob\", 12, \"blue\"),\n\
          (\"Alice\", 17, \"green\"),\n\
          (\"Eve\", 13, \"red\")\n\
          ]) in\n\n\
-         let requires=[(enforced=^^check(false), \"c is in header(t1) \")] in\n\
-         let ensures=[\n\
+         let _requires = [(enforced = ^^check(false), \"c is in header(t1) \
+         \")] in\n\
+         let _ensures = [\n\
          (enforced=^^check(false), \"v1 is of sort schema(t1)[c]\"),\n\
          (enforced=^^check(false), \"header(t2) is equal to header(t1)\"),\n\
          (enforced=^^check(false), \"for all c' in header(t2), if c' is equal \
          to c then schema(t2)[c'] is equal to the sort of v2\"),\n\
          (enforced=^^check(false), \"otherwise, then schema(t2)[c'] is equal \
          to schema(t1)[c']\"),\n\
-         (enforced=^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
+         (enforced = ^^check(false), \"nrows(t2) is equal to nrows(t1)\")\n\
          ] in\n\
-         let transform_column = fun (t:[?], c:String, f:(? -> ?)) ->\n\
-         map(t, fun r -> map(to_lvs(r), fun e -> if e.label == c then \
-         (label=e.label, value=f(e.value)) else e) |> from_lvs) : [?] in\n\n\
+         let transform_column =\n\
+         fun (t : [?], c : String, f : (? -> ?)) ->\n\
+         map(t, fun r -> map(to_lvs(r), fun e -> if e.label == c then (label = \
+         e.label, value = f(e.value)) else e) |> from_lvs) : [?] in\n\n\
          let expected = [\n\
          (name=\"Bob Smith\", age=12, favorite_color=\"blue\"),\n\
          (name=\"Alice Smith\", age=17, favorite_color=\"green\"),\n\
-         (name=\"Eve Smith\", age=13, favorite_color=\"red\")\n\
+         (name = \"Eve Smith\", age = 13, favorite_color = \"red\")\n\
          ] in\n\
-         test transform_column(students, \"name\", fun n -> n ++ \" Smith\") \
-         == expected end;\n\
+         test\n\
+         transform_column(students, \"name\", fun n -> n ++ \" Smith\") == \
+         expected end;\n\
          # Idiomatic way to do this #\n\
-         test map(students, fun r -> r ... (name=r.name ++ \" Smith\")) == \
+         test\n\
+         map(students, fun r -> r ... (name = r.name ++ \" Smith\")) == \
          expected end";
+      refractors = "()";
     } )

--- a/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesupdate.ml
+++ b/src/b2t2/slides/table_api/B2T2TableAPIUtilitiesupdate.ml
@@ -1,157 +1,188 @@
 let out : string * Haz3lcore.PersistentSegment.t =
   ( "B2T2 / Table API / Utilities / update",
     {
-      refractors = Haz3lcore.PersistentSegment.refractors_init_str;
       segment =
         "((Tile((id dfcf1a3c-132b-4db4-ad2b-9d39c412630f)(label(type = \
          in))(mold((out Exp)(in_(TPat Typ))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 45))(sort Exp))))))(shards(0 1 \
          2))(children(((Secondary((id \
-         300a8c6a-4d3f-4e01-85cf-696d3f514ef8)(content(Whitespace\" \
+         25398414-337c-4276-b32a-69830345cbd8)(content(Whitespace\" \
          \"))))(Tile((id \
          643b5fbf-7c7d-4ccc-8ff8-cc1dbac4be42)(label(GradebookEntry))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         ecc3055b-6cd4-42e6-a19c-43cf9ab82630)(content(Whitespace\" \
+         1a8c8ff9-ef45-41e4-ba1b-61cc98c6a552)(content(Whitespace\" \
          \")))))((Secondary((id \
-         3e256f43-77f8-4a75-838e-3e36197710bd)(content(Whitespace\" \
+         a4ddd389-5253-45c8-b85a-d666aac6b74f)(content(Whitespace\" \
          \"))))(Tile((id \
          2dcded10-fa7c-4514-9cc3-1d144af2ca10)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          75abf64e-7119-4931-85bf-649ec9e79a6a)(label(name))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         88156c50-75e1-44bc-aca9-201bfd8c83e5)(content(Whitespace\" \
+         \"))))(Tile((id \
          2156f4f3-d244-475e-a4b7-a132aeaefb6d)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         fa1ec078-6b3e-4c7d-920c-04ece6d396b2)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce3c6340-e11c-42cd-9395-8ed6e85e3a07)(label(String))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e2b28272-23fb-415a-8d9b-d883978208ac)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         3496b1db-1aeb-4b52-a73e-694ae9076853)(content(Whitespace\" \
+         a4dad3ec-0787-4c82-9ea2-c014635930a0)(content(Whitespace\" \
          \"))))(Tile((id \
          fe138807-b1c8-4763-a2cf-9ebc2ffa63b8)(label(age))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         ba2e4039-baa4-4280-8298-7a48a77ead22)(content(Whitespace\" \
+         \"))))(Tile((id \
          56cbb17f-4710-44b4-887b-aed4348d2c82)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7edbf8f4-cfc6-4350-89d8-3b05f35e03d9)(content(Whitespace\" \
+         \"))))(Tile((id \
          fd68285a-eb5b-4ef5-8c48-39d2b7c62446)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          b54d89fc-be32-4ff0-8ec0-bfaf7d5424b3)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         2fecb5d8-32fb-4ded-b97b-61fd242e9863)(content(Whitespace\" \
+         6d7137ec-eb10-4b6a-b39b-e83c1dae6264)(content(Whitespace\" \
          \"))))(Tile((id \
          9956bf10-90af-4d5a-ac41-3c466d4f8d08)(label(quiz1))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         f8a5f7c7-5f3c-4760-9ef2-3519bda2abd7)(content(Whitespace\" \
+         \"))))(Tile((id \
          2ab8d1aa-bd66-4c4c-a8fa-c98de026dfd1)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d280681c-b9cc-4cf2-a80f-dbf56b3a254d)(content(Whitespace\" \
+         \"))))(Tile((id \
          fe5510ec-5cd2-4b75-84f5-e56b366b4644)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          e9c914d3-ead8-40e5-a77c-68e1aa964a67)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         047205dd-7281-4744-bb70-ae8e1c69b1fe)(content(Whitespace\" \
+         40d0c554-c33f-4462-ba5f-7c93f53802fb)(content(Whitespace\" \
          \"))))(Tile((id \
          0eb12831-e6a2-4aa2-9535-62d7791abe8a)(label(quiz2))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         0dafe467-b55d-4740-ba27-5b2c1f15b5eb)(content(Whitespace\" \
+         \"))))(Tile((id \
          966793b7-6235-4473-b3f1-c9154a270aef)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6b1e5257-c751-4a14-91b1-82175623b3d3)(content(Whitespace\" \
+         \"))))(Tile((id \
          2befead7-6258-4460-b19e-f52aa200cac5)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          26854bfe-ac14-4822-ad66-29fd1dbec052)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         51db0020-d4ea-4630-89ad-f9b229f85999)(content(Whitespace\" \
+         a1734a03-4de6-4217-8ded-c96d3c161ad3)(content(Whitespace\" \
          \"))))(Tile((id \
          2e658b48-219d-44f1-b562-851960d407f4)(label(midterm))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         d9a5ba4d-88b5-43cf-9901-81777617ecab)(content(Whitespace\" \
+         \"))))(Tile((id \
          bebc0272-9a58-4414-8549-463e10627852)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         ec2411b5-f410-485f-8535-a2e8d3d794dc)(content(Whitespace\" \
+         \"))))(Tile((id \
          58a77292-3a1f-4ac1-875d-3d60d45c66dc)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          fe7b8ad5-a727-4285-8da3-806f1ed5e12f)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         9d74399d-65f2-4366-8345-a2b5d403386f)(content(Whitespace\" \
+         b916874a-23be-4749-9d56-73ecb290905f)(content(Whitespace\" \
          \"))))(Tile((id \
          7dcb1d76-d3af-4013-a1e0-85ea9c3b2736)(label(quiz3))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         58e5c8fa-472e-4856-b818-0f58554adca7)(content(Whitespace\" \
+         \"))))(Tile((id \
          c34cf1e3-e6c4-45b1-9c4a-15bc1c7194e3)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         81d1a0dd-598f-4fd6-b59f-757efa2a6e58)(content(Whitespace\" \
+         \"))))(Tile((id \
          3ed02400-24a2-4eba-9cb7-d6a29de4d4e8)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          04511a85-f215-40d2-8e0e-5466cf07d38b)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         f956c3ae-6db1-492f-9295-d0db68831186)(content(Whitespace\" \
+         754e9f6e-2554-40ef-9c05-5d08f80fe08f)(content(Whitespace\" \
          \"))))(Tile((id \
          bbf0f0a3-f4e1-4d88-a375-27ecb32c7a9c)(label(quiz4))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         28820428-8060-4817-abcf-e690b276b96d)(content(Whitespace\" \
+         \"))))(Tile((id \
          e09b20a7-b232-48e8-b767-3d76bd35aa1b)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7741f13a-8636-4954-b1eb-1360ea89b851)(content(Whitespace\" \
+         \"))))(Tile((id \
          b2020d55-197f-406b-afff-7015479371b8)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Tile((id \
          aa6a0fd8-bca1-4750-93d3-3c141b90d321)(label(,))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 44))(sort Typ))((shape(Concave \
          44))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         54745c88-84df-4fde-aba8-82f8aef81b20)(content(Whitespace\" \
+         cb1d5c35-7da8-47cf-a3ab-a244e1756d2f)(content(Whitespace\" \
          \"))))(Tile((id \
          b4613a78-28b5-49c8-81c4-1d0ab17d420c)(label(final))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0))(children())))(Tile((id \
+         Typ))))))(shards(0))(children())))(Secondary((id \
+         723238ae-0f27-4ea5-a16e-4c46403e3500)(content(Whitespace\" \
+         \"))))(Tile((id \
          8c8dd32c-3438-4b27-aead-9570067898da)(label(=))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 39))(sort Typ))((shape(Concave \
-         39))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         39))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         7f5dd4b5-0383-48f0-9843-6e3f2d1431d6)(content(Whitespace\" \
+         \"))))(Tile((id \
          153266cb-1882-4168-85bf-845f40b8461f)(label(Int))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         39736db5-12f4-41ce-b059-beb45ce85ea3)(content(Whitespace\" \
+         e16655c2-15c6-4e27-83a7-78d9ccc73ea0)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         31292829-57b9-41e1-8c13-985d8e36bcf9)(content(Whitespace\"\\n\"))))(Tile((id \
+         56631da9-b413-4cd3-8d3b-f73661a5dd05)(content(Whitespace\"\\n\"))))(Tile((id \
          b9704aad-7be3-4a84-a538-1b6c1dcb6434)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         9caac032-f753-4138-a49c-04fdc14d46c2)(content(Whitespace\" \
+         0030773a-1536-4255-8501-18433add9423)(content(Whitespace\" \
          \"))))(Tile((id \
          e092d293-619f-41e6-8470-8eb1859f72e1)(label(gradebook))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         891b029b-20c5-47e0-9285-44e8ee0c9ad6)(content(Whitespace\" \
+         d7cee9e0-cade-4196-8c73-12fef8c0c348)(content(Whitespace\" \
          \"))))(Tile((id \
          2af8edae-34f4-4ad4-9284-456abff8330d)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         ef0b4575-f38c-4a2f-b7ee-1e6ac7df4504)(content(Whitespace\" \
+         cad443a8-4ec1-47ce-8229-70a7b38e57eb)(content(Whitespace\" \
          \"))))(Tile((id dab7812e-288d-43d1-910e-78c4fa24c44b)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          e76d7310-afa3-4358-b624-d61610cbf830)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         e6dbe577-6b1b-4d61-8d3c-5eec3f8364c4)(content(Whitespace\" \
+         249c8023-4dfb-40a7-94be-2678fdc9947f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         5c83a6e3-c003-43f7-9d2d-27e705166123)(content(Whitespace\" \
+         95c3a128-2747-4cb8-9ec1-fd6b8c2c1dcd)(content(Whitespace\" \
          \"))))(Projector((id c2626850-3baa-40aa-ae36-32f1500ff3b2)(kind \
          Fold)(syntax(Tile((id \
          66a27340-0dad-4663-8751-9f4973f70a1e)(label(\"(\"\")\"))(mold((out \
@@ -365,34 +396,37 @@ let out : string * Haz3lcore.PersistentSegment.t =
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
          c1c2259b-93cb-49cd-ae73-4ff2ad5f37fb)(content(Whitespace\"\\n\")))))))))))))))(model\"((text\\\"\\\\226\\\\139\\\\177\\\")(expanded \
          false)(always_render false))\")))(Secondary((id \
-         e646e267-3c0c-4201-81a1-4d1a451381fe)(content(Whitespace\" \
+         1f6c836d-1687-4bb2-95da-9b84c65bcd74)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6cd9a2c8-e716-45cb-a84b-cf7f905fc86d)(content(Whitespace\"\\n\"))))(Tile((id \
+         d2a502fa-aba6-4b89-9cb2-3b7e3eb59ca8)(content(Whitespace\"\\n\"))))(Tile((id \
          f2a93ca6-44b8-416a-9087-a8867dc6db5f)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         78d0054d-06b6-498e-bf1f-d93a91d91180)(content(Whitespace\" \
+         2de997c2-aaa4-4d08-8610-0ede97ff21a6)(content(Whitespace\" \
          \"))))(Tile((id \
-         c847ccef-dd5b-401e-9491-7d80a3493340)(label(requires))(mold((out \
+         c847ccef-dd5b-401e-9491-7d80a3493340)(label(_requires))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b84a4ec2-7184-4450-ac73-3df062f330b0)(content(Whitespace\" \
+         5ffda50a-993c-479c-ad8d-79965321ffdd)(content(Whitespace\" \
          \")))))((Secondary((id \
-         ec168324-fff7-47cf-a028-701ef9d6d900)(content(Whitespace\" \
+         bc301c2d-96dd-4c57-b59b-756af29051a0)(content(Whitespace\" \
          \"))))(Tile((id 1fe0a301-fd29-4cd7-bbe9-bec401d519d4)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         8f34da4b-3e01-4675-9ab2-a19991c9012b)(content(Whitespace\"\\n\"))))(Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
          75a8c631-33ce-494b-916e-c17753a6affa)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          963da99b-9273-481b-a8d4-525c4fe99794)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         bb7ffb62-b04b-4d21-b27a-fc0ff88c96c8)(content(Whitespace\" \
+         \"))))(Tile((id \
          4ef6b815-f560-454c-8aac-422c32a91c06)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         22f83a10-e8d7-4a51-b915-5243efbd36f4)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         b81cb4e7-9fd1-43d7-9952-3689598922a2)(content(Whitespace\" \
+         \"))))(Projector((id 22f83a10-e8d7-4a51-b915-5243efbd36f4)(kind \
+         Checkbox)(syntax(Tile((id \
          f2e5555d-b836-4e3e-9937-dab4554a99d0)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -402,30 +436,29 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2b11a9f7-6c0c-427d-8666-75a5dac8ff2f)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         a1a4d2a6-1f1d-49c9-b87f-e110cace7f22)(content(Whitespace\" \
+         2cf03066-cf54-4d82-8658-59c4541f6f2a)(content(Whitespace\" \
          \"))))(Tile((id 94b58517-0c6c-4e01-aa42-e277c6f9c21e)(label(\"\\\"for \
          all c in header(r2), c is in header(t1)\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         049e6e8f-64d3-4d57-9187-302bd85d239f)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         46185fea-86ad-437e-8e5d-b227e684e0ce)(content(Whitespace\" \
+         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
+         f4989f0c-15ae-4baf-bf0b-f999e24cbf0b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         b5e9ab6b-1072-4f3b-b62d-9a6c356ce751)(content(Whitespace\"\\n\"))))(Tile((id \
+         377a920a-8c0e-4281-a3a6-d10a300bdb70)(content(Whitespace\"\\n\"))))(Tile((id \
          1b726877-f0b3-4ab8-bb60-b13892aba8b2)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         1de1e19f-3145-4d6c-82c3-996643ec5063)(content(Whitespace\" \
+         33c39d18-e7f2-4055-ba4c-3dc0368cc890)(content(Whitespace\" \
          \"))))(Tile((id \
-         5af4ee36-d8e7-4611-86ac-02d29313cdae)(label(ensures))(mold((out \
+         5af4ee36-d8e7-4611-86ac-02d29313cdae)(label(_ensures))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         5c1cc656-30e6-41b0-8bd3-2fa47b3defd7)(content(Whitespace\" \
+         e506a5c9-f784-4bd7-b614-0a4f97a0083f)(content(Whitespace\" \
          \")))))((Secondary((id \
-         309e9e78-c660-4257-a2a3-2c4df2a5f801)(content(Whitespace\" \
+         40c12714-265b-4b21-9f06-ffa58ce63868)(content(Whitespace\" \
          \"))))(Tile((id 72588cc8-cc50-4310-9676-4be985e37247)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
          Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
-         695b9872-bd89-427e-86a4-6e3225698240)(content(Whitespace\"\\n\"))))(Tile((id \
+         2e4746c8-ae1e-4e00-9f73-8253065de4b7)(content(Whitespace\"\\n\"))))(Tile((id \
          ea20195b-6124-4971-bb36-6d14f7871f66)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -454,7 +487,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          4259809b-1f96-480d-989d-73e2ed33a6d4)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         b3fbc34d-e5bd-477a-8518-e6a310b1b3d3)(content(Whitespace\"\\n\"))))(Tile((id \
+         7bc88218-2fe6-403c-95cb-2979dc7c3639)(content(Whitespace\"\\n\"))))(Tile((id \
          6846a991-105a-414b-b8df-88fd0cb94d0e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -483,7 +516,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e0867918-3714-450a-9244-3d989c22bf72)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         20ba40d6-608f-47bc-946d-84ef5245a499)(content(Whitespace\"\\n\"))))(Tile((id \
+         8ea91f78-f0a0-469b-8605-9a564a12892b)(content(Whitespace\"\\n\"))))(Tile((id \
          a95ceb01-cd71-4e8d-b4e0-f188147cc82f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -512,7 +545,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          30ae3998-14aa-4e7d-816c-b426f4ef0e65)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         04af7fcb-3c00-4f42-b4b2-2dcb50fd12ab)(content(Whitespace\"\\n\"))))(Tile((id \
+         c3b9a78a-3cb1-4d30-884f-59f7f98402f0)(content(Whitespace\"\\n\"))))(Tile((id \
          20e8e302-188d-44ec-98dd-80b177e14172)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -541,17 +574,21 @@ let out : string * Haz3lcore.PersistentSegment.t =
          50ca2dfe-1b9e-4609-8bb3-6cef8a617561)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f5476c34-bdb6-4cf0-a1bb-c477c6a5ce4d)(content(Whitespace\"\\n\"))))(Tile((id \
+         5ea8378c-77ca-4b77-89a7-30c90a31f698)(content(Whitespace\"\\n\"))))(Tile((id \
          7abf1490-ca86-4755-9c0c-77a9af07c95f)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          47a00930-680c-4551-bc5a-f4a59b2223ee)(label(enforced))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8cd89522-e465-41a8-b7e4-fa923667d23f)(content(Whitespace\" \
+         \"))))(Tile((id \
          28545ebd-5faf-4b40-9bd4-c6dc0fab84be)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Projector((id \
-         ef2316cd-c609-40c3-82b5-5bbc81053da7)(kind Checkbox)(syntax(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         74d92f2c-23fe-4638-b26b-099177800478)(content(Whitespace\" \
+         \"))))(Projector((id ef2316cd-c609-40c3-82b5-5bbc81053da7)(kind \
+         Checkbox)(syntax(Tile((id \
          d9cc1c07-bea8-4471-9415-71c5e5d0fef8)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -561,90 +598,98 @@ let out : string * Haz3lcore.PersistentSegment.t =
          a07cc875-2fdb-4cf1-be12-6f13a35c2eeb)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         2775d708-4aeb-41e8-aa00-b78ab687734f)(content(Whitespace\" \
+         50c7f162-8df5-4d9e-984a-e3526bc44efa)(content(Whitespace\" \
          \"))))(Tile((id \
          04031e56-4710-4db5-9e1f-2a744318384c)(label(\"\\\"nrows(t2) == \
          nrows(t1)\\\"\"))(mold((out Exp)(in_())(nibs(((shape Convex)(sort \
          Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children()))))))))(Secondary((id \
-         6a8f0791-1320-4078-8cad-8f45770855a0)(content(Whitespace\"\\n\")))))))))(Secondary((id \
-         17f7b828-d56d-4666-ba7b-5b6329ffd699)(content(Whitespace\" \
+         a0168051-d96c-495c-8a69-fae02e2d544c)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         8a05cd0c-ecf6-4974-bed0-7b263295e900)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         6aa5451f-1ff9-46e2-95fd-c390849f0be3)(content(Whitespace\"\\n\"))))(Tile((id \
+         3b8c3f3e-e296-4fed-8975-1d7dd1f34aeb)(content(Whitespace\"\\n\"))))(Tile((id \
          ccaacfb6-6f06-447c-8709-a3835ae14fc9)(label(let = in))(mold((out \
          Exp)(in_(Pat Exp))(nibs(((shape Convex)(sort Exp))((shape(Concave \
          45))(sort Exp))))))(shards(0 1 2))(children(((Secondary((id \
-         4067cfc4-7451-4b9a-bdc4-74926ff19867)(content(Whitespace\" \
+         d9f97aaf-fed8-4792-aa3a-3a18f8b1c009)(content(Whitespace\" \
          \"))))(Tile((id \
          e0bb26d5-7f86-49fa-abe8-a5f07af7c783)(label(update))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         b33f43f7-7416-4379-a11a-26da786b149c)(content(Whitespace\" \
+         6b7b09a5-a40b-4f39-a760-769f2968f971)(content(Whitespace\" \
          \")))))((Secondary((id \
-         2d25211b-860a-4d01-9836-16b3dc9af3e6)(content(Whitespace\" \
+         3e425bd2-128f-439f-b16e-26ecf5b1ffb5)(content(Whitespace\" \
          \"))))(Tile((id ef7b95f1-9203-4f9f-9e61-312eaa972549)(label(typfun \
          ->))(mold((out Exp)(in_(TPat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         82f97036-9926-4966-8aeb-279cc98d2428)(content(Whitespace\" \
+         dc6d702c-4914-4aa3-8938-588cdb8965a1)(content(Whitespace\" \
          \"))))(Tile((id \
          dbcd24e1-45fc-451f-bc75-67cccc9a8e77)(label(row))(mold((out \
          TPat)(in_())(nibs(((shape Convex)(sort TPat))((shape Convex)(sort \
          TPat))))))(shards(0))(children())))(Secondary((id \
-         789d2569-b266-4aae-b552-9e962f7f209f)(content(Whitespace\" \
+         660dee56-2e4c-4725-bd15-88ab07501d29)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         58a58f5b-9261-402a-87aa-ff66ce8a6e05)(content(Whitespace\" \
+         b0c4e1cd-87f7-47fc-96ec-07db913afaa5)(content(Whitespace\" \
          \"))))(Tile((id e5781f38-4199-4d97-93c3-14b2c1ab5d09)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         0c29fc71-d5e6-4a28-a2fb-d49db349522d)(content(Whitespace\" \
+         3be3a395-f0fb-4a62-9206-9b74b163b2dc)(content(Whitespace\" \
          \"))))(Tile((id \
          913e416b-b5ed-4ff6-a8e1-8673c1aca33f)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0 1))(children(((Tile((id \
          bff90a0f-9924-4848-ae64-f4ec45fc2be9)(label(t1))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         10b37ec2-9c34-42b3-8eed-ccde5a2f8ca5)(content(Whitespace\" \
+         \"))))(Tile((id \
          517c517a-7d03-4299-b9df-96326094ead8)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
-         2105de89-1543-4073-9710-a6625fc9a8f4)(label([ ]))(mold((out \
-         Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
-         Typ))))))(shards(0 1))(children(((Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         d93fddec-5ec9-4f83-bbd3-8a951b928ec8)(content(Whitespace\" \
+         \"))))(Tile((id 2105de89-1543-4073-9710-a6625fc9a8f4)(label([ \
+         ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
+         Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          72d7a47d-3e83-4f15-98d7-f9eb577146fb)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Tile((id \
          88102dfb-3381-4803-ab00-2fc9cdb030c4)(label(,))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 44))(sort Pat))((shape(Concave \
          44))(sort Pat))))))(shards(0))(children())))(Secondary((id \
-         e7d35603-ba06-416c-910b-7663e0d79210)(content(Whitespace\" \
+         78c8ab2f-e5e3-465a-a110-61d2a5b5d5a5)(content(Whitespace\" \
          \"))))(Tile((id \
          d1089bf3-af07-4e1c-95ed-befda420449d)(label(f))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
-         Pat))))))(shards(0))(children())))(Tile((id \
+         Pat))))))(shards(0))(children())))(Secondary((id \
+         2c1accb0-9664-4425-9947-8cb59e6c1d28)(content(Whitespace\" \
+         \"))))(Tile((id \
          a7523a4b-be1e-4445-9e53-69d0b7d99228)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
-         24))(sort Typ))))))(shards(0))(children())))(Tile((id \
+         24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
+         6336415e-3deb-47bb-941a-d9fb8befd193)(content(Whitespace\" \
+         \"))))(Tile((id \
          1c575e9d-effe-4986-b6f2-5d24a9cdc0f0)(label(\"(\"\")\"))(mold((out \
          Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0 1))(children(((Tile((id \
          88c619bd-428f-41e2-88c7-fd1d264501ab)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))(Secondary((id \
-         3edde7b6-1387-4400-9a25-4644a40d8124)(content(Whitespace\" \
+         2555abea-0e9b-4636-a30f-e1637f59ca7f)(content(Whitespace\" \
          \"))))(Tile((id \
          1e925a3a-5bfb-4474-ae6e-6c72230e8683)(label(->))(mold((out \
          Typ)(in_())(nibs(((shape(Concave 13))(sort Typ))((shape(Concave \
          13))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         6e200ca6-0ad9-4016-a0be-5a3e4f5d2f9e)(content(Whitespace\" \
+         a9b82d1b-063b-418c-8842-f8e3fa06ca59)(content(Whitespace\" \
          \"))))(Tile((id \
          bdcc8704-e3a2-4ac4-81ac-822ea3dfd4b4)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children())))))))))))))(Secondary((id \
-         c3ce261a-041d-46b2-9bfe-ceb4034cdc84)(content(Whitespace\" \
+         d10aa107-6ec7-420e-a52b-eb695ddfa26e)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         26ebf0e3-21ca-4d50-9d06-11059f7b4ae5)(content(Whitespace\"\\n\"))))(Tile((id \
+         dd89ba70-eea8-4953-9cd4-bed81943bf25)(content(Whitespace\" \
+         \"))))(Tile((id \
          3804338f-a678-43db-a544-439bcdcd5a3d)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -657,12 +702,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          da96bbe8-d45b-47da-8bae-368d8359ab64)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         81584bfd-8acd-44d2-9c58-0aa793d6bd13)(content(Whitespace\" \
+         3266d238-f98a-493e-abb9-bb81a46fb2d1)(content(Whitespace\" \
          \"))))(Tile((id 8e150ef8-6d68-4269-8c49-b3aa0da697fe)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         82cf3008-8589-43e5-8291-257cb0dc4ed5)(content(Whitespace\" \
+         7c067b8e-8ac8-43ca-a556-7c20425337e5)(content(Whitespace\" \
          \"))))(Tile((id \
          f1c8d557-e831-4b9c-bba9-26ccb4475e11)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -670,19 +715,19 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e7fd121c-05d3-495b-92b6-11d442e16848)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         baf18774-817f-4981-a17c-79773db7d6c4)(content(Whitespace\" \
+         2b411f99-ae14-48ed-a2d5-5eda697b32b9)(content(Whitespace\" \
          \"))))(Tile((id \
          204fd487-866a-4db9-ba38-74d35f8dbd5b)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         167549d5-9b48-4a67-9a8b-d25dcb7c5d3c)(content(Whitespace\" \
+         ae310035-1529-412a-b017-61b91c233568)(content(Whitespace\" \
          \"))))(Tile((id \
          25b5afd4-279e-4032-baf3-31637ea61aa5)(label(row))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         d58f02dc-9d30-4c7d-9849-96fd6f250731)(content(Whitespace\" \
+         969b84c8-9881-4b1c-90e6-91ec5c3d0d15)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         afed51d9-76c5-4600-96db-16f7231e0c20)(content(Whitespace\" \
+         458a0a1a-9e7f-453c-9f0f-b1307065135f)(content(Whitespace\" \
          \"))))(Tile((id \
          2a1ab089-4ff0-4c99-b354-72302de3a7de)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -690,22 +735,22 @@ let out : string * Haz3lcore.PersistentSegment.t =
          dd962a3a-8338-4834-8a2a-e67736b041b4)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         4975c72e-3179-45d5-9401-6ab24fccaeec)(content(Whitespace\" \
+         622a820e-5a80-4e7a-8c91-b176b66b591d)(content(Whitespace\" \
          \"))))(Tile((id \
          f836e02e-721a-40ad-a357-914a64f34ab2)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         1bac56d1-f039-4dd8-9aaf-5dc2ac1172ae)(content(Whitespace\" \
+         7cdcbcea-1a69-4513-a2f4-61c6b2e906e6)(content(Whitespace\" \
          \"))))(Tile((id \
          a5d87ef4-335a-4422-ba8e-df7759266190)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         82b4c2c5-729b-4129-9243-a8ad79513904)(content(Whitespace\" \
+         fa2ed3bd-714d-46da-89d6-ca0a3023d495)(content(Whitespace\" \
          \"))))(Tile((id \
          88612f64-c3ff-4d32-99df-61d732d57a53)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4c8b4e92-2ae6-40cc-9597-759031c3865c)(content(Whitespace\" \
+         3491e3fb-3fa3-4074-ba71-c1e62034d6c7)(content(Whitespace\" \
          \"))))(Tile((id \
          51944bb5-bcf2-42c3-b9f0-3d070135594d)(label(f))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
@@ -716,28 +761,26 @@ let out : string * Haz3lcore.PersistentSegment.t =
          aacb4a54-381a-4593-a011-4d9aba25d7d5)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         6e65a55e-af6e-49da-be61-2e578d4faf33)(content(Whitespace\" \
+         baa8bc2a-d899-4091-804b-5f9f95550480)(content(Whitespace\" \
          \"))))(Tile((id \
          798441d5-6478-4280-b1f2-107a3686fe9d)(label(:))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 24))(sort Exp))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         20c64fd5-e910-423f-bfe5-9ecc6829c581)(content(Whitespace\" \
+         9eec6a13-fb16-4da1-adc7-9378358721e5)(content(Whitespace\" \
          \"))))(Tile((id 0371203b-9e1f-4a50-a8cd-15db572d58b7)(label([ \
          ]))(mold((out Typ)(in_(Typ))(nibs(((shape Convex)(sort Typ))((shape \
          Convex)(sort Typ))))))(shards(0 1))(children(((Tile((id \
          14299a5a-02e6-4abc-b6f5-606e6b1f61be)(label(?))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         b2f45e31-198f-4f26-99af-24270e85a3d3)(content(Whitespace\" \
+         12ab9d7a-b3d1-4484-bf56-fcffaf88d4d5)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         0e05c490-9c11-436b-ba0e-a75b83c07205)(content(Whitespace\"\\n\"))))(Secondary((id \
-         678ae3b5-cccf-4ab1-bd5e-32ef0ef21c04)(content(Whitespace\"\\n\"))))(Tile((id \
+         9b4a2329-5175-473c-9976-4ce3d8290b5b)(content(Whitespace\"\\n\"))))(Secondary((id \
+         d748f941-f65e-4b21-b8de-1a7716d6fb68)(content(Whitespace\"\\n\"))))(Tile((id \
          7f66ab98-c707-4a1f-9eaa-273ed2aa6127)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         da7c126c-b16d-448d-bc3c-f62cace23cba)(content(Whitespace\"\\n\"))))(Secondary((id \
-         8ec38b28-4ec8-4184-9d3a-4410cbc026bb)(content(Whitespace\" \
-         \"))))(Tile((id \
+         c8058b30-9d61-4e52-8477-ebba4cfa261f)(content(Whitespace\"\\n\"))))(Tile((id \
          6c3b67bb-3b6b-4320-8a1c-599852e5afcf)(label(update))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -756,35 +799,43 @@ let out : string * Haz3lcore.PersistentSegment.t =
          e90a384d-f0d4-49ee-b1e6-26ca295c9c32)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8ac95cf6-1fd2-4039-a542-e14b962f57d8)(content(Whitespace\" \
+         7ebb117b-d20a-4caa-ae3d-27fdff30d521)(content(Whitespace\" \
          \"))))(Tile((id 2e7cfa57-377e-4b17-aac8-e08662611004)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         e0dfa146-ea5c-4edc-b832-091a7ca86f34)(content(Whitespace\" \
+         305015bd-4282-4ff7-abcd-6f7b65bf49b5)(content(Whitespace\" \
          \"))))(Tile((id \
          2e370274-1417-473e-bc5c-d07975549269)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         17fd1a84-95ff-499d-90c4-46001f5eedf1)(content(Whitespace\" \
+         0c4c2ed6-fa10-4dfd-b765-0e5ba70fb56b)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         d12d8342-75f0-4d09-adf1-b65c401f3c79)(content(Whitespace\" \
+         c91576e7-b685-4779-8d74-b2c12997cf13)(content(Whitespace\" \
          \"))))(Tile((id \
          765145d7-b7f3-479d-86a7-5e0ce913d965)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          c448a08b-d617-43c2-9f83-026de5ea6685)(label(midterm))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         061b8498-daf7-4cf7-83fa-e2d486c851c9)(content(Whitespace\" \
+         \"))))(Tile((id \
          e1fa9ddd-882f-439c-8f74-1150bd2d083f)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a07384f0-18de-4b32-8965-754842238473)(content(Whitespace\" \
+         \"))))(Tile((id \
          14427859-e9c2-4ccc-89d7-f2d192035b47)(label(85))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8686d934-08f2-4bc9-8527-01b8b3fbaeb9)(content(Whitespace\" \
+         \"))))(Tile((id \
          2a5b53e1-ef58-43fe-a9a1-25c0026a94d4)(label(<=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5747693d-57fd-47ab-ac63-8132634d30db)(content(Whitespace\" \
+         \"))))(Tile((id \
          ad98d9e1-515d-4671-be9b-d3a7ce329401)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -797,20 +848,28 @@ let out : string * Haz3lcore.PersistentSegment.t =
          8957d40f-adb1-4a47-b9a3-bfa663a787aa)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d90601df-7cfa-493d-b467-2239d54a40bd)(content(Whitespace\" \
+         8851f0ff-b8d3-4bd2-8484-64e8d9dc98d6)(content(Whitespace\" \
          \"))))(Tile((id \
          a9596282-5027-40c9-b2ae-c5d6764672f7)(label(final))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         bd634441-cb74-47af-a33d-ca2dd65a2940)(content(Whitespace\" \
+         \"))))(Tile((id \
          354b3a42-6ddd-48f2-9eec-3d01b8661d45)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         d6d19d5f-980c-41a8-9760-7e7d3a318113)(content(Whitespace\" \
+         \"))))(Tile((id \
          5823ae2a-8ce1-45bf-8df4-887282d6a47d)(label(85))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         8f9d8abe-d4c9-4922-bf12-1c587be5e869)(content(Whitespace\" \
+         \"))))(Tile((id \
          4da1314c-9635-495b-91fc-0246838f9899)(label(<=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         86df821d-ce5a-4b7c-92f8-082d2ae9e363)(content(Whitespace\" \
+         \"))))(Tile((id \
          7c4da9ec-0e36-4c97-81cb-9fb11b1f1def)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -820,16 +879,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          9f379a5a-5142-421d-bbab-c2cc886e492f)(label(final))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         90b264c1-1316-4961-a6ba-a6943752da8c)(content(Whitespace\" \
-         \"))))(Tile((id \
+         4ef33eb4-ac39-475e-95de-af2f9945866c)(content(Whitespace\"\\n\"))))(Tile((id \
          885a9052-211e-4b06-91a7-88f57e18cdc2)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f23769bc-5c29-4a90-b290-9da6cfb46755)(content(Whitespace\"\\n\"))))(Secondary((id \
-         590d473d-476e-4454-bec8-ab8282c02573)(content(Whitespace\" \
+         d5b42c6c-069d-4b5a-9eab-541017559731)(content(Whitespace\" \
          \"))))(Tile((id 0ddd4445-3555-4e95-9129-fecc9ce528b5)(label([ \
          ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
-         Convex)(sort Exp))))))(shards(0 1))(children(((Tile((id \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         c248ddc8-1d0d-4ec5-ae99-1fadd9c8c2e3)(content(Whitespace\"\\n\"))))(Tile((id \
          7291e0b7-4b02-4311-a69e-855468480733)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -943,7 +1001,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          84a05fb6-b42f-4d59-b20b-9546ca4725a5)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         e52a53ce-897c-4d67-b42e-13643dcee597)(content(Whitespace\"\\n\"))))(Tile((id \
+         60c20ab5-0e75-4f85-974b-96b359124873)(content(Whitespace\"\\n\"))))(Tile((id \
          0d940126-56cb-4a49-899c-9b4c351d3414)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1057,130 +1115,164 @@ let out : string * Haz3lcore.PersistentSegment.t =
          484cd3a2-10ec-49e4-ada7-7b2f9e4ee00a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         82e79e49-410d-4381-90ba-5d9554ad2f42)(content(Whitespace\"\\n\"))))(Tile((id \
+         d2a0d53a-f26e-4248-b414-2fc65915ec8e)(content(Whitespace\"\\n\"))))(Tile((id \
          5b0bb43c-e54c-436c-8f70-2710f9811cf2)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          a9daec18-a422-46a5-840a-f311b2b13611)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         157289c8-ad0e-4bf9-96c4-ebefff689c42)(content(Whitespace\" \
+         \"))))(Tile((id \
          f24d7d4c-b073-409e-99a3-ff06cf8f2d7d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         88104d70-e31d-4fbd-aa85-a8a816d5db90)(content(Whitespace\" \
+         \"))))(Tile((id \
          02f183af-6734-4550-a186-6bac97a5a55b)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          b00f9883-c1c6-4946-9334-b40e3b502f23)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8b871095-dc88-40f4-9fc3-546af2aab5f5)(content(Whitespace\" \
+         afee51d0-faa4-4961-84ac-a966b9e0c05b)(content(Whitespace\" \
          \"))))(Tile((id \
          dcc6b698-d863-4c12-973d-6a43ceff16dd)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         36dea950-37e0-4d90-9fc9-c214a881bc7f)(content(Whitespace\" \
+         \"))))(Tile((id \
          29f0924a-e3fc-4733-979c-26034992e643)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         3445bd5e-2578-423f-b19e-98565498e4d3)(content(Whitespace\" \
+         \"))))(Tile((id \
          5d115485-2e28-4672-b634-867b502fc672)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          6f737a02-a8f1-4ae2-9c0a-a5c9979b71ae)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         3bde0e08-427d-42b2-aa17-df1c650cf48b)(content(Whitespace\" \
+         e8197ae8-2067-4074-941f-723d9450910e)(content(Whitespace\" \
          \"))))(Tile((id \
          5909491c-902f-4bc9-a318-08c82bb7175e)(label(quiz1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a29e9acc-e2a0-428d-bdb2-8f4b77f1ec53)(content(Whitespace\" \
+         \"))))(Tile((id \
          0a937a03-071a-4fbf-b51c-89cf86160881)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4a7f9a52-7309-44a6-b032-0c9aff3b2f49)(content(Whitespace\" \
+         \"))))(Tile((id \
          ef5844c5-0c86-4eab-887c-c4319c40eff6)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          11b1bd61-4fd3-43cc-82bc-cfd9733fe6c3)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         cb8936c7-beac-4de0-bdae-2117592992f1)(content(Whitespace\" \
+         ba27742d-e00c-4e08-8d80-ee200f48c052)(content(Whitespace\" \
          \"))))(Tile((id \
          a26700fc-d1f3-45a6-b550-90a40cd0bd61)(label(quiz2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c537cd0e-29c3-4374-8df9-febed024f3ff)(content(Whitespace\" \
+         \"))))(Tile((id \
          ff9b6a6e-f4e7-4a14-825a-38a9aed633f7)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         798e4ee3-ea7b-4a6d-8ae0-abe203e39379)(content(Whitespace\" \
+         \"))))(Tile((id \
          8119971d-fdbb-4a89-a191-f287f120b022)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          513e3710-833b-4e6e-9094-753f49b67a3c)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         d989ce80-d66c-4f6b-a106-d876fe702d54)(content(Whitespace\" \
+         c270d2dd-3fa1-45b9-8d31-a2d217631e61)(content(Whitespace\" \
          \"))))(Tile((id \
          190fe680-5a3e-4c8c-846b-11ecba82b755)(label(midterm))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         523c3d63-12b4-4b7a-94b3-032fa115b417)(content(Whitespace\" \
+         \"))))(Tile((id \
          85111015-d65a-4b09-92f8-5eb0615d599c)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         bbaf2104-295d-4474-a771-e90782e2c923)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce98350c-03d2-4680-b9e2-8d047c093853)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          c7e23a7c-043a-485a-9709-6af5216668dc)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4ca252e4-03ea-48c4-bc01-d19573b3ce22)(content(Whitespace\" \
+         8b404f84-fcae-40f0-a766-ffb47f3e8e75)(content(Whitespace\" \
          \"))))(Tile((id \
          36be9d1e-d2bf-4cba-bb7a-8b91646f6f97)(label(quiz3))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         131f0dd6-ff86-4eff-b16f-414086eb3c1c)(content(Whitespace\" \
+         \"))))(Tile((id \
          dc387b4d-0e08-4762-b704-b488d8c01f81)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         48d2e1ce-0a71-4779-862a-2225fac3fd0f)(content(Whitespace\" \
+         \"))))(Tile((id \
          f1fcab89-9a49-443e-b79a-c9a7282133d3)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          1ce9d124-a650-4131-a2e8-276885d6b1e7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         6a458bf3-b1c8-49bd-a2e1-5f8a10f5ec1f)(content(Whitespace\" \
+         570dc608-c622-43dd-ab64-52c0bf728f3d)(content(Whitespace\" \
          \"))))(Tile((id \
          eec24731-7c30-489a-99b1-04ad8cbdf7a4)(label(quiz4))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         df507336-ff3a-406e-b19d-12d74e4add5d)(content(Whitespace\" \
+         \"))))(Tile((id \
          e47ff6a6-fff9-49f7-a48d-183063dc5c6b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         509a02de-823e-42ab-ba22-2029735d9a88)(content(Whitespace\" \
+         \"))))(Tile((id \
          dab191fe-50ef-4277-a92f-d97200c302d1)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          c95d1b97-f849-4f05-8671-75364ad58fe0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7dbc9a07-eb52-4f43-80d6-02304b739ac9)(content(Whitespace\" \
+         7a6a4dc6-49fe-48a4-a842-c52eed74f1d4)(content(Whitespace\" \
          \"))))(Tile((id \
          baf11d1b-9656-409e-8a09-13417ec0b751)(label(final))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         556b6228-e4cf-4549-9cfa-1e37c88eb57d)(content(Whitespace\" \
+         \"))))(Tile((id \
          40faf102-caf2-43e0-a187-98840c90f08b)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         a2232d1d-00e8-4299-8e22-1155e1b5314f)(content(Whitespace\" \
+         \"))))(Tile((id \
          f43c7964-0d8f-4b23-85e0-05e3585ff28a)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         44c29db2-ebbf-4822-a7e2-843c90c09650)(content(Whitespace\"\\n\")))))))))(Tile((id \
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         3269df91-4972-4b44-87cb-e19098afab4d)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         0ef93e01-97ed-4e94-8c28-1c748b8c555d)(content(Whitespace\" \
+         \")))))))))(Tile((id \
          40bc1cf0-36aa-4bc5-9582-49c35ca5cb04)(label(\";\"))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 35))(sort Exp))((shape(Concave \
          35))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         5554dad2-c650-4371-b005-b15261f6f919)(content(Whitespace\"\\n\"))))(Secondary((id \
-         81681d4f-df6d-404f-a96b-fc59cd6c2db2)(content(Whitespace\"\\n\"))))(Secondary((id \
+         39bd690c-b50c-46e2-b41b-5baefbfa27e9)(content(Whitespace\"\\n\"))))(Secondary((id \
+         e59d0b64-ce06-465e-b273-6ff1cb31ec63)(content(Whitespace\"\\n\"))))(Secondary((id \
          fd31b428-7492-4b06-ad3c-5d4d93449706)(content(Comment\"# Without \
          being polymorphic has better types #\"))))(Secondary((id \
-         1d1197b3-1b5d-4e6d-85f8-d48efdb0c5b7)(content(Whitespace\"\\n\"))))(Tile((id \
+         320086f1-1a3f-4cb1-bd03-a22a64c373b5)(content(Whitespace\"\\n\"))))(Tile((id \
          34b7c25a-e731-44ce-9dd7-7d5216af81c8)(label(test end))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Secondary((id \
-         d9acf0f4-f6bb-4c05-a217-c30d318eb6ed)(content(Whitespace\"\\n\"))))(Tile((id \
+         de3e2e70-a445-4f60-ab53-28fd670365b1)(content(Whitespace\"\\n\"))))(Tile((id \
          2c422b82-9b9a-4d57-b62c-e9a114dbfae6)(label(map))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1193,12 +1285,12 @@ let out : string * Haz3lcore.PersistentSegment.t =
          63495422-44fb-4204-bc87-8e66d7aeee2a)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         f8bc29d0-6802-4675-a9f6-a39ad2467fc8)(content(Whitespace\" \
+         b8bb376d-6d6f-443c-ae59-07e524fa802e)(content(Whitespace\" \
          \"))))(Tile((id a1ede9c8-1827-42ef-98af-45f4c95e32bc)(label(fun \
          ->))(mold((out Exp)(in_(Pat))(nibs(((shape Convex)(sort \
          Exp))((shape(Concave 37))(sort Exp))))))(shards(0 \
          1))(children(((Secondary((id \
-         b92a1a7c-0ba7-463f-a772-041170a542f7)(content(Whitespace\" \
+         a3ce9a7a-be63-477e-a0e3-35fe1caa90c8)(content(Whitespace\" \
          \"))))(Tile((id \
          38830201-0168-4e74-afc5-83a34b1f9a73)(label(\"(\"\")\"))(mold((out \
          Pat)(in_(Pat))(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
@@ -1206,45 +1298,53 @@ let out : string * Haz3lcore.PersistentSegment.t =
          2586a00a-3871-44b9-b4b9-fcbd97cf24eb)(label(r))(mold((out \
          Pat)(in_())(nibs(((shape Convex)(sort Pat))((shape Convex)(sort \
          Pat))))))(shards(0))(children())))(Secondary((id \
-         ba34db8c-3a3d-4d40-b8e6-b60246c79b60)(content(Whitespace\" \
+         507575ab-79d7-43c2-a388-2e099c5896d8)(content(Whitespace\" \
          \"))))(Tile((id \
          d4f7fad1-b245-43fa-9e3b-5135ac2b79bb)(label(:))(mold((out \
          Pat)(in_())(nibs(((shape(Concave 24))(sort Pat))((shape(Concave \
          24))(sort Typ))))))(shards(0))(children())))(Secondary((id \
-         c1ec3e17-6ec1-4886-897b-67a93cc2449b)(content(Whitespace\" \
+         1fba5f14-71c0-4897-a38d-fefe885cd066)(content(Whitespace\" \
          \"))))(Tile((id \
          9e6dbd54-a612-4c64-bde4-22b4fcca2274)(label(GradebookEntry))(mold((out \
          Typ)(in_())(nibs(((shape Convex)(sort Typ))((shape Convex)(sort \
          Typ))))))(shards(0))(children()))))))))(Secondary((id \
-         1950a320-7ea2-4b9c-a8e2-52a671ec85ee)(content(Whitespace\" \
+         95195d68-aa5f-47af-be61-de81adafec02)(content(Whitespace\" \
          \")))))))))(Secondary((id \
-         dd1f0fc6-b9d6-4054-9fb4-6fdd69e7e206)(content(Whitespace\" \
+         fbdd6f38-7488-4b18-9105-7ccebde5df61)(content(Whitespace\" \
          \"))))(Tile((id \
          9f1427e1-06f6-4f9f-9270-3cf17698891e)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Secondary((id \
-         61a60b8b-c3f5-4d94-b97d-547e3b8129b7)(content(Whitespace\" \
+         e613ae7a-2c57-42f5-a861-887e7f0ac38a)(content(Whitespace\" \
          \"))))(Tile((id \
          a8bc8db4-9bc8-449e-9310-d800e978c010)(label(...))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 28))(sort Exp))((shape(Concave \
          28))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7d00f622-996e-4663-ac47-866b1a59b1ba)(content(Whitespace\" \
+         f1c81611-5698-4829-8ebf-53514e4b83af)(content(Whitespace\" \
          \"))))(Tile((id \
          32064b7e-b0ce-46a8-9850-d7fe2951d883)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          4ccc225c-e39b-4f7b-93fe-0e542263d296)(label(midterm))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         f2da66b3-dc86-48ae-afcf-95043eb43ce9)(content(Whitespace\" \
+         \"))))(Tile((id \
          80e53726-5434-4632-a13b-2903b326a90e)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         56f27c74-c0e3-495f-8d7e-0b9d4c86fe6f)(content(Whitespace\" \
+         \"))))(Tile((id \
          1cd2c090-a6ff-44a1-8444-52469880d6b5)(label(85))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         13a5977f-206e-4add-a9ef-d881927222ad)(content(Whitespace\" \
+         \"))))(Tile((id \
          d8f0c025-4fc6-409e-a69e-1ec723fe5cce)(label(<=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         59a0a41e-460a-4546-9600-1a27d5aacb0c)(content(Whitespace\" \
+         \"))))(Tile((id \
          a19019e3-1643-4ba7-af28-f9085e6aeb8c)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1257,20 +1357,28 @@ let out : string * Haz3lcore.PersistentSegment.t =
          7772e114-1c01-4c37-8c7b-9ee50800e23b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         69f4b6e7-8fa3-428d-8af4-e4875da5382e)(content(Whitespace\" \
+         2691dacf-aed2-475f-977f-c71a3a84306a)(content(Whitespace\" \
          \"))))(Tile((id \
          ba71d82d-ff1c-4ab9-a570-4f600c7e7906)(label(final))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         24a68147-4733-46fc-a65e-ba710ea33195)(content(Whitespace\" \
+         \"))))(Tile((id \
          7523e6bb-ca6e-4f37-832d-b7825c425714)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         eabcaf4b-0773-4d5a-9f39-30d8ec716b8d)(content(Whitespace\" \
+         \"))))(Tile((id \
          afb59ba5-2174-4b95-acb2-de8f0f6e2cbe)(label(85))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         012e8386-6fa0-43c0-b04a-8b49819cedfa)(content(Whitespace\" \
+         \"))))(Tile((id \
          ce40912c-a549-4ab0-bb00-ee4c8ca7c078)(label(<=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
-         31))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c288abc3-3923-497c-91a0-cf76d9db3959)(content(Whitespace\" \
+         \"))))(Tile((id \
          94ddb568-d3a2-4585-a7d5-a8bec4671e15)(label(r))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
@@ -1280,15 +1388,15 @@ let out : string * Haz3lcore.PersistentSegment.t =
          f0a5314f-af87-4d89-80ad-8889789d0ce5)(label(final))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         bfbbcd61-43b5-4fad-a7e8-13faa72da610)(content(Whitespace\" \
-         \"))))(Tile((id \
+         f765821f-24a5-48f7-92af-558d186d2b99)(content(Whitespace\"\\n\"))))(Tile((id \
          afcdec02-239a-4d9b-b22a-14d3758e1699)(label(==))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 31))(sort Exp))((shape(Concave \
          31))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         7df47734-4b65-4b2f-9394-bbd34a4bfcb8)(content(Whitespace\"\\n\"))))(Tile((id \
-         a8e0e6c4-2ff3-449d-a08b-718169c8012d)(label([ ]))(mold((out \
-         Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0 1))(children(((Tile((id \
+         4a4b21b2-8129-4f2c-89c0-abf69e3e1c40)(content(Whitespace\" \
+         \"))))(Tile((id a8e0e6c4-2ff3-449d-a08b-718169c8012d)(label([ \
+         ]))(mold((out Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape \
+         Convex)(sort Exp))))))(shards(0 1))(children(((Secondary((id \
+         05414e3c-09e1-437d-88e6-73d1617d6b10)(content(Whitespace\"\\n\"))))(Tile((id \
          5c943e25-b50b-4ddb-bdc2-b03579d1100d)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1402,7 +1510,7 @@ let out : string * Haz3lcore.PersistentSegment.t =
          b479bd71-cee8-4f1b-8ff7-fab237dc8df0)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         818e6b0a-3ddd-4c2a-ac8a-5aabeb6f4912)(content(Whitespace\"\\n\"))))(Tile((id \
+         d44bd981-c10c-4864-b878-9a7d3e352be7)(content(Whitespace\"\\n\"))))(Tile((id \
          29a866e5-0169-4bf3-887f-52d7c230348e)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
@@ -1516,160 +1624,195 @@ let out : string * Haz3lcore.PersistentSegment.t =
          fe99c326-3644-4fc1-b263-95af267a7624)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         9544c03c-951c-477c-8dd2-bd6ad8f23ae6)(content(Whitespace\"\\n\"))))(Tile((id \
+         be653030-d930-42f6-9bd5-44b3aa2eac63)(content(Whitespace\"\\n\"))))(Tile((id \
          ed3fe96b-21ee-4b85-97f0-523911f9b738)(label(\"(\"\")\"))(mold((out \
          Exp)(in_(Exp))(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0 1))(children(((Tile((id \
          73182198-e00c-4dd9-89ac-34a5b9ddfbcc)(label(name))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         1b89021b-1a2e-480b-80ba-87e1ac13ae4e)(content(Whitespace\" \
+         \"))))(Tile((id \
          fc554105-2016-4ad0-8b98-5cfb7e192385)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         4e050c9a-fe20-40d9-b95d-8ec2bfed1757)(content(Whitespace\" \
+         \"))))(Tile((id \
          24fa27a8-69cc-40b6-ac93-6b3935df50cf)(label(\"\\\"Eve\\\"\"))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          28d5d01c-202d-4456-a476-f3bb390f5cba)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         8d85e758-56ed-4d5c-a876-d51fea4a4e11)(content(Whitespace\" \
+         5ca69dec-7924-4a9d-9f4d-7de4f0af0858)(content(Whitespace\" \
          \"))))(Tile((id \
          eed4e5ce-252b-4a0b-9fb3-aa7a066c1770)(label(age))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         c9dfdc50-63f3-4995-9fa2-2ba6b34e6fa0)(content(Whitespace\" \
+         \"))))(Tile((id \
          15a5fa6a-c787-4b80-b58a-8f03881d507d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         33421274-020f-492f-ba3a-8af8507f1ee7)(content(Whitespace\" \
+         \"))))(Tile((id \
          ea6beb7d-095e-41d2-9fcd-fffe0a20556e)(label(13))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          093b7355-d84b-48f1-b1f7-9dce2f3b4598)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         df7c2e63-7b7d-490a-b921-66923060973c)(content(Whitespace\" \
+         7f51f177-d477-4872-9415-98a9dbc0ac71)(content(Whitespace\" \
          \"))))(Tile((id \
          d547c46f-bc00-41ae-ae82-5362c94440a0)(label(quiz1))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b535df78-6a36-4fa7-997b-a6afe75af527)(content(Whitespace\" \
+         \"))))(Tile((id \
          6851de41-93a1-4cfe-9ce2-aa815d8bed64)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         11a48669-6995-4a52-9853-3ab42d8cde03)(content(Whitespace\" \
+         \"))))(Tile((id \
          0b552950-1c9e-45a7-9659-8d5368bb84d2)(label(7))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          6dd3ddf3-8aca-41f5-96a8-366d6651fd27)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         651656f7-4371-466f-a6d9-49e6a650a0cb)(content(Whitespace\" \
+         bea3336b-998f-4b9e-8b86-024bc33e5faa)(content(Whitespace\" \
          \"))))(Tile((id \
          94d20b70-d1e1-4a2d-9967-6da3c7d1386f)(label(quiz2))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         0095fb07-8e50-46cf-a854-ddf4faf1d887)(content(Whitespace\" \
+         \"))))(Tile((id \
          08da3ffe-ce6c-482f-ad6f-b44d8979256d)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         25be34d7-18ba-4c77-9b61-ba0d77b78db0)(content(Whitespace\" \
+         \"))))(Tile((id \
          4aa31d75-ead6-4252-a50b-ac714e4e9e8c)(label(9))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          4095dbf7-10a1-4b5d-ae97-315328395514)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         4dd6e719-5443-4303-b35f-6038b6c2ca6b)(content(Whitespace\" \
+         1040b7c6-cf04-4f1d-a765-32c4c92ddbee)(content(Whitespace\" \
          \"))))(Tile((id \
          602cae94-7e57-4be7-941e-aa0ec5528f71)(label(midterm))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         35c42521-ca90-4df2-a86b-819ba54535d6)(content(Whitespace\" \
+         \"))))(Tile((id \
          c728b6e8-90e7-4880-8ce4-353db671564a)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         c58e7223-36a8-4f35-bd78-4b9c46abb041)(content(Whitespace\" \
+         \"))))(Tile((id \
          b2e891d1-c17d-46d2-877a-1f583b976690)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          4cfaacc2-843c-40ca-a9bf-412cbf6b167b)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         599b4f5d-80fe-4eaf-bcb4-82b0c8152e47)(content(Whitespace\" \
+         9d4d9448-1d3e-42e1-b27f-0e6daf4e9376)(content(Whitespace\" \
          \"))))(Tile((id \
          960ddd84-657e-4ae8-8541-33d0a97de870)(label(quiz3))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b6f34163-bb9c-4676-b283-2e482c13940e)(content(Whitespace\" \
+         \"))))(Tile((id \
          d0a91a15-e078-477b-ba8f-5e67c30936cb)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         5669ac06-c136-4738-9a72-ffc47554dbf4)(content(Whitespace\" \
+         \"))))(Tile((id \
          0414e02e-ee38-497c-96e6-dc5d03c2b6d3)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          0c3f9183-18b2-4a68-829f-e246c7c9f489)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         0df618b4-9c17-4a20-9145-c70841200d91)(content(Whitespace\" \
+         d8f11882-f338-439f-8fe4-10f67beef695)(content(Whitespace\" \
          \"))))(Tile((id \
          b800f175-5d5b-4329-bacf-0a9f65029c6c)(label(quiz4))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         b3541432-160e-4a01-be57-321732b4f12c)(content(Whitespace\" \
+         \"))))(Tile((id \
          f12cb35b-af39-472f-9009-4e252108d6be)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         454f4ecd-923c-41c0-80d3-a68127e8bc61)(content(Whitespace\" \
+         \"))))(Tile((id \
          97c5293e-1f0d-47cf-8249-857bf753c95b)(label(8))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
          Exp))))))(shards(0))(children())))(Tile((id \
          dc6b20bd-8121-4169-b0f6-da63e92c31d7)(label(,))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 44))(sort Exp))((shape(Concave \
          44))(sort Exp))))))(shards(0))(children())))(Secondary((id \
-         187ae1b7-2f79-45da-902a-d0b965f4a192)(content(Whitespace\" \
+         38bedd83-0944-47f5-aec9-f6e606829169)(content(Whitespace\" \
          \"))))(Tile((id \
          fc466e19-e6ad-48ca-a2e6-fe4afa089984)(label(final))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))(Tile((id \
+         Exp))))))(shards(0))(children())))(Secondary((id \
+         a0129559-9c22-4ad4-a2fa-5aaef176e54f)(content(Whitespace\" \
+         \"))))(Tile((id \
          77240bbf-0f81-4d4d-9a7a-5dd7a4049168)(label(=))(mold((out \
          Exp)(in_())(nibs(((shape(Concave 39))(sort Exp))((shape(Concave \
-         39))(sort Exp))))))(shards(0))(children())))(Tile((id \
+         39))(sort Exp))))))(shards(0))(children())))(Secondary((id \
+         15dbce41-5edd-401f-b47a-433fbc1cd46b)(content(Whitespace\" \
+         \"))))(Tile((id \
          5055ae51-7d56-42d0-99c0-58d9c931c970)(label(false))(mold((out \
          Exp)(in_())(nibs(((shape Convex)(sort Exp))((shape Convex)(sort \
-         Exp))))))(shards(0))(children())))))))))))))(Secondary((id \
-         e0d9d94e-0151-4dab-ab45-ce974dd80727)(content(Whitespace\"\\n\"))))))))))";
+         Exp))))))(shards(0))(children()))))))))(Secondary((id \
+         42c99810-af20-4e8c-824a-7d5ff5e94713)(content(Whitespace\"\\n\")))))))))(Secondary((id \
+         c166a81c-8370-447b-bd18-a84fc744b8f4)(content(Whitespace\" \
+         \"))))))))))";
       backup_text =
-        "type GradebookEntry = (name=String, age=Int, quiz1=Int, quiz2=Int, \
-         midterm=Int, quiz3=Int, quiz4=Int, final=Int) in\n\
+        "type GradebookEntry = (name = String, age = Int, quiz1 = Int, quiz2 = \
+         Int, midterm = Int, quiz3 = Int, quiz4 = Int, final = Int) in\n\
          let gradebook : [GradebookEntry] = ^^fold([\n\
          (\"Bob\",   12, 8, 9, 77, 7, 9, 87),\n\
          (\"Alice\", 17, 6, 8, 88, 8, 7, 85),\n\
          (\"Eve\",   13, 7, 9, 84, 8, 8, 77)\n\
          ]) in\n\
-         let requires = [\n\
-         (enforced=^^check(false), \"for all c in header(r2), c is in \
-         header(t1)\")\n\
-         ] in\n\
-         let ensures = [\n\
+         let _requires = [(enforced = ^^check(false), \"for all c in \
+         header(r2), c is in header(t1)\")] in\n\
+         let _ensures = [\n\
          (enforced=^^check(true), \"schema(r1) == schema(t1)\"),\n\
          (enforced=^^check(false), \"header(t2) == header(t1)\"),\n\
          (enforced=^^check(false), \"for all c in header(t2): if c in \
          header(r2) then schema(t2)[c] == schema(r2)[c]\"),\n\
          (enforced=^^check(false), \"otherwise, schema(t2)[c] == \
          schema(t1)[c]\"),\n\
-         (enforced=^^check(false), \"nrows(t2) == nrows(t1)\")\n\
+         (enforced = ^^check(false), \"nrows(t2) == nrows(t1)\")\n\
          ] in\n\
-         let update = typfun row -> fun (t1:[row], f:(row -> ?)) ->\n\
+         let update = typfun row -> fun (t1 : [row], f : (row -> ?)) -> \
          map(t1, fun (r : row) -> (r : ?) ... f(r)) : [?] in\n\n\
          test\n\
-        \ update@<GradebookEntry>(gradebook, fun r -> (midterm=85<=r.midterm, \
-         final=85<=r.final)) ==\n\
-        \ [(name=\"Bob\", age=12, quiz1=8, quiz2=9, midterm=false, quiz3=7, \
+         update@<GradebookEntry>(gradebook, fun r -> (midterm = 85 <= \
+         r.midterm, final = 85 <= r.final))\n\
+         == [\n\
+         (name=\"Bob\", age=12, quiz1=8, quiz2=9, midterm=false, quiz3=7, \
          quiz4=9, final=true),\n\
          (name=\"Alice\", age=17, quiz1=6, quiz2=8, midterm=true, quiz3=8, \
          quiz4=7, final=true),\n\
-         (name=\"Eve\", age=13, quiz1=7, quiz2=9, midterm=false, quiz3=8, \
-         quiz4=8, final=false)]\n\
-         end;\n\n\
+         (name = \"Eve\", age = 13, quiz1 = 7, quiz2 = 9, midterm = false, \
+         quiz3 = 8, quiz4 = 8, final = false)\n\
+         ] end;\n\n\
          # Without being polymorphic has better types #\n\
          test\n\
-         map(gradebook, fun (r : GradebookEntry) -> r ... \
-         (midterm=85<=r.midterm, final=85<=r.final)) ==\n\
-         [(name=\"Bob\", age=12, quiz1=8, quiz2=9, midterm=false, quiz3=7, \
+         map(gradebook, fun (r : GradebookEntry) -> r ... (midterm = 85 <= \
+         r.midterm, final = 85 <= r.final))\n\
+         == [\n\
+         (name=\"Bob\", age=12, quiz1=8, quiz2=9, midterm=false, quiz3=7, \
          quiz4=9, final=true),\n\
          (name=\"Alice\", age=17, quiz1=6, quiz2=8, midterm=true, quiz3=8, \
          quiz4=7, final=true),\n\
-         (name=\"Eve\", age=13, quiz1=7, quiz2=9, midterm=false, quiz3=8, \
-         quiz4=8, final=false)]\n\
-         end";
+         (name = \"Eve\", age = 13, quiz1 = 7, quiz2 = 9, midterm = false, \
+         quiz3 = 8, quiz4 = 8, final = false)\n\
+         ] end";
+      refractors = "()";
     } )


### PR DESCRIPTION
## Summary

Closes #2057.

Operates on every slide under `src/b2t2/slides/`:

1. **Replaces removed `string_eq(a, b)` with `a == b`** in the slides that still referenced it (TableAPI Aggregate / Ordering / AccessSubcomponents / Subtable / DataCleaning / MissingValues, ExamplePrograms groupByRetentive / groupBySubtractive).

2. **Prefixes pattern-binding tiles flagged as unused variables with `_`** to silence those warnings. Covers `requires`, `ensures`, destructured pattern names like `score`, `l`, `v`, etc. across every slide.

3. **Pretty-prints all slides at width 140**. Width 140 keeps every row of the multi-column data tables on a single line — at width 80 the last row of the jellyAnon table (pHacking{Homo,Hetero}geneous.ml) splits across many lines.

The `src/web/init/docs/` slides are intentionally excluded from this PR — those have more custom formatting that the automated regeneration would disturb, so they'll be cleaned up separately.

The slide rewrites were generated with the `slide-*` CLI subcommands in #2282, but the resulting `.ml` files stand on their own — this PR only contains the regenerated slide content.

## Test plan

- [x] `make dev` builds cleanly
- [ ] B2T2 / Table API slides (Aggregate, Ordering, AccessSubcomponents, Subtable, DataCleaning, MissingValues) load cleanly with `==` replacing `string_eq`
- [x] B2T2 / Example Programs (groupByRetentive, groupBySubtractive) load cleanly
- [x] Pedagogical-error slides (Errors/*) still demonstrate their intended demo errors
- [x] jellyAnon tables (pHacking{Homo,Hetero}geneous) — every row fits on a single line in the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)