### PR TITLE
Fix stepper crash on filters with metavariable patterns (#2331)

### DIFF
--- a/src/language/proof/ProofHacks.re
+++ b/src/language/proof/ProofHacks.re
@@ -6,6 +6,23 @@ exception Found(Exp.t);
 // Find a subexpression by id (delegates to Exp.find_by_id)
 let find_exp_id = Exp.find_by_id;
 
+// Equality used to compare candidate occurrences against the target. We keep
+// every tolerance of `Equality.ignoring_ascriptions` (alpha-equivalence,
+// parens, ascriptions, function names, hole provenance, …) so the proof/axiom
+// call sites keep locating user-selected subexpressions as before, and flip
+// only `ignore_filters`. `ignore_filters` is precisely what made the
+// `Filter(Residue(...))` bookkeeping wrapper compare equal to the expression
+// underneath it: the search matched the wrapper and stopped before reaching the
+// real target id. With filters no longer transparent, nested same-kind wrappers
+// (`eval ... in pause ... in ...`) likewise stop matching spuriously.
+let structurally_equal: (Exp.t, Exp.t) => bool =
+  Equality.equality({
+    ...Equality.semantic_settings,
+    ignore_ascriptions: true,
+    ignore_filters: false,
+  }).
+    exp;
+
 // Given an expression e1 that appears in e2, count how many
 // times e1 appears with a different id before e1 in e2.
 let exp_idx = (e1: Exp.t, e2: Exp.t) => {
@@ -16,7 +33,7 @@ let exp_idx = (e1: Exp.t, e2: Exp.t) => {
         (cont, exp) =>
           if (Exp.rep_id(exp) == Exp.rep_id(e1)) {
             raise(Found(exp));
-          } else if (Equality.ignoring_ascriptions.exp(exp, e1)) {
+          } else if (structurally_equal(exp, e1)) {
             n := n^ + 1;
             exp;
           } else {
@@ -42,7 +59,7 @@ let nth_exp = (e1: Exp.t, n: int, e2: Exp.t) => {
     Exp.map_term(
       ~f_exp=
         (cont, exp) =>
-          if (Equality.ignoring_ascriptions.exp(exp, e1)) {
+          if (structurally_equal(exp, e1)) {
             if (count^ == n) {
               raise(Found(exp));
             } else {

--- a/test/evaluator/Test_StepperBase.re
+++ b/test/evaluator/Test_StepperBase.re
@@ -260,6 +260,112 @@ let run_step_chain =
   };
 };
 
+let fac_stop_program = {|
+eval $e in
+let fac : Int -> Int =
+  fun n ->
+    if n < 2 then 1 else n * fac(n - 1)
+in
+pause fac($v) in
+fac(3)|};
+
+let stepper_ctx =
+  SemanticCtx.of_ctx_and_env(Builtins.ctx_init(None), Builtins.closure_env);
+
+let calculate_stepper_view = (~fresh, elab, model) =>
+  Web.StepperView.Update.calculate(
+    ~settings=Calc.OldValue(CoreSettings.on),
+    ~ctx=Calc.OldValue(stepper_ctx),
+    fresh ? Calc.NewValue(elab) : Calc.OldValue(elab),
+    model,
+  );
+
+let update_stepper_view = (action, model) =>
+  Web.StepperView.Update.update(
+    ~settings=Web.Settings.Model.init,
+    action,
+    model,
+  ).
+    model;
+
+let missing_available_steps = (m: Web.MissingStep.Model.t) =>
+  m.next_steps
+  |> Calc.get_saved_exc(~print="expected calculated missing step")
+  |> (
+    fun
+    | EvaluatorStep.AutoStep(_) => []
+    | EvaluatorStep.AvailableSteps(steps) => steps
+  );
+
+let action_at_deepest_available =
+    (model: StepperBase.step_model): option(StepperBase.step_action) => {
+  let action_at_current = (model: StepperBase.step_model) =>
+    switch (model.step_kind) {
+    | StepperBase.MissingStep(m) =>
+      switch (missing_available_steps(m)) {
+      | [_, ..._] => Some(StepperBase.StepForward(0))
+      | [] => None
+      }
+    | _ => None
+    };
+
+  let rec loop = (model: StepperBase.step_model) =>
+    switch (model.next_step) {
+    | Some(next) =>
+      switch (loop(next)) {
+      | Some(action) => Some(StepperBase.NextStep(action))
+      | None => action_at_current(model)
+      }
+    | None => action_at_current(model)
+    };
+
+  loop(model);
+};
+
+let apply_deepest_available_action = (model: Web.StepperView.Model.t) =>
+  switch (action_at_deepest_available(model.root)) {
+  | Some(action) => update_stepper_view(action, model)
+  | None => Alcotest.fail("expected an available step")
+  };
+
+let stepper_pure_exp = elab =>
+  elab |> Substitution.in_exp(Builtins.env_init) |> Exp.replace_all_ids;
+
+let step_status_with_stepper_env = exp =>
+  EvaluatorStep.get_status(
+    ~settings=CoreSettings.on,
+    exp,
+    Builtins.closure_env,
+  );
+
+let rec count_available_steps_with_env = (~limit, ~exp, ~count) =>
+  if (limit <= 0) {
+    Alcotest.fail("step count exceeded limit");
+  } else {
+    switch (step_status_with_stepper_env(exp)) {
+    | AutoStep(step) =>
+      switch (EvaluatorStep.take_step(step)) {
+      | None => count
+      | Some(exp') =>
+        count_available_steps_with_env(~limit=limit - 1, ~exp=exp', ~count)
+      }
+    | AvailableSteps(steps) =>
+      switch (steps) {
+      | [] => count
+      | [step, ..._] =>
+        switch (EvaluatorStep.take_step(step)) {
+        | None => count
+        | Some(exp') =>
+          count_available_steps_with_env(
+            ~limit=limit - 1,
+            ~exp=exp',
+            ~count=count + 1,
+          )
+        }
+      }
+    };
+  };
+
 let tests = (
   "StepperBase",
   [
@@ -280,6 +386,41 @@ let tests = (
           exp,
           Calc.get_value(final_exp),
         );
+      },
+    ),
+    test_case(
+      "stepping a recursive filter does not crash (#2331)",
+      `Quick,
+      () => {
+        let elab = fac_stop_program |> parse_exp |> elaborate;
+        // Regression guard for the infinite-loop facet: pure evaluation of the
+        // filtered program terminates (the helper raises if it exceeds limit).
+        let pure_count =
+          count_available_steps_with_env(
+            ~limit=1000,
+            ~exp=stepper_pure_exp(elab),
+            ~count=0,
+          );
+        check(bool, "pure evaluation terminates", true, pure_count > 0);
+        // Regression guard for #2331: stepping the filter in the stepper view
+        // used to raise `exp_idx: e1 not found in e2` from `EvalObj.persist`,
+        // crashing the editor. Taking several steps must not throw.
+        let model =
+          Web.StepperView.Model.init
+          |> calculate_stepper_view(~fresh=true, elab);
+        let model =
+          model
+          |> apply_deepest_available_action
+          |> calculate_stepper_view(~fresh=false, elab);
+        let model =
+          model
+          |> apply_deepest_available_action
+          |> calculate_stepper_view(~fresh=false, elab);
+        let _model =
+          model
+          |> apply_deepest_available_action
+          |> calculate_stepper_view(~fresh=false, elab);
+        check(bool, "stepper did not crash", true, true);
       },
     ),
     // ============================================================


### PR DESCRIPTION
TL;DR: Don't skip over filters when calculating `exp_idx`. Not sure how turning off `ignore_filtres` affect the proof side of the stepper.

@Negabinary 