### PR TITLE
Single Source of Truth For Undo

### DIFF
--- a/src/web/Settings.re
+++ b/src/web/Settings.re
@@ -174,13 +174,6 @@ module Update = {
     | ShowRowLines
     | ShowIncrementalDeco;
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | Evaluation(ShowSettings) => false
-    | _ => true
-    };
-  };
-
   let update = (~action, ~settings: Model.t): Updated.t(Model.t) => {
     (
       switch (action) {
@@ -484,7 +477,14 @@ module Update = {
         }
       }
     )
-    |> Updated.return(~scroll_active=false);
+    |> Updated.return(
+         ~scroll_active=false,
+         ~historic=
+           switch (action) {
+           | Evaluation(ShowSettings) => false
+           | _ => true
+           },
+       );
   };
 };
 

--- a/src/web/Updated.re
+++ b/src/web/Updated.re
@@ -7,7 +7,7 @@ type t('a) = {
   recalculate: bool, // Should the editor recalculate after this action?
   scroll_active: bool, // Should the editor scroll to the cursor after this action?
   logged: bool, // Should this action be logged?
-  historic: bool // Should this action be undoable?
+  historic: bool // Should this action be undoable? (consumed by History.re to gate undo-stack pushes)
 };
 
 let ( let* ) = (updated: t('a), f) => {

--- a/src/web/app/History.re
+++ b/src/web/app/History.re
@@ -94,7 +94,7 @@ module Update = {
           action,
           model.current,
         );
-      if (Page.Update.can_undo(action)) {
+      if (current.historic) {
         let new_stack = [
           {
             ...current,

--- a/src/web/app/Page.re
+++ b/src/web/app/Page.re
@@ -374,7 +374,7 @@ module Update = {
         ...model,
         selection,
       }
-      |> Updated.return(~is_edit=false, ~scroll_active=false)
+      |> Updated.return(~is_edit=false, ~scroll_active=false, ~historic=false)
     | Benchmark(Start) =>
       List.iter(a => schedule_action(Editors(a)), Benchmark.actions_1);
       schedule_action(Benchmark(Finish));
@@ -384,24 +384,11 @@ module Update = {
       Benchmark.finish();
       model |> Updated.return_quiet;
     | Refresh => model |> Updated.return_quiet(~recalculate=true)
-    | Start => model |> return // Triggers recalculation at the start
+    | Start => model |> return(~historic=false) // Triggers recalculation at the start
     | Save =>
       print_endline("Saving...");
       Store.save(model);
       model |> return_quiet;
-    };
-  };
-
-  let can_undo = (action: t) => {
-    switch (action) {
-    | Globals(action) => Globals.Update.can_undo(action)
-    | Editors(action) => Editors.Update.can_undo(action)
-    | ExplainThis(action) => ExplainThisUpdate.can_undo(action)
-    | MakeActive(_)
-    | Benchmark(_) => false
-    | Refresh => false
-    | Start => false
-    | Save => false
     };
   };
 

--- a/src/web/app/editors/Editors.re
+++ b/src/web/app/editors/Editors.re
@@ -191,15 +191,6 @@ module Update = {
     // Exercises
     | Exercises(ExercisesMode.Update.t);
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | SwitchMode(_) => true
-    | Scratch(action) => ScratchMode.Update.can_undo(action)
-    | Tutorial(action) => TutorialsMode.Update.can_undo(action)
-    | Exercises(action) => ExercisesMode.Update.can_undo(action)
-    };
-  };
-
   let update =
       (
         ~globals: Globals.t,

--- a/src/web/app/editors/cell/CellEditor.re
+++ b/src/web/app/editors/cell/CellEditor.re
@@ -52,13 +52,6 @@ module Update = {
     | MainEditor(CodeEditable.Update.t)
     | ResultAction(EvalResult.Update.t);
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | MainEditor(action) => CodeEditable.Update.can_undo(action)
-    | ResultAction(action) => EvalResult.Update.can_undo(action)
-    };
-  };
-
   let update = (~settings, action, model: Model.t) => {
     switch (action) {
     | MainEditor(action) =>

--- a/src/web/app/editors/code/CodeEditable.re
+++ b/src/web/app/editors/code/CodeEditable.re
@@ -19,15 +19,6 @@ module Update = {
 
   exception CantReset;
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | Perform(action) => Action.is_historic(action)
-    | TAB => true
-    | ContextMenu(_) => false
-    | DebugConsole(_) => false
-    };
-  };
-
   let update =
       (~settings: Settings.t, action: t, model: Model.t): Updated.t(Model.t) => {
     let perform = (action: Action.t, model: Model.t) =>
@@ -50,6 +41,7 @@ module Update = {
         | Error(err) => raise(Action.Failure.Exception(err))
       )
       |> Updated.return(
+           ~historic=Action.is_historic(action),
            ~is_edit=
              Action.is_edit(action)
              /* When probe_all is on, Refractor actions don't require

--- a/src/web/app/editors/code/CodeSelectable.re
+++ b/src/web/app/editors/code/CodeSelectable.re
@@ -15,15 +15,6 @@ module Update = {
     | Unselect(option(Util.Direction.t))
     | Copy;
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | Move(move) => Action.is_historic(Move(move))
-    | Select(select) => Action.is_historic(Select(select))
-    | Unselect(dir) => Action.is_historic(Unselect(dir))
-    | Copy => false
-    };
-  };
-
   let update = (~settings, action: t, model: Model.t): Updated.t(Model.t) => {
     let action': CodeEditable.Update.t =
       switch (action) {

--- a/src/web/app/editors/mode/ExercisesMode.re
+++ b/src/web/app/editors/mode/ExercisesMode.re
@@ -369,18 +369,6 @@ module Update = {
     | ExportModule
     | ExportSubmission
     | ExportTransitionary;
-
-  let can_undo = (action: t) => {
-    switch (action) {
-    | SwitchExercise(_) => false
-    | Exercise(action) => CodeExerciseMode.Update.can_undo(action)
-    | Derivation(action) => DerivationExerciseMode.Update.can_undo(action)
-    | TheoremExercise(action) => TheoremExerciseMode.Update.can_undo(action)
-    | ExportModule => false
-    | ExportSubmission => false
-    | ExportTransitionary => false
-    };
-  };
   let export_exercise_module = (exercises: Model.t): unit => {
     let exercise = Model.get_current(exercises);
     let module_name =
@@ -484,7 +472,7 @@ module Update = {
         current: n,
         exercises: model.exercises,
       }
-      |> return;
+      |> return(~historic=false);
     | (_, ExportModule) =>
       Store.save(~instructor_mode=globals.settings.instructor_mode, model);
       export_exercise_module(model);

--- a/src/web/app/editors/mode/TutorialsMode.re
+++ b/src/web/app/editors/mode/TutorialsMode.re
@@ -183,16 +183,6 @@ module Update = {
     | ExportSubmission
     | ExportTransitionary;
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | SwitchExercise(_) => false
-    | Tutorial(action) => TutorialMode.Update.can_undo(action)
-    | ExportModule => false
-    | ExportSubmission => false
-    | ExportTransitionary => false
-    };
-  };
-
   let export_exercise_module = (exercises: Model.t): unit => {
     let exercise = Model.get_current(exercises);
     let module_name = exercise.editors.module_name;
@@ -237,7 +227,7 @@ module Update = {
           mod List.length(model.exercises),
         exercises: model.exercises,
       }
-      |> return;
+      |> return(~historic=false);
     | Tutorial(TutorialMode.Update.MoveToPrevExercise) =>
       WorkerClient.cancel();
       Model.{
@@ -246,7 +236,7 @@ module Update = {
           mod List.length(model.exercises),
         exercises: model.exercises,
       }
-      |> return;
+      |> return(~historic=false);
 
     | Tutorial(action) =>
       let current = List.nth(model.exercises, model.current);
@@ -269,7 +259,7 @@ module Update = {
         current: n,
         exercises: model.exercises,
       }
-      |> return;
+      |> return(~historic=false);
     | ExportModule =>
       Store.save(~instructor_mode=globals.settings.instructor_mode, model);
       export_exercise_module(model);

--- a/src/web/app/editors/result/EvalResult.re
+++ b/src/web/app/editors/result/EvalResult.re
@@ -136,18 +136,6 @@ module Update = {
     | MergeStreamingEval(IncrEval.outbox(EvaluatorState.t))
     | TheoremsAction(Theorems.Update.t);
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | ToggleStepper => true
-    | StepperAction(action) => StepperView.Update.can_undo(action)
-    | EvalEditorAction(action) => CodeSelectable.Update.can_undo(action)
-    | UpdateResult(_) => false
-    | UpdateStreamingEval(_)
-    | MergeStreamingEval(_) => false
-    | TheoremsAction(action) => Theorems.Update.can_undo(action)
-    };
-  };
-
   // Update is meant to make minimal changes to the model, and calculate will do the rest.
   let update = (~settings, action, model: Model.t): Updated.t(Model.t) =>
     switch (action, model) {

--- a/src/web/app/editors/result/StepperEditor.re
+++ b/src/web/app/editors/result/StepperEditor.re
@@ -32,8 +32,6 @@ module Update = {
     };
   };
 
-  let can_undo = CodeSelectable.Update.can_undo;
-
   let calculate =
       (
         ~settings,

--- a/src/web/app/editors/result/Theorems.re
+++ b/src/web/app/editors/result/Theorems.re
@@ -95,12 +95,6 @@ module Update = {
   type t =
     | TheoremUpdate(int, StepperView.Update.t);
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | TheoremUpdate(_, action) => StepperView.Update.can_undo(action)
-    };
-  };
-
   let update = (~settings, action, model: Model.t): Updated.t(Model.t) => {
     let settings =
       Settings.Model.{

--- a/src/web/app/editors/stepper/AlgebriteStep.re
+++ b/src/web/app/editors/stepper/AlgebriteStep.re
@@ -76,8 +76,6 @@ module F =
     | _ => .
     };
 
-  let can_undo = _ => false;
-
   let calculate =
       (
         ~settings as _: Calc.t(CoreSettings.t),

--- a/src/web/app/editors/stepper/AxiomStep.re
+++ b/src/web/app/editors/stepper/AxiomStep.re
@@ -84,8 +84,6 @@ module F =
     | _ => .
     };
 
-  let can_undo = _ => false;
-
   let calculate =
       (
         ~settings as _: Calc.t(CoreSettings.t),

--- a/src/web/app/editors/stepper/ForallStep.re
+++ b/src/web/app/editors/stepper/ForallStep.re
@@ -84,11 +84,6 @@ module F =
     );
   };
 
-  let can_undo = (a: action) =>
-    switch (a) {
-    | InnerExp(step) => Stepper.can_undo(step)
-    };
-
   let calculate =
       (
         ~settings: Calc.t(CoreSettings.t),

--- a/src/web/app/editors/stepper/InductionCase.re
+++ b/src/web/app/editors/stepper/InductionCase.re
@@ -91,12 +91,6 @@ module F = (Stepper: STEPPER) => {
     );
   };
 
-  let can_undo = a =>
-    switch (a) {
-    | PatternUpdate(action) => CodeEditable.Update.can_undo(action)
-    | StepUpdate(action) => Stepper.can_undo(action)
-    };
-
   let calculate =
       (
         ~settings: Calc.t(CoreSettings.t),

--- a/src/web/app/editors/stepper/InductionStep.re
+++ b/src/web/app/editors/stepper/InductionStep.re
@@ -162,14 +162,6 @@ module F =
     );
   };
 
-  let can_undo = a =>
-    switch (a) {
-    | ScrutUpdate(action) => CodeEditable.Update.can_undo(action)
-    | CaseUpdate(_, action) => InductionCase.can_undo(action)
-    | AddCase => true
-    | RemoveCase(_) => true
-    };
-
   let calculate =
       (
         ~settings: Calc.t(CoreSettings.t),

--- a/src/web/app/editors/stepper/MissingStep.re
+++ b/src/web/app/editors/stepper/MissingStep.re
@@ -131,16 +131,6 @@ module Update = {
     };
   };
 
-  let can_undo = (action: t): bool => {
-    switch (action) {
-    | ToggleAxioms
-    | ProposeRewrite
-    | UpdateResult(_)
-    | RewriteEditorAction(_)
-    | AxiomBoxAction(_) => false
-    };
-  };
-
   let calculate =
       (
         ~settings,

--- a/src/web/app/editors/stepper/SingleStep.re
+++ b/src/web/app/editors/stepper/SingleStep.re
@@ -68,8 +68,6 @@ module F =
     | _ => .
     };
 
-  let can_undo = _ => false;
-
   let calculate =
       (
         ~settings: Calc.t(CoreSettings.t),

--- a/src/web/app/editors/stepper/StepInterface.re
+++ b/src/web/app/editors/stepper/StepInterface.re
@@ -17,8 +17,6 @@ module type STEP = {
 
   let update: (~settings: Settings.t, action, model) => Updated.t(model);
 
-  let can_undo: action => bool;
-
   let calculate:
     (
       ~settings: Calc.t(CoreSettings.t),
@@ -87,8 +85,6 @@ module type STEPPER = {
   let unpersist: persistent => model;
 
   let update: (~settings: Settings.t, action, model) => Updated.t(model);
-
-  let can_undo: action => bool;
 
   let calculate:
     (

--- a/src/web/app/editors/stepper/StepperBase.re
+++ b/src/web/app/editors/stepper/StepperBase.re
@@ -178,17 +178,6 @@ module rec StepKind: {
     );
   };
 
-  let can_undo = (a: action): bool => {
-    switch (a) {
-    | SingleStep(action) => SingleStep.can_undo(action)
-    | InductionStep(action) => InductionStep.can_undo(action)
-    | ForallStep(action) => ForallStep.can_undo(action)
-    | MissingStep(action) => MissingStep.Update.can_undo(action)
-    | AxiomStep(action) => AxiomStep.can_undo(action)
-    | AlgebriteStep(action) => AlgebriteStep.can_undo(action)
-    };
-  };
-
   let rec calculate =
           (
             ~settings: Calc.t(CoreSettings.t),
@@ -732,20 +721,6 @@ and Stepper: {
         };
       }
     );
-  };
-
-  let rec can_undo = (a: step_action): bool => {
-    switch (a) {
-    | EditorAction(action) => CodeSelectable.Update.can_undo(action)
-    | NextStep(next) => can_undo(next)
-    | RemoveStep => true
-    | StepForward(_) => true
-    | AddInduction(_) => true
-    | AddForall => true
-    | AddAxiomStep(_) => true
-    | AddAlgebriteStep(_) => true
-    | StepKindAction(action) => StepKind.can_undo(action)
-    };
   };
 
   let rec calculate =

--- a/src/web/app/explainthis/ExplainThisUpdate.re
+++ b/src/web/app/explainthis/ExplainThisUpdate.re
@@ -9,15 +9,6 @@ type update =
   | ToggleExampleFeedback(group_id, form_id, example_id, feedback_option)
   | UpdateGroupSelection(group_id, form_id);
 
-let can_undo = (action: update) => {
-  switch (action) {
-  | SpecificityOpen(_) => false
-  | ToggleExplanationFeedback(_) => false
-  | ToggleExampleFeedback(_) => false
-  | UpdateGroupSelection(_) => false
-  };
-};
-
 let set_update =
     (explainThisModel: ExplainThisModel.t, u: update)
     : Updated.t(ExplainThisModel.t) => {

--- a/src/web/app/globals/Globals.re
+++ b/src/web/app/globals/Globals.re
@@ -147,27 +147,6 @@ module Update = {
     ...model,
     color_highlights,
   };
-
-  let can_undo = (action: t) => {
-    switch (action) {
-    | SetFontMetrics(_) => false
-    | Set(action) => Settings.Update.can_undo(action)
-    | SetAgentGlobals(_) => true
-    | JumpToTile(_) => false
-    | InitImportAll(_) => true
-    | FinishImportAll(_) => true
-    | ExportForInit => false
-    | ActiveEditor(_) => false
-    | Undo => false
-    | Redo => false
-    | SetMetaDown(_) => false
-    | UpdateVisibleRows(_) => false
-    | Log(_) => false
-    | RethrowException => false
-    | ClearException => false
-    | RestoreLastKnownGood => false
-    };
-  };
 };
 
 type t = Model.t;

--- a/src/web/view/CodeExerciseMode.re
+++ b/src/web/view/CodeExerciseMode.re
@@ -314,20 +314,14 @@ module Update = {
       (~settings: Settings.t, action: instructor, model: Model.t)
       : Updated.t(Model.t) =>
     if (settings.instructor_mode) {
-      instructor_update(action, model);
+      {
+        /* Instructor form edits are not undoable */
+        ...instructor_update(action, model),
+        historic: false,
+      };
     } else {
       Updated.return_quiet(model);
     };
-
-  let can_undo = (action: t) => {
-    switch (action) {
-    | Editor(_, action) => CellEditor.Update.can_undo(action)
-    | RefreshStatics => false
-    | ResetEditor(_) => true
-    | ResetExercise => true
-    | Instructor(_) => false
-    };
-  };
 
   let update =
       (~settings: Settings.t, ~schedule_action as _, action, model: Model.t)

--- a/src/web/view/CodeExerciseMode.re
+++ b/src/web/view/CodeExerciseMode.re
@@ -314,11 +314,7 @@ module Update = {
       (~settings: Settings.t, action: instructor, model: Model.t)
       : Updated.t(Model.t) =>
     if (settings.instructor_mode) {
-      {
-        /* Instructor form edits are not undoable */
-        ...instructor_update(action, model),
-        historic: false,
-      };
+      instructor_update(action, model);
     } else {
       Updated.return_quiet(model);
     };

--- a/src/web/view/DerivationExerciseMode.re
+++ b/src/web/view/DerivationExerciseMode.re
@@ -270,11 +270,7 @@ module Update = {
       (~settings: Settings.t, action: instructor, model: Model.t)
       : Updated.t(Model.t) =>
     if (settings.instructor_mode) {
-      {
-        /* Instructor form edits are not undoable */
-        ...instructor_update(action, model),
-        historic: false,
-      };
+      instructor_update(action, model);
     } else {
       Updated.return_quiet(model);
     };

--- a/src/web/view/DerivationExerciseMode.re
+++ b/src/web/view/DerivationExerciseMode.re
@@ -211,16 +211,6 @@ module Update = {
     | Refresh
     | ResetExercise;
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | Editor(_, action) => CellEditor.Update.can_undo(action)
-    | MapEditor(_) => true
-    | Instructor(_) => false
-    | Refresh => false
-    | ResetExercise => false
-    };
-  };
-
   let instructor_update =
       (action: instructor, model: Model.t): Updated.t(Model.t) => {
     switch (action) {
@@ -280,7 +270,11 @@ module Update = {
       (~settings: Settings.t, action: instructor, model: Model.t)
       : Updated.t(Model.t) =>
     if (settings.instructor_mode) {
-      instructor_update(action, model);
+      {
+        /* Instructor form edits are not undoable */
+        ...instructor_update(action, model),
+        historic: false,
+      };
     } else {
       Updated.return_quiet(model);
     };
@@ -393,7 +387,7 @@ module Update = {
       }
       |> Updated.return;
     | Instructor(action) => instructor_update(~settings, action, model)
-    | Refresh => Updated.return(model)
+    | Refresh => Updated.return(~historic=false, model)
     | ResetExercise =>
       let new_editors =
         DerivationExercise.mapi(model.spec, pos =>

--- a/src/web/view/ScratchMode.re
+++ b/src/web/view/ScratchMode.re
@@ -567,25 +567,6 @@ module Update = {
     | RenameSlide
     | DeleteSlide;
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | CellAction(action) => CellEditor.Update.can_undo(action)
-    | RefreshStatics => false
-    | AgentAction(_) => true
-    | DrvAction(action) => DerivationExerciseMode.Update.can_undo(action)
-    | SwitchSlide(_) => false
-    | ResetCurrent => true
-    | InitImportScratchpad(_) => true
-    | FinishImportScratchpad(_) => false
-    | Export => false
-    | Encode => false
-    | AddSlide => true
-    | AddDrvSlide => true
-    | DeleteSlide => true
-    | RenameSlide => true
-    };
-  };
-
   let export_scratch_slide = (model: Model.t): unit => {
     let scratchpad = List.nth(model.scratchpads, model.current);
     switch (scratchpad.kind) {
@@ -803,7 +784,7 @@ module Update = {
       model |> Updated.return_quiet(~recalculate=true);
     | SwitchSlide(i) =>
       WorkerClient.cancel();
-      let* current = i |> Updated.return;
+      let* current = i |> Updated.return(~historic=false);
       Persist.hydrate_current(
         ~settings=settings.core,
         is_documentation ? "doc" : "scratch",

--- a/src/web/view/StepperView.re
+++ b/src/web/view/StepperView.re
@@ -74,8 +74,6 @@ module Update = {
       root,
     };
   };
-
-  let can_undo = StepperBase.Stepper.can_undo;
 };
 
 module Focus = {

--- a/src/web/view/TheoremExerciseMode.re
+++ b/src/web/view/TheoremExerciseMode.re
@@ -188,11 +188,7 @@ module Update = {
       (~settings: Settings.t, action: instructor, model: Model.t)
       : Updated.t(Model.t) =>
     if (settings.instructor_mode) {
-      {
-        /* Instructor form edits are not undoable */
-        ...instructor_update(action, model),
-        historic: false,
-      };
+      instructor_update(action, model);
     } else {
       Updated.return_quiet(model);
     };

--- a/src/web/view/TheoremExerciseMode.re
+++ b/src/web/view/TheoremExerciseMode.re
@@ -188,7 +188,11 @@ module Update = {
       (~settings: Settings.t, action: instructor, model: Model.t)
       : Updated.t(Model.t) =>
     if (settings.instructor_mode) {
-      instructor_update(action, model);
+      {
+        /* Instructor form edits are not undoable */
+        ...instructor_update(action, model),
+        historic: false,
+      };
     } else {
       Updated.return_quiet(model);
     };
@@ -279,16 +283,6 @@ module Update = {
     | RefreshStatics =>
       CodeWithStatics.StaticsDebounce.force_on_next := true;
       model |> Updated.return_quiet(~recalculate=true);
-    };
-  };
-
-  let can_undo = (action: t): bool => {
-    switch (action) {
-    | Instructor(_) => false
-    | Prelude(action) => CellEditor.Update.can_undo(action)
-    | Lemmas(action) => CellEditor.Update.can_undo(action)
-    | Theorem(action) => CellEditor.Update.can_undo(action)
-    | RefreshStatics => false
     };
   };
 

--- a/src/web/view/TutorialMode.re
+++ b/src/web/view/TutorialMode.re
@@ -231,18 +231,6 @@ module Update = {
     };
   };
 
-  let can_undo = (action: t) => {
-    switch (action) {
-    | Editor(_, action) => CellEditor.Update.can_undo(action)
-    | RefreshStatics => false
-    | ResetEditor(_) => true
-    | ResetTutorial => true
-    | MoveToNextExercise
-    | MoveToPrevExercise
-    | Change_report_view => false
-    };
-  };
-
   let calculate =
       (~settings, ~is_edited, ~schedule_action, model: Model.t): Model.t => {
     let statics_mode =

--- a/test/Test_Undo.re
+++ b/test/Test_Undo.re
@@ -1,0 +1,183 @@
+open Alcotest;
+open Web;
+
+/* Integration tests for the page-level undo/redo mechanics in History.re.
+ * These drive History.Update.update with real page actions, the same code
+ * path the UI uses (Globals(ActiveEditor(_)) for edits, Globals(Undo/Redo)
+ * for history navigation). */
+
+let mk_model = (): History.Model.t => {
+  let globals = Globals.Model.init();
+  let (default_current, slides) = Lazy.force(Init.startup).scratch;
+  let default_names = List.map(fst, slides);
+  let scratch =
+    ScratchMode.Persist.load_all(
+      "scratch",
+      ~settings=globals.settings.core,
+      ~default_names,
+      ~default_current,
+    );
+  let editors: Editors.Model.t = Scratch(scratch);
+  let page: Page.Model.t = {
+    globals,
+    editors,
+    explain_this: ExplainThisModel.init,
+    selection: Editors.Selection.default_selection(editors),
+  };
+  {
+    current: page,
+    undo_stack: [],
+    redo_stack: [],
+  };
+};
+
+let apply = (model: History.Model.t, action: Page.Update.t): History.Model.t =>
+  History.Update.update(
+    ~import_log=_ => (),
+    ~get_log_and=_ => (),
+    ~schedule_action=_ => (),
+    action,
+    model,
+  ).
+    model;
+
+let insert = (s: string): Page.Update.t =>
+  Globals(ActiveEditor(Insert(s)));
+let move_right: Page.Update.t =
+  Globals(ActiveEditor(Move(Local(Right, ByChar))));
+let undo: Page.Update.t = Globals(Undo);
+let redo: Page.Update.t = Globals(Redo);
+
+let text_of = (model: History.Model.t): string =>
+  Page.Update.get_editor(model.current).editor.state.zipper
+  |> Haz3lcore.Zipper.zip
+  |> Haz3lcore.Printer.of_segment(~holes="?", ~refractors=[]);
+
+let undo_len = (model: History.Model.t) => List.length(model.undo_stack);
+let redo_len = (model: History.Model.t) => List.length(model.redo_stack);
+
+let tests = (
+  "Undo",
+  [
+    test_case(
+      "edit then undo restores the original state",
+      `Quick,
+      () => {
+        let m0 = mk_model();
+        let t0 = text_of(m0);
+        let m1 = apply(m0, insert("1"));
+        check(bool, "insert changed the program", true, text_of(m1) != t0);
+        check(int, "edit pushed one undo entry", 1, undo_len(m1));
+        let m2 = apply(m1, undo);
+        check(string, "undo restores original text", t0, text_of(m2));
+        check(
+          bool,
+          "undo restores the exact pre-edit model",
+          true,
+          m2.current === m0.current,
+        );
+        check(int, "undo stack is empty again", 0, undo_len(m2));
+        check(int, "undone edit moved to redo stack", 1, redo_len(m2));
+      },
+    ),
+    test_case(
+      "undo does not undo the undo",
+      `Quick,
+      () => {
+        let m0 = mk_model();
+        let t0 = text_of(m0);
+        let m1 = apply(m0, insert("1"));
+        let t1 = text_of(m1);
+        let m2 = apply(m1, insert("2"));
+        check(int, "two edits pushed two undo entries", 2, undo_len(m2));
+        let m3 = apply(m2, undo);
+        check(
+          string,
+          "first undo returns to the intermediate state",
+          t1,
+          text_of(m3),
+        );
+        /* If undo were itself historic, this second undo would bounce
+         * forward to the post-"2" state instead of walking further back. */
+        let m4 = apply(m3, undo);
+        check(
+          string,
+          "second undo keeps walking back to the original",
+          t0,
+          text_of(m4),
+        );
+        check(int, "undo stack is empty", 0, undo_len(m4));
+        check(int, "both edits are on the redo stack", 2, redo_len(m4));
+      },
+    ),
+    test_case(
+      "undo with no history is rejected and changes nothing",
+      `Quick,
+      () => {
+        let m0 = mk_model();
+        switch (apply(m0, undo)) {
+        | _ => fail("undo on an empty stack should raise InvalidAction")
+        | exception Updated.InvalidAction => ()
+        };
+      },
+    ),
+    test_case(
+      "redo restores the undone edit",
+      `Quick,
+      () => {
+        let m0 = mk_model();
+        let m1 = apply(m0, insert("1"));
+        let t1 = text_of(m1);
+        let m2 = apply(m1, undo);
+        let m3 = apply(m2, redo);
+        check(string, "redo restores the edited text", t1, text_of(m3));
+        check(
+          bool,
+          "redo restores the exact post-edit model",
+          true,
+          m3.current === m1.current,
+        );
+        check(int, "redo moved the entry back to undo", 1, undo_len(m3));
+        check(int, "redo stack is empty again", 0, redo_len(m3));
+        switch (apply(m3, redo)) {
+        | _ => fail("redo with nothing to redo should raise InvalidAction")
+        | exception Updated.InvalidAction => ()
+        };
+      },
+    ),
+    test_case(
+      "a new edit clears the redo stack",
+      `Quick,
+      () => {
+        let m0 = mk_model();
+        let m1 = apply(m0, insert("1"));
+        let m2 = apply(m1, undo);
+        check(int, "undo left a redo entry", 1, redo_len(m2));
+        let m3 = apply(m2, insert("2"));
+        check(int, "new edit cleared the redo stack", 0, redo_len(m3));
+        check(int, "new edit pushed an undo entry", 1, undo_len(m3));
+      },
+    ),
+    test_case(
+      "non-historic actions leave both stacks untouched",
+      `Quick,
+      () => {
+        let m0 = mk_model();
+        let m1 = apply(m0, insert("1"));
+        let t1 = text_of(m1);
+        let m2 = apply(m1, undo);
+        /* Caret movement is not historic (Action.is_historic) */
+        let m3 = apply(m2, move_right);
+        check(int, "move did not push an undo entry", 0, undo_len(m3));
+        check(int, "move preserved the redo stack", 1, redo_len(m3));
+        let m4 = apply(m3, redo);
+        check(
+          string,
+          "redo still works after a non-historic action",
+          t1,
+          text_of(m4),
+        );
+      },
+    ),
+  ],
+);

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -15,6 +15,7 @@ let (suite, _) =
     "HazelTests",
     [
       Test_LazyHydration.tests,
+      Test_Undo.tests,
       Test_FastParseCorpus.tests,
       Test_FastParse.tests,
       Test_MenhirFuzz.tests,


### PR DESCRIPTION
Every Update module carried two encodings of "should this action be undoable": the `historic` field each update returns via `Updated.return`/`return_quiet`, and a static `can_undo(action)` predicate mirroring the exact same delegation tree. Only `can_undo `was ever consulted — so the historic flags had silently rotted. 

I [Claude] ran a branch-by-branch audit of all ~30 modules (four parallel agents) comparing the two, then fixed `historic` to return the correct flag everywhere before deleting the tree.