### PR TITLE
Reject kinded typfun in annotations

### DIFF
--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -3782,7 +3782,13 @@ and upat_to_info_map =
       );
     | Asc(p, ann) =>
       let (ann, m) =
-        utyp_to_info_map(~ctx, ~ancestors=ancestors_inclusive, ann, m);
+        utyp_to_info_map(
+          ~ctx,
+          ~ancestors=ancestors_inclusive,
+          ~allow_typfun=false,
+          ann,
+          m,
+        );
       /* Desugar any Sig types in the annotation without full normalization */
       let ann_ty = Typ.desugar_sig(ctx, ann.user_term);
       let (p, p_elab, m) =
@@ -3832,6 +3838,7 @@ and utyp_to_info_map =
     (
       ~ctx,
       ~expects=TypExpectation.TypeExpected,
+      ~allow_typfun=true,
       ~ancestors,
       utyp: Typ.t,
       m: Map.t,
@@ -3873,6 +3880,8 @@ and utyp_to_info_map =
       ([m], None);
     };
     switch (expects, utyp.term) {
+    | (TypeExpected, TypFun(_, _)) when allow_typfun =>
+      ok(Message.Type(utyp))
     | (_, Unknown(Hole(Invalid(token)))) => err(BadToken(token))
     | (LabelExpected(_), Unknown(Hole(EmptyHole))) =>
       ok(Message.EmptyLabel)
@@ -4131,7 +4140,14 @@ and utyp_to_info_map =
   let _ = ancestors;
   let go =
       (~ctx=ctx, ~expects=TypExpectation.TypeExpected, t: Typ.t, m: Map.t) =>
-    utyp_to_info_map(~ctx, ~ancestors=ancestors_inclusive, ~expects, t, m);
+    utyp_to_info_map(
+      ~ctx,
+      ~ancestors=ancestors_inclusive,
+      ~expects,
+      ~allow_typfun,
+      t,
+      m,
+    );
   switch (term) {
   | Unknown(Hole(MultiHole(tms))) =>
     let (_, _, m) = multi(~ctx, ~ancestors=ancestors_inclusive, m, tms);

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -4095,12 +4095,6 @@ and utyp_to_info_map =
           ok(Message.Type(utyp));
         };
       };
-    | (TypeExpected | AnyKindExpected, TypFun(_, _)) =>
-      /* `TypFun` has an `Arrow` kind. Accept it as kind-OK at this
-         node; descendants are visited via the `TypFun` arm of the
-         outer `switch` with `AnyKindExpected` so a curried tail
-         doesn't repeat this check. */
-      ok(Message.Type(utyp))
     | (TypeExpected | AnyKindExpected, _) =>
       switch (kind_marks_for_expected_type(~expects, utyp)) {
       | [] => ok(Message.Type(utyp))

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -3882,6 +3882,13 @@ and utyp_to_info_map =
     switch (expects, utyp.term) {
     | (TypeExpected, TypFun(_, _)) when allow_typfun =>
       ok(Message.Type(utyp))
+    | (AnyKindExpected, TypFun(_, _)) =>
+      err(
+        TypKindMismatch({
+          expected: TypKind.Type,
+          actual: kind_of_typ(ctx, utyp),
+        }),
+      )
     | (_, Unknown(Hole(Invalid(token)))) => err(BadToken(token))
     | (LabelExpected(_), Unknown(Hole(EmptyHole))) =>
       ok(Message.EmptyLabel)

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -3882,13 +3882,6 @@ and utyp_to_info_map =
     switch (expects, utyp.term) {
     | (TypeExpected, TypFun(_, _)) when allow_typfun =>
       ok(Message.Type(utyp))
-    | (AnyKindExpected, TypFun(_, _)) =>
-      err(
-        TypKindMismatch({
-          expected: TypKind.Type,
-          actual: kind_of_typ(ctx, utyp),
-        }),
-      )
     | (_, Unknown(Hole(Invalid(token)))) => err(BadToken(token))
     | (LabelExpected(_), Unknown(Hole(EmptyHole))) =>
       ok(Message.EmptyLabel)
@@ -4348,6 +4341,13 @@ and utyp_to_info_map =
       utpat_to_info_map(~ctx, ~ancestors=ancestors_inclusive, utpat, m) |> snd;
     add(m);
   | TypFun(utpat, tbody) =>
+    let rec starts_with_typfun = (typ: Typ.t) =>
+      switch (typ.term) {
+      | TypFun(_, _) => true
+      | Parens(inner) => starts_with_typfun(inner)
+      | _ => false
+      };
+    let allow_typfun_in_body = allow_typfun && starts_with_typfun(tbody);
     let body_ctx =
       List.fold_left(
         (ctx, b: TPat.t) =>
@@ -4377,6 +4377,7 @@ and utyp_to_info_map =
            outer `TypFun` already accounts for that extra arrow in
            its own kind, so don't re-flag it here. */
         ~expects=AnyKindExpected,
+        ~allow_typfun=allow_typfun_in_body,
         m,
       )
       |> snd;

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -908,6 +908,25 @@ map@<Int, Int>([1, 2, 3], fun x -> x * 2)
        `T(Int)` normalizes through the existing higher-kinded
        reduction. */
     test_case(
+      "typfun is rejected where an annotation expects a Type",
+      `Quick,
+      () => {
+        let marks = static_errors({|let x : typfun A -> A = ? in x|});
+        check(
+          bool,
+          "kind mismatch",
+          true,
+          has_mark(
+            TypKindMismatch({
+              expected: TypKind.Type,
+              actual: TypKind.Arrow([TypKind.Type], TypKind.Type),
+            }),
+            marks,
+          ),
+        );
+      },
+    ),
+    test_case(
       "type T = typfun a -> body parses + checks like type T(a) = body",
       `Quick,
       () => {

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -927,6 +927,30 @@ map@<Int, Int>([1, 2, 3], fun x -> x * 2)
       },
     ),
     test_case(
+      "typfun kind errors are reported inside a type alias body",
+      `Quick,
+      () => {
+        let marks =
+          static_errors(
+            {|
+type T = typfun A -> typfun B -> (A, typfun C -> C) in ?
+|},
+          );
+        check(
+          bool,
+          "kind mismatch",
+          true,
+          has_mark(
+            TypKindMismatch({
+              expected: TypKind.Type,
+              actual: TypKind.Arrow([TypKind.Type], TypKind.Type),
+            }),
+            marks,
+          ),
+        );
+      },
+    ),
+    test_case(
       "type T = typfun a -> body parses + checks like type T(a) = body",
       `Quick,
       () => {

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -937,16 +937,23 @@ type T = typfun A -> typfun B -> (A, typfun C -> C) in ?
 |},
           );
         check(
-          bool,
-          "kind mismatch",
-          true,
-          has_mark(
-            TypKindMismatch({
-              expected: TypKind.Type,
-              actual: TypKind.Arrow([TypKind.Type], TypKind.Type),
-            }),
-            marks,
-          ),
+          list(testable_issue),
+          "kind mismatch only on the non-prenex typfun",
+          [
+            Marks([
+              TypKindMismatch({
+                expected: TypKind.Type,
+                actual: TypKind.Arrow([TypKind.Type], TypKind.Type),
+              }),
+            ]),
+            Marks([
+              TypKindMismatch({
+                expected: TypKind.Type,
+                actual: TypKind.Arrow([TypKind.Type], TypKind.Type),
+              }),
+            ]),
+          ],
+          List.map(mark => Marks([mark]), marks),
         );
       },
     ),


### PR DESCRIPTION
Fixes some missed errors when writing kinded types where only proper types are allowed (annotations) in #2254 