### PR TITLE
Add Debug sidebar panel for cursor Info inspection

### DIFF
--- a/src/web/Settings.re
+++ b/src/web/Settings.re
@@ -11,6 +11,7 @@ module Model = {
     instructor_mode: bool,
     benchmark: bool,
     show_log_panel: bool,
+    show_debug_panel: bool,
     explainThis: ExplainThisModel.Settings.t,
     sidebar: SidebarModel.Settings.t,
     /* Auto probe: automatically place a multi probe on the body of
@@ -57,6 +58,7 @@ module Model = {
     instructor_mode: false,
     benchmark: false,
     show_log_panel: false,
+    show_debug_panel: false,
     explainThis: {
       show: true,
       show_feedback: false,
@@ -70,6 +72,7 @@ module Model = {
         flat: false,
         expanded: [],
       },
+      debug_show_raw: false,
     },
     autoprobe_mode: false,
     agent_globals: AgentGlobals.init(),
@@ -148,6 +151,7 @@ module Update = {
     | ContextInspector
     | InstructorMode
     | ShowLogPanel
+    | ShowDebugPanel
     | Evaluation(evaluation)
     | Sidebar(SidebarModel.Settings.action)
     | ExplainThis(ExplainThisModel.Settings.action)
@@ -352,6 +356,13 @@ module Update = {
               ),
           },
         }
+      | Sidebar(ToggleDebugRaw) => {
+          ...settings,
+          sidebar: {
+            ...settings.sidebar,
+            debug_show_raw: !settings.sidebar.debug_show_raw,
+          },
+        }
       | ExplainThis(ToggleShowFeedback) => {
           ...settings,
           explainThis: {
@@ -381,6 +392,10 @@ module Update = {
           ...settings,
           show_log_panel:
             !settings.show_log_panel && ExerciseSettings.show_instructor,
+        }
+      | ShowDebugPanel => {
+          ...settings,
+          show_debug_panel: !settings.show_debug_panel,
         }
       | Benchmark => {
           ...settings,

--- a/src/web/Settings.re
+++ b/src/web/Settings.re
@@ -75,6 +75,7 @@ module Model = {
         expanded: [],
       },
       debug_show_raw: false,
+      debug_collapsed: [],
     },
     autoprobe_mode: false,
     agent_globals: AgentGlobals.init(),
@@ -384,6 +385,14 @@ module Update = {
             ...settings.sidebar,
             debug_show_raw: !settings.sidebar.debug_show_raw,
           },
+        }
+      | Sidebar(ToggleDebugCollapsed(key)) => {
+          ...settings,
+          sidebar:
+            SidebarModel.Settings.toggle_debug_collapsed(
+              key,
+              settings.sidebar,
+            ),
         }
       | ExplainThis(ToggleShowFeedback) => {
           ...settings,

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -487,6 +487,12 @@ module Selection = {
          mk(
            ~section="Settings",
            ~mdIcon="tune",
+           ~action=inject(Globals(Set(ShowDebugPanel))),
+           "Toggle Debug Sidebar",
+         ),
+         mk(
+           ~section="Settings",
+           ~mdIcon="tune",
            ~action=inject(Globals(Set(Dynamics))),
            "Toggle Dynamics",
          ),

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -24,6 +24,28 @@ let code_settings: Haz3lcore.ExpToSegment.Settings.t = {
   project_tables: false,
 };
 
+/* Same as code_settings but lets the pretty-printer break across lines for
+   terms/types that naturally span multiple lines (let/case bodies, large
+   records, ...). Used for the standalone term and type fields; context rows
+   keep code_settings so each `name : type` row stays on one line. */
+let code_settings_ml: Haz3lcore.ExpToSegment.Settings.t = {
+  ...code_settings,
+  inline: false,
+};
+
+/* Pretty-print a type/term to the same text the rendered view displays, by
+   printing the segment the code view is built from. Used so the copy button
+   matches what's on screen in rendered mode (raw mode copies `show`). */
+let typ_to_text = (~settings, typ: Typ.t): string =>
+  Haz3lcore.Printer.of_segment(
+    Haz3lcore.ExpToSegment.typ_to_segment(~settings, typ),
+  );
+
+let any_to_text = (~settings, any: Any.t): string =>
+  Haz3lcore.Printer.of_segment(
+    Haz3lcore.ExpToSegment.any_to_segment(~settings, any),
+  );
+
 /* Copies the raw `show` text to the clipboard. The payload is a thunk so the
    (potentially expensive) `show` only runs on click, not when the field is
    built. Revealed on field hover via CSS so it doesn't clutter the list. */
@@ -143,15 +165,17 @@ let field_typ = (~globals, ~raw, label: string, typ: Typ.t): Node.t =>
   raw
     ? field_str(label, Typ.show(typ))
     : field_node(
-        ~copy=Some(() => Typ.show(typ)),
+        ~copy=Some(() => typ_to_text(~settings=code_settings_ml, typ)),
         label,
-        CodeViewable.view_typ(~globals, ~settings=code_settings, typ),
+        CodeViewable.view_typ(~globals, ~settings=code_settings_ml, typ),
       );
 
 let field_any = (~globals, ~raw, label: string, any: Any.t): Node.t =>
   field_collapsible(
     ~globals,
-    ~copy=() => Any.show(any),
+    ~copy=
+      () =>
+        raw ? Any.show(any) : any_to_text(~settings=code_settings_ml, any),
     ~body=
       () =>
         raw
@@ -162,7 +186,11 @@ let field_any = (~globals, ~raw, label: string, any: Any.t): Node.t =>
           : div(
               ~attrs=[clss(["debug-field-value"])],
               [
-                CodeViewable.view_any(~globals, ~settings=code_settings, any),
+                CodeViewable.view_any(
+                  ~globals,
+                  ~settings=code_settings_ml,
+                  any,
+                ),
               ],
             ),
     label,
@@ -238,10 +266,53 @@ let co_ctx_view_rendered = (~globals, co_ctx: CoCtx.t): Node.t =>
     )
   };
 
