### PR TITLE
Unskip five sort tests; surface the hidden menhir elaboration test

### DIFF
--- a/test/Test_Elaboration.re
+++ b/test/Test_Elaboration.re
@@ -943,12 +943,20 @@ module MenhirElaborationTests = {
       )
     );
 
+  /* Skipped: menhir wraps each match-branch body in Asc(_, Unknown(SynSwitch))
+     where MakeTerm does not, so the two parses are unequal. Same
+     menhir/MakeTerm divergence class as the tests skipped via
+     [skip_menhir_maketerm_equivalent_test] in Test_Menhir.re. */
   let inconsistent_case_menhir = () =>
-    alco_check_menhir(
-      "Inconsistent branches where the first branch is an integer and second branch is a boolean (menhir)",
-      inconsistent_case_menhir_str,
-      inconsistent_case_uexp,
-    );
+    [@warning "-21"]
+    {
+      Alcotest.skip();
+      alco_check_menhir(
+        "Inconsistent branches where the first branch is an integer and second branch is a boolean (menhir)",
+        inconsistent_case_menhir_str,
+        inconsistent_case_uexp,
+      );
+    };
 
   //Consistent if statement menhir test
   let consistent_if_uexp: Exp.t = Exp.(if_(bool(false), int(8), int(6)));
@@ -1128,7 +1136,7 @@ x
     test_case("Empty hole (menhir)", `Quick, empty_hole_menhir),
     test_case("Free var (menhir)", `Quick, free_var_menhir),
     test_case("Bin op (menhir)", `Quick, bin_op_menhir),
-    /* test_case("Inconsistent case (menhir)", `Quick, inconsistent_case_menhir), */
+    test_case("Inconsistent case (menhir)", `Quick, inconsistent_case_menhir),
     test_case("Consistent if (menhir)", `Quick, consistent_if_menhir),
     test_case("Undefined test (menhir)", `Quick, undefined_menhir),
     test_case("List exp (menhir)", `Quick, list_exp_menhir),

--- a/test/evaluator/Test_Evaluator_Builtins_Lists.re
+++ b/test/evaluator/Test_Evaluator_Builtins_Lists.re
@@ -389,63 +389,36 @@ let tests = (
         {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Lt else Gt), [1])|},
       )
     ),
-    // These fail due to an eval bug
-    // Should work after https://github.com/hazelgrove/hazel/pull/1729
-    test_case(
-      "sort sorted list of 2 numbers",
-      `Quick,
-      () => {
-        let _ = Alcotest.skip();
-        parse_and_evaluate_test(
-          {|[1, 2]|},
-          {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Lt else Gt), [1, 2])|},
-        );
-      },
-    ),
-    test_case(
-      "sort unsorted list of 2 numbers",
-      `Quick,
-      () => {
-        let _ = Alcotest.skip();
-        parse_and_evaluate_test(
-          {|[1, 2]|},
-          {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Lt else Gt), [2, 1])|},
-        );
-      },
-    ),
-    test_case(
-      "sort unsorted list of 3 numbers",
-      `Quick,
-      () => {
-        let _ = Alcotest.skip();
-        parse_and_evaluate_test(
-          {|[1, 2, 3]|},
-          {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Lt else Gt), [1, 3, 2])|},
-        );
-      },
-    ),
-    test_case(
-      "sort ascending",
-      `Quick,
-      () => {
-        let _ = Alcotest.skip();
-        parse_and_evaluate_test(
-          {|[1, 1, 3, 4, 5]|},
-          {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Lt else Gt), [3, 1, 4, 1, 5])|},
-        );
-      },
-    ),
-    test_case(
-      "sort descending",
-      `Quick,
-      () => {
-        let _ = Alcotest.skip();
-        parse_and_evaluate_test(
-          {|[5, 4, 3, 1, 1]|},
-          {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Gt else Lt), [3, 1, 4, 1, 5])|},
-        );
-      },
-    ),
+    test_case("sort sorted list of 2 numbers", `Quick, () => {
+      parse_and_evaluate_test(
+        {|[1, 2]|},
+        {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Lt else Gt), [1, 2])|},
+      )
+    }),
+    test_case("sort unsorted list of 2 numbers", `Quick, () => {
+      parse_and_evaluate_test(
+        {|[1, 2]|},
+        {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Lt else Gt), [2, 1])|},
+      )
+    }),
+    test_case("sort unsorted list of 3 numbers", `Quick, () => {
+      parse_and_evaluate_test(
+        {|[1, 2, 3]|},
+        {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Lt else Gt), [1, 3, 2])|},
+      )
+    }),
+    test_case("sort ascending", `Quick, () => {
+      parse_and_evaluate_test(
+        {|[1, 1, 3, 4, 5]|},
+        {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Lt else Gt), [3, 1, 4, 1, 5])|},
+      )
+    }),
+    test_case("sort descending", `Quick, () => {
+      parse_and_evaluate_test(
+        {|[5, 4, 3, 1, 1]|},
+        {|sort(fun (x, y) -> if x == y then Eq else (if x < y then Gt else Lt), [3, 1, 4, 1, 5])|},
+      )
+    }),
     test_case("unique", `Quick, () =>
       parse_and_evaluate_test({|[1, 2, 3]|}, {|unique([1, 2, 2, 3, 1, 3])|})
     ),


### PR DESCRIPTION
Two tests that existed but never ran. Net effect is more coverage, not less.

## Five sort tests were skipped waiting on a PR that merged 14 months ago

`Test_Evaluator_Builtins_Lists` skipped five `sort` cases under:

```
// These fail due to an eval bug
// Should work after https://github.com/hazelgrove/hazel/pull/1729
```

#1729 merged 2025-07-02. All five pass now, so the `Alcotest.skip()` wrappers are
gone and the bodies are back to the same shape as their neighbours.

## `Test_Elaboration` had the suite's only commented-out registration

`"Inconsistent case (menhir)"` was commented out of the `tests` list while its
implementation stayed compiled — so it looked like a live test to anyone reading
the file, and was invisible to anyone reading the results.

Re-enabling it **fails, for a real reason**: menhir wraps each match-branch body
in `Asc(_, Unknown(SynSwitch))` where `MakeTerm` does not, so the two parses are
unequal. That is the same menhir/`MakeTerm` divergence class as the tests already
skipped via `skip_menhir_maketerm_equivalent_test` in `Test_Menhir.re`.

So it is now **registered and explicitly skipped**, with the reason recorded in a
comment next to it, rather than hidden in a commented-out line. It shows up in
the run as a skip instead of silently not existing.

This is a judgement call worth a reviewer's opinion: I chose "visible skip with a
documented reason" over "delete it" or "fix the divergence". Fixing it means
deciding whether menhir or `MakeTerm` is right about that `Asc` wrapper, which is
out of scope for a cleanup branch.

## Also

`Test_ExplainThis.re` had pre-existing formatting drift from the merge-base;
`make dev` auto-promotes it, so it is committed here to stop it showing up as
spurious churn in later branches.

## Verification

Full suite run at the time: **3302 tests, passing.** `make dev` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
