### PR TITLE
Deduplicate three copy-pasted implementations

### DIFF
--- a/src/haz3lcore/projectors/implementations/SliderCore.re
+++ b/src/haz3lcore/projectors/implementations/SliderCore.re
@@ -1,0 +1,79 @@
+open Util;
+open Virtual_dom.Vdom;
+open ProjectorBase;
+
+/* Shared implementation of the numeric slider projectors. SliderProj and
+   SliderFProj were byte-identical apart from the literal they edit, so the
+   only thing a variant supplies is how to read that literal out of an atom,
+   how to build one back from the slider's string value, and how to render it. */
+module type PARAMS = {
+  /* Prefixes the failure messages, e.g. "Slider: Get: ...". */
+  let name: string;
+  /* Names the literal in those messages, e.g. "integer". */
+  let literal: string;
+  /* The OCaml type of the literal being edited. */
+  type t;
+  let of_atom: Language.Atom.t => option(t);
+  let to_atom: string => Language.Atom.t;
+  let to_string: t => string;
+};
+
+module Make = (P: PARAMS) : Projector => {
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type model = unit;
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type action = unit;
+
+  let value_of = (any: Language.Any.t): option(P.t) =>
+    switch (any) {
+    | Exp({term: Atom(a), _}) => P.of_atom(a)
+    | _ => None
+    };
+
+  let init = (any: Language.Any.t) =>
+    switch (value_of(any)) {
+    | Some(_) => Some()
+    | None => None
+    };
+
+  let get = (info: info): P.t =>
+    switch (
+      info.syntax |> info.utility.seg_to_term |> OptUtil.and_then(value_of)
+    ) {
+    | Some(v) => v
+    | None => failwith(P.name ++ ": Get: not " ++ P.literal ++ " literal")
+    };
+
+  let put = (info: info, v: string): Base.segment =>
+    switch (
+      info.utility.lift_syntax(
+        ~inline=true,
+        fun
+        | Exp(t) =>
+          Exp({
+            ...t,
+            term: Atom(P.to_atom(v)),
+          })
+        | _ => failwith(P.name ++ ": Put: not " ++ P.literal ++ " literal"),
+        info.syntax,
+      )
+    ) {
+    | Some(s) => s
+    | None => failwith(P.name ++ ": Put: lift failed")
+    };
+
+  let focusable = Focusable.non;
+  let dynamics = false;
+  let elaborate_syntax = false;
+  let placeholder = (_, _) => ProjectorCore.Shape.inline(10);
+  let update = (model, _, _) => model;
+  let error = (_, _): option(ProjectorBase.error) => None;
+
+  let view = ({info, parent, _}: View.args(model, action)) =>
+    View.mk(
+      Util.WebUtil.range(
+        ~attrs=[Attr.on_input((_, v) => parent(SetSyntax(put(info, v))))],
+        info |> get |> P.to_string,
+      ),
+    );
+};

--- a/src/haz3lcore/projectors/implementations/SliderFProj.re
+++ b/src/haz3lcore/projectors/implementations/SliderFProj.re
@@ -1,63 +1,14 @@
-open Util;
-open Virtual_dom.Vdom;
-open ProjectorBase;
-
-module M: Projector = {
-  [@deriving (show({with_path: false}), sexp, yojson)]
-  type model = unit;
-  [@deriving (show({with_path: false}), sexp, yojson)]
-  type action = unit;
-
-  let float_of = (any: Language.Any.t): option(float) =>
-    switch (any) {
-    | Exp({term: Atom(Float(f)), _}) => Some(f)
-    | _ => None
-    };
-
-  let init = (any: Language.Any.t) =>
-    switch (float_of(any)) {
-    | Some(_) => Some()
-    | None => None
-    };
-
-  let get = (info: info): float =>
-    switch (
-      info.syntax |> info.utility.seg_to_term |> OptUtil.and_then(float_of)
-    ) {
-    | Some(f) => f
-    | None => failwith("SliderF: Get: not float literal")
-    };
-
-  let put = (info: info, v: string): Base.segment =>
-    switch (
-      info.utility.lift_syntax(
-        ~inline=true,
-        fun
-        | Exp(t) =>
-          Exp({
-            ...t,
-            term: Atom(Float(float_of_string(v))),
-          })
-        | _ => failwith("SliderF: Put: not float literal"),
-        info.syntax,
-      )
-    ) {
-    | Some(s) => s
-    | None => failwith("SliderF: Put: lift failed")
-    };
-
-  let focusable = Focusable.non;
-  let dynamics = false;
-  let elaborate_syntax = false;
-  let placeholder = (_, _) => ProjectorCore.Shape.inline(10);
-  let update = (model, _, _) => model;
-  let error = (_, _): option(ProjectorBase.error) => None;
-
-  let view = ({info, parent, _}: View.args(model, action)) =>
-    View.mk(
-      Util.WebUtil.range(
-        ~attrs=[Attr.on_input((_, v) => parent(SetSyntax(put(info, v))))],
-        info |> get |> Printf.sprintf("%.2f"),
-      ),
-    );
-};
+/* Slider over a Float literal. See SliderCore for the shared implementation. */
+module M =
+  SliderCore.Make({
+    let name = "SliderF";
+    let literal = "float";
+    type t = float;
+    let of_atom = (a: Language.Atom.t) =>
+      switch (a) {
+      | Float(f) => Some(f)
+      | _ => None
+      };
+    let to_atom = (v: string): Language.Atom.t => Float(float_of_string(v));
+    let to_string = Printf.sprintf("%.2f");
+  });

