### PR TITLE
Improve QCheck shrinker coverage

### DIFF
--- a/src/menhirParser/AST.re
+++ b/src/menhirParser/AST.re
@@ -680,6 +680,12 @@ and gen_pat_sized: (~minimal_idents: bool, int) => QCheck.Gen.t(pat) =
 let shrink_non_empty_string: QCheck.Shrink.t(string) =
   x => QCheck.Shrink.(filter(x => String.length(x) != 0, string, x));
 
+let pat_typ_opt = (p: pat): option(typ) =>
+  switch (p) {
+  | AscPat(_, t) => Some(t)
+  | _ => None
+  };
+
 let rec shrink_exp: QCheck.Shrink.t(exp) =
   QCheck.(
     (exp: exp) =>
@@ -752,6 +758,12 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
           }
         | Let(p, e1, e2) =>
           of_list([e1, e2])
+          <+> (
+            switch (pat_typ_opt(p)) {
+            | Some(t) => of_list([Asc(e1, t), Asc(e2, t)])
+            | None => Iter.empty
+            }
+          )
           <+> {
             let* shrunk = shrink_exp(e1);
             return(Let(p, shrunk, e2));
@@ -766,6 +778,12 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
           }
         | Theorem(p, e1, e2) =>
           of_list([e1, e2])
