### PR TITLE
Make clipboard access an Effect instead of scheduling one by hand

### DIFF
--- a/src/util/JsUtil.re
+++ b/src/util/JsUtil.re
@@ -189,10 +189,16 @@ let show_copy_toast = (): unit => {
     },
   );
 };
-/* Direct clipboard writes via the async Clipboard API. Used from editor
-   key handlers where the focused element is a non-editable div and
-   Firefox therefore refuses to dispatch a native `copy` event to the
-   page-level handler. Safe under a user gesture (keydown). */
+/* Clipboard access as Effects. Both directions go through the async
+   Clipboard API, because the editor's key handlers run with focus on a
+   non-editable div and Firefox refuses to dispatch native copy/paste
+   events there.
+
+   Defined with Ui_effect.Define1 — the same mechanism Bonsai builds
+   Effect.of_deferred_fun from — so callers compose these like any other
+   Effect rather than side-effecting on their own and scheduling the
+   result by hand. Both must be dispatched from an event handler: the
+   Clipboard API only grants access under a user gesture. */
 let has_clipboard_api = (): bool =>
   Js.to_bool(
     Js.Unsafe.fun_call(
@@ -203,32 +209,47 @@ let has_clipboard_api = (): bool =>
     ),
   );
 
-let write_clipboard = (str: string): unit =>
-  if (has_clipboard_api()) {
-    Js.Unsafe.fun_call(
-      Js.Unsafe.pure_js_expr(
-        "(function(s){navigator.clipboard.writeText(s);})",
-      ),
-      [|Js.Unsafe.inject(Js.string(str))|],
-    );
-  } else {
-    /* Older browsers: fall through to the shim/execCommand path. */
-    copy(str);
+module ClipboardHandler = {
+  module Action = {
+    type t(_) =
+      | Read_text: t(string)
+      | Write_text(string): t(unit);
   };
+  let handle = (type a, action: Action.t(a), ~on_response: a => unit) =>
+    switch (action) {
+    | Read_text =>
+      let cb = Js.wrap_callback(text => on_response(Js.to_string(text)));
+      Js.Unsafe.fun_call(
+        Js.Unsafe.pure_js_expr(
+          "(function(cb){navigator.clipboard.readText().then(cb);})",
+        ),
+        [|Js.Unsafe.inject(cb)|],
+      );
+    | Write_text(str) =>
+      /* Older browsers with no Clipboard API fall through to the
+         execCommand shim. */
+      if (has_clipboard_api()) {
+        Js.Unsafe.fun_call(
+          Js.Unsafe.pure_js_expr(
+            "(function(s){navigator.clipboard.writeText(s);})",
+          ),
+          [|Js.Unsafe.inject(Js.string(str))|],
+        );
+      } else {
+        copy(str);
+      };
+      on_response();
+    };
+};
+module Clipboard = Ui_effect.Define1(ClipboardHandler);
 
-/* Async clipboard read, used for editor-level Cmd+V. The Promise's
-   text result is delivered to `on_text`, which is expected to schedule
-   the resulting Effect via Bonsai.Effect.Expert.handle. */
-let read_clipboard = (on_text: string => unit): unit =>
-  if (has_clipboard_api()) {
-    let cb = Js.wrap_callback(text => on_text(Js.to_string(text)));
-    Js.Unsafe.fun_call(
-      Js.Unsafe.pure_js_expr(
-        "(function(cb){navigator.clipboard.readText().then(cb);})",
-      ),
-      [|Js.Unsafe.inject(cb)|],
-    );
-  };
+let write_clipboard = (str: string): Effect.t(unit) =>
+  Clipboard.inject(Write_text(str));
+
+/* Never completes when the browser has no Clipboard API — there is no
+   text to deliver, so there is no Paste to dispatch. */
+let read_clipboard = (): Effect.t(string) =>
+  has_clipboard_api() ? Clipboard.inject(Read_text) : Effect.never;
 
 let element_to_node = (element: Js.t(Dom_html.element)): Js.t(Dom.node) =>
   Js.Unsafe.coerce(element);

--- a/src/web/app/editors/code/CodeEditable.re
+++ b/src/web/app/editors/code/CodeEditable.re
@@ -576,34 +576,40 @@ module View = {
       /* Cache for paste reuse only when nothing was trimmed: a trimmed
          sub-token string must re-parse on paste, not round-trip to the
          full segment. */
-      if (str == full && !selection_has_refractors(z.refractors, segment)) {
-        Haz3lcore.Parser.set_segment_cache(Some(segment), str);
-      };
-      JsUtil.write_clipboard(str);
+      let cache_for_paste =
+        str == full && !selection_has_refractors(z.refractors, segment)
+          ? Effect.of_sync_fun(
+              () => Haz3lcore.Parser.set_segment_cache(Some(segment), str),
+              (),
+            )
+          : Effect.Ignore;
+      Effect.Many([cache_for_paste, JsUtil.write_clipboard(str)]);
     };
     let paste_from_clipboard = () =>
-      JsUtil.read_clipboard(text => {
-        let action =
-          Haz3lcore.Action.Paste(Util.StringUtil.trim_leading(text));
-        Bonsai.Effect.Expert.handle(inject(Perform(action)));
-      });
+      Effect.bind(JsUtil.read_clipboard(), ~f=text =>
+        inject(
+          Perform(
+            Haz3lcore.Action.Paste(Util.StringUtil.trim_leading(text)),
+          ),
+        )
+      );
     /* Inject for context-menu rows. Clipboard rows need view-layer side
        effects the core can't perform: Copy/Cut write the system clipboard
        before dispatch, and PasteFromClipboard starts an async read whose
        result is dispatched as the real Paste, closing the menu
-       immediately. Runs at event-firing time (see Menu.pointerdown_attr),
-       like the keyboard clipboard handlers below. */
+       immediately. Both are Effects, so the clipboard is touched when the
+       row fires rather than when its Effect is built. */
     let perform_from_menu = (c: ContextMenu.command): Ui_effect.t(unit) =>
       switch (c) {
       | Perform(Copy) =>
-        copy_selection();
-        inject(Perform(Copy));
+        Effect.Many([copy_selection(), inject(Perform(Copy))])
       | Perform(Cut) =>
-        copy_selection();
-        inject(Perform(Cut));
+        Effect.Many([copy_selection(), inject(Perform(Cut))])
       | PasteFromClipboard =>
-        paste_from_clipboard();
-        inject(ContextMenu(ContextMenu.Model.Close));
+        Effect.Many([
+          paste_from_clipboard(),
+          inject(ContextMenu(ContextMenu.Model.Close)),
+        ])
       | Perform(a) => inject(Perform(a))
       };
     /* Sync document-level listeners (click-outside + keyboard) for the
@@ -995,8 +1001,11 @@ module View = {
               alt: Up,
               _,
             } =>
-            copy_selection();
-            Effect.Many([Effect.Prevent_default, Effect.Stop_propagation]);
+            Effect.Many([
+              copy_selection(),
+              Effect.Prevent_default,
+              Effect.Stop_propagation,
+            ])
           | {
               key: D("x" | "X"),
               sys: Mac,
@@ -1015,12 +1024,12 @@ module View = {
               alt: Up,
               _,
             } =>
-            copy_selection();
             Effect.Many([
+              copy_selection(),
               Effect.Prevent_default,
               Effect.Stop_propagation,
               inject(Perform(Destruct(Right))),
-            ]);
+            ])
           | {
               key: D("v" | "V"),
               sys: Mac,
@@ -1039,8 +1048,11 @@ module View = {
               alt: Up,
               _,
             } =>
-            paste_from_clipboard();
-            Effect.Many([Effect.Prevent_default, Effect.Stop_propagation]);
+            Effect.Many([
+              paste_from_clipboard(),
+              Effect.Prevent_default,
+              Effect.Stop_propagation,
+            ])
           | _ =>
             /* 3. Normal editor key handling:
              *    context menu → projector handoff → Keyboard */

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -47,23 +47,25 @@ let typ_to_text = (~settings, typ: Typ.t): string =>
    empty holes explicitly as `?`, and the source segment is cached against that
    text so pasting back into Hazel restores the real (implicit) holes, while
    pasting into a plain text editor yields the `?` text. */
-let copy_segment = (segment: Haz3lcore.Segment.t): unit => {
+let copy_segment = (segment: Haz3lcore.Segment.t): Effect.t(unit) => {
   let str = Haz3lcore.Printer.of_segment(~holes="?", segment);
-  Haz3lcore.Parser.set_segment_cache(Some(segment), str);
-  Util.JsUtil.write_clipboard(str);
+  Effect.Many([
+    Effect.of_sync_fun(
+      () => Haz3lcore.Parser.set_segment_cache(Some(segment), str),
+      (),
+    ),
+    Util.JsUtil.write_clipboard(str),
+  ]);
 };
 
 /* Copy button; `on_copy` runs only on click (not when the field is built) and
    is revealed on field hover via CSS so it doesn't clutter the list. */
-let copy_button = (on_copy: unit => unit): Node.t =>
+let copy_button = (on_copy: unit => Effect.t(unit)): Node.t =>
   span(
     ~attrs=[
       clss(["debug-copy-button"]),
       Attr.title("Copy to clipboard"),
-      Attr.on_click(_ => {
-        on_copy();
-        Virtual_dom.Vdom.Effect.Ignore;
-      }),
+      Attr.on_click(_ => on_copy()),
     ],
     [text({|⧉|})],
   );
@@ -73,7 +75,7 @@ let copy_button = (on_copy: unit => unit): Node.t =>
 let label_row =
     (
       ~chevron: list(Node.t)=[],
-      ~copy: option(unit => unit)=None,
+      ~copy: option(unit => Effect.t(unit))=None,
       label: string,
     )
     : Node.t =>
@@ -118,7 +120,12 @@ let section =
 };
 
 let field_node =
-    (~copy: option(unit => unit)=None, label: string, body: Node.t): Node.t =>
+    (
+      ~copy: option(unit => Effect.t(unit))=None,
+      label: string,
+      body: Node.t,
+    )
+    : Node.t =>
   div(
     ~attrs=[clss(["debug-field"])],
     [
@@ -143,7 +150,7 @@ let field_str = (label: string, body: string): Node.t =>
 let field_collapsible =
     (
       ~globals: Globals.t,
-      ~copy: unit => unit,
+      ~copy: unit => Effect.t(unit),
       ~body: unit => Node.t,
       label: string,
     )


### PR DESCRIPTION
Addresses https://github.com/hazelgrove/hazel/pull/2341#discussion_r3806658226 — the `Bonsai.Effect.Expert.handle` in `CodeEditable`'s paste path. Targets `context-menu-clipboard` so the decision can be reviewed on its own.

## The problem

`Expert.handle` runs an effect outside the scheduler, and `ui_effect`'s own docs call it "only intended for internal use by this library, specifically by the attribute code." It was there because of `JsUtil.read_clipboard`'s signature:

```reason
let read_clipboard = (on_text: string => unit): unit => ...
```

A `string => unit` callback leaves the caller no way to hand the resulting `Paste` back as an effect, so the only option was to run one by hand.

## The fix

Both clipboard directions are now defined with `Ui_effect.Define1`, the mechanism Bonsai itself builds `Effect.of_deferred_fun` from (`bonsai/web/effect.ml`):

```reason
module ClipboardHandler = {
  module Action = {
    type t(_) =
      | Read_text: t(string)
      | Write_text(string): t(unit);
  };
  let handle = (type a, action: Action.t(a), ~on_response: a => unit) => ...;
};
module Clipboard = Ui_effect.Define1(ClipboardHandler);

let write_clipboard = (str: string): Effect.t(unit) => Clipboard.inject(Write_text(str));
let read_clipboard = (): Effect.t(string) =>
  has_clipboard_api() ? Clipboard.inject(Read_text) : Effect.never;
```

`Define`/`Define1` look like the intended public extension point rather than an escape hatch: they carry no `Expert`/`Private`/`For_testing` marker, and Bonsai uses them across the library boundary for `of_deferred_fun`, for the app's own `inject` in `web/start.ml`, and in `bonsai_driver`. Since `Effect.t` is an extensible variant with a private dispatch table, they're also the only way to add a case at all. Happy to switch to `Effect.Expert.of_fun` (one line, no GADT) if you'd rather — it only *constructs* an effect so it can't break scheduler discipline the way `handle` does, but it does sit in `Expert`.

Callers then just compose:

```reason
let paste_from_clipboard = () =>
  Effect.bind(JsUtil.read_clipboard(), ~f=text => inject(Perform(Paste(...))));
```

## Notes for review

- **The JS is unchanged** — same `navigator.clipboard.readText/writeText` calls, same `execCommand` fallback. Only the delivery mechanism moved.
- **Call ordering is preserved.** Copy/paste now run as items of the handler's `Effect.Many` rather than as eager calls before it, so the clipboard call happens a few stack frames later — still synchronously inside the same DOM event dispatch (`virtual_dom/attr.ml:340`), which is what the permission gate needs. They're ordered ahead of `Prevent_default` to match the previous sequence exactly.
- **`Parser.set_segment_cache` stays local**, lifted with `of_sync_fun`. It's a core mutation rather than a clipboard operation, so it didn't belong in `JsUtil`.
- **`DebugSidebar` came along** because `write_clipboard` changed type. Its five copy buttons had the same shape (`on_copy(); Effect.Ignore` inside `on_click`) and are now `unit => Effect.t(unit)`. They stay *thunks* deliberately: `copy_segment` runs `Printer.of_segment`, and an eager effect value would print every field on every render, which the comment at `DebugSidebar.re:61` explicitly guards against.
- **Still one `Expert.handle` left** at `CodeEditable.re:925`, in `EdgeScroll`'s `on_scroll`. Pre-existing, unrelated to clipboard, and a timer callback with no effect-returning seam — separate piece of work.

## Follow-up, deliberately not in this PR

`JsUtil.read_file` is the one other place in the tree with this exact shape — a callback-based one-shot async read whose result becomes an action — and `CSVProjector.re:182` pays for it with the same `Expert.handle` this PR removes:

```reason
JsUtil.read_file(file, content => Bonsai.Effect.Expert.handle(Effect.Many([...])));
```

Giving `read_file` the same treatment (`Effect.t(option(string))`) would turn that into an `Effect.bind`. I left it out because it is not a free swap: `read_file`'s three other callers (`Page.re:212`, `Logged.re:49`, `ScratchMode.re:921`) are all inside `update`, where the available seam is `~schedule_action: t => unit`. That seam is legitimate — `Main.re:79` defines it as `x => schedule_event(inject(x))`, Bonsai's own apply-action scheduler, not `Expert.handle` — so converting `read_file` means either keeping a callback variant for those three or moving the read up into the view layer. Worth doing, but it is a separate decision from this one.

For what it's worth, the other remaining `Expert.handle` sites (`BonsaiUtil`'s ResizeObserver, `MenuListener`, ninja-keys, `EdgeScroll`) are a different shape — repeating pushes *into* the framework, which `Define1` cannot express, since its `on_response` is one-shot. Those want other seams (`web_ui_element_size_hooks`, `Global_listeners`), not this one.

Manually verified in Firefox by @7h3kk1d (keyboard paste); `make dev` clean. Chrome pass still worth doing before this merges up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


