### PR TITLE
Disallow surface typfun

### DIFF
--- a/src/haz3lcore/TyDi/ErrorPrint.re
+++ b/src/haz3lcore/TyDi/ErrorPrint.re
@@ -160,6 +160,7 @@ let exp_mark_to_string = (ctx: Ctx.t, ana: Typ.t, m: Mark.t): string => {
   | TypParamApplyNonArrowKind(_)
   | TypParamApplyArityMismatch(_)
   | TypAbsApplyArityMismatch(_)
+  | TypFunNotSurfaceSyntax
   | TypDuplicateConstructor(_)
   | TypDuplicateLabels(_, _)
   | TypWantTypeFoundAp
@@ -207,6 +208,7 @@ let pat_marks_to_string =
 
 let typ_mark_string: Mark.t => string =
   fun
+  | TypFunNotSurfaceSyntax => "typfun is an internal type function; use a parameterized type alias instead"
   | TypFreeTypeVariable(name) => prn("Type variable %s is not bound", name)
   | BadToken(token) => prn("\"%s\" isn't a valid type token", token)
   | TypWantConstructorFoundAp => "Expected a constructor, found application"

--- a/src/haz3lcore/TyDi/ErrorPrint.re
+++ b/src/haz3lcore/TyDi/ErrorPrint.re
@@ -160,7 +160,6 @@ let exp_mark_to_string = (ctx: Ctx.t, ana: Typ.t, m: Mark.t): string => {
   | TypParamApplyNonArrowKind(_)
   | TypParamApplyArityMismatch(_)
   | TypAbsApplyArityMismatch(_)
-  | TypFunNotSurfaceSyntax
   | TypDuplicateConstructor(_)
   | TypDuplicateLabels(_, _)
   | TypWantTypeFoundAp
@@ -208,7 +207,6 @@ let pat_marks_to_string =
 
 let typ_mark_string: Mark.t => string =
   fun
-  | TypFunNotSurfaceSyntax => "typfun is an internal type function; use a parameterized type alias instead"
   | TypFreeTypeVariable(name) => prn("Type variable %s is not bound", name)
   | BadToken(token) => prn("\"%s\" isn't a valid type token", token)
   | TypWantConstructorFoundAp => "Expected a constructor, found application"

--- a/src/language/statics/Mark.re
+++ b/src/language/statics/Mark.re
@@ -85,7 +85,6 @@ type t =
      `typlam`, or `rec` (e.g. `poly A(a) -> ...`). The associated
      string is the head name (or `"?"` if the head is a hole). */
   | TPatParamNotAtAliasHead(string)
-  | TypFunNotSurfaceSyntax
   | TypFreeTypeVariable(string)
   | TypKindMismatch({
       expected: TypKind.t,

--- a/src/language/statics/Mark.re
+++ b/src/language/statics/Mark.re
@@ -85,6 +85,7 @@ type t =
      `typlam`, or `rec` (e.g. `poly A(a) -> ...`). The associated
      string is the head name (or `"?"` if the head is a hole). */
   | TPatParamNotAtAliasHead(string)
+  | TypFunNotSurfaceSyntax
   | TypFreeTypeVariable(string)
   | TypKindMismatch({
       expected: TypKind.t,

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -2426,6 +2426,37 @@ and uexp_to_info_map =
         );
       add(~elab_term, ~elab_syn_ty, ~marks=marks_match', ~co_ctx, m);
     | TyAlias(typat, utyp, body) =>
+      let rec curried_alias_head = (typat: TPat.t) =>
+        switch (typat.term) {
+        | Param(head, params) =>
+          curried_alias_head(head)
+          |> Option.map(((head, groups)) => (head, groups @ [params]))
+        | Var(_) => Some((typat, []))
+        | Parens(inner) => curried_alias_head(inner)
+        | Invalid(_)
+        | EmptyHole
+        | MultiHole(_)
+        | Tuple(_) => None
+        };
+      let binder_of_params = params =>
+        switch (params) {
+        | [param] => param
+        | _ => (Tuple(params): TPat.term) |> TPat.temp
+        };
+      let (typat, utyp) =
+        switch (curried_alias_head(typat)) {
+        | Some((head, [_first, _second, ..._] as groups)) =>
+          let utyp =
+            List.fold_right(
+              (params, body) =>
+                TypFun(binder_of_params(params), body) |> Typ.temp,
+              groups,
+              utyp,
+            );
+          (head, utyp);
+        | Some((_head, [] | [_]))
+        | None => (typat, utyp)
+        };
       /* Desugar Sig types so type aliases like `type T = {let x : Int}`
          store `Prod([TupLabel(...)])` rather than `Sig([...])` in the
          context (so meet/join can unify them with module expression
@@ -4095,8 +4126,6 @@ and utyp_to_info_map =
           ok(Message.Type(utyp));
         };
       };
-    | (TypeExpected | AnyKindExpected, TypFun(_, _)) =>
-      err(TypFunNotSurfaceSyntax)
     | (TypeExpected | AnyKindExpected, _) =>
       switch (kind_marks_for_expected_type(~expects, utyp)) {
       | [] => ok(Message.Type(utyp))

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -4096,11 +4096,7 @@ and utyp_to_info_map =
         };
       };
     | (TypeExpected | AnyKindExpected, TypFun(_, _)) =>
-      /* `TypFun` has an `Arrow` kind. Accept it as kind-OK at this
-         node; descendants are visited via the `TypFun` arm of the
-         outer `switch` with `AnyKindExpected` so a curried tail
-         doesn't repeat this check. */
-      ok(Message.Type(utyp))
+      err(TypFunNotSurfaceSyntax)
     | (TypeExpected | AnyKindExpected, _) =>
       switch (kind_marks_for_expected_type(~expects, utyp)) {
       | [] => ok(Message.Type(utyp))

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -2454,7 +2454,8 @@ and uexp_to_info_map =
               utyp,
             );
           (head, utyp);
-        | Some((_head, [] | [_]))
+        | Some((_, []))
+        | Some((_, [_]))
         | None => (typat, utyp)
         };
       /* Desugar Sig types so type aliases like `type T = {let x : Int}`

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -11,6 +11,13 @@ include StaticsBase;
 let add_info = Map.add_info;
 let add_missing_info = Map.add_missing_info;
 
+let rec is_surface_typfun = (typ: Typ.t): bool =>
+  switch (typ.term) {
+  | Parens(inner) => is_surface_typfun(inner)
+  | TypFun(_, _) => true
+  | _ => false
+  };
+
 /* Compute a type's kind without descending into descendants. The
    recursive `utyp_to_info_map` traversal puts kind marks on each node
    individually, so this helper is purely for "what kind does the
@@ -2425,6 +2432,22 @@ and uexp_to_info_map =
           branch_ids,
         );
       add(~elab_term, ~elab_syn_ty, ~marks=marks_match', ~co_ctx, m);
+    | TyAlias(typat, utyp, body) when is_surface_typfun(utyp) =>
+      let m =
+        utpat_to_info_map(~ctx, ~ancestors=ancestors_inclusive, typat, m)
+        |> snd;
+      let m =
+        utyp_to_info_map(
+          ~ctx,
+          ~ancestors=ancestors_inclusive,
+          ~expects=AnyKindExpected,
+          utyp,
+          m,
+        )
+        |> snd;
+      let ({co_ctx, elab_syn_ty, _}: Info.exp, body_elab, m) =
+        go(~ctx, ~ana, body, m);
+      add(~elab_term=body_elab, ~elab_syn_ty, ~marks=[], ~co_ctx, m);
     | TyAlias(typat, utyp, body) =>
       let rec curried_alias_head = (typat: TPat.t) =>
         switch (typat.term) {
@@ -2443,7 +2466,7 @@ and uexp_to_info_map =
         | [param] => param
         | _ => (Tuple(params): TPat.term) |> TPat.temp
         };
-      let (typat, utyp) =
+      let (typat, utyp, generated_typfun_depth) =
         switch (curried_alias_head(typat)) {
         | Some((head, [_first, _second, ..._] as groups)) =>
           let utyp =
@@ -2453,149 +2476,23 @@ and uexp_to_info_map =
               groups,
               utyp,
             );
-          (head, utyp);
+          (head, utyp, List.length(groups));
         | Some((_, []))
         | Some((_, [_]))
-        | None => (typat, utyp)
+        | None => (typat, utyp, 0)
         };
       /* Desugar Sig types so type aliases like `type T = {let x : Int}`
          store `Prod([TupLabel(...)])` rather than `Sig([...])` in the
          context (so meet/join can unify them with module expression
          types). */
       let utyp_desugared = Typ.desugar_sig(ctx, utyp);
-      /* `type T = typfun a, b -> body` is the prefix-binder spelling
-         of `type T(a, b) = body` — a single multi-binder `TypFun`.
-         Peel it so the alias takes the `Param`-branch path
-         (params extension, polymorphic constructor schemas,
-         tuple-arrow kind `(Type, …) -> Type`).
-
-         A *curried* form `type T = typfun a -> typfun b -> body`
-         is left intact: each unary `TypFun` stays as its own
-         binder so the alias has the curried kind
-         `Type -> Type -> kind(body)` and accepts curried
-         applications `T(a)(b)`. `peel_typlams` refuses to peel a
-         TypFun whose body is itself a TypFun. */
-      let rec strip_parens = (t: Typ.t): Typ.t =>
-        switch (t.term) {
-        | Parens(inner) => strip_parens(inner)
-        | Unknown(_)
-        | Atom(_)
-        | DrvQuoteTy(_)
-        | Label(_)
-        | ExplicitNonlabel
-        | Var(_)
-        | Projector(_)
-        | ProdProjection(_)
-        | List(_)
-        | Arrow(_)
-        | TupLabel(_)
-        | ProdExtension(_)
-        | Prod(_)
-        | Sum(_)
-        | Poly(_)
-        | ProofOf(_)
-        | Sig(_)
-        | TypTuple(_)
-        | TypFun(_)
-        | TypParamAp(_)
-        | Rec(_) => t
-        };
-      let peel_typlams = (typ: Typ.t): (list(TPat.t), Typ.t) => {
-        let stripped = strip_parens(typ);
-        switch (stripped.term) {
-        | TypFun(p, inner) =>
-          let stripped_inner = strip_parens(inner);
-          switch (stripped_inner.term) {
-          | TypFun(_) => ([], typ)
-          | Unknown(_)
-          | Atom(_)
-          | DrvQuoteTy(_)
-          | Label(_)
-          | ExplicitNonlabel
-          | Var(_)
-          | Parens(_)
-          | Projector(_)
-          | ProdProjection(_)
-          | List(_)
-          | Arrow(_)
-          | TupLabel(_)
-          | ProdExtension(_)
-          | Prod(_)
-          | Sum(_)
-          | Poly(_)
-          | ProofOf(_)
-          | Sig(_)
-          | TypTuple(_)
-          | TypParamAp(_)
-          | Rec(_) => (TPat.binders_of(p), stripped_inner)
-          };
-        | Unknown(_)
-        | Atom(_)
-        | DrvQuoteTy(_)
-        | Label(_)
-        | ExplicitNonlabel
-        | Var(_)
-        | Parens(_)
-        | Projector(_)
-        | ProdProjection(_)
-        | List(_)
-        | Arrow(_)
-        | TupLabel(_)
-        | ProdExtension(_)
-        | Prod(_)
-        | Sum(_)
-        | Poly(_)
-        | ProofOf(_)
-        | Sig(_)
-        | TypTuple(_)
-        | TypParamAp(_)
-        | Rec(_) => ([], typ)
-        };
-      };
-      /* If the typat is a bare `Var(name)` and the body has a
-         peelable single multi-binder `TypFun`, rebundle as
-         `Param(head, params)` so the rest of the branch treats this
-         identically to the explicit `type Name(params) = body`
-         spelling. The new `Param` reuses the original `Var` tile id
-         for its head so jump-to-definition lands on the alias
-         name. */
-      let (typat, utyp, utyp_desugared) =
-        switch (typat.term, peel_typlams(utyp_desugared)) {
-        | (Var(name), ([_, ..._] as params, inner_body)) =>
-          let head: TPat.t = {
-            term: Var(name),
-            annotation: typat.annotation,
-          };
-          let new_typat: TPat.t = {
-            term: Param(head, params),
-            annotation: typat.annotation,
-          };
-          let (_, inner_orig) = peel_typlams(utyp);
-          (new_typat, inner_orig, inner_body);
-        /* No rebundle: either typat isn't a `Var` (already a
-           `Param`/`Tuple`/etc.), or `peel_typlams` returned no
-           binders (body isn't a peelable `TypFun`). */
-        | (Var(_), ([], _))
-        | (
-            Param(_, _) | Tuple(_) | Parens(_) | Invalid(_) | EmptyHole |
-            MultiHole(_),
-            _,
-          ) => (
-            typat,
-            utyp,
-            utyp_desugared,
-          )
-        };
       /* Single source of truth for the alias's kind: stored on the
          `TVarEntry`, surfaced at the alias-name tpat through
          `~alias_kind`, and consumed by every downstream
          `kind_of_typ` lookup of a `Var(name)` reference to this
          alias. Mirrors the kind `kind_of_typ` derives from the
-         alias body — `(Type, …) -> kind(body)` for the rebundled
-         multi-binder case (with the params bound abstractly in the
-         body's context), or just `kind_of_typ(body)` otherwise (a
-         curried `typfun a -> typfun b -> Sum(...)` body yields
-         `Type -> Type -> Type`). */
+         alias body — `(Type, …) -> kind(body)` for a parameterized
+         alias, or `kind_of_typ(body)` otherwise. */
       let alias_body_kind =
         switch (typat.term) {
         | Param(_, params) =>
@@ -2725,6 +2622,7 @@ and uexp_to_info_map =
             ~ctx=ctx_for_def,
             ~ancestors=ancestors_inclusive,
             ~expects=AnyKindExpected,
+            ~generated_typfun_depth,
             utyp,
             m,
           )
@@ -2798,6 +2696,7 @@ and uexp_to_info_map =
             ~ctx=ctx_def,
             ~ancestors=ancestors_inclusive,
             ~expects=AnyKindExpected,
+            ~generated_typfun_depth,
             utyp,
             m,
           )
@@ -2829,6 +2728,7 @@ and uexp_to_info_map =
             ~ctx,
             ~ancestors=ancestors_inclusive,
             ~expects=AnyKindExpected,
+            ~generated_typfun_depth,
             utyp,
             m,
           )
@@ -3864,6 +3764,7 @@ and utyp_to_info_map =
     (
       ~ctx,
       ~expects=TypExpectation.TypeExpected,
+      ~generated_typfun_depth=0,
       ~ancestors,
       utyp: Typ.t,
       m: Map.t,
@@ -3905,6 +3806,9 @@ and utyp_to_info_map =
       ([m], None);
     };
     switch (expects, utyp.term) {
+    | (TypeExpected | AnyKindExpected, TypFun(_, _))
+        when generated_typfun_depth == 0 =>
+      err(TypFunNotSurfaceSyntax)
     | (_, Unknown(Hole(Invalid(token)))) => err(BadToken(token))
     | (LabelExpected(_), Unknown(Hole(EmptyHole))) =>
       ok(Message.EmptyLabel)
@@ -4163,7 +4067,14 @@ and utyp_to_info_map =
   let _ = ancestors;
   let go =
       (~ctx=ctx, ~expects=TypExpectation.TypeExpected, t: Typ.t, m: Map.t) =>
-    utyp_to_info_map(~ctx, ~ancestors=ancestors_inclusive, ~expects, t, m);
+    utyp_to_info_map(
+      ~ctx,
+      ~ancestors=ancestors_inclusive,
+      ~expects,
+      ~generated_typfun_depth,
+      t,
+      m,
+    );
   switch (term) {
   | Unknown(Hole(MultiHole(tms))) =>
     let (_, _, m) = multi(~ctx, ~ancestors=ancestors_inclusive, m, tms);
@@ -4386,6 +4297,7 @@ and utyp_to_info_map =
            outer `TypFun` already accounts for that extra arrow in
            its own kind, so don't re-flag it here. */
         ~expects=AnyKindExpected,
+        ~generated_typfun_depth=Int.max(0, generated_typfun_depth - 1),
         m,
       )
       |> snd;

--- a/src/menhirParser/AST.re
+++ b/src/menhirParser/AST.re
@@ -78,7 +78,7 @@ type tpat =
   | InvalidTPat(string)
   | EmptyHoleTPat
   | VarTPat(string)
-  | ParamTPat(string, list(tpat))
+  | ParamTPat(tpat, list(tpat))
   | TupleTPat(list(tpat));
 
 [@deriving (show({with_path: false}), sexp, eq)]
@@ -331,7 +331,7 @@ let gen_tpat_binder: (~minimal_idents: bool) => QCheck.Gen.t(tpat) =
 
 /**
  * `tpat` for the head of a `type T(a, …) = body` declaration. May be
- * a plain `Var(name)` or `ParamTPat(name, params)` with each param a
+ * a plain `Var(name)` or `ParamTPat(Var(name), params)` with each param a
  * fresh distinct variable. `TupleTPat` is rejected at the alias
  * head, so it isn't generated here.
  */
@@ -345,7 +345,7 @@ let gen_tpat_alias: (~minimal_idents: bool) => QCheck.Gen.t(tpat) =
       let* len = int_range(1, 3);
       let+ params =
         list_size(return(len), map(x => VarTPat(x), gen_ident));
-      ParamTPat(head, params);
+      ParamTPat(VarTPat(head), params);
     };
     oneof([gen_var, gen_param]);
   };

--- a/src/menhirParser/Conversion.re
+++ b/src/menhirParser/Conversion.re
@@ -577,8 +577,8 @@ and TPat: {
     | InvalidTPat(s) => invalid(s)
     | EmptyHoleTPat => empty_hole()
     | VarTPat(s) => var(s)
-    | ParamTPat(name, params) =>
-      param(var(name), List.map(of_menhir_ast, params))
+    | ParamTPat(head, params) =>
+      param(of_menhir_ast(head), List.map(of_menhir_ast, params))
     | TupleTPat(tps) => tuple(List.map(of_menhir_ast, tps))
     };
   };
@@ -588,13 +588,7 @@ and TPat: {
     | EmptyHole => EmptyHoleTPat
     | Var(x) => VarTPat(x)
     | Param(head, params) =>
-      let name =
-        switch (head.term) {
-        | Var(x) => x
-        | Invalid(s) => s
-        | _ => "?"
-        };
-      ParamTPat(name, List.map(of_core, params));
+      ParamTPat(of_core(head), List.map(of_core, params))
     | Tuple(tps) => TupleTPat(List.map(of_core, tps))
     /* Parens are dropped on conversion to the Menhir AST (the
        round-trip tests compare syntactic shape without surface

--- a/src/menhirParser/Parser.mly
+++ b/src/menhirParser/Parser.mly
@@ -328,8 +328,7 @@ tpat:
     | TP_TPAT; s = STRING {InvalidTPat(s)}
     | p = PROJECTOR_INVOKE {InvalidTPat(p)}
     | QUESTION {EmptyHoleTPat}
-    | v = IDENT; OPEN_PAREN; ps = separated_list(COMMA, tpat); CLOSE_PAREN {ParamTPat(v, ps)}
-    | v = CONSTRUCTOR_IDENT; OPEN_PAREN; ps = separated_list(COMMA, tpat); CLOSE_PAREN {ParamTPat(v, ps)}
+    | head = tpat; OPEN_PAREN; ps = separated_list(COMMA, tpat); CLOSE_PAREN {ParamTPat(head, ps)}
     | v = IDENT {VarTPat v}
     | v = CONSTRUCTOR_IDENT {VarTPat v}
 
@@ -420,4 +419,3 @@ modItem:
 sigItem:
     | LET; p = pat { SigItemLet(p) }
     | TYP; tp = tpat; SINGLE_EQUAL; ty = typ { SigItemType(tp, ty) }
-

--- a/src/web/app/explainthis/ExplainThis.re
+++ b/src/web/app/explainthis/ExplainThis.re
@@ -3208,7 +3208,7 @@ let get_doc =
       };
     | TypFun(_, _) =>
       simple(
-        "This is an internal type-level function introduced by a parameterized type declaration.",
+        "`typfun` is an internal type function introduced by a parameterized type declaration; do not use it in surface syntax.",
       )
     | TypParamAp(callee, ty_arg) =>
       let callee_id = List.nth(IdTagged.ids(callee), 0);

--- a/src/web/app/explainthis/ExplainThis.re
+++ b/src/web/app/explainthis/ExplainThis.re
@@ -3208,7 +3208,7 @@ let get_doc =
       };
     | TypFun(_, _) =>
       simple(
-        "`typfun` is an internal type function introduced by a parameterized type declaration; do not use it in surface syntax.",
+        "`typfun` introduces a type-level function. It has a higher kind, so it can define a parameterized type alias but cannot be used where a proper type is expected.",
       )
     | TypParamAp(callee, ty_arg) =>
       let callee_id = List.nth(IdTagged.ids(callee), 0);

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -543,12 +543,6 @@ let typ_mark_err_view = (~globals, m: Mark.t) => {
       text(" type argument" ++ (expected == 1 ? "" : "s") ++ ", got "),
       code(string_of_int(actual)),
     ]
-  | TypFunNotSurfaceSyntax => [
-      code("typfun"),
-      text(
-        " is an internal type function; use a parameterized type alias instead",
-      ),
-    ]
   | TypWantConstructorFoundAp
   | TypWantConstructorFoundType(_) => [text("Expected a constructor")]
   | TypWantTypeFoundAp => [text("Must be part of a sum type")]

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -269,6 +269,7 @@ let core_mark_err_view =
     | TypParamApplyNonArrowKind(_)
     | TypParamApplyArityMismatch(_)
     | TypAbsApplyArityMismatch(_)
+    | TypFunNotSurfaceSyntax
     | TypDuplicateConstructor(_)
     | TypDuplicateLabels(_, _)
     | TypWantTypeFoundAp
@@ -543,6 +544,12 @@ let typ_mark_err_view = (~globals, m: Mark.t) => {
       text(" type argument" ++ (expected == 1 ? "" : "s") ++ ", got "),
       code(string_of_int(actual)),
     ]
+  | TypFunNotSurfaceSyntax => [
+      code("typfun"),
+      text(
+        " is an internal type function; use a parameterized type alias instead",
+      ),
+    ]
   | TypWantConstructorFoundAp
   | TypWantConstructorFoundType(_) => [text("Expected a constructor")]
   | TypWantTypeFoundAp => [text("Must be part of a sum type")]
@@ -768,6 +775,7 @@ let exp_mark_err_view =
   | TypKindMismatch(_)
   | TypParamApplyNonArrowKind(_)
   | TypParamApplyArityMismatch(_)
+  | TypFunNotSurfaceSyntax
   | TypDuplicateConstructor(_)
   | TypDuplicateLabels(_, _)
   | TypWantTypeFoundAp

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -543,6 +543,12 @@ let typ_mark_err_view = (~globals, m: Mark.t) => {
       text(" type argument" ++ (expected == 1 ? "" : "s") ++ ", got "),
       code(string_of_int(actual)),
     ]
+  | TypFunNotSurfaceSyntax => [
+      code("typfun"),
+      text(
+        " is an internal type function; use a parameterized type alias instead",
+      ),
+    ]
   | TypWantConstructorFoundAp
   | TypWantConstructorFoundType(_) => [text("Expected a constructor")]
   | TypWantTypeFoundAp => [text("Must be part of a sum type")]

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -902,7 +902,7 @@ map@<Int, Int>([1, 2, 3], fun x -> x * 2)
       )
     }),
     test_case(
-      "typfun is rejected in a type alias body",
+      "typfun is accepted in a type alias body",
       `Quick,
       () => {
         let marks =
@@ -912,11 +912,11 @@ type Option = typfun a -> + None + Some(a) in
 let x : Option(Int) = Some(3) in x
 |},
           );
-        check(
-          bool,
-          "typfun mark",
-          true,
-          has_mark(TypFunNotSurfaceSyntax, marks),
+        Alcotest.check(
+          list(testable_issue),
+          "no static errors",
+          [],
+          List.map(m => Marks([m]), marks),
         );
       },
     ),
@@ -936,6 +936,44 @@ let x : Option(Int) = Some(3) in x
           "no static errors",
           [],
           List.map(m => Marks([m]), marks),
+        );
+      },
+    ),
+    test_case(
+      "curried parameterized type aliases are accepted",
+      `Quick,
+      () => {
+        let marks =
+          static_errors(
+            {|
+type Pair(A)(B) = (A, B) in
+let x : Pair(Int)(String) = (1, "x") in x
+|},
+          );
+        Alcotest.check(
+          list(testable_issue),
+          "no static errors",
+          [],
+          List.map(m => Marks([m]), marks),
+        );
+      },
+    ),
+    test_case(
+      "typfun is rejected where an annotation expects a Type",
+      `Quick,
+      () => {
+        let marks = static_errors({|let x : typfun A -> A = ? in x|});
+        check(
+          bool,
+          "kind mismatch",
+          true,
+          has_mark(
+            TypKindMismatch({
+              expected: TypKind.Type,
+              actual: TypKind.Arrow([TypKind.Type], TypKind.Type),
+            }),
+            marks,
+          ),
         );
       },
     ),

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -977,6 +977,30 @@ let x : Pair(Int)(String) = (1, "x") in x
         );
       },
     ),
+    test_case(
+      "typfun is rejected inside a type alias body",
+      `Quick,
+      () => {
+        let marks =
+          static_errors(
+            {|
+type T = typfun A -> typfun B -> (A, typfun C -> C) in ?
+|},
+          );
+        check(
+          bool,
+          "kind mismatch",
+          true,
+          has_mark(
+            TypKindMismatch({
+              expected: TypKind.Type,
+              actual: TypKind.Arrow([TypKind.Type], TypKind.Type),
+            }),
+            marks,
+          ),
+        );
+      },
+    ),
     /* Regression: applying a multi-binder type abstraction
        `e@<Int>` (one arg) when its `Poly` expects two reports a
        focused error on the *type application* with result type

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -902,24 +902,73 @@ map@<Int, Int>([1, 2, 3], fun x -> x * 2)
       )
     }),
     test_case(
-      "single-parameter type aliases support application syntax",
+      "type T = typfun a -> body parses + checks like type T(a) = body",
       `Quick,
       () => {
-        let marks =
-          static_errors(
-            {|
+      Alcotest.check(
+        list(testable_issue),
+        "no static errors on type-level typfun alias body",
+        [],
+        static_errors(
+          {|
 type Option(a) = + None + Some(a) in
 let x : Option(Int) = Some(3) in x
 |},
-          );
-        Alcotest.check(
-          list(testable_issue),
-          "no static errors",
-          [],
-          List.map(m => Marks([m]), marks),
-        );
-      },
-    ),
+        )
+        |> List.map(ms => Marks([ms])),
+      )
+    }),
+    test_case(
+      "type-level multi-binder typfun: type Either = typfun a, b -> ...",
+      `Quick,
+      () => {
+      Alcotest.check(
+        list(testable_issue),
+        "no static errors on type-level multi-binder typfun",
+        [],
+        static_errors(
+          {|
+type Either(a, b) = + Left(a) + Right(b) in
+let x : Either(Int, Bool) = Right(true) in x
+|},
+        )
+        |> List.map(ms => Marks([ms])),
+      )
+    }),
+    test_case(
+      "type-level curried typfun: type T = typfun a -> typfun b -> ...",
+      `Quick,
+      () => {
+      Alcotest.check(
+        list(testable_issue),
+        "no static errors on curried typfun and curried application",
+        [],
+        static_errors(
+          {|
+type PResult(err)(ok) = + Error(err) + Ok(ok) in
+type R = PResult(String)(Bool) in
+let x : R = Ok(true) in x
+|},
+        )
+        |> List.map(ms => Marks([ms])),
+      )
+    }),
+    test_case(
+      "curried typfun supports partial type-level application", `Quick, () => {
+      Alcotest.check(
+        list(testable_issue),
+        "no static errors using a curried typfun's partial application",
+        [],
+        static_errors(
+          {|
+type PResult(err)(ok) = + Error(err) + Ok(ok) in
+type StringResult = PResult(String) in
+let x : StringResult(Int) = Ok(7) in x
+|},
+        )
+        |> List.map(ms => Marks([ms])),
+      )
+    }),
     test_case(
       "typfun is rejected in a type alias body",
       `Quick,
@@ -936,44 +985,6 @@ let x : Option(Int) = Some(3) in x
           "typfun mark",
           true,
           has_mark(TypFunNotSurfaceSyntax, marks),
-        );
-      },
-    ),
-    test_case(
-      "parameterized type aliases remain accepted",
-      `Quick,
-      () => {
-        let marks =
-          static_errors(
-            {|
-type Option(A) = + None + Some(A) in
-let x : Option(Int) = Some(3) in x
-|},
-          );
-        Alcotest.check(
-          list(testable_issue),
-          "no static errors",
-          [],
-          List.map(m => Marks([m]), marks),
-        );
-      },
-    ),
-    test_case(
-      "curried parameterized type aliases are accepted",
-      `Quick,
-      () => {
-        let marks =
-          static_errors(
-            {|
-type Pair(A)(B) = (A, B) in
-let x : Pair(Int)(String) = (1, "x") in x
-|},
-          );
-        Alcotest.check(
-          list(testable_issue),
-          "no static errors",
-          [],
-          List.map(m => Marks([m]), marks),
         );
       },
     ),
@@ -1192,23 +1203,21 @@ A
       },
     ),
     test_case(
-      "recursive parameterized type aliases support application syntax",
+      "type-level recursive typfun: type List = typfun a -> + Nil + Cons(a, List(a))",
       `Quick,
       () => {
-        let marks =
-          static_errors(
-            {|
+      Alcotest.check(
+        list(testable_issue),
+        "no static errors on recursive type-level typfun",
+        [],
+        static_errors(
+          {|
 type List(a) = + Nil + Cons(a, List(a)) in
 let xs : List(Int) = Cons((1, Nil)) in xs
 |},
-          );
-        Alcotest.check(
-          list(testable_issue),
-          "no static errors",
-          [],
-          List.map(m => Marks([m]), marks),
-        );
-      },
-    ),
+        )
+        |> List.map(ms => Marks([ms])),
+      )
+    }),
   ],
 );

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -902,7 +902,26 @@ map@<Int, Int>([1, 2, 3], fun x -> x * 2)
       )
     }),
     test_case(
-      "typfun is accepted in a type alias body",
+      "single-parameter type aliases support application syntax",
+      `Quick,
+      () => {
+        let marks =
+          static_errors(
+            {|
+type Option(a) = + None + Some(a) in
+let x : Option(Int) = Some(3) in x
+|},
+          );
+        Alcotest.check(
+          list(testable_issue),
+          "no static errors",
+          [],
+          List.map(m => Marks([m]), marks),
+        );
+      },
+    ),
+    test_case(
+      "typfun is rejected in a type alias body",
       `Quick,
       () => {
         let marks =
@@ -912,11 +931,11 @@ type Option = typfun a -> + None + Some(a) in
 let x : Option(Int) = Some(3) in x
 |},
           );
-        Alcotest.check(
-          list(testable_issue),
-          "no static errors",
-          [],
-          List.map(m => Marks([m]), marks),
+        check(
+          bool,
+          "typfun mark",
+          true,
+          has_mark(TypFunNotSurfaceSyntax, marks),
         );
       },
     ),
@@ -965,39 +984,9 @@ let x : Pair(Int)(String) = (1, "x") in x
         let marks = static_errors({|let x : typfun A -> A = ? in x|});
         check(
           bool,
-          "kind mismatch",
+          "typfun mark",
           true,
-          has_mark(
-            TypKindMismatch({
-              expected: TypKind.Type,
-              actual: TypKind.Arrow([TypKind.Type], TypKind.Type),
-            }),
-            marks,
-          ),
-        );
-      },
-    ),
-    test_case(
-      "typfun is rejected inside a type alias body",
-      `Quick,
-      () => {
-        let marks =
-          static_errors(
-            {|
-type T = typfun A -> typfun B -> (A, typfun C -> C) in ?
-|},
-          );
-        check(
-          bool,
-          "kind mismatch",
-          true,
-          has_mark(
-            TypKindMismatch({
-              expected: TypKind.Type,
-              actual: TypKind.Arrow([TypKind.Type], TypKind.Type),
-            }),
-            marks,
-          ),
+          has_mark(TypFunNotSurfaceSyntax, marks),
         );
       },
     ),
@@ -1203,31 +1192,23 @@ A
       },
     ),
     test_case(
-      "type-level recursive typfun: type List = typfun a -> + Nil + Cons(a, List(a))",
+      "recursive parameterized type aliases support application syntax",
       `Quick,
       () => {
-      /* Self-reference inside a type-level typfun body: the alias
-         name `List` is captured as a recursive reference (the
-         `Var` branch of TyAlias detects it via `free_vars` and
-         wraps in `Rec`), and `List(Int)` normalizes via the
-         higher-kinded reduction.
-
-         `+ Cons(a, List(a))` declares Cons with a single tuple
-         payload `(a, List(a))`, so applications are
-         `Cons((1, Nil))`. Same shape as the prefix-binder form
-         `type List(a) = …` test elsewhere in this file. */
-      Alcotest.check(
-        list(testable_issue),
-        "no static errors on recursive type-level typfun",
-        [],
-        static_errors(
-          {|
-type List = typfun a -> + Nil + Cons(a, List(a)) in
+        let marks =
+          static_errors(
+            {|
+type List(a) = + Nil + Cons(a, List(a)) in
 let xs : List(Int) = Cons((1, Nil)) in xs
 |},
-        )
-        |> List.map(ms => Marks([ms])),
-      )
-    }),
+          );
+        Alcotest.check(
+          list(testable_issue),
+          "no static errors",
+          [],
+          List.map(m => Marks([m]), marks),
+        );
+      },
+    ),
   ],
 );

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -977,7 +977,7 @@ let x : StringResult(Int) = Ok(7) in x
           static_errors(
             {|
 type Option = typfun a -> + None + Some(a) in
-let x : Option(Int) = Some(3) in x
+?
 |},
           );
         check(
@@ -985,6 +985,17 @@ let x : Option(Int) = Some(3) in x
           "typfun mark",
           true,
           has_mark(TypFunNotSurfaceSyntax, marks),
+        );
+        check(
+          bool,
+          "no kind errors",
+          false,
+          List.exists(
+            fun
+            | Mark.TypKindMismatch(_) => true
+            | _ => false,
+            marks,
+          ),
         );
       },
     ),
