### PR TITLE
Force statics refresh on probe-id change

### DIFF
--- a/src/web/app/editors/Editors.re
+++ b/src/web/app/editors/Editors.re
@@ -323,6 +323,7 @@ module Update = {
         TutorialsMode.Update.calculate(
           ~schedule_action=a => schedule_action(Tutorial(a)),
           ~settings,
+          ~autoprobe_mode,
           ~is_edited,
           m,
         ),
@@ -332,6 +333,7 @@ module Update = {
         ExercisesMode.Update.calculate(
           ~schedule_action=a => schedule_action(Exercises(a)),
           ~settings,
+          ~autoprobe_mode,
           ~is_edited,
           m,
         ),

--- a/src/web/app/editors/code/CodeWithStatics.re
+++ b/src/web/app/editors/code/CodeWithStatics.re
@@ -159,26 +159,28 @@ module Update = {
      * `info_map`'s per-id `probe_targets` stale, so IncrEval's reuse_check
      * sees equal probe_targets and reuses the old `state.probes`, making a
      * newly placed probe show empty until the next force-refresh. */
-    let probes_changed = {
-      let current = CachedStatics.probe_ids_of_zipper(editor.state.zipper);
-      let cached = Language.Id.Map.map(_ => (), statics.targets);
-      !Language.Id.Map.equal((==), current, cached);
-    };
-    let statics =
+    let probes_differ = z =>
+      !Language.Id.Map.equal(
+        (==),
+        CachedStatics.probe_ids_of_zipper(z),
+        Language.Id.Map.map(_ => (), statics.targets),
+      );
+    let do_init = () =>
+      CachedStatics.init(
+        ~settings,
+        ~stitch,
+        ~ctx?,
+        ~ana?,
+        ~is_dynamic_term,
+        ~root=editor.root,
+        editor.state.zipper,
+      );
+    let needs_refresh =
       statics_mode == StaticsForce
-      || probes_changed
+      || probes_differ(editor.state.zipper)
       || is_edited
-      && statics_mode != StaticsDefer
-        ? CachedStatics.init(
-            ~settings,
-            ~stitch,
-            ~ctx?,
-            ~ana?,
-            ~is_dynamic_term,
-            ~root=editor.root,
-            editor.state.zipper,
-          )
-        : statics;
+      && statics_mode != StaticsDefer;
+    let statics = needs_refresh ? do_init() : statics;
 
     let editor =
       Editor.Update.calculate(
@@ -189,6 +191,12 @@ module Update = {
         dynamics,
         editor,
       );
+
+    /* Editor.calculate may have placed/removed probes (autoprobe target
+     * regeneration, collision cleanup). If so, statics needs to reflect
+     * the new probe_ids so eval_info_map's probe_targets are correct. */
+    let statics =
+      probes_differ(editor.state.zipper) ? do_init() : statics;
 
     /* Refresh `statics.targets` against the post-probe-effects refractors.
      * Cheap O(|probe_ids|) fold; only this field depends on refractors, so

--- a/src/web/app/editors/code/CodeWithStatics.re
+++ b/src/web/app/editors/code/CodeWithStatics.re
@@ -160,11 +160,12 @@ module Update = {
      * sees equal probe_targets and reuses the old `state.probes`, making a
      * newly placed probe show empty until the next force-refresh. */
     let probes_differ = z =>
-      !Language.Id.Map.equal(
-        (==),
-        CachedStatics.probe_ids_of_zipper(z),
-        Language.Id.Map.map(_ => (), statics.targets),
-      );
+      !
+        Language.Id.Map.equal(
+          (==),
+          CachedStatics.probe_ids_of_zipper(z),
+          Language.Id.Map.map(_ => (), statics.targets),
+        );
     let do_init = () =>
       CachedStatics.init(
         ~settings,
@@ -195,8 +196,7 @@ module Update = {
     /* Editor.calculate may have placed/removed probes (autoprobe target
      * regeneration, collision cleanup). If so, statics needs to reflect
      * the new probe_ids so eval_info_map's probe_targets are correct. */
-    let statics =
-      probes_differ(editor.state.zipper) ? do_init() : statics;
+    let statics = probes_differ(editor.state.zipper) ? do_init() : statics;
 
     /* Refresh `statics.targets` against the post-probe-effects refractors.
      * Cheap O(|probe_ids|) fold; only this field depends on refractors, so

--- a/src/web/app/editors/code/CodeWithStatics.re
+++ b/src/web/app/editors/code/CodeWithStatics.re
@@ -151,10 +151,24 @@ module Update = {
       )
       : Model.t => {
     /* Throttle gate: decide whether to do a full statics recompute this
-     * frame. When we reuse, `statics` keeps its ref — CachedSyntax.calculate
-     * then skips the shape pass via phys-eq on info_map/elaborated. */
+     * frame. When we reuse, `statics` keeps its ref so CachedSyntax.calculate
+     * skips the shape pass via phys-eq on info_map/elaborated.
+     *
+     * Bypass the debounce when probe ids changed. Otherwise `with_targets`
+     * updates `statics.targets` from the new refractors but leaves
+     * `info_map`'s per-id `probe_targets` stale, so IncrEval's reuse_check
+     * sees equal probe_targets and reuses the old `state.probes`, making a
+     * newly placed probe show empty until the next force-refresh. */
+    let probes_changed = {
+      let current = CachedStatics.probe_ids_of_zipper(editor.state.zipper);
+      let cached = Language.Id.Map.map(_ => (), statics.targets);
+      !Language.Id.Map.equal((==), current, cached);
+    };
     let statics =
-      statics_mode == StaticsForce || is_edited && statics_mode != StaticsDefer
+      statics_mode == StaticsForce
+      || probes_changed
+      || is_edited
+      && statics_mode != StaticsDefer
         ? CachedStatics.init(
             ~settings,
             ~stitch,

--- a/src/web/app/editors/mode/ExercisesMode.re
+++ b/src/web/app/editors/mode/ExercisesMode.re
@@ -492,7 +492,14 @@ module Update = {
   };
 
   let calculate =
-      (~settings, ~is_edited, ~schedule_action, model: Model.t): Model.t => {
+      (
+        ~settings,
+        ~autoprobe_mode,
+        ~is_edited,
+        ~schedule_action,
+        model: Model.t,
+      )
+      : Model.t => {
     let current_exercise = Model.get_current(model);
     let current_exercise =
       switch (current_exercise) {
@@ -500,6 +507,7 @@ module Update = {
         Model.Code(
           CodeExerciseMode.Update.calculate(
             ~settings,
+            ~autoprobe_mode,
             ~is_edited,
             ~schedule_action=a => schedule_action(Exercise(a)),
             ex,
@@ -509,6 +517,7 @@ module Update = {
         Model.Derivation(
           DerivationExerciseMode.Update.calculate(
             ~settings,
+            ~autoprobe_mode,
             ~is_edited,
             ~schedule_action=a => schedule_action(Derivation(a)),
             ex,
@@ -518,6 +527,7 @@ module Update = {
         Model.Theorem(
           TheoremExerciseMode.Update.calculate(
             ~settings,
+            ~autoprobe_mode,
             ~is_edited,
             ~schedule_action=a => schedule_action(TheoremExercise(a)),
             ex,

--- a/src/web/app/editors/mode/TutorialsMode.re
+++ b/src/web/app/editors/mode/TutorialsMode.re
@@ -282,10 +282,18 @@ module Update = {
     };
   };
   let calculate =
-      (~settings, ~is_edited, ~schedule_action, model: Model.t): Model.t => {
+      (
+        ~settings,
+        ~autoprobe_mode,
+        ~is_edited,
+        ~schedule_action,
+        model: Model.t,
+      )
+      : Model.t => {
     let exercise =
       TutorialMode.Update.calculate(
         ~settings,
+        ~autoprobe_mode,
         ~is_edited,
         ~schedule_action=a => schedule_action(Tutorial(a)),
         List.nth(model.exercises, model.current),

--- a/src/web/view/CodeExerciseMode.re
+++ b/src/web/view/CodeExerciseMode.re
@@ -397,7 +397,14 @@ module Update = {
   };
 
   let calculate =
-      (~settings, ~is_edited, ~schedule_action, model: Model.t): Model.t => {
+      (
+        ~settings,
+        ~autoprobe_mode,
+        ~is_edited,
+        ~schedule_action,
+        model: Model.t,
+      )
+      : Model.t => {
     let statics_mode =
       CodeWithStatics.StaticsDebounce.consume(~is_edited, ~schedule_refresh=() =>
         schedule_action(RefreshStatics)
@@ -427,6 +434,7 @@ module Update = {
           }
           |> CellEditor.Update.calculate(
                ~settings,
+               ~autoprobe_mode,
                ~is_edited,
                ~statics_mode,
                ~queue_worker=Some(queue_worker(pos)),
@@ -479,7 +487,7 @@ module Update = {
       let calculate = (statics, dynamics, ed) =>
         Editor.Update.calculate(
           ~settings,
-          ~autoprobe_mode=false,
+          ~autoprobe_mode,
           statics,
           dynamics,
           ~is_edited,

--- a/src/web/view/DerivationExerciseMode.re
+++ b/src/web/view/DerivationExerciseMode.re
@@ -374,7 +374,14 @@ module Update = {
   };
 
   let calculate =
-      (~settings, ~is_edited, ~schedule_action, model: Model.t): Model.t => {
+      (
+        ~settings,
+        ~autoprobe_mode,
+        ~is_edited,
+        ~schedule_action,
+        model: Model.t,
+      )
+      : Model.t => {
     let stitched_elabs = DerivationExercise.stitch_term(model.editors);
     let worker_request = ref([]);
     let queue_worker = (pos, expr) => {
@@ -408,6 +415,7 @@ module Update = {
           )
           |> CellEditor.Update.calculate(
                ~settings,
+               ~autoprobe_mode,
                ~is_edited,
                ~queue_worker=Some(queue_worker(pos)),
                ~stitch=_ =>
@@ -456,7 +464,7 @@ module Update = {
        statics to take */
     let editors: DerivationExercise.eds = {
       let calculate =
-        Editor.Update.calculate(~settings, ~autoprobe_mode=false, ~is_edited);
+        Editor.Update.calculate(~settings, ~autoprobe_mode, ~is_edited);
       {
         ...model.editors,
         prelude:

--- a/src/web/view/ScratchMode.re
+++ b/src/web/view/ScratchMode.re
@@ -1132,6 +1132,7 @@ module Update = {
       let new_m =
         DerivationExerciseMode.Update.calculate(
           ~settings,
+          ~autoprobe_mode,
           ~is_edited,
           ~schedule_action=a => schedule_action(DrvAction(a)),
           m,

--- a/src/web/view/TheoremExerciseMode.re
+++ b/src/web/view/TheoremExerciseMode.re
@@ -283,7 +283,14 @@ module Update = {
   };
 
   let calculate =
-      (~settings, ~is_edited, ~schedule_action, model: Model.t): Model.t => {
+      (
+        ~settings,
+        ~autoprobe_mode,
+        ~is_edited,
+        ~schedule_action,
+        model: Model.t,
+      )
+      : Model.t => {
     let statics_mode =
       CodeWithStatics.StaticsDebounce.consume(~is_edited, ~schedule_refresh=() =>
         schedule_action(RefreshStatics)
@@ -335,6 +342,7 @@ module Update = {
           model.cells.prelude
           |> CellEditor.Update.calculate(
                ~settings,
+               ~autoprobe_mode,
                ~is_edited,
                ~statics_mode,
                ~queue_worker=Some(queue_worker("prelude")),
@@ -345,6 +353,7 @@ module Update = {
           model.cells.lemmas
           |> CellEditor.Update.calculate(
                ~settings,
+               ~autoprobe_mode,
                ~is_edited,
                ~statics_mode,
                ~queue_worker=Some(queue_worker("lemmas")),
@@ -355,6 +364,7 @@ module Update = {
           model.cells.theorem
           |> CellEditor.Update.calculate(
                ~settings,
+               ~autoprobe_mode,
                ~is_edited,
                ~statics_mode,
                ~queue_worker=Some(queue_worker("theorem")),

--- a/src/web/view/TutorialMode.re
+++ b/src/web/view/TutorialMode.re
@@ -244,7 +244,14 @@ module Update = {
   };
 
   let calculate =
-      (~settings, ~is_edited, ~schedule_action, model: Model.t): Model.t => {
+      (
+        ~settings,
+        ~autoprobe_mode,
+        ~is_edited,
+        ~schedule_action,
+        model: Model.t,
+      )
+      : Model.t => {
     let statics_mode =
       CodeWithStatics.StaticsDebounce.consume(~is_edited, ~schedule_refresh=() =>
         schedule_action(RefreshStatics)
@@ -270,6 +277,7 @@ module Update = {
           }
           |> CellEditor.Update.calculate(
                ~settings,
+               ~autoprobe_mode,
                ~is_edited,
                ~statics_mode,
                ~queue_worker=Some(queue_worker(pos)),
@@ -318,7 +326,7 @@ module Update = {
        statics to take */
     let editors: Tutorial.p('a) = {
       let calculate =
-        Editor.Update.calculate(~settings, ~autoprobe_mode=false, ~is_edited);
+        Editor.Update.calculate(~settings, ~autoprobe_mode, ~is_edited);
       {
         id: model.editors.id,
         title: model.editors.title,


### PR DESCRIPTION
## Summary

Closes #2323.
(manual probes (and autoprobe placements) showed the empty-set indicator until the next edit instead of showing samples immediately.)

## Root cause

`StaticsDebounce` defers statics for 225ms on any `is_edited` action. `CachedStatics.with_targets` refreshes `statics.targets` from the new refractors each cycle but leaves the per-id `probe_targets` in `info_map` stale. The eval_info_map sent to the worker therefore has empty `probe_targets` at the top-level expression, so `IncrEval.reuse_check` sees the cached entry's `prev_probe_targets` match the current (stale) `info.probe_targets` and reuses the old state slice, which does not contain a sample for the newly placed probe.

The probe only updates on the next edit because the debounce timer eventually fires `RefreshStatics` (or another edit forces statics), recomputing `info_map` correctly.

## Fix

`CodeWithStatics.Update.calculate` now compares the zipper's current probe ids to the cached `statics.targets` keys. If they differ, it forces a full `CachedStatics.init` regardless of debounce state. Normal keystrokes (no probe change) still debounce as before.




Closes #2276
