### PR TITLE
Implicit type application using Unknown type

### DIFF
--- a/docs/parameterized-types.md
+++ b/docs/parameterized-types.md
@@ -222,6 +222,22 @@ values that might hide functions.
 Constructors whose schema is not actually polymorphic (e.g. a bare tag from
 `type x = + A`) are never wrapped.
 
+## Implicit value-level polymorphic application
+
+Ordinary value application also accepts a polymorphic callee without an
+explicit `@<...>` instantiation. Statics elaborates the callee by applying
+`?` to each leading `poly` binder before checking the value argument:
+
+```text
+id(1)  ~~>  id<?>(1)
+pair(3)(true)  ~~>  pair<?, ?>(3)(true)
+```
+
+This is gradual instantiation, not type inference from value arguments:
+`id(1)` synthesizes `?`, while `id@<Int>(1)` still synthesizes `Int`.
+That lets precise and gradual uses meet in surrounding expressions, e.g.
+`if true then id@<Int>(1) else id(0)` has type `Int`.
+
 ## Higher-kinded recursive types
 
 A parameterized recursive type like `type List(a) = + Nil + Cons(a, List(a))`

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -1714,19 +1714,24 @@ and uexp_to_info_map =
         let fn_ana =
           switch (Exp.ctr_name(fn)) {
           | Some(name) =>
-            switch (ConstructorStaticsHelpers.ctr_ana_typ(ctx, ana, name)) {
-            | Some(ty_ana) =>
-              switch (MatchedTyp.arrow(ctx, ty_ana)) {
-              | Some((ty1, ty2)) => Arrow(ty1, ty2) |> Typ.temp
+            switch (fn.term) {
+            | Constructor(_, Some(Some(ty)))
+                when MatchedTyp.poly_pair(ctx, ty) == None => ty
+            | _ =>
+              switch (ConstructorStaticsHelpers.ctr_ana_typ(ctx, ana, name)) {
+              | Some(ty_ana) =>
+                switch (MatchedTyp.arrow(ctx, ty_ana)) {
+                | Some((ty1, ty2)) => Arrow(ty1, ty2) |> Typ.temp
+                | None =>
+                  MatchedTyp.poly_pair(ctx, ty_ana) != None
+                    ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
+                    : Arrow(syn, syn) |> Typ.temp
+                }
               | None =>
-                MatchedTyp.poly_pair(ctx, ty_ana) != None
+                constructor_has_poly_schema(name)
                   ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
                   : Arrow(syn, syn) |> Typ.temp
               }
-            | None =>
-              constructor_has_poly_schema(name)
-                ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
-                : Arrow(syn, syn) |> Typ.temp
             }
           | None =>
             expects_poly_callee(fn)
@@ -1833,19 +1838,24 @@ and uexp_to_info_map =
       let fn_ana =
         switch (Exp.ctr_name(fn)) {
         | Some(name) =>
-          switch (ConstructorStaticsHelpers.ctr_ana_typ(ctx, ana, name)) {
-          | Some(ty_ana) =>
-            switch (MatchedTyp.arrow(ctx, ty_ana)) {
-            | Some((ty1, ty2)) => Arrow(ty1, ty2) |> Typ.temp
+          switch (fn.term) {
+          | Constructor(_, Some(Some(ty)))
+              when MatchedTyp.poly_pair(ctx, ty) == None => ty
+          | _ =>
+            switch (ConstructorStaticsHelpers.ctr_ana_typ(ctx, ana, name)) {
+            | Some(ty_ana) =>
+              switch (MatchedTyp.arrow(ctx, ty_ana)) {
+              | Some((ty1, ty2)) => Arrow(ty1, ty2) |> Typ.temp
+              | None =>
+                MatchedTyp.poly_pair(ctx, ty_ana) != None
+                  ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
+                  : Arrow(syn, syn) |> Typ.temp
+              }
             | None =>
-              MatchedTyp.poly_pair(ctx, ty_ana) != None
+              constructor_has_poly_schema(name)
                 ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
                 : Arrow(syn, syn) |> Typ.temp
             }
-          | None =>
-            constructor_has_poly_schema(name)
-              ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
-              : Arrow(syn, syn) |> Typ.temp
           }
         | None =>
           expects_poly_callee(fn)

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -455,6 +455,49 @@ and uexp_to_info_map =
       Unknown(Internal) |> Typ.temp,
     );
 
+  let implicit_poly_args = (binder: TPat.t): (Typ.t, list(Typ.t)) => {
+    let binders = TPat.binders_of(binder);
+    let args = List.init(List.length(binders), _ => Unknown(Internal) |> Typ.fresh);
+    let arg =
+      switch (args) {
+      | [arg] => arg
+      | _ => TypTuple(args) |> Typ.fresh
+      };
+    (arg, args);
+  };
+
+  let rec implicit_poly_instantiate = (ty: Typ.t, elab: Exp.t): (Typ.t, Exp.t) =>
+    switch (MatchedTyp.poly_pair(ctx, ty)) {
+    | Some((Some(binder), body)) =>
+      let (arg, args) = implicit_poly_args(binder);
+      let binders = TPat.binders_of(binder);
+      let body = Typ.subst_many(args, binders, body);
+      implicit_poly_instantiate(body, TypAp(elab, arg) |> Exp.fresh);
+    | Some((None, _))
+    | None => (ty, elab)
+    };
+
+  let rec expects_poly_callee = (e: Exp.t): bool =>
+    switch (e.term) {
+    | Var(v) =>
+      Ctx.lookup_var(ctx, v)
+      |> Option.map((entry: Ctx.var_entry) =>
+           MatchedTyp.poly_pair(ctx, entry.typ) != None
+         )
+      |> Option.value(~default=false)
+    | TypAbs(_) => true
+    | Parens(e)
+    | Projector(_, e) => expects_poly_callee(e)
+    | _ => false
+    };
+
+  let constructor_has_poly_schema = name =>
+    Ctx.lookup_ctr(ctx, name)
+    |> Option.map((entry: Ctx.var_entry) =>
+         MatchedTyp.poly_pair(ctx, entry.typ) != None
+       )
+    |> Option.value(~default=false);
+
   // This is the case where we aren't a singleton labeled tuple
   let default_case = () => {
     switch (term) {
@@ -1673,11 +1716,20 @@ and uexp_to_info_map =
             | Some(ty_ana) =>
               switch (MatchedTyp.arrow(ctx, ty_ana)) {
               | Some((ty1, ty2)) => Arrow(ty1, ty2) |> Typ.temp
-              | None => Arrow(syn, syn) |> Typ.temp
+              | None =>
+                MatchedTyp.poly_pair(ctx, ty_ana) != None
+                  ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
+                  : Arrow(syn, syn) |> Typ.temp
               }
-            | None => Arrow(syn, syn) |> Typ.temp
+            | None =>
+              constructor_has_poly_schema(name)
+                ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
+                : Arrow(syn, syn) |> Typ.temp
             }
-          | None => Arrow(syn, syn) |> Typ.temp
+          | None =>
+            expects_poly_callee(fn)
+              ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
+              : Arrow(syn, syn) |> Typ.temp
           };
         let (fn, fn_elab, m) = go(~ana=fn_ana, fn, m);
         switch (custom_statics) {
@@ -1698,7 +1750,9 @@ and uexp_to_info_map =
             arg,
           )
         | None =>
-          let (ty_in, ty_out) = MatchedTyp.arrow_tolerant(ctx, fn.ty);
+          let (fn_ty, fn_elab) =
+            implicit_poly_instantiate(fn.elab_syn_ty, fn_elab);
+          let (ty_in, ty_out) = MatchedTyp.arrow_tolerant(ctx, fn_ty);
           let (arg, arg_elab, m) = go(~ana=ty_in, arg, m);
           let elab_term = Ap(dir, fn_elab, arg_elab) |> rewrap;
           let co_ap = CoCtx.union([fn.co_ctx, arg.co_ctx]);
@@ -1781,11 +1835,20 @@ and uexp_to_info_map =
           | Some(ty_ana) =>
             switch (MatchedTyp.arrow(ctx, ty_ana)) {
             | Some((ty1, ty2)) => Arrow(ty1, ty2) |> Typ.temp
-            | None => Arrow(syn, syn) |> Typ.temp
+            | None =>
+              MatchedTyp.poly_pair(ctx, ty_ana) != None
+                ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
+                : Arrow(syn, syn) |> Typ.temp
             }
-          | None => Arrow(syn, syn) |> Typ.temp
+          | None =>
+            constructor_has_poly_schema(name)
+              ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
+              : Arrow(syn, syn) |> Typ.temp
           }
-        | None => Arrow(syn, syn) |> Typ.temp
+        | None =>
+          expects_poly_callee(fn)
+            ? Poly(EmptyHole |> TPat.fresh, syn) |> Typ.temp
+            : Arrow(syn, syn) |> Typ.temp
         };
       let (fn, fn_elab, m) = go(~ana=fn_ana, fn, m);
 
@@ -1808,7 +1871,9 @@ and uexp_to_info_map =
           args,
         )
       | None =>
-        let (ty_in, ty_out) = MatchedTyp.arrow_tolerant(ctx, fn.ty);
+        let (fn_ty, fn_elab) =
+          implicit_poly_instantiate(fn.elab_syn_ty, fn_elab);
+        let (ty_in, ty_out) = MatchedTyp.arrow_tolerant(ctx, fn_ty);
         let num_args = List.length(args);
         switch (MatchedTyp.args(ctx, ty_in, num_args)) {
         | L(ty_ins) =>

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -457,7 +457,8 @@ and uexp_to_info_map =
 
   let implicit_poly_args = (binder: TPat.t): (Typ.t, list(Typ.t)) => {
     let binders = TPat.binders_of(binder);
-    let args = List.init(List.length(binders), _ => Unknown(Internal) |> Typ.fresh);
+    let args =
+      List.init(List.length(binders), _ => Unknown(Internal) |> Typ.fresh);
     let arg =
       switch (args) {
       | [arg] => arg
@@ -466,7 +467,8 @@ and uexp_to_info_map =
     (arg, args);
   };
 
-  let rec implicit_poly_instantiate = (ty: Typ.t, elab: Exp.t): (Typ.t, Exp.t) =>
+  let rec implicit_poly_instantiate =
+          (ty: Typ.t, elab: Exp.t): (Typ.t, Exp.t) =>
     switch (MatchedTyp.poly_pair(ctx, ty)) {
     | Some((Some(binder), body)) =>
       let (arg, args) = implicit_poly_args(binder);

--- a/test/evaluator/Test_Evaluator_TypAp.re
+++ b/test/evaluator/Test_Evaluator_TypAp.re
@@ -43,6 +43,29 @@ let evaluated_is_self_typed_ctr = (src: string, name: string): (bool, Exp.t) => 
   (found^, evaluated);
 };
 
+let restatics_marks_after_eval = (src: string): list(Mark.t) => {
+  let exp = Haz3lcore.Parser.to_term(src, ~root=Exp) |> Option.get;
+  let (_info_map, elab) =
+    Statics.mk(CoreSettings.on, Language.Builtins.ctx_init(Some(Int)), exp);
+  let evaluated =
+    Evaluator.evaluate(~env=Language.Builtins.env_init, elab) |> fst;
+  let (restatics_map, _) =
+    Statics.mk(
+      CoreSettings.on,
+      Language.Builtins.ctx_init(Some(Int)),
+      evaluated,
+    );
+  Id.Map.fold(
+    (_, info, acc) =>
+      switch (info) {
+      | Info.InfoExp({marks, _}) => marks @ acc
+      | _ => acc
+      },
+    restatics_map,
+    [],
+  );
+};
+
 let tests = (
   "Evaluator.TypAp",
   [
@@ -136,6 +159,28 @@ map@<Int, Int>((fun x -> x + 1), [1, 2, 3])|},
           ok,
         );
       },
+    ),
+    test_case(
+      "Prelude Option: evaluated Some(1) re-statics without marks", `Quick, () =>
+      check(
+        int,
+        "re-statics of evaluated Some(1) produces no marks",
+        0,
+        List.length(restatics_marks_after_eval({|Some(1)|})),
+      )
+    ),
+    test_case(
+      "Mixed explicit and implicit Some evaluates and re-statics", `Quick, () =>
+      check(
+        int,
+        "re-statics of evaluated mixed Some branches produces no marks",
+        0,
+        List.length(
+          restatics_marks_after_eval(
+            {|if true then Some@<Int>(1) else Some(0)|},
+          ),
+        ),
+      )
     ),
     test_case(
       "Prelude Either: R(true) evaluates without explicit type-arg",

--- a/test/evaluator/Test_Evaluator_TypAp.re
+++ b/test/evaluator/Test_Evaluator_TypAp.re
@@ -75,6 +75,28 @@ map@<T>@<Int>(fun e -> string_length(e), ["hello","bar"])|},
 pair@<Int, Bool>(3)(true)|},
         )
       ),