+          <+> (
+            switch (pat_typ_opt(p)) {
+            | Some(t) => of_list([Asc(e1, t), Asc(e2, t)])
+            | None => Iter.empty
+            }
+          )
           <+> {
             let* shrunk = shrink_exp(e1);
             return(Theorem(p, shrunk, e2));
@@ -783,6 +801,12 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
           return(ProofObject(shrunk));
         | ForallExp(pat, e) =>
           return(e)
+          <+> (
+            switch (pat_typ_opt(pat)) {
+            | Some(t) => return(Asc(e, t))
+            | None => Iter.empty
+            }
+          )
           <+> {
             let* shrunk = shrink_exp(e);
             return(ForallExp(pat, shrunk));
@@ -793,6 +817,12 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
           }
         | Fun(p, e, name) =>
           return(e)
+          <+> (
+            switch (pat_typ_opt(p)) {
+            | Some(t) => return(Asc(e, t))
+            | None => Iter.empty
+            }
+          )
           <+> {
             let* shrunk = shrink_exp(e);
             return(Fun(p, shrunk, name): exp);
@@ -886,6 +916,12 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
           }
         | FixF(p, e) =>
           return(e)
+          <+> (
+            switch (pat_typ_opt(p)) {
+            | Some(t) => return(Asc(e, t))
+            | None => Iter.empty
+            }
+          )
           <+> {
             let* shrunk = shrink_exp(e);
             return(FixF(p, shrunk));

--- a/src/menhirParser/AST.re
+++ b/src/menhirParser/AST.re
@@ -686,27 +686,33 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
       Iter.(
         switch (exp) {
         | Atom(a) =>
-          switch (a) {
-          | Int(i) =>
-            switch (Bigint.to_int(i)) {
-            | Some(i) =>
-              Shrink.int(i) >|= ((i: int) => Atom(Int(Bigint.of_int(i))))
-            | None => Iter.empty
+          return(TupleExp([]))
+          <+> (
+            switch (a) {
+            | Int(i) =>
+              switch (Bigint.to_int(i)) {
+              | Some(i) =>
+                Shrink.int(i)
+                >|= ((i: int) => Atom(Int(Bigint.of_int(i))))
+              | None => Iter.empty
+              }
+            | String(s) =>
+              Shrink.string(s) >|= ((s: string) => Atom(String(s)))
+            | Bool(b) => Shrink.bool(b) >|= ((b: bool) => Atom(Bool(b)))
+            | Nat(n) =>
+              if (Bigint.(<)(n, Bigint.of_int(2))) {
+                Iter.empty;
+              } else {
+                return(Atom(Nat(Bigint.(/)(n, Bigint.of_int(2)))));
+              }
+            | SInt(i) => Shrink.int(i) >|= ((i: int) => Atom(SInt(i)))
+            | _ => Iter.empty
             }
-          | String(s) =>
-            Shrink.string(s) >|= ((s: string) => Atom(String(s)))
-          | Bool(b) => Shrink.bool(b) >|= ((b: bool) => Atom(Bool(b)))
-          | Nat(n) =>
-            if (Bigint.(<)(n, Bigint.of_int(2))) {
-              Iter.empty;
-            } else {
-              return(Atom(Nat(Bigint.(/)(n, Bigint.of_int(2)))));
-            }
-          | SInt(i) => Shrink.int(i) >|= ((i: int) => Atom(SInt(i)))
-          | _ => Iter.empty
-          }
-        | Var(x) => shrink_non_empty_string(x) >|= ((x: string) => Var(x)) // TODO This isn't great for vars
-        | Constructor(_, _) => Iter.empty // TODO Constructors. Shrinking needs to preserve constructor ident format
+          )
+        | Var(x) =>
+          return(TupleExp([]))
+          <+> (shrink_non_empty_string(x) >|= ((x: string) => Var(x))) // TODO This isn't great for vars
+        | Constructor(_, _) => return(TupleExp([])) // Constructor ident format is preserved; only allow collapse to unit
         | ListExp(l) =>
           let* shrunk = Shrink.list(l, ~shrink=shrink_exp);
           switch (shrunk) {
@@ -759,7 +765,7 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
             return(Let(shrunk, e1, e2));
           }
         | Theorem(p, e1, e2) =>
-          return(e1)
+          of_list([e1, e2])
           <+> {
             let* shrunk = shrink_exp(e1);
             return(Theorem(p, shrunk, e2));
@@ -776,7 +782,8 @@ let rec shrink_exp: QCheck.Shrink.t(exp) =
           let* shrunk = shrink_exp(t);
           return(ProofObject(shrunk));
         | ForallExp(pat, e) =>
-          {
+          return(e)
+          <+> {
             let* shrunk = shrink_exp(e);
             return(ForallExp(pat, shrunk));
           }
@@ -1053,29 +1060,33 @@ and shrink_pat: QCheck.Shrink.t(pat) =
       Iter.(
         switch (pat) {
         | AtomPat(a) =>
-          switch (a) {
-          | Int(i) =>
-            switch (Bigint.to_int(i)) {
-            | Some(i) =>
-              Shrink.int(i)
-              >|= ((i: int) => AtomPat(Int(Bigint.of_int(i))))
-            | None => Iter.empty
+          return(WildPat)
+          <+> (
+            switch (a) {
+            | Int(i) =>
+              switch (Bigint.to_int(i)) {
+              | Some(i) =>
+                Shrink.int(i)
+                >|= ((i: int) => AtomPat(Int(Bigint.of_int(i))))
+              | None => Iter.empty
+              }
+            | String(s) =>
+              Shrink.string(s) >|= ((s: string) => AtomPat(String(s)))
+            | Bool(b) => Shrink.bool(b) >|= ((b: bool) => AtomPat(Bool(b)))
+            | Nat(n) =>
+              if (Bigint.(<)(n, Bigint.of_int(2))) {
+                Iter.empty;
+              } else {
+                return(AtomPat(Nat(Bigint.(/)(n, Bigint.of_int(2)))));
+              }
+            | SInt(i) => Shrink.int(i) >|= ((i: int) => AtomPat(SInt(i)))
+            | _ => Iter.empty
             }
-          | String(s) =>
-            Shrink.string(s) >|= ((s: string) => AtomPat(String(s)))
-          | Bool(b) => Shrink.bool(b) >|= ((b: bool) => AtomPat(Bool(b)))
-          | Nat(n) =>
-            if (Bigint.(<)(n, Bigint.of_int(2))) {
-              Iter.empty;
-            } else {
-              return(AtomPat(Nat(Bigint.(/)(n, Bigint.of_int(2)))));
-            }
-          | SInt(i) => Shrink.int(i) >|= ((i: int) => AtomPat(SInt(i)))
-          | _ => Iter.empty
-          }
+          )
         | VarPat(x) =>
-          shrink_non_empty_string(x) >|= ((x: string) => VarPat(x))
-        | ConstructorPat(_) => Iter.empty // Needs to preserve constructor ident
+          return(WildPat)
+          <+> (shrink_non_empty_string(x) >|= ((x: string) => VarPat(x)))
+        | ConstructorPat(_) => return(WildPat) // Constructor ident format is preserved; only allow collapse to wild
         | ListPat(l) =>
           let* shrunk = Shrink.list(l, ~shrink=shrink_pat);
           switch (shrunk) {
@@ -1153,6 +1164,14 @@ and shrink_typ: QCheck.Shrink.t(typ) =
       Iter.(
         switch (typ) {
         | SumTyp(l) =>
+          let payloads =
+            List.filter_map(
+              fun
+              | Variant(_, Some(t)) => Some(t)
+              | BadEntry(t) => Some(t)
+              | Variant(_, None) => None,
+              l,
+            );
           let shrink_sumterm: QCheck.Shrink.t(sumterm) =
             QCheck.(
               (
@@ -1167,10 +1186,13 @@ and shrink_typ: QCheck.Shrink.t(typ) =
                   )
               )
             );
-          let* shrunk = Shrink.list(l, ~shrink=shrink_sumterm);
-          switch (shrunk) {
-          | [] => Iter.empty
-          | _ => return(SumTyp(shrunk))
+          of_list(payloads)
+          <+> {
+            let* shrunk = Shrink.list(l, ~shrink=shrink_sumterm);
+            switch (shrunk) {
+            | [] => Iter.empty
+            | _ => return(SumTyp(shrunk))
+            };
           };
         | TupleType(l) =>
           let* shrunk = Shrink.list(l, ~shrink=shrink_typ);

--- a/src/menhirParser/AST.re
+++ b/src/menhirParser/AST.re
@@ -1196,11 +1196,17 @@ and shrink_typ: QCheck.Shrink.t(typ) =
           }
         | TypVar(x) => Shrink.string(x) >|= ((x: string) => TypVar(x))
         | PolyType(tpat, t) =>
-          let* shrunk = shrink_typ(t);
-          return(PolyType(tpat, shrunk));
+          return(t)
+          <+> {
+            let* shrunk = shrink_typ(t);
+            return(PolyType(tpat, shrunk));
+          }
         | RecType(tpat, t) =>
-          let* shrunk = shrink_typ(t);
-          return(RecType(tpat, shrunk));
+          return(t)
+          <+> {
+            let* shrunk = shrink_typ(t);
+            return(RecType(tpat, shrunk));
+          }
         | ExplicitNonlabel => return(ExplicitNonlabel: typ)
         | ProofOfType(e) =>
           let* shrunk = shrink_exp(e);
@@ -1237,13 +1243,13 @@ and shrink_typ: QCheck.Shrink.t(typ) =
             let* shrunk2 = shrink_typ(t2);
             return(ProdExtension(t1, shrunk2));
           }
-        | IndicationTyp(_)
         | IntType
         | SIntType
         | StringType
         | FloatType
         | BoolType
-        | NatType
+        | NatType => return(TupleType([]))
+        | IndicationTyp(_)
         | UnknownType(_)
         | InvalidTyp(_)
         | Sig(_) => Iter.empty

--- a/test/README.md
+++ b/test/README.md
@@ -44,6 +44,29 @@ group or number:
 
 - For more CLI options, refer to the [Alcotest documentation](https://github.com/mirage/alcotest).
 
+### 3. Scaling QCheck Counts at Runtime
+
+Every QCheck property test declares a `~count` in source, but those counts can
+be multiplied at runtime via environment variables — no source edits needed:
+
+```sh
+QCHECK_LONG=1 QCHECK_LONG_FACTOR=10 ./run_tests test 'Statics.Properties'
+QCHECK_LONG=1 QCHECK_LONG_FACTOR=100 make test
+```
+
+- `QCHECK_LONG=1` enables QCheck's "long" mode in `QCheck_alcotest`.
+- `QCHECK_LONG_FACTOR=N` multiplies every test's `count` by `N` while long
+  mode is active.
+
+Useful when chasing rare counterexamples without bumping the per-test
+defaults (which would slow down regular CI/dev runs).
+
+Other useful QCheck env vars:
+
+- `QCHECK_SEED=<int>` — reproduce a previous run by reusing its random seed
+  (the seed is printed at the start of each run).
+- `QCHECK_VERBOSE=1` — print each generated case.
+
 ## Architecture
 
 - **`test/dune`** defines the test executable and two dune aliases (`@runtest` for all tests, `@test-quick` for quick tests). The `Makefile` targets invoke these aliases.


### PR DESCRIPTION
## Summary
- Type shrinker: `RecType`/`PolyType` now yield their bare body (drops the binder), matching the pattern `ArrowType` already used. Scalar leaves (Int/SInt/String/Float/Bool/Nat/Void) shrink to `TupleType([])` (unit) so the shrinker has a universal minimum to converge on.
- Expression shrinker: `ForallExp` now yields its body; `Theorem` yields both `e1` and `e2` (was only `e1`); `SumTyp` yields each variant's payload type; pattern leaves shrink to `WildPat`; expression leaves shrink to `()`.
- Ascribed-pattern binders (`Let`/`Fun`/`FixF`/`Theorem`/`ForallExp` wrapping an `AscPat`) shrink to a plain `Asc(body, t)`, surfacing the essential type info in the simplest context. This was directly motivated by Statics property-test counterexamples that previously kept a redundant lambda wrapper.
- `test/README.md`: documents `QCHECK_LONG=1 QCHECK_LONG_FACTOR=N` for runtime count scaling without source edits.

## Motivation
Running the Statics property tests on hazelgrove/hazel#2289 with higher counts surfaced `Not_found` crashes whose shrunk counterexamples were stuck in non-minimal forms (specific binder names, lambda wrappers around what should have been bare ascriptions, redundant leaf types). The shrinker had a few structural blind spots — addressed here — which now let counterexamples reach a much smaller canonical form. After these changes the bug minimum from #2289 reads as e.g. `let _ = () : rec _ -> rec _ -> Void in ()` instead of the previous 30+-token form.

## Test plan
- [ ] `make dev` builds clean
- [ ] `make test` (full property tests) still passes on dev
- [ ] Run `QCHECK_LONG=1 QCHECK_LONG_FACTOR=10 ./run_tests test 'Statics.Properties'` and confirm output

🤖 Generated with [Claude Code](https://claude.com/claude-code)