### PR TITLE
Add Hazel JSON ADT and yojson codec

### DIFF
--- a/src/haz3lcore/HazelJson.re
+++ b/src/haz3lcore/HazelJson.re
@@ -1,0 +1,165 @@
+open Util;
+open Language;
+
+/* Codec for converting between Yojson and Hazel expressions of the
+   built-in JSON ADT type defined in BuiltinsADT
+   (Assoc | Bool | Float | Int | List | String | Null) */
+module JsonADT = {
+  module Fresh = Language.IdTagged.FreshGrammar;
+
+  let ctr = (name: string): Language.Exp.t =>
+    Fresh.Exp.constructor(name, None);
+
+  let ap_ctr = (name: string, arg: Language.Exp.t): Language.Exp.t =>
+    Fresh.Exp.ap(Forward, ctr(name), arg);
+
+  /* Convert Yojson to a Hazel expression of the JSON ADT type */
+  let rec yojson_to_exp =
+          (json: Yojson.Safe.t): result(Language.Exp.t, string) =>
+    switch (json) {
+    | `Null => Ok(ctr("Null"))
+    | `Bool(b) => Ok(ap_ctr("Bool", Fresh.Exp.bool(b)))
+    | `Int(i) => Ok(ap_ctr("Int", Fresh.Exp.big_int(Bigint.of_int(i))))
+    | `Float(f) => Ok(ap_ctr("Float", Fresh.Exp.float(f)))
+    | `String(s) => Ok(ap_ctr("String", Fresh.Exp.string(s)))
+    | `List(elements) =>
+      elements
+      |> List.map(yojson_to_exp)
+      |> Result.all
+      |> Result.map(~f=exps => ap_ctr("List", Fresh.Exp.list_lit(exps)))
+    | `Assoc(pairs) =>
+      pairs
+      |> List.map(((key, value)) =>
+           yojson_to_exp(value)
+           |> Result.map(~f=v_exp =>
+                Fresh.Exp.tuple([Fresh.Exp.string(key), v_exp])
+              )
+         )
+      |> Result.all
+      |> Result.map(~f=pair_exps =>
+           ap_ctr("Assoc", Fresh.Exp.list_lit(pair_exps))
+         )
+    | `Intlit(_) => Error("Intlit not supported in JsonADT")
+    | `Tuple(_) => Error("Tuple not supported in JsonADT")
+    | `Variant(_) => Error("Variant not supported in JsonADT")
+    };
+
+  let yojson_to_any = (json: Yojson.Safe.t): result(Language.Any.t, string) =>
+    switch (yojson_to_exp(json)) {
+    | Ok(exp) => Ok(Exp(exp))
+    | Error(msg) => Error(msg)
+    };
+
+  /* Convert a Hazel expression of the JSON ADT type back to Yojson */
+  /* Recursively strip evaluation wrappers (Parens, Closure, etc.)
+     to get to the underlying value term. */
+  let rec strip_wrappers = (exp: Language.Exp.t): Language.Exp.t =>
+    switch (Exp.term_of(exp)) {
+    | Parens(inner)
+    | Closure(_, inner)
+    | Filter(_, inner)
+    | Asc(inner, _)
+    | Projector(_, inner) => strip_wrappers(inner)
+    | _ => exp
+    };
+
+  let cls_name = (exp: Language.Exp.t): string =>
+    Exp.show_cls(Exp.cls_of_term(Exp.term_of(exp)));
+
+  let rec exp_to_yojson =
+          (exp: Language.Exp.t): result(Yojson.Safe.t, string) => {
+    let exp = strip_wrappers(exp);
+    switch (Exp.term_of(exp)) {
+    | Constructor("Null", _) => Ok(`Null)
+    | Ap(_, fn_exp, arg) =>
+      let fn_exp = strip_wrappers(fn_exp);
+      let arg = strip_wrappers(arg);
+      switch (Exp.term_of(fn_exp)) {
+      | Constructor("Bool", _) =>
+        switch (Exp.term_of(arg)) {
+        | Atom(Bool(b)) => Ok(`Bool(b))
+        | _ => Error("JsonADT: Bool expects a boolean literal")
+        }
+      | Constructor("Int", _) =>
+        switch (Exp.term_of(arg)) {
+        | Atom(Int(i)) =>
+          switch (Bigint.to_int(i)) {
+          | Some(n) => Ok(`Int(n))
+          | None => Error("JsonADT: integer too large")
+          }
+        | UnOp(
+            Int(Minus) | Float(Minus) | SInt(Minus) | Nat(Minus),
+            neg_arg,
+          ) =>
+          let neg_arg = strip_wrappers(neg_arg);
+          switch (Exp.term_of(neg_arg)) {
+          | Atom(Int(i)) =>
+            switch (Bigint.to_int(i)) {
+            | Some(n) => Ok(`Int(- n))
+            | None => Error("JsonADT: integer too large")
+            }
+          | _ => Error("JsonADT: Int expects an integer literal")
+          };
+        | _ => Error("JsonADT: Int expects an integer literal")
+        }
+      | Constructor("Float", _) =>
+        switch (Exp.term_of(arg)) {
+        | Atom(Float(f)) => Ok(`Float(f))
+        | _ =>
+          Error(
+            "JsonADT: Float expects float literal, got: " ++ cls_name(arg),
+          )
+        }
+      | Constructor("String", _) =>
+        switch (Exp.term_of(arg)) {
+        | Atom(String(s)) => Ok(`String(StringUtil.unescape_linebreaks(s)))
+        | _ => Error("JsonADT: String expects a string literal")
+        }
+      | Constructor("List", _) =>
+        switch (Exp.term_of(arg)) {
+        | ListLit(elements) =>
+          elements
+          |> List.map(exp_to_yojson)
+          |> Result.all
+          |> Result.map(~f=json_elems => `List(json_elems))
+        | _ => Error("JsonADT: List expects a list literal")
+        }
+      | Constructor("Assoc", _) =>
+        switch (Exp.term_of(arg)) {
+        | ListLit(elements) =>
+          elements
+          |> List.map(convert_assoc_pair)
+          |> Result.all
+          |> Result.map(~f=pairs => `Assoc(pairs))
+        | _ => Error("JsonADT: Assoc expects a list literal")
+        }
+      | _ =>
+        Error("JsonADT: unrecognized JSON constructor: " ++ cls_name(fn_exp))
+      };
+    | _ => Error("JsonADT: unrecognized JSON expression: " ++ cls_name(exp))
+    };
+  }
+  and convert_assoc_pair =
+      (pair_exp: Language.Exp.t): result((string, Yojson.Safe.t), string) => {
+    let pair_exp = strip_wrappers(pair_exp);
+    switch (Exp.term_of(pair_exp)) {
+    | Tuple([key_exp, val_exp]) =>
+      let key_exp = strip_wrappers(key_exp);
+      switch (Exp.term_of(key_exp)) {
+      | Atom(String(k)) =>
+        switch (exp_to_yojson(val_exp)) {
+        | Ok(v) => Ok((k, v))
+        | Error(_) as e => e
+        }
+      | _ => Error("JsonADT: Assoc key must be a string literal")
+      };
+    | _ => Error("JsonADT: Assoc expects (String, JSON) pairs")
+    };
+  };
+
+  let any_to_yojson = (any: Language.Any.t): result(Yojson.Safe.t, string) =>
+    switch (any) {
+    | Exp(exp) => exp_to_yojson(exp)
+    | _ => Error("JsonADT: only Exp terms are supported")
+    };
+};