+    test_case("Implicit polymorphic id evaluates", `Quick, () =>
+      parse_and_evaluate_test(
+        "1",
+        {|let id : poly a -> a -> a = abs a -> fun x : a -> x in id(1)|},
+      )
+    ),
+    test_case("Implicit multi-binder polymorphic pair evaluates", `Quick, () =>
+      parse_and_evaluate_test(
+        "(3, true)",
+        {|let pair : poly a, b -> a -> b -> (a, b) =
+  abs a, b -> fun x : a -> fun y : b -> (x, y) in
+pair(3)(true)|},
+      )
+    ),
+    test_case("Implicit curried polymorphic const evaluates", `Quick, () =>
+      parse_and_evaluate_test(
+        "3",
+        {|let const : poly a -> poly b -> a -> b -> a =
+  abs a -> abs b -> fun x : a -> fun y : b -> x in
+const(3)(true)|},
+      )
+    ),
     /* Regression: a recursive polymorphic `map` with parenthesized
        multi-binder polymorphism (`poly (a, b) -> …`, internal
        `TPat.Tuple`) and `abs (a, b) -> …` must fully evaluate the

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -345,6 +345,22 @@ let x : Option(Int) = Some(3) in x
         ),
       )
     }),
+    test_case("explicit and implicit Some branches meet", `Quick, () => {
+      let marks =
+        static_errors(
+          {|
+type Option(a) = + None + Some(a) in
+if true then Some@<Int>(1) else Some(0)
+|},
+        );
+
+      Alcotest.check(
+        list(testable_issue),
+        "Static Errors",
+        [],
+        List.map(ms => Marks([ms]), marks),
+      );
+    }),
     test_case("elaboration wraps recursive Cons/Nil in TypAp", `Quick, () => {
       check(
         bool,

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -345,22 +345,26 @@ let x : Option(Int) = Some(3) in x
         ),
       )
     }),
-    test_case("explicit and implicit Some branches meet", `Quick, () => {
-      let marks =
-        static_errors(
-          {|
+    test_case(
+      "explicit and implicit Some branches meet",
+      `Quick,
+      () => {
+        let marks =
+          static_errors(
+            {|
 type Option(a) = + None + Some(a) in
 if true then Some@<Int>(1) else Some(0)
 |},
-        );
+          );
 
-      Alcotest.check(
-        list(testable_issue),
-        "Static Errors",
-        [],
-        List.map(ms => Marks([ms]), marks),
-      );
-    }),
+        Alcotest.check(
+          list(testable_issue),
+          "Static Errors",
+          [],
+          List.map(ms => Marks([ms]), marks),
+        );
+      },
+    ),
     test_case("elaboration wraps recursive Cons/Nil in TypAp", `Quick, () => {
       check(
         bool,

--- a/test/statics/Test_Statics_Polymorphism.re
+++ b/test/statics/Test_Statics_Polymorphism.re
@@ -40,6 +40,31 @@ let tests = (
       {|let x : poly a -> a = in let y : poly b -> b = x in 1|},
       Some(int()),
     ),
+    fully_consistent_typecheck(
+      "Implicit polymorphic function application instantiates with ?",
+      {|let id : poly a -> a -> a = abs a -> fun x : a -> x in id(1)|},
+      Some(unknown(Internal)),
+    ),
+    fully_consistent_typecheck(
+      "Explicit branch meets implicit polymorphic application",
+      {|let id : poly a -> a -> a = abs a -> fun x : a -> x in
+if true then id@<Int>(1) else id(0)|},
+      Some(int()),
+    ),
+    fully_consistent_typecheck(
+      "Implicit multi-binder polymorphic application instantiates all binders",
+      {|let pair : poly a, b -> a -> b -> (a, b) =
+  abs a, b -> fun x : a -> fun y : b -> (x, y) in
+pair(3)(true)|},
+      Some(prod([unknown(Internal), unknown(Internal)])),
+    ),
+    fully_consistent_typecheck(
+      "Implicit curried polymorphic application instantiates leading binders",
+      {|let const : poly a -> poly b -> a -> b -> a =
+  abs a -> abs b -> fun x : a -> fun y : b -> x in
+const(3)(true)|},
+      Some(unknown(Internal)),
+    ),
     inconsistent_typecheck(
       "Polymorphic Equality type inconsistency 1",
       {| 1 == 1. |} |> parse_exp,


### PR DESCRIPTION
Allows use of type functions in a normal application by filling type arguments by ?

Primary use of this is to allow writing an annotation on only one branch, and not require it on all branches, i.e. `if ? then Some@<Int>(1) else Some(0)` is a valid expression of type `Option(Int)`