### PR TITLE
Add Cut/Copy/Paste to the editor context menu

### DIFF
--- a/src/util/JsUtil.re
+++ b/src/util/JsUtil.re
@@ -189,10 +189,16 @@ let show_copy_toast = (): unit => {
     },
   );
 };
-/* Direct clipboard writes via the async Clipboard API. Used from editor
-   key handlers where the focused element is a non-editable div and
-   Firefox therefore refuses to dispatch a native `copy` event to the
-   page-level handler. Safe under a user gesture (keydown). */
+/* Clipboard access as Effects. Both directions go through the async
+   Clipboard API, because the editor's key handlers run with focus on a
+   non-editable div and Firefox refuses to dispatch native copy/paste
+   events there.
+
+   Defined with Ui_effect.Define1 — the same mechanism Bonsai builds
+   Effect.of_deferred_fun from — so callers compose these like any other
+   Effect rather than side-effecting on their own and scheduling the
+   result by hand. Both must be dispatched from an event handler: the
+   Clipboard API only grants access under a user gesture. */
 let has_clipboard_api = (): bool =>
   Js.to_bool(
     Js.Unsafe.fun_call(
@@ -203,32 +209,47 @@ let has_clipboard_api = (): bool =>
     ),
   );
 
-let write_clipboard = (str: string): unit =>
-  if (has_clipboard_api()) {
-    Js.Unsafe.fun_call(
-      Js.Unsafe.pure_js_expr(
-        "(function(s){navigator.clipboard.writeText(s);})",
-      ),
-      [|Js.Unsafe.inject(Js.string(str))|],
-    );
-  } else {
-    /* Older browsers: fall through to the shim/execCommand path. */
-    copy(str);
+module ClipboardHandler = {
+  module Action = {
+    type t(_) =
+      | Read_text: t(string)
+      | Write_text(string): t(unit);
   };
+  let handle = (type a, action: Action.t(a), ~on_response: a => unit) =>
+    switch (action) {
+    | Read_text =>
+      let cb = Js.wrap_callback(text => on_response(Js.to_string(text)));
+      Js.Unsafe.fun_call(
+        Js.Unsafe.pure_js_expr(
+          "(function(cb){navigator.clipboard.readText().then(cb);})",
+        ),
+        [|Js.Unsafe.inject(cb)|],
+      );
+    | Write_text(str) =>
+      /* Older browsers with no Clipboard API fall through to the
+         execCommand shim. */
+      if (has_clipboard_api()) {
+        Js.Unsafe.fun_call(
+          Js.Unsafe.pure_js_expr(
+            "(function(s){navigator.clipboard.writeText(s);})",
+          ),
+          [|Js.Unsafe.inject(Js.string(str))|],
+        );
+      } else {
+        copy(str);
+      };
+      on_response();
+    };
+};
+module Clipboard = Ui_effect.Define1(ClipboardHandler);
 
-/* Async clipboard read, used for editor-level Cmd+V. The Promise's
-   text result is delivered to `on_text`, which is expected to schedule
-   the resulting Effect via Bonsai.Effect.Expert.handle. */
-let read_clipboard = (on_text: string => unit): unit =>
-  if (has_clipboard_api()) {
-    let cb = Js.wrap_callback(text => on_text(Js.to_string(text)));
-    Js.Unsafe.fun_call(
-      Js.Unsafe.pure_js_expr(
-        "(function(cb){navigator.clipboard.readText().then(cb);})",
-      ),
-      [|Js.Unsafe.inject(cb)|],
-    );
-  };
+let write_clipboard = (str: string): Effect.t(unit) =>
+  Clipboard.inject(Write_text(str));
+
+/* Never completes when the browser has no Clipboard API — there is no
+   text to deliver, so there is no Paste to dispatch. */
+let read_clipboard = (): Effect.t(string) =>
+  has_clipboard_api() ? Clipboard.inject(Read_text) : Effect.never;
 
 let element_to_node = (element: Js.t(Dom_html.element)): Js.t(Dom.node) =>
   Js.Unsafe.coerce(element);

--- a/src/web/app/editors/code/CodeEditable.re
+++ b/src/web/app/editors/code/CodeEditable.re
@@ -576,34 +576,40 @@ module View = {
       /* Cache for paste reuse only when nothing was trimmed: a trimmed
          sub-token string must re-parse on paste, not round-trip to the
          full segment. */
-      if (str == full && !selection_has_refractors(z.refractors, segment)) {
-        Haz3lcore.Parser.set_segment_cache(Some(segment), str);
-      };
-      JsUtil.write_clipboard(str);
+      let cache_for_paste =
+        str == full && !selection_has_refractors(z.refractors, segment)
+          ? Effect.of_sync_fun(
+              () => Haz3lcore.Parser.set_segment_cache(Some(segment), str),
+              (),
+            )
+          : Effect.Ignore;
+      Effect.Many([cache_for_paste, JsUtil.write_clipboard(str)]);
     };
     let paste_from_clipboard = () =>
-      JsUtil.read_clipboard(text => {
-        let action =
-          Haz3lcore.Action.Paste(Util.StringUtil.trim_leading(text));
-        Bonsai.Effect.Expert.handle(inject(Perform(action)));
-      });
+      Effect.bind(JsUtil.read_clipboard(), ~f=text =>
+        inject(
+          Perform(
+            Haz3lcore.Action.Paste(Util.StringUtil.trim_leading(text)),
+          ),
+        )
+      );
     /* Inject for context-menu rows. Clipboard rows need view-layer side
        effects the core can't perform: Copy/Cut write the system clipboard
        before dispatch, and PasteFromClipboard starts an async read whose
        result is dispatched as the real Paste, closing the menu
-       immediately. Runs at event-firing time (see Menu.pointerdown_attr),
-       like the keyboard clipboard handlers below. */
+       immediately. Both are Effects, so the clipboard is touched when the
+       row fires rather than when its Effect is built. */
     let perform_from_menu = (c: ContextMenu.command): Ui_effect.t(unit) =>
       switch (c) {
       | Perform(Copy) =>
-        copy_selection();
-        inject(Perform(Copy));
+        Effect.Many([copy_selection(), inject(Perform(Copy))])
       | Perform(Cut) =>
-        copy_selection();
-        inject(Perform(Cut));
+        Effect.Many([copy_selection(), inject(Perform(Cut))])
       | PasteFromClipboard =>
-        paste_from_clipboard();
-        inject(ContextMenu(ContextMenu.Model.Close));
+        Effect.Many([
+          paste_from_clipboard(),
+          inject(ContextMenu(ContextMenu.Model.Close)),
+        ])
       | Perform(a) => inject(Perform(a))
       };
     /* Sync document-level listeners (click-outside + keyboard) for the
@@ -995,8 +1001,11 @@ module View = {
               alt: Up,
               _,
             } =>
-            copy_selection();
-            Effect.Many([Effect.Prevent_default, Effect.Stop_propagation]);
+            Effect.Many([
+              copy_selection(),
+              Effect.Prevent_default,
+              Effect.Stop_propagation,
+            ])
           | {
               key: D("x" | "X"),
               sys: Mac,
@@ -1015,12 +1024,12 @@ module View = {
               alt: Up,
               _,
             } =>
-            copy_selection();
             Effect.Many([
+              copy_selection(),
               Effect.Prevent_default,
               Effect.Stop_propagation,
               inject(Perform(Destruct(Right))),
-            ]);
+            ])
           | {
               key: D("v" | "V"),
               sys: Mac,
@@ -1039,8 +1048,11 @@ module View = {
               alt: Up,
               _,
             } =>
-            paste_from_clipboard();
-            Effect.Many([Effect.Prevent_default, Effect.Stop_propagation]);
+            Effect.Many([
+              paste_from_clipboard(),
+              Effect.Prevent_default,
+              Effect.Stop_propagation,
+            ])
           | _ =>
             /* 3. Normal editor key handling:
              *    context menu → projector handoff → Keyboard */

--- a/src/web/app/editors/code/CodeEditable.re
+++ b/src/web/app/editors/code/CodeEditable.re
@@ -543,6 +543,70 @@ module View = {
       | ReadOnly => (_ => Ui_effect.Ignore)
       | Editable({escape, _}) => escape
       };
+    /* Editor-level clipboard helpers. Bypass the page-level
+       on_copy/on_paste path because Firefox refuses to dispatch
+       native clipboard events to non-editable focused elements
+       (the editor div has tabindex(0) but is not contenteditable).
+       Shared by the keyboard shortcuts and the context menu. */
+    let selection_has_refractors =
+        (refractors: Haz3lcore.Zipper.Refractor.t, selection) =>
+      if (List.is_empty(refractors.manuals)) {
+        false;
+      } else {
+        let ids = Haz3lcore.Segment.ids(selection);
+        List.exists(
+          id =>
+            List.exists(
+              ((id2, _)) => Id.equal(id, id2),
+              refractors.manuals,
+            ),
+          ids,
+        );
+      };
+    let copy_selection = () => {
+      let z = model.editor.state.zipper;
+      let segment = z.selection.content;
+      let full =
+        Printer.of_segment(
+          ~indent=" ",
+          ~refractors=z.refractors.manuals,
+          segment,
+        );
+      let str = Zipper.trim_selected_text(z, full);
+      /* Cache for paste reuse only when nothing was trimmed: a trimmed
+         sub-token string must re-parse on paste, not round-trip to the
+         full segment. */
+      if (str == full && !selection_has_refractors(z.refractors, segment)) {
+        Haz3lcore.Parser.set_segment_cache(Some(segment), str);
+      };
+      JsUtil.write_clipboard(str);
+    };
+    let paste_from_clipboard = () =>
+      JsUtil.read_clipboard(text => {
+        let action =
+          Haz3lcore.Action.Paste(Util.StringUtil.trim_leading(text));
+        Bonsai.Effect.Expert.handle(inject(Perform(action)));
+      });
+    /* Inject for context-menu rows. Clipboard actions need view-layer
+       side effects the core can't perform: Copy/Cut write the system
+       clipboard before dispatch, and a menu Paste carries a placeholder
+       payload — read the system clipboard (async) and let the read
+       dispatch the real Paste, closing the menu immediately. Runs at
+       event-firing time (see Menu.pointerdown_attr), like the keyboard
+       clipboard handlers below. */
+    let perform_from_menu = (a: Action.t): Ui_effect.t(unit) =>
+      switch (a) {
+      | Copy =>
+        copy_selection();
+        inject(Perform(Copy));
+      | Cut =>
+        copy_selection();
+        inject(Perform(Cut));
+      | Paste(_) =>
+        paste_from_clipboard();
+        inject(ContextMenu(ContextMenu.Model.Close));
+      | a => inject(Perform(a))
+      };
     /* Sync document-level listeners (click-outside + keyboard) for the
      * context menu. Keys are dispatched at capture phase so the editor's
      * window-level handler doesn't see them while the menu is open. */
@@ -556,7 +620,7 @@ module View = {
             ~elaborated=model.statics.elaborated,
             ~zipper=model.editor.state.zipper,
             ~dispatch_menu=a => inject(ContextMenu(a)),
-            ~dispatch_action=a => inject(Perform(a)),
+            ~dispatch_action=perform_from_menu,
             model.context_menu,
             key_str,
           ),
@@ -594,7 +658,7 @@ module View = {
                   [],
                 ),
                 ContextMenu.view(
-                  ~inject=a => inject(Perform(a)),
+                  ~inject=perform_from_menu,
                   ~inject_menu=a => inject(ContextMenu(a)),
                   ~syntax=model.editor.syntax,
                   ~info_map=model.statics.info_map,
@@ -715,6 +779,34 @@ module View = {
         ? Some(Keyboard.mouse_modifier_chunk(globals.settings.core)) : None;
     };
 
+    /* True when a click location falls within the measured extent of
+       the current selection (approximated by its first/last pieces).
+       Right-click uses this to keep the selection alive so the context
+       menu's Cut/Copy can act on it. */
+    let click_in_selection = (click: Point.t): bool => {
+      let z = model.editor.state.zipper;
+      switch (z.selection.content) {
+      | [] => false
+      | [first, ..._] as content =>
+        let measured = model.editor.syntax.measured;
+        switch (
+          try(
+            Some((
+              Measured.find_p(first, measured),
+              Measured.find_p(ListUtil.last(content), measured),
+            ))
+          ) {
+          | _ => None
+          }
+        ) {
+        | None => false
+        | Some((head, tail)) =>
+          Point.compare(click, head.origin) >= 0
+          && Point.compare(click, tail.last) <= 0
+        };
+      };
+    };
+
     let move_or_select = (mouse: Pointer.Event.t, pointer_id: int) =>
       switch (mouse) {
       | {button: Left, shift: Down, _} =>
@@ -742,12 +834,17 @@ module View = {
           inject(Perform(Move(Goal(BindingSiteOfIndicatedVar)))),
         ])
       | {button: Right, ctrl, _} when ctrl != Down =>
-        Effect.Many([
-          //Effect.Stop_propagation,
-          Effect.Prevent_default,
-          inject(Perform(Move(Point(loc(mouse), None)))),
-          inject(ContextMenu(ContextMenu.Model.Toggle)),
-        ])
+        /* Right-click inside the selection keeps it (so the menu's
+           Cut/Copy apply to it); outside, move the caret to the click
+           location as a plain click would before opening the menu. */
+        Effect.Many(
+          [Effect.Prevent_default]
+          @ (
+            click_in_selection(loc(mouse))
+              ? [] : [inject(Perform(Move(Point(loc(mouse), None))))]
+          )
+          @ [inject(ContextMenu(ContextMenu.Model.Toggle))],
+        )
       | {button: Left, _} =>
         MouseState.pointerdown(loc(mouse));
         DragClass.add(mouse.current_target);
@@ -847,48 +944,6 @@ module View = {
         );
       } else {
         let z = model.editor.state.zipper;
-        /* Editor-level clipboard helpers. Bypass the page-level
-           on_copy/on_paste path because Firefox refuses to dispatch
-           native clipboard events to non-editable focused elements
-           (the editor div has tabindex(0) but is not contenteditable). */
-        let selection_has_refractors =
-            (refractors: Haz3lcore.Zipper.Refractor.t, selection) =>
-          if (List.is_empty(refractors.manuals)) {
-            false;
-          } else {
-            let ids = Haz3lcore.Segment.ids(selection);
-            List.exists(
-              id =>
-                List.exists(
-                  ((id2, _)) => Id.equal(id, id2),
-                  refractors.manuals,
-                ),
-              ids,
-            );
-          };
-        let copy_selection = () => {
-          let segment = z.selection.content;
-          let full =
-            Printer.of_segment(
-              ~indent=" ",
-              ~refractors=z.refractors.manuals,
-              segment,
-            );
-          let str = Zipper.trim_selected_text(z, full);
-          /* Cache for paste reuse only when nothing was trimmed: a trimmed
-             sub-token string must re-parse on paste, not round-trip to the
-             full segment. */
-          if (str == full && !selection_has_refractors(z.refractors, segment)) {
-            Haz3lcore.Parser.set_segment_cache(Some(segment), str);
-          };
-          JsUtil.write_clipboard(str);
-        };
-        let paste_from_clipboard = () =>
-          JsUtil.read_clipboard(text => {
-            let action =
-              Haz3lcore.Action.Paste(Util.StringUtil.trim_leading(text));
-            Bonsai.Effect.Expert.handle(inject(Perform(action)));
-          });
         Key.handler(~f=key => {
           /* 1. Check for arrow key escape at boundaries FIRST.
            *    Keyboard.handle_key_event always returns Some for arrows,

--- a/src/web/app/editors/code/CodeEditable.re
+++ b/src/web/app/editors/code/CodeEditable.re
@@ -587,25 +587,24 @@ module View = {
           Haz3lcore.Action.Paste(Util.StringUtil.trim_leading(text));
         Bonsai.Effect.Expert.handle(inject(Perform(action)));
       });
-    /* Inject for context-menu rows. Clipboard actions need view-layer
-       side effects the core can't perform: Copy/Cut write the system
-       clipboard before dispatch, and a menu Paste carries a placeholder
-       payload — read the system clipboard (async) and let the read
-       dispatch the real Paste, closing the menu immediately. Runs at
-       event-firing time (see Menu.pointerdown_attr), like the keyboard
-       clipboard handlers below. */
-    let perform_from_menu = (a: Action.t): Ui_effect.t(unit) =>
-      switch (a) {
-      | Copy =>
+    /* Inject for context-menu rows. Clipboard rows need view-layer side
+       effects the core can't perform: Copy/Cut write the system clipboard
+       before dispatch, and PasteFromClipboard starts an async read whose
+       result is dispatched as the real Paste, closing the menu
+       immediately. Runs at event-firing time (see Menu.pointerdown_attr),
+       like the keyboard clipboard handlers below. */
+    let perform_from_menu = (c: ContextMenu.command): Ui_effect.t(unit) =>
+      switch (c) {
+      | Perform(Copy) =>
         copy_selection();
         inject(Perform(Copy));
-      | Cut =>
+      | Perform(Cut) =>
         copy_selection();
         inject(Perform(Cut));
-      | Paste(_) =>
+      | PasteFromClipboard =>
         paste_from_clipboard();
         inject(ContextMenu(ContextMenu.Model.Close));
-      | a => inject(Perform(a))
+      | Perform(a) => inject(Perform(a))
       };
     /* Sync document-level listeners (click-outside + keyboard) for the
      * context menu. Keys are dispatched at capture phase so the editor's

--- a/src/web/app/editors/code/ContextMenu.re
+++ b/src/web/app/editors/code/ContextMenu.re
@@ -17,7 +17,7 @@ open Node;
 module Model = Menu;
 
 /* Menu dimensions for viewport calculations */
-let menu_height_estimate = 200.0; /* px */
+let menu_height_estimate = 260.0; /* px */
 let menu_width_estimate = 180.0; /* px - based on min-width: 160px + padding */
 
 /* CSS class for the editor menu's open direction. The column menu has its
@@ -70,10 +70,13 @@ module Shortcuts = {
   let livelit = () => Os.is_mac^ ? "⌥L" : "Alt+L";
   let introduce = () => Os.is_mac^ ? "⌘I" : "Ctrl+I";
   let select_current_term = () => Os.is_mac^ ? "⌘D" : "Ctrl+D";
+  let cut = () => Os.is_mac^ ? "⌘X" : "Ctrl+X";
+  let copy = () => Os.is_mac^ ? "⌘C" : "Ctrl+C";
+  let paste = () => Os.is_mac^ ? "⌘V" : "Ctrl+V";
 };
 
-let action_item = (~shortcut=?, ~tooltip=?, label, action) =>
-  Menu.action_item(~decoration=?shortcut, ~tooltip?, label, action);
+let action_item = (~shortcut=?, ~tooltip=?, ~enabled=true, label, action) =>
+  Menu.action_item(~decoration=?shortcut, ~tooltip?, ~enabled, label, action);
 
 let probe_data =
     (
@@ -191,6 +194,29 @@ let introduce_data =
     ]
   | _ => []
   };
+
+/* Cut/Copy/Paste rows. Dispatch goes through CodeEditable's
+ * clipboard-aware inject: Copy/Cut write the system clipboard before
+ * the action is performed, and Paste's empty payload is a placeholder
+ * replaced via an async system-clipboard read at dispatch time. */
+let clipboard_data = (z: Zipper.t): list(Menu.item(Action.t)) => {
+  let has_selection = !Selection.is_empty(z.selection);
+  [
+    action_item(
+      ~shortcut=Shortcuts.cut(),
+      ~enabled=has_selection,
+      "Cut",
+      Action.Cut,
+    ),
+    action_item(
+      ~shortcut=Shortcuts.copy(),
+      ~enabled=has_selection,
+      "Copy",
+      Action.Copy,
+    ),
+    action_item(~shortcut=Shortcuts.paste(), "Paste", Action.Paste("")),
+  ];
+};
 
 let select_current_term_data = (): list(Menu.item(Action.t)) => [
   action_item(
@@ -375,11 +401,13 @@ let get_sections =
   [
     /* Section 1: Navigation & Selection */
     jump_to_binding_data(ci) @ select_current_term_data(),
-    /* Section 2: Refactoring */
+    /* Section 2: Clipboard */
+    clipboard_data(z),
+    /* Section 3: Refactoring */
     introduce_data(ci),
-    /* Section 3: Probes/Statics (refractors) */
+    /* Section 4: Probes/Statics (refractors) */
     refractor_actions_data(~ci, info_map, z),
-    /* Section 4: Projectors (fold, livelits) */
+    /* Section 5: Projectors (fold, livelits) */
     Projectors.actions_data(z, info_map, ~elaborated),
   ]
   |> List.filter(section => section != []);

--- a/src/web/app/editors/code/ContextMenu.re
+++ b/src/web/app/editors/code/ContextMenu.re
@@ -9,7 +9,7 @@ open Node;
  * State, rendering, and keyboard handling all live in `Util.Menu`. This
  * file is the editor-specific *contents*: builders for the rows (probe,
  * statics, goto, introduce, select term, projectors) plus caret-anchored
- * positioning. Each `*_data` builder returns a `list(Menu.item(Action.t))`
+ * positioning. Each `*_data` builder returns a `list(Menu.item(command))`
  * for one menu section; `get_sections` assembles them in order. */
 
 /* Backward-compatible alias so call sites that reference
@@ -75,8 +75,31 @@ module Shortcuts = {
   let paste = () => Os.is_mac^ ? "⌘V" : "Ctrl+V";
 };
 
+/* What a menu row dispatches. Most rows are a plain editor action, but
+ * Paste can't be: the text it inserts is only available from an async
+ * system-clipboard read at click time, so the row carries the intent and
+ * the view layer supplies the text (see CodeEditable.perform_from_menu). */
+type command =
+  | Perform(Action.t)
+  | PasteFromClipboard;
+
 let action_item = (~shortcut=?, ~tooltip=?, ~enabled=true, label, action) =>
-  Menu.action_item(~decoration=?shortcut, ~tooltip?, ~enabled, label, action);
+  Menu.action_item(
+    ~decoration=?shortcut,
+    ~tooltip?,
+    ~enabled,
+    label,
+    Perform(action),
+  );
+
+let command_item = (~shortcut=?, ~tooltip=?, ~enabled=true, label, command) =>
+  Menu.action_item(
+    ~decoration=?shortcut,
+    ~tooltip?,
+    ~enabled,
+    label,
+    command,
+  );
 
 let probe_data =
     (
@@ -85,7 +108,7 @@ let probe_data =
       probe_status: ProbePerform.probe_status,
       ci: option(Language.Info.t),
     )
-    : list(Menu.item(Action.t)) =>
+    : list(Menu.item(command)) =>
   switch (ci) {
   | Some(InfoExp(_) | InfoPat(_)) when can_probe => [
       action_item(
@@ -121,7 +144,7 @@ let type_annotation_data =
       probe_status: ProbePerform.probe_status,
       ci: option(Language.Info.t),
     )
-    : list(Menu.item(Action.t)) =>
+    : list(Menu.item(command)) =>
   switch (ci) {
   | Some(InfoExp(_) | InfoPat(_)) when can_type => [
       action_item(
@@ -141,7 +164,7 @@ let type_annotation_data =
   };
 
 let jump_to_binding_data =
-    (ci: option(Language.Info.t)): list(Menu.item(Action.t)) =>
+    (ci: option(Language.Info.t)): list(Menu.item(command)) =>
   switch (OptUtil.and_then(Language.Info.get_binding_site, ci)) {
   | Some(_) => [
       action_item(
@@ -154,7 +177,7 @@ let jump_to_binding_data =
   };
 
 let introduce_data =
-    (ci: option(Language.Info.t)): list(Menu.item(Action.t)) =>
+    (ci: option(Language.Info.t)): list(Menu.item(command)) =>
   switch (ci) {
   | Some(
       Language.Info.InfoExp({
@@ -196,10 +219,18 @@ let introduce_data =
   };
 
 /* Cut/Copy/Paste rows. Dispatch goes through CodeEditable's
- * clipboard-aware inject: Copy/Cut write the system clipboard before
- * the action is performed, and Paste's empty payload is a placeholder
- * replaced via an async system-clipboard read at dispatch time. */
-let clipboard_data = (z: Zipper.t): list(Menu.item(Action.t)) => {
+ * clipboard-aware inject: Copy/Cut write the system clipboard before the
+ * action is performed, and Paste asks for a system-clipboard read whose
+ * result becomes the real Paste action.
+ *
+ * Cut/Copy gray out on an empty selection; Paste never does. The web has
+ * no way to see whether the clipboard is empty short of reading it, and
+ * that read is permission-gated and async (Chrome prompts once per
+ * origin, Firefox and Safari on every read) — so checking on menu-open
+ * would prompt on every right-click. Rich web editors (Google Docs, VS
+ * Code for the Web) leave Paste enabled for the same reason and only
+ * find out at click time. */
+let clipboard_data = (z: Zipper.t): list(Menu.item(command)) => {
   let has_selection = !Selection.is_empty(z.selection);
   [
     action_item(
@@ -214,11 +245,11 @@ let clipboard_data = (z: Zipper.t): list(Menu.item(Action.t)) => {
       "Copy",
       Action.Copy,
     ),
-    action_item(~shortcut=Shortcuts.paste(), "Paste", Action.Paste("")),
+    command_item(~shortcut=Shortcuts.paste(), "Paste", PasteFromClipboard),
   ];
 };
 
-let select_current_term_data = (): list(Menu.item(Action.t)) => [
+let select_current_term_data = (): list(Menu.item(command)) => [
   action_item(
     ~shortcut=Shortcuts.select_current_term(),
     "Select term",
@@ -332,7 +363,7 @@ module Projectors = {
         info_map: Language.Statics.Map.t,
         ~elaborated: Language.Exp.t,
       )
-      : list(Menu.item(Action.t)) => {
+      : list(Menu.item(command)) => {
     let current_kind = indicated_kind(z);
     let applicable = applicable_kinds(z, info_map, ~elaborated);
     let kinds =
@@ -346,7 +377,7 @@ module Projectors = {
         applicable,
       );
 
-    let make_item = (kind: ProjectorCore.Kind.t): Menu.item(Action.t) => {
+    let make_item = (kind: ProjectorCore.Kind.t): Menu.item(command) => {
       let name = display_name(kind);
       let shortcut = shortcut_of(~chosen_livelit, kind);
       let prefix =
@@ -372,7 +403,7 @@ let refractor_actions_data =
       info_map: Language.Statics.Map.t,
       z: Zipper.t,
     )
-    : list(Menu.item(Action.t)) => {
+    : list(Menu.item(command)) => {
   let id = Indicated.index(z) |> Option.value(~default=Id.invalid);
   let probe_status = ProbePerform.probe_status(id, info_map, z.refractors);
   let can_probe = ProbePerform.can_probe(id, info_map);
@@ -386,7 +417,7 @@ let refractor_actions_data =
  * Menu assembly
  * ============================================================
  * To add a new menu item:
- * 1. Create a `*_data` function returning list(Menu.item(Action.t))
+ * 1. Create a `*_data` function returning list(Menu.item(command))
  * 2. Add it to the appropriate section in get_sections below
  * ============================================================ */
 
@@ -396,7 +427,7 @@ let get_sections =
       ~elaborated: Language.Exp.t,
       z: Zipper.t,
     )
-    : list(list(Menu.item(Action.t))) => {
+    : list(list(Menu.item(command))) => {
   let ci = Indicated.ci_of(z, info_map);
   [
     /* Section 1: Navigation & Selection */
@@ -415,8 +446,7 @@ let get_sections =
 
 /* Flatten sections by interspersing `Menu.Divider` between non-empty ones. */
 let flatten_sections =
-    (sections: list(list(Menu.item(Action.t))))
-    : list(Menu.item(Action.t)) =>
+    (sections: list(list(Menu.item(command)))): list(Menu.item(command)) =>
   List.fold_left(
     (acc, section) =>
       switch (acc, section) {
@@ -434,7 +464,7 @@ let get_all_items =
       ~elaborated: Language.Exp.t,
       z: Zipper.t,
     )
-    : list(Menu.item(Action.t)) =>
+    : list(Menu.item(command)) =>
   flatten_sections(get_sections(~info_map, ~elaborated, z));
 
 /* ============================================================
@@ -463,7 +493,7 @@ module WithContext = {
         ~elaborated: Language.Exp.t,
         ~zipper: Zipper.t,
         ~dispatch_menu: Menu.action => Ui_effect.t(unit),
-        ~dispatch_action: Action.t => Ui_effect.t(unit),
+        ~dispatch_action: command => Ui_effect.t(unit),
         state: Menu.t,
         key_str: string,
       )
@@ -520,7 +550,7 @@ let get_direction =
 
 let view =
     (
-      ~inject: Action.t => Ui_effect.t(unit),
+      ~inject: command => Ui_effect.t(unit),
       ~inject_menu: Menu.action => Ui_effect.t(unit),
       ~syntax: Haz3lcore.CachedSyntax.t,
       ~info_map: Language.Statics.Map.t,

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -47,23 +47,25 @@ let typ_to_text = (~settings, typ: Typ.t): string =>
    empty holes explicitly as `?`, and the source segment is cached against that
    text so pasting back into Hazel restores the real (implicit) holes, while
    pasting into a plain text editor yields the `?` text. */
-let copy_segment = (segment: Haz3lcore.Segment.t): unit => {
+let copy_segment = (segment: Haz3lcore.Segment.t): Effect.t(unit) => {
   let str = Haz3lcore.Printer.of_segment(~holes="?", segment);
-  Haz3lcore.Parser.set_segment_cache(Some(segment), str);
-  Util.JsUtil.write_clipboard(str);
+  Effect.Many([
+    Effect.of_sync_fun(
+      () => Haz3lcore.Parser.set_segment_cache(Some(segment), str),
+      (),
+    ),
+    Util.JsUtil.write_clipboard(str),
+  ]);
 };
 
 /* Copy button; `on_copy` runs only on click (not when the field is built) and
    is revealed on field hover via CSS so it doesn't clutter the list. */
-let copy_button = (on_copy: unit => unit): Node.t =>
+let copy_button = (on_copy: unit => Effect.t(unit)): Node.t =>
   span(
     ~attrs=[
       clss(["debug-copy-button"]),
       Attr.title("Copy to clipboard"),
-      Attr.on_click(_ => {
-        on_copy();
-        Virtual_dom.Vdom.Effect.Ignore;
-      }),
+      Attr.on_click(_ => on_copy()),
     ],
     [text({|⧉|})],
   );
@@ -73,7 +75,7 @@ let copy_button = (on_copy: unit => unit): Node.t =>
 let label_row =
     (
       ~chevron: list(Node.t)=[],
-      ~copy: option(unit => unit)=None,
+      ~copy: option(unit => Effect.t(unit))=None,
       label: string,
     )
     : Node.t =>
@@ -118,7 +120,12 @@ let section =
 };
 
 let field_node =
-    (~copy: option(unit => unit)=None, label: string, body: Node.t): Node.t =>
+    (
+      ~copy: option(unit => Effect.t(unit))=None,
+      label: string,
+      body: Node.t,
+    )
+    : Node.t =>
   div(
     ~attrs=[clss(["debug-field"])],
     [
@@ -143,7 +150,7 @@ let field_str = (label: string, body: string): Node.t =>
 let field_collapsible =
     (
       ~globals: Globals.t,
-      ~copy: unit => unit,
+      ~copy: unit => Effect.t(unit),
       ~body: unit => Node.t,
       label: string,
     )

--- a/src/web/www/style/editor.css
+++ b/src/web/www/style/editor.css
@@ -641,6 +641,13 @@ svg:has(.child-line) {
 .context-menu .group .contents:hover .named-menu-item.selected:not(:hover) {
   background-color: transparent;
 }
+.context-menu .named-menu-item.disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.context-menu .group .contents .named-menu-item.disabled:hover {
+  background-color: transparent;
+}
 .context-menu .named-menu-item .menu-shortcut {
   margin-left: auto;
   padding-left: 1em;


### PR DESCRIPTION
## Summary

Adds a clipboard section (Cut / Copy / Paste) to the editor's right-click context menu, with platform-appropriate shortcut chips (⌘X/⌘C/⌘V on Mac, Ctrl+X/C/V elsewhere).

- **Cut / Copy** are grayed out when the selection is empty. They write the system clipboard using the same helpers as the existing Cmd/Ctrl+C/X keyboard path (including the segment-cache fast-paste optimization), which were hoisted out of the key handler so both paths share them.
- **Paste** is always available. ~~Menu items carry an `Action.t` payload, so the menu's Paste uses a placeholder `Paste("")`; the new `perform_from_menu` inject intercepts it, reads the system clipboard asynchronously, and dispatches the real `Paste(text)` when it arrives, closing the menu immediately.~~
  **Revised** ([review](https://github.com/hazelgrove/hazel/pull/2341#discussion_r3476994230)): rows carry `ContextMenu.command = Perform(Action.t) | PasteFromClipboard` instead of a bare `Action.t`, so no placeholder action exists at all. `action_item` wraps its argument in `Perform` — every row builder is unchanged — and the Paste row carries `PasteFromClipboard`, which `perform_from_menu` turns into the real `Paste(text)` once the async clipboard read lands, closing the menu immediately.
  Paste is never grayed out, because the web can't report whether the clipboard is empty short of reading it, and that read is permission-gated and async (Chrome prompts once per origin, Firefox and Safari on every read) — testing it on menu-open would prompt on every right-click. Google Docs and VS Code for the Web leave Paste enabled for the same reason and find out at click time.
- **Right-click now preserves selections.** Previously right-click always dispatched `Move(Point(...))`, collapsing the selection before the menu opened — which would have made Copy useless. A new `click_in_selection` hit test keeps the selection when the click lands inside its measured extent; clicks outside still move the caret as before.
- Added `.disabled` styling for context-menu rows (dimmed, no hover highlight) and bumped the menu height estimate used for open-direction flipping, since the menu gained three permanent rows.

Known approximation: the hit test uses the selection's first/last piece measurements, so for char-level selections that split a token the "inside" region can be slightly wider than the highlighted text.

## Testing

- `make dev` builds clean.
- Manual: select code → right-click inside the selection → Cut/Copy act on it; right-click elsewhere → caret moves, Cut/Copy disabled, Paste inserts clipboard contents. Keyboard menu navigation (arrows/Enter) drives the same actions.
- The `command`-type revision above still wants a manual re-check — same flows, different dispatch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