--- a/src/haz3lcore/projectors/implementations/SliderProj.re
+++ b/src/haz3lcore/projectors/implementations/SliderProj.re
@@ -1,63 +1,16 @@
 open Util;
-open Virtual_dom.Vdom;
-open ProjectorBase;
 
-module M: Projector = {
-  [@deriving (show({with_path: false}), sexp, yojson)]
-  type model = unit;
-  [@deriving (show({with_path: false}), sexp, yojson)]
-  type action = unit;
-
-  let int_of = (any: Language.Any.t): option(Bigint.t) =>
-    switch (any) {
-    | Exp({term: Atom(Int(i)), _}) => Some(i)
-    | _ => None
-    };
-
-  let init = (any: Language.Any.t) =>
-    switch (int_of(any)) {
-    | Some(_) => Some()
-    | None => None
-    };
-
-  let get = (info: info): Bigint.t =>
-    switch (
-      info.syntax |> info.utility.seg_to_term |> OptUtil.and_then(int_of)
-    ) {
-    | Some(i) => i
-    | None => failwith("Slider: Get: not integer literal")
-    };
-
-  let put = (info: info, v: string): Base.segment =>
-    switch (
-      info.utility.lift_syntax(
-        ~inline=true,
-        fun
-        | Exp(t) =>
-          Exp({
-            ...t,
-            term: Atom(Int(Bigint.of_string(v))),
-          })
-        | _ => failwith("Slider: Put: not integer literal"),
-        info.syntax,
-      )
-    ) {
-    | Some(s) => s
-    | None => failwith("Slider: Put: lift failed")
-    };
-
-  let focusable = Focusable.non;
-  let dynamics = false;
-  let elaborate_syntax = false;
-  let placeholder = (_, _) => ProjectorCore.Shape.inline(10);
-  let update = (model, _, _) => model;
-  let error = (_, _): option(ProjectorBase.error) => None;
-
-  let view = ({info, parent, _}: View.args(model, action)) =>
-    View.mk(
-      Util.WebUtil.range(
-        ~attrs=[Attr.on_input((_, v) => parent(SetSyntax(put(info, v))))],
-        info |> get |> Bigint.to_string,
-      ),
-    );
-};
+/* Slider over an Int literal. See SliderCore for the shared implementation. */
+module M =
+  SliderCore.Make({
+    let name = "Slider";
+    let literal = "integer";
+    type t = Bigint.t;
+    let of_atom = (a: Language.Atom.t) =>
+      switch (a) {
+      | Int(i) => Some(i)
+      | _ => None
+      };
+    let to_atom = (v: string): Language.Atom.t => Int(Bigint.of_string(v));
+    let to_string = Bigint.to_string;
+  });

--- a/src/haz3lcore/projectors/implementations/TableRenderer.re
+++ b/src/haz3lcore/projectors/implementations/TableRenderer.re
@@ -514,35 +514,8 @@ let update: (model, action) => model =
     };
   };
 
