### PR TITLE
Fix char-level copy regression: copying sub-token range copies whole token

### DIFF
--- a/src/haz3lcore/zipper/Printer.re
+++ b/src/haz3lcore/zipper/Printer.re
@@ -98,6 +98,12 @@ let of_segment =
   |> add_caret(~caret, ~selection_anchor)
   |> String.concat("\n");
 
+let selected_text =
+    (~holes=" ", ~indent="", ~refractors=[], z: Zipper.t): string => {
+  let full = of_segment(~holes, ~indent, ~refractors, z.selection.content);
+  Zipper.trim_selected_text(z, full);
+};
+
 /* Use this to pretty-print zippers. See above comments on holes */
 let of_zipper =
     (

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -987,6 +987,12 @@ module Caret = {
   let inner_offset_for_token = (idx: int, token: Token.t): int =>
     Token.is_string(token) ? string_offset(token, idx) : idx + 1;
 
+  /* Like inner_offset_for_token but counts GRAPHEMES, not display columns: a
+     wide char (e.g. an emoji) in a string literal is one grapheme but two
+     columns. Used for clipboard text slicing, where the column count would
+     over-trim and leave a trailing quote. */
+  let inner_grapheme_offset = (idx: int): int => idx + 1;
+
   /* Grid position of the caret */
   /* Convert a caret to a concrete grid point for rendering and hit testing. */
   let point = (measured: Measured.t, z: t): Point.t =>
@@ -1036,7 +1042,7 @@ let selection_trim_offsets = (z: t): (int, int) => {
       };
     let shard = List.hd(Piece.disassemble(p));
     switch (Piece.token_of(shard)) {
-    | Some(tok) => Caret.inner_offset_for_token(inner_n, tok)
+    | Some(_) => Caret.inner_grapheme_offset(inner_n)
     | None => 0
     };
   };
@@ -1051,7 +1057,7 @@ let selection_trim_offsets = (z: t): (int, int) => {
     switch (Piece.token_of(last_shard)) {
     | Some(tok) =>
       let tok_len = Unicode.length(tok);
-      tok_len - Caret.inner_offset_for_token(inner_n, tok);
+      tok_len - Caret.inner_grapheme_offset(inner_n);
     | None => 0
     };
   };

--- a/src/web/app/editors/code/CodeEditable.re
+++ b/src/web/app/editors/code/CodeEditable.re
@@ -869,13 +869,17 @@ module View = {
           };
         let copy_selection = () => {
           let segment = z.selection.content;
-          let str =
+          let full =
             Printer.of_segment(
               ~indent=" ",
               ~refractors=z.refractors.manuals,
               segment,
             );
-          if (!selection_has_refractors(z.refractors, segment)) {
+          let str = Zipper.trim_selected_text(z, full);
+          /* Cache for paste reuse only when nothing was trimmed: a trimmed
+             sub-token string must re-parse on paste, not round-trip to the
+             full segment. */
+          if (str == full && !selection_has_refractors(z.refractors, segment)) {
             Haz3lcore.Parser.set_segment_cache(Some(segment), str);
           };
           JsUtil.write_clipboard(str);

--- a/src/web/app/editors/code/CodeWithStatics.re
+++ b/src/web/app/editors/code/CodeWithStatics.re
@@ -67,13 +67,11 @@ module Model = {
       Some(
         () => {
           let z = model.editor.state.zipper;
-          let full =
-            Printer.of_segment(
-              ~indent=" ",
-              ~refractors=z.refractors.manuals,
-              z.selection.content,
-            );
-          Zipper.trim_selected_text(z, full);
+          Printer.selected_text(
+            ~indent=" ",
+            ~refractors=z.refractors.manuals,
+            z,
+          );
         },
       ),
     selection: Some(model.editor.state.zipper.selection.content),

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -3630,6 +3630,16 @@ let char_selection_tests = [
     ~z=mk_zipper({|§x ++ "wo¦rld"|}),
     ~expected={|x ++ "wo|},
   ),
+  test_copy(
+    ~name="Copy emoji inside string literal (multi-codepoint char)",
+    ~z=mk_zipper({|"§😀¦"|}),
+    ~expected={|😀|},
+  ),
+  test_copy(
+    ~name="Copy ascii char before emoji in string",
+    ~z=mk_zipper({|"§a¦😀"|}),
+    ~expected="a",
+  ),
   /* P. Cut and paste with char-level selections */
   test_case(
     "Cut and paste partial keyword (via Cut)",

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -220,13 +220,7 @@ let test_copy = (~name, ~z: Zipper.t, ~expected: string): test_case(_) =>
     name,
     `Quick,
     () => {
-      let full =
-        Printer.of_segment(
-          ~holes=convex_char,
-          ~indent="",
-          z.selection.content,
-        );
-      let actual = Zipper.trim_selected_text(z, full);
+      let actual = Printer.selected_text(~holes=convex_char, ~indent="", z);
       check(testable(Fmt.string, String.equal), name, expected, actual);
     },
   );
@@ -3615,6 +3609,26 @@ let char_selection_tests = [
     ~name="Copy whole token selection (anchor=Outer, caret=Outer)",
     ~z=mk_zipper({|§apple¦|}),
     ~expected="apple",
+  ),
+  test_copy(
+    ~name="Copy middle of string literal: ll from \"hello\"",
+    ~z=mk_zipper({|"he§ll¦o"|}),
+    ~expected="ll",
+  ),
+  test_copy(
+    ~name="Copy inside int literal: 45 from 123456",
+    ~z=mk_zipper({|123§45¦6|}),
+    ~expected="45",
+  ),
+  test_copy(
+    ~name="Copy cross-token, both ends inside: t x = tr",
+    ~z=mk_zipper({|le§t x = tr¦ue|}),
+    ~expected="t x = tr",
+  ),
+  test_copy(
+    ~name="Copy cross-token ending inside string: x ++ \"wo",
+    ~z=mk_zipper({|§x ++ "wo¦rld"|}),
+    ~expected={|x ++ "wo|},
   ),
   /* P. Cut and paste with char-level selections */
   test_case(


### PR DESCRIPTION
## Bug
Copying a sub-token selection copies the **whole token** instead of the selected characters. E.g. selecting `ll` inside the string literal `"hello"` and pressing Cmd/Ctrl+C puts `"hello"` on the clipboard.

## Root cause
This regressed in #2306 ("fix: Cmd+C/V/X in Firefox after editor focus"). That PR removed the page-level copy handler — which computed the clipboard text via `cursor.selected_text` → `Zipper.trim_selected_text` (correct char-level trim) — and replaced it with a new `CodeEditable.copy_selection` that prints `z.selection.content` **without** the trim:

```reason
let str = Printer.of_segment(~indent=" ", ~refractors=..., z.selection.content);
```

The trim logic (`Zipper.trim_selected_text` / `selection_trim_offsets`) and its tests already existed (added with char-level selections), but only the test path and `CodeWithStatics` called it — so the copy handler quietly skipped it and the existing tests stayed green.

## Fix
- Add `Printer.selected_text` as the single source of truth for "what gets copied" (print the selection content, then trim to the char-level boundaries).
- Route all three callers through it: `CodeEditable.copy_selection`, `CodeWithStatics`'s `selected_text` accessor, and the `test_copy` test helper — so the trim can't silently regress in just one path again.
- `copy_selection` caches the segment for paste reuse **only when nothing was trimmed** (a trimmed sub-token string must re-parse on paste, not round-trip back to the full segment).

## Tests
`test_copy` now exercises the same `Printer.selected_text` the UI uses (previously it duplicated the logic, which is why it couldn't catch this). Added cases for:
- sub-range inside a string literal (`"he§ll¦o"` → `ll`)
- sub-range inside an int literal (`123§45¦6` → `45`)
- cross-token range with both ends inside tokens (`le§t x = tr¦ue` → `t x = tr`)
- cross-token range ending inside a string

Verified red→green: without the trim, `Copy middle of token: ppl from apple` fails; with it, the full suite passes (`@test-quick`, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: Unicode over-trim (emoji in string literals)

A second bug in the same trim path: copying a sub-range inside a string containing a wide character (e.g. selecting the emoji in `"😀"`) copied `😀"` — one extra trailing quote.

`selection_trim_offsets` computed the trim using `Caret.inner_offset_for_token`, which returns **display columns** (a wide char like an emoji is 2 columns), but the clipboard slicing (`Unicode.length` / `Token.split_nth`) counts **graphemes** (emoji = 1). So the right trim under-counted by one grapheme. ASCII strings were unaffected (columns == graphemes there).

Fix: add `Caret.inner_grapheme_offset` (grapheme-based, `idx + 1`) and use it in `selection_trim_offsets`; `inner_offset_for_token` (columns) stays for caret/highlight positioning, which legitimately needs columns. Tests added: emoji inside a string literal, and an ascii char before an emoji.
