### PR TITLE
[Back Burner] CSS Audit

### DIFF
--- a/docs/style/elements.md
+++ b/docs/style/elements.md
@@ -1,0 +1,101 @@
+# Elements
+
+Every UI inside a surface is built from a small set of **content primitives** composed inside **layout containers**.
+
+- **Content primitives** — generic appearance, default styling, no parent assumptions.
+- **Layout containers** — provide CSS context that restyles their children.
+
+A primitive's look depends on its parent. A `Button` on a workspace surface looks like a button; the same `Button` inside `Tabs` looks like a tab. Only layout containers may restyle their children.
+
+The workspace and menu surfaces have separate primitive sets. The workspace primitives are listed first; menu primitives at the bottom.
+
+## Workspace primitives
+
+### Button
+Icon button. Wobble + scale on hover.
+
+Variants: `~kind` (link / file-upload), `~disabled`, `~active`, `~subtle`, `~tooltip`.
+
+### Toggle
+Binary on/off switch. No label — wrap in a `ListRow` if you need text alongside.
+
+### TextInput
+Text field. Variants: `~multiline`.
+
+### Select
+Dropdown.
+
+### Heading
+Three levels, each ported from an existing pattern:
+
+- **h1** — exercise title style (`.title-cell .title-text`): large, bold, BR4. For page and section titles.
+- **h2** — all-caps cell caption (`.cell-caption strong`): small, bold, uppercase, BR3. For section labels and panel titles.
+- **h3** — probarium subtle (`#probe-sidebar .legend .title`): small, regular, BR2. For subtle subsection labels.
+
+### CodeInline
+Code or type content embedded in a workspace. The bridge between workspace surface and code surface.
+
+### Badge
+Small labeled indicator. Variants: `~tone` (status / count / kbd).
+
+### Divider
+Visual separator. Variants: `~orientation` (horizontal / vertical).
+
+### ProgressBar
+Two flavours:
+
+- **continuous** (default) — track + fill whose width is the progress. Ports the agent context meter.
+- **segmented** — track containing a row of clickable status-coded segments (`pass` / `fail` / `indet`). Ports the test-panel `.test-bar`.
+
+Both support an optional `.label` above the track.
+
+### ListRow
+A row in a list. Slots: *leading* (icon / control / none), *label*, *trailing* (control / badge / none). State variants: `~active`, `~expanded`, `~selected`. Status variants: `~error`, `~syntax`, `~warning`, `~hole` (each adds a left accent + tinted bg, ported from `.problem-row` in sidebar.css).
+
+The highest-leverage primitive — replaces problem rows, legend items, settings rows, history rows. (Menu items may end up on a separate menu surface and are not absorbed here.)
+
+## Layout containers
+
+A container restyles its children via CSS descendant selectors. The children stay generic.
+
+```css
+.tabs .button         { /* tab look */ }
+.tabs .button.active  { /* active tab */ }
+```
+
+```reason
+tabs([
+  Button.button(~active=true,  Icons.problems,   switch_to_problems),
+  Button.button(~active=false, Icons.assistant,  switch_to_assistant),
+])
+```
+
+### Tabs
+A row of buttons styled as tabs. Each child `Button` owns its own `~active` state. Three forms:
+
+- default (vertical) — sidebar tab strip with a right-border active indicator
+- `.horizontal` — bordered segmented control (probarium sample-color-scheme)
+- `.title` — bold uppercase mode-labels with `/` separator, used as a switchable panel title (probarium / printarium)
+
+## Composition rules
+
+- Only layout containers restyle their children. Regular `<div>`s do not.
+- Layout containers should stay few to keep the implicit-styling cost low. Looking at a primitive in isolation should usually be enough to predict how it will render.
+
+## Menu surface primitives
+
+Distinct from the workspace primitives — the menu surface has its own typography and item-row patterns.
+
+### MenuItem
+A single clickable row inside a menu. Slots: leading icon, label, optional trailing keyboard shortcut. State variants: `~selected`.
+
+### MenuGroup
+A labeled section: a name heading and a list of menu items. Adjacent groups get a hairline divider automatically.
+
+### MenuDivider
+Thin separator between items within a group. Distinct from the workspace `Divider` — tighter and tuned for menu density.
+
+## Open
+
+- **Toolbar** as a second workspace layout container — a row of small flat buttons. Skip until a third use site appears.
+- **Segmented control** is already covered by `Tabs.horizontal`.

