### PR TITLE
fix: bump conf-pkg-config lock pin to 5 to unbreak CI

### DIFF
--- a/hazel.opam.locked
+++ b/hazel.opam.locked
@@ -51,7 +51,7 @@ depends: [
   "conf-gmp-powm-sec" {= "4"}
   "conf-libffi" {= "2.0.0"}
   "conf-libssl" {= "4"}
-  "conf-pkg-config" {= "4"}
+  "conf-pkg-config" {= "5"}
   "conf-zlib" {= "1"}
   "core" {= "v0.16.2"}
   "core_bench" {= "v0.16.0"}


### PR DESCRIPTION
## Problem

All CI runs are failing at `opam install . --deps-only --with-test --locked` with:

```
[ERROR] Package conflict!
  * No agreement on the version of conf-pkg-config:
    - deps-of-hazel → conf-libssl >= 4 → conf-pkg-config >= 5
    - deps-of-hazel → conf-pkg-config = 4
```

ocaml/opam-repository#29976 updated existing `conf-*` package versions in place — `conf-libssl.4`, `conf-libffi.2.0.0`, and `conf-zlib.1` now require `conf-pkg-config >= 5`. Since our lock file pins `conf-pkg-config = 4`, the locked solve became unsatisfiable. (`conf-*` packages are virtual probes for system libraries, so upstream edits them retroactively rather than cutting new versions.)

## Fix

Bump the lock pin `conf-pkg-config` 4 → 5. Version 5 only changed Windows (msys2/cygwin) dependencies relative to 4, so nothing else in the lock file needs to move for Linux CI or macOS.

Verified locally that the locked solve succeeds with both the default solver and `builtin-0install` (the solver CI uses).

Also unblocks the scheduled `bot-update-deps` runs, which were failing for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)