### PR TITLE
Fix caret landing on wrong piece after Inner-caret edits near Emojis

### DIFF
--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -827,8 +827,29 @@ let adj_pos = (d: Direction.t, z: t): t =>
     }
   };
 
-let put_down_core = (seg: Segment.t, z: t): t =>
-  z |> replace_selection(Right, seg) |> unselect;
+/* Unselects with the caret forced Outer. `directional_unselect` repairs
+ * an Inner caret left dangling by the unselect (Inner(n) is
+ * right-neighbor-relative) by stepping one piece right; but the caller's
+ * `adj_pos(Right)` takes that same step deliberately, to land the
+ * segment on the caret's right. Applying both steps the caret a piece
+ * too far, so `Inner(n)` ends up indexing the wrong token — e.g.
+ * backspacing in `1 + "aa|"` leaves the caret pointing into the space
+ * before the string. The repair is redundant here: adj_pos re-establishes
+ * the invariant on its own. */
+let put_down_core = (seg: Segment.t, z: t): t => {
+  let caret = z.caret;
+  let z =
+    {
+      ...z,
+      caret: Outer,
+    }
+    |> replace_selection(Right, seg)
+    |> unselect;
+  {
+    ...z,
+    caret,
+  };
+};
 
 /* Like put_down_core but skips Relatives.reassemble.
  * Used for Inner-caret edits where the replaced token would

--- a/src/haz3lcore/zipper/Zipper.re
+++ b/src/haz3lcore/zipper/Zipper.re
@@ -827,15 +827,9 @@ let adj_pos = (d: Direction.t, z: t): t =>
     }
   };
 
-/* Unselects with the caret forced Outer. `directional_unselect` repairs
- * an Inner caret left dangling by the unselect (Inner(n) is
- * right-neighbor-relative) by stepping one piece right; but the caller's
- * `adj_pos(Right)` takes that same step deliberately, to land the
- * segment on the caret's right. Applying both steps the caret a piece
- * too far, so `Inner(n)` ends up indexing the wrong token — e.g.
- * backspacing in `1 + "aa|"` leaves the caret pointing into the space
- * before the string. The repair is redundant here: adj_pos re-establishes
- * the invariant on its own. */
+/* Unselect with the caret Outer: directional_unselect would step an Inner
+ * caret one piece right, and the caller's adj_pos(Right) already does that,
+ * leaving Inner(n) indexing the wrong token. */
 let put_down_core = (seg: Segment.t, z: t): t => {
   let caret = z.caret;
   let z =

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -498,7 +498,10 @@ let wrap_quote = (char: string, z: t, ~root): option(t) => {
   if (!is_valid_quote_content(char, text)) {
     None;
   } else {
-    let z = destroy_selection(z);
+    /* The selection is gone, so a char-level Inner caret left over from
+     * it no longer indexes anything; keep it and later edits misread it
+     * against whatever piece ends up on the right. */
+    let z = destroy_selection(z) |> Caret.set(Outer);
     if (Token.is_comment_delim(char)) {
       let comment = "#" ++ text ++ "#";
       let piece = Piece.mk_secondary(Id.mk(), comment);

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -498,9 +498,8 @@ let wrap_quote = (char: string, z: t, ~root): option(t) => {
   if (!is_valid_quote_content(char, text)) {
     None;
   } else {
-    /* The selection is gone, so a char-level Inner caret left over from
-     * it no longer indexes anything; keep it and later edits misread it
-     * against whatever piece ends up on the right. */
+    /* An Inner caret left over from the destroyed selection would be
+     * misread against whatever piece ends up on the right. */
     let z = destroy_selection(z) |> Caret.set(Outer);
     if (Token.is_comment_delim(char)) {
       let comment = "#" ++ text ++ "#";

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -4767,8 +4767,8 @@ b|}))
 ];
 
 /* Backspacing inside a token whose piece has a left sibling: the
- * replacement token must land on the caret's right, so the Inner index
- * keeps referring to it. */
+ * replacement must land on the caret's right for Inner(n) to still
+ * refer to it. */
 let inner_destruct_tests = [
   test(
     ~name="Backspace inside string with left sibling",
@@ -4790,9 +4790,7 @@ let inner_destruct_tests = [
     ~acts=mk({|1 + "aa"¦|}) @ mv_l(2) @ [Destruct(Right)],
     ~goal={|1 + "a¦"|},
   ),
-  /* Wrapping a char-level selection in quotes drops the selection, so
-   * the leftover Inner caret must go too, or the next edit indexes it
-   * against an unrelated piece. */
+  /* Quote-wrapping drops the selection; its Inner caret must go too. */
   test(
     ~name="Wrap char-level selection in quotes",
     ~acts=
@@ -4815,12 +4813,11 @@ let inner_destruct_tests = [
   ),
 ];
 
-/* Grapheme clusters (emoji, combining marks) are a single Inner caret
- * position but multiple bytes/UTF-16 units, and emoji are two columns
- * wide. Editing next to one must stay in grapheme units throughout. */
+/* A grapheme cluster is one Inner caret position but several bytes, so
+ * editing beside one must stay in grapheme units throughout. */
 let grapheme_tests = [
-  /* Pins that Intl.Segmenter is available in the test environment: the
-     code-point fallback in Unicode.graphemes would count 5 and 2 here. */
+  /* Also pins that Intl.Segmenter is present: the code-point fallback in
+     Unicode.graphemes would count 5 and 2 here. */
   test_case(
     "Multi-codepoint clusters count as one grapheme",
     `Quick,

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -4766,6 +4766,163 @@ b|}))
   ),
 ];
 
+/* Backspacing inside a token whose piece has a left sibling: the
+ * replacement token must land on the caret's right, so the Inner index
+ * keeps referring to it. */
+let inner_destruct_tests = [
+  test(
+    ~name="Backspace inside string with left sibling",
+    ~acts=mk({|1 + "aa"¦|}) @ mv_l(1) @ [Destruct(Left)],
+    ~goal={|1 + "a¦"|},
+  ),
+  test(
+    ~name="Backspace twice inside string with left sibling",
+    ~acts=mk({|1 + "aa"¦|}) @ mv_l(1) @ [Destruct(Left), Destruct(Left)],
+    ~goal={|1 + "¦"|},
+  ),
+  test(
+    ~name="Backspace inside identifier with left sibling",
+    ~acts=mk({|1 + abc¦|}) @ mv_l(1) @ [Destruct(Left)],
+    ~goal={|1 + a¦c|},
+  ),
+  test(
+    ~name="Delete forward inside string with left sibling",
+    ~acts=mk({|1 + "aa"¦|}) @ mv_l(2) @ [Destruct(Right)],
+    ~goal={|1 + "a¦"|},
+  ),
+  /* Wrapping a char-level selection in quotes drops the selection, so
+   * the leftover Inner caret must go too, or the next edit indexes it
+   * against an unrelated piece. */
+  test(
+    ~name="Wrap char-level selection in quotes",
+    ~acts=
+      mk({|"aa" ++ "x"¦|})
+      @ mv_l(4)
+      @ [Select(Resize(Local(Left, ByChar))), Insert("\"")],
+    ~goal={|"aa" ~"++"~¦ "x"|},
+  ),
+  test(
+    ~name="Delete after wrapping char-level selection in quotes",
+    ~acts=
+      mk({|"aa" ++ "x"¦|})
+      @ mv_l(4)
+      @ [
+        Select(Resize(Local(Left, ByChar))),
+        Insert("\""),
+        Destruct(Right),
+      ],
+    ~goal={|"aa" ~"++"~¦"x"|},
+  ),
+];
+
+/* Grapheme clusters (emoji, combining marks) are a single Inner caret
+ * position but multiple bytes/UTF-16 units, and emoji are two columns
+ * wide. Editing next to one must stay in grapheme units throughout. */
+let grapheme_tests = [
+  /* Pins that Intl.Segmenter is available in the test environment: the
+     code-point fallback in Unicode.graphemes would count 5 and 2 here. */
+  test_case(
+    "Multi-codepoint clusters count as one grapheme",
+    `Quick,
+    () => {
+      check(int, "ZWJ family", 1, Token.length({|👨‍👩‍👧|}));
+      check(int, "e + combining acute", 1, Token.length({|é|}));
+      check(int, "emoji", 1, Token.length({|😀|}));
+    },
+  ),
+  test(
+    ~name="Insert after emoji in string",
+    ~acts=mk({|"😀"¦|}) @ mv_l(1) @ [Insert("1")],
+    ~goal={|"😀1¦"|},
+  ),
+  test(
+    ~name="Insert then backspace after emoji in string",
+    ~acts=mk({|"😀"¦|}) @ mv_l(1) @ [Insert("1"), Destruct(Left)],
+    ~goal={|"😀¦"|},
+  ),
+  test(
+    ~name="Insert two then backspace twice after emoji in string",
+    ~acts=
+      mk({|"😀"¦|})
+      @ mv_l(1)
+      @ string_to_ltr_actions("11")
+      @ [Destruct(Left), Destruct(Left)],
+    ~goal={|"😀¦"|},
+  ),
+  test(
+    ~name="Backspace the emoji itself",
+    ~acts=mk({|"😀"¦|}) @ mv_l(1) @ [Destruct(Left)],
+    ~goal={|"¦"|},
+  ),
+  test(
+    ~name="Delete forward over emoji from start of string",
+    ~acts=mk({|"😀"¦|}) @ mv_l(2) @ [Destruct(Right)],
+    ~goal={|"¦"|},
+  ),
+  test(
+    ~name="Insert before emoji in string",
+    ~acts=mk({|"😀"¦|}) @ mv_l(2) @ [Insert("1")],
+    ~goal={|"1¦😀"|},
+  ),
+  test(
+    ~name="Insert then backspace before emoji in string",
+    ~acts=mk({|"😀"¦|}) @ mv_l(2) @ [Insert("1"), Destruct(Left)],
+    ~goal={|"¦😀"|},
+  ),
+  test(
+    ~name="Insert then backspace after mid-string emoji",
+    ~acts=mk({|"a😀b"¦|}) @ mv_l(2) @ [Insert("1"), Destruct(Left)],
+    ~goal={|"a😀¦b"|},
+  ),
+  test(
+    ~name="Backspace mid-string emoji",
+    ~acts=mk({|"a😀b"¦|}) @ mv_l(2) @ [Destruct(Left)],
+    ~goal={|"a¦b"|},
+  ),
+  test(
+    ~name="Move by char across emoji round trip",
+    ~acts=mk({|"a😀b"¦|}) @ mv_l(3) @ mv_r(1),
+    ~goal={|"a😀¦b"|},
+  ),
+  test(
+    ~name="Insert then backspace after emoji, string with left sibling",
+    ~acts=mk({|1 + "😀"¦|}) @ mv_l(1) @ [Insert("1"), Destruct(Left)],
+    ~goal={|1 + "😀¦"|},
+  ),
+  test(
+    ~name="Insert two then backspace twice after emoji, left sibling",
+    ~acts=
+      mk({|1 + "😀"¦|})
+      @ mv_l(1)
+      @ string_to_ltr_actions("11")
+      @ [Destruct(Left), Destruct(Left)],
+    ~goal={|1 + "😀¦"|},
+  ),
+  test(
+    ~name="Backspace the emoji itself, string with left sibling",
+    ~acts=mk({|1 + "a😀"¦|}) @ mv_l(1) @ [Destruct(Left)],
+    ~goal={|1 + "a¦"|},
+  ),
+  test(
+    ~name="Insert two then backspace twice after combining-mark grapheme",
+    ~acts=
+      mk({|"é"¦|})
+      @ mv_l(1)
+      @ string_to_ltr_actions("11")
+      @ [Destruct(Left), Destruct(Left)],
+    ~goal={|"é¦"|},
+  ),
+  test(
+    ~name="Insert two then backspace twice after ZWJ emoji",
+    ~acts=
+      mk({|"👨‍👩‍👧"¦|})
+      @ mv_l(1)
+      @ string_to_ltr_actions("11")
+      @ [Destruct(Left), Destruct(Left)],
+    ~goal={|"👨‍👩‍👧¦"|},
+  ),
+];
+
 let tests = [
   ("Editing.DragToZeroWidth", drag_to_zero_width_tests),
   ("Editing.MoveAfterCharSelect", move_after_char_select_tests),
@@ -4793,4 +4950,6 @@ let tests = [
   ("Editing.MultiDelimSelectionBugs", multi_delim_selection_bug_tests),
   ("Editing.MultiDelimBackpackBugs", multi_delim_backpack_tests),
   ("Editing.CrossBoundary", cross_boundary_tests),
+  ("Editing.InnerDestruct", inner_destruct_tests),
+  ("Editing.Grapheme", grapheme_tests),
 ];


### PR DESCRIPTION
Fixes: In a string with an emoji, typing `11` after the emoji and backspacing twice raises `Invalid_argument("Grapheme.remove_nth")`; with one backspace the caret visibly jumps to before the emoji. Adds a bunch of tests for related edges.
