### PR TITLE
Fix Skel.push_output crash when reassociating a second in below a nested let

### DIFF
--- a/src/haz3lcore/zipper/Reassociate.re
+++ b/src/haz3lcore/zipper/Reassociate.re
@@ -426,11 +426,21 @@ let accept_candidate =
   let candidate_stats = stats_of(~anchors, Relatives.zip(local_relatives));
   if (should_accept_repair(base_stats, candidate_stats)) {
     {
+      /* Reassembly only regrouts tile children (Segment.inner_regrout); the
+         sibling level must be regrouted here. Otherwise, when reassociation
+         absorbs a sibling that was serving as an operand (e.g. an `in`
+         monotile that was the outer let's body) into a form as a shard, the
+         siblings are left nonconvex and Segment.skel crashes downstream. */
+
       ...z,
-      relatives: {
-        siblings: local_relatives.siblings,
-        ancestors: local_relatives.ancestors @ outer_ancestors,
-      },
+      relatives:
+        Relatives.regrout(
+          Left,
+          {
+            siblings: local_relatives.siblings,
+            ancestors: local_relatives.ancestors @ outer_ancestors,
+          },
+        ),
     };
   } else {
     z;

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -55,7 +55,22 @@ let perform =
   List.fold_left(
     (z: Zipper.t, a: Action.t) =>
       switch (perform(a, z, ~root=Exp)) {
-      | Ok(z) => z
+      | Ok(z) =>
+        /* Term construction must be total on every reachable editor state
+         * (statics/display consume it after every action). Checking here
+         * (rather than only on the pre-state of the NEXT action) means the
+         * final state of every test is covered too. */
+        switch (MakeTerm.from_zip_for_sem(z, ~root=Exp)) {
+        | _ => z
+        | exception e =>
+          print_endline("Zipper: " ++ Zipper.show(z));
+          Alcotest.fail(
+            "Malformed state after action "
+            ++ Action.show(a)
+            ++ ": "
+            ++ Printexc.to_string(e),
+          );
+        }
       | Error(err) =>
         print_endline("Zipper: " ++ Zipper.show(z));
         Alcotest.fail("Failed on action: " ++ Action.Failure.show(err));

--- a/test/Test_Reassociate.re
+++ b/test/Test_Reassociate.re
@@ -1003,6 +1003,96 @@ in
       };
     },
   ),
+  /* With `let a = <hole> in` stubbed out across lines, typing an incomplete
+   * `let b = ` in the definition position and then a second `in` BELOW the
+   * existing `in` should reassociate: the existing `in` closes the inner let
+   * and the new `in` closes the outer. Regression: this raised
+   * Failure("Skel.push_output: split_kids: index out of bounds"). */
+  test_case(
+    "Second in below nested incomplete let reassociates without crash",
+    `Quick,
+    () => {
+      let z0 =
+        Test_Editing.mk("let a = \n¦\nin \n")
+        |> Test_Editing.perform(
+             ~settings=deep_reassociate_settings,
+             Zipper.init(),
+           );
+      let z1 =
+        Test_Editing.string_to_ltr_actions("let b = ")
+        |> Test_Editing.perform(~settings=deep_reassociate_settings, z0);
+      let z2 =
+        Test_Editing.perform(
+          ~settings=deep_reassociate_settings,
+          z1,
+          [Move(End)],
+        );
+      let z3 =
+        Test_Editing.string_to_ltr_actions("in ")
+        |> Test_Editing.perform(~settings=deep_reassociate_settings, z2);
+      let n = complete_count(["let", "=", "in"], z3);
+      if (Test_Editing.zip_has_incomplete(z3) || n != 2) {
+        Alcotest.fail(
+          Printf.sprintf(
+            "Expected 2 complete lets, no incomplete tiles; got %d complete, incomplete=%b",
+            n,
+            Test_Editing.zip_has_incomplete(z3),
+          ),
+        );
+      };
+      /* The crash surfaced in term construction on the post-reassociation
+       * zipper; assert it directly rather than relying on a next action. */
+      switch (MakeTerm.from_zip_for_sem(z3, ~root=Exp)) {
+      | _ => ()
+      | exception e =>
+        Alcotest.fail(
+          "MakeTerm failed post-reassoc: " ++ Printexc.to_string(e),
+        )
+      };
+    },
+  ),
+  /* Same shape but the outer let already has a body (`c`), so the second
+   * `in` is typed just before existing content instead of at the document
+   * end. Exercises the accept-path regrout where no new grout is needed. */
+  test_case(
+    "Second in before outer body reassociates without crash",
+    `Quick,
+    () => {
+      let z0 =
+        Test_Editing.mk("let a = \n¦\nin \nc")
+        |> Test_Editing.perform(
+             ~settings=deep_reassociate_settings,
+             Zipper.init(),
+           );
+      let z1 =
+        Test_Editing.string_to_ltr_actions("let b = ")
+        |> Test_Editing.perform(~settings=deep_reassociate_settings, z0);
+      let z2 =
+        [Action.Move(End)]
+        @ Test_Editing.mv_l(1)
+        |> Test_Editing.perform(~settings=deep_reassociate_settings, z1);
+      let z3 =
+        Test_Editing.string_to_ltr_actions("in ")
+        |> Test_Editing.perform(~settings=deep_reassociate_settings, z2);
+      let n = complete_count(["let", "=", "in"], z3);
+      if (Test_Editing.zip_has_incomplete(z3) || n != 2) {
+        Alcotest.fail(
+          Printf.sprintf(
+            "Expected 2 complete lets, no incomplete tiles; got %d complete, incomplete=%b",
+            n,
+            Test_Editing.zip_has_incomplete(z3),
+          ),
+        );
+      };
+      switch (MakeTerm.from_zip_for_sem(z3, ~root=Exp)) {
+      | _ => ()
+      | exception e =>
+        Alcotest.fail(
+          "MakeTerm failed post-reassoc: " ++ Printexc.to_string(e),
+        )
+      };
+    },
+  ),
 ];
 
 let tests = [

--- a/test/Test_Reassociate.re
+++ b/test/Test_Reassociate.re
@@ -1053,13 +1053,14 @@ in
   ),
   /* Same shape but the outer let already has a body (`c`), so the second
    * `in` is typed just before existing content instead of at the document
-   * end. Exercises the accept-path regrout where no new grout is needed. */
+   * end (space-separated so the keyword doesn't merge with it). Exercises
+   * the accept-path regrout where no new grout is needed. */
   test_case(
     "Second in before outer body reassociates without crash",
     `Quick,
     () => {
       let z0 =
-        Test_Editing.mk("let a = \n¦\nin \nc")
+        Test_Editing.mk("let a = \n¦\nin \n c")
         |> Test_Editing.perform(
              ~settings=deep_reassociate_settings,
              Zipper.init(),
@@ -1069,7 +1070,7 @@ in
         |> Test_Editing.perform(~settings=deep_reassociate_settings, z0);
       let z2 =
         [Action.Move(End)]
-        @ Test_Editing.mv_l(1)
+        @ Test_Editing.mv_l(2)
         |> Test_Editing.perform(~settings=deep_reassociate_settings, z1);
       let z3 =
         Test_Editing.string_to_ltr_actions("in ")


### PR DESCRIPTION
fix: editor will crash if you

write:
```
let a = 
  |
in
```
then:
```
let a = 
  let b = |
in
```
then:
```
let a = 
  let b = 
in
in|
```
