### PR TITLE
fix: Cmd+C/V/X in Firefox after editor focus

### DIFF
--- a/src/util/JsUtil.re
+++ b/src/util/JsUtil.re
@@ -615,24 +615,3 @@ let navigate_probes =
   | None => None
   };
 };
-
-/* Walk up the DOM (max_depth levels) checking if any ancestor has the given CSS class */
-let has_ancestor_class =
-    (~max_depth=5, el: Js.t(Dom_html.element), class_name: string): bool => {
-  let rec go = (el: Js.t(Dom_html.element), depth: int): bool =>
-    if (depth > max_depth) {
-      false;
-    } else if (Js.to_bool(el##.classList##contains(Js.string(class_name)))) {
-      true;
-    } else {
-      switch (Js.Opt.to_option(el##.parentNode)) {
-      | Some(parent_node) =>
-        switch (Js.Opt.to_option(Dom_html.CoerceTo.element(parent_node))) {
-        | Some(parent) => go(parent, depth + 1)
-        | None => false
-        }
-      | None => false
-      };
-    };
-  go(el, 0);
-};

--- a/src/util/JsUtil.re
+++ b/src/util/JsUtil.re
@@ -129,6 +129,47 @@ let copy = (str: string) => {
   );
 };
 
+/* Direct clipboard writes via the async Clipboard API. Used from editor
+   key handlers where the focused element is a non-editable div and
+   Firefox therefore refuses to dispatch a native `copy` event to the
+   page-level handler. Safe under a user gesture (keydown). */
+let has_clipboard_api = (): bool =>
+  Js.to_bool(
+    Js.Unsafe.fun_call(
+      Js.Unsafe.pure_js_expr(
+        "(function(){return typeof navigator.clipboard !== 'undefined';})",
+      ),
+      [||],
+    ),
+  );
+
+let write_clipboard = (str: string): unit =>
+  if (has_clipboard_api()) {
+    Js.Unsafe.fun_call(
+      Js.Unsafe.pure_js_expr(
+        "(function(s){navigator.clipboard.writeText(s);})",
+      ),
+      [|Js.Unsafe.inject(Js.string(str))|],
+    );
+  } else {
+    /* Older browsers: fall through to the shim/execCommand path. */
+    copy(str);
+  };
+
+/* Async clipboard read, used for editor-level Cmd+V. The Promise's
+   text result is delivered to `on_text`, which is expected to schedule
+   the resulting Effect via Bonsai.Effect.Expert.handle. */
+let read_clipboard = (on_text: string => unit): unit =>
+  if (has_clipboard_api()) {
+    let cb = Js.wrap_callback(text => on_text(Js.to_string(text)));
+    Js.Unsafe.fun_call(
+      Js.Unsafe.pure_js_expr(
+        "(function(cb){navigator.clipboard.readText().then(cb);})",
+      ),
+      [|Js.Unsafe.inject(cb)|],
+    );
+  };
+
 let element_to_node = (element: Js.t(Dom_html.element)): Js.t(Dom.node) =>
   Js.Unsafe.coerce(element);
 

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -731,20 +731,18 @@ module View = {
         Effect.Ignore;
       }),
       Attr.on_copy(evt => {
+        /* Only hijack copy when the target lives inside a code editor —
+           editor-level Cmd+C now handles its own clipboard write, but the
+           native event still bubbles in cases where focus is on #page or
+           the editor's tabindex div without our key handler having run.
+           For sidebar / system-message / agent-message / inputs, fall
+           through to the browser's default DOM-selection copy. */
         let target = Js.Opt.to_option(evt##.target);
         switch (target) {
         | Some(el) =>
-          let elId = Js.Opt.to_option(Js.Unsafe.coerce(el)##.id);
-          if (is_input_field(elId)) {
-            ();
-          } else {
-            let el = Js.Unsafe.coerce(el);
-            if (JsUtil.has_ancestor_class(el, "system-message")
-                || JsUtil.has_ancestor_class(el, "agent-message")) {
-              ();
-            } else {
-              copy(cursor);
-            };
+          let el = Js.Unsafe.coerce(el);
+          if (JsUtil.has_ancestor_class(el, "code-editor")) {
+            copy(cursor);
           };
         | None => ()
         };

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -569,61 +569,7 @@ module Selection = {
 };
 
 module View = {
-  let is_input_field = (elId: option(string)) => {
-    switch (elId) {
-    | Some("title-input-box")
-    | Some("module-name-input")
-    | Some("prompt-input-box")
-    | Some("test-required-input")
-    | Some("point-max-input")
-    | Some("agent-api-key-input") => true
-    | Some(id) when String.starts_with(~prefix="hint-input", id) => true
-    | Some(id) when String.starts_with(~prefix="syntax-hint-input", id) =>
-      true
-    | Some(id) when String.starts_with(~prefix="impl-hint-input", id) => true
-    | _ => false
-    };
-  };
-
-  let selection_has_refractors =
-      (
-        refractors: Haz3lcore.Zipper.Refractor.t,
-        selection: Haz3lcore.Segment.t,
-      )
-      : bool =>
-    if (List.is_empty(refractors.manuals)) {
-      false;
-    } else {
-      let ids = Haz3lcore.Segment.ids(selection);
-      List.exists(
-        id =>
-          List.exists(((id2, _)) => Id.equal(id, id2), refractors.manuals),
-        ids,
-      );
-    };
-
-  let copy = (cursor: Cursor.cursor(Editors.Update.t)): unit => {
-    let str = (cursor.selected_text |> Option.value(~default=() => ""))();
-    let should_set =
-      switch (cursor.editor, cursor.selection) {
-      | (Some(editor), Some(selection)) =>
-        /* If the selection contains refractors, we forgo the segment cache
-         * for the sake of preserving refractors in the copy via expanding
-         * their text invocation form, i.e. ^^refractor_name(<syntax>) */
-        !selection_has_refractors(editor.state.zipper.refractors, selection)
-      | _ => true
-      };
-    should_set
-      ? Haz3lcore.Parser.set_segment_cache(cursor.selection, str) : ();
-    JsUtil.copy(str);
-  };
-
-  let handlers =
-      (
-        ~inject: Update.t => Ui_effect.t(unit),
-        ~cursor: Cursor.cursor(Editors.Update.t),
-        model: Model.t,
-      ) => {
+  let handlers = (~inject: Update.t => Ui_effect.t(unit), model: Model.t) => {
     let handle_key_event = (key: Key.t): Effect.t(unit) => {
       let meta_down = key.meta == Down;
       let meta_effects =
@@ -729,64 +675,6 @@ module View = {
       Attr.on_focus(_ => {
         JsUtil.focus_clipboard_shim();
         Effect.Ignore;
-      }),
-      Attr.on_copy(evt => {
-        /* Only hijack copy when the target lives inside a code editor —
-           editor-level Cmd+C now handles its own clipboard write, but the
-           native event still bubbles in cases where focus is on #page or
-           the editor's tabindex div without our key handler having run.
-           For sidebar / system-message / agent-message / inputs, fall
-           through to the browser's default DOM-selection copy. */
-        let target = Js.Opt.to_option(evt##.target);
-        switch (target) {
-        | Some(el) =>
-          let el = Js.Unsafe.coerce(el);
-          if (JsUtil.has_ancestor_class(el, "code-editor")) {
-            copy(cursor);
-          };
-        | None => ()
-        };
-        Effect.Ignore;
-      }),
-      Attr.on_cut(evt => {
-        let target = Js.Opt.to_option(evt##.target);
-        switch (target) {
-        | Some(el) =>
-          let elId = Js.Opt.to_option(Js.Unsafe.coerce(el)##.id);
-          if (is_input_field(elId)) {
-            Effect.Ignore;
-          } else {
-            copy(cursor);
-            switch (cursor.editor_action(Destruct(Right))) {
-            | Some(action) => inject(Editors(action))
-            | None => Effect.Ignore
-            };
-          };
-        | None => Effect.Ignore
-        };
-      }),
-    ]
-    @ [
-      Attr.on_paste(evt => {
-        let target = Js.Opt.to_option(evt##.target);
-        switch (target) {
-        | Some(el) =>
-          let elId = Js.Opt.to_option(Js.Unsafe.coerce(el)##.id);
-          if (is_input_field(elId)) {
-            Effect.Ignore;
-          } else {
-            let text =
-              Js.to_string(evt##.clipboardData##getData(Js.string("text")));
-            let action =
-              Haz3lcore.Action.Paste(Util.StringUtil.trim_leading(text));
-            Dom.preventDefault(evt);
-            switch (cursor.editor_action(action)) {
-            | None => Effect.Ignore
-            | Some(action) => inject(Editors(action))
-            };
-          };
-        | None => Effect.Ignore
-        };
       }),
     ];
   };
@@ -993,7 +881,7 @@ module View = {
       Selection.get_cursor_info(~inject, ~selection=model.selection, model);
     NinjaKeys.initialize(cursor.contextual_actions);
     div(
-      ~attrs=[Attr.id("page"), ...handlers(~cursor, ~inject, model)],
+      ~attrs=[Attr.id("page"), ...handlers(~inject, model)],
       [FontSpecimen.view, JsUtil.clipboard_shim]
       @ main_view(~log_model, ~get_log_and, ~cursor, ~inject, model),
     );

--- a/src/web/app/editors/cell/InstructorEditViews.re
+++ b/src/web/app/editors/cell/InstructorEditViews.re
@@ -6,10 +6,8 @@ open Node;
    Provides pencil/confirm/cancel UI for editing a title, module name, and
    prompt (with markdown rendering for the prompt via ExplainThis). */
 
-/* The DOM ids below are also recognized by Page.View.is_input_field so that
-   keyboard shortcuts are bypassed while these inputs have focus. Only one
-   exercise is visible at a time, so reusing these ids across exercise kinds
-   is safe. */
+/* Only one exercise is visible at a time, so reusing these ids across
+   exercise kinds is safe. */
 let title_input_id = "title-input-box";
 let module_name_input_id = "module-name-input";
 let prompt_input_id = "prompt-input-box";

--- a/src/web/app/editors/code/CodeEditable.re
+++ b/src/web/app/editors/code/CodeEditable.re
@@ -782,6 +782,44 @@ module View = {
         );
       } else {
         let z = model.editor.state.zipper;
+        /* Editor-level clipboard helpers. Bypass the page-level
+           on_copy/on_paste path because Firefox refuses to dispatch
+           native clipboard events to non-editable focused elements
+           (the editor div has tabindex(0) but is not contenteditable). */
+        let selection_has_refractors =
+            (refractors: Haz3lcore.Zipper.Refractor.t, selection) =>
+          if (List.is_empty(refractors.manuals)) {
+            false;
+          } else {
+            let ids = Haz3lcore.Segment.ids(selection);
+            List.exists(
+              id =>
+                List.exists(
+                  ((id2, _)) => Id.equal(id, id2),
+                  refractors.manuals,
+                ),
+              ids,
+            );
+          };
+        let copy_selection = () => {
+          let segment = z.selection.content;
+          let str =
+            Printer.of_segment(
+              ~indent=" ",
+              ~refractors=z.refractors.manuals,
+              segment,
+            );
+          if (!selection_has_refractors(z.refractors, segment)) {
+            Haz3lcore.Parser.set_segment_cache(Some(segment), str);
+          };
+          JsUtil.write_clipboard(str);
+        };
+        let paste_from_clipboard = () =>
+          JsUtil.read_clipboard(text => {
+            let action =
+              Haz3lcore.Action.Paste(Util.StringUtil.trim_leading(text));
+            Bonsai.Effect.Expert.handle(inject(Perform(action)));
+          });
         Key.handler(~f=key => {
           /* 1. Check for arrow key escape at boundaries FIRST.
            *    Keyboard.handle_key_event always returns Some for arrows,
@@ -813,8 +851,75 @@ module View = {
                 && z.relatives.ancestors == []
                 && snd(Siblings.neighbors(z.relatives.siblings)) == None =>
             Effect.Many([Effect.Prevent_default, escape(Right)])
+          /* 2. Cmd/Ctrl + C/X/V handled here rather than via the page
+             on_copy/on_paste handlers, so they keep working in
+             Firefox when focus is on a non-editable editor div. */
+          | {
+              key: D("c" | "C"),
+              sys: Mac,
+              shift: Up,
+              meta: Down,
+              ctrl: Up,
+              alt: Up,
+              _,
+            }
+          | {
+              key: D("c" | "C"),
+              sys: PC,
+              shift: Up,
+              meta: Up,
+              ctrl: Down,
+              alt: Up,
+              _,
+            } =>
+            copy_selection();
+            Effect.Many([Effect.Prevent_default, Effect.Stop_propagation]);
+          | {
+              key: D("x" | "X"),
+              sys: Mac,
+              shift: Up,
+              meta: Down,
+              ctrl: Up,
+              alt: Up,
+              _,
+            }
+          | {
+              key: D("x" | "X"),
+              sys: PC,
+              shift: Up,
+              meta: Up,
+              ctrl: Down,
+              alt: Up,
+              _,
+            } =>
+            copy_selection();
+            Effect.Many([
+              Effect.Prevent_default,
+              Effect.Stop_propagation,
+              inject(Perform(Destruct(Right))),
+            ]);
+          | {
+              key: D("v" | "V"),
+              sys: Mac,
+              shift: Up,
+              meta: Down,
+              ctrl: Up,
+              alt: Up,
+              _,
+            }
+          | {
+              key: D("v" | "V"),
+              sys: PC,
+              shift: Up,
+              meta: Up,
+              ctrl: Down,
+              alt: Up,
+              _,
+            } =>
+            paste_from_clipboard();
+            Effect.Many([Effect.Prevent_default, Effect.Stop_propagation]);
           | _ =>
-            /* 2. Normal editor key handling:
+            /* 3. Normal editor key handling:
              *    context menu → projector handoff → Keyboard */
             switch (Selection.handle_key_event(~selection=(), model, key)) {
             | Some(action) =>

--- a/test/evaluator/Test_Evaluator_Incremental.re
+++ b/test/evaluator/Test_Evaluator_Incremental.re
@@ -1327,7 +1327,12 @@ n|};
   };
   let (r1, _, incr1) = eval_incr(exp1);
   let (r2, _, incr2) = eval_incr(~prev=incr1, exp2);
-  check(dhexp_typ, "Run 1: string_length(\"hello\") = 5", parse_exp("5"), r1);
+  check(
+    dhexp_typ,
+    "Run 1: string_length(\"hello\") = 5",
+    parse_exp("5"),
+    r1,
+  );
   check(dhexp_typ, "Run 2: result unchanged = 5", parse_exp("5"), r2);
   /* The bug we're pinning: without seeding the reuse_map from env, the
    * builtin name in the Ap's co_ctx forces a permanent cache miss here. */


### PR DESCRIPTION
## Summary

Firefox copy/paste shortcuts (Cmd+C, Cmd+V, Cmd+X) silently failed inside the editor after clicking into a cell.

Root cause: PR #2198 (keyboard architecture refactor) decentralized focus into per-editor `tabindex(0)` divs. Firefox only dispatches native `copy`/`paste`/`cut` events to **editable** elements (input/textarea/contenteditable). Once focus landed on a `.code-editor` div, the page-level `Attr.on_copy`/`on_paste`/`on_cut` handlers in `Page.re` never fired, so the clipboard was never written. Chrome is more permissive and fires the events on any focused tabindex element, which is why we didn't notice sooner.

## Changes

- **`src/util/JsUtil.re`** — add `write_clipboard` / `read_clipboard` using the async Clipboard API (`navigator.clipboard.writeText` / `readText`). Feature-detected with a fallback to the existing `execCommand`-based `copy` for browsers without the API.
- **`src/web/app/editors/code/CodeEditable.re`** — handle Cmd/Ctrl + C/X/V directly in the active editor's `Key.handler`. The handler serializes the current zipper selection with `Printer.of_segment` (refractor-aware, same as the old `Page.View.copy`), updates the segment cache when there are no refractors, and writes to the clipboard directly. Cmd+X additionally dispatches `Destruct(Right)`. Cmd+V calls `navigator.clipboard.readText()` and schedules `Perform(Paste(...))` on resolve via `Bonsai.Effect.Expert.handle`.
- **`src/web/app/Page.re`** — ~~narrow the page-level `Attr.on_copy` to only hijack copy when the event target is inside a `.code-editor`...~~ Per review (4eb3b559ea): page-level `on_copy`/`on_cut`/`on_paste` removed entirely, along with the `is_input_field` / `selection_has_refractors` / `copy` helpers that only supported them. Editor-level handlers in `CodeEditable` are now the single clipboard path; sidebar / inputs / agent messages fall through to the browser's default DOM-selection copy.
- **`src/util/JsUtil.re`** — drop now-unused `has_ancestor_class`.

~~The page-level `on_copy`/`on_cut`/`on_paste` handlers remain as a fallback for cases where focus is on `#page` rather than an editor (e.g., before any editor click).~~

## Related

- PR #2198 — the keyboard refactor that triggered the regression.
- Issue #1593 — drag-select interference from the clipboard shim's `on_focus`. Not fixed here, but decoupling editor clipboard from native events opens the door to softening that focus call in a follow-up.
- Fixes #2314.

## Test plan

Manual (no e2e harness).

In **Firefox**:
- [x] Load page, click into an editor cell, keyboard-select a term, Cmd+C, paste into another app → selection text on clipboard.
- [x] Cmd+X → text removed from editor and on clipboard.
- [x] Copy text from another app, click into editor, Cmd+V → text inserted.
- [x] Repeat after blur/focus cycle (click outside, back in) — keeps working.
- [x] Select text in the sidebar, Cmd+C → sidebar text on clipboard (not editor content).
- [x] Cmd+C with refractors in selection → expanded `^^refractor_name(...)` form lands on clipboard.
- [x] Focus an input field (title/module/prompt/hint inputs, API key), Cmd+C/X/V → normal text input behavior, no editor action.
- [x] Fresh load, Cmd+C before clicking any editor → no crash; browser default copy.

In **Chrome**:
- [x] Same scenarios above — no regression.

cc @Negabinary