### PR TITLE
Remove unused open EditingPrelude in Test_ReparseDocSlides

### DIFF
--- a/test/Test_ReparseDocSlides.re
+++ b/test/Test_ReparseDocSlides.re
@@ -7,7 +7,6 @@
 open Web;
 open Alcotest;
 open Haz3lcore;
-open EditingPrelude;
 
 let doc_slides: list((string, CellEditor.Model.persistent)) =
   snd(Lazy.force(Init.startup).documentation);


### PR DESCRIPTION
The dead-code sweep (8e71fe2ba2, #2436) removed the last uses of `EditingPrelude` in `test/Test_ReparseDocSlides.re` but left the `open` behind, so every build since has emitted:

```
File "test/Test_ReparseDocSlides.re", line 10, characters 0-19:
Warning 33 [unused-open]: unused open Dune__exe.EditingPrelude.
```

This deletes the one dead `open`. `make dev` is warning-free at this site and the quick suite passes (3438 tests).

Warnings like this one currently slip through because CI doesn't fail on them; #2422 adjusts the CI builds to enforce release warnings on `test/`, which would have caught this at the source. This PR clears the existing offender so that check can land clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)