-let icon_size = 20.;
-
-let simple_icon = (~transform="", ~view: string, ds: list(string)) =>
-  /* takes a list of paths as strings, a viewport as a string,
-     and an optional (string) transform to apply to each */
-  Node.create_svg(
-    "svg",
-    ~attrs=
-      Attr.[
-        create("viewBox", view),
-        create("width", Printf.sprintf("%fpx", icon_size)),
-        create("height", Printf.sprintf("%fpx", icon_size)),
-        create("preserveAspectRatio", "none"),
-      ],
-    List.map(
-      d =>
-        Node.create_svg(
-          "path",
-          ~attrs=
-            [Attr.create("d", d)]
-            @ (transform == "" ? [] : [Attr.create("transform", transform)]),
-          [],
-        ),
-      ds,
-    ),
-  );
-
 let table_icon =
-  simple_icon(
+  SvgUtil.simple_icon(
     ~view="0 0 8 8",
     [
       "m 1.32307 3.96929 a 0.2645835 0.2645835 0 0 0 -0.26563 0.26367 0.2645835 0.2645835 0 0 0 0.26563 0.26562 h 5.82031 a 0.2645835 0.2645835 0 0 0 0.26562 -0.26562 0.2645835 0.2645835 0 0 0 -0.26562 -0.26367 z",

--- a/src/util/SvgUtil.re
+++ b/src/util/SvgUtil.re
@@ -1,5 +1,32 @@
 open Virtual_dom.Vdom;
 
+let icon_size = 20.;
+
+/* Takes a list of paths as strings, a viewport as a string, and an optional
+   (string) transform to apply to each. */
+let simple_icon = (~transform="", ~view: string, ds: list(string)) =>
+  Node.create_svg(
+    "svg",
+    ~attrs=
+      Attr.[
+        create("viewBox", view),
+        create("width", Printf.sprintf("%fpx", icon_size)),
+        create("height", Printf.sprintf("%fpx", icon_size)),
+        create("preserveAspectRatio", "none"),
+      ],
+    List.map(
+      d =>
+        Node.create_svg(
+          "path",
+          ~attrs=
+            [Attr.create("d", d)]
+            @ (transform == "" ? [] : [Attr.create("transform", transform)]),
+          [],
+        ),
+      ds,
+    ),
+  );
+
 module Point = {
   type t = {
     x: float,

--- a/src/web/app/common/Icons.re
+++ b/src/web/app/common/Icons.re
@@ -1,31 +1,5 @@
 open Virtual_dom.Vdom;
-
-let icon_size = 20.;
-
-let simple_icon = (~transform="", ~view: string, ds: list(string)) =>
-  /* takes a list of paths as strings, a viewport as a string,
-     and an optional (string) transform to apply to each */
-  Node.create_svg(
-    "svg",
-    ~attrs=
-      Attr.[
-        create("viewBox", view),
-        create("width", Printf.sprintf("%fpx", icon_size)),
-        create("height", Printf.sprintf("%fpx", icon_size)),
-        create("preserveAspectRatio", "none"),
-      ],
-    List.map(
-      d =>
-        Node.create_svg(
-          "path",
-          ~attrs=
-            [Attr.create("d", d)]
-            @ (transform == "" ? [] : [Attr.create("transform", transform)]),
-          [],
-        ),
-      ds,
-    ),
-  );
+open Util.SvgUtil;
 
 let disk =
   simple_icon(

--- a/src/web/exercises/Tutorial.re
+++ b/src/web/exercises/Tutorial.re
@@ -183,97 +183,6 @@ let wrap = (term, editor: Editor.t): TermItem.t => {
 let term_of = (editor: Editor.t): Language.Exp.t =>
   MakeTerm.from_zip_for_sem(editor.state.zipper, ~root=editor.root).term;
 
-let rec append_exp = (e1: Language.Exp.t, e2: Language.Exp.t): Language.Exp.t => {
-  switch (e1.term) {
-  | EmptyHole
-  | Invalid(_)
-  | MultiHole(_)
-  | DynamicErrorHole(_)
-  | Undefined
-  | Deferral(_)
-  | Atom(_)
-  | DrvQuote(_)
-  | ListLit(_)
-  | Constructor(_)
-  | Closure(_)
-  | Fun(_)
-  | TypFun(_)
-  | FixF(_)
-  | Tuple(_)
-  | TupLabel(_)
-  | TupleExtension(_)
-  | Label(_)
-  | ExplicitNonlabel
-  | Dot(_)
-  | Var(_)
-  | Ap(_)
-  | TypAp(_)
-  | DeferredAp(_)
-  | If(_)
-  | Test(_)
-  | HintedTest(_)
-  | Parens(_)
-  | Projector(_)
-  | Cons(_)
-  | ListConcat(_)
-  | LivelitName(_)
-  | UnOp(_)
-  | BinOp(_)
-  | BuiltinFun(_)
-  | Module(_)
-  | ModuleExp(_)
-  | Asc(_)
-  | ProofObject(_)
-  | Forall(_)
-  | Match(_) => {
-      term: Seq(e1, e2),
-      annotation: Language.IdTagged.IdTag.fresh(),
-    }
-  | Seq(e11, e12) =>
-    let e12' = append_exp(e12, e2);
-    {
-      term: Seq(e11, e12'),
-      annotation:
-        Language.IdTagged.IdTag.mk_internal(Language.IdTagged.ids(e1)),
-    };
-  | Filter(kind, ebody) =>
-    let ebody' = append_exp(ebody, e2);
-    {
-      term: Filter(kind, ebody'),
-      annotation:
-        Language.IdTagged.IdTag.mk_internal(Language.IdTagged.ids(e1)),
-    };
-  | Let(p, edef, ebody) =>
-    let ebody' = append_exp(ebody, e2);
-    {
-      term: Let(p, edef, ebody'),
-      annotation:
-        Language.IdTagged.IdTag.mk_internal(Language.IdTagged.ids(e1)),
-    };
-  | Theorem(p, edef, ebody) =>
-    let ebody' = append_exp(ebody, e2);
-    {
-      term: Theorem(p, edef, ebody'),
-      annotation:
-        Language.IdTagged.IdTag.mk_internal(Language.IdTagged.ids(e1)),
-    };
-  | TyAlias(tp, tdef, ebody) =>
-    let ebody' = append_exp(ebody, e2);
-    {
-      term: TyAlias(tp, tdef, ebody'),
-      annotation:
-        Language.IdTagged.IdTag.mk_internal(Language.IdTagged.ids(e1)),
-    };
-  | Use(t, ebody) =>
-    let ebody' = append_exp(ebody, e2);
-    {
-      term: Use(t, ebody'),
-      annotation:
-        Language.IdTagged.IdTag.mk_internal(Language.IdTagged.ids(e1)),
-    };
-  };
-};
-
 let stitch_term = (eds: p('a)): stitched(TermItem.t) => {
   ();
 
@@ -291,8 +200,14 @@ let stitch_term = (eds: p('a)): stitched(TermItem.t) => {
 
   let hidden_tests_term =
     eds.wrapper
-      ? append_exp(wrapped_user_impl, term_of(eds.hidden_tests.tests))
-      : append_exp(user_impl_term, term_of(eds.hidden_tests.tests));
+      ? EditorUtil.append_exp(
+          wrapped_user_impl,
+          term_of(eds.hidden_tests.tests),
+        )
+      : EditorUtil.append_exp(
+          user_impl_term,
+          term_of(eds.hidden_tests.tests),
+        );
 
   {
     user_impl: wrap(user_impl_term, eds.your_impl),

--- a/src/web/exercises/TutorialGrading.re
+++ b/src/web/exercises/TutorialGrading.re
@@ -1,44 +1,9 @@
 open Language;
-open Util;
 open Virtual_dom.Vdom;
 open Node;
 open Tutorial;
 
-[@deriving (show({with_path: false}), sexp, yojson)]
-type percentage = float;
-[@deriving (show({with_path: false}), sexp, yojson)]
-type points = float;
-[@deriving (show({with_path: false}), sexp, yojson)]
-type score = (points, points);
-
-let score_of_percent = (percent, max_points) => {
-  let max_points = float_of_int(max_points);
-  (percent *. max_points, max_points);
-};
-
-let score_view = ((earned: points, max: points)) => {
-  div(
-    ~attrs=[
-      Attr.classes([
-        "test-percent",
-        Float.equal(earned, max) ? "all-pass" : "some-fail",
-      ]),
-    ],
-    [text(Printf.sprintf("%.1f / %.1f pts", earned, max))],
-  );
-};
-
-let percentage_view = (p: percentage) => {
-  div(
-    ~attrs=[
-      Attr.classes([
-        "test-percent",
-        Float.equal(p, 1.) ? "all-pass" : "some-fail",
-      ]),
-    ],
-    [text(Printf.sprintf("%.0f%%", 100. *. p))],
-  );
-};
+include Grading;
 
 module TestValidationReport = {
   type t = {


### PR DESCRIPTION
Eight files, +145/−308. Three independent de-duplications, one per commit. Unlike
the rest of the stack these *change* code rather than delete it, so each commit
carries an argument for why the surviving version is equivalent.

## 1. Grading primitives and the SVG icon helper

`Grading.re` documents itself as the shared primitives module and
`CodeGrading.re` does `include Grading;`. **`TutorialGrading.re` did not** — it
re-declared `type percentage`/`points`/`score`, `score_of_percent`, `score_view`
and `percentage_view` verbatim, down to the `Printf` format strings. Replaced with
`include Grading;`, which also picks up `pending_score_view`, the one primitive it
had not copied.

Separately, `icon_size`/`simple_icon` were byte-identical in `Icons.re` (web) and
`TableRenderer.re` (haz3lcore). `haz3lcore` cannot depend on `web`, so it had been
retyped. Hoisted into `Util.SvgUtil`, which both libraries reach and which already
opens `Virtual_dom`.

## 2. Point `Tutorial.re` at `EditorUtil.append_exp`

`append_exp` existed three times. `EditorUtil.re` is canonical; `CodeExercise`'s
copy was already dead and went in the preceding branch; `Tutorial`'s was the last
live duplicate.

**Verified equivalent rather than assumed**, because the two built annotations
differently:

| | Tutorial | EditorUtil |
|---|---|---|
| base case | `IdTag.fresh()` | `IdTag.mk([Haz3lcore.Id.mk()], empty_secondary)` |
| recursive | `IdTag.mk_internal(ids(e1))` | `IdTag.mk(ids(e1), empty_secondary)` |

`IdTagged.re:36-47` makes `mk_internal(ids)` structurally equal to
`mk(ids, empty_secondary)`, and `fresh()` equal to
`{ids: [Id.mk()], secondary: empty_secondary}`.

The remaining question was whether `Haz3lcore.Id.mk` and the `Id.mk` resolved
inside `IdTagged.re` are the same generator — **there are three modules named `Id`
in this repo.** Both `src/language/Id.re` and `src/haz3lcore/Id.re` are
`include Util.Id;`, so they share the one `Uuidm.v4_gen` closure.

Constructor coverage is also identical: both dispatch recursively on exactly
`Seq`, `Filter`, `Let`, `Theorem`, `TyAlias` and `Use`, and both put the same 41
constructors in the catch-all — including `ModuleExp`, which an earlier copy
handled recursively.

## 3. Functorize `SliderProj` / `SliderFProj`

63 lines each, 52 identical — the entire difference was `Bigint` vs `float`: which
atom they read, which atom they build, how they render. `SliderCore.Make` now holds
the shared body and each variant supplies only that difference, 14-16 lines apiece.

`Atom.t` is the natural seam: both were matching `Exp({term: Atom(Int(i)), _})` /
`Atom(Float(f))` and rebuilding the same way, so `PARAMS` asks for
`of_atom`/`to_atom`/`to_string` and nothing else.

Net −17 lines, which undersells it — the point is that a change to slider
behaviour is now one edit rather than two that can drift apart.

Failure message wording is preserved (`"Slider: Get: not integer literal"`,
`"SliderF: Put: not float literal"`) via a separate `literal` label rather than
being degraded to the module name. `ProjectorInit.re:12-13` references
`SliderProj.M`/`SliderFProj.M` and is unchanged.

## Verification

`make test-quick`: 3,225 passing. dev, test and release builds clean.

Both sliders were also exercised by hand in the browser — dragged each, and the
cursor inspector read `Projector (Slider) : Int` and `Projector (SliderF) : Float`.
That check matters here because a functor that typechecks can still be wired to the
wrong literal, and no test covers projector interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