+/* Text analogs of the rendered ctx/co_ctx layouts, so the copy button matches
+   what's displayed in rendered mode (raw mode copies `show`). */
+let ctx_entry_text = (entry: Ctx.entry): string =>
+  switch (entry) {
+  | VarEntry({name, typ, _}) =>
+    name ++ " : " ++ typ_to_text(~settings=code_settings, typ)
+  | ConstructorEntry({name, typ, _}) =>
+    "ctor " ++ name ++ " : " ++ typ_to_text(~settings=code_settings, typ)
+  | TVarEntry({name, kind: Singleton(ty), _}) =>
+    "type " ++ name ++ " = " ++ typ_to_text(~settings=code_settings, ty)
+  | TVarEntry({name, kind: Abstract, _}) => "type " ++ name
+  | LivelitEntry(_) => "livelit"
+  };
+
+let ctx_to_text = (ctx: Ctx.t): string =>
+  switch (ctx.entries) {
+  | [] => "(empty)"
+  | entries => String.concat("\n", List.map(ctx_entry_text, entries))
+  };
+
+let co_ctx_to_text = (co_ctx: CoCtx.t): string =>
+  switch (co_ctx) {
+  | [] => "(empty)"
+  | _ =>
+    String.concat(
+      "\n",
+      List.map(
+        ((name, entries)) =>
+          name
+          ++ String.concat(
+               "",
+               List.map(
+                 (e: CoCtx.entry) =>
+                   "\n  : "
+                   ++ typ_to_text(~settings=code_settings, e.expected_ty),
+                 entries,
+               ),
+             ),
+        co_ctx,
+      ),
+    )
+  };
+
 let field_ctx = (~globals, ~raw, label: string, ctx: Ctx.t): Node.t =>
   field_collapsible(
     ~globals,
-    ~copy=() => Ctx.show(ctx),
+    ~copy=() => raw ? Ctx.show(ctx) : ctx_to_text(ctx),
     ~body=
       () =>
         raw
@@ -259,7 +330,7 @@ let field_ctx = (~globals, ~raw, label: string, ctx: Ctx.t): Node.t =>
 let field_co_ctx = (~globals, ~raw, label: string, co_ctx: CoCtx.t): Node.t =>
   field_collapsible(
     ~globals,
-    ~copy=() => CoCtx.show(co_ctx),
+    ~copy=() => raw ? CoCtx.show(co_ctx) : co_ctx_to_text(co_ctx),
     ~body=
       () =>
         raw

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -63,6 +63,84 @@ let field_any = (~globals, ~raw, label: string, any: Any.t): Node.t =>
 
 let id_str = (id: Id.t): string => Id.to_string(id);
 
+let typ_node = (~globals, typ: Typ.t): Node.t =>
+  CodeViewable.view_typ(~globals, ~settings=code_settings, typ);
+
+let ctx_row = (label: Node.t, body: option(Node.t)): Node.t =>
+  div(
+    ~attrs=[clss(["debug-ctx-row"])],
+    [div(~attrs=[clss(["debug-ctx-name"])], [label])]
+    @ (
+      switch (body) {
+      | None => []
+      | Some(b) => [div(~attrs=[clss(["debug-ctx-body"])], [b])]
+      }
+    ),
+  );
+
+let ctx_entry_node = (~globals, entry: Ctx.entry): Node.t =>
+  switch (entry) {
+  | VarEntry({name, typ, _}) =>
+    ctx_row(text(name ++ " :"), Some(typ_node(~globals, typ)))
+  | ConstructorEntry({name, typ, _}) =>
+    ctx_row(text("ctor " ++ name ++ " :"), Some(typ_node(~globals, typ)))
+  | TVarEntry({name, kind: Singleton(ty), _}) =>
+    ctx_row(text("type " ++ name ++ " ="), Some(typ_node(~globals, ty)))
+  | TVarEntry({name, kind: Abstract, _}) =>
+    ctx_row(text("type " ++ name), None)
+  | LivelitEntry(_) => ctx_row(text("livelit"), None)
+  };
+
+let ctx_view_rendered = (~globals, ctx: Ctx.t): Node.t =>
+  switch (ctx.entries) {
+  | [] => div(~attrs=[clss(["debug-ctx-empty"])], [text("(empty)")])
+  | entries =>
+    div(
+      ~attrs=[clss(["debug-ctx"])],
+      List.map(ctx_entry_node(~globals), entries),
+    )
+  };
+
+let co_ctx_entry_node =
+    (~globals, name: Var.t, entries: list(CoCtx.entry)): Node.t => {
+  let uses =
+    List.map(
+      (e: CoCtx.entry) =>
+        div(
+          ~attrs=[clss(["debug-coctx-use"])],
+          [text(": "), typ_node(~globals, e.expected_ty)],
+        ),
+      entries,
+    );
+  div(
+    ~attrs=[clss(["debug-coctx-var"])],
+    [div(~attrs=[clss(["debug-ctx-name"])], [text(name)])] @ uses,
+  );
+};
+
+let co_ctx_view_rendered = (~globals, co_ctx: CoCtx.t): Node.t =>
+  switch (co_ctx) {
+  | [] => div(~attrs=[clss(["debug-ctx-empty"])], [text("(empty)")])
+  | _ =>
+    div(
+      ~attrs=[clss(["debug-coctx"])],
+      List.map(
+        ((name, entries)) => co_ctx_entry_node(~globals, name, entries),
+        co_ctx,
+      ),
+    )
+  };
+
+let field_ctx = (~globals, ~raw, label: string, ctx: Ctx.t): Node.t =>
+  raw
+    ? field_str(label, Ctx.show(ctx))
+    : field_node(label, ctx_view_rendered(~globals, ctx));
+
+let field_co_ctx = (~globals, ~raw, label: string, co_ctx: CoCtx.t): Node.t =>
+  raw
+    ? field_str(label, CoCtx.show(co_ctx))
+    : field_node(label, co_ctx_view_rendered(~globals, co_ctx));
+
 let ancestors_str = (ancestors: Info.ancestors): string =>
   switch (ancestors) {
   | [] => "[]"
@@ -110,7 +188,8 @@ let exp_view = (~globals, ~raw, info: Info.exp): list(Node.t) => [
   field_typ(~globals, ~raw, "ty (post-fix)", info.ty),
   field_str("marks", marks_str(info.marks)),
   field_str("warnings", warnings_str(info.warnings)),
-  field_str("co_ctx", CoCtx.show(info.co_ctx)),
+  field_ctx(~globals, ~raw, "ctx", info.ctx),
+  field_co_ctx(~globals, ~raw, "co_ctx", info.co_ctx),
   field_str("label_inference", label_inference_str(info.label_inference)),
   field_str(
     "inferred_label",
@@ -135,7 +214,8 @@ let pat_view = (~globals, ~raw, info: Info.pat): list(Node.t) => [
   field_typ(~globals, ~raw, "ty (post-fix)", info.ty),
   field_str("marks", marks_str(info.marks)),
   field_str("warnings", warnings_str(info.warnings)),
-  field_str("co_ctx", CoCtx.show(info.co_ctx)),
+  field_ctx(~globals, ~raw, "ctx", info.ctx),
+  field_co_ctx(~globals, ~raw, "co_ctx", info.co_ctx),
   field_str("constraint_", Coverage.Constraint.show(info.constraint_)),
   field_str("label_inference", label_inference_str(info.label_inference)),
   field_str(
@@ -154,6 +234,7 @@ let typ_view = (~globals, ~raw, info: Info.typ): list(Node.t) => [
   field_str("expects", TypExpectation.show(info.expects)),
   field_str("marks", marks_str(info.marks)),
   field_str("warnings", warnings_str(info.warnings)),
+  field_ctx(~globals, ~raw, "ctx", info.ctx),
 ];
 
 let tpat_view = (~globals, ~raw, info: Info.tpat): list(Node.t) => [
@@ -164,6 +245,7 @@ let tpat_view = (~globals, ~raw, info: Info.tpat): list(Node.t) => [
   field_any(~globals, ~raw, "user_term", TPat(info.user_term)),
   field_str("marks", marks_str(info.marks)),
   field_str("warnings", warnings_str(info.warnings)),
+  field_ctx(~globals, ~raw, "ctx", info.ctx),
 ];
 
 let secondary_view = (s: Info.secondary): list(Node.t) => [
@@ -173,28 +255,31 @@ let secondary_view = (s: Info.secondary): list(Node.t) => [
   field_str("sort", Sort.show(s.sort)),
 ];
 
-let mod_view = (m: Info.mod_): list(Node.t) => [
+let mod_view = (~globals, ~raw, m: Info.mod_): list(Node.t) => [
   section_title("InfoMod"),
   field_str("id", id_str(m.id)),
   field_str("cls", Cls.show(m.cls)),
   field_str("sort", Sort.show(m.sort)),
   field_str("ancestors", ancestors_str(m.ancestors)),
+  field_ctx(~globals, ~raw, "ctx", m.ctx),
 ];
 
-let sig_view = (s: Info.sig_): list(Node.t) => [
+let sig_view = (~globals, ~raw, s: Info.sig_): list(Node.t) => [
   section_title("InfoSig"),
   field_str("id", id_str(s.id)),
   field_str("cls", Cls.show(s.cls)),
   field_str("sort", Sort.show(s.sort)),
   field_str("ancestors", ancestors_str(s.ancestors)),
+  field_ctx(~globals, ~raw, "ctx", s.ctx),
 ];
 
-let mpat_view = (m: Info.mpat): list(Node.t) => [
+let mpat_view = (~globals, ~raw, m: Info.mpat): list(Node.t) => [
   section_title("InfoMPat"),
   field_str("id", id_str(m.id)),
   field_str("cls", Cls.show(m.cls)),
   field_str("sort", Sort.show(m.sort)),
   field_str("ancestors", ancestors_str(m.ancestors)),
+  field_ctx(~globals, ~raw, "ctx", m.ctx),
 ];
 
 let drv_view = (_: DrvInfo.t): list(Node.t) => [
@@ -208,9 +293,9 @@ let info_view = (~globals, ~raw, ci: Info.t): list(Node.t) =>
   | InfoPat(i) => pat_view(~globals, ~raw, i)
   | InfoTyp(i) => typ_view(~globals, ~raw, i)
   | InfoTPat(i) => tpat_view(~globals, ~raw, i)
-  | InfoMod(m) => mod_view(m)
-  | InfoSig(s) => sig_view(s)
-  | InfoMPat(m) => mpat_view(m)
+  | InfoMod(m) => mod_view(~globals, ~raw, m)
+  | InfoSig(s) => sig_view(~globals, ~raw, s)
+  | InfoMPat(m) => mpat_view(~globals, ~raw, m)
   | Secondary(s) => secondary_view(s)
   | InfoDrv(d) => drv_view(d)
   };

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -33,29 +33,34 @@ let code_settings_ml: Haz3lcore.ExpToSegment.Settings.t = {
   inline: false,
 };
 
-/* Pretty-print a type/term to the same text the rendered view displays, by
-   printing the segment the code view is built from. Used so the copy button
-   matches what's on screen in rendered mode (raw mode copies `show`). */
+/* Pretty-print a type to the text the rendered view displays, with empty
+   (convex) holes shown explicitly as `?`. Used by the ctx/co_ctx copy text,
+   which has no single pasteable segment to round-trip. */
 let typ_to_text = (~settings, typ: Typ.t): string =>
   Haz3lcore.Printer.of_segment(
+    ~holes="?",
     Haz3lcore.ExpToSegment.typ_to_segment(~settings, typ),
   );
 
-let any_to_text = (~settings, any: Any.t): string =>
-  Haz3lcore.Printer.of_segment(
-    Haz3lcore.ExpToSegment.any_to_segment(~settings, any),
-  );
+/* Copy a rendered term/type the way the editor does: the printed text shows
+   empty holes explicitly as `?`, and the source segment is cached against that
+   text so pasting back into Hazel restores the real (implicit) holes, while
+   pasting into a plain text editor yields the `?` text. */
+let copy_segment = (segment: Haz3lcore.Segment.t): unit => {
+  let str = Haz3lcore.Printer.of_segment(~holes="?", segment);
+  Haz3lcore.Parser.set_segment_cache(Some(segment), str);
+  Util.JsUtil.write_clipboard(str);
+};
 
-/* Copies the raw `show` text to the clipboard. The payload is a thunk so the
-   (potentially expensive) `show` only runs on click, not when the field is
-   built. Revealed on field hover via CSS so it doesn't clutter the list. */
-let copy_button = (payload: unit => string): Node.t =>
+/* Copy button; `on_copy` runs only on click (not when the field is built) and
+   is revealed on field hover via CSS so it doesn't clutter the list. */
+let copy_button = (on_copy: unit => unit): Node.t =>
   span(
     ~attrs=[
       clss(["debug-copy-button"]),
-      Attr.title("Copy raw value to clipboard"),
+      Attr.title("Copy to clipboard"),
       Attr.on_click(_ => {
-        Util.JsUtil.write_clipboard(payload());
+        on_copy();
         Virtual_dom.Vdom.Effect.Ignore;
       }),
     ],
@@ -67,7 +72,7 @@ let copy_button = (payload: unit => string): Node.t =>
 let label_row =
     (
       ~chevron: list(Node.t)=[],
-      ~copy: option(unit => string)=None,
+      ~copy: option(unit => unit)=None,
       label: string,
     )
     : Node.t =>
@@ -112,7 +117,7 @@ let section =
 };
 
 let field_node =
-    (~copy: option(unit => string)=None, label: string, body: Node.t): Node.t =>
+    (~copy: option(unit => unit)=None, label: string, body: Node.t): Node.t =>
   div(
     ~attrs=[clss(["debug-field"])],
     [
@@ -125,7 +130,7 @@ let field_str = (label: string, body: string): Node.t =>
   div(
     ~attrs=[clss(["debug-field"])],
     [
-      label_row(~copy=Some(() => body), label),
+      label_row(~copy=Some(() => Util.JsUtil.write_clipboard(body)), label),
       pre(~attrs=[clss(["debug-field-value", "raw"])], [text(body)]),
     ],
   );
@@ -137,7 +142,7 @@ let field_str = (label: string, body: string): Node.t =>
 let field_collapsible =
     (
       ~globals: Globals.t,
-      ~copy: unit => string,
+      ~copy: unit => unit,
       ~body: unit => Node.t,
       label: string,
     )
@@ -162,20 +167,31 @@ let field_collapsible =
 };
 
 let field_typ = (~globals, ~raw, label: string, typ: Typ.t): Node.t =>
-  raw
-    ? field_str(label, Typ.show(typ))
-    : field_node(
-        ~copy=Some(() => typ_to_text(~settings=code_settings_ml, typ)),
-        label,
-        CodeViewable.view_typ(~globals, ~settings=code_settings_ml, typ),
-      );
+  if (raw) {
+    field_str(label, Typ.show(typ));
+  } else {
+    let seg =
+      Haz3lcore.ExpToSegment.typ_to_segment(~settings=code_settings_ml, typ);
+    field_node(
+      ~copy=Some(() => copy_segment(seg)),
+      label,
+      CodeViewable.view_segment(~globals, seg),
+    );
+  };
 
 let field_any = (~globals, ~raw, label: string, any: Any.t): Node.t =>
   field_collapsible(
     ~globals,
     ~copy=
       () =>
-        raw ? Any.show(any) : any_to_text(~settings=code_settings_ml, any),
+        raw
+          ? Util.JsUtil.write_clipboard(Any.show(any))
+          : copy_segment(
+              Haz3lcore.ExpToSegment.any_to_segment(
+                ~settings=code_settings_ml,
+                any,
+              ),
+            ),
     ~body=
       () =>
         raw
@@ -312,7 +328,9 @@ let co_ctx_to_text = (co_ctx: CoCtx.t): string =>
 let field_ctx = (~globals, ~raw, label: string, ctx: Ctx.t): Node.t =>
   field_collapsible(
     ~globals,
-    ~copy=() => raw ? Ctx.show(ctx) : ctx_to_text(ctx),
+    ~copy=
+      () =>
+        Util.JsUtil.write_clipboard(raw ? Ctx.show(ctx) : ctx_to_text(ctx)),
     ~body=
       () =>
         raw
@@ -330,7 +348,11 @@ let field_ctx = (~globals, ~raw, label: string, ctx: Ctx.t): Node.t =>
 let field_co_ctx = (~globals, ~raw, label: string, co_ctx: CoCtx.t): Node.t =>
   field_collapsible(
     ~globals,
-    ~copy=() => raw ? CoCtx.show(co_ctx) : co_ctx_to_text(co_ctx),
+    ~copy=
+      () =>
+        Util.JsUtil.write_clipboard(
+          raw ? CoCtx.show(co_ctx) : co_ctx_to_text(co_ctx),
+        ),
     ~body=
       () =>
         raw

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -24,14 +24,77 @@ let code_settings: Haz3lcore.ExpToSegment.Settings.t = {
   project_tables: false,
 };
 
-let section_title = (title: string): Node.t =>
-  div(~attrs=[clss(["debug-section-title"])], [text(title)]);
+/* Copies the raw `show` text to the clipboard. The payload is a thunk so the
+   (potentially expensive) `show` only runs on click, not when the field is
+   built. Revealed on field hover via CSS so it doesn't clutter the list. */
+let copy_button = (payload: unit => string): Node.t =>
+  span(
+    ~attrs=[
+      clss(["debug-copy-button"]),
+      Attr.title("Copy raw value to clipboard"),
+      Attr.on_click(_ => {
+        Util.JsUtil.write_clipboard(payload());
+        Virtual_dom.Vdom.Effect.Ignore;
+      }),
+    ],
+    [text({|⧉|})],
+  );
 
-let field_node = (label: string, body: Node.t): Node.t =>
+/* Label row: optional collapse chevron, the field name, and (when `copy` is
+   given) a copy button carrying the raw `show` text. */
+let label_row =
+    (
+      ~chevron: list(Node.t)=[],
+      ~copy: option(unit => string)=None,
+      label: string,
+    )
+    : Node.t =>
+  div(
+    ~attrs=[clss(["debug-field-label"])],
+    chevron
+    @ [span(~attrs=[clss(["debug-field-name"])], [text(label)])]
+    @ (
+      switch (copy) {
+      | None => []
+      | Some(f) => [copy_button(f)]
+      }
+    ),
+  );
+
+/* Collapsible section header; clicking toggles visibility of `fields`. The
+   fields are a thunk so a collapsed section builds none of them — and since
+   the panel only ever renders the single section under the cursor, that is
+   the dominant cost. Collapse state is keyed by the section title. */
+let section =
+    (~globals: Globals.t, title: string, fields: unit => list(Node.t))
+    : list(Node.t) => {
+  let collapsed =
+    SidebarModel.Settings.is_debug_collapsed(title, globals.settings.sidebar);
+  let title_node =
+    div(
+      ~attrs=[
+        clss(["debug-section-title"]),
+        Attr.on_click(_ =>
+          globals.inject_global(Set(Sidebar(ToggleDebugCollapsed(title))))
+        ),
+      ],
+      [
+        span(
+          ~attrs=[clss(["debug-section-chevron"])],
+          [text(collapsed ? {|▸|} : {|▾|})],
+        ),
+        text(title),
+      ],
+    );
+  [title_node] @ (collapsed ? [] : fields());
+};
+
+let field_node =
+    (~copy: option(unit => string)=None, label: string, body: Node.t): Node.t =>
   div(
     ~attrs=[clss(["debug-field"])],
     [
-      div(~attrs=[clss(["debug-field-label"])], [text(label)]),
+      label_row(~copy, label),
       div(~attrs=[clss(["debug-field-value"])], [body]),
     ],
   );
@@ -40,26 +103,70 @@ let field_str = (label: string, body: string): Node.t =>
   div(
     ~attrs=[clss(["debug-field"])],
     [
-      div(~attrs=[clss(["debug-field-label"])], [text(label)]),
+      label_row(~copy=Some(() => body), label),
       pre(~attrs=[clss(["debug-field-value", "raw"])], [text(body)]),
     ],
   );
+
+/* A collapsible field for heavy values (contexts, term dumps). The body is a
+   thunk so a collapsed field renders nothing below its label, and `copy` is a
+   thunk so the raw `show` only runs on click. Collapse state is keyed by the
+   field label. */
+let field_collapsible =
+    (
+      ~globals: Globals.t,
+      ~copy: unit => string,
+      ~body: unit => Node.t,
+      label: string,
+    )
+    : Node.t => {
+  let collapsed =
+    SidebarModel.Settings.is_debug_collapsed(label, globals.settings.sidebar);
+  let chevron =
+    span(
+      ~attrs=[
+        clss(["debug-field-chevron"]),
+        Attr.on_click(_ =>
+          globals.inject_global(Set(Sidebar(ToggleDebugCollapsed(label))))
+        ),
+      ],
+      [text(collapsed ? {|▸|} : {|▾|})],
+    );
+  div(
+    ~attrs=[clss(["debug-field"])],
+    [label_row(~chevron=[chevron], ~copy=Some(copy), label)]
+    @ (collapsed ? [] : [body()]),
+  );
+};
 
 let field_typ = (~globals, ~raw, label: string, typ: Typ.t): Node.t =>
   raw
     ? field_str(label, Typ.show(typ))
     : field_node(
+        ~copy=Some(() => Typ.show(typ)),
         label,
         CodeViewable.view_typ(~globals, ~settings=code_settings, typ),
       );
 
 let field_any = (~globals, ~raw, label: string, any: Any.t): Node.t =>
-  raw
-    ? field_str(label, Any.show(any))
-    : field_node(
-        label,
-        CodeViewable.view_any(~globals, ~settings=code_settings, any),
-      );
+  field_collapsible(
+    ~globals,
+    ~copy=() => Any.show(any),
+    ~body=
+      () =>
+        raw
+          ? pre(
+              ~attrs=[clss(["debug-field-value", "raw"])],
+              [text(Any.show(any))],
+            )
+          : div(
+              ~attrs=[clss(["debug-field-value"])],
+              [
+                CodeViewable.view_any(~globals, ~settings=code_settings, any),
+              ],
+            ),
+    label,
+  );
 
 let id_str = (id: Id.t): string => Id.to_string(id);
 
@@ -132,14 +239,40 @@ let co_ctx_view_rendered = (~globals, co_ctx: CoCtx.t): Node.t =>
   };
 
 let field_ctx = (~globals, ~raw, label: string, ctx: Ctx.t): Node.t =>
-  raw
-    ? field_str(label, Ctx.show(ctx))
-    : field_node(label, ctx_view_rendered(~globals, ctx));
+  field_collapsible(
+    ~globals,
+    ~copy=() => Ctx.show(ctx),
+    ~body=
+      () =>
+        raw
+          ? pre(
+              ~attrs=[clss(["debug-field-value", "raw"])],
+              [text(Ctx.show(ctx))],
+            )
+          : div(
+              ~attrs=[clss(["debug-field-value"])],
+              [ctx_view_rendered(~globals, ctx)],
+            ),
+    label,
+  );
 
 let field_co_ctx = (~globals, ~raw, label: string, co_ctx: CoCtx.t): Node.t =>
-  raw
-    ? field_str(label, CoCtx.show(co_ctx))
-    : field_node(label, co_ctx_view_rendered(~globals, co_ctx));
+  field_collapsible(
+    ~globals,
+    ~copy=() => CoCtx.show(co_ctx),
+    ~body=
+      () =>
+        raw
+          ? pre(
+              ~attrs=[clss(["debug-field-value", "raw"])],
+              [text(CoCtx.show(co_ctx))],
+            )
+          : div(
+              ~attrs=[clss(["debug-field-value"])],
+              [co_ctx_view_rendered(~globals, co_ctx)],
+            ),
+    label,
+  );
 
 let ancestors_str = (ancestors: Info.ancestors): string =>
   switch (ancestors) {
@@ -176,116 +309,136 @@ let label_inference_str = (li: option(Info.label_inference(_))): string =>
     )
   };
 
-let exp_view = (~globals, ~raw, info: Info.exp): list(Node.t) => [
-  section_title("InfoExp"),
-  field_str("id", id_str(Exp.rep_id(info.user_term))),
-  field_str("cls", Cls.show(info.cls)),
-  field_str("ancestors", ancestors_str(info.ancestors)),
-  field_any(~globals, ~raw, "user_term", Exp(info.user_term)),
-  field_any(~globals, ~raw, "elab_term", Exp(info.elab_term)),
-  field_typ(~globals, ~raw, "ana", info.ana),
-  field_typ(~globals, ~raw, "elab_syn_ty", info.elab_syn_ty),
-  field_typ(~globals, ~raw, "ty (post-fix)", info.ty),
-  field_str("marks", marks_str(info.marks)),
-  field_str("warnings", warnings_str(info.warnings)),
-  field_ctx(~globals, ~raw, "ctx", info.ctx),
-  field_co_ctx(~globals, ~raw, "co_ctx", info.co_ctx),
-  field_str("label_inference", label_inference_str(info.label_inference)),
-  field_str(
-    "inferred_label",
-    Option.value(info.inferred_label, ~default="None"),
-  ),
-  field_str("label_sort", string_of_bool(info.label_sort)),
-  field_str(
-    "dot_labels",
-    "[" ++ String.concat(", ", info.dot_labels) ++ "]",
-  ),
-];
+let exp_view = (~globals, ~raw, info: Info.exp): list(Node.t) =>
+  section(~globals, "InfoExp", () =>
+    [
+      field_str("id", id_str(Exp.rep_id(info.user_term))),
+      field_str("cls", Cls.show(info.cls)),
+      field_str("ancestors", ancestors_str(info.ancestors)),
+      field_any(~globals, ~raw, "user_term", Exp(info.user_term)),
+      field_any(~globals, ~raw, "elab_term", Exp(info.elab_term)),
+      field_typ(~globals, ~raw, "ana", info.ana),
+      field_typ(~globals, ~raw, "elab_syn_ty", info.elab_syn_ty),
+      field_typ(~globals, ~raw, "ty (post-fix)", info.ty),
+      field_str("marks", marks_str(info.marks)),
+      field_str("warnings", warnings_str(info.warnings)),
+      field_ctx(~globals, ~raw, "ctx", info.ctx),
+      field_co_ctx(~globals, ~raw, "co_ctx", info.co_ctx),
+      field_str(
+        "label_inference",
+        label_inference_str(info.label_inference),
+      ),
+      field_str(
+        "inferred_label",
+        Option.value(info.inferred_label, ~default="None"),
+      ),
+      field_str("label_sort", string_of_bool(info.label_sort)),
+      field_str(
+        "dot_labels",
+        "[" ++ String.concat(", ", info.dot_labels) ++ "]",
+      ),
+    ]
+  );
 
-let pat_view = (~globals, ~raw, info: Info.pat): list(Node.t) => [
-  section_title("InfoPat"),
-  field_str("id", id_str(Pat.rep_id(info.user_term))),
-  field_str("cls", Cls.show(info.cls)),
-  field_str("ancestors", ancestors_str(info.ancestors)),
-  field_any(~globals, ~raw, "user_term", Pat(info.user_term)),
-  field_any(~globals, ~raw, "elab_term", Pat(info.elab_term)),
-  field_typ(~globals, ~raw, "ana", info.ana),
-  field_typ(~globals, ~raw, "elab_syn_ty", info.elab_syn_ty),
-  field_typ(~globals, ~raw, "ty (post-fix)", info.ty),
-  field_str("marks", marks_str(info.marks)),
-  field_str("warnings", warnings_str(info.warnings)),
-  field_ctx(~globals, ~raw, "ctx", info.ctx),
-  field_co_ctx(~globals, ~raw, "co_ctx", info.co_ctx),
-  field_str("constraint_", Coverage.Constraint.show(info.constraint_)),
-  field_str("label_inference", label_inference_str(info.label_inference)),
-  field_str(
-    "inferred_label",
-    Option.value(info.inferred_label, ~default="None"),
-  ),
-  field_str("label_sort", string_of_bool(info.label_sort)),
-];
+let pat_view = (~globals, ~raw, info: Info.pat): list(Node.t) =>
+  section(~globals, "InfoPat", () =>
+    [
+      field_str("id", id_str(Pat.rep_id(info.user_term))),
+      field_str("cls", Cls.show(info.cls)),
+      field_str("ancestors", ancestors_str(info.ancestors)),
+      field_any(~globals, ~raw, "user_term", Pat(info.user_term)),
+      field_any(~globals, ~raw, "elab_term", Pat(info.elab_term)),
+      field_typ(~globals, ~raw, "ana", info.ana),
+      field_typ(~globals, ~raw, "elab_syn_ty", info.elab_syn_ty),
+      field_typ(~globals, ~raw, "ty (post-fix)", info.ty),
+      field_str("marks", marks_str(info.marks)),
+      field_str("warnings", warnings_str(info.warnings)),
+      field_ctx(~globals, ~raw, "ctx", info.ctx),
+      field_co_ctx(~globals, ~raw, "co_ctx", info.co_ctx),
+      field_str("constraint_", Coverage.Constraint.show(info.constraint_)),
+      field_str(
+        "label_inference",
+        label_inference_str(info.label_inference),
+      ),
+      field_str(
+        "inferred_label",
+        Option.value(info.inferred_label, ~default="None"),
+      ),
+      field_str("label_sort", string_of_bool(info.label_sort)),
+    ]
+  );
 
-let typ_view = (~globals, ~raw, info: Info.typ): list(Node.t) => [
-  section_title("InfoTyp"),
-  field_str("id", id_str(Typ.rep_id(info.user_term))),
-  field_str("cls", Cls.show(info.cls)),
-  field_str("ancestors", ancestors_str(info.ancestors)),
-  field_typ(~globals, ~raw, "user_term", info.user_term),
-  field_str("expects", TypExpectation.show(info.expects)),
-  field_str("marks", marks_str(info.marks)),
-  field_str("warnings", warnings_str(info.warnings)),
-  field_ctx(~globals, ~raw, "ctx", info.ctx),
-];
+let typ_view = (~globals, ~raw, info: Info.typ): list(Node.t) =>
+  section(~globals, "InfoTyp", () =>
+    [
+      field_str("id", id_str(Typ.rep_id(info.user_term))),
+      field_str("cls", Cls.show(info.cls)),
+      field_str("ancestors", ancestors_str(info.ancestors)),
+      field_typ(~globals, ~raw, "user_term", info.user_term),
+      field_str("expects", TypExpectation.show(info.expects)),
+      field_str("marks", marks_str(info.marks)),
+      field_str("warnings", warnings_str(info.warnings)),
+      field_ctx(~globals, ~raw, "ctx", info.ctx),
+    ]
+  );
 
-let tpat_view = (~globals, ~raw, info: Info.tpat): list(Node.t) => [
-  section_title("InfoTPat"),
-  field_str("id", id_str(TPat.rep_id(info.user_term))),
-  field_str("cls", Cls.show(info.cls)),
-  field_str("ancestors", ancestors_str(info.ancestors)),
-  field_any(~globals, ~raw, "user_term", TPat(info.user_term)),
-  field_str("marks", marks_str(info.marks)),
-  field_str("warnings", warnings_str(info.warnings)),
-  field_ctx(~globals, ~raw, "ctx", info.ctx),
-];
+let tpat_view = (~globals, ~raw, info: Info.tpat): list(Node.t) =>
+  section(~globals, "InfoTPat", () =>
+    [
+      field_str("id", id_str(TPat.rep_id(info.user_term))),
+      field_str("cls", Cls.show(info.cls)),
+      field_str("ancestors", ancestors_str(info.ancestors)),
+      field_any(~globals, ~raw, "user_term", TPat(info.user_term)),
+      field_str("marks", marks_str(info.marks)),
+      field_str("warnings", warnings_str(info.warnings)),
+      field_ctx(~globals, ~raw, "ctx", info.ctx),
+    ]
+  );
 
-let secondary_view = (s: Info.secondary): list(Node.t) => [
-  section_title("Secondary"),
-  field_str("id", id_str(s.id)),
-  field_str("cls", Cls.show(s.cls)),
-  field_str("sort", Sort.show(s.sort)),
-];
+let secondary_view = (~globals, s: Info.secondary): list(Node.t) =>
+  section(~globals, "Secondary", () =>
+    [
+      field_str("id", id_str(s.id)),
+      field_str("cls", Cls.show(s.cls)),
+      field_str("sort", Sort.show(s.sort)),
+    ]
+  );
 
-let mod_view = (~globals, ~raw, m: Info.mod_): list(Node.t) => [
-  section_title("InfoMod"),
-  field_str("id", id_str(m.id)),
-  field_str("cls", Cls.show(m.cls)),
-  field_str("sort", Sort.show(m.sort)),
-  field_str("ancestors", ancestors_str(m.ancestors)),
-  field_ctx(~globals, ~raw, "ctx", m.ctx),
-];
+let mod_view = (~globals, ~raw, m: Info.mod_): list(Node.t) =>
+  section(~globals, "InfoMod", () =>
+    [
+      field_str("id", id_str(m.id)),
+      field_str("cls", Cls.show(m.cls)),
+      field_str("sort", Sort.show(m.sort)),
+      field_str("ancestors", ancestors_str(m.ancestors)),
+      field_ctx(~globals, ~raw, "ctx", m.ctx),
+    ]
+  );
 
-let sig_view = (~globals, ~raw, s: Info.sig_): list(Node.t) => [
-  section_title("InfoSig"),
-  field_str("id", id_str(s.id)),
-  field_str("cls", Cls.show(s.cls)),
-  field_str("sort", Sort.show(s.sort)),
-  field_str("ancestors", ancestors_str(s.ancestors)),
-  field_ctx(~globals, ~raw, "ctx", s.ctx),
-];
+let sig_view = (~globals, ~raw, s: Info.sig_): list(Node.t) =>
+  section(~globals, "InfoSig", () =>
+    [
+      field_str("id", id_str(s.id)),
+      field_str("cls", Cls.show(s.cls)),
+      field_str("sort", Sort.show(s.sort)),
+      field_str("ancestors", ancestors_str(s.ancestors)),
+      field_ctx(~globals, ~raw, "ctx", s.ctx),
+    ]
+  );
 
-let mpat_view = (~globals, ~raw, m: Info.mpat): list(Node.t) => [
-  section_title("InfoMPat"),
-  field_str("id", id_str(m.id)),
-  field_str("cls", Cls.show(m.cls)),
-  field_str("sort", Sort.show(m.sort)),
-  field_str("ancestors", ancestors_str(m.ancestors)),
-  field_ctx(~globals, ~raw, "ctx", m.ctx),
-];
+let mpat_view = (~globals, ~raw, m: Info.mpat): list(Node.t) =>
+  section(~globals, "InfoMPat", () =>
+    [
+      field_str("id", id_str(m.id)),
+      field_str("cls", Cls.show(m.cls)),
+      field_str("sort", Sort.show(m.sort)),
+      field_str("ancestors", ancestors_str(m.ancestors)),
+      field_ctx(~globals, ~raw, "ctx", m.ctx),
+    ]
+  );
 
-let drv_view = (_: DrvInfo.t): list(Node.t) => [
-  section_title("InfoDrv"),
-  field_str("(see DrvInfo)", "—"),
-];
+let drv_view = (~globals, _: DrvInfo.t): list(Node.t) =>
+  section(~globals, "InfoDrv", () => [field_str("(see DrvInfo)", "—")]);
 
 let info_view = (~globals, ~raw, ci: Info.t): list(Node.t) =>
   switch (ci) {
@@ -296,8 +449,8 @@ let info_view = (~globals, ~raw, ci: Info.t): list(Node.t) =>
   | InfoMod(m) => mod_view(~globals, ~raw, m)
   | InfoSig(s) => sig_view(~globals, ~raw, s)
   | InfoMPat(m) => mpat_view(~globals, ~raw, m)
-  | Secondary(s) => secondary_view(s)
-  | InfoDrv(d) => drv_view(d)
+  | Secondary(s) => secondary_view(~globals, s)
+  | InfoDrv(d) => drv_view(~globals, d)
   };
 
 let toggle_bar = (~globals: Globals.t): Node.t => {

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -546,6 +546,155 @@ let info_view = (~globals, ~raw, ci: Info.t): list(Node.t) =>
   | InfoDrv(d) => drv_view(~globals, d)
   };
 
+/* ---- Syntax sections: the syntactic/zipper layer under the cursor, ----
+   orthogonal to the statics Info above. Sourced from cursor.indicated_piece
+   and cursor.editor (zipper + cached syntax). */
+
+let shape_str = (s: Haz3lcore.Nib.Shape.t): string =>
+  Haz3lcore.Nib.Shape.show(s);
+
+let sort_str = (s: Sort.t): string => Sort.to_string(s);
+
+/* The tile/grout/secondary/projector immediately under the caret. */
+let indicated_piece_fields = (p: Haz3lcore.Piece.t): list(Node.t) =>
+  [field_str("id", id_str(Haz3lcore.Piece.id(p)))]
+  @ Haz3lcore.Piece.get(
+      (w: Haz3lcore.Secondary.t) => {
+        let kind =
+          Haz3lcore.Secondary.is_comment(w)
+            ? "comment"
+            : Haz3lcore.Secondary.is_linebreak(w) ? "linebreak" : "whitespace";
+        [
+          field_str("kind", "Secondary (" ++ kind ++ ")"),
+          field_str(
+            "content",
+            String.escaped(Haz3lcore.Secondary.get_string(w.content)),
+          ),
+        ];
+      },
+      (g: Haz3lcore.Grout.t) =>
+        [
+          field_str("kind", "Grout"),
+          field_str(
+            "shape",
+            switch (g.shape) {
+            | Haz3lcore.Grout.Convex => "Convex"
+            | Concave => "Concave"
+            },
+          ),
+        ],
+      (t: Haz3lcore.Tile.t) => {
+        let (l, r) = Haz3lcore.Tile.shapes(t);
+        [
+          field_str("kind", "Tile"),
+          field_str("label", String.concat(" ", t.label)),
+          field_str("mold.out", sort_str(t.mold.out)),
+          field_str(
+            "mold.in_",
+            "[" ++ String.concat(", ", List.map(sort_str, t.mold.in_)) ++ "]",
+          ),
+          field_str("nibs", shape_str(l) ++ " … " ++ shape_str(r)),
+          field_str(
+            "shards",
+            "["
+            ++ String.concat(", ", List.map(string_of_int, t.shards))
+            ++ "]",
+          ),
+          field_str("children", string_of_int(List.length(t.children))),
+          field_str(
+            "complete",
+            string_of_bool(Haz3lcore.Tile.is_complete(t)),
+          ),
+        ];
+      },
+      _ => [field_str("kind", "Projector")],
+      p,
+    );
+
+/* Caret, selection, and backpack from the editor's zipper. */
+let zipper_fields = (z: Haz3lcore.Zipper.t): list(Node.t) => {
+  let sel = z.selection;
+  let backpack = Haz3lcore.Zipper.local_backpack(z);
+  [
+    field_str("caret", Haz3lcore.CaretBase.show(z.caret)),
+    field_str("selection.focus", Util.Direction.show(sel.focus)),
+    field_str("selection.pieces", string_of_int(List.length(sel.content))),
+    field_str(
+      "selection.empty",
+      string_of_bool(Haz3lcore.Selection.is_empty(sel)),
+    ),
+    field_str(
+      "backpack",
+      string_of_int(List.length(backpack)) ++ " tile(s)",
+    ),
+  ];
+};
+
+/* Layout position of the indicated piece, from the measured cache. */
+let measured_fields =
+    (p: Haz3lcore.Piece.t, measured: Haz3lcore.Measured.t): list(Node.t) =>
+  switch (Haz3lcore.Measured.find_by_id(Haz3lcore.Piece.id(p), measured)) {
+  | None => [field_str("measurement", "(not measured)")]
+  | Some({origin, last}) => [
+      field_str(
+        "origin",
+        Printf.sprintf("row %d, col %d", origin.row, origin.col),
+      ),
+      field_str(
+        "last",
+        Printf.sprintf("row %d, col %d", last.row, last.col),
+      ),
+    ]
+  };
+
+/* Whole-editor / segment summary. */
+let editor_fields = (editor: Haz3lcore.Editor.t): list(Node.t) => {
+  let syntax = editor.syntax;
+  [
+    field_str("root sort", sort_str(editor.root)),
+    field_str("syntax stale", string_of_bool(syntax.old)),
+    field_str("segment pieces", string_of_int(List.length(syntax.segment))),
+    field_str(
+      "projectors",
+      string_of_int(List.length(syntax.projector_list)),
+    ),
+    field_str(
+      "backpack (cached)",
+      string_of_int(List.length(syntax.cached_backpack)) ++ " tile(s)",
+    ),
+  ];
+};
+
+let syntax_view = (~globals, ~cursor: Cursor.cursor(_)): list(Node.t) => {
+  let piece_sec =
+    switch (cursor.indicated_piece) {
+    | None => []
+    | Some(p) =>
+      section(~globals, "Indicated Piece", () => indicated_piece_fields(p))
+    };
+  let (zipper_sec, measured_sec, editor_sec) =
+    switch (cursor.editor) {
+    | None => ([], [], [])
+    | Some(editor) =>
+      let zipper_sec =
+        section(~globals, "Caret & Selection", () =>
+          zipper_fields(editor.state.zipper)
+        );
+      let measured_sec =
+        switch (cursor.indicated_piece) {
+        | None => []
+        | Some(p) =>
+          section(~globals, "Measured", () =>
+            measured_fields(p, editor.syntax.measured)
+          )
+        };
+      let editor_sec =
+        section(~globals, "Segment", () => editor_fields(editor));
+      (zipper_sec, measured_sec, editor_sec);
+    };
+  piece_sec @ zipper_sec @ measured_sec @ editor_sec;
+};
+
 let toggle_bar = (~globals: Globals.t): Node.t => {
   let raw = globals.settings.sidebar.debug_show_raw;
   let on_click = _ => globals.inject_global(Set(Sidebar(ToggleDebugRaw)));
@@ -580,9 +729,17 @@ let view = (~globals: Globals.t, ~cursor: Cursor.cursor(_)): Node.t => {
       toggle_bar(~globals),
       div(
         ~attrs=[clss(["panel-body"])],
-        switch (cursor.info) {
-        | None => [text("No info at cursor.")]
-        | Some(ci) => info_view(~globals, ~raw, ci)
+        {
+          let info_sections =
+            switch (cursor.info) {
+            | None => []
+            | Some(ci) => info_view(~globals, ~raw, ci)
+            };
+          let syntax_sections = syntax_view(~globals, ~cursor);
+          switch (info_sections, syntax_sections) {
+          | ([], []) => [text("No info at cursor.")]
+          | _ => info_sections @ syntax_sections
+          };
         },
       ),
     ],

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -1,0 +1,259 @@
+open Virtual_dom.Vdom;
+open Node;
+open Util.WebUtil;
+open Language;
+
+/* Debug sidebar panel: dumps the statics Info metadata for the term under the
+   cursor. Intended for developers — wired up behind `show_debug_panel`.
+
+   Has two display modes, toggled at the top of the panel:
+   - Rendered (default): types and terms are pretty-printed via CodeViewable.
+   - Raw: every field is dumped via its derived `show`. */
+
+let code_settings: Haz3lcore.ExpToSegment.Settings.t = {
+  secondary: AutoFormat,
+  parenthesization: Defensive,
+  label_format: QuoteWhenNecessary,
+  inline: true,
+  fold_case_clauses: false,
+  fold_fn_bodies: `NoFold,
+  hide_fixpoints: false,
+  show_ascriptions: true,
+  show_filters: false,
+  show_unknown_as_hole: true,
+  project_tables: false,
+};
+
+let section_title = (title: string): Node.t =>
+  div(~attrs=[clss(["debug-section-title"])], [text(title)]);
+
+let field_node = (label: string, body: Node.t): Node.t =>
+  div(
+    ~attrs=[clss(["debug-field"])],
+    [
+      div(~attrs=[clss(["debug-field-label"])], [text(label)]),
+      div(~attrs=[clss(["debug-field-value"])], [body]),
+    ],
+  );
+
+let field_str = (label: string, body: string): Node.t =>
+  div(
+    ~attrs=[clss(["debug-field"])],
+    [
+      div(~attrs=[clss(["debug-field-label"])], [text(label)]),
+      pre(~attrs=[clss(["debug-field-value", "raw"])], [text(body)]),
+    ],
+  );
+
+let field_typ = (~globals, ~raw, label: string, typ: Typ.t): Node.t =>
+  raw
+    ? field_str(label, Typ.show(typ))
+    : field_node(
+        label,
+        CodeViewable.view_typ(~globals, ~settings=code_settings, typ),
+      );
+
+let field_any = (~globals, ~raw, label: string, any: Any.t): Node.t =>
+  raw
+    ? field_str(label, Any.show(any))
+    : field_node(
+        label,
+        CodeViewable.view_any(~globals, ~settings=code_settings, any),
+      );
+
+let id_str = (id: Id.t): string => Id.to_string(id);
+
+let ancestors_str = (ancestors: Info.ancestors): string =>
+  switch (ancestors) {
+  | [] => "[]"
+  | _ => "[" ++ String.concat(", ", List.map(id_str, ancestors)) ++ "]"
+  };
+
+let marks_str = (marks: list(Mark.t)): string =>
+  switch (marks) {
+  | [] => "[]"
+  | _ =>
+    "[\n  " ++ String.concat(",\n  ", List.map(Mark.show, marks)) ++ "\n]"
+  };
+
+let warnings_str = (warnings: list(Warning.list_item)): string =>
+  switch (warnings) {
+  | [] => "[]"
+  | _ =>
+    "[\n  "
+    ++ String.concat(",\n  ", List.map(Warning.show_list_item, warnings))
+    ++ "\n]"
+  };
+
+let label_inference_str = (li: option(Info.label_inference(_))): string =>
+  switch (li) {
+  | None => "None"
+  | Some(SingletonLabelInference({label, _})) =>
+    "SingletonLabelInference(" ++ label ++ ")"
+  | Some(MultiLabelInference({reordered, introduced_labels})) =>
+    Printf.sprintf(
+      "MultiLabelInference(reordered=%b, introduced=[%s])",
+      reordered,
+      String.concat(", ", introduced_labels),
+    )
+  };
+
+let exp_view = (~globals, ~raw, info: Info.exp): list(Node.t) => [
+  section_title("InfoExp"),
+  field_str("id", id_str(Exp.rep_id(info.user_term))),
+  field_str("cls", Cls.show(info.cls)),
+  field_str("ancestors", ancestors_str(info.ancestors)),
+  field_any(~globals, ~raw, "user_term", Exp(info.user_term)),
+  field_any(~globals, ~raw, "elab_term", Exp(info.elab_term)),
+  field_typ(~globals, ~raw, "ana", info.ana),
+  field_typ(~globals, ~raw, "elab_syn_ty", info.elab_syn_ty),
+  field_typ(~globals, ~raw, "ty (post-fix)", info.ty),
+  field_str("marks", marks_str(info.marks)),
+  field_str("warnings", warnings_str(info.warnings)),
+  field_str("co_ctx", CoCtx.show(info.co_ctx)),
+  field_str("label_inference", label_inference_str(info.label_inference)),
+  field_str(
+    "inferred_label",
+    Option.value(info.inferred_label, ~default="None"),
+  ),
+  field_str("label_sort", string_of_bool(info.label_sort)),
+  field_str(
+    "dot_labels",
+    "[" ++ String.concat(", ", info.dot_labels) ++ "]",
+  ),
+];
+
+let pat_view = (~globals, ~raw, info: Info.pat): list(Node.t) => [
+  section_title("InfoPat"),
+  field_str("id", id_str(Pat.rep_id(info.user_term))),
+  field_str("cls", Cls.show(info.cls)),
+  field_str("ancestors", ancestors_str(info.ancestors)),
+  field_any(~globals, ~raw, "user_term", Pat(info.user_term)),
+  field_any(~globals, ~raw, "elab_term", Pat(info.elab_term)),
+  field_typ(~globals, ~raw, "ana", info.ana),
+  field_typ(~globals, ~raw, "elab_syn_ty", info.elab_syn_ty),
+  field_typ(~globals, ~raw, "ty (post-fix)", info.ty),
+  field_str("marks", marks_str(info.marks)),
+  field_str("warnings", warnings_str(info.warnings)),
+  field_str("co_ctx", CoCtx.show(info.co_ctx)),
+  field_str("constraint_", Coverage.Constraint.show(info.constraint_)),
+  field_str("label_inference", label_inference_str(info.label_inference)),
+  field_str(
+    "inferred_label",
+    Option.value(info.inferred_label, ~default="None"),
+  ),
+  field_str("label_sort", string_of_bool(info.label_sort)),
+];
+
+let typ_view = (~globals, ~raw, info: Info.typ): list(Node.t) => [
+  section_title("InfoTyp"),
+  field_str("id", id_str(Typ.rep_id(info.user_term))),
+  field_str("cls", Cls.show(info.cls)),
+  field_str("ancestors", ancestors_str(info.ancestors)),
+  field_typ(~globals, ~raw, "user_term", info.user_term),
+  field_str("expects", TypExpectation.show(info.expects)),
+  field_str("marks", marks_str(info.marks)),
+  field_str("warnings", warnings_str(info.warnings)),
+];
+
+let tpat_view = (~globals, ~raw, info: Info.tpat): list(Node.t) => [
+  section_title("InfoTPat"),
+  field_str("id", id_str(TPat.rep_id(info.user_term))),
+  field_str("cls", Cls.show(info.cls)),
+  field_str("ancestors", ancestors_str(info.ancestors)),
+  field_any(~globals, ~raw, "user_term", TPat(info.user_term)),
+  field_str("marks", marks_str(info.marks)),
+  field_str("warnings", warnings_str(info.warnings)),
+];
+
+let secondary_view = (s: Info.secondary): list(Node.t) => [
+  section_title("Secondary"),
+  field_str("id", id_str(s.id)),
+  field_str("cls", Cls.show(s.cls)),
+  field_str("sort", Sort.show(s.sort)),
+];
+
+let mod_view = (m: Info.mod_): list(Node.t) => [
+  section_title("InfoMod"),
+  field_str("id", id_str(m.id)),
+  field_str("cls", Cls.show(m.cls)),
+  field_str("sort", Sort.show(m.sort)),
+  field_str("ancestors", ancestors_str(m.ancestors)),
+];
+
+let sig_view = (s: Info.sig_): list(Node.t) => [
+  section_title("InfoSig"),
+  field_str("id", id_str(s.id)),
+  field_str("cls", Cls.show(s.cls)),
+  field_str("sort", Sort.show(s.sort)),
+  field_str("ancestors", ancestors_str(s.ancestors)),
+];
+
+let mpat_view = (m: Info.mpat): list(Node.t) => [
+  section_title("InfoMPat"),
+  field_str("id", id_str(m.id)),
+  field_str("cls", Cls.show(m.cls)),
+  field_str("sort", Sort.show(m.sort)),
+  field_str("ancestors", ancestors_str(m.ancestors)),
+];
+
+let drv_view = (_: DrvInfo.t): list(Node.t) => [
+  section_title("InfoDrv"),
+  field_str("(see DrvInfo)", "—"),
+];
+
+let info_view = (~globals, ~raw, ci: Info.t): list(Node.t) =>
+  switch (ci) {
+  | InfoExp(i) => exp_view(~globals, ~raw, i)
+  | InfoPat(i) => pat_view(~globals, ~raw, i)
+  | InfoTyp(i) => typ_view(~globals, ~raw, i)
+  | InfoTPat(i) => tpat_view(~globals, ~raw, i)
+  | InfoMod(m) => mod_view(m)
+  | InfoSig(s) => sig_view(s)
+  | InfoMPat(m) => mpat_view(m)
+  | Secondary(s) => secondary_view(s)
+  | InfoDrv(d) => drv_view(d)
+  };
+
+let toggle_bar = (~globals: Globals.t): Node.t => {
+  let raw = globals.settings.sidebar.debug_show_raw;
+  let on_click = _ => globals.inject_global(Set(Sidebar(ToggleDebugRaw)));
+  div(
+    ~attrs=[clss(["debug-toggle-bar"])],
+    [
+      div(
+        ~attrs=[clss(["debug-toggle-label"])],
+        [text(raw ? "Showing raw internal structure" : "Showing rendered")],
+      ),
+      div(
+        ~attrs=[
+          clss(["debug-toggle-button"]),
+          Attr.on_click(on_click),
+          Attr.title("Toggle between rendered code and raw `show` output"),
+        ],
+        [text(raw ? "Show rendered" : "Show raw")],
+      ),
+    ],
+  );
+};
+
+let view = (~globals: Globals.t, ~cursor: Cursor.cursor(_)): Node.t => {
+  let raw = globals.settings.sidebar.debug_show_raw;
+  div(
+    ~attrs=[Attr.id("debug-sidebar"), clss(["panel"])],
+    [
+      div(
+        ~attrs=[clss(["panel-title-bar"])],
+        [text("Debug — Cursor Info")],
+      ),
+      toggle_bar(~globals),
+      div(
+        ~attrs=[clss(["panel-body"])],
+        switch (cursor.info) {
+        | None => [text("No info at cursor.")]
+        | Some(ci) => info_view(~globals, ~raw, ci)
+        },
+      ),
+    ],
+  );
+};

--- a/src/web/app/sidebar/Sidebar.re
+++ b/src/web/app/sidebar/Sidebar.re
@@ -82,6 +82,15 @@ let log_control_tab = (~globals: Globals.t): Node.t =>
     ~globals,
   );
 
+let debug_info_tab = (~globals: Globals.t): Node.t =>
+  tab_of(
+    ~panel=DebugInfo,
+    ~cls=["debug-info-button"],
+    ~icon=Icons.info,
+    ~tooltip="Switch to Debug Info Panel",
+    ~globals,
+  );
+
 let problems_tab_icon =
     (counts: list((SidebarModel.Settings.problem_category, int))): Node.t => {
   open SidebarModel.Settings;
@@ -172,6 +181,9 @@ let persistent_view =
         ]
         @ (
           globals.settings.show_log_panel ? [log_control_tab(~globals)] : []
+        )
+        @ (
+          globals.settings.show_debug_panel ? [debug_info_tab(~globals)] : []
         ),
       ),
     ],
@@ -321,6 +333,7 @@ let view =
                 ~log_entries_count=log_count,
               )
             | Problems => ProblemSidebar.view(~globals, ~cursor, ~ctx)
+            | DebugInfo => DebugSidebar.view(~globals, ~cursor)
             },
           ],
         )

--- a/src/web/app/sidebar/SidebarModel.re
+++ b/src/web/app/sidebar/SidebarModel.re
@@ -7,7 +7,8 @@ module Settings = {
     | HelpfulAssistant
     | Probes
     | LogControl
-    | Problems;
+    | Problems
+    | DebugInfo;
 
   [@deriving (show({with_path: false}), sexp, yojson, enumerate)]
   type problem_category =
@@ -127,11 +128,13 @@ module Settings = {
     show: bool,
     panel,
     problems: problems_settings,
+    debug_show_raw: bool,
   };
 
   [@deriving (show({with_path: false}), sexp, yojson)]
   type action =
     | ToggleShow
     | SwitchPanel(panel)
-    | Problems(problems_action);
+    | Problems(problems_action)
+    | ToggleDebugRaw;
 };

--- a/src/web/app/sidebar/SidebarModel.re
+++ b/src/web/app/sidebar/SidebarModel.re
@@ -155,12 +155,33 @@ module Settings = {
     panel,
     problems: problems_settings,
     debug_show_raw: bool,
+    /* Collapsed debug sidebar sections/fields, keyed by section title or
+       field label. Persists across cursor moves so collapsing e.g. "ctx"
+       keeps it collapsed regardless of the term under the cursor. */
+    debug_collapsed: list(string),
   };
+
+  let is_debug_collapsed = (key: string, settings: t) =>
+    List.mem(key, settings.debug_collapsed);
+
+  let toggle_debug_collapsed = (key: string, settings: t): t =>
+    if (is_debug_collapsed(key, settings)) {
+      {
+        ...settings,
+        debug_collapsed: List.filter(k => k != key, settings.debug_collapsed),
+      };
+    } else {
+      {
+        ...settings,
+        debug_collapsed: [key, ...settings.debug_collapsed],
+      };
+    };
 
   [@deriving (show({with_path: false}), sexp, yojson)]
   type action =
     | ToggleShow
     | SwitchPanel(panel)
     | Problems(problems_action)
-    | ToggleDebugRaw;
+    | ToggleDebugRaw
+    | ToggleDebugCollapsed(string);
 };

--- a/src/web/view/NutMenu.re
+++ b/src/web/view/NutMenu.re
@@ -211,6 +211,12 @@ let dev_group = (~globals: Globals.t) => {
         setting: ShowIncrementalDeco,
         tooltip: Some("Show incremental evaluator cache hits"),
       },
+      {
+        name: "Debug Sidebar",
+        active: globals.settings.show_debug_panel,
+        setting: ShowDebugPanel,
+        tooltip: Some("Show the debug info sidebar panel"),
+      },
     ]
     @ (
       ExerciseSettings.show_instructor

--- a/src/web/www/style/sidebar.css
+++ b/src/web/www/style/sidebar.css
@@ -538,3 +538,47 @@
   max-height: 14em;
   overflow: auto;
 }
+
+#debug-sidebar .debug-ctx,
+#debug-sidebar .debug-coctx {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+}
+
+#debug-sidebar .debug-ctx-empty {
+  font-style: italic;
+  color: var(--BR4);
+}
+
+#debug-sidebar .debug-ctx-row,
+#debug-sidebar .debug-coctx-var {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4em;
+  padding: 0.1em 0;
+  border-bottom: 1px dotted var(--BR1);
+}
+
+#debug-sidebar .debug-ctx-row:last-child,
+#debug-sidebar .debug-coctx-var:last-child {
+  border-bottom: none;
+}
+
+#debug-sidebar .debug-ctx-name {
+  font-weight: 600;
+  color: var(--BR4);
+}
+
+#debug-sidebar .debug-ctx-body {
+  flex: 1;
+  min-width: 0;
+}
+
+#debug-sidebar .debug-coctx-use {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3em;
+  color: var(--BR4);
+}

--- a/src/web/www/style/sidebar.css
+++ b/src/web/www/style/sidebar.css
@@ -515,6 +515,12 @@
   overflow-x: auto;
 }
 
+#debug-sidebar .debug-field-value:not(.raw) .code {
+  /* .code otherwise forces --base-font-size, rendering larger than the raw
+     <pre>; inherit the field-value size so both modes match. */
+  font-size: inherit;
+}
+
 #debug-sidebar .debug-section-title {
   display: flex;
   align-items: center;

--- a/src/web/www/style/sidebar.css
+++ b/src/web/www/style/sidebar.css
@@ -450,17 +450,18 @@
   height: 100%;
   overflow: hidden;
   font-family: var(--ui-font);
-  font-size: 11pt;
+  /* Slightly denser than the base UI scale; children size relative to this. */
+  font-size: 0.85em;
   background-color: var(--ui-bkg);
 }
 
 #debug-sidebar .panel-title-bar {
   flex: 0 0 auto;
   padding: 0.5em 0.8em;
-  border-bottom: 1px solid var(--BR2);
-  font-weight: 600;
-  color: var(--BR4);
-  background-color: var(--T2);
+  border-bottom: 1px solid var(--BR1);
+  font-weight: bold;
+  text-transform: uppercase;
+  color: var(--ui-header-text);
 }
 
 #debug-sidebar .panel-body {
@@ -478,23 +479,23 @@
   justify-content: space-between;
   gap: 0.6em;
   padding: 0.35em 0.8em;
-  border-bottom: 1px solid var(--BR2);
+  border-bottom: 1px solid var(--BR1);
   background-color: color-mix(in srgb, var(--T1) 70%, transparent);
 }
 
 #debug-sidebar .debug-toggle-label {
-  font-size: 9.5pt;
+  font-size: 0.86em;
   color: var(--STONE);
   font-style: italic;
 }
 
 #debug-sidebar .debug-toggle-button {
   padding: 0.2em 0.6em;
-  font-size: 9.5pt;
+  font-size: 0.86em;
   font-weight: 600;
   color: var(--BR4);
   background-color: var(--SAND);
-  border: 1px solid var(--BR2);
+  border: 1px solid var(--BR1);
   border-radius: 3px;
   cursor: pointer;
   user-select: none;
@@ -515,17 +516,36 @@
 }
 
 #debug-sidebar .debug-section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.3em;
   margin: 0.8em 0 0.4em;
   padding-bottom: 0.2em;
   font-weight: 600;
-  font-size: 11pt;
+  font-size: 1em;
   color: var(--BR4);
-  border-bottom: 1px solid var(--BR2);
+  border-bottom: 1px solid var(--BR1);
   letter-spacing: 0.02em;
+  cursor: pointer;
+  user-select: none;
 }
 
 #debug-sidebar .debug-section-title:first-child {
   margin-top: 0;
+}
+
+#debug-sidebar .debug-section-chevron,
+#debug-sidebar .debug-field-chevron {
+  flex-shrink: 0;
+  font-size: 0.7em;
+  opacity: 0.4;
+  cursor: pointer;
+  user-select: none;
+}
+
+#debug-sidebar .debug-section-title:hover .debug-section-chevron,
+#debug-sidebar .debug-field-chevron:hover {
+  opacity: 0.7;
 }
 
 #debug-sidebar .debug-field {
@@ -537,19 +557,51 @@
 }
 
 #debug-sidebar .debug-field-label {
+  display: flex;
+  align-items: center;
+  gap: 0.3em;
   font-family: var(--ui-font);
-  font-size: 9.5pt;
+  font-size: 0.86em;
   font-weight: 600;
   color: var(--STONE);
   letter-spacing: 0.02em;
   margin-bottom: 0.15em;
 }
 
+#debug-sidebar .debug-field-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Copy button: hidden until the field is hovered to keep the dense list
+   uncluttered. */
+#debug-sidebar .debug-copy-button {
+  margin-left: auto;
+  flex-shrink: 0;
+  padding: 0 0.25em;
+  font-size: 0.9em;
+  opacity: 0;
+  cursor: pointer;
+  color: var(--BR3);
+  transition: opacity 0.12s ease, color 0.12s ease;
+}
+
+#debug-sidebar .debug-field:hover .debug-copy-button {
+  opacity: 0.55;
+}
+
+#debug-sidebar .debug-copy-button:hover {
+  opacity: 1;
+  color: var(--BR4);
+}
+
 #debug-sidebar .debug-field-value {
   margin: 0;
   padding: 0.25em 0.35em;
   font-family: var(--code-font);
-  font-size: 9pt;
+  font-size: 0.82em;
   line-height: 1.35;
   white-space: pre-wrap;
   word-break: break-word;

--- a/src/web/www/style/sidebar.css
+++ b/src/web/www/style/sidebar.css
@@ -419,3 +419,122 @@
   color: var(--BR3);
   padding: 1em;
 }
+
+/* ===== Debug Info Panel ===== */
+
+#debug-sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  font-family: var(--ui-font);
+  font-size: 11pt;
+  background-color: var(--ui-bkg);
+}
+
+#debug-sidebar .panel-title-bar {
+  flex: 0 0 auto;
+  padding: 0.5em 0.8em;
+  border-bottom: 1px solid var(--BR2);
+  font-weight: 600;
+  color: var(--BR4);
+  background-color: var(--T2);
+}
+
+#debug-sidebar .panel-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0.5em 0.8em 2em;
+  scrollbar-color: var(--main-scroll-thumb) var(--NONE);
+}
+
+#debug-sidebar .debug-toggle-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6em;
+  padding: 0.35em 0.8em;
+  border-bottom: 1px solid var(--BR2);
+  background-color: color-mix(in srgb, var(--T1) 70%, transparent);
+}
+
+#debug-sidebar .debug-toggle-label {
+  font-size: 9.5pt;
+  color: var(--STONE);
+  font-style: italic;
+}
+
+#debug-sidebar .debug-toggle-button {
+  padding: 0.2em 0.6em;
+  font-size: 9.5pt;
+  font-weight: 600;
+  color: var(--BR4);
+  background-color: var(--SAND);
+  border: 1px solid var(--BR2);
+  border-radius: 3px;
+  cursor: pointer;
+  user-select: none;
+}
+
+#debug-sidebar .debug-toggle-button:hover {
+  background-color: var(--T2);
+  border-color: var(--BR3);
+}
+
+#debug-sidebar .debug-field-value:not(.raw) {
+  /* Rendered code views bring their own typography; keep the wrapper plain. */
+  padding: 0.15em 0.25em;
+  background-color: var(--SAND);
+  border: 1px solid var(--BR1);
+  border-radius: 2px;
+  overflow-x: auto;
+}
+
+#debug-sidebar .debug-section-title {
+  margin: 0.8em 0 0.4em;
+  padding-bottom: 0.2em;
+  font-weight: 600;
+  font-size: 11pt;
+  color: var(--BR4);
+  border-bottom: 1px solid var(--BR2);
+  letter-spacing: 0.02em;
+}
+
+#debug-sidebar .debug-section-title:first-child {
+  margin-top: 0;
+}
+
+#debug-sidebar .debug-field {
+  margin: 0.35em 0;
+  padding: 0.25em 0.4em;
+  border-left: 2px solid var(--BR2);
+  background-color: color-mix(in srgb, var(--T1) 60%, transparent);
+  border-radius: 2px;
+}
+
+#debug-sidebar .debug-field-label {
+  font-family: var(--ui-font);
+  font-size: 9.5pt;
+  font-weight: 600;
+  color: var(--STONE);
+  letter-spacing: 0.02em;
+  margin-bottom: 0.15em;
+}
+
+#debug-sidebar .debug-field-value {
+  margin: 0;
+  padding: 0.25em 0.35em;
+  font-family: var(--code-font);
+  font-size: 9pt;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--STONE);
+  background-color: var(--SAND);
+  border: 1px solid var(--BR1);
+  border-radius: 2px;
+  max-height: 14em;
+  overflow: auto;
+}


### PR DESCRIPTION
## Summary

Adds a **Debug** sidebar panel for inspecting the statics `Info` metadata of the term under the cursor. Intended as a developer tool, wired up behind a new `show_debug_panel` setting.

## Details

- **`DebugSidebar.re`** — new panel that dumps the cursor's `Info` fields. Two display modes toggled at the top:
  - *Rendered* (default): types and terms pretty-printed via `CodeViewable`.
  - *Raw*: every field dumped via its derived `show`.
- Renders `ctx` and `co_ctx` as readable rows (var/constructor/type-var/livelit entries, expected-type uses).
- **`SidebarModel.re` / `Sidebar.re` / `Page.re`** — adds the `DebugInfo` panel case and tab.
- **`Settings.re` / `NutMenu.re`** — new `show_debug_panel` toggle gating the tab.
- **`sidebar.css`** — styling for the debug panel sections, fields, and ctx rows.

## Test plan

- `make dev` builds cleanly.
- Manual: enable the debug panel via the nut menu, place the cursor on various terms, and verify rendered/raw fields plus `ctx`/`co_ctx` display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