--- a/docs/style/surfaces.md
+++ b/docs/style/surfaces.md
@@ -1,0 +1,60 @@
+# Surfaces & Placements
+
+Every container in the Hazel UI is described by two independent choices:
+
+- **Surface** — interior identity: background, typography, headings, buttons, list rows. "What kind of place is this?"
+- **Placement** — relationship to the parent: border, radius, outer padding, shadow. "How does this sit in its container?"
+
+Surface owns *internal layout* (how the things inside space themselves). Placement owns the *edge*.
+
+## Surfaces
+
+There are three.
+
+### Code
+Monospace font, syntax-colored tokens, cursor, code-specific background, statics decorations.
+
+Variants (within the surface):
+- **editable** — the main editor
+- **read-only** — code that can't be edited
+- **evaluator** — code with live evaluation output
+
+### Workspace
+UI font, normal text, workspace headings, buttons, list rows, toggles. The general-purpose container interior — sidebars, exercise bodies, dialogs, tooltips.
+
+### Menu
+Yellow-tinted background, tight padding, hover-to-select item rows, grouped sections with labeled headings. Used for menus, dropdowns, context menus. Always raised with shadow + outline.
+
+A menu either floats (all four corners rounded) or is anchored to one of its corners — `.tl / .tr / .bl / .br` mark the anchor; that corner is sharp and only the opposite corner is rounded.
+
+Menus have a default `max-height: 70vh` and scroll their contents when they exceed it.
+
+## Placements
+
+Placements apply only to the **code** and **workspace** surfaces. Menus have no placement variants.
+
+### inset — *code only*
+Recessed border, no shadow. The code editor sits visually below its parent.
+
+### inline — *workspace only*
+Flush with parent at the top level. When nested inside another workspace, the container gets an outline + radius + padding so it reads as a contained section.
+
+### raised — *workspace only*
+Same chrome as a nested inline, plus a shadow. Used for popovers, and (composed with a backdrop and centered positioning) modal-style dialogs.
+
+### tooltip — *workspace only*
+Tight padding, small text scale, anchored, info-only chrome.
+
+When a placement needs to scale typography (e.g. tooltip's smaller text), it overrides the surface's defaults directly rather than picking from a layered scale.
+
+## Valid combinations
+
+| Combination | Examples |
+|---|---|
+| code × inset | main editor, mini editors, read-only code, stepper output |
+| workspace × inline | sidebars, exercise body, tutorial body, projector UIs |
+| workspace × raised | assistant suggestions, explain-this, settings dialog (with backdrop + centered positioning) |
+| workspace × tooltip | icon tooltips, hover info |
+| menu (no placement) | nut menu, context menu, dropdown menus, slash menu |
+
+Modal-style dialogs (settings, confirmations) are not their own placement. They are composed: `raised` provides the chrome, a backdrop element dims the page, and the caller positions the surface centered on the page.

--- a/src/web/app/common/Components.re
+++ b/src/web/app/common/Components.re
@@ -1,0 +1,329 @@
+/* Components — the workspace surface design system.
+
+   This is where to come for standard UI elements (buttons, headings,
+   list rows, etc.) on the workspace surface. Menu items live in
+   `Menu.re`. The legacy icon/toggle helpers in `Widgets.re` will be
+   migrated over here over time.
+
+   These generate the HTML structure expected by
+   src/web/www/style/workspace/workspace.css. See docs/style/elements.md
+   for the catalog. */
+
+open Virtual_dom.Vdom;
+open Node;
+open Util.WebUtil;
+
+/* ============================================================
+   Surface base
+   ============================================================ */
+
+let surface =
+    (
+      ~attrs=[],
+      ~placement: option([ | `Inline | `Raised | `Tooltip])=?,
+      children,
+    ) => {
+  let placement_cls =
+    switch (placement) {
+    | Some(`Inline) => ["inline"]
+    | Some(`Raised) => ["raised"]
+    | Some(`Tooltip) => ["tooltip"]
+    | None => []
+    };
+  div(
+    ~attrs=[clss(["workspace-surface"] @ placement_cls)] @ attrs,
+    children,
+  );
+};
+
+/* ============================================================
+   Heading
+   ============================================================ */
+
+let heading = (~level: [ | `H1 | `H2 | `H3]=`H2, ~attrs=[], children) => {
+  let level_cls =
+    switch (level) {
+    | `H1 => "h1"
+    | `H2 => "h2"
+    | `H3 => "h3"
+    };
+  div(~attrs=[clss(["heading", level_cls])] @ attrs, children);
+};
+
+let h1 = (~attrs=[], children) => heading(~level=`H1, ~attrs, children);
+let h2 = (~attrs=[], children) => heading(~level=`H2, ~attrs, children);
+let h3 = (~attrs=[], children) => heading(~level=`H3, ~attrs, children);
+
+/* ============================================================
+   Button — visible icon button. Pass `~subtle=true` for the deriver
+   style that fades in on parent hover.
+   ============================================================ */
+
+let button =
+    (
+      ~attrs=[],
+      ~active=false,
+      ~disabled=false,
+      ~subtle=false,
+      ~tooltip="",
+      children,
+      action,
+    ) => {
+  let cls =
+    ["button"]
+    @ (active ? ["active"] : [])
+    @ (disabled ? ["disabled"] : [])
+    @ (subtle ? ["subtle"] : []);
+  div(
+    ~attrs=
+      [
+        clss(cls),
+        Attr.title(tooltip),
+        Attr.on_mousedown(_ => unless(disabled, action)),
+      ]
+      @ attrs,
+    children,
+  );
+};
+
+/* ============================================================
+   Toggle
+   ============================================================ */
+
+let toggle = (~attrs=[], ~active=false, ~tooltip="", action) =>
+  div(
+    ~attrs=
+      [
+        clss(["toggle"] @ (active ? ["active"] : [])),
+        Attr.title(tooltip),
+        Attr.on_pointerdown(_ => action),
+      ]
+      @ attrs,
+    [div(~attrs=[clss(["knob"])], [])],
+  );
+
+/* ============================================================
+   Text input
+   ============================================================ */
+
+let text_input =
+    (
+      ~attrs=[],
+      ~placeholder="",
+      ~value="",
+      ~multiline=false,
+      on_input: string => Ui_effect.t(unit),
+    ) =>
+  multiline
+    ? textarea(
+        ~attrs=
+          [
+            clss(["text-input"]),
+            Attr.placeholder(placeholder),
+            Attr.value(value),
+            Attr.on_input((_, s) => on_input(s)),
+          ]
+          @ attrs,
+        [],
+      )
+    : input(
+        ~attrs=
+          [
+            clss(["text-input"]),
+            Attr.placeholder(placeholder),
+            Attr.value(value),
+            Attr.on_input((_, s) => on_input(s)),
+          ]
+          @ attrs,
+        (),
+      );
+
+/* ============================================================
+   Select — dropdown. `options` is a list of (value, label).
+   ============================================================ */
+
+let select_ =
+    (
+      ~attrs=[],
+      ~selected: string,
+      ~options: list((string, string)),
+      on_change: string => Ui_effect.t(unit),
+    ) =>
+  select(
+    ~attrs=[clss(["select"]), Attr.on_change((_, s) => on_change(s))] @ attrs,
+    List.map(
+      ((v, label)) =>
+        option(
+          ~attrs=
+            [Attr.value(v)]
+            @ (v == selected ? [Attr.create("selected", "selected")] : []),
+          [text(label)],
+        ),
+      options,
+    ),
+  );
+
+/* ============================================================
+   Code inline
+   ============================================================ */
+
+let code_inline = (~attrs=[], children) =>
+  span(~attrs=[clss(["code-inline"])] @ attrs, children);
+
+/* ============================================================
+   Badge
+   ============================================================ */
+
+let badge =
+    (
+      ~tone: [ | `Error | `Warning | `Ok | `Count | `Kbd]=`Count,
+      ~attrs=[],
+      children,
+    ) => {
+  let tone_cls =
+    switch (tone) {
+    | `Error => ["status", "error"]
+    | `Warning => ["status", "warning"]
+    | `Ok => ["status", "ok"]
+    | `Count => ["count"]
+    | `Kbd => ["kbd"]
+    };
+  span(~attrs=[clss(["badge"] @ tone_cls)] @ attrs, children);
+};
+
+/* ============================================================
+   Divider
+   ============================================================ */
+
+let divider = (~vertical=false, ~attrs=[], ()) =>
+  Node.hr(
+    ~attrs=[clss(["divider"] @ (vertical ? ["vertical"] : []))] @ attrs,
+  );
+
+/* ============================================================
+   Progress bar — Fill is a continuous bar; Segments is a row of
+   status-coded clickable cells.
+   ============================================================ */
+
+type progress_segment = [ | `Pass | `Fail | `Indet];
+
+type progress_kind =
+  | Fill(float) /* 0.0–1.0 */
+  | Segments(list(progress_segment));
+
+let progress_bar = (~label="", ~attrs=[], kind: progress_kind) => {
+  let label_node =
+    label == "" ? [] : [div(~attrs=[clss(["label"])], [text(label)])];
+  let body =
+    switch (kind) {
+    | Fill(p) =>
+      let pct = Printf.sprintf("%d%%", int_of_float(p *. 100.));
+      div(
+        ~attrs=[clss(["track"])],
+        [
+          div(
+            ~attrs=[clss(["fill"]), Attr.create("style", "width: " ++ pct)],
+            [],
+          ),
+        ],
+      );
+    | Segments(segs) =>
+      div(
+        ~attrs=[clss(["track"])],
+        List.map(
+          seg => {
+            let seg_cls =
+              switch (seg) {
+              | `Pass => "pass"
+              | `Fail => "fail"
+              | `Indet => "indet"
+              };
+            div(~attrs=[clss(["segment", seg_cls])], []);
+          },
+          segs,
+        ),
+      )
+    };
+  let segmented_cls =
+    switch (kind) {
+    | Fill(_) => []
+    | Segments(_) => ["segmented"]
+    };
+  div(
+    ~attrs=[clss(["progress-bar"] @ segmented_cls)] @ attrs,
+    label_node @ [body],
+  );
+};
+
+/* ============================================================
+   List row — leading / label / trailing slots, state and status
+   variants.
+   ============================================================ */
+
+type list_row_status = [ | `Error | `Syntax | `Warning | `Hole];
+
+let list_row =
+    (
+      ~attrs=[],
+      ~leading: option(Node.t)=?,
+      ~trailing: option(Node.t)=?,
+      ~active=false,
+      ~expanded=false,
+      ~status: option(list_row_status)=?,
+      ~on_click=?,
+      label,
+    ) => {
+  let status_cls =
+    switch (status) {
+    | Some(`Error) => ["error"]
+    | Some(`Syntax) => ["syntax"]
+    | Some(`Warning) => ["warning"]
+    | Some(`Hole) => ["hole"]
+    | None => []
+    };
+  let state_cls =
+    (active ? ["active"] : []) @ (expanded ? ["expanded"] : []);
+  let event_attrs =
+    switch (on_click) {
+    | Some(action) => [Attr.on_click(_ => action)]
+    | None => []
+    };
+  let slot = (cls, contents) =>
+    switch (contents) {
+    | Some(n) => [div(~attrs=[clss([cls])], [n])]
+    | None => []
+    };
+  div(
+    ~attrs=
+      [clss(["list-row"] @ state_cls @ status_cls)] @ event_attrs @ attrs,
+    slot("leading", leading)
+    @ [div(~attrs=[clss(["label"])], [label])]
+    @ slot("trailing", trailing),
+  );
+};
+
+/* ============================================================
+   Row — horizontal flex group
+   ============================================================ */
+
+let row = (~attrs=[], children) =>
+  div(~attrs=[clss(["row"])] @ attrs, children);
+
+/* ============================================================
+   Tabs — vertical (default), horizontal segmented, or title
+   ============================================================ */
+
+let tabs =
+    (
+      ~direction: [ | `Vertical | `Horizontal | `Title]=`Vertical,
+      ~attrs=[],
+      children,
+    ) => {
+  let direction_cls =
+    switch (direction) {
+    | `Vertical => []
+    | `Horizontal => ["horizontal"]
+    | `Title => ["title"]
+    };
+  div(~attrs=[clss(["tabs"] @ direction_cls)] @ attrs, children);
+};

--- a/src/web/app/common/Components.re
+++ b/src/web/app/common/Components.re
@@ -20,7 +20,14 @@ open Util.WebUtil;
 let surface =
     (
       ~attrs=[],
-      ~placement: option([ | `Inline | `Raised | `Tooltip])=?,
+      ~placement:
+         option(
+           [
+             | `Inline
+             | `Raised
+             | `Tooltip
+           ],
+         )=?,
       children,
     ) => {
   let placement_cls =
@@ -40,7 +47,16 @@ let surface =
    Heading
    ============================================================ */
 
-let heading = (~level: [ | `H1 | `H2 | `H3]=`H2, ~attrs=[], children) => {
+let heading =
+    (
+      ~level: [
+         | `H1
+         | `H2
+         | `H3
+       ]=`H2,
+      ~attrs=[],
+      children,
+    ) => {
   let level_cls =
     switch (level) {
     | `H1 => "h1"
@@ -53,6 +69,11 @@ let heading = (~level: [ | `H1 | `H2 | `H3]=`H2, ~attrs=[], children) => {
 let h1 = (~attrs=[], children) => heading(~level=`H1, ~attrs, children);
 let h2 = (~attrs=[], children) => heading(~level=`H2, ~attrs, children);
 let h3 = (~attrs=[], children) => heading(~level=`H3, ~attrs, children);
+
+/* Subtitle — small subdued inline label, typically used next to a
+   heading inside a Row (e.g. "(Read-Only)" alongside "PRELUDE"). */
+let subtitle = (~attrs=[], children) =>
+  span(~attrs=[clss(["subtitle"])] @ attrs, children);
 
 /* ============================================================
    Button — visible icon button. Pass `~subtle=true` for the deriver
@@ -74,14 +95,10 @@ let button =
     @ (active ? ["active"] : [])
     @ (disabled ? ["disabled"] : [])
     @ (subtle ? ["subtle"] : []);
+  let handler = disabled ? (_ => Effect.Many([])) : action;
   div(
     ~attrs=
-      [
-        clss(cls),
-        Attr.title(tooltip),
-        Attr.on_mousedown(_ => unless(disabled, action)),
-      ]
-      @ attrs,
+      [clss(cls), Attr.title(tooltip), Attr.on_mousedown(handler)] @ attrs,
     children,
   );
 };
@@ -150,7 +167,8 @@ let select_ =
       on_change: string => Ui_effect.t(unit),
     ) =>
   select(
-    ~attrs=[clss(["select"]), Attr.on_change((_, s) => on_change(s))] @ attrs,
+    ~attrs=
+      [clss(["select"]), Attr.on_change((_, s) => on_change(s))] @ attrs,
     List.map(
       ((v, label)) =>
         option(
@@ -176,7 +194,13 @@ let code_inline = (~attrs=[], children) =>
 
 let badge =
     (
-      ~tone: [ | `Error | `Warning | `Ok | `Count | `Kbd]=`Count,
+      ~tone: [
+         | `Error
+         | `Warning
+         | `Ok
+         | `Count
+         | `Kbd
+       ]=`Count,
       ~attrs=[],
       children,
     ) => {
@@ -205,7 +229,11 @@ let divider = (~vertical=false, ~attrs=[], ()) =>
    status-coded clickable cells.
    ============================================================ */
 
-type progress_segment = [ | `Pass | `Fail | `Indet];
+type progress_segment = [
+  | `Pass
+  | `Fail
+  | `Indet
+];
 
 type progress_kind =
   | Fill(float) /* 0.0–1.0 */
@@ -260,7 +288,12 @@ let progress_bar = (~label="", ~attrs=[], kind: progress_kind) => {
    variants.
    ============================================================ */
 
-type list_row_status = [ | `Error | `Syntax | `Warning | `Hole];
+type list_row_status = [
+  | `Error
+  | `Syntax
+  | `Warning
+  | `Hole
+];
 
 let list_row =
     (
@@ -315,7 +348,11 @@ let row = (~attrs=[], children) =>
 
 let tabs =
     (
-      ~direction: [ | `Vertical | `Horizontal | `Title]=`Vertical,
+      ~direction: [
+         | `Vertical
+         | `Horizontal
+         | `Title
+       ]=`Vertical,
       ~attrs=[],
       children,
     ) => {

--- a/src/web/app/common/Menu.re
+++ b/src/web/app/common/Menu.re
@@ -1,0 +1,96 @@
+/* Menu — primitives for the menu surface.
+
+   Distinct from the workspace surface (see `Components.re`). The menu
+   surface has its own background, typography, and item-row patterns;
+   used for nut menus, dropdowns, context menus.
+
+   These generate the HTML structure expected by
+   src/web/www/style/menu/menu.css. */
+
+open Virtual_dom.Vdom;
+open Node;
+open Util.WebUtil;
+
+/* ============================================================
+   Surface — menu shell. Optional corner anchor; without one the menu
+   floats and all four corners are rounded.
+   ============================================================ */
+
+let surface =
+    (
+      ~attrs=[],
+      ~anchor: option([ | `TL | `TR | `BL | `BR])=?,
+      children,
+    ) => {
+  let anchor_cls =
+    switch (anchor) {
+    | Some(`TL) => ["tl"]
+    | Some(`TR) => ["tr"]
+    | Some(`BL) => ["bl"]
+    | Some(`BR) => ["br"]
+    | None => []
+    };
+  div(~attrs=[clss(["menu-surface"] @ anchor_cls)] @ attrs, children);
+};
+
+/* ============================================================
+   Menu item — clickable row with leading icon, label, optional
+   trailing shortcut.
+   ============================================================ */
+
+let item =
+    (
+      ~attrs=[],
+      ~selected=false,
+      ~icon: option(Node.t)=?,
+      ~shortcut: option(string)=?,
+      ~on_click=?,
+      label,
+    ) => {
+  let icon_children =
+    switch (icon) {
+    | Some(n) => [n]
+    | None => []
+    };
+  let shortcut_children =
+    switch (shortcut) {
+    | Some(s) => [div(~attrs=[clss(["shortcut"])], [text(s)])]
+    | None => []
+    };
+  let event_attrs =
+    switch (on_click) {
+    | Some(action) => [Attr.on_click(_ => action)]
+    | None => []
+    };
+  div(
+    ~attrs=
+      [clss(["menu-item"] @ (selected ? ["selected"] : []))]
+      @ event_attrs
+      @ attrs,
+    icon_children
+    @ [div(~attrs=[clss(["label"])], [label])]
+    @ shortcut_children,
+  );
+};
+
+/* ============================================================
+   Menu group — named section. Adjacent groups get a hairline divider
+   between them automatically via the CSS `:has(+ .menu-group)`.
+   ============================================================ */
+
+let group = (~attrs=[], name: string, items: list(Node.t)) =>
+  div(
+    ~attrs=[clss(["menu-group"])] @ attrs,
+    [
+      div(~attrs=[clss(["name"])], [text(name)]),
+      div(~attrs=[clss(["contents"])], items),
+    ],
+  );
+
+/* ============================================================
+   Menu divider — thin separator between items in a group. Distinct
+   from `Components.divider`.
+   ============================================================ */
+
+let divider = (~attrs=[], ()) =>
+  div(~attrs=[clss(["menu-divider"])] @ attrs, []);

--- a/src/web/app/common/Menu.re
+++ b/src/web/app/common/Menu.re
@@ -19,7 +19,15 @@ open Util.WebUtil;
 let surface =
     (
       ~attrs=[],
-      ~anchor: option([ | `TL | `TR | `BL | `BR])=?,
+      ~anchor:
+         option(
+           [
+             | `TL
+             | `TR
+             | `BL
+             | `BR
+           ],
+         )=?,
       children,
     ) => {
   let anchor_cls =

--- a/src/web/app/common/Widgets.re
+++ b/src/web/app/common/Widgets.re
@@ -108,4 +108,3 @@ let file_select_button_named =
       ),
     ],
   );
-

--- a/src/web/app/common/Widgets.re
+++ b/src/web/app/common/Widgets.re
@@ -108,3 +108,4 @@ let file_select_button_named =
       ),
     ],
   );
+

--- a/src/web/app/editors/cell/CellCommon.re
+++ b/src/web/app/editors/cell/CellCommon.re
@@ -1,7 +1,10 @@
 open Virtual_dom.Vdom;
 open Node;
 
-/* Helpers for creating cell ui components - mostly used by exercise mode */
+/* Helpers for creating cell UI components — used by exercise & tutorial
+   modes. Cell layout (`.cell`, `.cell-item`, `.title-cell`, etc.) is
+   defined in cell.css and stays bespoke; everything visual on the cell
+   (captions, titles, buttons, surfaces) goes through Components. */
 
 let narrative_cell = (content: Node.t) =>
   div(
@@ -12,38 +15,51 @@ let narrative_cell = (content: Node.t) =>
 let simple_cell_item = (content: list(Node.t)) =>
   div(~attrs=[Attr.classes(["cell-item"])], content);
 
+/* Caption — section label inside a cell. The bolded part uses the
+   design-system h2 heading; the optional `~rest` is rendered as a
+   non-uppercase Components.subtitle next to it in a Row. */
 let caption = (~rest: option(string)=?, bolded: string) =>
-  div(
-    ~attrs=[Attr.classes(["cell-caption"])],
-    [strong([text(bolded)])] @ (rest |> Option.map(text) |> Option.to_list),
-  );
+  switch (rest) {
+  | None => Components.heading(~level=`H2, [text(bolded)])
+  | Some(r) =>
+    Components.row([
+      Components.heading(~level=`H2, [text(bolded)]),
+      Components.subtitle([text(r)]),
+    ])
+  };
 
 let simple_cell_view = (items: list(t)) =>
   div(~attrs=[Attr.class_("cell")], items);
 
-let report_footer_view = content => {
-  div(~attrs=[Attr.classes(["cell-item", "cell-report"])], content);
-};
+/* Unlocked cell — used in derivation mode for cells that get the
+   editable left-border accent. */
+let unlocked_cell_view = (items: list(t)) =>
+  div(~attrs=[Attr.classes(["cell", "unlocked"])], items);
 
-let panel = (~classes=[], content, ~footer: option(t)) => {
+let report_footer_view = content =>
+  div(~attrs=[Attr.classes(["cell-item", "cell-report"])], content);
+
+let panel = (~classes=[], content, ~footer: option(t)) =>
   simple_cell_view(
     [
       div(~attrs=[Attr.classes(["cell-item", "panel"] @ classes)], content),
     ]
     @ Option.to_list(footer),
   );
-};
 
-let title_cell = title => {
+/* Title cell — large exercise title. Uses the design-system h1 heading
+   inside the `.title-cell` layout wrapper. */
+let title_cell = title =>
   simple_cell_view([
     div(
       ~attrs=[Attr.class_("title-cell")],
-      [div(~attrs=[Attr.class_("title-text")], [text(title)])],
+      [Components.heading(~level=`H1, [text(title)])],
     ),
   ]);
-};
 
-let wrong_impl_caption = (~inject_delete, sub: string, n: int) => {
+/* Wrong-impl caption — caption row with a trailing delete button.
+   Used inline above each buggy implementation cell. */
+let wrong_impl_caption = (~inject_delete, sub: string, n: int) =>
   div(
     ~attrs=[Attr.class_("wrong-impl-cell-caption")],
     [
@@ -52,19 +68,38 @@ let wrong_impl_caption = (~inject_delete, sub: string, n: int) => {
         ~attrs=[
           Attr.class_("instructor-edit-icon"),
           Attr.on_mousedown(_ =>
-            Virtual_dom.Vdom.Effect.(
-              Many([Prevent_default, Stop_propagation])
-            )
+            Effect.Many([Effect.Prevent_default, Effect.Stop_propagation])
           ),
         ],
         [
-          Widgets.button(
-            Icons.delete,
-            _ => inject_delete(n),
+          Components.button(
             ~tooltip="Delete Buggy Implementation",
+            [Icons.delete],
+            _ => inject_delete(n),
           ),
         ],
       ),
     ],
   );
-};
+
+/* Add-impl button row — sits below the buggy implementations as a
+   "+" button. Used only by CodeExerciseMode. */
+let add_impl_caption = (~tooltip, ~action: Effect.t(unit)) =>
+  div(
+    ~attrs=[Attr.class_("wrong-impl-cell-caption")],
+    [
+      div(
+        ~attrs=[
+          Attr.class_("instructor-edit-icon"),
+          Attr.id("add-icon"),
+        ],
+        [Components.button(~tooltip, [Icons.add], _ => action)],
+      ),
+    ],
+  );
+
+/* Empty-state placeholder — used when a cell has no contents to show
+   (e.g. "No context available"). Renders a single subtitle line in
+   a simple cell item. */
+let empty_state = (message: string) =>
+  simple_cell_item([Components.subtitle([text(message)])]);

--- a/src/web/app/editors/cell/InstructorEditViews.re
+++ b/src/web/app/editors/cell/InstructorEditViews.re
@@ -3,16 +3,25 @@ open Virtual_dom.Vdom;
 open Node;
 
 /* Reusable instructor-mode header editors for exercises.
-   Provides pencil/confirm/cancel UI for editing a title, module name, and
-   prompt (with markdown rendering for the prompt via ExplainThis). */
+   Provides pencil/confirm/cancel UI for editing a title, module name,
+   and prompt (with markdown rendering for the prompt via ExplainThis). */
 
-/* The DOM ids below are also recognized by Page.View.is_input_field so that
-   keyboard shortcuts are bypassed while these inputs have focus. Only one
-   exercise is visible at a time, so reusing these ids across exercise kinds
-   is safe. */
+/* The DOM ids below are also recognized by Page.View.is_input_field so
+   that keyboard shortcuts are bypassed while these inputs have focus.
+   Only one exercise is visible at a time, so reusing these ids across
+   exercise kinds is safe. */
 let title_input_id = "title-input-box";
 let module_name_input_id = "module-name-input";
 let prompt_input_id = "prompt-input-box";
+
+/* Pencil/confirm/cancel buttons rendered with the design-system Button.
+   The `.edit-icon` wrapper preserves the existing positioning rules
+   (see cell.css). */
+let edit_icon = (~tooltip="", icon, action) =>
+  div(
+    ~attrs=[Attr.class_("edit-icon")],
+    [Components.button(~tooltip, [icon], action)],
+  );
 
 /* Title: bold headline, editable in instructor mode. */
 let title_view =
@@ -31,55 +40,43 @@ let title_view =
       Obj.magic(Js_of_ocaml.Js.some(JsUtil.get_elem_by_id(title_input_id)))##.value;
     Effect.Many([update_title(new_value), toggle_editing(ev)]);
   };
+  let body =
+    instructor_mode
+      ? is_editing
+          ? div(
+              ~attrs=[Attr.class_("title-edit")],
+              [
+                input(
+                  ~attrs=[
+                    Attr.class_("title-text"),
+                    Attr.id(title_input_id),
+                    Attr.value(title),
+                    Attr.on_focus(on_focus_textbox),
+                  ],
+                  (),
+                ),
+                edit_icon(Icons.confirm, confirm),
+                edit_icon(Icons.cancel, toggle_editing),
+              ],
+            )
+          : div(
+              ~attrs=[Attr.class_("title-edit")],
+              [
+                div(
+                  ~attrs=[
+                    Attr.classes([
+                      "title-text",
+                      title == "" ? "title-placeholder" : "",
+                    ]),
+                  ],
+                  [text(placeholder)],
+                ),
+                edit_icon(Icons.pencil, toggle_editing),
+              ],
+            )
+      : Components.heading(~level=`H1, [text(title)]);
   CellCommon.simple_cell_view([
-    div(
-      ~attrs=[Attr.class_("title-cell")],
-      [
-        instructor_mode
-          ? is_editing
-              ? div(
-                  ~attrs=[Attr.class_("title-edit")],
-                  [
-                    input(
-                      ~attrs=[
-                        Attr.class_("title-text"),
-                        Attr.id(title_input_id),
-                        Attr.value(title),
-                        Attr.on_focus(on_focus_textbox),
-                      ],
-                      (),
-                    ),
-                    div(
-                      ~attrs=[Attr.class_("edit-icon")],
-                      [Widgets.button(Icons.confirm, confirm)],
-                    ),
-                    div(
-                      ~attrs=[Attr.class_("edit-icon")],
-                      [Widgets.button(Icons.cancel, toggle_editing)],
-                    ),
-                  ],
-                )
-              : div(
-                  ~attrs=[Attr.class_("title-edit")],
-                  [
-                    div(
-                      ~attrs=[
-                        Attr.classes([
-                          "title-text",
-                          title == "" ? "title-placeholder" : "",
-                        ]),
-                      ],
-                      [text(placeholder)],
-                    ),
-                    div(
-                      ~attrs=[Attr.class_("edit-icon")],
-                      [Widgets.button(Icons.pencil, toggle_editing)],
-                    ),
-                  ],
-                )
-          : div(~attrs=[Attr.class_("title-text")], [text(title)]),
-      ],
-    ),
+    div(~attrs=[Attr.class_("title-cell")], [body]),
   ]);
 };
 
@@ -121,14 +118,8 @@ let module_name_view =
                     ],
                     (),
                   ),
-                  div(
-                    ~attrs=[Attr.class_("edit-icon")],
-                    [Widgets.button(Icons.confirm, confirm)],
-                  ),
-                  div(
-                    ~attrs=[Attr.class_("edit-icon")],
-                    [Widgets.button(Icons.cancel, toggle_editing)],
-                  ),
+                  edit_icon(Icons.confirm, confirm),
+                  edit_icon(Icons.cancel, toggle_editing),
                 ],
               )
             : div(
@@ -143,10 +134,7 @@ let module_name_view =
                     ],
                     [text(placeholder)],
                   ),
-                  div(
-                    ~attrs=[Attr.class_("edit-icon")],
-                    [Widgets.button(Icons.pencil, toggle_editing)],
-                  ),
+                  edit_icon(Icons.pencil, toggle_editing),
                 ],
               ),
         ],
@@ -154,8 +142,8 @@ let module_name_view =
     : Node.none;
 };
 
-/* Prompt: rendered markdown in both view and student modes; textarea when
-   instructor toggles editing. */
+/* Prompt: rendered markdown in both view and student modes; textarea
+   when instructor toggles editing. */
 let prompt_view =
     (
       ~globals: Globals.t,
@@ -203,14 +191,8 @@ let prompt_view =
                       ),
                     ],
                   ),
-                  div(
-                    ~attrs=[Attr.class_("edit-icon")],
-                    [Widgets.button(Icons.confirm, confirm)],
-                  ),
-                  div(
-                    ~attrs=[Attr.class_("edit-icon")],
-                    [Widgets.button(Icons.cancel, toggle_editing)],
-                  ),
+                  edit_icon(Icons.confirm, confirm),
+                  edit_icon(Icons.cancel, toggle_editing),
                 ],
               )
             : div(
@@ -227,7 +209,13 @@ let prompt_view =
                   ),
                   div(
                     ~attrs=[Attr.class_("edit-pencil")],
-                    [Widgets.button(Icons.pencil, toggle_editing)],
+                    [
+                      Components.button(
+                        ~tooltip="Edit Prompt",
+                        [Icons.pencil],
+                        toggle_editing,
+                      ),
+                    ],
                   ),
                 ],
               )

