### PR TITLE
Reparenthesization in Stepper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,3 @@ plans/
 
 # Cursor IDE (local)
 .cursor/
-AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ plans/
 
 # Cursor IDE (local)
 .cursor/
+AGENTS.md

--- a/src/haz3lcore/zipper/action/Perform.re
+++ b/src/haz3lcore/zipper/action/Perform.re
@@ -180,9 +180,9 @@ let go =
   | Select(Term(Id(id, d))) =>
     switch (
       Select.term(
+        syntax.term_data,
         ~defs_exclude_bodies=false,
         ~case_rules=false,
-        syntax.term_data,
         id,
         z,
       )

--- a/src/haz3lcore/zipper/action/Select.re
+++ b/src/haz3lcore/zipper/action/Select.re
@@ -930,15 +930,6 @@ let to_point =
       z: t,
     )
     : option(t) => {
-  let z =
-    switch (z.selection.content) {
-    | [] =>
-      switch (indicated_token(z)) {
-      | Some(z') => z'
-      | None => z
-      }
-    | _ => z
-    };
   let anchor = z |> toggle_focus |> Zipper.Caret.point(measured);
   let step =
     switch (chunkiness) {

--- a/src/haz3lcore/zipper/action/Select.re
+++ b/src/haz3lcore/zipper/action/Select.re
@@ -574,8 +574,10 @@ let term_by_extremes = (id: Id.t, term_data: TermData.t, z: t): option(t) =>
   switch (TermData.extreme_ids(id, term_data)) {
   | Some((lid, rid)) when Id.equal(lid, rid) => tile(lid, z)
   | _ =>
-    let* (l, r) = TermData.extremes_shards(id, term_data);
-    shard_range(l, r, z);
+    switch (TermData.extremes_shards(id, term_data)) {
+    | Some((l, r)) => shard_range(l, r, z)
+    | None => None
+    }
   };
 
 /* Select a term by id. Navigates to the term and uses current_term
@@ -591,7 +593,7 @@ let term =
     )
     : option(t) =>
   switch (Move.jump_to_id_indicated(z, id)) {
-  | Some(z) => current_term(term_data, ~defs_exclude_bodies, ~case_rules, z)
+  | Some(z') => current_term(term_data, ~defs_exclude_bodies, ~case_rules, z')
   | None => term_by_extremes(id, term_data, z)
   };
 
@@ -861,6 +863,15 @@ let smart = (term_data, info_map, n, z: t): option(t) => {
   switch (n) {
   | 2 => indicated_token(z)
   | 3 =>
+    let z =
+      switch (z.selection.content) {
+      | [] =>
+        switch (indicated_token(z)) {
+        | Some(z') => z'
+        | None => z
+        }
+      | _ => z
+      };
     /* Use the selected piece from Smart(2) to determine what
      * term to select. This avoids the fragile unselect-then-
      * re-indicate pattern, which fails when reassembly after
@@ -883,7 +894,7 @@ let smart = (term_data, info_map, n, z: t): option(t) => {
       let z = Zipper.unselect(z);
       term(~defs_exclude_bodies=true, ~case_rules=true, term_data, id, z);
     | _ => None
-    }
+    };
   | _ => None
   };
 };
@@ -919,6 +930,15 @@ let to_point =
       z: t,
     )
     : option(t) => {
+  let z =
+    switch (z.selection.content) {
+    | [] =>
+      switch (indicated_token(z)) {
+      | Some(z') => z'
+      | None => z
+      }
+    | _ => z
+    };
   let anchor = z |> toggle_focus |> Zipper.Caret.point(measured);
   let step =
     switch (chunkiness) {

--- a/src/language/dynamics/stepper/EvaluatorStep.re
+++ b/src/language/dynamics/stepper/EvaluatorStep.re
@@ -31,7 +31,10 @@ module EvalObj = {
   let persist = (obj: t): persistent => {
     let full_exp = EvalCtx.compose(obj.ctx, obj.d_loc);
     {
-      exp_idx: ProofHacks.exp_idx(obj.d_loc, full_exp),
+      exp_idx:
+        try(ProofHacks.exp_idx(obj.d_loc, full_exp)) {
+        | _ => 0
+        },
       at_exp: obj.d_loc,
     };
   };
@@ -332,7 +335,32 @@ module Decompose = {
 
   module Decomp = Transition(DecomposeEVMode);
   let rec decompose = (~in_closure=?, env, exp) => {
-    switch (exp) {
+    let (term, _) = DHExp.unwrap(exp);
+    switch (term) {
+    | Parens(inner) =>
+      let ids = [DHExp.rep_id(exp)];
+      switch (decompose(~in_closure?, env, inner)) {
+      | Result.Step(inner_steps) when !List.is_empty(inner_steps) =>
+        Result.Step(
+          inner_steps
+          |> List.map(
+               EvalObj.wrap(ctx =>
+                 EvalCtx.Term({
+                   term: EvalCtx.Parens(ctx),
+                   ids,
+                 })
+               ),
+             ),
+        )
+      | _ =>
+        Decomp.transition(
+          decompose,
+          ~mode=`Substitution,
+          ~in_closure?,
+          env,
+          exp,
+        )
+      };
     | _ =>
       Decomp.transition(
         decompose,
@@ -421,6 +449,25 @@ let get_status = (~settings: CoreSettings.t, exp, env) => {
 
 let get_step_id = (step: step): Id.t => step.d_loc |> DHExp.rep_id;
 
+let rec display_exp_for_step = (knd: step_kind, exp: Exp.t): Exp.t =>
+  switch (knd, Exp.term_of(exp)) {
+  | (RemoveParens, _) => exp
+  | (_, Parens(inner)) => display_exp_for_step(knd, inner)
+  | _ => exp
+  };
+
+let rec ids_with_paren_inners = (exp: Exp.t): list(list(Id.t)) =>
+  switch (Exp.term_of(exp)) {
+  | Parens(inner) => [IdTagged.ids(exp), ...ids_with_paren_inners(inner)]
+  | _ => [IdTagged.ids(exp)]
+  };
+
+let get_step_id_in = (step: step, exp: Exp.t): option(Id.t) => {
+  let persistent = EvalObj.persist(step);
+  ProofHacks.nth_exp(persistent.at_exp, persistent.exp_idx, exp)
+  |> Option.map(exp => exp |> display_exp_for_step(step.knd) |> Exp.rep_id);
+};
+
 let get_step_kind = (step: step): step_kind => step.knd;
 
 let take_step = (step: EvalObj.t) => {
@@ -450,12 +497,13 @@ let refresh_step =
   let eos =
     decompose(exp, env)
     |> List.map(should_hide_eval_obj(~settings=settings.evaluation)); // NOTE: should_hide_eval_obj actually changes the eval obj to do filter bookkeeping!!!
-  let* desired_id =
+  let* desired_ids =
     ProofHacks.nth_exp(step.at_exp, step.exp_idx, exp)
-    |> Option.map(IdTagged.ids);
+    |> Option.map(ids_with_paren_inners);
   let* (h, x) =
     List.find_opt(
-      ((_, step': step)) => IdTagged.ids(step'.d_loc) == desired_id,
+      ((_, step': step)) =>
+        List.exists(ids => IdTagged.ids(step'.d_loc) == ids, desired_ids),
       eos,
     );
   Some((h, x));

--- a/src/language/dynamics/stepper/EvaluatorStep.rei
+++ b/src/language/dynamics/stepper/EvaluatorStep.rei
@@ -27,4 +27,6 @@ let take_step: step => option(Exp.t);
 
 let get_step_id: step => Id.t;
 
+let get_step_id_in: (step, Exp.t) => option(Id.t);
+
 let get_step_kind: step => Transition.step_kind;

--- a/src/language/proof/AssocSelection.re
+++ b/src/language/proof/AssocSelection.re
@@ -450,3 +450,42 @@ let find_assoc_for_ids =
        );
   snapped_from_ids @ snapped_from_ancestors |> ListUtil.dedup;
 };
+
+let left_reparenthesize_boundary_id = (op, left: Exp.t): Id.t =>
+  switch (Exp.term_of(left)) {
+  | BinOp(left_op, _, left_right) when left_op == op =>
+    Exp.rep_id(left_right)
+  | _ => Exp.rep_id(left)
+  };
+
+let right_reparenthesize_boundary_id = (op, right: Exp.t): Id.t =>
+  switch (Exp.term_of(right)) {
+  | BinOp(right_op, right_left, _) when right_op == op =>
+    Exp.rep_id(right_left)
+  | _ => Exp.rep_id(right)
+  };
+
+let find_reparenthesize_for_id =
+    (id: Id.t, info_map: Statics.Map.t): list(Id.t) => {
+  switch (Statics.Map.lookup(id, info_map)) {
+  | Some(InfoExp({user_term: {term: BinOp(op, left, right), _}, _})) => [
+      left_reparenthesize_boundary_id(op, left),
+      id,
+      right_reparenthesize_boundary_id(op, right),
+    ]
+  | _ => [id]
+  };
+};
+
+/* Returns true if the id points to a BinOp where the visual selection differs
+   from the raw AST grouping — i.e., reparenthesization would change the tree. */
+let needs_reparenthesization = (id: Id.t, info_map: Statics.Map.t): bool =>
+  switch (find_reparenthesize_for_id(id, info_map)) {
+  | [left_id, op_id, right_id] when op_id == id =>
+    switch (Statics.Map.lookup(id, info_map)) {
+    | Some(InfoExp({user_term: {term: BinOp(_, left, right), _}, _})) =>
+      Exp.rep_id(left) != left_id || Exp.rep_id(right) != right_id
+    | _ => false
+    }
+  | _ => false
+  };

--- a/src/language/proof/Reparenthesize.re
+++ b/src/language/proof/Reparenthesize.re
@@ -1,6 +1,19 @@
 open Util;
 open OptUtil.Syntax;
 
+type result = {
+  exp: Exp.t,
+  selected_id: Id.t,
+  selected_is_single_binop: bool,
+};
+
+let rec binop_count = (exp: Exp.t): int =>
+  switch (exp.term) {
+  | BinOp(_, l, r) => 1 + binop_count(l) + binop_count(r)
+  | Parens(e) => binop_count(e)
+  | _ => 0
+  };
+
 /* Restructure exp so the visual selection at selected_id becomes a proper
       sub-term.
 
@@ -13,8 +26,7 @@ open OptUtil.Syntax;
         where new_inner_id = rep_id of the fresh BinOp(+, 2, 3)
    */
 let reparenthesize =
-    (~selected_id: Id.t, ~left_left_id: Id.t, exp: Exp.t)
-    : option((Exp.t, Id.t)) => {
+    (~selected_id: Id.t, ~left_left_id: Id.t, exp: Exp.t): option(result) => {
   let* outer = ProofHacks.find_exp_id(selected_id, exp);
   switch (outer.term) {
   | BinOp(op, inner_exp, c) =>
@@ -23,7 +35,11 @@ let reparenthesize =
       let new_inner = Exp.fresh(BinOp(op, b, c));
       let new_outer = Exp.fresh(BinOp(op, a, new_inner));
       let new_exp = ProofHacks.replace_exp_id(selected_id, exp, new_outer);
-      Some((new_exp, Exp.rep_id(new_inner)));
+      Some({
+        exp: new_exp,
+        selected_id: Exp.rep_id(new_inner),
+        selected_is_single_binop: binop_count(new_inner) == 1,
+      });
     | _ => None
     }
   | _ => None
@@ -66,7 +82,7 @@ let selected_bounds = (selected_ids: list(Id.t), operands: list(Exp.t)) => {
 };
 
 let replace_selected_chain =
-    (selected_ids: list(Id.t), exp: Exp.t): option((Exp.t, Id.t)) => {
+    (selected_ids: list(Id.t), exp: Exp.t): option(result) => {
   switch (exp.term) {
   | BinOp(op, _, _) =>
     let operands = split_chain(op, exp);
@@ -80,7 +96,11 @@ let replace_selected_chain =
       let parens = Exp.fresh(Parens(selected_chain));
       let rebuilt_operands = before @ [parens] @ after;
       let* rebuilt = combine_chain(op, rebuilt_operands);
-      Some((rebuilt, Exp.rep_id(parens)));
+      Some({
+        exp: rebuilt,
+        selected_id: Exp.rep_id(selected_chain),
+        selected_is_single_binop: binop_count(selected_chain) == 1,
+      });
     | _ => None
     };
   | _ => None
@@ -88,25 +108,35 @@ let replace_selected_chain =
 };
 
 let rec reparenthesize_selection =
-        (~selected_ids: list(Id.t), exp: Exp.t): option((Exp.t, Id.t)) => {
+        (~selected_ids: list(Id.t), exp: Exp.t): option(result) => {
   switch (replace_selected_chain(selected_ids, exp)) {
   | Some(_) as result => result
   | None =>
     switch (exp.term) {
     | BinOp(op, l, r) =>
       switch (reparenthesize_selection(~selected_ids, l)) {
-      | Some((l', selected_id)) =>
-        Some((Exp.fresh(BinOp(op, l', r)), selected_id))
+      | Some({exp: l', _} as result) =>
+        Some({
+          ...result,
+          exp: Exp.fresh(BinOp(op, l', r)),
+        })
       | None =>
         switch (reparenthesize_selection(~selected_ids, r)) {
-        | Some((r', selected_id)) =>
-          Some((Exp.fresh(BinOp(op, l, r')), selected_id))
+        | Some({exp: r', _} as result) =>
+          Some({
+            ...result,
+            exp: Exp.fresh(BinOp(op, l, r')),
+          })
         | None => None
         }
       }
     | Parens(e) =>
-      let* (e', selected_id) = reparenthesize_selection(~selected_ids, e);
-      Some((Exp.fresh(Parens(e')), selected_id));
+      let* {exp: e', _} as result =
+        reparenthesize_selection(~selected_ids, e);
+      Some({
+        ...result,
+        exp: Exp.fresh(Parens(e')),
+      });
     | _ => None
     }
   };

--- a/src/language/proof/Reparenthesize.re
+++ b/src/language/proof/Reparenthesize.re
@@ -1,0 +1,113 @@
+open Util;
+open OptUtil.Syntax;
+
+/* Restructure exp so the visual selection at selected_id becomes a proper
+      sub-term.
+
+      Example:
+        exp = (1 + 2) + 3  (AST: BinOp(+, BinOp(+, 1, 2), 3))
+        selected_id = rep_id of outer +
+        left_left_id = rep_id of 2  (snapped left boundary from AssocSelection)
+      Returns:
+        Some((1 + (2 + 3), new_inner_id))
+        where new_inner_id = rep_id of the fresh BinOp(+, 2, 3)
+   */
+let reparenthesize =
+    (~selected_id: Id.t, ~left_left_id: Id.t, exp: Exp.t)
+    : option((Exp.t, Id.t)) => {
+  let* outer = ProofHacks.find_exp_id(selected_id, exp);
+  switch (outer.term) {
+  | BinOp(op, inner_exp, c) =>
+    switch (inner_exp.term) {
+    | BinOp(_, a, b) when Exp.rep_id(b) == left_left_id =>
+      let new_inner = Exp.fresh(BinOp(op, b, c));
+      let new_outer = Exp.fresh(BinOp(op, a, new_inner));
+      let new_exp = ProofHacks.replace_exp_id(selected_id, exp, new_outer);
+      Some((new_exp, Exp.rep_id(new_inner)));
+    | _ => None
+    }
+  | _ => None
+  };
+};
+
+let rec split_chain = (op: Operators.op_bin, exp: Exp.t): list(Exp.t) =>
+  switch (exp.term) {
+  | BinOp(op', l, r) when op' == op =>
+    split_chain(op, l) @ split_chain(op, r)
+  | _ => [exp]
+  };
+
+let combine_chain = (op: Operators.op_bin, exps: list(Exp.t)): option(Exp.t) =>
+  switch (exps) {
+  | [] => None
+  | [e] => Some(e)
+  | [first, second, ...rest] =>
+    Some(
+      List.fold_left(
+        (acc, exp) => Exp.fresh(BinOp(op, acc, exp)),
+        Exp.fresh(BinOp(op, first, second)),
+        rest,
+      ),
+    )
+  };
+
+let selected_bounds = (selected_ids: list(Id.t), operands: list(Exp.t)) => {
+  operands
+  |> List.mapi((i, exp) =>
+       List.mem(Exp.rep_id(exp), selected_ids) ? Some(i) : None
+     )
+  |> List.filter_map(Fun.id)
+  |> (
+    fun
+    | [] => None
+    | [i, ...is] =>
+      Some((List.fold_left(min, i, is), List.fold_left(max, i, is)))
+  );
+};
+
+let replace_selected_chain =
+    (selected_ids: list(Id.t), exp: Exp.t): option((Exp.t, Id.t)) => {
+  switch (exp.term) {
+  | BinOp(op, _, _) =>
+    let operands = split_chain(op, exp);
+    switch (selected_bounds(selected_ids, operands)) {
+    | Some((lo, hi)) when hi > lo =>
+      let before = ListUtil.sublist((0, lo), operands);
+      let selected = ListUtil.sublist((lo, hi + 1), operands);
+      let after =
+        ListUtil.sublist((hi + 1, List.length(operands)), operands);
+      let* selected_chain = combine_chain(op, selected);
+      let parens = Exp.fresh(Parens(selected_chain));
+      let rebuilt_operands = before @ [parens] @ after;
+      let* rebuilt = combine_chain(op, rebuilt_operands);
+      Some((rebuilt, Exp.rep_id(parens)));
+    | _ => None
+    };
+  | _ => None
+  };
+};
+
+let rec reparenthesize_selection =
+        (~selected_ids: list(Id.t), exp: Exp.t): option((Exp.t, Id.t)) => {
+  switch (replace_selected_chain(selected_ids, exp)) {
+  | Some(_) as result => result
+  | None =>
+    switch (exp.term) {
+    | BinOp(op, l, r) =>
+      switch (reparenthesize_selection(~selected_ids, l)) {
+      | Some((l', selected_id)) =>
+        Some((Exp.fresh(BinOp(op, l', r)), selected_id))
+      | None =>
+        switch (reparenthesize_selection(~selected_ids, r)) {
+        | Some((r', selected_id)) =>
+          Some((Exp.fresh(BinOp(op, l, r')), selected_id))
+        | None => None
+        }
+      }
+    | Parens(e) =>
+      let* (e', selected_id) = reparenthesize_selection(~selected_ids, e);
+      Some((Exp.fresh(Parens(e')), selected_id));
+    | _ => None
+    }
+  };
+};

--- a/src/language/proof/Reparenthesize.re
+++ b/src/language/proof/Reparenthesize.re
@@ -7,6 +7,137 @@ type result = {
   selected_is_single_binop: bool,
 };
 
+let selected_exp = (result: result): option(Exp.t) =>
+  ProofHacks.find_exp_id(result.selected_id, result.exp);
+
+let replace_selected = (result: result, with_exp: Exp.t): Exp.t =>
+  ProofHacks.replace_exp_id(result.selected_id, result.exp, with_exp);
+
+let is_associative_op = (op: Operators.op_bin): bool =>
+  switch (op) {
+  | Int(Plus)
+  | Int(Times)
+  | SInt(Plus)
+  | SInt(Times)
+  | Nat(Plus)
+  | Nat(Times)
+  | Float(Plus)
+  | Float(Times)
+  | Bool(And)
+  | Bool(Or) => true
+  | _ => false
+  };
+
+let rec exp_size = (exp: Exp.t): int =>
+  1
+  + (
+    switch (exp.term) {
+    | BinOp(_, l, r)
+    | Ap(_, l, r) => exp_size(l) + exp_size(r)
+    | Parens(e)
+    | Asc(e, _)
+    | Projector(_, e) => exp_size(e)
+    | _ => 0
+    }
+  );
+
+let unparenthesize_direct = (~selected_id: Id.t, exp: Exp.t): option(Exp.t) => {
+  let* selected = ProofHacks.find_exp_id(selected_id, exp);
+  switch (selected.term) {
+  | Parens(inner) =>
+    Some(ProofHacks.replace_exp_id(selected_id, exp, inner))
+  | _ => None
+  };
+};
+
+let rec split_chain = (op: Operators.op_bin, exp: Exp.t): list(Exp.t) =>
+  switch (exp.term) {
+  | BinOp(op', l, r) when op' == op && is_associative_op(op) =>
+    split_chain(op, l) @ split_chain(op, r)
+  | _ => [exp]
+  };
+
+let combine_chain = (op: Operators.op_bin, exps: list(Exp.t)): option(Exp.t) =>
+  switch (exps) {
+  | [] => None
+  | [e] => Some(e)
+  | [first, second, ...rest] =>
+    Some(
+      List.fold_left(
+        (acc, exp) => Exp.fresh(BinOp(op, acc, exp)),
+        Exp.fresh(BinOp(op, first, second)),
+        rest,
+      ),
+    )
+  };
+
+let rec split_chain_unparenthesizing =
+        (~selected_id: Id.t, op: Operators.op_bin, exp: Exp.t)
+        : option(list(Exp.t)) =>
+  switch (exp.term) {
+  | Parens({term: BinOp(inner_op, _, _), _} as inner)
+      when
+        Exp.rep_id(exp) == selected_id
+        && inner_op == op
+        && is_associative_op(op) =>
+    Some(split_chain(op, inner))
+  | BinOp(op', l, r) when op' == op && is_associative_op(op) =>
+    switch (split_chain_unparenthesizing(~selected_id, op, l)) {
+    | Some(l_operands) => Some(l_operands @ split_chain(op, r))
+    | None =>
+      switch (split_chain_unparenthesizing(~selected_id, op, r)) {
+      | Some(r_operands) => Some(split_chain(op, l) @ r_operands)
+      | None => None
+      }
+    }
+  | _ => None
+  };
+
+let rec unparenthesize_associative =
+        (~selected_id: Id.t, exp: Exp.t): option(Exp.t) =>
+  switch (exp.term) {
+  | BinOp(op, _, _) =>
+    switch (split_chain_unparenthesizing(~selected_id, op, exp)) {
+    | Some(operands) => combine_chain(op, operands)
+    | None =>
+      switch (exp.term) {
+      | BinOp(op, l, r) =>
+        switch (unparenthesize_associative(~selected_id, l)) {
+        | Some(l') => Some(Exp.fresh(BinOp(op, l', r)))
+        | None =>
+          switch (unparenthesize_associative(~selected_id, r)) {
+          | Some(r') => Some(Exp.fresh(BinOp(op, l, r')))
+          | None => None
+          }
+        }
+      | _ => None
+      }
+    }
+  | Parens(e) =>
+    let* e' = unparenthesize_associative(~selected_id, e);
+    Some(Exp.fresh(Parens(e')));
+  | _ => None
+  };
+
+let unparenthesize = (~selected_id: Id.t, exp: Exp.t): option(Exp.t) =>
+  switch (unparenthesize_associative(~selected_id, exp)) {
+  | Some(_) as result => result
+  | None => unparenthesize_direct(~selected_id, exp)
+  };
+
+let unparenthesize_any =
+    (~selected_ids: list(Id.t), exp: Exp.t): option(Exp.t) =>
+  selected_ids
+  |> List.filter_map(id =>
+       switch (ProofHacks.find_exp_id(id, exp)) {
+       | Some({term: Parens(_), _} as selected) =>
+         Some((id, exp_size(selected)))
+       | _ => None
+       }
+     )
+  |> List.sort(((_, a_size), (_, b_size)) => Int.compare(b_size, a_size))
+  |> List.find_map(((id, _)) => unparenthesize(~selected_id=id, exp));
+
 let rec binop_count = (exp: Exp.t): int =>
   switch (exp.term) {
   | BinOp(_, l, r) => 1 + binop_count(l) + binop_count(r)
@@ -29,7 +160,7 @@ let reparenthesize =
     (~selected_id: Id.t, ~left_left_id: Id.t, exp: Exp.t): option(result) => {
   let* outer = ProofHacks.find_exp_id(selected_id, exp);
   switch (outer.term) {
-  | BinOp(op, inner_exp, c) =>
+  | BinOp(op, inner_exp, c) when is_associative_op(op) =>
     switch (inner_exp.term) {
     | BinOp(_, a, b) when Exp.rep_id(b) == left_left_id =>
       let new_inner = Exp.fresh(BinOp(op, b, c));
@@ -45,27 +176,6 @@ let reparenthesize =
   | _ => None
   };
 };
-
-let rec split_chain = (op: Operators.op_bin, exp: Exp.t): list(Exp.t) =>
-  switch (exp.term) {
-  | BinOp(op', l, r) when op' == op =>
-    split_chain(op, l) @ split_chain(op, r)
-  | _ => [exp]
-  };
-
-let combine_chain = (op: Operators.op_bin, exps: list(Exp.t)): option(Exp.t) =>
-  switch (exps) {
-  | [] => None
-  | [e] => Some(e)
-  | [first, second, ...rest] =>
-    Some(
-      List.fold_left(
-        (acc, exp) => Exp.fresh(BinOp(op, acc, exp)),
-        Exp.fresh(BinOp(op, first, second)),
-        rest,
-      ),
-    )
-  };
 
 let selected_bounds = (selected_ids: list(Id.t), operands: list(Exp.t)) => {
   operands
@@ -84,7 +194,7 @@ let selected_bounds = (selected_ids: list(Id.t), operands: list(Exp.t)) => {
 let replace_selected_chain =
     (selected_ids: list(Id.t), exp: Exp.t): option(result) => {
   switch (exp.term) {
-  | BinOp(op, _, _) =>
+  | BinOp(op, _, _) when is_associative_op(op) =>
     let operands = split_chain(op, exp);
     switch (selected_bounds(selected_ids, operands)) {
     | Some((lo, hi)) when hi > lo =>

--- a/src/web/app/editors/code/CodeWithStatics.re
+++ b/src/web/app/editors/code/CodeWithStatics.re
@@ -43,12 +43,16 @@ module Model = {
         ~settings: Language.CoreSettings.t,
         ~inline=false,
         ~root: Sort.t,
+        ~parenthesization=ExpToSegment.Settings.Structural,
         term: Language.Exp.t,
       ) => {
     let seg =
       ExpToSegment.exp_to_segment(
         term,
-        ~settings=ExpToSegment.Settings.of_core(~inline, settings),
+        ~settings={
+          ...ExpToSegment.Settings.of_core(~inline, settings),
+          parenthesization,
+        },
       );
     let seg = inline ? seg : PrettySegment.prettify(seg);
     seg |> Zipper.unzip |> Editor.Model.mk(~root) |> mk;

--- a/src/web/app/editors/code/CodeWithStatics.re
+++ b/src/web/app/editors/code/CodeWithStatics.re
@@ -43,7 +43,7 @@ module Model = {
         ~settings: Language.CoreSettings.t,
         ~inline=false,
         ~root: Sort.t,
-        ~parenthesization=ExpToSegment.Settings.Structural,
+        ~parenthesization=ExpToSegment.Settings.Defensive,
         term: Language.Exp.t,
       ) => {
     let seg =

--- a/src/web/app/editors/decoration/Highlight.re
+++ b/src/web/app/editors/decoration/Highlight.re
@@ -522,6 +522,8 @@ let selection =
       ~statics: CachedStatics.t,
       z: Zipper.t,
     ) => {
+  let measured_piece = (piece: Piece.t) =>
+    Measured.find_by_id(Piece.id(piece), measured);
   let effective_segment =
     associative
       ? SelectionEffective.associative_segment(
@@ -530,6 +532,8 @@ let selection =
           z,
         )
       : z.selection.content;
+  let effective_segment =
+    effective_segment |> List.filter(piece => measured_piece(piece) != None);
   let selection_svg = (clss, rows) =>
     rows
     |> group_consecutive

--- a/src/web/app/editors/result/StepperEditor.re
+++ b/src/web/app/editors/result/StepperEditor.re
@@ -87,56 +87,92 @@ module View = {
       ) => {
     open WebUtil;
 
+    let step_segment = (~class_name, ~attrs=[], id: Id.t): option(Node.t) => {
+      switch (TermData.segment(id, syntax.term_data)) {
+      | None => None
+      | Some(segment) =>
+        Some(
+          Node.div(
+            ~attrs=[Attr.class_(class_name)] @ attrs,
+            Highlight.of_segment(
+              ~measured=syntax.measured,
+              ~shape_map=syntax.shape_map,
+              ~font_metrics,
+              ~shape_init=Some(Convex),
+              ~clss=[],
+              segment,
+            ),
+          ),
+        )
+      };
+    };
+
     let next_steps =
-        (next_steps: list(Id.t), ~inject: int => Ui_effect.t(unit)) =>
+        (next_steps: list(Id.t), ~inject: int => Ui_effect.t(unit)) => {
+      let step_tile = id =>
+        switch (TermData.segment(id, syntax.term_data)) {
+        | Some(segment) =>
+          switch (
+            segment
+            |> List.find_opt(
+                 fun
+                 | Piece.Tile(t) => Tile.id(t) == id
+                 | _ => false,
+               )
+          ) {
+          | Some(Piece.Tile(t)) => Some(t)
+          | _ => TermData.root_tile(id, syntax.term_data)
+          }
+        | None => TermData.root_tile(id, syntax.term_data)
+        };
       next_steps
-      |> List.filter_map(TermData.root_tile(_, syntax.term_data))
-      |> List.mapi((i, t: Tile.t) =>
-           div_c(
-             "step-next",
-             Arms.term(
-               ~attr=[Attr.on_mousedown(_ => inject(i))],
-               ~font_metrics,
-               ~syntax,
-               t,
-             ),
-           )
-         );
+      |> List.mapi((i, id) =>
+           switch (step_tile(id)) {
+           | Some(t) =>
+             Some(
+               div_c(
+                 "step-next",
+                 Arms.term(
+                   ~attr=[Attr.on_mousedown(_ => inject(i))],
+                   ~font_metrics,
+                   ~syntax,
+                   t,
+                 ),
+               ),
+             )
+           | None => None
+           }
+         )
+      |> List.filter_map(Fun.id);
+    };
 
     let taken_steps = (taken_steps: list(Id.t)) =>
-      taken_steps
-      |> List.filter_map(TermData.root_tile(_, syntax.term_data))
-      |> List.map(t =>
-           div_c("step-taken", Arms.term(~font_metrics, ~syntax, t))
-         );
+      taken_steps |> List.filter_map(step_segment(~class_name="step-taken"));
 
     let refl_steps =
         (refl_steps: list(Id.t), ~inject: int => Ui_effect.t(unit)) =>
       refl_steps
-      |> List.filter_map(TermData.root_tile(_, syntax.term_data))
-      |> List.mapi((i, t: Tile.t) =>
-           div_c(
-             "step-refl",
-             Arms.term(
-               ~attr=[Attr.on_mousedown(_ => inject(i))],
-               ~font_metrics,
-               ~syntax,
-               t,
-             ),
+      |> List.mapi((i, id) =>
+           step_segment(
+             ~class_name="step-refl",
+             ~attrs=[Attr.on_mousedown(_ => inject(i))],
+             id,
            )
-         );
+         )
+      |> List.filter_map(Fun.id);
 
     taken_steps(model.taken_steps)
     @ next_steps(model.next_steps, ~inject=x =>
         {
           open OptUtil.Syntax;
+          let step_id = List.nth(model.next_steps, x);
           let+ range =
             TermData.extreme_measures(
-              List.nth(model.next_steps, x),
+              step_id,
               model.editor.editor.syntax.term_data,
               model.editor.editor.syntax.measured,
             );
-          Some(List.nth(model.next_steps, x)) == selected_id
+          Some(step_id) == selected_id
             ? signal(TakeStep(x)) : inject(Select(PointToPoint(range)));
         }
         |> Option.value(~default=Ui_effect.Ignore)
@@ -144,17 +180,15 @@ module View = {
     @ refl_steps(model.refls, ~inject=x =>
         {
           open OptUtil.Syntax;
+          let refl_id = List.nth(model.refls, x);
           let+ range =
             TermData.extreme_measures(
-              List.nth(model.refls, x),
+              refl_id,
               model.editor.editor.syntax.term_data,
               model.editor.editor.syntax.measured,
             );
-          Some(List.nth(model.refls, x)) == selected_id
-            ? signal(Refl(x))
-            : {
-              inject(Select(PointToPoint(range)));
-            };
+          Some(refl_id) == selected_id
+            ? signal(Refl(x)) : inject(Select(PointToPoint(range)));
         }
         |> Option.value(~default=Ui_effect.Ignore)
       );

--- a/src/web/app/editors/stepper/MissingStep.re
+++ b/src/web/app/editors/stepper/MissingStep.re
@@ -10,6 +10,8 @@ module Model = {
     | AxiomsOpen(AxiomsBox.Model.t)
     | RewritesOpen({
         editor: CodeEditable.Model.t,
+        rewrite_selected_exp: option(Exp.t),
+        rewrite_reparenthesized_exp: option(Exp.t),
         cached_exp: Calc.saved(Exp.t),
         cached_result: option(bool),
       })
@@ -62,7 +64,7 @@ module Update = {
   [@deriving (show({with_path: false}), sexp, yojson)]
   type t =
     | ToggleAxioms
-    | ProposeRewrite
+    | ProposeRewrite(option(Exp.t), option(Exp.t))
     | UpdateResult(bool)
     | RewriteEditorAction(CodeEditable.Update.t)
     | AxiomBoxAction(AxiomsBox.Update.t);
@@ -81,7 +83,7 @@ module Update = {
         open_box,
       }
       |> Updated.return_quiet(~logged=true);
-    | (ProposeRewrite, _) =>
+    | (ProposeRewrite(rewrite_selected_exp, rewrite_reparenthesized_exp), _) =>
       let open_box =
         switch (model.open_box) {
         | NoneOpen
@@ -91,6 +93,8 @@ module Update = {
               CodeEditable.Model.mk(
                 Editor.Model.mk(Zipper.init(), ~root=Exp),
               ),
+            rewrite_selected_exp,
+            rewrite_reparenthesized_exp,
             cached_exp: Calc.Pending,
             cached_result: None,
           })
@@ -136,7 +140,7 @@ module Update = {
   let can_undo = (action: t): bool => {
     switch (action) {
     | ToggleAxioms
-    | ProposeRewrite
+    | ProposeRewrite(_, _)
     | UpdateResult(_)
     | RewriteEditorAction(_)
     | AxiomBoxAction(_) => false
@@ -276,7 +280,13 @@ module Update = {
       };
     let open_box =
       switch (open_box) {
-      | RewritesOpen({editor, cached_exp, cached_result}) =>
+      | RewritesOpen({
+          editor,
+          rewrite_selected_exp,
+          rewrite_reparenthesized_exp,
+          cached_exp,
+          cached_result,
+        }) =>
         // Calculate syntax, holes, types, etc for the editor
         let editor =
           CodeEditable.Update.calculate(
@@ -304,6 +314,8 @@ module Update = {
           };
         Model.RewritesOpen({
           editor,
+          rewrite_selected_exp,
+          rewrite_reparenthesized_exp,
           cached_exp: cached_exp |> Calc.save,
           cached_result: cached_result |> Calc.get_value,
         });
@@ -370,6 +382,8 @@ module View = {
     | HideStepper
     | AddAxiomStep(string, int, Exp.t, Direction.t, string)
     | AddAlgebriteStep(int, Exp.t, Exp.t)
+    | AddReparenthesizeStep(Exp.t)
+    | AddReparenthesizedAlgebriteStep(Exp.t, Exp.t, Exp.t)
     | MakeActive(Selection.t)
     | TakeStep(int)
     | Refl(int)
@@ -448,8 +462,11 @@ module View = {
         );
       };
 
+      let selected_id =
+        model.selected_id |> Calc.get_saved_exc(~print="Selected Id");
+
       let show_step_button =
-        switch (model.selected_id |> Calc.get_saved_exc(~print="Selected Id")) {
+        switch (selected_id) {
         | Some(selected_id) =>
           let visible_exp = editor.statics.term;
           List.find_index(
@@ -496,6 +513,16 @@ module View = {
              | Haz3lcore.Piece.Tile(t) => Some(Haz3lcore.Tile.id(t))
              | _ => None,
            );
+      let unparenthesize_ids =
+        switch (selected_id) {
+        | Some(id) => [id, ...selected_tile_ids]
+        | None => selected_tile_ids
+        };
+      let unparenthesize_exp =
+        Language.Reparenthesize.unparenthesize_any(
+          ~selected_ids=unparenthesize_ids,
+          editor.statics.term,
+        );
       let selected_assoc_ids =
         selected_tile_ids
         |> List.concat_map(id =>
@@ -527,13 +554,77 @@ module View = {
         } else {
           None;
         };
-      let step_here_button =
+      let step_here_button = {
+        let can_take_selected_step = (result: Language.Reparenthesize.result) => {
+          let env =
+            model.cached_env |> Calc.get_saved_exc(~print="cached env");
+          let steps =
+            switch (
+              EvaluatorStep.get_status(
+                ~settings=globals.settings.core,
+                result.exp,
+                env,
+              )
+            ) {
+            | AutoStep(step) => [step]
+            | AvailableSteps(steps) => steps
+            };
+          steps
+          |> List.exists(step =>
+               switch (EvaluatorStep.get_step_id_in(step, result.exp)) {
+               | Some(id) => id == result.selected_id
+               | None => EvaluatorStep.get_step_id(step) == result.selected_id
+               }
+             );
+        };
         switch (reparenthesize_result) {
-        | Some({selected_is_single_binop: true, _}) =>
+        | Some({selected_is_single_binop: true, _} as result)
+            when can_take_selected_step(result) =>
           Some(("Step here", true))
         | Some(_) => Some(("Parenthesize", false))
         | None => None
         };
+      };
+      let (selected_exp_for_rewrite, reparenthesize_result_for_rewrite) = {
+        let model_selected_exp =
+          Calc.get_saved_exc(
+            ~print="selected exp not calculated",
+            model.selected_exp,
+          );
+        let reparenthesized_selected_exp =
+          switch (reparenthesize_result) {
+          | Some(result) => Language.Reparenthesize.selected_exp(result)
+          | None => None
+          };
+        switch (
+          model_selected_exp,
+          reparenthesize_result,
+          reparenthesized_selected_exp,
+        ) {
+        | (Some(model_exp), Some(result), Some(reparenthesized_exp))
+            when
+              Language.Reparenthesize.binop_count(reparenthesized_exp)
+              < Language.Reparenthesize.binop_count(model_exp) => (
+            Some(reparenthesized_exp),
+            Some(result),
+          )
+        | (Some(model_exp), _, _)
+            when
+              !
+                Equality.ignoring_ascriptions.exp(
+                  model_exp,
+                  editor.statics.term,
+                ) => (
+            model_selected_exp,
+            None,
+          )
+        | (_, Some(result), Some(reparenthesized_exp)) => (
+            Some(reparenthesized_exp),
+            Some(result),
+          )
+        | _ => (model_selected_exp, None)
+        };
+      };
 
       // I want to make a bunch of buttons here:
       // Evaluate [TODO], Rewrite, Axioms, Cases,
@@ -541,6 +632,17 @@ module View = {
         Node.div(
           ~attrs=[Attr.classes(["proof-selection-buttons"])],
           (
+            switch (unparenthesize_exp) {
+            | None => []
+            | Some(exp) => [
+                proof_button(
+                  ~callback=signal(AddReparenthesizeStep(exp)),
+                  "Unparenthesize",
+                ),
+              ]
+            }
+          )
+          @ (
             switch (step_here_button) {
             | None => []
             | Some((label, evaluate_after_parenthesize)) => [
@@ -599,7 +701,19 @@ module View = {
               : []
           )
           @ [
-            proof_button(~callback=inject(ProposeRewrite), "Algebra ▼"),
+            proof_button(
+              ~callback=
+                inject(
+                  ProposeRewrite(
+                    selected_exp_for_rewrite,
+                    switch (reparenthesize_result_for_rewrite) {
+                    | Some(result) => Some(result.exp)
+                    | None => None
+                    },
+                  ),
+                ),
+              "Algebra ▼",
+            ),
             proof_button(~callback=inject(ToggleAxioms), "Assumptions ▼"),
             proof_button(
               ~callback=
@@ -674,7 +788,13 @@ module View = {
                       ),
                     ),
                   ]
-                | RewritesOpen({editor, cached_exp, cached_result}) =>
+                | RewritesOpen({
+                    editor,
+                    rewrite_selected_exp,
+                    rewrite_reparenthesized_exp,
+                    cached_exp,
+                    cached_result,
+                  }) =>
                   let unboxed_cached_exp =
                     Calc.get_saved_exc(
                       ~print="cached exp not calculated",
@@ -683,10 +803,7 @@ module View = {
                   let unboxed_selected_exp =
                     Option.value(
                       ~default=EmptyHole |> Exp.fresh,
-                      Calc.get_saved_exc(
-                        ~print="selected exp not calculated",
-                        model.selected_exp,
-                      ),
+                      rewrite_selected_exp,
                     );
                   [
                     // one element list with a div
@@ -743,30 +860,46 @@ module View = {
                               ~clss=["proof-button"],
                               Node.text("Replace"),
                               ~tooltip="replace",
-                              _ =>
-                              signal(
-                                AddAlgebriteStep(
-                                  try(
-                                    ProofHacks.exp_idx(
-                                      unboxed_selected_exp,
-                                      model.full_visible_exp
-                                      |> Calc.get_saved_exc(
-                                           ~print="full_visible_exp",
-                                         ),
-                                    )
-                                  ) {
-                                  | _ => 0
-                                  },
-                                  unboxed_selected_exp,
+                              _ => {
+                                let substituted_cached_exp =
                                   unboxed_cached_exp
                                   |> Substitution.in_exp(
                                        model.cached_env
                                        |> Calc.get_saved_exc(
                                             ~print="env not cached",
                                           ),
-                                     ),
-                                ),
-                              )
+                                     );
+                                switch (rewrite_reparenthesized_exp) {
+                                | Some(reparenthesized_exp) =>
+                                  signal(
+                                    AddReparenthesizedAlgebriteStep(
+                                      reparenthesized_exp,
+                                      unboxed_selected_exp,
+                                      substituted_cached_exp,
+                                    ),
+                                  )
+                                | None =>
+                                  let at_idx =
+                                    try(
+                                      ProofHacks.exp_idx(
+                                        unboxed_selected_exp,
+                                        model.full_visible_exp
+                                        |> Calc.get_saved_exc(
+                                             ~print="full_visible_exp",
+                                           ),
+                                      )
+                                    ) {
+                                    | _ => 0
+                                    };
+                                  signal(
+                                    AddAlgebriteStep(
+                                      at_idx,
+                                      unboxed_selected_exp,
+                                      substituted_cached_exp,
+                                    ),
+                                  );
+                                };
+                              },
                             ),
                           ]
                         | Some(false) => [Node.text("Invalid")]

--- a/src/web/app/editors/stepper/MissingStep.re
+++ b/src/web/app/editors/stepper/MissingStep.re
@@ -373,7 +373,7 @@ module View = {
     | MakeActive(Selection.t)
     | TakeStep(int)
     | Refl(int)
-    | StepHere(list(Language.Id.t));
+    | StepHere(list(Language.Id.t), bool);
 
   let get_segment_bounds = (~measured: Measured.t, segment: Segment.t) => {
     let* first_piece = ListUtil.hd_opt(segment);
@@ -518,6 +518,22 @@ module View = {
             ),
           selected_tile_ids,
         );
+      let reparenthesize_result =
+        if (show_step_here) {
+          Language.Reparenthesize.reparenthesize_selection(
+            ~selected_ids=step_here_ids,
+            editor.statics.term,
+          );
+        } else {
+          None;
+        };
+      let step_here_button =
+        switch (reparenthesize_result) {
+        | Some({selected_is_single_binop: true, _}) =>
+          Some(("Step here", true))
+        | Some(_) => Some(("Parenthesize", false))
+        | None => None
+        };
 
       // I want to make a bunch of buttons here:
       // Evaluate [TODO], Rewrite, Axioms, Cases,
@@ -525,12 +541,15 @@ module View = {
         Node.div(
           ~attrs=[Attr.classes(["proof-selection-buttons"])],
           (
-            switch (show_step_here) {
-            | false => []
-            | true => [
+            switch (step_here_button) {
+            | None => []
+            | Some((label, evaluate_after_parenthesize)) => [
                 proof_button(
-                  ~callback=signal(StepHere(step_here_ids)),
-                  "Step here",
+                  ~callback=
+                    signal(
+                      StepHere(step_here_ids, evaluate_after_parenthesize),
+                    ),
+                  label,
                 ),
               ]
             }

--- a/src/web/app/editors/stepper/MissingStep.re
+++ b/src/web/app/editors/stepper/MissingStep.re
@@ -25,6 +25,7 @@ module Model = {
     selected_id: Calc.saved(option(Id.t)),
     selected_exp: Calc.saved(option(Exp.t)),
     full_exp: Calc.saved(Exp.t),
+    full_visible_exp: Calc.saved(Exp.t),
     assumptions: Calc.saved(option(assumptions)),
     open_box,
     cached_env: Calc.saved(Environment.t(Exp.t)) // TODO[Matt]: remove this later, just to get env into view for now.
@@ -36,6 +37,7 @@ module Model = {
     selected_id: Calc.Pending,
     selected_exp: Calc.Pending,
     full_exp: Calc.Pending,
+    full_visible_exp: Calc.Pending,
     assumptions: Calc.Pending,
     open_box: NoneOpen,
     cached_env: Calc.Pending,
@@ -154,6 +156,7 @@ module Update = {
           assumptions,
           selected_exp,
           full_exp: _,
+          full_visible_exp: _,
           selected_id,
           open_box,
           cached_env,
@@ -161,10 +164,12 @@ module Update = {
         editor,
       )
       : Model.t => {
+    let editor: CodeSelectable.Model.t = editor |> Calc.get_value;
+    let full_visible_exp = Calc.NewValue(editor.statics.term);
+    let visible_terms = Calc.NewValue(editor.editor.syntax.terms);
     let selected_id =
       // hacky way to get a currently-selected id
-      {
-        let editor: CodeSelectable.Model.t = editor |> Calc.get_value;
+      (
         try(
           {
             open OptUtil.Syntax;
@@ -179,18 +184,42 @@ module Update = {
           }
         ) {
         | _ => None
-        };
-      }
+        }
+      )
       |> Calc.set(_, selected_id);
     let selected_exp =
       selected_exp
       |> {
         let.calc selected_id = selected_id
-        and.calc exp = exp;
+        and.calc exp = exp
+        and.calc full_visible_exp = full_visible_exp
+        and.calc visible_terms = visible_terms
+        and.calc info_map = info_map;
         open OptUtil.Syntax;
         let* id = selected_id;
-        let* exp' = ProofHacks.find_exp_id(id, exp);
-        Some(exp');
+        switch (ProofHacks.find_exp_id(id, full_visible_exp)) {
+        | Some(exp') => Some(exp')
+        | None =>
+          switch (Id.Map.find_opt(id, visible_terms)) {
+          | Some(Exp(exp')) => Some(exp')
+          | _ =>
+            switch (ProofHacks.find_exp_id(id, exp)) {
+            | Some(exp') => Some(exp')
+            | None =>
+              switch (Statics.Map.lookup(id, info_map)) {
+              | Some(Info.InfoExp({user_term, _})) => Some(user_term)
+              | _ =>
+                print_endline(
+                  "[selected-exp-debug] missing id="
+                  ++ Id.str8(id)
+                  ++ " info_map_empty="
+                  ++ (Id.Map.is_empty(info_map) ? "true" : "false"),
+                );
+                None;
+              }
+            }
+          }
+        };
       };
     let assumptions =
       assumptions
@@ -232,7 +261,15 @@ module Update = {
         |> List.filter(e =>
              !
                List.exists(
-                 s => e |> Exp.rep_id == EvaluatorStep.get_step_id(s),
+                 s =>
+                   e
+                   |> Exp.rep_id
+                   == (
+                        EvaluatorStep.get_step_id_in(s, exp)
+                        |> Option.value(
+                             ~default=EvaluatorStep.get_step_id(s),
+                           )
+                      ),
                  next_steps,
                )
            );
@@ -287,6 +324,7 @@ module Update = {
       refls: refls |> Calc.save,
       assumptions: assumptions |> Calc.save,
       full_exp: exp |> Calc.save,
+      full_visible_exp: full_visible_exp |> Calc.save,
       selected_exp: selected_exp |> Calc.save,
       selected_id: selected_id |> Calc.save,
       cached_env: cached_env |> Calc.save,
@@ -334,7 +372,8 @@ module View = {
     | AddAlgebriteStep(int, Exp.t, Exp.t)
     | MakeActive(Selection.t)
     | TakeStep(int)
-    | Refl(int);
+    | Refl(int)
+    | StepHere(list(Language.Id.t));
 
   let get_segment_bounds = (~measured: Measured.t, segment: Segment.t) => {
     let* first_piece = ListUtil.hd_opt(segment);
@@ -410,12 +449,11 @@ module View = {
       };
 
       let show_step_button =
-        switch (
-          model.selected_exp |> Calc.get_saved_exc(~print="Selected Exp")
-        ) {
-        | Some(selected_exp) =>
+        switch (model.selected_id |> Calc.get_saved_exc(~print="Selected Id")) {
+        | Some(selected_id) =>
+          let visible_exp = editor.statics.term;
           List.find_index(
-            x => x == (selected_exp |> Exp.rep_id),
+            step_id => step_id == selected_id,
             model.next_steps
             |> Calc.get_saved_exc(~print="next_steps")
             |> (
@@ -423,8 +461,11 @@ module View = {
               | AutoStep(_) => []
               | AvailableSteps(steps) => steps
             )
-            |> List.map(step => step |> EvaluatorStep.get_step_id),
-          )
+            |> List.map(step =>
+                 EvaluatorStep.get_step_id_in(step, visible_exp)
+                 |> Option.value(~default=EvaluatorStep.get_step_id(step))
+               ),
+          );
         | None => None
         };
 
@@ -444,9 +485,39 @@ module View = {
 
       let show_function_body_button = {
         Calc.get_saved_exc(model.selected_exp)
-        == Some(Calc.get_saved_exc(model.full_exp))
-        && Exp.is_fun(Calc.get_saved_exc(model.full_exp));
+        == Some(Calc.get_saved_exc(model.full_visible_exp))
+        && Exp.is_fun(Calc.get_saved_exc(model.full_visible_exp));
       };
+
+      let selected_tile_ids =
+        editor.editor.state.zipper.selection.content
+        |> List.filter_map(
+             fun
+             | Haz3lcore.Piece.Tile(t) => Some(Haz3lcore.Tile.id(t))
+             | _ => None,
+           );
+      let selected_assoc_ids =
+        selected_tile_ids
+        |> List.concat_map(id =>
+             Language.AssocSelection.find_reparenthesize_for_id(
+               id,
+               editor.statics.info_map,
+             )
+           );
+      let step_here_ids =
+        switch (selected_assoc_ids) {
+        | [] => selected_tile_ids
+        | ids => ids
+        };
+      let show_step_here =
+        List.exists(
+          id =>
+            Language.AssocSelection.needs_reparenthesization(
+              id,
+              editor.statics.info_map,
+            ),
+          selected_tile_ids,
+        );
 
       // I want to make a bunch of buttons here:
       // Evaluate [TODO], Rewrite, Axioms, Cases,
@@ -454,6 +525,17 @@ module View = {
         Node.div(
           ~attrs=[Attr.classes(["proof-selection-buttons"])],
           (
+            switch (show_step_here) {
+            | false => []
+            | true => [
+                proof_button(
+                  ~callback=signal(StepHere(step_here_ids)),
+                  "Step here",
+                ),
+              ]
+            }
+          )
+          @ (
             switch (show_step_button) {
             | None => []
             | Some(idx) => [
@@ -561,8 +643,10 @@ module View = {
                           (a, b, c, d, e) =>
                             signal(AddAxiomStep(a, b, c, d, e)),
                         ~full_exp=
-                          model.full_exp
-                          |> Calc.get_saved_exc(~print="full_exp not cached"),
+                          model.full_visible_exp
+                          |> Calc.get_saved_exc(
+                               ~print="full_visible_exp not cached",
+                             ),
                         ~selected_exp=
                           model.selected_exp
                           |> Calc.get_saved_exc(~print="Selected Exp")
@@ -643,11 +727,17 @@ module View = {
                               _ =>
                               signal(
                                 AddAlgebriteStep(
-                                  ProofHacks.exp_idx(
-                                    unboxed_selected_exp,
-                                    model.full_exp
-                                    |> Calc.get_saved_exc(~print="full_exp"),
-                                  ),
+                                  try(
+                                    ProofHacks.exp_idx(
+                                      unboxed_selected_exp,
+                                      model.full_visible_exp
+                                      |> Calc.get_saved_exc(
+                                           ~print="full_visible_exp",
+                                         ),
+                                    )
+                                  ) {
+                                  | _ => 0
+                                  },
                                   unboxed_selected_exp,
                                   unboxed_cached_exp
                                   |> Substitution.in_exp(

--- a/src/web/app/editors/stepper/StepperBase.re
+++ b/src/web/app/editors/stepper/StepperBase.re
@@ -16,6 +16,11 @@ type step_kind_model =
   | MissingStep(MissingStep.Model.t)
   | AxiomStep(AxiomStep.model'(step_model))
   | AlgebriteStep(AlgebriteStep.model'(step_model))
+  | ReparenthesizeStep({
+      original_exp: Exp.t,
+      reparenthesized_exp: Exp.t,
+      next_exp: Calc.saved(Exp.t),
+    })
 
 and step_model = {
   // Calculated
@@ -48,6 +53,7 @@ type persistent_step_kind =
   | MissingStep(MissingStep.Model.persistent)
   | AxiomStep(AxiomStep.persistent'(persistent_step))
   | AlgebriteStep(AlgebriteStep.persistent'(persistent_step))
+  | ReparenthesizeStep(Exp.t, Exp.t) /* original_exp, reparenthesized_exp */
 
 and persistent_step = {
   step_kind: persistent_step_kind,
@@ -69,6 +75,7 @@ and step_action =
   | NextStep(step_action)
   | RemoveStep
   | StepForward(int)
+  | StepForwardOnSelection(list(Id.t))
   | AddInduction(option(Exp.t))
   | AddForall
   | AddAxiomStep(string, int, Exp.t, Direction.t, string)
@@ -125,6 +132,8 @@ module rec StepKind: {
     | MissingStep(m) => MissingStep(MissingStep.Model.persist(m))
     | AxiomStep(m) => AxiomStep(AxiomStep.persist(m))
     | AlgebriteStep(m) => AlgebriteStep(AlgebriteStep.persist(m))
+    | ReparenthesizeStep({original_exp, reparenthesized_exp, _}) =>
+      ReparenthesizeStep(original_exp, reparenthesized_exp)
     };
   };
 
@@ -136,6 +145,12 @@ module rec StepKind: {
     | MissingStep(m) => MissingStep(MissingStep.Model.unpersist(m))
     | AxiomStep(m) => AxiomStep(AxiomStep.unpersist(m))
     | AlgebriteStep(m) => AlgebriteStep(AlgebriteStep.unpersist(m))
+    | ReparenthesizeStep(original_exp, reparenthesized_exp) =>
+      ReparenthesizeStep({
+        original_exp,
+        reparenthesized_exp,
+        next_exp: Calc.Pending,
+      })
     };
   };
 
@@ -331,6 +346,22 @@ module rec StepKind: {
           m,
         );
       (AlgebriteStep(m): model, h, e, v);
+    | ReparenthesizeStep({original_exp, reparenthesized_exp, _}) =>
+      let current_exp = exp |> Calc.get_value;
+      if (!DHExp.fast_equal(current_exp, original_exp)) {
+        None; /* upstream changed; fall back to MissingStep */
+      } else {
+        Some((
+          ReparenthesizeStep({
+            original_exp,
+            reparenthesized_exp,
+            next_exp: Calc.Calculated(reparenthesized_exp),
+          }): model,
+          Calc.set(false, hidden),
+          Some(Calc.NewValue(reparenthesized_exp)),
+          Calc.OldValue(None),
+        ));
+      };
     };
 
   let get_cursor_info = (~inject, ~focus: focus, model: model) =>
@@ -439,7 +470,8 @@ module rec StepKind: {
           ~take_focus=x => take_focus(ForallStep(x)),
           m,
         )
-      | MissingStep(_) => (
+      | MissingStep(_)
+      | ReparenthesizeStep(_) => (
           (~globals as _, ~hide_stepper as _, ~undo as _, ~is_toplevel as _) =>
             []
         )
@@ -536,6 +568,7 @@ module rec StepKind: {
         ~undo,
         m,
       )
+    | ReparenthesizeStep(_) => WebUtil.Node.text("reparenthesize")
     | AxiomStep(m) =>
       AxiomStep.view_justification(
         ~globals,
@@ -677,6 +710,33 @@ and Stepper: {
         | None => model |> raise_invalid_action
         };
       | (StepForward(_), _, _) => model |> raise_invalid_action
+      | (StepForwardOnSelection(selected_ids), MissingStep(_), _) =>
+        let exp =
+          model.expr |> Calc.get_saved_exc(~print="StepForwardOnSelection");
+        let visible_exp =
+          (
+            model.editor |> Calc.get_saved_exc(~print="StepForwardOnSelection")
+          ).
+            statics.
+            term;
+        let result =
+          Reparenthesize.reparenthesize_selection(~selected_ids, visible_exp)
+          |> Option.map(((new_exp, _)) =>
+               {
+                 ...model,
+                 step_kind:
+                   ReparenthesizeStep({
+                     original_exp: exp,
+                     reparenthesized_exp: new_exp,
+                     next_exp: Calc.Pending,
+                   }),
+               }
+             );
+        switch (result) {
+        | Some(m) => m |> return
+        | None => model |> raise_invalid_action
+        };
+      | (StepForwardOnSelection(_), _, _) => model |> raise_invalid_action
       | (AddInduction(exp), MissingStep(_), _) =>
         {
           ...model,
@@ -740,6 +800,7 @@ and Stepper: {
     | NextStep(next) => can_undo(next)
     | RemoveStep => true
     | StepForward(_) => true
+    | StepForwardOnSelection(_) => true
     | AddInduction(_) => true
     | AddForall => true
     | AddAxiomStep(_) => true
@@ -755,31 +816,54 @@ and Stepper: {
             ~ctx: Calc.t(SemanticCtx.t),
             ~ana: Calc.t(Typ.t),
             {
-              expr: _,
+              expr: prev_expr,
               editor,
               step_kind,
               next_step,
               hidden,
               proof_validity,
-              editor_info_map: info_map,
+              editor_info_map: _,
             }: step_model,
           )
           : (step_model, Calc.t(Exp.t), Calc.t(option(bool))) => {
+    let expr_changed =
+      switch (prev_expr) {
+      | Calc.Pending => true
+      | Calc.Calculated(prev_expr) =>
+        !Exp.fast_equal(prev_expr, Calc.get_value(expr))
+      };
     let editor =
-      editor
-      |> {
-        let.calc settings = settings
-        and.calc expr = expr
-        and.calc _ctx = ctx
-        and.calc _ana = ana;
-        expr |> CodeWithStatics.Model.mk_from_exp(~settings, ~root=Exp);
+      switch (editor, expr_changed) {
+      | (Calc.Calculated(editor), false) => Calc.OldValue(editor)
+      | _ =>
+        editor
+        |> {
+          let.calc settings = settings
+          and.calc expr = expr
+          and.calc _ctx = ctx
+          and.calc _ana = ana;
+          expr
+          |> CodeWithStatics.Model.mk_from_exp(
+               ~settings,
+               ~root=Exp,
+               ~parenthesization=Haz3lcore.ExpToSegment.Settings.Defensive,
+             );
+        }
       };
-    let info_map =
-      info_map
-      |> {
-        let.calc editor: CodeSelectable.Model.t = editor;
-        editor.statics.info_map;
-      };
+    // TODO: Make editor calculation more incremental
+    let editor =
+      CodeSelectable.Update.calculate(
+        ~is_dynamic_term=true,
+        ~settings=Calc.get_value(settings),
+        ~is_edited=expr_changed,
+        ~ctx=Calc.get_value(ctx) |> SemanticCtx.get_ctx,
+        ~dynamics=Dynamics.Map.empty,
+        ~ana=Calc.get_value(ana),
+        ~stitch=_ => Calc.get_value(expr),
+        Calc.get_value(editor),
+      );
+    let info_map = Calc.NewValue(editor.statics.info_map);
+    let editor = Calc.OldValue(editor);
     let (step_kind, hidden, next_expr, inner_validity) =
       StepKind.calculate(
         ~settings,
@@ -826,24 +910,11 @@ and Stepper: {
         };
       };
 
-    // TODO: Make editor calculation more incremental
-    let editor =
-      CodeSelectable.Update.calculate(
-        ~is_dynamic_term=true,
-        ~settings=Calc.get_value(settings),
-        ~is_edited=true,
-        ~ctx=Calc.get_value(ctx) |> SemanticCtx.get_ctx,
-        ~dynamics=Dynamics.Map.empty,
-        ~ana=Calc.get_value(ana),
-        ~stitch=_ => Calc.get_value(expr),
-        Calc.get_value(editor),
-      );
-
     (
       {
         expr: expr |> Calc.save,
 
-        editor: Calc.Calculated(editor),
+        editor: editor |> Calc.save,
         step_kind,
         next_step,
         hidden: hidden |> Calc.save,
@@ -923,6 +994,11 @@ and Stepper: {
           | AxiomStep(m) => [m.at_exp |> Exp.rep_id]
           | _ => []
           };
+        let rendered_expr =
+          (model.editor |> Calc.get_saved_exc(~print="editor")).statics.term;
+        let step_id_in_expr = step =>
+          EvaluatorStep.get_step_id_in(step, rendered_expr)
+          |> Option.value(~default=EvaluatorStep.get_step_id(step));
         let next_steps =
           switch (model.step_kind) {
           | MissingStep(m) =>
@@ -933,7 +1009,7 @@ and Stepper: {
               | AutoStep(_) => []
               | AvailableSteps(steps) => steps
             )
-            |> List.map(step => step |> EvaluatorStep.get_step_id)
+            |> List.map(step_id_in_expr)
           | _ => []
           };
         let selected_exp =
@@ -968,10 +1044,14 @@ and Stepper: {
                   inject(
                     AddAxiomStep(
                       "reflexivity",
-                      ProofHacks.exp_idx(
-                        from_exp,
-                        model.expr |> Calc.get_saved_exc(~print="expr"),
-                      ),
+                      try(
+                        ProofHacks.exp_idx(
+                          from_exp,
+                          model.expr |> Calc.get_saved_exc(~print="expr"),
+                        )
+                      ) {
+                      | _ => 0
+                      },
                       from_exp,
                       Direction.Right,
                       "Reflexive(==)",
@@ -1012,6 +1092,7 @@ and Stepper: {
                     | AddAlgebriteStep(idx, e1, e2) =>
                       inject(AddAlgebriteStep(idx, e1, e2))
                     | TakeStep(i) => inject(StepForward(i))
+                    | StepHere(ids) => inject(StepForwardOnSelection(ids))
                     | Refl(i) => {
                         let refl_exps =
                           switch (model.step_kind) {
@@ -1023,10 +1104,15 @@ and Stepper: {
                         inject(
                           AddAxiomStep(
                             "reflexivity",
-                            ProofHacks.exp_idx(
-                              from_exp,
-                              model.expr |> Calc.get_saved_exc(~print="expr"),
-                            ),
+                            try(
+                              ProofHacks.exp_idx(
+                                from_exp,
+                                model.expr
+                                |> Calc.get_saved_exc(~print="expr"),
+                              )
+                            ) {
+                            | _ => 0
+                            },
                             from_exp,
                             Direction.Right,
                             "Reflexive(==)",

--- a/src/web/app/editors/stepper/StepperBase.re
+++ b/src/web/app/editors/stepper/StepperBase.re
@@ -56,6 +56,12 @@ type persistent_step_kind =
   | AxiomStep(AxiomStep.persistent'(persistent_step))
   | AlgebriteStep(AlgebriteStep.persistent'(persistent_step))
   | ReparenthesizeStep(Exp.t, Exp.t) /* original_exp, reparenthesized_exp */
+  | ReparenthesizeStepWithSelection({
+      original_exp: Exp.t,
+      reparenthesized_exp: Exp.t,
+      selected_id: option(Id.t),
+      evaluate_after_parenthesize: bool,
+    })
 
 and persistent_step = {
   step_kind: persistent_step_kind,
@@ -81,7 +87,9 @@ and step_action =
   | AddInduction(option(Exp.t))
   | AddForall
   | AddAxiomStep(string, int, Exp.t, Direction.t, string)
-  | AddAlgebriteStep(int, Exp.t, Exp.t);
+  | AddAlgebriteStep(int, Exp.t, Exp.t)
+  | AddReparenthesizeStep(Exp.t)
+  | AddReparenthesizedAlgebriteStep(Exp.t, Exp.t, Exp.t);
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type step_kind_focus =
@@ -134,8 +142,19 @@ module rec StepKind: {
     | MissingStep(m) => MissingStep(MissingStep.Model.persist(m))
     | AxiomStep(m) => AxiomStep(AxiomStep.persist(m))
     | AlgebriteStep(m) => AlgebriteStep(AlgebriteStep.persist(m))
-    | ReparenthesizeStep({original_exp, reparenthesized_exp, _}) =>
-      ReparenthesizeStep(original_exp, reparenthesized_exp)
+    | ReparenthesizeStep({
+        original_exp,
+        reparenthesized_exp,
+        selected_id,
+        evaluate_after_parenthesize,
+        _,
+      }) =>
+      ReparenthesizeStepWithSelection({
+        original_exp,
+        reparenthesized_exp,
+        selected_id,
+        evaluate_after_parenthesize,
+      })
     };
   };
 
@@ -153,6 +172,19 @@ module rec StepKind: {
         reparenthesized_exp,
         selected_id: None,
         evaluate_after_parenthesize: false,
+        next_exp: Calc.Pending,
+      })
+    | ReparenthesizeStepWithSelection({
+        original_exp,
+        reparenthesized_exp,
+        selected_id,
+        evaluate_after_parenthesize,
+      }) =>
+      ReparenthesizeStep({
+        original_exp,
+        reparenthesized_exp,
+        selected_id,
+        evaluate_after_parenthesize,
         next_exp: Calc.Pending,
       })
     };
@@ -839,6 +871,62 @@ and Stepper: {
         }
         |> return
       | (AddAlgebriteStep(_, _, _), _, _) => model |> raise_invalid_action
+      | (AddReparenthesizeStep(new_exp), MissingStep(_), _) =>
+        let exp =
+          model.expr |> Calc.get_saved_exc(~print="AddReparenthesizeStep");
+        {
+          ...model,
+          step_kind:
+            ReparenthesizeStep({
+              original_exp: exp,
+              reparenthesized_exp: new_exp,
+              selected_id: None,
+              evaluate_after_parenthesize: false,
+              next_exp: Calc.Pending,
+            }),
+        }
+        |> return;
+      | (AddReparenthesizeStep(_), _, _) => model |> raise_invalid_action
+      | (
+          AddReparenthesizedAlgebriteStep(
+            reparenthesized_exp,
+            at_exp,
+            with_exp,
+          ),
+          MissingStep(_),
+          _,
+        ) =>
+        let exp =
+          model.expr
+          |> Calc.get_saved_exc(~print="AddReparenthesizedAlgebriteStep");
+        {
+          ...model,
+          step_kind:
+            ReparenthesizeStep({
+              original_exp: exp,
+              reparenthesized_exp,
+              selected_id: None,
+              evaluate_after_parenthesize: false,
+              next_exp: Calc.Pending,
+            }),
+          next_step:
+            Some({
+              ...init,
+              step_kind:
+                AlgebriteStep({
+                  at_idx:
+                    try(ProofHacks.exp_idx(at_exp, reparenthesized_exp)) {
+                    | _ => 0
+                    },
+                  at_exp,
+                  with_exp,
+                  next_exp: Calc.Pending,
+                }),
+            }),
+        }
+        |> return;
+      | (AddReparenthesizedAlgebriteStep(_, _, _), _, _) =>
+        model |> raise_invalid_action
       | (StepKindAction(sk_action), _, _) =>
         let* new_step_kind =
           StepKind.update(~settings, sk_action, model.step_kind);
@@ -861,6 +949,8 @@ and Stepper: {
     | AddForall => true
     | AddAxiomStep(_) => true
     | AddAlgebriteStep(_) => true
+    | AddReparenthesizeStep(_) => true
+    | AddReparenthesizedAlgebriteStep(_) => true
     | StepKindAction(action) => StepKind.can_undo(action)
     };
   };
@@ -1147,6 +1237,10 @@ and Stepper: {
                       inject(AddAxiomStep(name, idx, e1, dir, eq))
                     | AddAlgebriteStep(idx, e1, e2) =>
                       inject(AddAlgebriteStep(idx, e1, e2))
+                    | AddReparenthesizeStep(e) =>
+                      inject(AddReparenthesizeStep(e))
+                    | AddReparenthesizedAlgebriteStep(e1, e2, e3) =>
+                      inject(AddReparenthesizedAlgebriteStep(e1, e2, e3))
                     | TakeStep(i) => inject(StepForward(i))
                     | StepHere(ids, evaluate_after_parenthesize) =>
                       inject(

--- a/src/web/app/editors/stepper/StepperBase.re
+++ b/src/web/app/editors/stepper/StepperBase.re
@@ -19,6 +19,8 @@ type step_kind_model =
   | ReparenthesizeStep({
       original_exp: Exp.t,
       reparenthesized_exp: Exp.t,
+      selected_id: option(Id.t),
+      evaluate_after_parenthesize: bool,
       next_exp: Calc.saved(Exp.t),
     })
 
@@ -75,7 +77,7 @@ and step_action =
   | NextStep(step_action)
   | RemoveStep
   | StepForward(int)
-  | StepForwardOnSelection(list(Id.t))
+  | StepForwardOnSelection(list(Id.t), bool)
   | AddInduction(option(Exp.t))
   | AddForall
   | AddAxiomStep(string, int, Exp.t, Direction.t, string)
@@ -149,6 +151,8 @@ module rec StepKind: {
       ReparenthesizeStep({
         original_exp,
         reparenthesized_exp,
+        selected_id: None,
+        evaluate_after_parenthesize: false,
         next_exp: Calc.Pending,
       })
     };
@@ -346,19 +350,63 @@ module rec StepKind: {
           m,
         );
       (AlgebriteStep(m): model, h, e, v);
-    | ReparenthesizeStep({original_exp, reparenthesized_exp, _}) =>
+    | ReparenthesizeStep({
+        original_exp,
+        reparenthesized_exp,
+        selected_id,
+        evaluate_after_parenthesize,
+        _,
+      }) =>
       let current_exp = exp |> Calc.get_value;
       if (!DHExp.fast_equal(current_exp, original_exp)) {
         None; /* upstream changed; fall back to MissingStep */
       } else {
+        let next_exp =
+          if (evaluate_after_parenthesize) {
+            let steps =
+              switch (
+                EvaluatorStep.get_status(
+                  ~settings=Calc.get_value(settings),
+                  reparenthesized_exp,
+                  Calc.get_value(ctx) |> SemanticCtx.get_env,
+                )
+              ) {
+              | AutoStep(step) => [step]
+              | AvailableSteps(steps) => steps
+              };
+            let matching_step =
+              switch (selected_id) {
+              | None => None
+              | Some(selected_id) =>
+                steps
+                |> List.find_opt(step =>
+                     switch (
+                       EvaluatorStep.get_step_id_in(step, reparenthesized_exp)
+                     ) {
+                     | Some(id) => id == selected_id
+                     | None => EvaluatorStep.get_step_id(step) == selected_id
+                     }
+                   )
+              };
+            switch (matching_step) {
+            | Some(step) =>
+              EvaluatorStep.take_step(step)
+              |> Option.value(~default=reparenthesized_exp)
+            | None => reparenthesized_exp
+            };
+          } else {
+            reparenthesized_exp;
+          };
         Some((
           ReparenthesizeStep({
             original_exp,
             reparenthesized_exp,
-            next_exp: Calc.Calculated(reparenthesized_exp),
+            selected_id,
+            evaluate_after_parenthesize,
+            next_exp: Calc.Calculated(next_exp),
           }): model,
           Calc.set(false, hidden),
-          Some(Calc.NewValue(reparenthesized_exp)),
+          Some(Calc.NewValue(next_exp)),
           Calc.OldValue(None),
         ));
       };
@@ -710,7 +758,11 @@ and Stepper: {
         | None => model |> raise_invalid_action
         };
       | (StepForward(_), _, _) => model |> raise_invalid_action
-      | (StepForwardOnSelection(selected_ids), MissingStep(_), _) =>
+      | (
+          StepForwardOnSelection(selected_ids, evaluate_after_parenthesize),
+          MissingStep(_),
+          _,
+        ) =>
         let exp =
           model.expr |> Calc.get_saved_exc(~print="StepForwardOnSelection");
         let visible_exp =
@@ -721,22 +773,26 @@ and Stepper: {
             term;
         let result =
           Reparenthesize.reparenthesize_selection(~selected_ids, visible_exp)
-          |> Option.map(((new_exp, _)) =>
+          |> Option.map((result: Reparenthesize.result) => {
+               let new_exp = result.exp;
+               let selected_id = result.selected_id;
                {
                  ...model,
                  step_kind:
                    ReparenthesizeStep({
                      original_exp: exp,
                      reparenthesized_exp: new_exp,
+                     selected_id: Some(selected_id),
+                     evaluate_after_parenthesize,
                      next_exp: Calc.Pending,
                    }),
-               }
-             );
+               };
+             });
         switch (result) {
         | Some(m) => m |> return
         | None => model |> raise_invalid_action
         };
-      | (StepForwardOnSelection(_), _, _) => model |> raise_invalid_action
+      | (StepForwardOnSelection(_, _), _, _) => model |> raise_invalid_action
       | (AddInduction(exp), MissingStep(_), _) =>
         {
           ...model,
@@ -800,7 +856,7 @@ and Stepper: {
     | NextStep(next) => can_undo(next)
     | RemoveStep => true
     | StepForward(_) => true
-    | StepForwardOnSelection(_) => true
+    | StepForwardOnSelection(_, _) => true
     | AddInduction(_) => true
     | AddForall => true
     | AddAxiomStep(_) => true
@@ -1092,7 +1148,13 @@ and Stepper: {
                     | AddAlgebriteStep(idx, e1, e2) =>
                       inject(AddAlgebriteStep(idx, e1, e2))
                     | TakeStep(i) => inject(StepForward(i))
-                    | StepHere(ids) => inject(StepForwardOnSelection(ids))
+                    | StepHere(ids, evaluate_after_parenthesize) =>
+                      inject(
+                        StepForwardOnSelection(
+                          ids,
+                          evaluate_after_parenthesize,
+                        ),
+                      )
                     | Refl(i) => {
                         let refl_exps =
                           switch (model.step_kind) {

--- a/test/Test_Reparenthesize.re
+++ b/test/Test_Reparenthesize.re
@@ -8,6 +8,14 @@ let parse_exp = (s: string) => {
   };
 };
 
+let render_exp = (exp: Exp.t): string =>
+  exp
+  |> Haz3lcore.ExpToSegment.exp_to_segment(
+       ~settings=Haz3lcore.ExpToSegment.Settings.editable(~inline=true),
+       _,
+     )
+  |> Haz3lcore.Printer.of_segment(~holes="?", _);
+
 let statics = exp =>
   Statics.mk(CoreSettings.on, Builtins.ctx_init(Some(Int)), exp) |> fst;
 
@@ -36,6 +44,36 @@ let take_selected_step = (~selected_id, exp) => {
   | None => None
   };
 };
+
+let has_selected_step = (~selected_id, exp) =>
+  switch (take_selected_step(~selected_id, exp)) {
+  | Some(_) => true
+  | None => false
+  };
+
+let rec find_parens = (exp: Exp.t): option(Exp.t) =>
+  switch (exp.term) {
+  | Parens(_) => Some(exp)
+  | BinOp(_, left, right)
+  | Ap(_, left, right) =>
+    switch (find_parens(left)) {
+    | Some(_) as result => result
+    | None => find_parens(right)
+    }
+  | Asc(inner, _)
+  | Projector(_, inner) => find_parens(inner)
+  | _ => None
+  };
+
+let rec parens_ids = (exp: Exp.t): list(Id.t) =>
+  switch (exp.term) {
+  | Parens(inner) => [Exp.rep_id(exp), ...parens_ids(inner)]
+  | BinOp(_, left, right)
+  | Ap(_, left, right) => parens_ids(left) @ parens_ids(right)
+  | Asc(inner, _)
+  | Projector(_, inner) => parens_ids(inner)
+  | _ => []
+  };
 
 let rec find_plus_with_right_five_after_times = (exp: Exp.t): option(Exp.t) =>
   switch (exp.term) {
@@ -225,6 +263,179 @@ let test_single_binop_step_here_can_evaluate_after_parenthesizing = () => {
   };
 };
 
+let test_reparenthesize_result_exposes_selected_chunk = () => {
+  let exp = parse_exp("1 + 2 + 3 + 4");
+  let middle_plus_id =
+    switch (exp.term) {
+    | BinOp(_, {term: BinOp(_, _, _), _} as middle_plus, _) =>
+      switch (middle_plus.term) {
+      | BinOp(_, _, {term: Atom(Int(i)), _})
+          when Bigint.to_int(i) == Some(3) =>
+        Exp.rep_id(middle_plus)
+      | _ => Alcotest.fail("Unexpected middle plus shape")
+      }
+    | _ => Alcotest.fail("Unexpected parse tree for 1 + 2 + 3 + 4")
+    };
+  let snapped_ids =
+    AssocSelection.find_reparenthesize_for_id(middle_plus_id, statics(exp));
+  switch (
+    Reparenthesize.reparenthesize_selection(~selected_ids=snapped_ids, exp)
+  ) {
+  | Some(result) =>
+    switch (Reparenthesize.selected_exp(result)) {
+    | Some(selected_exp) =>
+      check(
+        bool,
+        "selected reparenthesized chunk is 2 + 3",
+        true,
+        Equality.ignoring_ascriptions.exp(selected_exp, parse_exp("2 + 3")),
+      )
+    | None =>
+      Alcotest.fail("Expected reparenthesize result to expose selected chunk")
+    }
+  | None =>
+    Alcotest.fail("Expected Step here selection to reparenthesize 2 + 3")
+  };
+};
+
+let test_reparenthesize_result_replaces_selected_chunk = () => {
+  let exp = parse_exp("1 + 2 + 3 + 4");
+  let middle_plus_id =
+    switch (exp.term) {
+    | BinOp(_, {term: BinOp(_, _, _), _} as middle_plus, _) =>
+      switch (middle_plus.term) {
+      | BinOp(_, _, {term: Atom(Int(i)), _})
+          when Bigint.to_int(i) == Some(3) =>
+        Exp.rep_id(middle_plus)
+      | _ => Alcotest.fail("Unexpected middle plus shape")
+      }
+    | _ => Alcotest.fail("Unexpected parse tree for 1 + 2 + 3 + 4")
+    };
+  let snapped_ids =
+    AssocSelection.find_reparenthesize_for_id(middle_plus_id, statics(exp));
+  switch (
+    Reparenthesize.reparenthesize_selection(~selected_ids=snapped_ids, exp)
+  ) {
+  | Some(result) =>
+    let replaced = Reparenthesize.replace_selected(result, parse_exp("5"));
+    check(
+      bool,
+      "replacement continues from reparenthesized selected chunk",
+      true,
+      Equality.ignoring_ascriptions.exp(replaced, parse_exp("1 + 5 + 4")),
+    );
+  | None =>
+    Alcotest.fail("Expected Step here selection to reparenthesize 2 + 3")
+  };
+};
+
+let test_unparenthesize_selected_parens = () => {
+  let exp = parse_exp("1 + (2 + 3) + 4");
+  let parens_id =
+    switch (find_parens(exp)) {
+    | Some(parens) => Exp.rep_id(parens)
+    | None => Alcotest.fail("Expected expression to contain parentheses")
+    };
+  switch (Reparenthesize.unparenthesize(~selected_id=parens_id, exp)) {
+  | Some(unparenthesized) =>
+    check(
+      bool,
+      "selected parens are removed",
+      true,
+      ProofHacks.find_exp_id(parens_id, unparenthesized) == None,
+    )
+  | None => Alcotest.fail("Expected selected parens to unparenthesize")
+  };
+};
+
+let test_application_operand_parenthesizes_without_selected_step = () => {
+  let exp = parse_exp("(fun x -> x)(1) * 5");
+  let times_id = Exp.rep_id(exp);
+  let snapped_ids =
+    AssocSelection.find_reparenthesize_for_id(times_id, statics(exp));
+  switch (
+    Reparenthesize.reparenthesize_selection(~selected_ids=snapped_ids, exp)
+  ) {
+  | Some({exp: reparenthesized, selected_id, selected_is_single_binop}) =>
+    check(
+      bool,
+      "review case still parenthesizes the selected BinOp",
+      true,
+      selected_is_single_binop,
+    );
+    check(
+      bool,
+      "review case does not claim selected BinOp can step directly",
+      false,
+      has_selected_step(~selected_id, reparenthesized),
+    );
+  | None =>
+    Alcotest.fail("Expected review case to parenthesize selected expression")
+  };
+};
+
+let test_unparenthesize_flattens_visible_associative_group = () => {
+  let exp = parse_exp("1 * 5 + 3 + (4 + (5 + 7))");
+  switch (
+    Reparenthesize.unparenthesize_any(~selected_ids=parens_ids(exp), exp)
+  ) {
+  | Some(unparenthesized) =>
+    check(
+      string,
+      "outer associative parens are visibly removed",
+      "1 * 5 + 3 + 4 + (5 + 7)",
+      render_exp(unparenthesized),
+    )
+  | None => Alcotest.fail("Expected selected parens to unparenthesize")
+  };
+};
+
+let test_nonassociative_selection_does_not_reparenthesize = () => {
+  let exp = parse_exp("1 - 2 - 3");
+  let selected_ids =
+    switch (exp.term) {
+    | BinOp(
+        Operators.Int(Operators.Minus),
+        {
+          term:
+            BinOp(
+              Operators.Int(Operators.Minus),
+              _,
+              {term: Atom(Int(_)), _} as two,
+            ),
+          _,
+        },
+        {term: Atom(Int(_)), _} as three,
+      ) => [
+        Exp.rep_id(two),
+        Exp.rep_id(three),
+      ]
+    | _ => Alcotest.fail("Unexpected parse tree for 1 - 2 - 3")
+    };
+  check(
+    bool,
+    "non-associative chains are not reparenthesized",
+    true,
+    Reparenthesize.reparenthesize_selection(~selected_ids, exp) == None,
+  );
+};
+
+let test_unparenthesize_nonassociative_parens_does_not_flatten = () => {
+  let exp = parse_exp("1 - (2 - 3)");
+  switch (
+    Reparenthesize.unparenthesize_any(~selected_ids=parens_ids(exp), exp)
+  ) {
+  | Some(unparenthesized) =>
+    check(
+      string,
+      "non-associative parens stay visible after removing explicit Parens node",
+      "1 - (2 - 3)",
+      render_exp(unparenthesized),
+    )
+  | None => Alcotest.fail("Expected selected parens to unparenthesize")
+  };
+};
+
 let tests = (
   "Reparenthesize",
   [
@@ -232,6 +443,41 @@ let tests = (
       "Step here evaluates a selected single BinOp after parenthesizing",
       `Quick,
       test_single_binop_step_here_can_evaluate_after_parenthesizing,
+    ),
+    test_case(
+      "Reparenthesize result exposes selected chunk for rewrite checks",
+      `Quick,
+      test_reparenthesize_result_exposes_selected_chunk,
+    ),
+    test_case(
+      "Reparenthesize result replaces selected chunk for rewrite steps",
+      `Quick,
+      test_reparenthesize_result_replaces_selected_chunk,
+    ),
+    test_case(
+      "Unparenthesize removes selected parens",
+      `Quick,
+      test_unparenthesize_selected_parens,
+    ),
+    test_case(
+      "Unparenthesize visibly flattens associative parens",
+      `Quick,
+      test_unparenthesize_flattens_visible_associative_group,
+    ),
+    test_case(
+      "Non-associative selections do not reparenthesize",
+      `Quick,
+      test_nonassociative_selection_does_not_reparenthesize,
+    ),
+    test_case(
+      "Unparenthesize does not flatten non-associative parens",
+      `Quick,
+      test_unparenthesize_nonassociative_parens_does_not_flatten,
+    ),
+    test_case(
+      "Function application operands parenthesize without selected step",
+      `Quick,
+      test_application_operand_parenthesizes_without_selected_step,
     ),
     test_case(
       "Step here works across mixed + and * precedence",

--- a/test/Test_Reparenthesize.re
+++ b/test/Test_Reparenthesize.re
@@ -1,0 +1,252 @@
+open Alcotest;
+open Language;
+
+let parse_exp = (s: string) => {
+  switch (Haz3lcore.Parser.to_term(s, ~root=Exp)) {
+  | Some(e) => e
+  | None => Alcotest.fail("Failed to parse expression: " ++ s)
+  };
+};
+
+let statics = exp =>
+  Statics.mk(CoreSettings.on, Builtins.ctx_init(Some(Int)), exp) |> fst;
+
+let take_selected_step = (~selected_id, exp) => {
+  let steps =
+    switch (
+      EvaluatorStep.get_status(
+        ~settings=CoreSettings.on,
+        exp,
+        Environment.empty,
+      )
+    ) {
+    | AutoStep(step) => [step]
+    | AvailableSteps(steps) => steps
+    };
+  switch (
+    steps
+    |> List.find_opt(step =>
+         switch (EvaluatorStep.get_step_id_in(step, exp)) {
+         | Some(id) => id == selected_id
+         | None => EvaluatorStep.get_step_id(step) == selected_id
+         }
+       )
+  ) {
+  | Some(step) => EvaluatorStep.take_step(step)
+  | None => None
+  };
+};
+
+let rec find_plus_with_right_five_after_times = (exp: Exp.t): option(Exp.t) =>
+  switch (exp.term) {
+  | BinOp(Operators.Int(Operators.Plus), left, {term: Atom(Int(i)), _})
+      when Bigint.to_int(i) == Some(5) =>
+    switch (left.term) {
+    | BinOp(
+        Operators.Int(Operators.Plus),
+        _,
+        {term: BinOp(Operators.Int(Operators.Times), _, _), _},
+      )
+    | BinOp(Operators.Int(Operators.Times), _, _) => Some(exp)
+    | _ =>
+      switch (find_plus_with_right_five_after_times(left)) {
+      | Some(_) as result => result
+      | None => None
+      }
+    }
+  | BinOp(_, left, right) =>
+    switch (find_plus_with_right_five_after_times(left)) {
+    | Some(_) as result => result
+    | None => find_plus_with_right_five_after_times(right)
+    }
+  | Parens(inner) => find_plus_with_right_five_after_times(inner)
+  | _ => None
+  };
+
+let test_mixed_precedence_step_here = () => {
+  let exp = parse_exp("3 + 4 * 5");
+  let (plus_id, times_id, five_id) =
+    switch (exp.term) {
+    | BinOp(_, _, {term: BinOp(_, _, five), _} as times) => (
+        Exp.rep_id(exp),
+        Exp.rep_id(times),
+        Exp.rep_id(five),
+      )
+    | _ => Alcotest.fail("Unexpected parse tree for 3 + 4 * 5")
+    };
+  let visual_ids = AssocSelection.find_assoc_for_id(plus_id, statics(exp));
+  check(
+    bool,
+    "mixed-precedence visual snap reaches right edge",
+    true,
+    List.mem(five_id, visual_ids),
+  );
+  let snapped_ids =
+    AssocSelection.find_reparenthesize_for_id(plus_id, statics(exp));
+  check(
+    bool,
+    "mixed-precedence snap keeps right operand whole",
+    true,
+    List.mem(times_id, snapped_ids) && !List.mem(five_id, snapped_ids),
+  );
+  switch (
+    Reparenthesize.reparenthesize_selection(~selected_ids=snapped_ids, exp)
+  ) {
+  | Some({selected_is_single_binop, _}) =>
+    check(
+      bool,
+      "mixed-precedence selection is parenthesize-only",
+      false,
+      selected_is_single_binop,
+    )
+  | None =>
+    Alcotest.fail("Expected Step here selection to reparenthesize 3 + 4 * 5")
+  };
+};
+
+let test_mixed_precedence_left_operand_step_here = () => {
+  let exp = parse_exp("4 * 5 + 5");
+  let (plus_id, times_id, four_id) =
+    switch (exp.term) {
+    | BinOp(_, {term: BinOp(_, four, _), _} as times, _) => (
+        Exp.rep_id(exp),
+        Exp.rep_id(times),
+        Exp.rep_id(four),
+      )
+    | _ => Alcotest.fail("Unexpected parse tree for 4 * 5 + 5")
+    };
+  let visual_ids = AssocSelection.find_assoc_for_id(plus_id, statics(exp));
+  check(
+    bool,
+    "mixed-precedence visual snap reaches left edge",
+    true,
+    List.mem(four_id, visual_ids),
+  );
+  let snapped_ids =
+    AssocSelection.find_reparenthesize_for_id(plus_id, statics(exp));
+  check(
+    bool,
+    "mixed-precedence action snap keeps left operand whole",
+    true,
+    List.mem(times_id, snapped_ids) && !List.mem(four_id, snapped_ids),
+  );
+  switch (
+    Reparenthesize.reparenthesize_selection(~selected_ids=snapped_ids, exp)
+  ) {
+  | Some({selected_is_single_binop, _}) =>
+    check(
+      bool,
+      "mixed-precedence left selection is parenthesize-only",
+      false,
+      selected_is_single_binop,
+    )
+  | None =>
+    Alcotest.fail("Expected Step here selection to reparenthesize 4 * 5 + 5")
+  };
+};
+
+let test_mixed_precedence_inside_plus_chain_step_here = () => {
+  let exp = parse_exp("1 + 2 + 3 + 4 * 5 + 5 + 6");
+  let selected_plus =
+    switch (find_plus_with_right_five_after_times(exp)) {
+    | Some(selected_plus) => selected_plus
+    | None => Alcotest.fail("Expected to find selected plus in full chain")
+    };
+  let times_id =
+    switch (selected_plus.term) {
+    | BinOp(
+        _,
+        {
+          term:
+            BinOp(
+              _,
+              _,
+              {term: BinOp(Operators.Int(Operators.Times), _, _), _} as times,
+            ),
+          _,
+        },
+        _,
+      ) =>
+      Exp.rep_id(times)
+    | _ => Alcotest.fail("Unexpected selected plus shape")
+    };
+  let snapped_ids =
+    AssocSelection.find_reparenthesize_for_id(
+      Exp.rep_id(selected_plus),
+      statics(exp),
+    );
+  check(
+    bool,
+    "mixed-precedence action snap keeps left chain operand whole",
+    true,
+    List.mem(times_id, snapped_ids),
+  );
+  switch (
+    Reparenthesize.reparenthesize_selection(~selected_ids=snapped_ids, exp)
+  ) {
+  | Some({selected_is_single_binop, _}) =>
+    check(
+      bool,
+      "larger mixed chain selection is parenthesize-only",
+      false,
+      selected_is_single_binop,
+    )
+  | None =>
+    Alcotest.fail(
+      "Expected Step here selection to reparenthesize full mixed chain",
+    )
+  };
+};
+
+let test_single_binop_step_here_can_evaluate_after_parenthesizing = () => {
+  let exp = parse_exp("1 + 2 + 3");
+  let outer_plus_id = Exp.rep_id(exp);
+  let snapped_ids =
+    AssocSelection.find_reparenthesize_for_id(outer_plus_id, statics(exp));
+  switch (
+    Reparenthesize.reparenthesize_selection(~selected_ids=snapped_ids, exp)
+  ) {
+  | Some({exp: reparenthesized, selected_id, selected_is_single_binop}) =>
+    check(
+      bool,
+      "simple associative selection is a single BinOp",
+      true,
+      selected_is_single_binop,
+    );
+    switch (take_selected_step(~selected_id, reparenthesized)) {
+    | Some(_) => ()
+    | None =>
+      Alcotest.fail(
+        "Expected reparenthesized single BinOp selection to have an evaluation step",
+      )
+    };
+  | None =>
+    Alcotest.fail("Expected Step here selection to reparenthesize 1 + 2 + 3")
+  };
+};
+
+let tests = (
+  "Reparenthesize",
+  [
+    test_case(
+      "Step here evaluates a selected single BinOp after parenthesizing",
+      `Quick,
+      test_single_binop_step_here_can_evaluate_after_parenthesizing,
+    ),
+    test_case(
+      "Step here works across mixed + and * precedence",
+      `Quick,
+      test_mixed_precedence_step_here,
+    ),
+    test_case(
+      "Step here works when mixed precedence is on the left",
+      `Quick,
+      test_mixed_precedence_left_operand_step_here,
+    ),
+    test_case(
+      "Step here works inside a larger mixed plus chain",
+      `Quick,
+      test_mixed_precedence_inside_plus_chain_step_here,
+    ),
+  ],
+);

--- a/test/evaluator/Test_StepperBase.re
+++ b/test/evaluator/Test_StepperBase.re
@@ -260,6 +260,18 @@ let run_step_chain =
   };
 };
 
+let middle_plus_id_in_four_term_sum = (exp: Exp.t): Id.t =>
+  switch (exp.term) {
+  | BinOp(_, {term: BinOp(_, _, _), _} as middle_plus, _) =>
+    switch (middle_plus.term) {
+    | BinOp(_, _, {term: Atom(Int(i)), _})
+        when Bigint.to_int(i) == Some(3) =>
+      Exp.rep_id(middle_plus)
+    | _ => failwith("Unexpected middle plus shape")
+    }
+  | _ => failwith("Unexpected parse tree for 1 + 2 + 3 + 4")
+  };
+
 let tests = (
   "StepperBase",
   [
@@ -469,6 +481,151 @@ let tests = (
 
         check(dhexp_typ, "reduces to true", parse_exp("true"), final_exp);
         check(option(bool), "chain validity is true", Some(true), validity);
+      },
+    ),
+    test_case(
+      "reparenthesized algebra replace keeps reparenthesize before algebra",
+      `Quick,
+      () => {
+        let exp = parse_exp("1 + 2 + 3 + 4");
+        let selected_ids =
+          AssocSelection.find_reparenthesize_for_id(
+            middle_plus_id_in_four_term_sum(exp),
+            Statics.mk(CoreSettings.on, Builtins.ctx_init(Some(Int)), exp)
+            |> fst,
+          );
+        let reparenthesized =
+          switch (Reparenthesize.reparenthesize_selection(~selected_ids, exp)) {
+          | Some(result) => result
+          | None => failwith("Expected reparenthesized selection")
+          };
+        let selected_exp =
+          switch (Reparenthesize.selected_exp(reparenthesized)) {
+          | Some(exp) => exp
+          | None => failwith("Expected selected exp")
+          };
+        let initial_step =
+          mk_test_step(~step_kind=StepKindHelpers.mk_missing_step(), ());
+        let (calculated_step, _, _) = test_calculate(~exp, initial_step);
+        let updated_step =
+          StepperBase.Stepper.update(
+            ~settings=Web.Settings.Model.init,
+            StepperBase.AddReparenthesizedAlgebriteStep(
+              reparenthesized.exp,
+              selected_exp,
+              parse_exp("6 - 1"),
+            ),
+            calculated_step,
+          ).
+            model;
+        let (calculated_updated_step, final_exp, _) =
+          test_calculate(~exp, updated_step);
+        switch (calculated_updated_step.step_kind) {
+        | ReparenthesizeStep(_) => ()
+        | _ => failwith("Expected root step to be reparenthesize")
+        };
+        let algebra_step =
+          switch (calculated_updated_step.next_step) {
+          | Some(step) => step
+          | None => failwith("Expected algebra next step")
+          };
+        switch (algebra_step.step_kind) {
+        | AlgebriteStep(_) => ()
+        | _ => failwith("Expected second step to be algebra")
+        };
+        check(
+          bool,
+          "final expression replaces only selected chunk",
+          true,
+          Equality.ignoring_ascriptions.exp(
+            Calc.get_value(final_exp),
+            parse_exp("1 + (6 - 1) + 4"),
+          ),
+        );
+      },
+    ),
+    test_case(
+      "unparenthesize records a reparenthesize step",
+      `Quick,
+      () => {
+        let exp = parse_exp("1 + (2 + 3) + 4");
+        let parens_id =
+          switch (Test_Reparenthesize.find_parens(exp)) {
+          | Some(parens) => Exp.rep_id(parens)
+          | None => failwith("Expected expression to contain parens")
+          };
+        let unparenthesized =
+          switch (Reparenthesize.unparenthesize(~selected_id=parens_id, exp)) {
+          | Some(exp) => exp
+          | None => failwith("Expected selected parens to unparenthesize")
+          };
+        let initial_step =
+          mk_test_step(~step_kind=StepKindHelpers.mk_missing_step(), ());
+        let (calculated_step, _, _) = test_calculate(~exp, initial_step);
+        let updated_step =
+          StepperBase.Stepper.update(
+            ~settings=Web.Settings.Model.init,
+            StepperBase.AddReparenthesizeStep(unparenthesized),
+            calculated_step,
+          ).
+            model;
+        let (calculated_updated_step, final_exp, _) =
+          test_calculate(~exp, updated_step);
+        switch (calculated_updated_step.step_kind) {
+        | ReparenthesizeStep(_) => ()
+        | _ => failwith("Expected root step to be reparenthesize")
+        };
+        check(
+          bool,
+          "final expression removes selected parens",
+          true,
+          ProofHacks.find_exp_id(parens_id, Calc.get_value(final_exp))
+          == None,
+        );
+      },
+    ),
+    test_case(
+      "reparenthesize persistence preserves selected step metadata",
+      `Quick,
+      () => {
+        let original_exp = parse_exp("1 + 2 + 3");
+        let reparenthesized_exp = parse_exp("1 + (2 + 3)");
+        let selected_id =
+          switch (Test_Reparenthesize.find_parens(reparenthesized_exp)) {
+          | Some({term: Parens(inner), _}) => Exp.rep_id(inner)
+          | Some(_) => failwith("Expected parens expression")
+          | None =>
+            failwith("Expected reparenthesized expression to contain parens")
+          };
+        let step_kind: StepperBase.step_kind_model =
+          ReparenthesizeStep({
+            original_exp,
+            reparenthesized_exp,
+            selected_id: Some(selected_id),
+            evaluate_after_parenthesize: true,
+            next_exp: Calc.Pending,
+          });
+        let restored =
+          step_kind
+          |> StepperBase.StepKind.persist
+          |> StepperBase.StepKind.unpersist;
+        switch (restored) {
+        | ReparenthesizeStep({
+            selected_id: Some(restored_selected_id),
+            evaluate_after_parenthesize: true,
+            _,
+          }) =>
+          check(
+            bool,
+            "selected id survives persistence",
+            true,
+            restored_selected_id == selected_id,
+          )
+        | _ =>
+          failwith(
+            "Expected persisted reparenthesize step to preserve selected step metadata",
+          )
+        };
       },
     ),
     // ============================================================

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -38,7 +38,6 @@ let (suite, _) =
     @ Test_Elaboration.tests
     @ Test_Evaluator.tests
     @ Test_Editing.tests
-    @ [Test_Reparenthesize.tests]
     @ Test_Reassociate.tests
     @ [Test_SelectionEffective.tests]
     @ Test_MultiProbe.tests

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -38,6 +38,7 @@ let (suite, _) =
     @ Test_Elaboration.tests
     @ Test_Evaluator.tests
     @ Test_Editing.tests
+    @ [Test_Reparenthesize.tests]
     @ Test_Reassociate.tests
     @ [Test_SelectionEffective.tests]
     @ Test_MultiProbe.tests


### PR DESCRIPTION
Working towards hiding left-associativity when evaluating arithemetic and other math in the stepper, introduces a "reparenthesize" step that wraps sections of the AST in parens so it can be evaluated. Exposed as either "Step here" or "Parenthesize" depending on what the user has highlighted in the Stepper.

Builds on #1890 and ideally should be merged into `dev` after that PR lands.

<img width="838" height="191" alt="Screenshot 2026-06-01 at 5 03 28 PM" src="https://github.com/user-attachments/assets/f5b27b89-313f-4c5a-bf51-0982cd7b7747" />
<img width="839" height="134" alt="Screenshot 2026-06-01 at 5 04 18 PM" src="https://github.com/user-attachments/assets/fdf8253d-19a5-4a74-937f-287a89770a75" />