--- a/src/language/builtins/BuiltinsADT.re
+++ b/src/language/builtins/BuiltinsADT.re
@@ -172,11 +172,68 @@ module Option = {
   ];
 };
 
+module JSON = {
+  /* Self-reference for the recursive type */
+  let self: Typ.t = var("JSON");
+
+  /* type JSON =
+     + Assoc([(String, JSON)])
+     + Bool(Bool)
+     + Float(Float)
+     + Int(Int)
+     + List([JSON])
+     + String(String)
+     + Null */
+  let t: Typ.t =
+    rec_(
+      Fresh.TPat.var("JSON"),
+      sum_type([
+        ("Assoc", Some(list(prod([string(), self])))),
+        ("Bool", Some(bool())),
+        ("Float", Some(float())),
+        ("Int", Some(int())),
+        ("List", Some(list(self))),
+        ("String", Some(string())),
+        ("Null", None),
+      ]),
+    );
+
+  open IdTagged.FreshGrammar;
+  let json_assoc =
+    Exp.constructor("Assoc", Some(Some(arrow(unknown(SynSwitch), t))));
+  let json_bool =
+    Exp.constructor("Bool", Some(Some(arrow(unknown(SynSwitch), t))));
+  let json_float =
+    Exp.constructor("Float", Some(Some(arrow(unknown(SynSwitch), t))));
+  let json_int =
+    Exp.constructor("Int", Some(Some(arrow(unknown(SynSwitch), t))));
+  let json_list =
+    Exp.constructor("List", Some(Some(arrow(unknown(SynSwitch), t))));
+  let json_string =
+    Exp.constructor("String", Some(Some(arrow(unknown(SynSwitch), t))));
+  let json_null = Exp.constructor("Null", Some(Some(t)));
+
+  let pat_json_assoc =
+    Pat.constructor("Assoc", Some(Some(arrow(unknown(SynSwitch), t))));
+  let pat_json_bool =
+    Pat.constructor("Bool", Some(Some(arrow(unknown(SynSwitch), t))));
+  let pat_json_float =
+    Pat.constructor("Float", Some(Some(arrow(unknown(SynSwitch), t))));
+  let pat_json_int =
+    Pat.constructor("Int", Some(Some(arrow(unknown(SynSwitch), t))));
+  let pat_json_list =
+    Pat.constructor("List", Some(Some(arrow(unknown(SynSwitch), t))));
+  let pat_json_string =
+    Pat.constructor("String", Some(Some(arrow(unknown(SynSwitch), t))));
+  let pat_json_null = Pat.constructor("Null", Some(Some(t)));
+};
+
 // List of type aliases to add to the context
 let type_aliases: list((string, Typ.t)) = [
   ("Ord", Ord.t),
   ("Option", Option.t),
   ("Either", Either.t),
+  ("JSON", JSON.t),
   ("$Meta", meta_type),
 ];
 