--- a/src/web/view/CodeExerciseMode.re
+++ b/src/web/view/CodeExerciseMode.re
@@ -1,6 +1,5 @@
 open Haz3lcore;
 open Virtual_dom.Vdom;
-open Node;
 open Util;
 
 /* The exercises mode interface for a single exercise. Composed of multiple editors and results. */
@@ -773,8 +772,8 @@ module View = {
                 prelude.editor.statics.info_map,
               );
             switch (correct_impl_trailing_hole_ctx, prelude_trailing_hole_ctx) {
-            | (None, _) => Node.div([text("No context available (1)")])
-            | (_, None) => Node.div([text("No context available (2)")]) // TODO show exercise configuration error
+            | (None, _) => CellCommon.empty_state("No context available (1)")
+            | (_, None) => CellCommon.empty_state("No context available (2)") // TODO show exercise configuration error
             | (
                 Some(correct_impl_trailing_hole_ctx),
                 Some(prelude_trailing_hole_ctx),
@@ -785,7 +784,7 @@ module View = {
                   prelude_trailing_hole_ctx,
                 );
               switch (specific_ctx) {
-              | None => Node.div([text("No context available")]) // TODO show exercise configuration error
+              | None => CellCommon.empty_state("No context available") // TODO show exercise configuration error
               | Some(specific_ctx) =>
                 ContextInspector.ctx_view(~globals, specific_ctx)
               };
@@ -867,34 +866,20 @@ module View = {
     let add_wrong_impl_view =
       CellCommon.simple_cell_view([
         CellCommon.simple_cell_item([
-          div(
-            ~attrs=[Attr.class_("wrong-impl-cell-caption")],
-            [
-              div(
-                ~attrs=[
-                  Attr.class_("instructor-edit-icon"),
-                  Attr.id("add-icon"),
-                ],
-                [
-                  Widgets.button(
-                    Icons.add,
-                    _ =>
-                      Ui_effect.Many([
-                        inject(Instructor(AddBuggyImplementation)),
-                        signal(
-                          MakeActive(
-                            Cell(
-                              HiddenBugs(List.length(hidden_bugs)),
-                              MainEditor,
-                            ),
-                          ),
-                        ),
-                      ]),
-                    ~tooltip="Add Buggy Implementation",
+          CellCommon.add_impl_caption(
+            ~tooltip="Add Buggy Implementation",
+            ~action=
+              Ui_effect.Many([
+                inject(Instructor(AddBuggyImplementation)),
+                signal(
+                  MakeActive(
+                    Cell(
+                      HiddenBugs(List.length(hidden_bugs)),
+                      MainEditor,
+                    ),
                   ),
-                ],
-              ),
-            ],
+                ),
+              ]),
           ),
         ]),
       ]);

--- a/src/web/view/DerivationExerciseMode.re
+++ b/src/web/view/DerivationExerciseMode.re
@@ -1144,28 +1144,25 @@ module View = {
       );
 
     let derivations_view =
-      div(
-        ~attrs=[Attr.classes(["cell", "unlocked"])],
-        [
-          CellCommon.caption("Derivation"),
-          div(
-            ~attrs=[Attr.classes(["cell-item", "derivation-panel"])],
-            (info_tree |> List.mapi(derivation_view))
-            @ (
-              if (globals.settings.instructor_mode) {
-                [
-                  div(
-                    ~attrs=[Attr.class_("cell-derivation")],
-                    [add_abbr_btn_view(~index=List.length(eds.trees))],
-                  ),
-                ];
-              } else {
-                [];
-              }
-            ),
+      CellCommon.unlocked_cell_view([
+        CellCommon.caption("Derivation"),
+        div(
+          ~attrs=[Attr.classes(["cell-item", "derivation-panel"])],
+          (info_tree |> List.mapi(derivation_view))
+          @ (
+            if (globals.settings.instructor_mode) {
+              [
+                div(
+                  ~attrs=[Attr.class_("cell-derivation")],
+                  [add_abbr_btn_view(~index=List.length(eds.trees))],
+                ),
+              ];
+            } else {
+              [];
+            }
           ),
-        ],
-      );
+        ),
+      ]);
 
     let editing_flags = model.editing_flags;
     let on_focus_textbox = _ => signal(MakeActive(TextBox));
@@ -1202,50 +1199,37 @@ module View = {
         ~update_prompt=p => inject(Instructor(UpdatePrompt(p))),
       );
 
-    let option_view = (name, n) =>
-      option(
-        ~attrs=n == name ? [Attr.create("selected", "selected")] : [],
-        [text(n)],
-      );
-
     let rule_set_view = {
       let can_edit = globals.settings.instructor_mode || scratch_mode;
+      let selected_name = RuleImage.show_rule_set(eds.rule_set);
       let control =
         if (can_edit) {
-          select(
+          Components.select_(
             ~attrs=[
               Attr.class_("rule-set-select"),
               Attr.title("Toggle Rule Set"),
-              Attr.on_change((_, name) => {
-                let rule_set = RuleImage.rule_set_of_string(name);
-                inject(
-                  MapEditor(
-                    m =>
-                      {
-                        ...m,
-                        rule_set,
-                      },
-                  ),
-                );
-              }),
             ],
-            List.map(
-              option_view(RuleImage.show_rule_set(eds.rule_set)),
-              RuleImage.all_of_rule_set |> List.map(RuleImage.show_rule_set),
-            ),
+            ~selected=selected_name,
+            ~options=
+              RuleImage.all_of_rule_set
+              |> List.map(s => {
+                   let n = RuleImage.show_rule_set(s);
+                   (n, n);
+                 }),
+            name => {
+              let rule_set = RuleImage.rule_set_of_string(name);
+              inject(MapEditor(m => {...m, rule_set}));
+            },
           );
         } else {
-          text(RuleImage.show_rule_set(eds.rule_set));
+          text(selected_name);
         };
-      /* Use .unlocked so the cell picks up the same left-border accent as
-         the Setup/Derivation cells above/below it. */
-      div(
-        ~attrs=[Attr.classes(["cell", "unlocked"])],
-        [
-          CellCommon.caption("Rule Set"),
-          CellCommon.simple_cell_item([control]),
-        ],
-      );
+      /* Use unlocked_cell_view so the cell picks up the same left-border
+         accent as the Setup/Derivation cells above/below it. */
+      CellCommon.unlocked_cell_view([
+        CellCommon.caption("Rule Set"),
+        CellCommon.simple_cell_item([control]),
+      ]);
     };
 
     let prelude_view =

--- a/src/web/www/style/code/code.css
+++ b/src/web/www/style/code/code.css
@@ -1,0 +1,54 @@
+/* Code surface — base styles.
+   See docs/style/surfaces.md. */
+
+.code-surface {
+  font-family: var(--code-font);
+  font-size: var(--base-font-size);
+  line-height: var(--line-height);
+  color: var(--STONE);
+  background: var(--SAND);
+  padding: 0.6em 0.8em;
+}
+
+/* Inset placement — hex-cut shape ported from `.inline-editor-wrapper`
+   (stepper.css), used in induction pattern editors.
+
+   `clip-path` is applied AFTER `filter` per the CSS painting order,
+   which means a `drop-shadow` on the same element gets clipped away
+   along with the box. So the shadow is hosted on the surface itself
+   and the hex clip is applied to a `::before` that paints the hex bg
+   + border behind the content. The content sits on top, unclipped.
+*/
+.code-surface.inset {
+  position: relative;
+  background: transparent;
+  filter:
+    drop-shadow(0 1px 2px var(--SHADOW))
+    drop-shadow(0 6px 12px var(--SHADOW));
+}
+
+.code-surface.inset::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--SAND);
+  border: 1px dotted var(--cell-result-border);
+  clip-path: polygon(
+    0.5em 0%,
+    calc(100% - 0.5em) 0%,
+    100% 50%,
+    calc(100% - 0.5em) 100%,
+    0.5em 100%,
+    0% 50%
+  );
+  z-index: 0;
+}
+
+.code-surface.inset > * {
+  position: relative;
+  z-index: 1;
+}
+
+.token.kw  { color: var(--BR4); font-weight: bold; }
+.token.id  { color: var(--token-exp); }
+.token.num { color: var(--token-typ); }

--- a/src/web/www/style/menu/menu.css
+++ b/src/web/www/style/menu/menu.css
@@ -1,0 +1,104 @@
+/* Menu surface — its own surface, distinct from workspace.
+   Yellow-tinted background, tight padding, hover-to-select item rows.
+   Always raised with shadow + outline; placement is implicit (anchored).
+   Ports nut-menu.css and the `.context-menu` block in editor.css. */
+
+/* ============================================================
+   Menu surface — base
+   ============================================================ */
+
+.menu-surface {
+  font-family: var(--ui-font);
+  color: var(--menu-item-text);
+  background: var(--menu-bkg);
+  outline: 0.6px solid var(--menu-outline);
+  box-shadow: 0px 10px 20px var(--menu-shadow);
+  border-radius: 0.5em;
+  padding: 0.2em;
+  min-width: 160px;
+  max-height: 70vh;
+  overflow-y: auto;
+  scrollbar-color: var(--menu-scroll-thumb) var(--menu-scroll-track);
+  scrollbar-width: thin;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Corner anchoring — without one of these, the menu floats and all four
+   corners are rounded. With one of `.tl / .tr / .bl / .br`, that corner is
+   the trigger-side (sharp) and the opposite corner is the only rounded one.
+   Ports the nut-menu submenu (`0 0 0.5em 0` — top-left anchor)
+   and the spirit of `.context-menu.open-down-*`. */
+.menu-surface.tl { border-radius: 0 0 0.5em 0; }
+.menu-surface.tr { border-radius: 0 0 0 0.5em; }
+.menu-surface.bl { border-radius: 0 0.5em 0 0; }
+.menu-surface.br { border-radius: 0.5em 0 0 0; }
+
+/* ============================================================
+   Menu item — single clickable row with label + optional shortcut
+   ============================================================ */
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.05em 0.5em 0.05em 0.7em;
+  color: var(--menu-item-text);
+  cursor: pointer;
+  border-radius: 0.2em;
+}
+
+.menu-item:hover,
+.menu-item.selected {
+  background-color: var(--SAND);
+}
+
+.menu-item > .label {
+  flex: 1;
+}
+
+.menu-item > .shortcut {
+  margin-left: auto;
+  padding-left: 1em;
+  font-size: 0.85em;
+  opacity: 0.6;
+}
+
+/* ============================================================
+   Menu group — labeled section (name + contents)
+   ============================================================ */
+
+.menu-group {
+  display: flex;
+  flex-direction: column;
+  padding: 0 0 0.5em 0;
+}
+
+.menu-group:has(+ .menu-group) {
+  border-bottom: 0.3px solid var(--menu-divider);
+}
+
+.menu-group > .name {
+  padding: 0.4em 0.5em 0.2em 0.75em;
+  color: var(--menu-group-name);
+  font-size: 0.85em;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.menu-group > .contents {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ============================================================
+   Menu divider — thin hairline between items in the same group
+   ============================================================ */
+
+.menu-divider {
+  height: 0.6px;
+  background: var(--menu-outline);
+  margin: 6px 0.5em;
+  border: none;
+}

--- a/src/web/www/style/workspace/palette.html
+++ b/src/web/www/style/workspace/palette.html
@@ -1,0 +1,427 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Hazel — Workspace Palette</title>
+  <link rel="stylesheet" href="../fonts.css">
+  <link rel="stylesheet" href="../variables.css">
+  <link rel="stylesheet" href="../animations.css">
+  <link rel="stylesheet" href="../code/code.css">
+  <link rel="stylesheet" href="workspace.css">
+  <link rel="stylesheet" href="../menu/menu.css">
+  <style>
+    /* Page-only layout. Everything visual should come from workspace.css. */
+    html, body { margin: 0; padding: 0; min-height: 100%; }
+    .palette { max-width: 960px; margin: 0 auto; padding: 2em 2.5em 6em; }
+    .palette section { margin-bottom: 2em; }
+    .palette .stage {
+      min-height: 8em;
+      background: var(--T3);
+      border-radius: var(--radius-sm);
+      padding: var(--space-md);
+      position: relative;
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body class="workspace-surface inline">
+<div class="palette">
+
+  <h1 class="heading h1">Workspace Palette</h1>
+  <p>Static reference. CSS in <code class="code-inline">workspace.css</code> / <code class="code-inline">code.css</code> developed against this page. See <a href="../../../../docs/style/surfaces.md">surfaces</a>, <a href="../../../../docs/style/elements.md">elements</a>.</p>
+
+  <!-- ============ SURFACES ============ -->
+  <section id="surfaces">
+    <h2 class="heading h1">Surfaces</h2>
+
+    <p>Every container in the UI uses one of two surfaces. The <em>code</em> surface is for the syntax-coloured monospace editor and its evaluator output. The <em>workspace</em> surface is the general-purpose UI interior — sidebars, exercise bodies, menus, dialogs, tooltips — and is what this whole page is rendered on.</p>
+
+    <div class="heading h2">Code surface</div>
+    <div class="code-surface">
+      <span class="token kw">let</span> <span class="token id">x</span> = <span class="token num">1</span> <span class="token kw">in</span> <span class="token id">x</span> + <span class="token num">2</span>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Workspace surface with composed flow</div>
+
+    <div class="heading h1">Soil composition</div>
+    <p>Soils are typically classified into three textural categories based on the proportions of <span class="code-inline">sand</span>, <span class="code-inline">silt</span>, and <span class="code-inline">clay</span> particles. Sandy soils drain quickly but hold few nutrients. Loamy soils strike a balance — retaining moisture while staying workable. Clay soils hold water and nutrients but compact under pressure.</p>
+    <p>The pH of a soil also matters: most garden plants prefer slightly acidic to neutral conditions, between 6.0 and 7.0. <a href="#">More on soil chemistry</a>.</p>
+
+    <div class="heading h3">Properties</div>
+    <div class="list-row">
+      <div class="leading">⬢</div>
+      <div class="label">Sandy soils drain quickly but hold few nutrients</div>
+      <div class="trailing"><span class="badge count">↑</span></div>
+    </div>
+    <div class="list-row">
+      <div class="leading">⬢</div>
+      <div class="label">Loamy soils retain moisture while remaining workable</div>
+      <div class="trailing"><span class="badge status ok">✓</span></div>
+    </div>
+    <div class="list-row">
+      <div class="leading">⬢</div>
+      <div class="label">Clay soils may waterlog if overwatered</div>
+      <div class="trailing"><span class="badge status warning">!</span></div>
+    </div>
+  </section>
+
+  <!-- ============ PRIMITIVES ============ -->
+  <section id="primitives">
+    <h2 class="heading h1">Content primitives</h2>
+
+    <div class="heading h2">Button</div>
+    <p>Default, active, and disabled states. Ports <code class="code-inline">.cell-result .icon</code> — wobble and scale on hover.</p>
+    <div class="row">
+      <div class="button"><span>⚙</span></div>
+      <div class="button active"><span>⚙</span></div>
+      <div class="button disabled"><span>⚙</span></div>
+      <div class="button"><span>↗</span></div>
+      <div class="button"><span>📂</span></div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Subtle button</div>
+    <p>Ports <code class="code-inline">.stepper .subtle-button</code> — opacity 0 until the parent is hovered. Used in derivation contexts where action buttons should fade in only when relevant.</p>
+    <div class="row" style="padding: var(--space-sm); background: var(--SAND); border-radius: var(--radius-sm);">
+      <span>Hover anywhere on this row to reveal the subtle button →</span>
+      <div class="button subtle"><span>⚙</span></div>
+      <div class="button subtle"><span>✕</span></div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Toggle</div>
+    <p>Binary on/off switch. Faithful port of <code class="code-inline">toggle.css</code>, including the inset shadow on the track.</p>
+    <div class="row">
+      <div class="toggle"><div class="knob"></div></div>
+      <div class="toggle active"><div class="knob"></div></div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">TextInput</div>
+    <p>Ports the agent chat input: 8px radius, hairline border, SAND fill, BR3 outline on focus.</p>
+    <div class="row">
+      <input class="text-input" placeholder="Single line">
+      <textarea class="text-input" placeholder="Multiline" rows="2"></textarea>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Select</div>
+    <p>Ports the top mode selector — transparent by default, with a pill-shaped fill on hover.</p>
+    <div class="row">
+      <select class="select">
+        <option>Tutorial</option>
+        <option>Scratch</option>
+        <option>Exercise</option>
+      </select>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Heading</div>
+    <p>Three levels, with body text between them so vertical rhythm is visible. h1 ports the exercise title; h2 ports the all-caps cell caption; h3 ports the subtle probarium subsection label.</p>
+
+    <div class="heading h1">Soils of the temperate zone</div>
+    <p>Soils form through the slow weathering of bedrock and the accumulation of organic matter from decomposing plants and animals. Climate, topography, and time together determine which soil profile develops at a given site.</p>
+    <div class="heading h2">Horizons</div>
+    <p>A mature soil is layered into horizons. The O horizon at the surface holds fresh organic litter; below it, the A horizon mixes humus with mineral grains. Deeper still, the B horizon accumulates clays and iron oxides leached down from above.</p>
+    <div class="heading h3">The C horizon</div>
+    <p>The C horizon sits at the base of the profile, just above unweathered bedrock. It consists largely of partially weathered parent material that has not yet been pulled into the active rooting zone.</p>
+
+    <hr class="divider">
+
+    <div class="heading h2">CodeInline</div>
+    <p>Used for embedded identifiers and short type expressions inside prose. The expression <span class="code-inline">x + 1</span> has type <span class="code-inline">Int</span>.</p>
+
+    <hr class="divider">
+
+    <div class="heading h2">Badge</div>
+    <p>Status (error / warning / ok), count, and keyboard variants.</p>
+    <div class="row">
+      <span class="badge status error">!</span>
+      <span class="badge status warning">!</span>
+      <span class="badge status ok">✓</span>
+      <span class="badge count">3</span>
+      <span class="badge kbd">⌘ K</span>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">ProgressBar</div>
+    <p>Two flavours. Continuous: ports the agent token-context-meter — a <code class="code-inline">.track</code> with a <code class="code-inline">.fill</code> whose width is the progress.</p>
+    <div class="progress-bar" style="max-width: 12em;">
+      <div class="label">Context · 42% used</div>
+      <div class="track"><div class="fill" style="width: 42%;"></div></div>
+    </div>
+
+    <p style="margin-top: 1em;">Segmented (<code class="code-inline">.segmented</code>): ports the test-panel <code class="code-inline">.test-bar</code> — clickable status-coded segments (pass / fail / indet).</p>
+    <div class="progress-bar segmented" style="max-width: 16em;">
+      <div class="label">Tests · 4 / 6 passing</div>
+      <div class="track">
+        <div class="segment pass" title="Test 1: Pass"></div>
+        <div class="segment pass" title="Test 2: Pass"></div>
+        <div class="segment fail" title="Test 3: Fail"></div>
+        <div class="segment pass" title="Test 4: Pass"></div>
+        <div class="segment indet" title="Test 5: Indeterminate"></div>
+        <div class="segment pass" title="Test 6: Pass"></div>
+      </div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Divider</div>
+    <p>Above the line.</p>
+    <hr class="divider">
+    <p>Below the line.</p>
+
+    <hr class="divider">
+
+    <div class="heading h2">ListRow</div>
+    <p>Slots: leading / label / trailing. State variants: <code class="code-inline">active</code>, <code class="code-inline">expanded</code>. Corresponds to <code class="code-inline">.problem-row</code> (sidebar) and <code class="code-inline">.history-chat-item</code> (agent).</p>
+    <div class="list-row">
+      <div class="leading"><span>📄</span></div>
+      <div class="label">A list row with leading icon and trailing badge</div>
+      <div class="trailing"><span class="badge count">2</span></div>
+    </div>
+    <div class="list-row active">
+      <div class="leading"><span>📄</span></div>
+      <div class="label">An active list row</div>
+    </div>
+    <div class="list-row expanded">
+      <div class="leading"><span>▾</span></div>
+      <div class="label">An expanded list row</div>
+    </div>
+    <div class="list-row">
+      <div class="label">A bare list row (no leading, no trailing)</div>
+    </div>
+
+    <p style="margin-top: 1em;">Status variants — port <code class="code-inline">.problem-row.{,syntax,hole,warning}</code> from the problems panel. Each adds a left-accent border + tinted bg; <code class="code-inline">.active</code> intensifies both.</p>
+    <div class="list-row error">
+      <div class="label">An error row (default red — <code class="code-inline">.error</code>)</div>
+    </div>
+    <div class="list-row error active">
+      <div class="label">An active error row</div>
+    </div>
+    <div class="list-row syntax">
+      <div class="label">A syntax row (<code class="code-inline">.syntax</code>)</div>
+    </div>
+    <div class="list-row warning">
+      <div class="label">A warning row (<code class="code-inline">.warning</code>)</div>
+    </div>
+    <div class="list-row hole">
+      <div class="label">A hole row (<code class="code-inline">.hole</code>)</div>
+    </div>
+  </section>
+
+  <!-- ============ LAYOUT CONTAINERS ============ -->
+  <section id="containers">
+    <h2 class="heading h1">Layout containers</h2>
+
+    <div class="heading h2">Tabs (vertical)</div>
+    <p>Ports <code class="code-inline">#persistent .tab</code>. Container is fit-content; right-border indicates the active tab.</p>
+    <div class="tabs">
+      <div class="button active"><span>📄</span></div>
+      <div class="button"><span>⚙</span></div>
+      <div class="button"><span>?</span></div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Tabs (horizontal)</div>
+    <p>Ports the probarium sample-color-scheme <code class="code-inline">.segmented-control</code>: bordered strip, equal-width segments, Y1 fill when active.</p>
+    <div class="tabs horizontal">
+      <div class="button active">Calls</div>
+      <div class="button">Hybrid</div>
+      <div class="button">Steps</div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Tabs (title)</div>
+    <p>Ports the probarium <code class="code-inline">.main-title .mode-label</code> pattern: bold uppercase mode-labels used as a switchable panel title, with a <code class="code-inline">/</code> separator. Shown inside an inline workspace, which is its real context.</p>
+    <div class="workspace-surface inline">
+      <div class="tabs title">
+        <div class="button active">Probarium</div>
+        <div class="button">Printarium</div>
+      </div>
+      <p>Panel contents go here. The title-tabs sit at the top and let the reader switch between modes for this panel.</p>
+    </div>
+
+  </section>
+
+  <!-- ============ PLACEMENTS ============ -->
+  <section id="placements">
+    <h2 class="heading h1">Placements</h2>
+
+    <div class="heading h2">workspace × inline</div>
+    <p>A workspace nested inside another workspace gets the probarium outline-rect treatment.</p>
+    <div class="workspace-surface inline">
+      <p>This is an inline workspace nested inside the page-level workspace. The outline + radius is supplied automatically by the descendant-selector rule, so authors don't have to add it themselves.</p>
+      <p>Inline placement at the very top of the tree (the body, for instance) stays chromeless because nothing is its workspace-surface ancestor.</p>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">workspace × raised</div>
+    <p>Same chrome as inline, plus a shadow. Used for menus and popovers.</p>
+    <div class="stage">
+      <div class="workspace-surface raised" style="display: inline-block;">
+        <p style="margin: 0;">A raised workspace surface.</p>
+      </div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Settings dialog</div>
+    <p>Composed of <code class="code-inline">raised</code> + <code class="code-inline">.modal-backdrop</code> + centred positioning. Not its own placement.</p>
+    <div class="stage">
+      <div class="modal-backdrop"></div>
+      <div class="workspace-surface raised" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); min-width: 16em;">
+        <div class="heading h2">Confirm</div>
+        <p>A modal interrupts the flow.</p>
+        <div class="row">
+          <div class="button"><span>✓</span></div>
+          <div class="button"><span>✕</span></div>
+        </div>
+      </div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">workspace × tooltip</div>
+    <p>Tight padding, small text scale, anchored — for hover info on icons and widgets.</p>
+    <div class="workspace-surface tooltip">Small info on hover</div>
+
+    <hr class="divider">
+
+    <div class="heading h2">code × inset</div>
+    <p>A workspace containing an inset code surface — the recessed border indicates the editor.</p>
+    <div class="code-surface inset">
+      <span class="token kw">fun</span> <span class="token id">f</span>(<span class="token id">x</span>) -&gt; <span class="token id">x</span> + <span class="token num">1</span>
+    </div>
+  </section>
+
+  <!-- ============ MENU SURFACE ============ -->
+  <section id="menu">
+    <h2 class="heading h1">Menu surface</h2>
+
+    <p>The menu surface is separate from the workspace surface. It has its own background (yellow-tinted), typography, and item-row patterns. Always raised with a shadow + outline; placement is implicit (anchored to a trigger).</p>
+
+    <div class="heading h2">Menu item</div>
+    <p>A single clickable row inside a menu. Slots: leading icon, label, optional trailing keyboard shortcut.</p>
+    <div class="menu-surface" style="max-width: 16em;">
+      <div class="menu-item">
+        <span>⚙</span>
+        <div class="label">Settings</div>
+        <div class="shortcut">⌘ ,</div>
+      </div>
+      <div class="menu-item selected">
+        <span>📂</span>
+        <div class="label">Open file</div>
+        <div class="shortcut">⌘ O</div>
+      </div>
+      <div class="menu-item">
+        <span>💾</span>
+        <div class="label">Save</div>
+        <div class="shortcut">⌘ S</div>
+      </div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Menu groups</div>
+    <p>A menu can be split into named groups; adjacent groups get a hairline divider automatically.</p>
+    <div class="menu-surface" style="max-width: 18em;">
+      <div class="menu-group">
+        <div class="name">File</div>
+        <div class="contents">
+          <div class="menu-item"><span>📄</span><div class="label">New</div><div class="shortcut">⌘ N</div></div>
+          <div class="menu-item"><span>📂</span><div class="label">Open</div><div class="shortcut">⌘ O</div></div>
+          <div class="menu-item"><span>💾</span><div class="label">Save</div><div class="shortcut">⌘ S</div></div>
+        </div>
+      </div>
+      <div class="menu-group">
+        <div class="name">Edit</div>
+        <div class="contents">
+          <div class="menu-item"><span>↶</span><div class="label">Undo</div><div class="shortcut">⌘ Z</div></div>
+          <div class="menu-item"><span>↷</span><div class="label">Redo</div><div class="shortcut">⇧ ⌘ Z</div></div>
+        </div>
+      </div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Anchored to a corner</div>
+    <p>When the menu is attached to a trigger, the corner closest to the trigger is sharpened and only the opposite corner is rounded. <code class="code-inline">.tl / .tr / .bl / .br</code> select the anchor. Without one of these, the menu is floating and all four corners are rounded (as in the examples above).</p>
+    <div class="row" style="align-items: flex-start; gap: 2em;">
+      <div>
+        <div class="heading h3"><code class="code-inline">.tl</code></div>
+        <div class="menu-surface tl" style="min-width: 8em;">
+          <div class="menu-item"><div class="label">Item</div></div>
+          <div class="menu-item"><div class="label">Item</div></div>
+        </div>
+      </div>
+      <div>
+        <div class="heading h3"><code class="code-inline">.tr</code></div>
+        <div class="menu-surface tr" style="min-width: 8em;">
+          <div class="menu-item"><div class="label">Item</div></div>
+          <div class="menu-item"><div class="label">Item</div></div>
+        </div>
+      </div>
+      <div>
+        <div class="heading h3"><code class="code-inline">.bl</code></div>
+        <div class="menu-surface bl" style="min-width: 8em;">
+          <div class="menu-item"><div class="label">Item</div></div>
+          <div class="menu-item"><div class="label">Item</div></div>
+        </div>
+      </div>
+      <div>
+        <div class="heading h3"><code class="code-inline">.br</code></div>
+        <div class="menu-surface br" style="min-width: 8em;">
+          <div class="menu-item"><div class="label">Item</div></div>
+          <div class="menu-item"><div class="label">Item</div></div>
+        </div>
+      </div>
+    </div>
+
+    <hr class="divider">
+
+    <div class="heading h2">Scrolling menu</div>
+    <p>The menu surface has a default <code class="code-inline">max-height: 70vh</code>; taller contents scroll inside the menu (here forced smaller with an inline override).</p>
+    <div class="menu-surface" style="max-width: 16em; max-height: 10em;">
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 1</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 2</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 3</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 4</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 5</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 6</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 7</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 8</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 9</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 10</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 11</div></div>
+      <div class="menu-item"><span>📄</span><div class="label">Open recent 12</div></div>
+    </div>
+  </section>
+
+</div>
+<script>
+  // Make demo controls interactive so users can see hover/active animations.
+  // Not part of the design system — palette-only.
+  document.querySelectorAll('.toggle').forEach(t => {
+    t.addEventListener('click', () => t.classList.toggle('active'));
+  });
+  document.querySelectorAll('.menu-item').forEach(item => {
+    item.addEventListener('click', () => {
+      item.parentElement.querySelectorAll('.menu-item.selected').forEach(s => s.classList.remove('selected'));
+      item.classList.add('selected');
+    });
+  });
+</script>
+</body>
+</html>

--- a/src/web/www/style/workspace/workspace.css
+++ b/src/web/www/style/workspace/workspace.css
@@ -105,6 +105,23 @@
   margin-top: 0;
 }
 
+/* Subtitle — small subdued inline label, typically used as a
+   non-uppercase aside next to a heading (e.g. "(Read-Only)", "#1").
+   Matches the heading's bottom margin (none) when used inside a row. */
+.subtitle {
+  font-size: var(--text-sm);
+  color: var(--BR4);
+  font-weight: normal;
+  opacity: 0.7;
+}
+
+/* When heading or subtitle is laid out inside a row, drop their
+   vertical margins so the row's baseline alignment works. */
+.row > .heading,
+.row > .subtitle {
+  margin: 0;
+}
+
 /* ============================================================
    Button — visible icon button. Ports the `.cell-result .icon`
    pattern (stepper top "remove step" button, settings-modal,

--- a/src/web/www/style/workspace/workspace.css
+++ b/src/web/www/style/workspace/workspace.css
@@ -1,0 +1,670 @@
+/* Workspace surface — base + primitives + containers + placements.
+   Conservative port: values match dominant patterns in the legacy CSS.
+   See docs/style/surfaces.md and docs/style/elements.md. */
+
+/* ============================================================
+   Local scale tokens (values chosen to match existing patterns).
+   Promote to variables.css once stable.
+   ============================================================ */
+
+:root {
+  --space-xs: 0.2em;
+  --space-sm: 0.5em;
+  --space-md: 0.75em;
+  --space-lg: 1em;
+
+  --radius-sm: 0.3em;
+  --radius-md: 0.4em;
+  --radius-pill: 999px;
+
+  --text-sm: 0.85em;
+  --text-md: 1em;
+  --text-lg: 1.2em;
+
+  --transition-base: 0.2s ease;
+}
+
+/* ============================================================
+   Workspace surface — base
+   ============================================================ */
+
+.workspace-surface {
+  font-family: var(--ui-font);
+  font-size: var(--base-font-size);
+  color: var(--STONE);
+  background: var(--ui-bkg);
+  line-height: var(--line-height);
+}
+
+.workspace-surface p { margin: 0 0 0.8em; }
+.workspace-surface p:last-child { margin-bottom: 0; }
+
+/* Hyperlinks — ports `.agent-main-menu-info a` */
+.workspace-surface a {
+  color: var(--BR3);
+  text-decoration: underline;
+  transition: color var(--transition-base);
+}
+.workspace-surface a:hover {
+  color: var(--BR4);
+}
+
+/* ============================================================
+   Row — flex horizontal with default gap; for inline groups
+   ============================================================ */
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+/* ============================================================
+   Heading — three levels, each ported from an existing pattern:
+   - h1 ports `.title-cell .title-text` (cell.css): exercise title.
+   - h2 ports `.cell-caption strong` (cell.css): all-caps cell label.
+   - h3 ports `#probe-sidebar .legend .title` (probesystem.css):
+     small subtle subsection label.
+   ============================================================ */
+
+.heading {
+  font-family: var(--ui-font);
+  margin: 0;
+}
+
+/* Headings own both their top and bottom rhythm — generous top margin to
+   space them from preceding content; tight bottom margin to group with
+   the content that follows. :first-child suppresses top space at the
+   start of a container. Margin-collapsing handles adjacent cases. */
+
+.heading.h1 {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: var(--BR4);
+  margin: 1.5em 0 0.4em;
+}
+
+.heading.h2 {
+  font-size: 0.85em;
+  font-weight: bold;
+  color: var(--ui-header-text);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 1.5em 0 0.3em;
+}
+
+.heading.h3 {
+  font-size: 0.85em;
+  font-weight: normal;
+  color: var(--BR2);
+  margin: 1.2em 0 0.3em;
+}
+
+.heading:first-child {
+  margin-top: 0;
+}
+
+/* ============================================================
+   Button — visible icon button. Ports the `.cell-result .icon`
+   pattern (stepper top "remove step" button, settings-modal,
+   nut-menu): 20px wrap, BR2 colour, wobble + scale + brightness
+   animation on hover.
+
+   `.button.subtle` ports `.stepper .subtle-button`: opacity 0
+   until the parent (or the button itself) is hovered.
+   ============================================================ */
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  min-height: 20px;
+  padding: 0;
+  background: transparent;
+  color: var(--BR2);
+  cursor: pointer;
+  user-select: none;
+  transition: opacity 0.3s;
+}
+
+.button > * {
+  transition: transform var(--transition-base),
+              filter var(--transition-base);
+  display: inline-block;
+}
+
+.button > svg {
+  fill: var(--BR2);
+}
+
+.button:hover > * {
+  animation: wobble 0.6s ease 0s 1 normal forwards;
+  transform: scale(1.3);
+  filter: brightness(1.1);
+}
+
+.button.disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.button.disabled:hover > * {
+  animation: none;
+  transform: none;
+  filter: none;
+}
+
+.button.active > * {
+  transform: scale(1.15);
+}
+
+.tabs > .button:hover > *,
+.tabs.horizontal > .button:hover > *,
+.tabs.title > .button:hover > * {
+  animation: none;
+  transform: none;
+  filter: none;
+}
+
+.button.subtle {
+  opacity: 0;
+}
+
+.button.subtle:hover,
+*:hover > .button.subtle {
+  opacity: 1;
+}
+
+/* ============================================================
+   Toggle — faithful port of toggle.css
+   ============================================================ */
+
+.toggle {
+  display: inline-block;
+  position: relative;
+  height: 1.2em;
+  width: 2em;
+  background-color: var(--shard-exp);
+  border-radius: 2em;
+  cursor: pointer;
+  border: solid 1px transparent;
+  box-shadow: inset 1px 1px 9px -3px rgb(4 4 4 / 8%),
+              1px 2px 6px -2px rgb(0 0 0 / 1%);
+  transition: margin 0.1s ease-in;
+}
+
+.toggle:hover {
+  animation: wobble 0.4s ease 0s 1 normal none;
+}
+
+.toggle > .knob {
+  width: 0.9em;
+  height: 0.9em;
+  background-color: var(--toggle-knob);
+  border: solid 1px rgba(126, 126, 126, 0.07);
+  border-radius: 1.5em;
+  margin: 1px 0.9em 1px 1px;
+  box-shadow: 0 1px 3px rgb(106 106 106 / 26%),
+              0 5px 1px rgb(106 106 106 / 13%);
+  transition: margin 0.1s ease-in;
+}
+
+.toggle.active { background-color: var(--BR2); }
+.toggle.active > .knob {
+  margin-left: 0.9em;
+  margin-right: 1px;
+}
+
+/* ============================================================
+   Text input — ports `.user-message-input` (agent-chat-messages):
+   8px radius, 0.6px BR2 border, SAND fill, BR3 border + outline on focus.
+   ============================================================ */
+
+.text-input {
+  font-family: var(--ui-font);
+  font-size: var(--text-md);
+  color: var(--STONE);
+  background-color: var(--SAND);
+  padding: 0.6em 0.8em;
+  border: 0.6px solid var(--BR2);
+  border-radius: 8px;
+  transition: border-color var(--transition-base);
+}
+
+.text-input:hover {
+  border-color: var(--BR3);
+}
+
+.text-input:focus {
+  outline: 0.6px solid var(--BR3);
+  border-color: var(--BR3);
+}
+
+/* ============================================================
+   Select — ports `#top-bar #editor-mode select`:
+   transparent, BR4 colour, pill radius, SAND fill on hover.
+   ============================================================ */
+
+.select {
+  font-family: var(--ui-font);
+  font-size: inherit;
+  color: var(--select-text);
+  background: transparent;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  padding: 0.2em 0.6em;
+  border-radius: 1em;
+  transition: background-color var(--transition-base);
+}
+
+.select:hover {
+  background-color: var(--SAND);
+}
+
+/* ============================================================
+   Code inline
+   ============================================================ */
+
+.code-inline {
+  font-family: var(--code-font);
+  font-size: 0.9em;
+  padding: 0.1em 0.3em;
+  background: var(--SAND);
+  color: var(--token-exp);
+  border-radius: 0.2em;
+}
+
+/* ============================================================
+   Badge — semantics ported from `.tab-status-indicator`,
+   `.ci-status-*`, test pass/fail vars
+   ============================================================ */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.4em;
+  height: 1.4em;
+  padding: 0 var(--space-sm);
+  font-size: var(--text-sm);
+  font-weight: bold;
+  border-radius: var(--radius-pill);
+  background: var(--BR2);
+  color: var(--SAND);
+}
+
+.badge.status.error   { background: var(--ci-status-error-bkg);   color: var(--ci-status-error-text); }
+.badge.status.warning { background: var(--ci-status-warning-bkg); color: var(--ci-status-warning-text); }
+.badge.status.ok      { background: var(--test-pass-active);      color: var(--test-pass); }
+
+.badge.count { background: var(--BR2); color: var(--SAND); }
+
+.badge.kbd {
+  font-family: var(--code-font);
+  background: var(--T2);
+  color: var(--BR4);
+  border-radius: var(--radius-sm);
+  font-weight: normal;
+}
+
+/* ============================================================
+   Progress bar — two flavours.
+
+   Continuous: ports the agent token-context-meter
+     (agent-chat-messages.css). `.track` contains a `.fill`
+     whose width is the progress.
+
+   Segmented: ports the test-panel `.test-bar`. `.track` contains
+     a row of `.segment` divs, each status-coded and clickable.
+   ============================================================ */
+
+.progress-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+}
+
+.progress-bar > .label {
+  font-family: var(--code-font);
+  font-size: 0.72em;
+  color: var(--BR4);
+  text-align: center;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
+.progress-bar > .track {
+  height: 5px;
+  border-radius: 3px;
+  background-color: var(--context-meter-track);
+  overflow: hidden;
+  width: 100%;
+}
+
+.progress-bar > .track > .fill {
+  height: 100%;
+  border-radius: 3px;
+  background-color: var(--context-meter-fill);
+  transition: width 0.2s ease;
+}
+
+/* Segmented variant — clickable status-coded segments. */
+.progress-bar.segmented > .track {
+  background: transparent;
+  border-radius: 0;
+  overflow: visible;
+  height: 0.5em;
+  display: flex;
+  gap: 1px;
+}
+
+.progress-bar.segmented > .track > .segment {
+  flex: 1;
+  cursor: pointer;
+  transition: background-color var(--transition-base);
+}
+
+.progress-bar.segmented > .track > .segment:first-child { border-radius: 0.3em 0 0 0.3em; }
+.progress-bar.segmented > .track > .segment:last-child  { border-radius: 0 0.3em 0.3em 0; }
+.progress-bar.segmented > .track > .segment:only-child  { border-radius: 0.3em; }
+
+.progress-bar.segmented > .track > .segment.pass        { background: var(--test-pass); }
+.progress-bar.segmented > .track > .segment.fail        { background: var(--test-fail); }
+.progress-bar.segmented > .track > .segment.indet       { background: var(--test-indet); }
+.progress-bar.segmented > .track > .segment.pass:hover  { background: var(--test-pass-active); }
+.progress-bar.segmented > .track > .segment.fail:hover  { background: var(--test-fail-active); }
+.progress-bar.segmented > .track > .segment.indet:hover { background: var(--test-indet-active); }
+
+/* ============================================================
+   Divider
+   ============================================================ */
+
+.divider {
+  height: 1px;
+  width: 100%;
+  background: var(--BR1);
+  border: none;
+  margin: var(--space-sm) 0;
+}
+
+.divider.vertical {
+  width: 1px;
+  height: 1em;
+  margin: 0 var(--space-sm);
+  display: inline-block;
+  background: var(--BR1);
+}
+
+/* ============================================================
+   List row — ports `.problem-row` structural styling
+   (Corresponds to .problem-row in sidebar.css and
+    .history-chat-item in agent-chat.css. Menu items are likely
+    their own surface — not absorbed here.)
+   ============================================================ */
+
+.list-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  padding-left: var(--space-md);
+  cursor: pointer;
+  transition: background-color var(--transition-base);
+  border-top: 1px solid var(--BR2);
+  border-bottom: 1px solid var(--BR2);
+}
+
+.list-row + .list-row {
+  border-top: none;
+}
+
+.list-row:hover { background-color: var(--menu-item-hover-bkg); }
+
+.list-row > .leading,
+.list-row > .trailing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.list-row > .label {
+  flex: 1;
+  min-width: 0;
+}
+
+.list-row.active {
+  background-color: var(--Y1);
+  font-weight: 600;
+}
+
+.list-row.expanded { background-color: var(--T2); }
+
+/* Status variants — port `.problem-row.{,syntax,hole,warning}` from
+   sidebar.css. Each adds a left accent + tinted background; hover and
+   active intensify both. */
+
+.list-row.error {
+  border-left: 3px solid color-mix(in srgb, var(--R1) 40%, transparent);
+  background-color: color-mix(in srgb, var(--R0) 50%, transparent);
+}
+.list-row.error:hover {
+  background-color: var(--R0);
+  filter: brightness(0.95);
+}
+.list-row.error.active {
+  border-left: 5px solid var(--R2);
+  background-color: var(--ci-status-error-bkg);
+  box-shadow: inset 0 0 0 1px var(--R1);
+}
+
+.list-row.syntax {
+  border-left: 3px solid color-mix(in srgb, var(--Y1) 60%, transparent);
+  background-color: color-mix(in srgb, var(--Y0) 50%, transparent);
+}
+.list-row.syntax:hover {
+  background-color: var(--Y0);
+}
+.list-row.syntax.active {
+  border-left: 5px solid var(--Y2);
+  background-color: color-mix(in srgb, var(--Y0) 80%, transparent);
+  box-shadow: inset 0 0 0 1px var(--Y1);
+}
+
+.list-row.hole {
+  border-left: 3px solid color-mix(in srgb, var(--hole-stroke) 60%, transparent);
+  background-color: color-mix(in srgb, var(--hole-fill) 50%, transparent);
+}
+.list-row.hole:hover {
+  background-color: var(--hole-fill);
+}
+.list-row.hole.active {
+  border-left: 5px solid var(--hole-active);
+  background-color: color-mix(in srgb, var(--hole-fill) 80%, transparent);
+  box-shadow: inset 0 0 0 1px var(--hole-stroke);
+}
+
+.list-row.warning {
+  border-left: 3px solid color-mix(in srgb, var(--warning-hole-stroke) 60%, transparent);
+  background-color: color-mix(in srgb, var(--warning-hole-fill) 50%, transparent);
+}
+.list-row.warning:hover {
+  background-color: var(--warning-hole-fill);
+}
+.list-row.warning.active {
+  border-left: 5px solid var(--warning-hole-stroke);
+  background-color: color-mix(in srgb, var(--warning-hole-fill) 80%, transparent);
+  box-shadow: inset 0 0 0 1px var(--warning-hole-stroke);
+}
+
+/* ============================================================
+   Tabs container — vertical strip ports `#persistent .tab`
+   (sidebar.css); horizontal ports the probarium `.mode-label`
+   pattern with a `/` separator between items.
+   ============================================================ */
+
+.tabs {
+  display: flex;
+  flex-direction: column;
+  width: fit-content;
+}
+
+.tabs > .button {
+  box-sizing: border-box;
+  min-height: 2.5em;
+  min-width: 2.5em;
+  background: transparent;
+  border-radius: 0;
+  border-right: 0.2em solid transparent;
+  fill: var(--BR3);
+  transition: color var(--transition-base), fill var(--transition-base);
+}
+
+.tabs > .button:hover:not(.active) {
+  background: transparent;
+  fill: var(--BR4);
+  color: var(--BR4);
+}
+
+.tabs > .button.active {
+  background: transparent;
+  border-right-color: var(--BR3);
+  padding-left: 0.2em;
+  color: var(--BR4);
+  fill: var(--BR4);
+}
+
+/* Horizontal — ports the probarium sample-color-scheme
+   `.segmented-control`: bordered strip, equal-width segments
+   separated by hairlines, Y1 fill when active. */
+.tabs.horizontal {
+  display: flex;
+  flex-direction: row;
+  width: auto;
+  border: 1px solid var(--BR1);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.tabs.horizontal > .button {
+  flex: 1;
+  text-align: center;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--BR1);
+  border-radius: 0;
+  padding: 0.2em 0.4em;
+  font-family: var(--ui-font);
+  font-size: var(--text-sm);
+  font-weight: normal;
+  text-transform: none;
+  color: var(--STONE);
+  min-height: 0;
+  min-width: 0;
+}
+
+.tabs.horizontal > .button:last-child {
+  border-right: none;
+}
+
+.tabs.horizontal > .button:hover:not(.active) {
+  background: var(--Y0);
+}
+
+.tabs.horizontal > .button.active {
+  background: var(--Y1);
+  color: var(--BR4);
+  font-weight: 500;
+}
+
+/* Title — ports the probarium `#probe-sidebar .main-title`
+   pattern: bold uppercase mode-label group used as a switchable
+   panel title. Bigger and bolder than `.horizontal`; no border. */
+.tabs.title {
+  display: flex;
+  flex-direction: row;
+  width: auto;
+  gap: 0.6em;
+  align-items: center;
+}
+
+.tabs.title > .button {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  min-height: 0;
+  min-width: 0;
+  font-family: var(--ui-font);
+  font-size: var(--text-md);
+  font-weight: bold;
+  text-transform: uppercase;
+  color: var(--BR1);
+}
+
+.tabs.title > .button:hover:not(.active) {
+  background: transparent;
+  color: var(--BR2);
+}
+
+.tabs.title > .button.active {
+  background: transparent;
+  color: var(--ui-header-text);
+}
+
+.tabs.title > .button + .button::before {
+  content: "/";
+  color: var(--BR1);
+  margin-right: 0.6em;
+  font-weight: normal;
+}
+
+/* ============================================================
+   Placements
+   ============================================================ */
+
+.workspace-surface.inline {
+  /* default — flush with parent, no chrome at the top level */
+}
+
+/* A workspace nested inside another workspace gets the probarium
+   outline-rect treatment (`#probe-sidebar .panel`) so it reads
+   as a contained section. The outer page-level workspace stays
+   chromeless because nothing is its workspace-surface ancestor. */
+.workspace-surface .workspace-surface.inline {
+  outline: 1px solid var(--BR1);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm);
+}
+
+/* `raised` is the same chrome as nested inline, plus a shadow.
+   Used for menus, popovers, and (composed with a backdrop and
+   centred positioning) modal-style dialogs. */
+.workspace-surface.raised {
+  outline: 1px solid var(--BR1);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm);
+  box-shadow: 0px 10px 20px var(--menu-shadow);
+}
+
+/* `tooltip` keeps things small and light */
+.workspace-surface.tooltip {
+  display: inline-block;
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--text-sm);
+  background: var(--SAND);
+  color: var(--STONE);
+  border: 1px solid var(--BR2);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 2px 6px var(--SHADOW);
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background-color: #00000060;
+}


### PR DESCRIPTION
I've been getting a Claude to take a look over the "workspace" areas of the editor, (panels, exercises/tutorial mode, basically anything that's not code or nut menu) and see if we can build some re-usable components from them instead of having bespoke buttons everywhere and apparently 34 different font size values throughout the editor.

see https://hazel.org/build/workspace-primitives/style/workspace/palette.html