### PR TITLE
Swap TutorialSettings for student builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,11 @@ change-deps:
 
 setup-instructor:
 	cp src/web/exercises/settings/ExerciseSettings_instructor.re src/web/exercises/settings/ExerciseSettings.re
+	cp src/web/exercises/settings/TutorialSettings_instructor.re src/web/exercises/settings/TutorialSettings.re
 
-setup-student: 
+setup-student:
 	cp src/web/exercises/settings/ExerciseSettings_student.re src/web/exercises/settings/ExerciseSettings.re
+	cp src/web/exercises/settings/TutorialSettings_student.re src/web/exercises/settings/TutorialSettings.re
 
 dev-helper: setup-zarith
 	dune fmt --auto-promote || true


### PR DESCRIPTION
`setup-instructor` / `setup-student` swapped `ExerciseSettings` but never
`TutorialSettings`, so `TutorialSettings.re` stayed at its committed
`show_instructor = true` in **every** build.

`src/web/app/editors/mode/TutorialsMode.re:437` gates the "Toggle Instructor
Mode" widget on that flag, so **student builds shipped the instructor toggle in
tutorial mode.**

The `_instructor` / `_student` variants already existed and hold the values you
would expect — only the `cp` rules in the Makefile were missing:

```
TutorialSettings.re            show_instructor = true    (committed state)
TutorialSettings_instructor.re show_instructor = true
TutorialSettings_student.re    show_instructor = false   (never copied anywhere)
```

## The fix

Two `cp` lines, mirroring the `ExerciseSettings` ones that were already there.

## Consequence for contributors

As with `ExerciseSettings.re`, `TutorialSettings.re` is now rewritten by
`make dev` / `make dev-student`, so it will show as modified in a student
checkout. Same pre-existing pattern, one more file.

## Verification

`dune build @src/fmt src --profile release` clean. Worth confirming in a
browser: `make dev-student`, then check that tutorial mode no longer offers the
instructor toggle — I have not run that check, and it is the only thing that
proves the user-visible half.

---

This is the only user-visible change in the surrounding cleanup work; everything
else there is dead-code removal, tooling, or interfaces. It is based directly on
`dev` so it can merge without waiting on any of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
