### PR TITLE
Fix eval worker postMessage stack overflow on deep results (#2368)

### DIFF
--- a/src/web/Settings.re
+++ b/src/web/Settings.re
@@ -76,6 +76,7 @@ module Model = {
       },
       debug_show_raw: false,
       debug_collapsed: [],
+      wire_disabled: [],
     },
     autoprobe_mode: false,
     agent_globals: AgentGlobals.init(),
@@ -391,6 +392,14 @@ module Update = {
           sidebar:
             SidebarModel.Settings.toggle_debug_collapsed(
               key,
+              settings.sidebar,
+            ),
+        }
+      | Sidebar(ToggleWireDisabled(name)) => {
+          ...settings,
+          sidebar:
+            SidebarModel.Settings.toggle_wire_disabled(
+              name,
               settings.sidebar,
             ),
         }

--- a/src/web/Settings.re
+++ b/src/web/Settings.re
@@ -77,7 +77,7 @@ module Model = {
       debug_show_raw: false,
       /* Start the Worker Messaging benchmark section collapsed so it doesn't
          run by default (benchmarking is gated on the section being expanded).
-         Must match DebugSidebar.worker_messaging_title. */
+         Must match WorkerMessagingSection.title. */
       debug_collapsed: ["Worker Messaging"],
       /* Only the active encoding (Marshal) is benchmarked by default; Direct
          and Sexp start unchecked. */

--- a/src/web/Settings.re
+++ b/src/web/Settings.re
@@ -75,8 +75,13 @@ module Model = {
         expanded: [],
       },
       debug_show_raw: false,
-      debug_collapsed: [],
-      wire_disabled: [],
+      /* Start the Worker Messaging benchmark section collapsed so it doesn't
+         run by default (benchmarking is gated on the section being expanded).
+         Must match DebugSidebar.worker_messaging_title. */
+      debug_collapsed: ["Worker Messaging"],
+      /* Only the active encoding (Marshal) is benchmarked by default; Direct
+         and Sexp start unchecked. */
+      worker_encodings: [WorkerServer.Marshal],
     },
     autoprobe_mode: false,
     agent_globals: AgentGlobals.init(),
@@ -395,13 +400,9 @@ module Update = {
               settings.sidebar,
             ),
         }