@@ -198,6 +255,11 @@ let constructors: Ctx.t = {
       let cons_map =
         switch (Typ.term_of(typ)) {
         | Sum(cons_map) => cons_map
+        | Rec(_, tbody) =>
+          switch (Typ.term_of(tbody)) {
+          | Sum(cons_map) => cons_map
+          | _ => failwith("Type alias must be a sum type")
+          }
         | _ => failwith("Type alias must be a sum type")
         };
       Ctx.add_ctrs(ctx, name, cons_map);

--- a/test/Test_HazelJson_JsonADT.re
+++ b/test/Test_HazelJson_JsonADT.re
@@ -1,0 +1,119 @@
+open Alcotest;
+open Haz3lcore;
+
+let yojson_testable = testable(Yojson.Safe.pp, Yojson.Safe.equal);
+let yojson_result_testable = result(yojson_testable, string);
+
+let test_round_trip = (~name, ~json: Yojson.Safe.t) =>
+  test_case(
+    name,
+    `Quick,
+    () => {
+      let exp_result = HazelJson.JsonADT.yojson_to_exp(json);
+      switch (exp_result) {
+      | Ok(exp) =>
+        let json_result = HazelJson.JsonADT.exp_to_yojson(exp);
+        check(yojson_result_testable, name, Ok(json), json_result);
+      | Error(msg) => fail("yojson_to_exp failed: " ++ msg)
+      };
+    },
+  );
+
+let tests = (
+  "HazelJson.JsonADT",
+  [
+    /* Null */
+    test_round_trip(~name="null", ~json=`Null),
+    /* Bool */
+    test_round_trip(~name="bool_true", ~json=`Bool(true)),
+    test_round_trip(~name="bool_false", ~json=`Bool(false)),
+    /* Int */
+    test_round_trip(~name="int_zero", ~json=`Int(0)),
+    test_round_trip(~name="int_positive", ~json=`Int(42)),
+    test_round_trip(~name="int_negative", ~json=`Int(-7)),
+    test_round_trip(~name="int_large", ~json=`Int(999999)),
+    /* Float */
+    test_round_trip(~name="float_positive", ~json=`Float(3.14)),
+    test_round_trip(~name="float_zero", ~json=`Float(0.0)),
+    test_round_trip(~name="float_negative", ~json=`Float(-2.5)),
+    /* String */
+    test_round_trip(~name="string_hello", ~json=`String("hello")),
+    test_round_trip(~name="string_empty", ~json=`String("")),
+    test_round_trip(~name="string_spaces", ~json=`String("hello world")),
+    /* List */
+    test_round_trip(~name="list_empty", ~json=`List([])),
+    test_round_trip(~name="list_single_int", ~json=`List([`Int(42)])),
+    test_round_trip(
+      ~name="list_multiple_ints",
+      ~json=`List([`Int(1), `Int(2), `Int(3)]),
+    ),
+    test_round_trip(
+      ~name="list_mixed_types",
+      ~json=`List([`Int(1), `String("two"), `Bool(true)]),
+    ),
+    test_round_trip(
+      ~name="list_nested",
+      ~json=`List([`List([`Int(1), `Int(2)]), `List([`Int(3)])]),
+    ),
+    /* Assoc (JSON objects) */
+    test_round_trip(~name="assoc_empty", ~json=`Assoc([])),
+    test_round_trip(
+      ~name="assoc_single",
+      ~json=`Assoc([("key", `Int(42))]),
+    ),
+    test_round_trip(
+      ~name="assoc_multiple",
+      ~json=`Assoc([("name", `String("Alice")), ("age", `Int(30))]),
+    ),
+    /* Nested/compositional */
+    test_round_trip(
+      ~name="nested_assoc_in_list",
+      ~json=
+        `List([
+          `Assoc([("id", `Int(1)), ("name", `String("Alice"))]),
+          `Assoc([("id", `Int(2)), ("name", `String("Bob"))]),
+        ]),
+    ),
+    test_round_trip(
+      ~name="nested_list_in_assoc",
+      ~json=`Assoc([("items", `List([`Int(1), `Int(2), `Int(3)]))]),
+    ),
+    test_round_trip(
+      ~name="deeply_nested",
+      ~json=
+        `Assoc([
+          (
+            "data",
+            `Assoc([("values", `List([`Int(1), `Null, `Bool(true)]))]),
+          ),
+          ("meta", `String("test")),
+        ]),
+    ),
+    test_round_trip(
+      ~name="null_in_list",
+      ~json=`List([`Null, `Int(1), `Null]),
+    ),
+    test_round_trip(
+      ~name="complex_nested",
+      ~json=
+        `Assoc([
+          (
+            "users",
+            `List([
+              `Assoc([
+                ("name", `String("Alice")),
+                ("scores", `List([`Int(95), `Int(87), `Int(92)])),
+                ("active", `Bool(true)),
+              ]),
+              `Assoc([
+                ("name", `String("Bob")),
+                ("scores", `List([])),
+                ("active", `Bool(false)),
+              ]),
+            ]),
+          ),
+          ("count", `Int(2)),
+        ]),
+    ),
+  ],
+);

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -26,6 +26,7 @@ let (suite, _) =
       Test_MakeTerm.tests,
       Test_Menhir.tests,
       Test_StringUtil.tests,
+      Test_HazelJson_JsonADT.tests,
       Test_PatternMatch.tests,
       Test_Equality.tests,
       Test_Substitution.tests,


### PR DESCRIPTION
Adds a builtin recursive JSON ADT (Assoc | Bool | Float | Int | List | String | Null) to BuiltinsADT, with Rec-aware constructor registration, and a new HazelJson.JsonADT codec converting between Yojson and Hazel expressions of the builtin JSON type.