@@ -998,6 +1009,17 @@ let x : Option(Int) = Some(3) in x
           "typfun mark",
           true,
           has_mark(TypFunNotSurfaceSyntax, marks),
+        );
+        check(
+          bool,
+          "no kind errors",
+          false,
+          List.exists(
+            fun
+            | Mark.TypKindMismatch(_) => true
+            | _ => false,
+            marks,
+          ),
         );
       },
     ),

--- a/test/statics/Test_Statics_ParameterizedTypes.re
+++ b/test/statics/Test_Statics_ParameterizedTypes.re
@@ -901,96 +901,44 @@ map@<Int, Int>([1, 2, 3], fun x -> x * 2)
         |> List.map(ms => Marks([ms])),
       )
     }),
-    /* Type-level type function as the body of a type alias.
-       `type T = typfun a -> body` is the prefix-binder form of
-       `type T(a) = body` and should produce the same kind /
-       elaboration shape: `T` has kind `Type -> Type` and
-       `T(Int)` normalizes through the existing higher-kinded
-       reduction. */
     test_case(
-      "type T = typfun a -> body parses + checks like type T(a) = body",
+      "typfun is rejected in a type alias body",
       `Quick,
       () => {
-      Alcotest.check(
-        list(testable_issue),
-        "no static errors on type-level typfun alias body",
-        [],
-        static_errors(
-          {|
+        let marks =
+          static_errors(
+            {|
 type Option = typfun a -> + None + Some(a) in
 let x : Option(Int) = Some(3) in x
 |},
-        )
-        |> List.map(ms => Marks([ms])),
-      )
-    }),
+          );
+        check(
+          bool,
+          "typfun mark",
+          true,
+          has_mark(TypFunNotSurfaceSyntax, marks),
+        );
+      },
+    ),
     test_case(
-      "type-level multi-binder typfun: type Either = typfun a, b -> ...",
+      "parameterized type aliases remain accepted",
       `Quick,
       () => {
-      Alcotest.check(
-        list(testable_issue),
-        "no static errors on type-level multi-binder typfun",
-        [],
-        static_errors(
-          {|
-type Either = typfun a, b -> + Left(a) + Right(b) in
-let x : Either(Int, Bool) = Right(true) in x
+        let marks =
+          static_errors(
+            {|
+type Option(A) = + None + Some(A) in
+let x : Option(Int) = Some(3) in x
 |},
-        )
-        |> List.map(ms => Marks([ms])),
-      )
-    }),
-    /* Curried `typfun a -> typfun b -> body` keeps each unary
-       `TypFun` distinct: the alias has the *curried* kind
-       `Type -> Type -> kind(body)` (rather than the tuple-arrow
-       `(Type, Type) -> Type` of the multi-binder form
-       `typfun a, b -> body`). Applying it one argument at a time
-       must succeed at every prefix:
-         T(String) :: Type -> Type
-         T(String)(Exp) :: Type
-       The previous implementation aggressively flattened the
-       curried chain into a multi-binder `TypFun(Tuple([a, b]), body)`,
-       which gave `T` kind `(Type, Type) -> Type` and rejected the
-       partial application `T(String)` as an arity error. */
-    test_case(
-      "type-level curried typfun: type T = typfun a -> typfun b -> ...",
-      `Quick,
-      () => {
-      Alcotest.check(
-        list(testable_issue),
-        "no static errors on curried typfun and curried application",
-        [],
-        static_errors(
-          {|
-type PResult = typfun err -> typfun ok -> + Error(err) + Ok(ok) in
-type R = PResult(String)(Bool) in
-let x : R = Ok(true) in x
-|},
-        )
-        |> List.map(ms => Marks([ms])),
-      )
-    }),
-    /* Companion to the curried-typfun test: the *partial*
-       application `PResult(String)` (without the second arg) must
-       have kind `Type -> Type`. Used as a type alias body, it
-       defines a new unary type constructor. */
-    test_case(
-      "curried typfun supports partial type-level application", `Quick, () => {
-      Alcotest.check(
-        list(testable_issue),
-        "no static errors using a curried typfun's partial application",
-        [],
-        static_errors(
-          {|
-type PResult = typfun err -> typfun ok -> + Error(err) + Ok(ok) in
-type StringResult = PResult(String) in
-let x : StringResult(Int) = Ok(7) in x
-|},
-        )
-        |> List.map(ms => Marks([ms])),
-      )
-    }),
+          );
+        Alcotest.check(
+          list(testable_issue),
+          "no static errors",
+          [],
+          List.map(m => Marks([m]), marks),
+        );
+      },
+    ),
     /* Regression: applying a multi-binder type abstraction
        `e@<Int>` (one arg) when its `Poly` expects two reports a
        focused error on the *type application* with result type

--- a/test/statics/Test_Statics_Prelude.re
+++ b/test/statics/Test_Statics_Prelude.re
@@ -106,7 +106,6 @@ let rec equal_mark: (Mark.t, Mark.t) => bool =
     | (BadTheorem(t1), BadTheorem(t2)) => Typ.fast_equal(t1, t2)
     | (Redundant, Redundant) => true
     | (ExpectedConstructor, ExpectedConstructor) => true
-    | (TypFunNotSurfaceSyntax, TypFunNotSurfaceSyntax) => true
     | (TypFreeTypeVariable(a), TypFreeTypeVariable(b)) => a == b
     | (
         TypKindMismatch({expected: e1, actual: a1}),

--- a/test/statics/Test_Statics_Prelude.re
+++ b/test/statics/Test_Statics_Prelude.re
@@ -106,6 +106,7 @@ let rec equal_mark: (Mark.t, Mark.t) => bool =
     | (BadTheorem(t1), BadTheorem(t2)) => Typ.fast_equal(t1, t2)
     | (Redundant, Redundant) => true
     | (ExpectedConstructor, ExpectedConstructor) => true
+    | (TypFunNotSurfaceSyntax, TypFunNotSurfaceSyntax) => true
     | (TypFreeTypeVariable(a), TypFreeTypeVariable(b)) => a == b
     | (
         TypKindMismatch({expected: e1, actual: a1}),


### PR DESCRIPTION
Disallowing typfun in the surface syntax as mentioned in #2254. The actual missing errors when using typfun explicitly where proper types are expected is fixed instead in #2401 

Adds curried type function syntax for `type T(A)(B) = L(A) + R(B)` etc. to allow writing curried types