-      | Sidebar(ToggleWireDisabled(name)) => {
+      | Sidebar(ToggleWorkerEncoding(e)) => {
           ...settings,
-          sidebar:
-            SidebarModel.Settings.toggle_wire_disabled(
-              name,
-              settings.sidebar,
-            ),
+          sidebar: SidebarModel.Settings.toggle_encoding(e, settings.sidebar),
         }
       | ExplainThis(ToggleShowFeedback) => {
           ...settings,

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -406,10 +406,19 @@ module Update = {
 
   let calculate =
       (~schedule_action, ~is_edited, ~dynamics: bool, model: Model.t) => {
-    /* Gate worker wire benchmarking on the debug panel (the flag isn't
-       reachable at the WorkerClient.request call sites, which see only
-       settings.core). This runs before the modes below queue any request. */
-    WireMetrics.enabled := model.globals.settings.show_debug_panel;
+    /* Gate worker wire benchmarking on the Wire Metrics panel being visible:
+       the debug panel is on AND its section is expanded. The flag isn't
+       reachable at the WorkerClient.request call sites (which see only
+       settings.core), so we sync it here, before the modes below queue any
+       request. Skipping it while collapsed avoids the (potentially large)
+       per-request measurement cost when nothing is watching. */
+    WireMetrics.enabled :=
+      model.globals.settings.show_debug_panel
+      && !
+           SidebarModel.Settings.is_debug_collapsed(
+             DebugSidebar.wire_metrics_title,
+             model.globals.settings.sidebar,
+           );
     let editors =
       Editors.Update.calculate(
         ~settings=

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -412,14 +412,15 @@ module Update = {
        settings.core), so we sync it here, before the modes below queue any
        request. Skipping it while collapsed avoids the (potentially large)
        per-request measurement cost when nothing is watching. */
-    WireMetrics.enabled :=
+    WorkerMetrics.enabled :=
       model.globals.settings.show_debug_panel
       && !
            SidebarModel.Settings.is_debug_collapsed(
              DebugSidebar.worker_messaging_title,
              model.globals.settings.sidebar,
            );
-    WireMetrics.disabled_wires := model.globals.settings.sidebar.wire_disabled;
+    WorkerMetrics.enabled_encodings :=
+      model.globals.settings.sidebar.worker_encodings;
     let editors =
       Editors.Update.calculate(
         ~settings=

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -406,9 +406,9 @@ module Update = {
 
   let calculate =
       (~schedule_action, ~is_edited, ~dynamics: bool, model: Model.t) => {
-    /* Gate worker wire benchmarking on the Wire Metrics panel being visible:
-       the debug panel is on AND its section is expanded. The flag isn't
-       reachable at the WorkerClient.request call sites (which see only
+    /* Gate worker-messaging benchmarking on the Worker Messaging panel being
+       visible: the debug panel is on AND its section is expanded. The flag
+       isn't reachable at the WorkerClient.request call sites (which see only
        settings.core), so we sync it here, before the modes below queue any
        request. Skipping it while collapsed avoids the (potentially large)
        per-request measurement cost when nothing is watching. */
@@ -416,7 +416,7 @@ module Update = {
       model.globals.settings.show_debug_panel
       && !
            SidebarModel.Settings.is_debug_collapsed(
-             DebugSidebar.wire_metrics_title,
+             DebugSidebar.worker_messaging_title,
              model.globals.settings.sidebar,
            );
     WireMetrics.disabled_wires := model.globals.settings.sidebar.wire_disabled;

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -406,6 +406,10 @@ module Update = {
 
   let calculate =
       (~schedule_action, ~is_edited, ~dynamics: bool, model: Model.t) => {
+    /* Gate worker wire benchmarking on the debug panel (the flag isn't
+       reachable at the WorkerClient.request call sites, which see only
+       settings.core). This runs before the modes below queue any request. */
+    WireMetrics.enabled := model.globals.settings.show_debug_panel;
     let editors =
       Editors.Update.calculate(
         ~settings=

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -406,12 +406,8 @@ module Update = {
 
   let calculate =
       (~schedule_action, ~is_edited, ~dynamics: bool, model: Model.t) => {
-    /* Gate worker-messaging benchmarking on the Worker Messaging panel being
-       visible: the debug panel is on AND its section is expanded. The flag
-       isn't reachable at the WorkerClient.request call sites (which see only
-       settings.core), so we sync it here, before the modes below queue any
-       request. Skipping it while collapsed avoids the (potentially large)
-       per-request measurement cost when nothing is watching. */
+    /* Sync worker-messaging benchmark gating here (settings aren't reachable at
+       the WorkerClient.request call sites); only run when the panel is open. */
     WorkerMetrics.sync(
       ~enabled=
         model.globals.settings.show_debug_panel

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -419,6 +419,7 @@ module Update = {
              DebugSidebar.wire_metrics_title,
              model.globals.settings.sidebar,
            );
+    WireMetrics.disabled_wires := model.globals.settings.sidebar.wire_disabled;
     let editors =
       Editors.Update.calculate(
         ~settings=

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -412,15 +412,16 @@ module Update = {
        settings.core), so we sync it here, before the modes below queue any
        request. Skipping it while collapsed avoids the (potentially large)
        per-request measurement cost when nothing is watching. */
-    WorkerMetrics.enabled :=
-      model.globals.settings.show_debug_panel
-      && !
-           SidebarModel.Settings.is_debug_collapsed(
-             DebugSidebar.worker_messaging_title,
-             model.globals.settings.sidebar,
-           );
-    WorkerMetrics.enabled_encodings :=
-      model.globals.settings.sidebar.worker_encodings;
+    WorkerMetrics.sync(
+      ~enabled=
+        model.globals.settings.show_debug_panel
+        && !
+             SidebarModel.Settings.is_debug_collapsed(
+               WorkerMessagingSection.title,
+               model.globals.settings.sidebar,
+             ),
+      ~encodings=model.globals.settings.sidebar.worker_encodings,
+    );
     let editors =
       Editors.Update.calculate(
         ~settings=

--- a/src/web/app/sidebar/DebugSection.re
+++ b/src/web/app/sidebar/DebugSection.re
@@ -1,0 +1,8 @@
+/* Interface for a debug sidebar section: a stable `title` (also its collapse
+   key) and a `view` producing the section body. DebugSidebar wraps the body in
+   its collapsible `section` driver, so `view` returns just the fields. Modeled
+   on the STEPPER signature in editors/stepper/StepInterface.re. */
+module type S = {
+  let title: string;
+  let view: (~globals: Globals.t) => list(Util.WebUtil.Node.t);
+};

--- a/src/web/app/sidebar/DebugSection.re
+++ b/src/web/app/sidebar/DebugSection.re
@@ -1,7 +1,6 @@
 /* Interface for a debug sidebar section: a stable `title` (also its collapse
    key) and a `view` producing the section body. DebugSidebar wraps the body in
-   its collapsible `section` driver, so `view` returns just the fields. Modeled
-   on the STEPPER signature in editors/stepper/StepInterface.re. */
+   its collapsible `section` driver, so `view` returns just the fields. */
 module type S = {
   let title: string;
   let view: (~globals: Globals.t) => list(Util.WebUtil.Node.t);

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -718,8 +718,8 @@ let toggle_bar = (~globals: Globals.t): Node.t => {
 };
 
 /* ---- Worker Messaging: how the main thread talks to the eval Web Worker ----
-   Per-request benchmarks of the candidate wire protocols (WireMetrics) that
-   encode payloads crossing the main-thread <-> Web Worker boundary, populated
+   Per-request benchmarks of the candidate encodings (WorkerMetrics) that
+   pack payloads crossing the main-thread <-> Web Worker boundary, populated
    only while the debug panel is open. All requests share one table so columns
    line up across them; each request is separated by a bold `#N` group row
    (request) and a lighter `response` sub-row, a row per variant under each.
@@ -751,17 +751,20 @@ let wm_group_row = (~cls: string, label: string): Node.t =>
     ),
   ]);
 
-let wm_metric_row = (m: WireMetrics.dir_metric): Node.t => {
+let wm_metric_row = (m: WorkerMetrics.dir_metric): Node.t => {
   let total = m.encode_ms +. m.clone_ms +. m.decode_ms;
   /* Compact glyph keeps the column narrow; the full message (e.g. the
-     overflow exception for a failed variant) is on the cell's tooltip. */
+     overflow exception for a failed encoding) is on the cell's tooltip. */
   let (status_glyph, status_cls, status_title) =
     switch (m.status) {
     | Ok => ({|✓|}, "wm-ok", "ok")
     | Failed(e) => ({|✕|}, "wm-fail", e)
     };
   Node.tr([
-    Node.td(~attrs=[clss(["wm-wire"])], [text(m.wire)]),
+    Node.td(
+      ~attrs=[clss(["wm-wire"])],
+      [text(WorkerServer.show_encoding(m.encoding))],
+    ),
     Node.td([text(ms_str(m.encode_ms))]),
     Node.td([text(ms_str(m.clone_ms))]),
     Node.td([text(ms_str(m.decode_ms))]),
@@ -777,7 +780,7 @@ let wm_metric_row = (m: WireMetrics.dir_metric): Node.t => {
 /* The rows contributed by one request: a request group header (which also
    starts the visual separation from the previous request), its variant rows,
    then a lighter response sub-header and its rows. */
-let wm_record_rows = (r: WireMetrics.record): list(Node.t) => {
+let wm_record_rows = (r: WorkerMetrics.record): list(Node.t) => {
   let req_label =
     Printf.sprintf(
       "#%d · %d %s · request",
@@ -805,41 +808,33 @@ let wm_record_rows = (r: WireMetrics.record): list(Node.t) => {
    section costs nothing. Collapse state is keyed by this exact string. */
 let worker_messaging_title = "Worker Messaging";
 
-let wire_names: list(string) =
-  List.map(
-    (wire: (module WorkerServer.WIRE)) => {
-      module M = (val wire);
-      M.name;
-    },
-    WorkerServer.all_wires,
-  );
-
-/* Per-variant on/off chip. A disabled variant is not benchmarked at all (so a
-   slow one like sexp can be skipped); state persists via sidebar settings. */
-let wire_toggle = (~globals: Globals.t, name: string): Node.t => {
-  let off =
-    SidebarModel.Settings.is_wire_disabled(name, globals.settings.sidebar);
+/* Per-encoding on/off chip. Only enabled encodings are benchmarked (so a slow
+   one like Sexp can be skipped); state persists via sidebar settings. */
+let encoding_toggle = (~globals: Globals.t, e: WorkerServer.encoding): Node.t => {
+  let on =
+    SidebarModel.Settings.is_encoding_enabled(e, globals.settings.sidebar);
+  let name = WorkerServer.show_encoding(e);
   div(
     ~attrs=[
-      clss(["wm-toggle", off ? "off" : "on"]),
+      clss(["wm-toggle", on ? "on" : "off"]),
       Attr.title(
-        (off ? "Enable" : "Disable")
+        (on ? "Disable" : "Enable")
         ++ " benchmarking of the "
         ++ name
-        ++ " wire",
+        ++ " encoding",
       ),
       Attr.on_click(_ =>
-        globals.inject_global(Set(Sidebar(ToggleWireDisabled(name))))
+        globals.inject_global(Set(Sidebar(ToggleWorkerEncoding(e))))
       ),
     ],
-    [text((off ? {|☐|} : {|☑|}) ++ " " ++ name)],
+    [text((on ? {|☑|} : {|☐|}) ++ " " ++ name)],
   );
 };
 
-let wire_toggles = (~globals): Node.t =>
+let encoding_toggles = (~globals): Node.t =>
   div(
     ~attrs=[clss(["wm-toggles"])],
-    List.map(wire_toggle(~globals), wire_names),
+    List.map(encoding_toggle(~globals), WorkerServer.all_of_encoding),
   );
 
 /* Column-unit legend: the time columns carry no per-cell suffix, so state the
@@ -856,9 +851,9 @@ let wm_legend: Node.t =
 
 let worker_messaging_view = (~globals): list(Node.t) =>
   section(~globals, worker_messaging_title, () =>
-    [wire_toggles(~globals)]
+    [encoding_toggles(~globals)]
     @ (
-      switch (WireMetrics.history^) {
+      switch (WorkerMetrics.history^) {
       | [] => [
           div(
             ~attrs=[clss(["wm-empty"])],
@@ -874,7 +869,7 @@ let worker_messaging_view = (~globals): list(Node.t) =>
                 ~attrs=[clss(["wire-metrics-table"])],
                 [
                   Node.tr([
-                    wm_head("wire"),
+                    wm_head("encoding"),
                     wm_head("enc"),
                     wm_head("clone"),
                     wm_head("dec"),

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -803,38 +803,78 @@ let wm_record_rows = (r: WireMetrics.record): list(Node.t) => {
    section costs nothing. Collapse state is keyed by this exact string. */
 let wire_metrics_title = "Wire Metrics";
 
+let wire_names: list(string) =
+  List.map(
+    (wire: (module WorkerServer.WIRE)) => {
+      module M = (val wire);
+      M.name;
+    },
+    WorkerServer.all_wires,
+  );
+
+/* Per-variant on/off chip. A disabled variant is not benchmarked at all (so a
+   slow one like sexp can be skipped); state persists via sidebar settings. */
+let wire_toggle = (~globals: Globals.t, name: string): Node.t => {
+  let off =
+    SidebarModel.Settings.is_wire_disabled(name, globals.settings.sidebar);
+  div(
+    ~attrs=[
+      clss(["wm-toggle", off ? "off" : "on"]),
+      Attr.title(
+        (off ? "Enable" : "Disable")
+        ++ " benchmarking of the "
+        ++ name
+        ++ " wire",
+      ),
+      Attr.on_click(_ =>
+        globals.inject_global(Set(Sidebar(ToggleWireDisabled(name))))
+      ),
+    ],
+    [text((off ? {|☐|} : {|☑|}) ++ " " ++ name)],
+  );
+};
+
+let wire_toggles = (~globals): Node.t =>
+  div(
+    ~attrs=[clss(["wm-toggles"])],
+    List.map(wire_toggle(~globals), wire_names),
+  );
+
 let wire_metrics_view = (~globals): list(Node.t) =>
   section(~globals, wire_metrics_title, () =>
-    switch (WireMetrics.history^) {
-    | [] => [
-        div(
-          ~attrs=[clss(["wm-empty"])],
-          [text("No requests recorded yet — evaluate a program.")],
-        ),
-      ]
-    | records => [
-        div(
-          ~attrs=[clss(["wm-scroll"])],
-          [
-            Node.table(
-              ~attrs=[clss(["wire-metrics-table"])],
-              [
-                Node.tr([
-                  wm_head("wire"),
-                  wm_head("enc"),
-                  wm_head("clone"),
-                  wm_head("dec"),
-                  wm_head("total"),
-                  wm_head("size"),
-                  wm_head("ok?"),
-                ]),
-                ...List.concat_map(wm_record_rows, records),
-              ],
-            ),
-          ],
-        ),
-      ]
-    }
+    [wire_toggles(~globals)]
+    @ (
+      switch (WireMetrics.history^) {
+      | [] => [
+          div(
+            ~attrs=[clss(["wm-empty"])],
+            [text("No requests recorded yet — evaluate a program.")],
+          ),
+        ]
+      | records => [
+          div(
+            ~attrs=[clss(["wm-scroll"])],
+            [
+              Node.table(
+                ~attrs=[clss(["wire-metrics-table"])],
+                [
+                  Node.tr([
+                    wm_head("wire"),
+                    wm_head("enc"),
+                    wm_head("clone"),
+                    wm_head("dec"),
+                    wm_head("total"),
+                    wm_head("size"),
+                    wm_head("ok?"),
+                  ]),
+                  ...List.concat_map(wm_record_rows, records),
+                ],
+              ),
+            ],
+          ),
+        ]
+      }
+    )
   );
 
 let view = (~globals: Globals.t, ~cursor: Cursor.cursor(_)): Node.t => {

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -717,11 +717,13 @@ let toggle_bar = (~globals: Globals.t): Node.t => {
   );
 };
 
-/* ---- Wire Metrics: per-request benchmarks of the worker wire protocols ----
-   (WireMetrics), populated only while the debug panel is open. All requests
-   share one table so columns line up across them; each request is separated
-   by a bold `#N` group row (request) and a lighter `response` sub-row, a row
-   per variant under each. Correlated by request id. */
+/* ---- Worker Messaging: how the main thread talks to the eval Web Worker ----
+   Per-request benchmarks of the candidate wire protocols (WireMetrics) that
+   encode payloads crossing the main-thread <-> Web Worker boundary, populated
+   only while the debug panel is open. All requests share one table so columns
+   line up across them; each request is separated by a bold `#N` group row
+   (request) and a lighter `response` sub-row, a row per variant under each.
+   Correlated by request id. */
 
 /* Adaptive precision so a slow variant's wide milliseconds (e.g. sexp at
    ~17000ms) don't blow out the column: drop decimals as the value grows. */
@@ -801,7 +803,7 @@ let wm_record_rows = (r: WireMetrics.record): list(Node.t) => {
 /* Section title, shared with Page.Update.calculate: benchmarking is gated on
    this section being both shown (debug panel on) and expanded, so a collapsed
    section costs nothing. Collapse state is keyed by this exact string. */
-let wire_metrics_title = "Wire Metrics";
+let worker_messaging_title = "Worker Messaging";
 
 let wire_names: list(string) =
   List.map(
@@ -840,8 +842,20 @@ let wire_toggles = (~globals): Node.t =>
     List.map(wire_toggle(~globals), wire_names),
   );
 
-let wire_metrics_view = (~globals): list(Node.t) =>
-  section(~globals, wire_metrics_title, () =>
+/* Column-unit legend: the time columns carry no per-cell suffix, so state the
+   unit (ms) and expand the abbreviations. Size shows its own B/K/M suffix. */
+let wm_legend: Node.t =
+  div(
+    ~attrs=[clss(["wm-legend"])],
+    [
+      text(
+        "Times in ms (encode / structuredClone / decode / total); size approximate.",
+      ),
+    ],
+  );
+
+let worker_messaging_view = (~globals): list(Node.t) =>
+  section(~globals, worker_messaging_title, () =>
     [wire_toggles(~globals)]
     @ (
       switch (WireMetrics.history^) {
@@ -852,6 +866,7 @@ let wire_metrics_view = (~globals): list(Node.t) =>
           ),
         ]
       | records => [
+          wm_legend,
           div(
             ~attrs=[clss(["wm-scroll"])],
             [
@@ -902,7 +917,7 @@ let view = (~globals: Globals.t, ~cursor: Cursor.cursor(_)): Node.t => {
             | _ => info_sections @ syntax_sections
             };
           /* Metrics render regardless of cursor state. */
-          cursor_sections @ wire_metrics_view(~globals);
+          cursor_sections @ worker_messaging_view(~globals);
         },
       ),
     ],

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -717,6 +717,108 @@ let toggle_bar = (~globals: Globals.t): Node.t => {
   );
 };
 
+/* ---- Wire Metrics: per-request benchmarks of the worker wire protocols ----
+   (WireMetrics), populated only while the debug panel is open. Correlated by
+   request id, one table per direction (request/response), a row per variant. */
+
+let ms_str = (f: float): string => Printf.sprintf("%.2f", f);
+
+let size_str = (bytes: int): string =>
+  bytes >= 1024 * 1024
+    ? Printf.sprintf("%.1fM", float_of_int(bytes) /. 1024. /. 1024.)
+    : bytes >= 1024
+        ? Printf.sprintf("%.1fK", float_of_int(bytes) /. 1024.)
+        : string_of_int(bytes) ++ "B";
+
+let wm_head = (label: string): Node.t =>
+  Node.td(~attrs=[clss(["wm-head"])], [text(label)]);
+
+let wm_metric_row = (m: WireMetrics.dir_metric): Node.t => {
+  let total = m.encode_ms +. m.clone_ms +. m.decode_ms;
+  let (status_text, status_cls) =
+    switch (m.status) {
+    | Ok => ("ok", "wm-ok")
+    | Failed(e) => (e, "wm-fail")
+    };
+  Node.tr([
+    Node.td(~attrs=[clss(["wm-wire"])], [text(m.wire)]),
+    Node.td([text(ms_str(m.encode_ms))]),
+    Node.td([text(ms_str(m.clone_ms))]),
+    Node.td([text(ms_str(m.decode_ms))]),
+    Node.td(~attrs=[clss(["wm-total"])], [text(ms_str(total))]),
+    Node.td([text(size_str(m.size_bytes))]),
+    Node.td(
+      ~attrs=[clss([status_cls]), Attr.title(status_text)],
+      [text(status_text)],
+    ),
+  ]);
+};
+
+let wm_direction_table =
+    (label: string, rows: list(WireMetrics.dir_metric)): Node.t =>
+  Node.table(
+    ~attrs=[clss(["wire-metrics-table"])],
+    [
+      Node.tr([
+        Node.td(
+          ~attrs=[Attr.create("colspan", "7"), clss(["wm-caption"])],
+          [text(label)],
+        ),
+      ]),
+      Node.tr([
+        wm_head("wire"),
+        wm_head("enc"),
+        wm_head("clone"),
+        wm_head("dec"),
+        wm_head("total"),
+        wm_head("size"),
+        wm_head("status"),
+      ]),
+      ...List.map(wm_metric_row, rows),
+    ],
+  );
+
+let wm_record_view = (r: WireMetrics.record): Node.t => {
+  let title =
+    Printf.sprintf(
+      "#%d · %d %s",
+      r.id,
+      r.entries,
+      r.entries == 1 ? "entry" : "entries",
+    );
+  let response_table =
+    switch (r.response) {
+    | [] => [
+        div(
+          ~attrs=[clss(["wm-pending"])],
+          [text("response pending / timed out")],
+        ),
+      ]
+    | rows => [wm_direction_table("response", rows)]
+    };
+  div(
+    ~attrs=[clss(["wm-record"])],
+    [
+      div(~attrs=[clss(["wm-record-title"])], [text(title)]),
+      wm_direction_table("request", r.request),
+    ]
+    @ response_table,
+  );
+};
+
+let wire_metrics_view = (~globals): list(Node.t) =>
+  section(~globals, "Wire Metrics", () =>
+    switch (WireMetrics.history^) {
+    | [] => [
+        div(
+          ~attrs=[clss(["wm-empty"])],
+          [text("No requests recorded yet — evaluate a program.")],
+        ),
+      ]
+    | records => List.map(wm_record_view, records)
+    }
+  );
+
 let view = (~globals: Globals.t, ~cursor: Cursor.cursor(_)): Node.t => {
   let raw = globals.settings.sidebar.debug_show_raw;
   div(
@@ -736,10 +838,13 @@ let view = (~globals: Globals.t, ~cursor: Cursor.cursor(_)): Node.t => {
             | Some(ci) => info_view(~globals, ~raw, ci)
             };
           let syntax_sections = syntax_view(~globals, ~cursor);
-          switch (info_sections, syntax_sections) {
-          | ([], []) => [text("No info at cursor.")]
-          | _ => info_sections @ syntax_sections
-          };
+          let cursor_sections =
+            switch (info_sections, syntax_sections) {
+            | ([], []) => [text("No info at cursor.")]
+            | _ => info_sections @ syntax_sections
+            };
+          /* Metrics render regardless of cursor state. */
+          cursor_sections @ wire_metrics_view(~globals);
         },
       ),
     ],

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -718,10 +718,17 @@ let toggle_bar = (~globals: Globals.t): Node.t => {
 };
 
 /* ---- Wire Metrics: per-request benchmarks of the worker wire protocols ----
-   (WireMetrics), populated only while the debug panel is open. Correlated by
-   request id, one table per direction (request/response), a row per variant. */
+   (WireMetrics), populated only while the debug panel is open. All requests
+   share one table so columns line up across them; each request is separated
+   by a bold `#N` group row (request) and a lighter `response` sub-row, a row
+   per variant under each. Correlated by request id. */
 
-let ms_str = (f: float): string => Printf.sprintf("%.2f", f);
+/* Adaptive precision so a slow variant's wide milliseconds (e.g. sexp at
+   ~17000ms) don't blow out the column: drop decimals as the value grows. */
+let ms_str = (f: float): string =>
+  f >= 100.
+    ? Printf.sprintf("%.0f", f)
+    : f >= 10. ? Printf.sprintf("%.1f", f) : Printf.sprintf("%.2f", f);
 
 let size_str = (bytes: int): string =>
   bytes >= 1024 * 1024
@@ -733,12 +740,23 @@ let size_str = (bytes: int): string =>
 let wm_head = (label: string): Node.t =>
   Node.td(~attrs=[clss(["wm-head"])], [text(label)]);
 
+/* A full-width label row separating request groups within the shared table. */
+let wm_group_row = (~cls: string, label: string): Node.t =>
+  Node.tr([
+    Node.td(
+      ~attrs=[Attr.create("colspan", "7"), clss(["wm-group", cls])],
+      [text(label)],
+    ),
+  ]);
+
 let wm_metric_row = (m: WireMetrics.dir_metric): Node.t => {
   let total = m.encode_ms +. m.clone_ms +. m.decode_ms;
-  let (status_text, status_cls) =
+  /* Compact glyph keeps the column narrow; the full message (e.g. the
+     overflow exception for a failed variant) is on the cell's tooltip. */
+  let (status_glyph, status_cls, status_title) =
     switch (m.status) {
-    | Ok => ("ok", "wm-ok")
-    | Failed(e) => (e, "wm-fail")
+    | Ok => ({|✓|}, "wm-ok", "ok")
+    | Failed(e) => ({|✕|}, "wm-fail", e)
     };
   Node.tr([
     Node.td(~attrs=[clss(["wm-wire"])], [text(m.wire)]),
@@ -748,62 +766,36 @@ let wm_metric_row = (m: WireMetrics.dir_metric): Node.t => {
     Node.td(~attrs=[clss(["wm-total"])], [text(ms_str(total))]),
     Node.td([text(size_str(m.size_bytes))]),
     Node.td(
-      ~attrs=[clss([status_cls]), Attr.title(status_text)],
-      [text(status_text)],
+      ~attrs=[clss([status_cls]), Attr.title(status_title)],
+      [text(status_glyph)],
     ),
   ]);
 };
 
-let wm_direction_table =
-    (label: string, rows: list(WireMetrics.dir_metric)): Node.t =>
-  Node.table(
-    ~attrs=[clss(["wire-metrics-table"])],
-    [
-      Node.tr([
-        Node.td(
-          ~attrs=[Attr.create("colspan", "7"), clss(["wm-caption"])],
-          [text(label)],
-        ),
-      ]),
-      Node.tr([
-        wm_head("wire"),
-        wm_head("enc"),
-        wm_head("clone"),
-        wm_head("dec"),
-        wm_head("total"),
-        wm_head("size"),
-        wm_head("status"),
-      ]),
-      ...List.map(wm_metric_row, rows),
-    ],
-  );
-
-let wm_record_view = (r: WireMetrics.record): Node.t => {
-  let title =
+/* The rows contributed by one request: a request group header (which also
+   starts the visual separation from the previous request), its variant rows,
+   then a lighter response sub-header and its rows. */
+let wm_record_rows = (r: WireMetrics.record): list(Node.t) => {
+  let req_label =
     Printf.sprintf(
-      "#%d · %d %s",
+      "#%d · %d %s · request",
       r.id,
       r.entries,
       r.entries == 1 ? "entry" : "entries",
     );
-  let response_table =
+  let response_rows =
     switch (r.response) {
-    | [] => [
-        div(
-          ~attrs=[clss(["wm-pending"])],
-          [text("response pending / timed out")],
-        ),
+    | [] => [wm_group_row(~cls="wm-note", "response pending / timed out")]
+    | rows => [
+        wm_group_row(~cls="wm-resp", "response"),
+        ...List.map(wm_metric_row, rows),
       ]
-    | rows => [wm_direction_table("response", rows)]
     };
-  div(
-    ~attrs=[clss(["wm-record"])],
-    [
-      div(~attrs=[clss(["wm-record-title"])], [text(title)]),
-      wm_direction_table("request", r.request),
-    ]
-    @ response_table,
-  );
+  [
+    wm_group_row(~cls="wm-req", req_label),
+    ...List.map(wm_metric_row, r.request),
+  ]
+  @ response_rows;
 };
 
 let wire_metrics_view = (~globals): list(Node.t) =>
@@ -815,7 +807,28 @@ let wire_metrics_view = (~globals): list(Node.t) =>
           [text("No requests recorded yet — evaluate a program.")],
         ),
       ]
-    | records => List.map(wm_record_view, records)
+    | records => [
+        div(
+          ~attrs=[clss(["wm-scroll"])],
+          [
+            Node.table(
+              ~attrs=[clss(["wire-metrics-table"])],
+              [
+                Node.tr([
+                  wm_head("wire"),
+                  wm_head("enc"),
+                  wm_head("clone"),
+                  wm_head("dec"),
+                  wm_head("total"),
+                  wm_head("size"),
+                  wm_head("ok?"),
+                ]),
+                ...List.concat_map(wm_record_rows, records),
+              ],
+            ),
+          ],
+        ),
+      ]
     }
   );
 

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -798,8 +798,13 @@ let wm_record_rows = (r: WireMetrics.record): list(Node.t) => {
   @ response_rows;
 };
 
+/* Section title, shared with Page.Update.calculate: benchmarking is gated on
+   this section being both shown (debug panel on) and expanded, so a collapsed
+   section costs nothing. Collapse state is keyed by this exact string. */
+let wire_metrics_title = "Wire Metrics";
+
 let wire_metrics_view = (~globals): list(Node.t) =>
-  section(~globals, "Wire Metrics", () =>
+  section(~globals, wire_metrics_title, () =>
     switch (WireMetrics.history^) {
     | [] => [
         div(

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -717,175 +717,10 @@ let toggle_bar = (~globals: Globals.t): Node.t => {
   );
 };
 
-/* ---- Worker Messaging: how the main thread talks to the eval Web Worker ----
-   Per-request benchmarks of the candidate encodings (WorkerMetrics) that
-   pack payloads crossing the main-thread <-> Web Worker boundary, populated
-   only while the debug panel is open. All requests share one table so columns
-   line up across them; each request is separated by a bold `#N` group row
-   (request) and a lighter `response` sub-row, a row per variant under each.
-   Correlated by request id. */
-
-/* Adaptive precision so a slow variant's wide milliseconds (e.g. sexp at
-   ~17000ms) don't blow out the column: drop decimals as the value grows. */
-let ms_str = (f: float): string =>
-  f >= 100.
-    ? Printf.sprintf("%.0f", f)
-    : f >= 10. ? Printf.sprintf("%.1f", f) : Printf.sprintf("%.2f", f);
-
-let size_str = (bytes: int): string =>
-  bytes >= 1024 * 1024
-    ? Printf.sprintf("%.1fM", float_of_int(bytes) /. 1024. /. 1024.)
-    : bytes >= 1024
-        ? Printf.sprintf("%.1fK", float_of_int(bytes) /. 1024.)
-        : string_of_int(bytes) ++ "B";
-
-let wm_head = (label: string): Node.t =>
-  Node.td(~attrs=[clss(["wm-head"])], [text(label)]);
-
-/* A full-width label row separating request groups within the shared table. */
-let wm_group_row = (~cls: string, label: string): Node.t =>
-  Node.tr([
-    Node.td(
-      ~attrs=[Attr.create("colspan", "7"), clss(["wm-group", cls])],
-      [text(label)],
-    ),
-  ]);
-
-let wm_metric_row = (m: WorkerMetrics.dir_metric): Node.t => {
-  let total = m.encode_ms +. m.clone_ms +. m.decode_ms;
-  /* Compact glyph keeps the column narrow; the full message (e.g. the
-     overflow exception for a failed encoding) is on the cell's tooltip. */
-  let (status_glyph, status_cls, status_title) =
-    switch (m.status) {
-    | Ok => ({|✓|}, "wm-ok", "ok")
-    | Failed(e) => ({|✕|}, "wm-fail", e)
-    };
-  Node.tr([
-    Node.td(
-      ~attrs=[clss(["wm-wire"])],
-      [text(WorkerServer.show_encoding(m.encoding))],
-    ),
-    Node.td([text(ms_str(m.encode_ms))]),
-    Node.td([text(ms_str(m.clone_ms))]),
-    Node.td([text(ms_str(m.decode_ms))]),
-    Node.td(~attrs=[clss(["wm-total"])], [text(ms_str(total))]),
-    Node.td([text(size_str(m.size_bytes))]),
-    Node.td(
-      ~attrs=[clss([status_cls]), Attr.title(status_title)],
-      [text(status_glyph)],
-    ),
-  ]);
-};
-
-/* The rows contributed by one request: a request group header (which also
-   starts the visual separation from the previous request), its variant rows,
-   then a lighter response sub-header and its rows. */
-let wm_record_rows = (r: WorkerMetrics.record): list(Node.t) => {
-  let req_label =
-    Printf.sprintf(
-      "#%d · %d %s · request",
-      r.id,
-      r.entries,
-      r.entries == 1 ? "entry" : "entries",
-    );
-  let response_rows =
-    switch (r.response) {
-    | [] => [wm_group_row(~cls="wm-note", "response pending / timed out")]
-    | rows => [
-        wm_group_row(~cls="wm-resp", "response"),
-        ...List.map(wm_metric_row, rows),
-      ]
-    };
-  [
-    wm_group_row(~cls="wm-req", req_label),
-    ...List.map(wm_metric_row, r.request),
-  ]
-  @ response_rows;
-};
-
-/* Section title, shared with Page.Update.calculate: benchmarking is gated on
-   this section being both shown (debug panel on) and expanded, so a collapsed
-   section costs nothing. Collapse state is keyed by this exact string. */
-let worker_messaging_title = "Worker Messaging";
-
-/* Per-encoding on/off chip. Only enabled encodings are benchmarked (so a slow
-   one like Sexp can be skipped); state persists via sidebar settings. */
-let encoding_toggle = (~globals: Globals.t, e: WorkerServer.encoding): Node.t => {
-  let on =
-    SidebarModel.Settings.is_encoding_enabled(e, globals.settings.sidebar);
-  let name = WorkerServer.show_encoding(e);
-  div(
-    ~attrs=[
-      clss(["wm-toggle", on ? "on" : "off"]),
-      Attr.title(
-        (on ? "Disable" : "Enable")
-        ++ " benchmarking of the "
-        ++ name
-        ++ " encoding",
-      ),
-      Attr.on_click(_ =>
-        globals.inject_global(Set(Sidebar(ToggleWorkerEncoding(e))))
-      ),
-    ],
-    [text((on ? {|☑|} : {|☐|}) ++ " " ++ name)],
-  );
-};
-
-let encoding_toggles = (~globals): Node.t =>
-  div(
-    ~attrs=[clss(["wm-toggles"])],
-    List.map(encoding_toggle(~globals), WorkerServer.all_of_encoding),
-  );
-
-/* Column-unit legend: the time columns carry no per-cell suffix, so state the
-   unit (ms) and expand the abbreviations. Size shows its own B/K/M suffix. */
-let wm_legend: Node.t =
-  div(
-    ~attrs=[clss(["wm-legend"])],
-    [
-      text(
-        "Times in ms (encode / structuredClone / decode / total); size approximate.",
-      ),
-    ],
-  );
-
-let worker_messaging_view = (~globals): list(Node.t) =>
-  section(~globals, worker_messaging_title, () =>
-    [encoding_toggles(~globals)]
-    @ (
-      switch (WorkerMetrics.history^) {
-      | [] => [
-          div(
-            ~attrs=[clss(["wm-empty"])],
-            [text("No requests recorded yet — evaluate a program.")],
-          ),
-        ]
-      | records => [
-          wm_legend,
-          div(
-            ~attrs=[clss(["wm-scroll"])],
-            [
-              Node.table(
-                ~attrs=[clss(["wire-metrics-table"])],
-                [
-                  Node.tr([
-                    wm_head("encoding"),
-                    wm_head("enc"),
-                    wm_head("clone"),
-                    wm_head("dec"),
-                    wm_head("total"),
-                    wm_head("size"),
-                    wm_head("ok?"),
-                  ]),
-                  ...List.concat_map(wm_record_rows, records),
-                ],
-              ),
-            ],
-          ),
-        ]
-      }
-    )
-  );
+/* Render a debug section (DebugSection.S) inside the collapsible `section`
+   wrapper, so a section module only provides its title + body. */
+let render_section = (module S: DebugSection.S, ~globals): list(Node.t) =>
+  section(~globals, S.title, () => S.view(~globals));
 
 let view = (~globals: Globals.t, ~cursor: Cursor.cursor(_)): Node.t => {
   let raw = globals.settings.sidebar.debug_show_raw;
@@ -912,7 +747,8 @@ let view = (~globals: Globals.t, ~cursor: Cursor.cursor(_)): Node.t => {
             | _ => info_sections @ syntax_sections
             };
           /* Metrics render regardless of cursor state. */
-          cursor_sections @ worker_messaging_view(~globals);
+          cursor_sections
+          @ render_section((module WorkerMessagingSection), ~globals);
         },
       ),
     ],

--- a/src/web/app/sidebar/SidebarModel.re
+++ b/src/web/app/sidebar/SidebarModel.re
@@ -159,6 +159,12 @@ module Settings = {
        field label. Persists across cursor moves so collapsing e.g. "ctx"
        keeps it collapsed regardless of the term under the cursor. */
     debug_collapsed: list(string),
+    /* Wire-protocol variants (by WorkerServer.WIRE name) the user has turned
+       off in the Wire Metrics panel; disabled variants are not benchmarked,
+       so e.g. the slow sexp variant can be skipped. Defaulted so existing
+       persisted settings (which lack this field) still load. */
+    [@sexp.default []] [@yojson.default []]
+    wire_disabled: list(string),
   };
 
   let is_debug_collapsed = (key: string, settings: t) =>
@@ -177,11 +183,28 @@ module Settings = {
       };
     };
 
+  let is_wire_disabled = (name: string, settings: t) =>
+    List.mem(name, settings.wire_disabled);
+
+  let toggle_wire_disabled = (name: string, settings: t): t =>
+    if (is_wire_disabled(name, settings)) {
+      {
+        ...settings,
+        wire_disabled: List.filter(n => n != name, settings.wire_disabled),
+      };
+    } else {
+      {
+        ...settings,
+        wire_disabled: [name, ...settings.wire_disabled],
+      };
+    };
+
   [@deriving (show({with_path: false}), sexp, yojson)]
   type action =
     | ToggleShow
     | SwitchPanel(panel)
     | Problems(problems_action)
     | ToggleDebugRaw
-    | ToggleDebugCollapsed(string);
+    | ToggleDebugCollapsed(string)
+    | ToggleWireDisabled(string);
 };

--- a/src/web/app/sidebar/SidebarModel.re
+++ b/src/web/app/sidebar/SidebarModel.re
@@ -159,12 +159,14 @@ module Settings = {
        field label. Persists across cursor moves so collapsing e.g. "ctx"
        keeps it collapsed regardless of the term under the cursor. */
     debug_collapsed: list(string),
-    /* Wire-protocol variants (by WorkerServer.WIRE name) the user has turned
-       off in the Worker Messaging panel; disabled variants are not benchmarked,
-       so e.g. the slow sexp variant can be skipped. Defaulted so existing
-       persisted settings (which lack this field) still load. */
-    [@sexp.default []] [@yojson.default []]
-    wire_disabled: list(string),
+    /* Encodings (WorkerServer.encoding) enabled in the Worker Messaging panel;
+       only these are benchmarked. Defaults to just the active encoding
+       (Marshal) — Direct and Sexp start off — and is defaulted on load so
+       existing persisted settings (which lack this field) still load. */
+    [@sexp.default [WorkerServer.Marshal]] [@yojson.default
+                                              [WorkerServer.Marshal]
+                                            ]
+    worker_encodings: list(WorkerServer.encoding),
   };
 
   let is_debug_collapsed = (key: string, settings: t) =>
@@ -183,19 +185,19 @@ module Settings = {
       };
     };
 
-  let is_wire_disabled = (name: string, settings: t) =>
-    List.mem(name, settings.wire_disabled);
+  let is_encoding_enabled = (e: WorkerServer.encoding, settings: t) =>
+    List.mem(e, settings.worker_encodings);
 
-  let toggle_wire_disabled = (name: string, settings: t): t =>
-    if (is_wire_disabled(name, settings)) {
+  let toggle_encoding = (e: WorkerServer.encoding, settings: t): t =>
+    if (is_encoding_enabled(e, settings)) {
       {
         ...settings,
-        wire_disabled: List.filter(n => n != name, settings.wire_disabled),
+        worker_encodings: List.filter(x => x != e, settings.worker_encodings),
       };
     } else {
       {
         ...settings,
-        wire_disabled: [name, ...settings.wire_disabled],
+        worker_encodings: [e, ...settings.worker_encodings],
       };
     };
 
@@ -206,5 +208,5 @@ module Settings = {
     | Problems(problems_action)
     | ToggleDebugRaw
     | ToggleDebugCollapsed(string)
-    | ToggleWireDisabled(string);
+    | ToggleWorkerEncoding(WorkerServer.encoding);
 };

--- a/src/web/app/sidebar/SidebarModel.re
+++ b/src/web/app/sidebar/SidebarModel.re
@@ -160,7 +160,7 @@ module Settings = {
        keeps it collapsed regardless of the term under the cursor. */
     debug_collapsed: list(string),
     /* Wire-protocol variants (by WorkerServer.WIRE name) the user has turned
-       off in the Wire Metrics panel; disabled variants are not benchmarked,
+       off in the Worker Messaging panel; disabled variants are not benchmarked,
        so e.g. the slow sexp variant can be skipped. Defaulted so existing
        persisted settings (which lack this field) still load. */
     [@sexp.default []] [@yojson.default []]

--- a/src/web/app/sidebar/WorkerMessagingSection.re
+++ b/src/web/app/sidebar/WorkerMessagingSection.re
@@ -1,0 +1,167 @@
+open Virtual_dom.Vdom;
+open Node;
+open Util.WebUtil;
+
+/* The "Worker Messaging" debug sidebar section: how the main thread talks to
+   the eval Web Worker. Per-request benchmarks of the candidate encodings
+   (WorkerMetrics) that pack payloads crossing the boundary, populated only
+   while the panel is open. All requests share one table so columns line up;
+   each request is a bold `#N` group row plus a lighter `response` sub-row, one
+   row per encoding under each. Implements DebugSection.S. */
+
+let title = "Worker Messaging";
+
+/* Durations are Core.Time_ns.Span, sizes Core.Byte_units — each formatted via
+   its own to_string_hum, so the value carries its unit. A None field (a stage
+   that didn't complete) renders as an em dash rather than a misleading 0. */
+let dash = {|—|};
+
+let span_str = (s: option(Core.Time_ns.Span.t)): string =>
+  switch (s) {
+  | None => dash
+  | Some(s) => Core.Time_ns.Span.to_string_hum(~decimals=2, s)
+  };
+
+let bytes_str = (b: option(Core.Byte_units.t)): string =>
+  switch (b) {
+  | None => dash
+  | Some(b) => Core.Byte_units.to_string_hum(b)
+  };
+
+let wm_head = (label: string): Node.t =>
+  Node.td(~attrs=[clss(["wm-head"])], [text(label)]);
+
+/* A full-width label row separating request groups within the shared table. */
+let wm_group_row = (~cls: string, label: string): Node.t =>
+  Node.tr([
+    Node.td(
+      ~attrs=[Attr.create("colspan", "7"), clss(["wm-group", cls])],
+      [text(label)],
+    ),
+  ]);
+
+let wm_metric_row = (m: WorkerMetrics.dir_metric): Node.t => {
+  let total =
+    switch (m.encode, m.clone, m.decode) {
+    | (Some(a), Some(b), Some(c)) => Some(Core.Time_ns.Span.(a + b + c))
+    | _ => None
+    };
+  /* Compact glyph keeps the column narrow; any failure message is on the
+     cell's tooltip. */
+  let (glyph, cls, tooltip) =
+    switch (m.error) {
+    | None => ({|✓|}, "wm-ok", "ok")
+    | Some(e) => ({|✕|}, "wm-fail", e)
+    };
+  Node.tr([
+    Node.td(
+      ~attrs=[clss(["wm-wire"])],
+      [text(WorkerServer.show_encoding(m.encoding))],
+    ),
+    Node.td([text(span_str(m.encode))]),
+    Node.td([text(span_str(m.clone))]),
+    Node.td([text(span_str(m.decode))]),
+    Node.td(~attrs=[clss(["wm-total"])], [text(span_str(total))]),
+    Node.td([text(bytes_str(m.size))]),
+    Node.td(~attrs=[clss([cls]), Attr.title(tooltip)], [text(glyph)]),
+  ]);
+};
+
+/* The rows contributed by one request: a request group header (which also
+   starts the visual separation from the previous request), its encoding rows,
+   then a lighter response sub-header and its rows. */
+let wm_record_rows = (r: WorkerMetrics.record): list(Node.t) => {
+  let req_label =
+    Printf.sprintf(
+      "#%d · %d %s · request",
+      r.id,
+      r.entries,
+      r.entries == 1 ? "entry" : "entries",
+    );
+  let response_rows =
+    switch (r.response) {
+    | [] => [wm_group_row(~cls="wm-note", "response pending / timed out")]
+    | rows => [
+        wm_group_row(~cls="wm-resp", "response"),
+        ...List.map(wm_metric_row, rows),
+      ]
+    };
+  [
+    wm_group_row(~cls="wm-req", req_label),
+    ...List.map(wm_metric_row, r.request),
+  ]
+  @ response_rows;
+};
+
+/* Per-encoding on/off chip. Only enabled encodings are benchmarked (so a slow
+   one like Sexp can be skipped); state persists via sidebar settings. */
+let encoding_toggle = (~globals: Globals.t, e: WorkerServer.encoding): Node.t => {
+  let on =
+    SidebarModel.Settings.is_encoding_enabled(e, globals.settings.sidebar);
+  let name = WorkerServer.show_encoding(e);
+  div(
+    ~attrs=[
+      clss(["wm-toggle", on ? "on" : "off"]),
+      Attr.title(
+        (on ? "Disable" : "Enable")
+        ++ " benchmarking of the "
+        ++ name
+        ++ " encoding",
+      ),
+      Attr.on_click(_ =>
+        globals.inject_global(Set(Sidebar(ToggleWorkerEncoding(e))))
+      ),
+    ],
+    [text((on ? {|☑|} : {|☐|}) ++ " " ++ name)],
+  );
+};
+
+let encoding_toggles = (~globals): Node.t =>
+  div(
+    ~attrs=[clss(["wm-toggles"])],
+    List.map(encoding_toggle(~globals), WorkerServer.all_of_encoding),
+  );
+
+/* Column legend: expand the abbreviations. The durations and size carry their
+   own units via Span / Byte_units formatting. */
+let wm_legend: Node.t =
+  div(
+    ~attrs=[clss(["wm-legend"])],
+    [text("encode / structuredClone / decode / total; size approximate.")],
+  );
+
+let view = (~globals: Globals.t): list(Node.t) =>
+  [encoding_toggles(~globals)]
+  @ (
+    switch (WorkerMetrics.history^) {
+    | [] => [
+        div(
+          ~attrs=[clss(["wm-empty"])],
+          [text("No requests recorded yet — evaluate a program.")],
+        ),
+      ]
+    | records => [
+        wm_legend,
+        div(
+          ~attrs=[clss(["wm-scroll"])],
+          [
+            Node.table(
+              ~attrs=[clss(["wire-metrics-table"])],
+              [
+                Node.tr([
+                  wm_head("encoding"),
+                  wm_head("enc"),
+                  wm_head("clone"),
+                  wm_head("dec"),
+                  wm_head("total"),
+                  wm_head("size"),
+                  wm_head("ok?"),
+                ]),
+                ...List.concat_map(wm_record_rows, records),
+              ],
+            ),
+          ],
+        ),
+      ]
+    }
+  );

--- a/src/web/app/sidebar/WorkerMessagingSection.re
+++ b/src/web/app/sidebar/WorkerMessagingSection.re
@@ -11,22 +11,17 @@ open Util.WebUtil;
 
 let title = "Worker Messaging";
 
-/* Durations are Core.Time_ns.Span, sizes Core.Byte_units — each formatted via
-   its own to_string_hum, so the value carries its unit. A None field (a stage
-   that didn't complete) renders as an em dash rather than a misleading 0. */
-let dash = {|—|};
-
-let span_str = (s: option(Core.Time_ns.Span.t)): string =>
-  switch (s) {
-  | None => dash
-  | Some(s) => Core.Time_ns.Span.to_string_hum(~decimals=2, s)
+/* Format an optional metric, showing an em dash for a stage that didn't
+   complete rather than a misleading 0. Durations are Core.Time_ns.Span and
+   sizes Core.Byte_units, each carrying its own unit via to_string_hum. */
+let opt_str = (to_string: 'a => string, x: option('a)): string =>
+  switch (x) {
+  | None => {|—|}
+  | Some(x) => to_string(x)
   };
 
-let bytes_str = (b: option(Core.Byte_units.t)): string =>
-  switch (b) {
-  | None => dash
-  | Some(b) => Core.Byte_units.to_string_hum(b)
-  };
+let span_str = opt_str(s => Core.Time_ns.Span.to_string_hum(~decimals=2, s));
+let bytes_str = opt_str(b => Core.Byte_units.to_string_hum(b));
 
 let wm_head = (label: string): Node.t =>
   Node.td(~attrs=[clss(["wm-head"])], [text(label)]);

--- a/src/web/dune
+++ b/src/web/dune
@@ -14,7 +14,12 @@
  (libraries language)
  (js_of_ocaml)
  (preprocess
-  (pps js_of_ocaml-ppx ppx_yojson_conv ppx_sexp_conv ppx_deriving.show)))
+  (pps
+   js_of_ocaml-ppx
+   ppx_yojson_conv
+   ppx_sexp_conv
+   ppx_deriving.show
+   ppx_enumerate)))
 
 (library
  (name web)

--- a/src/web/util/WireMetrics.re
+++ b/src/web/util/WireMetrics.re
@@ -1,0 +1,184 @@
+open Js_of_ocaml;
+
+/* Per-request benchmarking of the worker wire protocols (WorkerServer.WIRE).
+ *
+ * For every variant in WorkerServer.all_wires we encode the real payload,
+ * run it through the browser's structuredClone (the same serializer
+ * postMessage uses, so an encoding that overflows the clone stack — e.g.
+ * DirectWire on a deep result, #2368 — surfaces here as a caught exception),
+ * then decode, timing each stage and approximating the wire size. Results
+ * feed the Wire Metrics table in DebugSidebar.
+ *
+ * Everything runs on the main thread; nothing crosses to the worker. Gated by
+ * `enabled` (synced from show_debug_panel in Page.Update.calculate) so normal
+ * editing pays nothing. */
+
+let enabled = ref(false);
+
+type status =
+  | Ok
+  | Failed(string);
+
+/* One wire variant measured in one direction. */
+type dir_metric = {
+  wire: string,
+  encode_ms: float,
+  clone_ms: float,
+  decode_ms: float,
+  size_bytes: int,
+  status,
+};
+
+type record = {
+  id: int,
+  entries: int, /* length of the original request/response list */
+  request: list(dir_metric),
+  response: list(dir_metric),
+};
+
+let history_limit = 10;
+let history: ref(list(record)) = ref([]); /* newest first */
+
+let id_counter = ref(0);
+let next_id = (): int => {
+  incr(id_counter);
+  id_counter^;
+};
+
+/* structuredClone: the serializer postMessage applies to its argument. */
+let clone_fn =
+  Js.Unsafe.pure_js_expr("(function (x) { return structuredClone(x); })");
+let structured_clone: 'a. 'a => 'a =
+  x => Js.Unsafe.fun_call(clone_fn, [|Js.Unsafe.inject(x)|]);
+
+/* Approximate in-memory footprint of an arbitrary wire form (string, OCaml
+ * value graph, plain object, or typed arrays), by an iterative walk with a
+ * visited set so shared/DAG structure isn't double-counted. Numbers 8B,
+ * strings by length, typed arrays by byteLength, object/array headers ~8B per
+ * slot. Only a relative measure across variants, not an exact byte count. */
+let size_fn =
+  Js.Unsafe.pure_js_expr(
+    {|(function (root) {
+         var seen = new Set(), stack = [root], total = 0;
+         while (stack.length) {
+           var v = stack.pop();
+           if (v === null || v === undefined) continue;
+           var t = typeof v;
+           if (t === 'number') { total += 8; }
+           else if (t === 'string') { total += v.length; }
+           else if (t === 'boolean') { total += 4; }
+           else if (t === 'object') {
+             if (seen.has(v)) continue;
+             seen.add(v);
+             if (ArrayBuffer.isView(v)) { total += v.byteLength; }
+             else if (Array.isArray(v)) {
+               total += 8 * v.length;
+               for (var i = 0; i < v.length; i++) stack.push(v[i]);
+             } else {
+               var ks = Object.keys(v);
+               for (var i = 0; i < ks.length; i++) {
+                 total += ks[i].length + 8;
+                 stack.push(v[ks[i]]);
+               }
+             }
+           }
+         }
+         return total;
+       })|},
+  );
+let size_bytes: 'a. 'a => int =
+  x => Js.Unsafe.fun_call(size_fn, [|Js.Unsafe.inject(x)|]);
+
+let timed: 'a. (unit => 'a) => (float, 'a) =
+  f => {
+    let t0 = Util.JsUtil.precise_timestamp();
+    let x = f();
+    (Util.JsUtil.precise_timestamp() -. t0, x);
+  };
+
+/* Measure encode -> structuredClone -> decode for one wire direction. Each
+ * stage that runs before an exception keeps its timing; the first stage to
+ * throw sets status to Failed and stops (later stages stay 0). */
+let measure:
+  'w 'a.
+  (~name: string, ~encode: unit => 'w, ~decode: 'w => 'a) => dir_metric
+ =
+  (~name, ~encode, ~decode) => {
+    let enc = ref(0.)
+    and cln = ref(0.)
+    and dec = ref(0.)
+    and sz = ref(0);
+    let status =
+      switch (
+        {
+          let (e, encoded) = timed(encode);
+          enc := e;
+          let (c, cloned) = timed(() => structured_clone(encoded));
+          cln := c;
+          sz := size_bytes(cloned);
+          let (d, _) = timed(() => decode(cloned));
+          dec := d;
+        }
+      ) {
+      | () => Ok
+      | exception exn => Failed(Printexc.to_string(exn))
+      };
+    {
+      wire: name,
+      encode_ms: enc^,
+      clone_ms: cln^,
+      decode_ms: dec^,
+      size_bytes: sz^,
+      status,
+    };
+  };
+
+let push = (r: record): unit =>
+  history := [r, ...Util.ListUtil.take(history_limit - 1, history^)];
+
+let record_request = (id: int, req: WorkerServer.Request.t): unit => {
+  let request =
+    List.map(
+      (wire: (module WorkerServer.WIRE)) => {
+        module M = (val wire);
+        measure(
+          ~name=M.name,
+          ~encode=() => M.encode_request(req),
+          ~decode=M.decode_request,
+        );
+      },
+      WorkerServer.all_wires,
+    );
+  push({
+    id,
+    entries: List.length(req),
+    request,
+    response: [],
+  });
+};
+
+let record_response = (id: int, resp: WorkerServer.Response.t): unit => {
+  let response =
+    List.map(
+      (wire: (module WorkerServer.WIRE)) => {
+        module M = (val wire);
+        measure(
+          ~name=M.name,
+          ~encode=() => M.encode_response(resp),
+          ~decode=M.decode_response,
+        );
+      },
+      WorkerServer.all_wires,
+    );
+  history :=
+    List.map(
+      (r: record) =>
+        r.id == id
+          ? {
+            ...r,
+            response,
+          }
+          : r,
+      history^,
+    );
+};

--- a/src/web/util/WireMetrics.re
+++ b/src/web/util/WireMetrics.re
@@ -1,13 +1,15 @@
 open Js_of_ocaml;
 
-/* Per-request benchmarking of the worker wire protocols (WorkerServer.WIRE).
+/* Data for the "Worker Messaging" debug panel: how the main thread talks to
+ * the eval Web Worker. Per-request benchmarking of the candidate wire
+ * protocols (WorkerServer.WIRE) that encode payloads across the boundary.
  *
  * For every variant in WorkerServer.all_wires we encode the real payload,
  * run it through the browser's structuredClone (the same serializer
  * postMessage uses, so an encoding that overflows the clone stack — e.g.
  * DirectWire on a deep result, #2368 — surfaces here as a caught exception),
  * then decode, timing each stage and approximating the wire size. Results
- * feed the Wire Metrics table in DebugSidebar.
+ * feed the Worker Messaging table in DebugSidebar.
  *
  * Everything runs on the main thread; nothing crosses to the worker. Gated by
  * `enabled` (synced from show_debug_panel in Page.Update.calculate) so normal

--- a/src/web/util/WireMetrics.re
+++ b/src/web/util/WireMetrics.re
@@ -15,6 +15,20 @@ open Js_of_ocaml;
 
 let enabled = ref(false);
 
+/* Wire names (WorkerServer.WIRE.name) the user has turned off in the panel;
+   synced from settings in Page.Update.calculate. A disabled variant is not
+   measured at all, so e.g. the slow sexp variant can be skipped. */
+let disabled_wires: ref(list(string)) = ref([]);
+
+let active_wires = (): list(module WorkerServer.WIRE) =>
+  List.filter(
+    (wire: (module WorkerServer.WIRE)) => {
+      module M = (val wire);
+      !List.mem(M.name, disabled_wires^);
+    },
+    WorkerServer.all_wires,
+  );
+
 type status =
   | Ok
   | Failed(string);
@@ -147,7 +161,7 @@ let record_request = (id: int, req: WorkerServer.Request.t): unit => {
           ~decode=M.decode_request,
         );
       },
-      WorkerServer.all_wires,
+      active_wires(),
     );
   push({
     id,
@@ -168,7 +182,7 @@ let record_response = (id: int, resp: WorkerServer.Response.t): unit => {
           ~decode=M.decode_response,
         );
       },
-      WorkerServer.all_wires,
+      active_wires(),
     );
   history :=
     List.map(

--- a/src/web/util/WorkerClient.re
+++ b/src/web/util/WorkerClient.re
@@ -4,10 +4,13 @@ open WorkerServer;
 let name = "worker.js"; // Worker file name
 let timeoutDuration = 20000; // Worker timeout in ms
 
-let initWorker: unit => Js.t(Worker.worker(Request.t, Response.t)) =
+/* Worker exchanges marshaled Wire payloads, not live values, to dodge the
+ * structured-clone stack overflow on deep results (#2368; see WorkerServer.Wire).
+ * Callers still deal in Request.t/Response.t. */
+let initWorker: unit => Js.t(Worker.worker(Wire.request, Wire.response)) =
   () => Worker.create(name);
 
-let workerRef: ref(Js.t(Worker.worker(Request.t, Response.t))) =
+let workerRef: ref(Js.t(Worker.worker(Wire.request, Wire.response))) =
   ref(initWorker());
 
 let timeoutId = ref(None);
@@ -32,7 +35,7 @@ let request =
         | None => ()
         };
         timeoutId.contents = None; /* Clear timeout after response */
-        evt##.data |> handler;
+        Wire.decode_response(evt##.data) |> handler;
         Js._true;
       });
   };
@@ -47,7 +50,7 @@ let request =
 
   setupWorkerMessageHandler(workerRef.contents);
 
-  workerRef.contents##postMessage(req);
+  workerRef.contents##postMessage(Wire.encode_request(req));
 
   let onTimeout = (): unit => {
     restart_worker();

--- a/src/web/util/WorkerClient.re
+++ b/src/web/util/WorkerClient.re
@@ -4,9 +4,11 @@ open WorkerServer;
 let name = "worker.js"; // Worker file name
 let timeoutDuration = 20000; // Worker timeout in ms
 
-/* Worker exchanges marshaled Wire payloads, not live values, to dodge the
- * structured-clone stack overflow on deep results (#2368; see WorkerServer.Wire).
- * Callers still deal in Request.t/Response.t. */
+/* Worker exchanges columnar Wire payloads (flat typed arrays), not live
+ * values, to dodge the structured-clone stack overflow on deep results
+ * (#2368; see WorkerServer.Wire). Callers still deal in Request.t/Response.t.
+ * When the debug panel is on, WireMetrics benchmarks the other variants
+ * locally on the side. */
 let initWorker: unit => Js.t(Worker.worker(Wire.request, Wire.response)) =
   () => Worker.create(name);
 
@@ -27,6 +29,16 @@ let request =
       ~timeout: Request.t => unit,
     )
     : unit => {
+  /* When metrics are on, tag this request so the response can be correlated,
+   * and benchmark the request-side encodings before posting. */
+  let metrics_id =
+    if (WireMetrics.enabled^) {
+      let id = WireMetrics.next_id();
+      WireMetrics.record_request(id, req);
+      Some(id);
+    } else {
+      None;
+    };
   let setupWorkerMessageHandler = worker => {
     worker##.onmessage :=
       Dom.handler(evt => {
@@ -35,7 +47,14 @@ let request =
         | None => ()
         };
         timeoutId.contents = None; /* Clear timeout after response */
-        Wire.decode_response(evt##.data) |> handler;
+        let resp = Wire.decode_response(evt##.data);
+        /* Hand the result off first; benchmarking the other variants can take
+         * tens of ms and must not delay evaluation latency. */
+        handler(resp);
+        switch (metrics_id) {
+        | Some(id) => WireMetrics.record_response(id, resp)
+        | None => ()
+        };
         Js._true;
       });
   };

--- a/src/web/util/WorkerClient.re
+++ b/src/web/util/WorkerClient.re
@@ -4,12 +4,9 @@ open WorkerServer;
 let name = "worker.js"; // Worker file name
 let timeoutDuration = 20000; // Worker timeout in ms
 
-/* Worker exchanges Active-encoding payloads (a flat string produced by jsoo's
- * iterative Marshal, which structured clone copies without recursing), not live
- * values, to dodge the structured-clone stack overflow on deep results (#2368;
- * see WorkerServer.Active). Callers still deal in Request.t/Response.t. When the
- * debug panel is on, WorkerMetrics benchmarks the other encodings locally on
- * the side. */
+/* Worker exchanges Active-encoding payloads, not live values, to dodge the
+ * structured-clone overflow on deep results (#2368; see WorkerServer.Active).
+ * Callers still deal in Request.t/Response.t. */
 let initWorker: unit => Js.t(Worker.worker(Active.request, Active.response)) =
   () => Worker.create(name);
 

--- a/src/web/util/WorkerClient.re
+++ b/src/web/util/WorkerClient.re
@@ -4,11 +4,12 @@ open WorkerServer;
 let name = "worker.js"; // Worker file name
 let timeoutDuration = 20000; // Worker timeout in ms
 
-/* Worker exchanges columnar Wire payloads (flat typed arrays), not live
- * values, to dodge the structured-clone stack overflow on deep results
- * (#2368; see WorkerServer.Wire). Callers still deal in Request.t/Response.t.
- * When the debug panel is on, WireMetrics benchmarks the other variants
- * locally on the side. */
+/* Worker exchanges Wire payloads (a flat string produced by jsoo's iterative
+ * Marshal, which structured clone copies without recursing), not live values,
+ * to dodge the structured-clone stack overflow on deep results (#2368; see
+ * WorkerServer.Wire). Callers still deal in Request.t/Response.t. When the
+ * debug panel is on, WireMetrics benchmarks the other variants locally on the
+ * side. */
 let initWorker: unit => Js.t(Worker.worker(Wire.request, Wire.response)) =
   () => Worker.create(name);
 

--- a/src/web/util/WorkerClient.re
+++ b/src/web/util/WorkerClient.re
@@ -4,16 +4,16 @@ open WorkerServer;
 let name = "worker.js"; // Worker file name
 let timeoutDuration = 20000; // Worker timeout in ms
 
-/* Worker exchanges Wire payloads (a flat string produced by jsoo's iterative
- * Marshal, which structured clone copies without recursing), not live values,
- * to dodge the structured-clone stack overflow on deep results (#2368; see
- * WorkerServer.Wire). Callers still deal in Request.t/Response.t. When the
- * debug panel is on, WireMetrics benchmarks the other variants locally on the
- * side. */
-let initWorker: unit => Js.t(Worker.worker(Wire.request, Wire.response)) =
+/* Worker exchanges Active-encoding payloads (a flat string produced by jsoo's
+ * iterative Marshal, which structured clone copies without recursing), not live
+ * values, to dodge the structured-clone stack overflow on deep results (#2368;
+ * see WorkerServer.Active). Callers still deal in Request.t/Response.t. When the
+ * debug panel is on, WorkerMetrics benchmarks the other encodings locally on
+ * the side. */
+let initWorker: unit => Js.t(Worker.worker(Active.request, Active.response)) =
   () => Worker.create(name);
 
-let workerRef: ref(Js.t(Worker.worker(Wire.request, Wire.response))) =
+let workerRef: ref(Js.t(Worker.worker(Active.request, Active.response))) =
   ref(initWorker());
 
 let timeoutId = ref(None);
@@ -33,9 +33,9 @@ let request =
   /* When metrics are on, tag this request so the response can be correlated,
    * and benchmark the request-side encodings before posting. */
   let metrics_id =
-    if (WireMetrics.enabled^) {
-      let id = WireMetrics.next_id();
-      WireMetrics.record_request(id, req);
+    if (WorkerMetrics.enabled^) {
+      let id = WorkerMetrics.next_id();
+      WorkerMetrics.record_request(id, req);
       Some(id);
     } else {
       None;
@@ -48,12 +48,12 @@ let request =
         | None => ()
         };
         timeoutId.contents = None; /* Clear timeout after response */
-        let resp = Wire.decode_response(evt##.data);
+        let resp = Active.decode_response(evt##.data);
         /* Hand the result off first; benchmarking the other variants can take
          * tens of ms and must not delay evaluation latency. */
         handler(resp);
         switch (metrics_id) {
-        | Some(id) => WireMetrics.record_response(id, resp)
+        | Some(id) => WorkerMetrics.record_response(id, resp)
         | None => ()
         };
         Js._true;
@@ -70,7 +70,7 @@ let request =
 
   setupWorkerMessageHandler(workerRef.contents);
 
-  workerRef.contents##postMessage(Wire.encode_request(req));
+  workerRef.contents##postMessage(Active.encode_request(req));
 
   let onTimeout = (): unit => {
     restart_worker();

--- a/src/web/util/WorkerMetrics.re
+++ b/src/web/util/WorkerMetrics.re
@@ -7,20 +7,29 @@ open Js_of_ocaml;
  * For every enabled encoding we encode the real payload, run it through the
  * browser's structuredClone (the same serializer postMessage uses, so an
  * encoding that overflows the clone stack — e.g. Direct on a deep result,
- * #2368 — surfaces here as a caught exception), then decode, timing each stage
- * and approximating the encoded size. Results feed the Worker Messaging table
- * in DebugSidebar.
+ * #2368 — surfaces here as a caught exception), then decode, timing each stage;
+ * the encoded size is reported by the encoding itself. Results feed the Worker
+ * Messaging table in DebugSidebar.
  *
  * Everything runs on the main thread; nothing crosses to the worker. Gated by
- * `enabled` (synced from show_debug_panel in Page.Update.calculate) so normal
- * editing pays nothing. */
+ * `enabled` (synced from settings in Page.Update.calculate via `sync`) so
+ * normal editing pays nothing. */
 
 let enabled = ref(false);
 
-/* Encodings the user has turned on in the panel (WorkerServer.encoding);
-   synced from settings in Page.Update.calculate. Only enabled encodings are
-   measured, so e.g. the slow sexp encoding can be skipped. */
+/* Encodings the user has turned on in the panel (WorkerServer.encoding). Only
+   enabled encodings are measured, so e.g. the slow sexp encoding can be
+   skipped. */
 let enabled_encodings: ref(list(WorkerServer.encoding)) = ref([]);
+
+/* Sync the gating flags from settings; called once per update cycle from
+   Page.Update.calculate (the only place with the full app settings in scope). */
+let sync =
+    (~enabled as is_enabled: bool, ~encodings: list(WorkerServer.encoding))
+    : unit => {
+  enabled := is_enabled;
+  enabled_encodings := encodings;
+};
 
 let active_encodings = (): list(WorkerServer.encoding) =>
   List.filter(
@@ -28,18 +37,16 @@ let active_encodings = (): list(WorkerServer.encoding) =>
     WorkerServer.all_of_encoding,
   );
 
-type status =
-  | Ok
-  | Failed(string);
-
-/* One encoding measured in one direction. */
+/* One encoding measured in one direction. A stage's duration/size is None if it
+ * didn't complete; `error` holds the message of the stage that threw (if any),
+ * so a failure reads as an absence rather than a misleading 0. */
 type dir_metric = {
   encoding: WorkerServer.encoding,
-  encode_ms: float,
-  clone_ms: float,
-  decode_ms: float,
-  size_bytes: int,
-  status,
+  encode: option(Core.Time_ns.Span.t),
+  clone: option(Core.Time_ns.Span.t),
+  decode: option(Core.Time_ns.Span.t),
+  size: option(Core.Byte_units.t),
+  error: option(string),
 };
 
 type record = {
@@ -64,86 +71,54 @@ let clone_fn =
 let structured_clone: 'a. 'a => 'a =
   x => Js.Unsafe.fun_call(clone_fn, [|Js.Unsafe.inject(x)|]);
 
-/* Approximate in-memory footprint of an arbitrary wire form (string, OCaml
- * value graph, plain object, or typed arrays), by an iterative walk with a
- * visited set so shared/DAG structure isn't double-counted. Numbers 8B,
- * strings by length, typed arrays by byteLength, object/array headers ~8B per
- * slot. Only a relative measure across variants, not an exact byte count. */
-let size_fn =
-  Js.Unsafe.pure_js_expr(
-    {|(function (root) {
-         var seen = new Set(), stack = [root], total = 0;
-         while (stack.length) {
-           var v = stack.pop();
-           if (v === null || v === undefined) continue;
-           var t = typeof v;
-           if (t === 'number') { total += 8; }
-           else if (t === 'string') { total += v.length; }
-           else if (t === 'boolean') { total += 4; }
-           else if (t === 'object') {
-             if (seen.has(v)) continue;
-             seen.add(v);
-             if (ArrayBuffer.isView(v)) { total += v.byteLength; }
-             else if (Array.isArray(v)) {
-               total += 8 * v.length;
-               for (var i = 0; i < v.length; i++) stack.push(v[i]);
-             } else {
-               var ks = Object.keys(v);
-               for (var i = 0; i < ks.length; i++) {
-                 total += ks[i].length + 8;
-                 stack.push(v[ks[i]]);
-               }
-             }
-           }
-         }
-         return total;
-       })|},
-  );
-let size_bytes: 'a. 'a => int =
-  x => Js.Unsafe.fun_call(size_fn, [|Js.Unsafe.inject(x)|]);
-
-let timed: 'a. (unit => 'a) => (float, 'a) =
+let timed: 'a. (unit => 'a) => (Core.Time_ns.Span.t, 'a) =
   f => {
     let t0 = Util.JsUtil.precise_timestamp();
     let x = f();
-    (Util.JsUtil.precise_timestamp() -. t0, x);
+    (Core.Time_ns.Span.of_ms(Util.JsUtil.precise_timestamp() -. t0), x);
   };
 
-/* Measure encode -> structuredClone -> decode for one wire direction. Each
- * stage that runs before an exception keeps its timing; the first stage to
- * throw sets status to Failed and stops (later stages stay 0). */
+/* Measure encode -> size -> structuredClone -> decode for one direction. Each
+ * stage that completes records its value; the first stage to throw sets `error`
+ * and leaves it and later stages None (never a misleading 0). Size is asked of
+ * the encoding via `size`. */
 let measure:
   'w 'a.
-  (~encoding: WorkerServer.encoding, ~encode: unit => 'w, ~decode: 'w => 'a) =>
+  (
+    ~encoding: WorkerServer.encoding,
+    ~encode: unit => 'w,
+    ~size: 'w => Core.Byte_units.t,
+    ~decode: 'w => 'a
+  ) =>
   dir_metric
  =
-  (~encoding, ~encode, ~decode) => {
-    let enc = ref(0.)
-    and cln = ref(0.)
-    and dec = ref(0.)
-    and sz = ref(0);
-    let status =
+  (~encoding, ~encode, ~size, ~decode) => {
+    let enc = ref(None)
+    and cln = ref(None)
+    and dec = ref(None)
+    and sz = ref(None);
+    let error =
       switch (
         {
           let (e, encoded) = timed(encode);
-          enc := e;
+          enc := Some(e);
+          sz := Some(size(encoded));
           let (c, cloned) = timed(() => structured_clone(encoded));
-          cln := c;
-          sz := size_bytes(cloned);
+          cln := Some(c);
           let (d, _) = timed(() => decode(cloned));
-          dec := d;
+          dec := Some(d);
         }
       ) {
-      | () => Ok
-      | exception exn => Failed(Printexc.to_string(exn))
+      | () => None
+      | exception exn => Some(Printexc.to_string(exn))
       };
     {
       encoding,
-      encode_ms: enc^,
-      clone_ms: cln^,
-      decode_ms: dec^,
-      size_bytes: sz^,
-      status,
+      encode: enc^,
+      clone: cln^,
+      decode: dec^,
+      size: sz^,
+      error,
     };
   };
 
@@ -158,6 +133,7 @@ let record_request = (id: int, req: WorkerServer.Request.t): unit => {
         measure(
           ~encoding=e,
           ~encode=() => M.encode_request(req),
+          ~size=M.size_request,
           ~decode=M.decode_request,
         );
       },
@@ -179,6 +155,7 @@ let record_response = (id: int, resp: WorkerServer.Response.t): unit => {
         measure(
           ~encoding=e,
           ~encode=() => M.encode_response(resp),
+          ~size=M.size_response,
           ~decode=M.decode_response,
         );
       },

--- a/src/web/util/WorkerMetrics.re
+++ b/src/web/util/WorkerMetrics.re
@@ -1,15 +1,15 @@
 open Js_of_ocaml;
 
 /* Data for the "Worker Messaging" debug panel: how the main thread talks to
- * the eval Web Worker. Per-request benchmarking of the candidate wire
- * protocols (WorkerServer.WIRE) that encode payloads across the boundary.
+ * the eval Web Worker. Per-request benchmarking of the candidate encodings
+ * (WorkerServer.encoding / ENCODING) that pack payloads across the boundary.
  *
- * For every variant in WorkerServer.all_wires we encode the real payload,
- * run it through the browser's structuredClone (the same serializer
- * postMessage uses, so an encoding that overflows the clone stack — e.g.
- * DirectWire on a deep result, #2368 — surfaces here as a caught exception),
- * then decode, timing each stage and approximating the wire size. Results
- * feed the Worker Messaging table in DebugSidebar.
+ * For every enabled encoding we encode the real payload, run it through the
+ * browser's structuredClone (the same serializer postMessage uses, so an
+ * encoding that overflows the clone stack — e.g. Direct on a deep result,
+ * #2368 — surfaces here as a caught exception), then decode, timing each stage
+ * and approximating the encoded size. Results feed the Worker Messaging table
+ * in DebugSidebar.
  *
  * Everything runs on the main thread; nothing crosses to the worker. Gated by
  * `enabled` (synced from show_debug_panel in Page.Update.calculate) so normal
@@ -17,27 +17,24 @@ open Js_of_ocaml;
 
 let enabled = ref(false);
 
-/* Wire names (WorkerServer.WIRE.name) the user has turned off in the panel;
-   synced from settings in Page.Update.calculate. A disabled variant is not
-   measured at all, so e.g. the slow sexp variant can be skipped. */
-let disabled_wires: ref(list(string)) = ref([]);
+/* Encodings the user has turned on in the panel (WorkerServer.encoding);
+   synced from settings in Page.Update.calculate. Only enabled encodings are
+   measured, so e.g. the slow sexp encoding can be skipped. */
+let enabled_encodings: ref(list(WorkerServer.encoding)) = ref([]);
 
-let active_wires = (): list(module WorkerServer.WIRE) =>
+let active_encodings = (): list(WorkerServer.encoding) =>
   List.filter(
-    (wire: (module WorkerServer.WIRE)) => {
-      module M = (val wire);
-      !List.mem(M.name, disabled_wires^);
-    },
-    WorkerServer.all_wires,
+    e => List.mem(e, enabled_encodings^),
+    WorkerServer.all_of_encoding,
   );
 
 type status =
   | Ok
   | Failed(string);
 
-/* One wire variant measured in one direction. */
+/* One encoding measured in one direction. */
 type dir_metric = {
-  wire: string,
+  encoding: WorkerServer.encoding,
   encode_ms: float,
   clone_ms: float,
   decode_ms: float,
@@ -117,9 +114,10 @@ let timed: 'a. (unit => 'a) => (float, 'a) =
  * throw sets status to Failed and stops (later stages stay 0). */
 let measure:
   'w 'a.
-  (~name: string, ~encode: unit => 'w, ~decode: 'w => 'a) => dir_metric
+  (~encoding: WorkerServer.encoding, ~encode: unit => 'w, ~decode: 'w => 'a) =>
+  dir_metric
  =
-  (~name, ~encode, ~decode) => {
+  (~encoding, ~encode, ~decode) => {
     let enc = ref(0.)
     and cln = ref(0.)
     and dec = ref(0.)
@@ -140,7 +138,7 @@ let measure:
       | exception exn => Failed(Printexc.to_string(exn))
       };
     {
-      wire: name,
+      encoding,
       encode_ms: enc^,
       clone_ms: cln^,
       decode_ms: dec^,
@@ -155,15 +153,15 @@ let push = (r: record): unit =>
 let record_request = (id: int, req: WorkerServer.Request.t): unit => {
   let request =
     List.map(
-      (wire: (module WorkerServer.WIRE)) => {
-        module M = (val wire);
+      (e: WorkerServer.encoding) => {
+        module M = (val WorkerServer.module_of_encoding(e));
         measure(
-          ~name=M.name,
+          ~encoding=e,
           ~encode=() => M.encode_request(req),
           ~decode=M.decode_request,
         );
       },
-      active_wires(),
+      active_encodings(),
     );
   push({
     id,
@@ -176,15 +174,15 @@ let record_request = (id: int, req: WorkerServer.Request.t): unit => {
 let record_response = (id: int, resp: WorkerServer.Response.t): unit => {
   let response =
     List.map(
-      (wire: (module WorkerServer.WIRE)) => {
-        module M = (val wire);
+      (e: WorkerServer.encoding) => {
+        module M = (val WorkerServer.module_of_encoding(e));
         measure(
-          ~name=M.name,
+          ~encoding=e,
           ~encode=() => M.encode_response(resp),
           ~decode=M.decode_response,
         );
       },
-      active_wires(),
+      active_encodings(),
     );
   history :=
     List.map(

--- a/src/web/util/WorkerServer.re
+++ b/src/web/util/WorkerServer.re
@@ -40,7 +40,7 @@ module Response = {
  * live Request.t/Response.t into some `request`/`response` form crossing the
  * worker boundary. The forms are abstract so only encode/decode can produce
  * them and the two directions can't be swapped. `name` labels the variant in
- * the Wire Metrics debug panel. Several implementations follow; the one wired
+ * the Worker Messaging debug panel. Several implementations follow; the one wired
  * into WorkerClient/on_request is the active protocol, the rest exist to be
  * benchmarked against it (see WireMetrics). */
 module type WIRE = {

--- a/src/web/util/WorkerServer.re
+++ b/src/web/util/WorkerServer.re
@@ -36,21 +36,17 @@ module Response = {
     Util.StructureShareSexp.structure_share_in(sexp_of_t, t_of_sexp);
 };
 
-/* The candidate encodings for the worker payloads. `Marshal` is the active one
- * (see `Active`); the others are benchmarked against it in the Worker Messaging
- * debug panel (see WorkerMetrics). Display and persistence strings are
- * ppx-derived (show/sexp/yojson), and `enumerate` gives `all_of_encoding`, so
- * there are no hand-maintained name lists. */
+/* Candidate encodings for the worker payloads; `Marshal` is active (see
+ * `Active`), the rest are benchmarked against it (WorkerMetrics). Strings and
+ * `all_of_encoding` are ppx-derived — no hand-maintained name lists. */
 [@deriving (show({with_path: false}), sexp, yojson, enumerate)]
 type encoding =
   | Direct
   | Marshal
   | Sexp;
 
-/* An encoding is an encode/decode pair for each direction that turns a live
- * Request.t/Response.t into some `request`/`response` form crossing the worker
- * boundary. The forms are abstract so only encode/decode can produce them and
- * the two directions can't be swapped. */
+/* An encode/decode pair per direction; the forms are abstract so only
+ * encode/decode can cross the boundary and the directions can't be swapped. */
 module type ENCODING = {
   type request;
   type response;
@@ -58,17 +54,15 @@ module type ENCODING = {
   let decode_request: request => Request.t;
   let encode_response: Response.t => response;
   let decode_response: response => Response.t;
-  /* Size of the encoded form, reported by each encoding since only it knows its
-   * representation (exact for the string encodings, an in-memory-footprint
-   * estimate for the identity one). Used by WorkerMetrics. */
+  /* Size of the encoded form (exact for the string encodings, an estimate for
+   * the identity one), reported here since only the encoding knows its form. */
   let size_request: request => Core.Byte_units.t;
   let size_response: response => Core.Byte_units.t;
 };
 
-/* Post the live value graph unchanged — the pre-#2368 behavior. Chrome's
- * structured-clone serializer is recursive and overflows on deep payloads, so
- * this is unsafe as the active encoding; it's kept as the baseline the metrics
- * path exercises (the overflow surfaces as a caught exception there). */
+/* Post the live value graph unchanged (pre-#2368 behavior): unsafe as the
+ * active encoding since Chrome's clone overflows on deep payloads, kept as the
+ * benchmark baseline (the overflow surfaces there as a caught exception). */
 module DirectEncoding: ENCODING = {
   open Js_of_ocaml;
   type request = Request.t;
@@ -77,9 +71,8 @@ module DirectEncoding: ENCODING = {
   let decode_request = Fun.id;
   let encode_response = Fun.id;
   let decode_response = Fun.id;
-  /* No serialized form, so approximate the in-memory footprint by an iterative
-   * walk with a visited set (shared/DAG structure isn't double-counted). Only a
-   * relative measure against the string encodings, not an exact byte count. */
+  /* No serialized form, so estimate the in-memory footprint by an iterative
+   * walk with a visited set (a relative measure, not exact bytes). */
   let size_fn =
     Js.Unsafe.pure_js_expr(
       {|(function (root) {
@@ -119,9 +112,8 @@ module DirectEncoding: ENCODING = {
   let size_response = (r: response) => size(r);
 };
 
-/* Serialize with jsoo's Marshal (iterative, so depth-safe) to a flat string
- * that structured clone copies without recursing. This is the active encoding
- * (see `Active`) and the #2368 fix. */
+/* jsoo Marshal (iterative → depth-safe) to a flat string clone copies without
+ * recursing. The active encoding and the #2368 fix. */
 module MarshalEncoding: ENCODING = {
   type request = string;
   type response = string;
@@ -138,9 +130,8 @@ module MarshalEncoding: ENCODING = {
     Core.Byte_units.of_bytes_int(String.length(w));
 };
 
-/* Serialize via the derived sexp converters to a string. Measures the general
- * sexp layer; its converters recurse per AST level, so deep expressions
- * overflow (a known limitation, not exercised as the active encoding). */
+/* Serialize via the derived sexp converters; recurses per AST level, so deep
+ * expressions overflow — a benchmark comparison only. */
 module SexpEncoding: ENCODING = {
   type request = string;
   type response = string;
@@ -158,8 +149,7 @@ module SexpEncoding: ENCODING = {
     Core.Byte_units.of_bytes_int(String.length(w));
 };
 
-/* Behavior for an encoding tag. Exhaustive, so adding a variant is a compile
- * error until it's wired up here. */
+/* Behavior for an encoding tag (exhaustive — a new variant must be added). */
 let module_of_encoding = (e: encoding): (module ENCODING) =>
   switch (e) {
   | Direct => (module DirectEncoding)
@@ -167,8 +157,8 @@ let module_of_encoding = (e: encoding): (module ENCODING) =>
   | Sexp => (module SexpEncoding)
   };
 
-/* The active encoding crossing the worker boundary (WorkerClient / on_request).
- * Swap this alias to change it; the panel benchmarks every encoding. */
+/* The active encoding on the boundary (WorkerClient / on_request); swap to
+ * change it. */
 module Active = MarshalEncoding;
 
 let work = (req_value: Request.value): Response.value => {

--- a/src/web/util/WorkerServer.re
+++ b/src/web/util/WorkerServer.re
@@ -36,15 +36,22 @@ module Response = {
     Util.StructureShareSexp.structure_share_in(sexp_of_t, t_of_sexp);
 };
 
-/* A wire protocol is an encode/decode pair for each direction that turns a
- * live Request.t/Response.t into some `request`/`response` form crossing the
- * worker boundary. The forms are abstract so only encode/decode can produce
- * them and the two directions can't be swapped. `name` labels the variant in
- * the Worker Messaging debug panel. Several implementations follow; the one wired
- * into WorkerClient/on_request is the active protocol, the rest exist to be
- * benchmarked against it (see WireMetrics). */
-module type WIRE = {
-  let name: string;
+/* The candidate encodings for the worker payloads. `Marshal` is the active one
+ * (see `Active`); the others are benchmarked against it in the Worker Messaging
+ * debug panel (see WorkerMetrics). Display and persistence strings are
+ * ppx-derived (show/sexp/yojson), and `enumerate` gives `all_of_encoding`, so
+ * there are no hand-maintained name lists. */
+[@deriving (show({with_path: false}), sexp, yojson, enumerate)]
+type encoding =
+  | Direct
+  | Marshal
+  | Sexp;
+
+/* An encoding is an encode/decode pair for each direction that turns a live
+ * Request.t/Response.t into some `request`/`response` form crossing the worker
+ * boundary. The forms are abstract so only encode/decode can produce them and
+ * the two directions can't be swapped. */
+module type ENCODING = {
   type request;
   type response;
   let encode_request: Request.t => request;
@@ -55,10 +62,9 @@ module type WIRE = {
 
 /* Post the live value graph unchanged — the pre-#2368 behavior. Chrome's
  * structured-clone serializer is recursive and overflows on deep payloads, so
- * this is unsafe as an active protocol; it's kept as the baseline the metrics
+ * this is unsafe as the active encoding; it's kept as the baseline the metrics
  * path exercises (the overflow surfaces as a caught exception there). */
-module DirectWire: WIRE = {
-  let name = "direct";
+module DirectEncoding: ENCODING = {
   type request = Request.t;
   type response = Response.t;
   let encode_request = Fun.id;
@@ -68,10 +74,9 @@ module DirectWire: WIRE = {
 };
 
 /* Serialize with jsoo's Marshal (iterative, so depth-safe) to a flat string
- * that structured clone copies without recursing. This is the active protocol
- * (see `Wire` below) and the #2368 fix. */
-module MarshalWire: WIRE = {
-  let name = "marshal";
+ * that structured clone copies without recursing. This is the active encoding
+ * (see `Active`) and the #2368 fix. */
+module MarshalEncoding: ENCODING = {
   type request = string;
   type response = string;
   let encode_request = (req: Request.t): request =>
@@ -85,9 +90,8 @@ module MarshalWire: WIRE = {
 
 /* Serialize via the derived sexp converters to a string. Measures the general
  * sexp layer; its converters recurse per AST level, so deep expressions
- * overflow (a known limitation, not exercised as an active protocol). */
-module SexpWire: WIRE = {
-  let name = "sexp";
+ * overflow (a known limitation, not exercised as the active encoding). */
+module SexpEncoding: ENCODING = {
   type request = string;
   type response = string;
   let encode_request = (req: Request.t): request =>
@@ -100,16 +104,18 @@ module SexpWire: WIRE = {
     Response.t_of_sexp(Sexplib.Sexp.of_string(w));
 };
 
-/* The active protocol crossing the worker boundary (WorkerClient / on_request).
- * Swap this alias to change it; the panel benchmarks every entry in all_wires. */
-module Wire = MarshalWire;
+/* Behavior for an encoding tag. Exhaustive, so adding a variant is a compile
+ * error until it's wired up here. */
+let module_of_encoding = (e: encoding): (module ENCODING) =>
+  switch (e) {
+  | Direct => (module DirectEncoding)
+  | Marshal => (module MarshalEncoding)
+  | Sexp => (module SexpEncoding)
+  };
 
-/* All wire variants, for the metrics benchmark loop (WireMetrics). */
-let all_wires: list(module WIRE) = [
-  (module DirectWire),
-  (module MarshalWire),
-  (module SexpWire),
-];
+/* The active encoding crossing the worker boundary (WorkerClient / on_request).
+ * Swap this alias to change it; the panel benchmarks every encoding. */
+module Active = MarshalEncoding;
 
 let work = (req_value: Request.value): Response.value => {
   let Request.{expr, targets, eval_info_map, prev} = req_value;
@@ -135,10 +141,10 @@ let work = (req_value: Request.value): Response.value => {
   };
 };
 
-let on_request = (req: Wire.request): unit => {
+let on_request = (req: Active.request): unit => {
   let resp: Response.t =
-    Wire.decode_request(req) |> List.map(((k, v)) => (k, work(v)));
-  Js_of_ocaml.Worker.post_message(Wire.encode_response(resp));
+    Active.decode_request(req) |> List.map(((k, v)) => (k, work(v)));
+  Js_of_ocaml.Worker.post_message(Active.encode_response(resp));
 };
 
 let start = () => Js_of_ocaml.Worker.set_onmessage(on_request);

--- a/src/web/util/WorkerServer.re
+++ b/src/web/util/WorkerServer.re
@@ -36,26 +36,41 @@ module Response = {
     Util.StructureShareSexp.structure_share_in(sexp_of_t, t_of_sexp);
 };
 
-/* Marshaled wire forms of the worker payloads.
- *
- * post_message structured-clones its argument, and Chrome's clone serializer
- * is recursive: it overflows on deep (but finite, acyclic) payloads (#2368).
- * jsoo's Marshal is iterative and yields a flat string that clones without
- * recursing. The payloads are closure-free (clone rejects closures yet
- * succeeds here before overflowing), so Marshal without the unsupported
- * Closures flag is safe.
- *
- * The types are abstract so the boundary stays typed Worker.worker(request,
- * response), not (string, string): only the encode/decode functions can cross
- * it and the two directions can't be swapped. */
-module Wire: {
+/* A wire protocol is an encode/decode pair for each direction that turns a
+ * live Request.t/Response.t into some `request`/`response` form crossing the
+ * worker boundary. The forms are abstract so only encode/decode can produce
+ * them and the two directions can't be swapped. `name` labels the variant in
+ * the Wire Metrics debug panel. Several implementations follow; the one wired
+ * into WorkerClient/on_request is the active protocol, the rest exist to be
+ * benchmarked against it (see WireMetrics). */
+module type WIRE = {
+  let name: string;
   type request;
   type response;
   let encode_request: Request.t => request;
   let decode_request: request => Request.t;
   let encode_response: Response.t => response;
   let decode_response: response => Response.t;
-} = {
+};
+
+/* Post the live value graph unchanged — the pre-#2368 behavior. Chrome's
+ * structured-clone serializer is recursive and overflows on deep payloads, so
+ * this is unsafe as an active protocol; it's kept as the baseline the metrics
+ * path exercises (the overflow surfaces as a caught exception there). */
+module DirectWire: WIRE = {
+  let name = "direct";
+  type request = Request.t;
+  type response = Response.t;
+  let encode_request = Fun.id;
+  let decode_request = Fun.id;
+  let encode_response = Fun.id;
+  let decode_response = Fun.id;
+};
+
+/* Serialize with jsoo's Marshal (iterative, so depth-safe) to a flat string
+ * that structured clone copies without recursing. The PR #2370 approach. */
+module MarshalWire: WIRE = {
+  let name = "marshal";
   type request = string;
   type response = string;
   let encode_request = (req: Request.t): request =>
@@ -66,6 +81,170 @@ module Wire: {
   let decode_response = (w: response): Response.t =>
     Marshal.from_string(w, 0);
 };
+
+/* Serialize via the derived sexp converters to a string. Measures the general
+ * sexp layer; its converters recurse per AST level, so deep expressions
+ * overflow (a known limitation, not exercised as an active protocol). */
+module SexpWire: WIRE = {
+  let name = "sexp";
+  type request = string;
+  type response = string;
+  let encode_request = (req: Request.t): request =>
+    Sexplib.Sexp.to_string(Request.sexp_of_t(req));
+  let decode_request = (w: request): Request.t =>
+    Request.t_of_sexp(Sexplib.Sexp.of_string(w));
+  let encode_response = (resp: Response.t): response =>
+    Sexplib.Sexp.to_string(Response.sexp_of_t(resp));
+  let decode_response = (w: response): Response.t =>
+    Response.t_of_sexp(Sexplib.Sexp.of_string(w));
+};
+
+/* Flattened wire forms of the worker payloads.
+ *
+ * post_message structured-clones its argument, and Chrome's clone serializer
+ * is recursive: it overflows on deep (but finite, acyclic) payloads (#2368).
+ * Serializing to a string (Marshal/sexp) sidesteps that but is slow for
+ * large payloads, so instead we re-shape the value. jsoo represents every
+ * OCaml block as a JS array, so `flatten` scans the graph once, numbering
+ * blocks in discovery order, and packs it columnar:
+ *
+ *   lens  Float64Array  length of block i
+ *   data  Float64Array  every block's fields, concatenated in block order;
+ *                       a field that is a child block holds the child's
+ *                       block number, a numeric leaf holds itself, and a
+ *                       non-numeric leaf (string) holds a dummy
+ *   refs  Float64Array  ascending data positions holding child block numbers
+ *   vpos  Float64Array  ascending data positions holding non-numeric leaves
+ *   vals  Array         the non-numeric leaves, paired with vpos
+ *
+ * The wire object is thus a fixed handful of flat arrays no matter how deep
+ * the payload is, so the clone never recurses, and the numeric bulk lives
+ * in typed arrays the serializer copies as raw bytes. `unflatten` rebuilds
+ * the blocks in one pass, walking refs/vpos in lockstep with data. Sharing
+ * is preserved (blocks are numbered by identity), so DAG-shaped payloads
+ * don't expand. Non-numeric leaves must be structured-clone-safe, exactly
+ * as every leaf had to be when the value graph was posted directly.
+ *
+ * The types are abstract so the boundary stays typed Worker.worker(request,
+ * response) and only encode/decode can cross it, with the two directions
+ * not swappable. */
+module Wire: WIRE = {
+  open Js_of_ocaml;
+
+  let name = "columnar";
+
+  type request = Js.Unsafe.any;
+  type response = Js.Unsafe.any;
+
+  let flatten_fn =
+    Js.Unsafe.pure_js_expr(
+      {|(function (root) {
+           if (!Array.isArray(root)) return { imm: root };
+           var seen = new Map(), work = [root];
+           var lens = [root.length], data = [], refs = [], vpos = [], vals = [];
+           seen.set(root, 0);
+           for (var w = 0; w < work.length; w++) {
+             var b = work[w];
+             for (var j = 0; j < b.length; j++) {
+               var f = b[j];
+               if (Array.isArray(f)) {
+                 var i = seen.get(f);
+                 if (i === undefined) {
+                   i = work.length;
+                   seen.set(f, i);
+                   work.push(f);
+                   lens.push(f.length);
+                 }
+                 refs.push(data.length);
+                 data.push(i);
+               } else if (typeof f === 'number') {
+                 data.push(f);
+               } else {
+                 vpos.push(data.length);
+                 vals.push(f);
+                 data.push(0);
+               }
+             }
+           }
+           return {
+             lens: new Float64Array(lens),
+             data: new Float64Array(data),
+             refs: new Float64Array(refs),
+             vpos: new Float64Array(vpos),
+             vals: vals
+           };
+         })|},
+    );
+
+  let unflatten_fn =
+    Js.Unsafe.pure_js_expr(
+      {|(function (wire) {
+           if (wire.lens === undefined) return wire.imm;
+           var lens = wire.lens, data = wire.data, refs = wire.refs,
+               vpos = wire.vpos, vals = wire.vals;
+           var n = lens.length, blocks = new Array(n);
+           for (var i = 0; i < n; i++) blocks[i] = new Array(lens[i]);
+           var p = 0, r = 0, s = 0;
+           for (var i = 0; i < n; i++) {
+             var b = blocks[i], len = lens[i];
+             for (var j = 0; j < len; j++, p++) {
+               if (r < refs.length && refs[r] === p) {
+                 b[j] = blocks[data[p]];
+                 r++;
+               } else if (s < vpos.length && vpos[s] === p) {
+                 b[j] = vals[s];
+                 s++;
+               } else {
+                 b[j] = data[p];
+               }
+             }
+           }
+           return blocks[0];
+         })|},
+    );
+
+  let flatten: Js.Unsafe.any => Js.Unsafe.any =
+    v => Js.Unsafe.fun_call(flatten_fn, [|v|]);
+  let unflatten: Js.Unsafe.any => Js.Unsafe.any =
+    w => Js.Unsafe.fun_call(unflatten_fn, [|w|]);
+
+  let encode_request = (req: Request.t): request =>
+    flatten(Js.Unsafe.inject(req));
+  let decode_request = (w: request): Request.t => Obj.magic(unflatten(w));
+  let encode_response = (resp: Response.t): response =>
+    flatten(Js.Unsafe.inject(resp));
+  let decode_response = (w: response): Response.t =>
+    Obj.magic(unflatten(w));
+};
+
+/* Alternative wire (#2368 follow-up experiment): the plain-OCaml version of
+ * "use an array instead of a list". Encode converts the top-level
+ * request/response list to an OCaml array — which jsoo represents as one
+ * wide JS array — and the result is posted directly; decode converts back.
+ * Only the spine it converts gets flatter: everything inside each entry
+ * still crosses as its natural nested graph, so a payload that is deep
+ * *inside* an entry (a long ListLit, a deeply nested AST) still makes
+ * structured clone recurse and can still overflow it (#2368). It exists to
+ * measure the "arrays instead of lists" idea against Wire's columnar
+ * packing, which flattens every spine at once. */
+module ArrayWire: WIRE = {
+  let name = "array";
+  type request = array((key, Request.value));
+  type response = array((key, Response.value));
+  let encode_request = Array.of_list;
+  let decode_request = Array.to_list;
+  let encode_response = Array.of_list;
+  let decode_response = Array.to_list;
+};
+
+/* All wire variants, for the metrics benchmark loop (WireMetrics). */
+let all_wires: list(module WIRE) = [
+  (module DirectWire),
+  (module MarshalWire),
+  (module SexpWire),
+  (module Wire),
+  (module ArrayWire),
+];
 
 let work = (req_value: Request.value): Response.value => {
   let Request.{expr, targets, eval_info_map, prev} = req_value;

--- a/src/web/util/WorkerServer.re
+++ b/src/web/util/WorkerServer.re
@@ -68,7 +68,8 @@ module DirectWire: WIRE = {
 };
 
 /* Serialize with jsoo's Marshal (iterative, so depth-safe) to a flat string
- * that structured clone copies without recursing. The PR #2370 approach. */
+ * that structured clone copies without recursing. This is the active protocol
+ * (see `Wire` below) and the #2368 fix. */
 module MarshalWire: WIRE = {
   let name = "marshal";
   type request = string;
@@ -99,151 +100,15 @@ module SexpWire: WIRE = {
     Response.t_of_sexp(Sexplib.Sexp.of_string(w));
 };
 
-/* Flattened wire forms of the worker payloads.
- *
- * post_message structured-clones its argument, and Chrome's clone serializer
- * is recursive: it overflows on deep (but finite, acyclic) payloads (#2368).
- * Serializing to a string (Marshal/sexp) sidesteps that but is slow for
- * large payloads, so instead we re-shape the value. jsoo represents every
- * OCaml block as a JS array, so `flatten` scans the graph once, numbering
- * blocks in discovery order, and packs it columnar:
- *
- *   lens  Float64Array  length of block i
- *   data  Float64Array  every block's fields, concatenated in block order;
- *                       a field that is a child block holds the child's
- *                       block number, a numeric leaf holds itself, and a
- *                       non-numeric leaf (string) holds a dummy
- *   refs  Float64Array  ascending data positions holding child block numbers
- *   vpos  Float64Array  ascending data positions holding non-numeric leaves
- *   vals  Array         the non-numeric leaves, paired with vpos
- *
- * The wire object is thus a fixed handful of flat arrays no matter how deep
- * the payload is, so the clone never recurses, and the numeric bulk lives
- * in typed arrays the serializer copies as raw bytes. `unflatten` rebuilds
- * the blocks in one pass, walking refs/vpos in lockstep with data. Sharing
- * is preserved (blocks are numbered by identity), so DAG-shaped payloads
- * don't expand. Non-numeric leaves must be structured-clone-safe, exactly
- * as every leaf had to be when the value graph was posted directly.
- *
- * The types are abstract so the boundary stays typed Worker.worker(request,
- * response) and only encode/decode can cross it, with the two directions
- * not swappable. */
-module Wire: WIRE = {
-  open Js_of_ocaml;
-
-  let name = "columnar";
-
-  type request = Js.Unsafe.any;
-  type response = Js.Unsafe.any;
-
-  let flatten_fn =
-    Js.Unsafe.pure_js_expr(
-      {|(function (root) {
-           if (!Array.isArray(root)) return { imm: root };
-           var seen = new Map(), work = [root];
-           var lens = [root.length], data = [], refs = [], vpos = [], vals = [];
-           seen.set(root, 0);
-           for (var w = 0; w < work.length; w++) {
-             var b = work[w];
-             for (var j = 0; j < b.length; j++) {
-               var f = b[j];
-               if (Array.isArray(f)) {
-                 var i = seen.get(f);
-                 if (i === undefined) {
-                   i = work.length;
-                   seen.set(f, i);
-                   work.push(f);
-                   lens.push(f.length);
-                 }
-                 refs.push(data.length);
-                 data.push(i);
-               } else if (typeof f === 'number') {
-                 data.push(f);
-               } else {
-                 vpos.push(data.length);
-                 vals.push(f);
-                 data.push(0);
-               }
-             }
-           }
-           return {
-             lens: new Float64Array(lens),
-             data: new Float64Array(data),
-             refs: new Float64Array(refs),
-             vpos: new Float64Array(vpos),
-             vals: vals
-           };
-         })|},
-    );
-
-  let unflatten_fn =
-    Js.Unsafe.pure_js_expr(
-      {|(function (wire) {
-           if (wire.lens === undefined) return wire.imm;
-           var lens = wire.lens, data = wire.data, refs = wire.refs,
-               vpos = wire.vpos, vals = wire.vals;
-           var n = lens.length, blocks = new Array(n);
-           for (var i = 0; i < n; i++) blocks[i] = new Array(lens[i]);
-           var p = 0, r = 0, s = 0;
-           for (var i = 0; i < n; i++) {
-             var b = blocks[i], len = lens[i];
-             for (var j = 0; j < len; j++, p++) {
-               if (r < refs.length && refs[r] === p) {
-                 b[j] = blocks[data[p]];
-                 r++;
-               } else if (s < vpos.length && vpos[s] === p) {
-                 b[j] = vals[s];
-                 s++;
-               } else {
-                 b[j] = data[p];
-               }
-             }
-           }
-           return blocks[0];
-         })|},
-    );
-
-  let flatten: Js.Unsafe.any => Js.Unsafe.any =
-    v => Js.Unsafe.fun_call(flatten_fn, [|v|]);
-  let unflatten: Js.Unsafe.any => Js.Unsafe.any =
-    w => Js.Unsafe.fun_call(unflatten_fn, [|w|]);
-
-  let encode_request = (req: Request.t): request =>
-    flatten(Js.Unsafe.inject(req));
-  let decode_request = (w: request): Request.t => Obj.magic(unflatten(w));
-  let encode_response = (resp: Response.t): response =>
-    flatten(Js.Unsafe.inject(resp));
-  let decode_response = (w: response): Response.t =>
-    Obj.magic(unflatten(w));
-};
-
-/* Alternative wire (#2368 follow-up experiment): the plain-OCaml version of
- * "use an array instead of a list". Encode converts the top-level
- * request/response list to an OCaml array — which jsoo represents as one
- * wide JS array — and the result is posted directly; decode converts back.
- * Only the spine it converts gets flatter: everything inside each entry
- * still crosses as its natural nested graph, so a payload that is deep
- * *inside* an entry (a long ListLit, a deeply nested AST) still makes
- * structured clone recurse and can still overflow it (#2368). It exists to
- * measure the "arrays instead of lists" idea against Wire's columnar
- * packing, which flattens every spine at once. */
-module ArrayWire: WIRE = {
-  let name = "array";
-  type request = array((key, Request.value));
-  type response = array((key, Response.value));
-  let encode_request = Array.of_list;
-  let decode_request = Array.to_list;
-  let encode_response = Array.of_list;
-  let decode_response = Array.to_list;
-};
+/* The active protocol crossing the worker boundary (WorkerClient / on_request).
+ * Swap this alias to change it; the panel benchmarks every entry in all_wires. */
+module Wire = MarshalWire;
 
 /* All wire variants, for the metrics benchmark loop (WireMetrics). */
 let all_wires: list(module WIRE) = [
   (module DirectWire),
   (module MarshalWire),
   (module SexpWire),
-  (module Wire),
-  (module ArrayWire),
 ];
 
 let work = (req_value: Request.value): Response.value => {

--- a/src/web/util/WorkerServer.re
+++ b/src/web/util/WorkerServer.re
@@ -58,6 +58,11 @@ module type ENCODING = {
   let decode_request: request => Request.t;
   let encode_response: Response.t => response;
   let decode_response: response => Response.t;
+  /* Size of the encoded form, reported by each encoding since only it knows its
+   * representation (exact for the string encodings, an in-memory-footprint
+   * estimate for the identity one). Used by WorkerMetrics. */
+  let size_request: request => Core.Byte_units.t;
+  let size_response: response => Core.Byte_units.t;
 };
 
 /* Post the live value graph unchanged — the pre-#2368 behavior. Chrome's
@@ -65,12 +70,53 @@ module type ENCODING = {
  * this is unsafe as the active encoding; it's kept as the baseline the metrics
  * path exercises (the overflow surfaces as a caught exception there). */
 module DirectEncoding: ENCODING = {
+  open Js_of_ocaml;
   type request = Request.t;
   type response = Response.t;
   let encode_request = Fun.id;
   let decode_request = Fun.id;
   let encode_response = Fun.id;
   let decode_response = Fun.id;
+  /* No serialized form, so approximate the in-memory footprint by an iterative
+   * walk with a visited set (shared/DAG structure isn't double-counted). Only a
+   * relative measure against the string encodings, not an exact byte count. */
+  let size_fn =
+    Js.Unsafe.pure_js_expr(
+      {|(function (root) {
+           var seen = new Set(), stack = [root], total = 0;
+           while (stack.length) {
+             var v = stack.pop();
+             if (v === null || v === undefined) continue;
+             var t = typeof v;
+             if (t === 'number') { total += 8; }
+             else if (t === 'string') { total += v.length; }
+             else if (t === 'boolean') { total += 4; }
+             else if (t === 'object') {
+               if (seen.has(v)) continue;
+               seen.add(v);
+               if (ArrayBuffer.isView(v)) { total += v.byteLength; }
+               else if (Array.isArray(v)) {
+                 total += 8 * v.length;
+                 for (var i = 0; i < v.length; i++) stack.push(v[i]);
+               } else {
+                 var ks = Object.keys(v);
+                 for (var i = 0; i < ks.length; i++) {
+                   total += ks[i].length + 8;
+                   stack.push(v[ks[i]]);
+                 }
+               }
+             }
+           }
+           return total;
+         })|},
+    );
+  let size: 'a. 'a => Core.Byte_units.t =
+    x =>
+      Core.Byte_units.of_bytes_int(
+        Js.Unsafe.fun_call(size_fn, [|Js.Unsafe.inject(x)|]),
+      );
+  let size_request = (r: request) => size(r);
+  let size_response = (r: response) => size(r);
 };
 
 /* Serialize with jsoo's Marshal (iterative, so depth-safe) to a flat string
@@ -86,6 +132,10 @@ module MarshalEncoding: ENCODING = {
     Marshal.to_string(resp, []);
   let decode_response = (w: response): Response.t =>
     Marshal.from_string(w, 0);
+  let size_request = (w: request) =>
+    Core.Byte_units.of_bytes_int(String.length(w));
+  let size_response = (w: response) =>
+    Core.Byte_units.of_bytes_int(String.length(w));
 };
 
 /* Serialize via the derived sexp converters to a string. Measures the general
@@ -102,6 +152,10 @@ module SexpEncoding: ENCODING = {
     Sexplib.Sexp.to_string(Response.sexp_of_t(resp));
   let decode_response = (w: response): Response.t =>
     Response.t_of_sexp(Sexplib.Sexp.of_string(w));
+  let size_request = (w: request) =>
+    Core.Byte_units.of_bytes_int(String.length(w));
+  let size_response = (w: response) =>
+    Core.Byte_units.of_bytes_int(String.length(w));
 };
 
 /* Behavior for an encoding tag. Exhaustive, so adding a variant is a compile

--- a/src/web/util/WorkerServer.re
+++ b/src/web/util/WorkerServer.re
@@ -36,6 +36,37 @@ module Response = {
     Util.StructureShareSexp.structure_share_in(sexp_of_t, t_of_sexp);
 };
 
+/* Marshaled wire forms of the worker payloads.
+ *
+ * post_message structured-clones its argument, and Chrome's clone serializer
+ * is recursive: it overflows on deep (but finite, acyclic) payloads (#2368).
+ * jsoo's Marshal is iterative and yields a flat string that clones without
+ * recursing. The payloads are closure-free (clone rejects closures yet
+ * succeeds here before overflowing), so Marshal without the unsupported
+ * Closures flag is safe.
+ *
+ * The types are abstract so the boundary stays typed Worker.worker(request,
+ * response), not (string, string): only the encode/decode functions can cross
+ * it and the two directions can't be swapped. */
+module Wire: {
+  type request;
+  type response;
+  let encode_request: Request.t => request;
+  let decode_request: request => Request.t;
+  let encode_response: Response.t => response;
+  let decode_response: response => Response.t;
+} = {
+  type request = string;
+  type response = string;
+  let encode_request = (req: Request.t): request =>
+    Marshal.to_string(req, []);
+  let decode_request = (w: request): Request.t => Marshal.from_string(w, 0);
+  let encode_response = (resp: Response.t): response =>
+    Marshal.to_string(resp, []);
+  let decode_response = (w: response): Response.t =>
+    Marshal.from_string(w, 0);
+};
+
 let work = (req_value: Request.value): Response.value => {
   let Request.{expr, targets, eval_info_map, prev} = req_value;
   switch (
@@ -60,9 +91,10 @@ let work = (req_value: Request.value): Response.value => {
   };
 };
 
-let on_request = (req: Request.t): unit => {
-  let resp: Response.t = req |> List.map(((k, v)) => (k, work(v)));
-  Js_of_ocaml.Worker.post_message(resp);
+let on_request = (req: Wire.request): unit => {
+  let resp: Response.t =
+    Wire.decode_request(req) |> List.map(((k, v)) => (k, work(v)));
+  Js_of_ocaml.Worker.post_message(Wire.encode_response(resp));
 };
 
 let start = () => Js_of_ocaml.Worker.set_onmessage(on_request);

--- a/src/web/www/style/sidebar.css
+++ b/src/web/www/style/sidebar.css
@@ -663,7 +663,7 @@
   color: var(--BR4);
 }
 
-/* Wire Metrics section: per-variant on/off chips above the shared table. */
+/* Worker Messaging section: per-variant on/off chips above the shared table. */
 #debug-sidebar .wm-toggles {
   display: flex;
   flex-wrap: wrap;
@@ -763,4 +763,11 @@
   opacity: 0.6;
   font-style: italic;
   margin: 0.3em 0;
+}
+
+/* Units legend above the shared table. */
+#debug-sidebar .wm-legend {
+  opacity: 0.6;
+  font-style: italic;
+  margin: 0.2em 0;
 }

--- a/src/web/www/style/sidebar.css
+++ b/src/web/www/style/sidebar.css
@@ -662,3 +662,68 @@
   gap: 0.3em;
   color: var(--BR4);
 }
+
+/* Wire Metrics section: per-request wire-protocol benchmark tables. */
+#debug-sidebar .wm-record {
+  margin: 0.4em 0 0.8em;
+}
+
+#debug-sidebar .wm-record-title {
+  font-weight: 600;
+  color: var(--BR4);
+  margin: 0.5em 0 0.2em;
+}
+
+#debug-sidebar .wire-metrics-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 0.3em;
+}
+
+#debug-sidebar .wire-metrics-table td {
+  padding: 0.1em 0.3em;
+  text-align: right;
+  white-space: nowrap;
+}
+
+#debug-sidebar .wire-metrics-table .wm-caption {
+  text-align: left;
+  font-style: italic;
+  opacity: 0.7;
+  padding-top: 0.3em;
+}
+
+#debug-sidebar .wire-metrics-table .wm-head {
+  font-weight: 600;
+  color: var(--BR3);
+  border-bottom: 1px solid var(--BR1);
+}
+
+#debug-sidebar .wire-metrics-table .wm-wire {
+  text-align: left;
+  font-weight: 600;
+}
+
+#debug-sidebar .wire-metrics-table .wm-total {
+  font-weight: 600;
+}
+
+#debug-sidebar .wire-metrics-table .wm-ok {
+  color: var(--G0);
+}
+
+#debug-sidebar .wire-metrics-table .wm-fail {
+  color: var(--R2);
+  text-align: left;
+  max-width: 8em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#debug-sidebar .wm-empty,
+#debug-sidebar .wm-pending {
+  opacity: 0.6;
+  font-style: italic;
+  margin: 0.3em 0;
+}

--- a/src/web/www/style/sidebar.css
+++ b/src/web/www/style/sidebar.css
@@ -663,8 +663,37 @@
   color: var(--BR4);
 }
 
-/* Wire Metrics section: all requests share one benchmark table so columns
-   align; requests are separated by styled group rows. */
+/* Wire Metrics section: per-variant on/off chips above the shared table. */
+#debug-sidebar .wm-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3em;
+  margin: 0.3em 0;
+}
+
+#debug-sidebar .wm-toggle {
+  cursor: pointer;
+  user-select: none;
+  padding: 0.05em 0.35em;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+#debug-sidebar .wm-toggle.on {
+  color: var(--BR4);
+}
+
+#debug-sidebar .wm-toggle.off {
+  opacity: 0.5;
+  text-decoration: line-through;
+}
+
+#debug-sidebar .wm-toggle:hover {
+  background: var(--T3);
+}
+
+/* All requests share one benchmark table so columns align; requests are
+   separated by styled group rows. */
 #debug-sidebar .wm-scroll {
   overflow-x: auto; /* wide numbers scroll rather than clip the status column */
   margin-top: 0.3em;

--- a/src/web/www/style/sidebar.css
+++ b/src/web/www/style/sidebar.css
@@ -663,35 +663,23 @@
   color: var(--BR4);
 }
 
-/* Wire Metrics section: per-request wire-protocol benchmark tables. */
-#debug-sidebar .wm-record {
-  margin: 0.4em 0 0.8em;
-}
-
-#debug-sidebar .wm-record-title {
-  font-weight: 600;
-  color: var(--BR4);
-  margin: 0.5em 0 0.2em;
+/* Wire Metrics section: all requests share one benchmark table so columns
+   align; requests are separated by styled group rows. */
+#debug-sidebar .wm-scroll {
+  overflow-x: auto; /* wide numbers scroll rather than clip the status column */
+  margin-top: 0.3em;
 }
 
 #debug-sidebar .wire-metrics-table {
   width: 100%;
   border-collapse: collapse;
   font-variant-numeric: tabular-nums;
-  margin-bottom: 0.3em;
 }
 
 #debug-sidebar .wire-metrics-table td {
-  padding: 0.1em 0.3em;
+  padding: 0.1em 0.25em;
   text-align: right;
   white-space: nowrap;
-}
-
-#debug-sidebar .wire-metrics-table .wm-caption {
-  text-align: left;
-  font-style: italic;
-  opacity: 0.7;
-  padding-top: 0.3em;
 }
 
 #debug-sidebar .wire-metrics-table .wm-head {
@@ -702,11 +690,32 @@
 
 #debug-sidebar .wire-metrics-table .wm-wire {
   text-align: left;
-  font-weight: 600;
+  padding-left: 0.6em;
 }
 
 #debug-sidebar .wire-metrics-table .wm-total {
   font-weight: 600;
+}
+
+/* Group separators. `wm-req` starts a new request (strong top rule + tint);
+   `wm-resp` is the lighter response sub-header within the same request. */
+#debug-sidebar .wire-metrics-table .wm-group {
+  text-align: left;
+  padding: 0.25em 0.3em 0.15em;
+}
+
+#debug-sidebar .wire-metrics-table .wm-req {
+  font-weight: 600;
+  color: var(--BR4);
+  background: var(--T3);
+  border-top: 2px solid var(--BR2);
+}
+
+#debug-sidebar .wire-metrics-table .wm-resp,
+#debug-sidebar .wire-metrics-table .wm-note {
+  font-style: italic;
+  color: var(--BR3);
+  opacity: 0.8;
 }
 
 #debug-sidebar .wire-metrics-table .wm-ok {
@@ -721,8 +730,7 @@
   text-overflow: ellipsis;
 }
 
-#debug-sidebar .wm-empty,
-#debug-sidebar .wm-pending {
+#debug-sidebar .wm-empty {
   opacity: 0.6;
   font-style: italic;
   margin: 0.3em 0;

--- a/test/Test_WorkerServer.re
+++ b/test/Test_WorkerServer.re
@@ -1,20 +1,12 @@
 /**
  * Round-trip tests for the eval-worker encodings (issue #2368).
  *
- * Each WorkerServer.encoding is exercised through the same battery: a
- * payload is encoded, optionally run through structuredClone (the same
- * serializer postMessage hands payloads to — so this is the real boundary),
- * then decoded. These run under js_of_ocaml (node); node's test stack is 8MB,
- * so the deep cases guard the encoding and round-trip fidelity rather than
- * Chrome's smaller clone-stack limit.
- *
- * Coverage is per variant by what each can safely carry:
- *   - marshal is depth-proof — deep + wide + shallow.
- *   - direct, sexp only get shallow/narrow payloads. Their failure on
- *     deep input is NOT asserted here: raw structuredClone on a deep graph
- *     overflows V8's *native* stack, which segfaults node uncatchably (in a
- *     browser it throws a catchable RangeError — that asymmetry is exactly why
- *     the app wraps the metrics path in try/catch). Verified manually in-browser.
+ * Two things matter: Marshal (the active encoding) stays depth-proof through
+ * structuredClone, and every encoding is isomorphic (decode ∘ encode = id) on a
+ * normal program. Deep failure of direct/sexp is NOT asserted — raw
+ * structuredClone on a deep graph overflows V8's native stack and segfaults
+ * node uncatchably (in-browser it throws a catchable RangeError; that asymmetry
+ * is why the app wraps the metrics path in try/catch).
  */
 open Alcotest;
 open Language;
@@ -29,9 +21,8 @@ let structured_clone: 'a. 'a => 'a =
       [|Js_of_ocaml.Js.Unsafe.inject(x)|],
     );
 
-/* A round-trip driver for one encoding: encode -> (clone?) -> decode.
- * The abstract encoded type stays inside the closure (only Response.t escapes),
- * so this composes over all encodings uniformly. */
+/* Encode -> (clone?) -> decode through one encoding; the abstract encoded type
+ * stays inside the closure so this composes over all encodings uniformly. */
 let rt_of_encoding =
     (encoding: (module WorkerServer.ENCODING))
     : ((~clone: bool, WorkerServer.Response.t) => WorkerServer.Response.t) => {
@@ -43,51 +34,9 @@ let rt_of_encoding =
   };
 };
 
-/* Build a `Parens`-nested expression `depth` levels deep, iteratively so that
- * constructing the fixture does not itself recurse `depth` frames deep. */
-let deep_exp = (depth: int): Exp.t => {
-  let e = ref(Exp.fresh(EmptyHole));
-  for (_ in 1 to depth) {
-    e := Exp.fresh(Parens(e^));
-  };
-  e^;
-};
-
 let response_of_exp = (e: Exp.t): WorkerServer.Response.t => [
   ("cell", Ok((e, EvaluatorState.init))),
 ];
-
-/* Reaching decode without raising is the Stack_overflow guard. For
- * correctness we compare marshaled bytes of the public Response.t (test-only;
- * jsoo's Marshal is iterative and deterministic) rather than the values,
- * whose polymorphic `=` would itself recurse `depth` deep. */
-let assert_round_trips =
-    (~rt, ~clone: bool, resp: WorkerServer.Response.t): unit => {
-  let restored = rt(~clone, resp);
-  check(
-    string,
-    "round-trips to identical bytes",
-    Marshal.to_string(resp, []),
-    Marshal.to_string(restored, []),
-  );
-};
-
-let test_deep_round_trip =
-    (~rt, ~name: string, ~clone: bool, ~depth: int): test_case(_) =>
-  test_case(name, `Quick, () =>
-    assert_round_trips(~rt, ~clone, response_of_exp(deep_exp(depth)))
-  );
-
-let test_wide_list_round_trip = (~rt, ~name: string, ~n: int): test_case(_) =>
-  test_case(name, `Quick, () =>
-    assert_round_trips(
-      ~rt,
-      ~clone=true,
-      response_of_exp(
-        Exp.fresh(ListLit(List.init(n, i => Exp.fresh(Atom(SInt(i)))))),
-      ),
-    )
-  );
 
 let parse = (s: string): Exp.t =>
   switch (Haz3lcore.Parser.to_term(s, ~root=Exp)) {
@@ -95,115 +44,55 @@ let parse = (s: string): Exp.t =>
   | None => fail("Failed to parse: " ++ s)
   };
 
-/* A normal (shallow) program still round-trips, and the decoded expression is
- * equal to the original — the protocol change touches every evaluation. */
-let test_realistic_round_trip =
-    (~rt, ~name: string, ~code: string): test_case(_) =>
+/* Marshal must stay depth-proof: a `Parens`-nesting 20k deep round-trips
+ * through structuredClone. Built iteratively so the fixture itself doesn't
+ * recurse; compared as marshaled bytes since polymorphic `=` would recurse. */
+let test_marshal_depth_proof = (): test_case(_) =>
   test_case(
-    name,
+    "Marshal: deep (20k) through structuredClone",
     `Quick,
     () => {
-      let e = parse(code);
-      let restored = rt(~clone=true, response_of_exp(e));
-      switch (restored) {
+      let e = ref(Exp.fresh(EmptyHole));
+      for (_ in 1 to 20000) {
+        e := Exp.fresh(Parens(e^));
+      };
+      let rt = rt_of_encoding((module WorkerServer.MarshalEncoding));
+      let resp = response_of_exp(e^);
+      check(
+        string,
+        "round-trips to identical bytes",
+        Marshal.to_string(resp, []),
+        Marshal.to_string(rt(~clone=true, resp), []),
+      );
+    },
+  );
+
+/* Every encoding is isomorphic on a normal program: decode ∘ encode preserves
+ * the expression. */
+let test_isomorphic =
+    (~name: string, encoding: (module WorkerServer.ENCODING)): test_case(_) =>
+  test_case(
+    name ++ ": isomorphic",
+    `Quick,
+    () => {
+      let rt = rt_of_encoding(encoding);
+      let e = parse("let x = [1, 2, 3] in x");
+      switch (rt(~clone=true, response_of_exp(e))) {
       | [("cell", Ok((e', _))), ..._] =>
-        check(
-          bool,
-          "decoded expression equals original",
-          true,
-          Exp.fast_equal(e, e'),
-        )
+        check(bool, "decoded equals original", true, Exp.fast_equal(e, e'))
       | _ => fail("round-trip did not preserve response shape")
       };
     },
   );
-
-/* A block reaching the boundary twice must decode as one block referenced
- * twice, not two copies — otherwise DAG-shaped payloads (e.g. IncrEval.prev)
- * expand on the way across. This is asserted for the variants that preserve
- * sharing: marshal records sharing, and structuredClone (direct) preserves
- * aliasing. (sexp is a tree format that legitimately duplicates shared
- * structure, so it is excluded — see its group below.) */
-let test_sharing_preserved = (~rt): test_case(_) =>
-  test_case(
-    "Sharing preserved",
-    `Quick,
-    () => {
-      let shared = parse("[1, 2, 3]");
-      let resp: WorkerServer.Response.t = [
-        ("a", Ok((shared, EvaluatorState.init))),
-        ("b", Ok((shared, EvaluatorState.init))),
-      ];
-      switch (rt(~clone=true, resp)) {
-      | [("a", Ok((a, _))), ("b", Ok((b, _)))] =>
-        check(bool, "decoded occurrences are physically equal", true, a === b)
-      | _ => fail("round-trip did not preserve response shape")
-      };
-    },
-  );
-
-/* Shared battery every variant must pass. Sharing preservation is asserted
- * per group (below) rather than here: it holds for all variants except sexp,
- * which is a tree serialization and legitimately duplicates shared structure. */
-let shallow_tests = (~rt): list(test_case(_)) => [
-  test_realistic_round_trip(
-    ~rt,
-    ~name="Let with list",
-    ~code="let x = [1, 2, 3] in x",
-  ),
-  test_realistic_round_trip(
-    ~rt,
-    ~name="Factorial",
-    ~code=
-      "let fact = fun n -> if n <= 0 then 1 else n * fact(n - 1) in fact(5)",
-  ),
-];
-
-let marshal = rt_of_encoding((module WorkerServer.MarshalEncoding));
-let sexp = rt_of_encoding((module WorkerServer.SexpEncoding));
-let direct = rt_of_encoding((module WorkerServer.DirectEncoding));
 
 let tests = [
   (
-    /* Marshal is iterative, so also depth- and width-proof. */
-    "WorkerServer.MarshalEncoding",
+    "WorkerServer encodings",
     [
-      test_deep_round_trip(
-        ~rt=marshal,
-        ~name="Deep through structuredClone (20k)",
-        ~clone=true,
-        ~depth=20000,
-      ),
-      test_wide_list_round_trip(
-        ~rt=marshal,
-        ~name="Wide list through structuredClone (10k)",
-        ~n=10_000,
-      ),
-    ]
-    @ shallow_tests(~rt=marshal)
-    @ [test_sharing_preserved(~rt=marshal)],
-  ),
-  (
-    /* Direct = identity. clone=false is a trivial identity round-trip; deep
-     * clone=true is the #2368 crash and deliberately not exercised (see file
-     * header). Sharing + shallow still validate the identity path. */
-    "WorkerServer.DirectEncoding",
-    [
-      test_deep_round_trip(
-        ~rt=direct,
-        ~name="Deep identity (20k)",
-        ~clone=false,
-        ~depth=20000,
-      ),
-    ]
-    @ shallow_tests(~rt=direct)
-    @ [test_sharing_preserved(~rt=direct)],
-  ),
-  (
-    /* Sexp converters recurse per level, so deep payloads are out of scope.
-     * No sharing assertion: sexp is a tree format and legitimately duplicates
-     * shared sub-structure (the derived converters don't record DAG sharing). */
-    "WorkerServer.SexpEncoding",
-    shallow_tests(~rt=sexp),
+      test_marshal_depth_proof(),
+      test_isomorphic(~name="Marshal", (module WorkerServer.MarshalEncoding)),
+      test_isomorphic(~name="Direct", (module WorkerServer.DirectEncoding)),
+      test_isomorphic(~name="Sexp", (module WorkerServer.SexpEncoding)),
+    ],
   ),
 ];

--- a/test/Test_WorkerServer.re
+++ b/test/Test_WorkerServer.re
@@ -9,8 +9,8 @@
  * Chrome's smaller clone-stack limit.
  *
  * Coverage is per variant by what each can safely carry:
- *   - columnar (Wire) and marshal are depth-proof — deep + wide + shallow.
- *   - direct, array, sexp only get shallow/narrow payloads. Their failure on
+ *   - marshal is depth-proof — deep + wide + shallow.
+ *   - direct, sexp only get shallow/narrow payloads. Their failure on
  *     deep input is NOT asserted here: raw structuredClone on a deep graph
  *     overflows V8's *native* stack, which segfaults node uncatchably (in a
  *     browser it throws a catchable RangeError — that asymmetry is exactly why
@@ -18,8 +18,6 @@
  */
 open Alcotest;
 open Language;
-
-module Wire = WorkerServer.Wire;
 
 /* The same serializer postMessage applies to its argument. */
 let structured_clone: 'a. 'a => 'a =
@@ -122,9 +120,10 @@ let test_realistic_round_trip =
 
 /* A block reaching the boundary twice must decode as one block referenced
  * twice, not two copies — otherwise DAG-shaped payloads (e.g. IncrEval.prev)
- * expand on the way across. Every variant preserves sharing: columnar numbers
- * blocks by identity, marshal/sexp record sharing, and structuredClone (direct,
- * array) preserves aliasing. */
+ * expand on the way across. This is asserted for the variants that preserve
+ * sharing: marshal records sharing, and structuredClone (direct) preserves
+ * aliasing. (sexp is a tree format that legitimately duplicates shared
+ * structure, so it is excluded — see its group below.) */
 let test_sharing_preserved = (~rt): test_case(_) =>
   test_case(
     "Sharing preserved",
@@ -160,43 +159,11 @@ let shallow_tests = (~rt): list(test_case(_)) => [
   ),
 ];
 
-let columnar = rt_of_wire((module WorkerServer.Wire));
 let marshal = rt_of_wire((module WorkerServer.MarshalWire));
 let sexp = rt_of_wire((module WorkerServer.SexpWire));
 let direct = rt_of_wire((module WorkerServer.DirectWire));
-let array = rt_of_wire((module WorkerServer.ArrayWire));
 
 let tests = [
-  (
-    "WorkerServer.Wire",
-    [
-      test_deep_round_trip(
-        ~rt=columnar,
-        ~name="Deep (1k)",
-        ~clone=false,
-        ~depth=1000,
-      ),
-      test_deep_round_trip(
-        ~rt=columnar,
-        ~name="Deep (20k)",
-        ~clone=false,
-        ~depth=20000,
-      ),
-      test_deep_round_trip(
-        ~rt=columnar,
-        ~name="Deep through structuredClone (20k)",
-        ~clone=true,
-        ~depth=20000,
-      ),
-      test_wide_list_round_trip(
-        ~rt=columnar,
-        ~name="Wide list through structuredClone (10k)",
-        ~n=10_000,
-      ),
-    ]
-    @ shallow_tests(~rt=columnar)
-    @ [test_sharing_preserved(~rt=columnar)],
-  ),
   (
     /* Marshal is iterative, so also depth- and width-proof. */
     "WorkerServer.MarshalWire",
@@ -238,19 +205,5 @@ let tests = [
      * shared sub-structure (the derived converters don't record DAG sharing). */
     "WorkerServer.SexpWire",
     shallow_tests(~rt=sexp),
-  ),
-  (
-    /* ArrayWire flattens only the top-level spine; the list inside a single
-     * entry crosses raw, so keep the wide case at 1k. */
-    "WorkerServer.ArrayWire",
-    [
-      test_wide_list_round_trip(
-        ~rt=array,
-        ~name="Wide list through structuredClone (1k)",
-        ~n=1_000,
-      ),
-    ]
-    @ shallow_tests(~rt=array)
-    @ [test_sharing_preserved(~rt=array)],
   ),
 ];

--- a/test/Test_WorkerServer.re
+++ b/test/Test_WorkerServer.re
@@ -1,7 +1,7 @@
 /**
- * Round-trip tests for the eval-worker wire protocols (issue #2368).
+ * Round-trip tests for the eval-worker encodings (issue #2368).
  *
- * Each WorkerServer.WIRE variant is exercised through the same battery: a
+ * Each WorkerServer.encoding is exercised through the same battery: a
  * payload is encoded, optionally run through structuredClone (the same
  * serializer postMessage hands payloads to — so this is the real boundary),
  * then decoded. These run under js_of_ocaml (node); node's test stack is 8MB,
@@ -29,13 +29,13 @@ let structured_clone: 'a. 'a => 'a =
       [|Js_of_ocaml.Js.Unsafe.inject(x)|],
     );
 
-/* A round-trip driver for one wire variant: encode -> (clone?) -> decode.
- * The abstract wire type stays inside the closure (only Response.t escapes),
- * so this composes over all variants uniformly. */
-let rt_of_wire =
-    (wire: (module WorkerServer.WIRE))
+/* A round-trip driver for one encoding: encode -> (clone?) -> decode.
+ * The abstract encoded type stays inside the closure (only Response.t escapes),
+ * so this composes over all encodings uniformly. */
+let rt_of_encoding =
+    (encoding: (module WorkerServer.ENCODING))
     : ((~clone: bool, WorkerServer.Response.t) => WorkerServer.Response.t) => {
-  module M = (val wire);
+  module M = (val encoding);
   (~clone, resp) => {
     let w = M.encode_response(resp);
     let w = clone ? structured_clone(w) : w;
@@ -159,14 +159,14 @@ let shallow_tests = (~rt): list(test_case(_)) => [
   ),
 ];
 
-let marshal = rt_of_wire((module WorkerServer.MarshalWire));
-let sexp = rt_of_wire((module WorkerServer.SexpWire));
-let direct = rt_of_wire((module WorkerServer.DirectWire));
+let marshal = rt_of_encoding((module WorkerServer.MarshalEncoding));
+let sexp = rt_of_encoding((module WorkerServer.SexpEncoding));
+let direct = rt_of_encoding((module WorkerServer.DirectEncoding));
 
 let tests = [
   (
     /* Marshal is iterative, so also depth- and width-proof. */
-    "WorkerServer.MarshalWire",
+    "WorkerServer.MarshalEncoding",
     [
       test_deep_round_trip(
         ~rt=marshal,
@@ -187,7 +187,7 @@ let tests = [
     /* Direct = identity. clone=false is a trivial identity round-trip; deep
      * clone=true is the #2368 crash and deliberately not exercised (see file
      * header). Sharing + shallow still validate the identity path. */
-    "WorkerServer.DirectWire",
+    "WorkerServer.DirectEncoding",
     [
       test_deep_round_trip(
         ~rt=direct,
@@ -203,7 +203,7 @@ let tests = [
     /* Sexp converters recurse per level, so deep payloads are out of scope.
      * No sharing assertion: sexp is a tree format and legitimately duplicates
      * shared sub-structure (the derived converters don't record DAG sharing). */
-    "WorkerServer.SexpWire",
+    "WorkerServer.SexpEncoding",
     shallow_tests(~rt=sexp),
   ),
 ];

--- a/test/Test_WorkerServer.re
+++ b/test/Test_WorkerServer.re
@@ -1,15 +1,49 @@
 /**
- * Round-trip tests for the eval-worker wire protocol (issue #2368).
+ * Round-trip tests for the eval-worker wire protocols (issue #2368).
  *
- * These run under js_of_ocaml (node), so they exercise jsoo's real Marshal —
- * iterative, so it doesn't stack-overflow on deep structures. They guard the
- * encoding, not Chrome's structured-clone limit (which the string sidesteps and
- * node doesn't reproduce).
+ * Each WorkerServer.WIRE variant is exercised through the same battery: a
+ * payload is encoded, optionally run through structuredClone (the same
+ * serializer postMessage hands payloads to — so this is the real boundary),
+ * then decoded. These run under js_of_ocaml (node); node's test stack is 8MB,
+ * so the deep cases guard the encoding and round-trip fidelity rather than
+ * Chrome's smaller clone-stack limit.
+ *
+ * Coverage is per variant by what each can safely carry:
+ *   - columnar (Wire) and marshal are depth-proof — deep + wide + shallow.
+ *   - direct, array, sexp only get shallow/narrow payloads. Their failure on
+ *     deep input is NOT asserted here: raw structuredClone on a deep graph
+ *     overflows V8's *native* stack, which segfaults node uncatchably (in a
+ *     browser it throws a catchable RangeError — that asymmetry is exactly why
+ *     the app wraps the metrics path in try/catch). Verified manually in-browser.
  */
 open Alcotest;
 open Language;
 
 module Wire = WorkerServer.Wire;
+
+/* The same serializer postMessage applies to its argument. */
+let structured_clone: 'a. 'a => 'a =
+  x =>
+    Js_of_ocaml.Js.Unsafe.fun_call(
+      Js_of_ocaml.Js.Unsafe.pure_js_expr(
+        "(function (x) { return structuredClone(x); })",
+      ),
+      [|Js_of_ocaml.Js.Unsafe.inject(x)|],
+    );
+
+/* A round-trip driver for one wire variant: encode -> (clone?) -> decode.
+ * The abstract wire type stays inside the closure (only Response.t escapes),
+ * so this composes over all variants uniformly. */
+let rt_of_wire =
+    (wire: (module WorkerServer.WIRE))
+    : ((~clone: bool, WorkerServer.Response.t) => WorkerServer.Response.t) => {
+  module M = (val wire);
+  (~clone, resp) => {
+    let w = M.encode_response(resp);
+    let w = clone ? structured_clone(w) : w;
+    M.decode_response(w);
+  };
+};
 
 /* Build a `Parens`-nested expression `depth` levels deep, iteratively so that
  * constructing the fixture does not itself recurse `depth` frames deep. */
@@ -25,12 +59,13 @@ let response_of_exp = (e: Exp.t): WorkerServer.Response.t => [
   ("cell", Ok((e, EvaluatorState.init))),
 ];
 
-/* Reaching decode without raising is the Stack_overflow guard. For correctness
- * we compare marshaled bytes of the public Response.t (Marshal is
- * deterministic) rather than the values, whose polymorphic `=` would itself
- * recurse `depth` deep. */
-let assert_marshal_round_trips = (resp: WorkerServer.Response.t): unit => {
-  let restored = Wire.decode_response(Wire.encode_response(resp));
+/* Reaching decode without raising is the Stack_overflow guard. For
+ * correctness we compare marshaled bytes of the public Response.t (test-only;
+ * jsoo's Marshal is iterative and deterministic) rather than the values,
+ * whose polymorphic `=` would itself recurse `depth` deep. */
+let assert_round_trips =
+    (~rt, ~clone: bool, resp: WorkerServer.Response.t): unit => {
+  let restored = rt(~clone, resp);
   check(
     string,
     "round-trips to identical bytes",
@@ -39,9 +74,21 @@ let assert_marshal_round_trips = (resp: WorkerServer.Response.t): unit => {
   );
 };
 
-let test_deep_round_trip = (~name: string, ~depth: int): test_case(_) =>
+let test_deep_round_trip =
+    (~rt, ~name: string, ~clone: bool, ~depth: int): test_case(_) =>
   test_case(name, `Quick, () =>
-    assert_marshal_round_trips(response_of_exp(deep_exp(depth)))
+    assert_round_trips(~rt, ~clone, response_of_exp(deep_exp(depth)))
+  );
+
+let test_wide_list_round_trip = (~rt, ~name: string, ~n: int): test_case(_) =>
+  test_case(name, `Quick, () =>
+    assert_round_trips(
+      ~rt,
+      ~clone=true,
+      response_of_exp(
+        Exp.fresh(ListLit(List.init(n, i => Exp.fresh(Atom(SInt(i)))))),
+      ),
+    )
   );
 
 let parse = (s: string): Exp.t =>
@@ -52,14 +99,14 @@ let parse = (s: string): Exp.t =>
 
 /* A normal (shallow) program still round-trips, and the decoded expression is
  * equal to the original — the protocol change touches every evaluation. */
-let test_realistic_round_trip = (~name: string, ~code: string): test_case(_) =>
+let test_realistic_round_trip =
+    (~rt, ~name: string, ~code: string): test_case(_) =>
   test_case(
     name,
     `Quick,
     () => {
       let e = parse(code);
-      let resp = response_of_exp(e);
-      let restored = Wire.decode_response(Wire.encode_response(resp));
+      let restored = rt(~clone=true, response_of_exp(e));
       switch (restored) {
       | [("cell", Ok((e', _))), ..._] =>
         check(
@@ -73,21 +120,137 @@ let test_realistic_round_trip = (~name: string, ~code: string): test_case(_) =>
     },
   );
 
+/* A block reaching the boundary twice must decode as one block referenced
+ * twice, not two copies — otherwise DAG-shaped payloads (e.g. IncrEval.prev)
+ * expand on the way across. Every variant preserves sharing: columnar numbers
+ * blocks by identity, marshal/sexp record sharing, and structuredClone (direct,
+ * array) preserves aliasing. */
+let test_sharing_preserved = (~rt): test_case(_) =>
+  test_case(
+    "Sharing preserved",
+    `Quick,
+    () => {
+      let shared = parse("[1, 2, 3]");
+      let resp: WorkerServer.Response.t = [
+        ("a", Ok((shared, EvaluatorState.init))),
+        ("b", Ok((shared, EvaluatorState.init))),
+      ];
+      switch (rt(~clone=true, resp)) {
+      | [("a", Ok((a, _))), ("b", Ok((b, _)))] =>
+        check(bool, "decoded occurrences are physically equal", true, a === b)
+      | _ => fail("round-trip did not preserve response shape")
+      };
+    },
+  );
+
+/* Shared battery every variant must pass. Sharing preservation is asserted
+ * per group (below) rather than here: it holds for all variants except sexp,
+ * which is a tree serialization and legitimately duplicates shared structure. */
+let shallow_tests = (~rt): list(test_case(_)) => [
+  test_realistic_round_trip(
+    ~rt,
+    ~name="Let with list",
+    ~code="let x = [1, 2, 3] in x",
+  ),
+  test_realistic_round_trip(
+    ~rt,
+    ~name="Factorial",
+    ~code=
+      "let fact = fun n -> if n <= 0 then 1 else n * fact(n - 1) in fact(5)",
+  ),
+];
+
+let columnar = rt_of_wire((module WorkerServer.Wire));
+let marshal = rt_of_wire((module WorkerServer.MarshalWire));
+let sexp = rt_of_wire((module WorkerServer.SexpWire));
+let direct = rt_of_wire((module WorkerServer.DirectWire));
+let array = rt_of_wire((module WorkerServer.ArrayWire));
+
 let tests = [
   (
     "WorkerServer.Wire",
     [
-      test_deep_round_trip(~name="Deep expression (1k)", ~depth=1000),
-      test_deep_round_trip(~name="Deep expression (20k)", ~depth=20000),
-      test_realistic_round_trip(
-        ~name="Let with list",
-        ~code="let x = [1, 2, 3] in x",
+      test_deep_round_trip(
+        ~rt=columnar,
+        ~name="Deep (1k)",
+        ~clone=false,
+        ~depth=1000,
       ),
-      test_realistic_round_trip(
-        ~name="Factorial",
-        ~code=
-          "let fact = fun n -> if n <= 0 then 1 else n * fact(n - 1) in fact(5)",
+      test_deep_round_trip(
+        ~rt=columnar,
+        ~name="Deep (20k)",
+        ~clone=false,
+        ~depth=20000,
       ),
-    ],
+      test_deep_round_trip(
+        ~rt=columnar,
+        ~name="Deep through structuredClone (20k)",
+        ~clone=true,
+        ~depth=20000,
+      ),
+      test_wide_list_round_trip(
+        ~rt=columnar,
+        ~name="Wide list through structuredClone (10k)",
+        ~n=10_000,
+      ),
+    ]
+    @ shallow_tests(~rt=columnar)
+    @ [test_sharing_preserved(~rt=columnar)],
+  ),
+  (
+    /* Marshal is iterative, so also depth- and width-proof. */
+    "WorkerServer.MarshalWire",
+    [
+      test_deep_round_trip(
+        ~rt=marshal,
+        ~name="Deep through structuredClone (20k)",
+        ~clone=true,
+        ~depth=20000,
+      ),
+      test_wide_list_round_trip(
+        ~rt=marshal,
+        ~name="Wide list through structuredClone (10k)",
+        ~n=10_000,
+      ),
+    ]
+    @ shallow_tests(~rt=marshal)
+    @ [test_sharing_preserved(~rt=marshal)],
+  ),
+  (
+    /* Direct = identity. clone=false is a trivial identity round-trip; deep
+     * clone=true is the #2368 crash and deliberately not exercised (see file
+     * header). Sharing + shallow still validate the identity path. */
+    "WorkerServer.DirectWire",
+    [
+      test_deep_round_trip(
+        ~rt=direct,
+        ~name="Deep identity (20k)",
+        ~clone=false,
+        ~depth=20000,
+      ),
+    ]
+    @ shallow_tests(~rt=direct)
+    @ [test_sharing_preserved(~rt=direct)],
+  ),
+  (
+    /* Sexp converters recurse per level, so deep payloads are out of scope.
+     * No sharing assertion: sexp is a tree format and legitimately duplicates
+     * shared sub-structure (the derived converters don't record DAG sharing). */
+    "WorkerServer.SexpWire",
+    shallow_tests(~rt=sexp),
+  ),
+  (
+    /* ArrayWire flattens only the top-level spine; the list inside a single
+     * entry crosses raw, so keep the wide case at 1k. */
+    "WorkerServer.ArrayWire",
+    [
+      test_wide_list_round_trip(
+        ~rt=array,
+        ~name="Wide list through structuredClone (1k)",
+        ~n=1_000,
+      ),
+    ]
+    @ shallow_tests(~rt=array)
+    @ [test_sharing_preserved(~rt=array)],
   ),
 ];

--- a/test/Test_WorkerServer.re
+++ b/test/Test_WorkerServer.re
@@ -1,0 +1,93 @@
+/**
+ * Round-trip tests for the eval-worker wire protocol (issue #2368).
+ *
+ * These run under js_of_ocaml (node), so they exercise jsoo's real Marshal —
+ * iterative, so it doesn't stack-overflow on deep structures. They guard the
+ * encoding, not Chrome's structured-clone limit (which the string sidesteps and
+ * node doesn't reproduce).
+ */
+open Alcotest;
+open Language;
+
+module Wire = WorkerServer.Wire;
+
+/* Build a `Parens`-nested expression `depth` levels deep, iteratively so that
+ * constructing the fixture does not itself recurse `depth` frames deep. */
+let deep_exp = (depth: int): Exp.t => {
+  let e = ref(Exp.fresh(EmptyHole));
+  for (_ in 1 to depth) {
+    e := Exp.fresh(Parens(e^));
+  };
+  e^;
+};
+
+let response_of_exp = (e: Exp.t): WorkerServer.Response.t => [
+  ("cell", Ok((e, EvaluatorState.init))),
+];
+
+/* Reaching decode without raising is the Stack_overflow guard. For correctness
+ * we compare marshaled bytes of the public Response.t (Marshal is
+ * deterministic) rather than the values, whose polymorphic `=` would itself
+ * recurse `depth` deep. */
+let assert_marshal_round_trips = (resp: WorkerServer.Response.t): unit => {
+  let restored = Wire.decode_response(Wire.encode_response(resp));
+  check(
+    string,
+    "round-trips to identical bytes",
+    Marshal.to_string(resp, []),
+    Marshal.to_string(restored, []),
+  );
+};
+
+let test_deep_round_trip = (~name: string, ~depth: int): test_case(_) =>
+  test_case(name, `Quick, () =>
+    assert_marshal_round_trips(response_of_exp(deep_exp(depth)))
+  );
+
+let parse = (s: string): Exp.t =>
+  switch (Haz3lcore.Parser.to_term(s, ~root=Exp)) {
+  | Some(e) => e
+  | None => fail("Failed to parse: " ++ s)
+  };
+
+/* A normal (shallow) program still round-trips, and the decoded expression is
+ * equal to the original — the protocol change touches every evaluation. */
+let test_realistic_round_trip = (~name: string, ~code: string): test_case(_) =>
+  test_case(
+    name,
+    `Quick,
+    () => {
+      let e = parse(code);
+      let resp = response_of_exp(e);
+      let restored = Wire.decode_response(Wire.encode_response(resp));
+      switch (restored) {
+      | [("cell", Ok((e', _))), ..._] =>
+        check(
+          bool,
+          "decoded expression equals original",
+          true,
+          Exp.fast_equal(e, e'),
+        )
+      | _ => fail("round-trip did not preserve response shape")
+      };
+    },
+  );
+
+let tests = [
+  (
+    "WorkerServer.Wire",
+    [
+      test_deep_round_trip(~name="Deep expression (1k)", ~depth=1000),
+      test_deep_round_trip(~name="Deep expression (20k)", ~depth=20000),
+      test_realistic_round_trip(
+        ~name="Let with list",
+        ~code="let x = [1, 2, 3] in x",
+      ),
+      test_realistic_round_trip(
+        ~name="Factorial",
+        ~code=
+          "let fact = fun n -> if n <= 0 then 1 else n * fact(n - 1) in fact(5)",
+      ),
+    ],
+  ),
+];

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -31,6 +31,7 @@ let (suite, _) =
       Test_Equality.tests,
       Test_Substitution.tests,
     ]
+    @ Test_WorkerServer.tests
     @ Test_AgentTools.tests
     @ [Test_AgentUX.tests]
     @ Test_ExpToSegment.all


### PR DESCRIPTION
## Problem

Evaluating certain programs threw in the eval worker on **Chrome only**:

```
Uncaught RangeError: Failed to execute 'postMessage' on 'DedicatedWorkerGlobalScope': Maximum call stack size exceeded
    at post_message (worker.ml)
    at on_request (WorkerServer.re)
```

Repro: a large list bound to a variable (e.g. ~100 rows of labeled tuples) even when the computed result is trivial, like `length(x)` or `3 + 1`. Does not reproduce in Firefox.

## Root cause

`WorkerServer.on_request` / `WorkerClient.request` posted the raw OCaml value graph across the worker boundary. `postMessage` hands it to the browser's structured-clone serializer, which in Chrome is **recursive** and overflows its (relatively small) stack on a deep — but finite, acyclic — payload. Firefox's limit is higher, so it tolerated the same payload.

## Fix

Encode the request/response with jsoo's **`Marshal`** (iterative → a flat string that structured clone copies without recursing), so a deep-but-finite payload crosses the boundary without hitting the clone serializer's recursion limit. This is the active encoding — `WorkerServer.Active`, a one-line alias `module Active = MarshalEncoding`.

The boundary stays typed `Worker.worker(request, response)` via an abstract `WorkerServer.ENCODING` module signature: only `encode`/`decode` can cross it and the two directions can't be swapped.

## Worker Messaging debug panel

To choose an encoding on real workloads, the diff keeps an **`encoding` variant** (`Direct | Marshal | Sexp`, with display strings and `all_of_encoding` ppx-derived — no hand-maintained name lists) behind the abstract `ENCODING` signature, plus a **"Worker Messaging" section in the Debug sidebar** — how the main thread talks to the eval Web Worker — that benchmarks each enabled encoding per request (encode / structuredClone / decode timing + size), correlated by request id.

- Metrics are typed: durations are `Core.Time_ns.Span`, sizes `Core.Byte_units` (each encoding reports its own size via the `ENCODING` signature). A stage that throws renders as `—` with the error on a tooltip, not a misleading `0`.
- **Defaults:** the section starts **collapsed** (so no benchmarking runs) and only **`marshal`** is enabled; the enabled set (`worker_encodings`) and per-encoding toggles persist in settings, so a slow encoding like `sexp` stays off.
- Benchmarking is gated on the panel being visible and synced once per cycle via `WorkerMetrics.sync` (the settings that gate it aren't reachable at the `WorkerClient.request` call site).
- The section lives in its own `WorkerMessagingSection.re` behind a small `DebugSection.S` interface, rendered by a generic driver in `DebugSidebar`. Swapping the active encoding is the one-line `module Active = …` alias.

## What we explored, then removed

Two additional encodings were benchmarked during the analysis and have since been **removed from the code** (preserved in git history on this branch). Documenting them here for the record:

- ~~**`columnar`** — was briefly the active protocol.~~ Packs the jsoo value graph into a handful of flat typed arrays (`flatten`/`unflatten`, custom JS via `Js.Unsafe`): a fixed set of `Float64Array`s regardless of depth, so structured clone never recurses *and* no intermediate string is built. Blocks are numbered by identity, so sharing/DAG structure is preserved. Benchmarks put it at **~2× faster than Marshal and fully depth-proof**. **Dropped** because it leaned on `Js.Unsafe`/`Obj.magic` and jsoo's block-representation internals for a payload where Marshal is already fast enough — Marshal's simplicity and safety won once the metrics settled the question. (added in `4e47e876fe`)
- **`array`** — converts only the top-level request/response list spine to an OCaml array. Everything *inside* each entry still crosses as its natural nested graph, so a payload that is deep inside an entry still overflows structured clone — i.e. it does **not** fix #2368. Kept only as a benchmark contrast to the columnar packing; removed.

## Testing

- `Test_WorkerServer` (4 tests): **Marshal is depth-proof** — a 20k-deep payload round-trips through `structuredClone`; and **every encoding is isomorphic** — one round-trip-equality test each for `direct` / `marshal` / `sexp`. (Deep failure of direct/sexp isn't asserted: raw `structuredClone` on a deep graph segfaults node uncatchably, whereas in-browser it throws a catchable `RangeError`.)
- `make dev` clean, no compiler warnings.
- **Chrome (manual):** the original `Marshal`-based fix (`a5c49701eb`) evaluated the repro correctly. Re-verification of the current active path + the Worker Messaging panel (durations/sizes render via `Span`/`Byte_units`; a failed `direct` shows `—`) is pending against the latest rebuild.

Closes #2368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
