### PR TITLE
Coverage: don't crash on TupLabel with non-Label in label position (#2074)

### DIFF
--- a/src/language/statics/Coverage.re
+++ b/src/language/statics/Coverage.re
@@ -332,9 +332,9 @@ module UnseenPatternList: UnseenPatternList = {
       let (first_n, tl) = partition_first_n(num_elts, pat_list, []);
 
       cons_pat_t(tuple(List.rev(first_n)), {pat: tl});
-    | TupLabel(body, _) =>
+    | TupLabel(label_pos, _) =>
       // associate the tuple's labels to element in the unseen list
-      switch (IdTagged.term_of(body)) {
+      switch (IdTagged.term_of(label_pos)) {
       | Label(pat_label) =>
         switch (pat_list) {
         | [] =>
@@ -342,7 +342,8 @@ module UnseenPatternList: UnseenPatternList = {
         | [hd, ...tl] =>
           cons_pat_t(tup_label(label(pat_label), hd), {pat: tl})
         }
-      | _ => failwith("TupLabel without a label in unseen pattern list")
+      // No label (e.g. label_pos is EmptyHole) — skip this column.
+      | _ => unseen_pattern
       }
     | List(_) =>
       switch (ctr.ctr) {

--- a/test/Test_Coverage.re
+++ b/test/Test_Coverage.re
@@ -1279,6 +1279,18 @@ let exhaustive_bools_with_wilds =
     |},
   );
 
+// Regression for #2074.
+let regression_2074_tuplabel_emptyhole_label =
+  test_case(
+    "TupLabel with EmptyHole label in let-binding doesn't crash", `Quick, () =>
+    switch (Haz3lcore.Parser.to_term("let (?=?) = 1 in 1", ~root=Exp)) {
+    | None => Alcotest.fail("parse failed")
+    | Some(term) =>
+      let _ = statics(term);
+      ();
+    }
+  );
+
 let tests = (
   "Pattern Coverage Checker",
   [
@@ -1343,5 +1355,6 @@ let tests = (
     exhaustive_ints_with_wilds,
     exhaustive_strings_with_wilds,
     exhaustive_bools_with_wilds,
+    regression_2074_tuplabel_emptyhole_label,
   ],
 );

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -650,6 +650,12 @@ let insertion_tests = [
     ~acts=mk({|string_capitalize¦1)|}) @ [Insert("(")],
     ~goal={|string_capitalize(¦1)|},
   ),
+  /* Regression for #2074. */
+  test(
+    ~name="Tuple label keyword-expanding to `let` doesn't crash",
+    ~acts=string_to_ltr_actions("(le=)") @ mv_l(3) @ [Insert("t")],
+    ~goal={|(let¦?=?)|},
+  ),
 ];
 
 let destruct_tests = [


### PR DESCRIPTION
## Summary

Closes #2074.

`Coverage.cons_ctr` was raising `Failure "TupLabel without a label in unseen pattern list"` whenever a binding pattern's column type was `TupLabel(label_pos, _)` and `label_pos` wasn't a clean `Label(_)`. That term shape arises in two normal cases:

1. **Hand-written holes in the label position** — e.g. `let (?=?) = 1 in 1` parses cleanly into `TupLabel(EmptyHole, EmptyHole)` (per `MakeTerm.re:926`), but exhaustiveness checking on the let pattern crashes. Same for `fun (?=?) -> ...`.
2. **Transient editor states** — typing `t` in `(le=?)` keyword-expands `le` → `let`. Remolding doesn't manage to absorb the existing tuple-label `=` into the new `let` form's `=` shard while the surrounding `(...)` is in place, so MakeTerm sees the `=` as the binary `TupleLabeledExp` infix with hole operands and produces `TupLabel(EmptyHole, _)`. The `let` keyword in the segment drags the malformed labeled-tuple element into a binding-pattern context, Coverage runs, and crashes.

Both cases blow the editor up via Async_kernel surfacing the unhandled exception out of `Page.calculate`.

## Fix

Restore the pre-11d1f82e8e behavior: `| _ => unseen_pattern`. The failwith was introduced in that commit replacing the working pass-through on the assumption that the label position was always `Label(_)`. We can't construct a labeled-tuple pattern without a label, so leave the unseen list unchanged and skip the column.

Also renames the local variable `body` → `label_pos` so the position it represents inside `TupLabel(_, _)` is obvious at the match site.

## Tests

- `test/Test_Coverage.re` — `let (?=?) = 1 in 1` runs statics without raising. Crashes on dev.
- `test/Test_Editing.re` — typing `t` in `(le=?)` doesn't crash. Crashes on dev.

`make dev` clean, `make test-quick` passes (2625 tests).

## Test plan

- [x] `make test-quick`
- [x] In the running app: open a scratchpad, type `(le=` then move caret between `e` and `=` and type `t`. Editor stays alive.
- [x] In the running app: type `let (?=?) = 1 in ?`. No crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)