### PR TITLE
test: disable two seed-flaky evaluator properties, pin them as expected failures

### DIFF
--- a/test/QCheck_Util.re
+++ b/test/QCheck_Util.re
@@ -4,18 +4,26 @@ open QCheck;
 open MenhirParser;
 
 /**
+ * Render a core expression as editable syntax, for QCheck counterexamples and
+ * Alcotest failure output. `editable` rather than `of_core(_, CoreSettings.off)`
+ * deliberately: the latter hides ascriptions and folds function bodies, so two
+ * expressions that `Equality.semantic` counts as different can print
+ * identically. Reading this is a loss of information either way.
+ */
+let show_core_exp = exp =>
+  exp
+  |> ExpToSegment.exp_to_segment(
+       ~settings=ExpToSegment.Settings.editable(~inline=true),
+       _,
+     )
+  |> Printer.of_segment(~holes="?", _);
+
+/**
  * An arbitrary generator for expressions of type `Exp.t`.
  * This uses the generator from the menhirParser AST to produce random instances of `Exp.t`
  * for property-based testing.
  */
 let arb_exp = (~minimal_idents: bool, size: int) => {
-  let show_core_exp = exp =>
-    exp
-    |> ExpToSegment.exp_to_segment(
-         ~settings=ExpToSegment.Settings.editable(~inline=true),
-         _,
-       )
-    |> Printer.of_segment(~holes="?", _);
   let arb_exp =
     map(
       ~rev=

--- a/test/QCheck_Util.re
+++ b/test/QCheck_Util.re
@@ -5,10 +5,9 @@ open MenhirParser;
 
 /**
  * Render a core expression as editable syntax, for QCheck counterexamples and
- * Alcotest failure output. `editable` rather than `of_core(_, CoreSettings.off)`
- * deliberately: the latter hides ascriptions and folds function bodies, so two
- * expressions that `Equality.semantic` counts as different can print
- * identically. Reading this is a loss of information either way.
+ * Alcotest failure output. Not `of_core(_, CoreSettings.off)`: that hides
+ * ascriptions and folds function bodies, so expressions `Equality.semantic`
+ * counts as different can print identically.
  */
 let show_core_exp = exp =>
   exp

--- a/test/evaluator/Test_Evaluator_Properties.re
+++ b/test/evaluator/Test_Evaluator_Properties.re
@@ -1,4 +1,3 @@
-open Haz3lcore;
 open Language;
 open Test_Evaluator_Prelude;
 open Alcotest;
@@ -47,19 +46,13 @@ let qcheck_evaluator_does_not_crash_test =
     }
   });
 
-let show_core_exp = exp =>
-  exp
-  |> ExpToSegment.exp_to_segment(
-       ~settings=
-         ExpToSegment.Settings.of_core(~inline=true, CoreSettings.off),
-       _,
-     )
-  |> Printer.of_segment(~holes="?", _);
-
-/* Output is easier to view through ExpToSegment. This may result in a loss of
-   information. */
+/* Rendered by the same function that prints QCheck counterexamples, so a
+   failure here and a failure from the generator read alike. */
 let testable_core_exp =
-  testable(Fmt.using(show_core_exp, Fmt.string), Equality.semantic.exp);
+  testable(
+    Fmt.using(QCheck_Util.show_core_exp, Fmt.string),
+    Equality.semantic.exp,
+  );
 
 /* Elaborate `uexp`, reduce it with the evaluator and with the stepper, and
    `check` the two results against each other with `testable`: pass
@@ -193,8 +186,12 @@ let qcheck_pattern_equivalence_test =
             LimitedCompleted((first_exp, _)),
             LimitedCompleted((second_exp, _)),
           ) =>
-          print_endline("First expression: " ++ show_core_exp(first));
-          print_endline("Second expression: " ++ show_core_exp(second));
+          print_endline(
+            "First expression: " ++ QCheck_Util.show_core_exp(first),
+          );
+          print_endline(
+            "Second expression: " ++ QCheck_Util.show_core_exp(second),
+          );
           Alcotest.check(
             dhexp_typ,
             "Evaluated expressions are equal",

--- a/test/evaluator/Test_Evaluator_Properties.re
+++ b/test/evaluator/Test_Evaluator_Properties.re
@@ -46,19 +46,16 @@ let qcheck_evaluator_does_not_crash_test =
     }
   });
 
-/* Rendered by the same function that prints QCheck counterexamples, so a
-   failure here and a failure from the generator read alike. */
 let testable_core_exp =
   testable(
     Fmt.using(QCheck_Util.show_core_exp, Fmt.string),
     Equality.semantic.exp,
   );
 
-/* Elaborate `uexp`, reduce it with the evaluator and with the stepper, and
-   `check` the two results against each other with `testable`: pass
-   `testable_core_exp` to assert they agree, or `neg(testable_core_exp)` to
-   assert they still differ. Returns false when the case was filtered out — a
-   step limit, or a raise these properties skip — and nothing was compared. */
+/* Reduce `uexp` with the evaluator and with the stepper and `check` the two
+   against each other: pass `testable_core_exp` to assert they agree, or
+   `neg(testable_core_exp)` to assert they still differ. False when the case was
+   filtered out and nothing was compared. */
 let check_evaluator_against_stepper =
     (~step_limit: int, ~testable: testable(Exp.t), ~msg: string, uexp: Exp.t)
     : bool =>
@@ -102,8 +99,7 @@ let qcheck_stepper_confluence =
     ~count=1000,
     QCheck_Util.arb_exp(~minimal_idents=true, 10),
     uexp => {
-      /* `check` raises on a disagreement; a filtered-out case is not a
-         failure, so the compared/not-compared answer is discarded here. */
+      /* Failure arrives as a raise from `check`; the bool is only vacuity. */
       ignore(
         check_evaluator_against_stepper(
           ~step_limit=100,
@@ -116,11 +112,9 @@ let qcheck_stepper_confluence =
     },
   );
 
-/* Disabled: fails on any seed that draws a duplicate binder, where one of the
-   two freshens it and the other does not. Known bug
-   https://github.com/hazelgrove/hazel/issues/2128 (dup #2372). The test after
-   this one pins that counterexample and goes red once the bug is fixed, which
-   is the signal to re-enable this property. */
+/* Disabled: fails on any seed that draws a duplicate binder — known bug
+   https://github.com/hazelgrove/hazel/issues/2128 (dup #2372). The test below
+   pins that counterexample and goes red once it is fixed. */
 let qcheck_stepper_confluence_disabled =
   test_case(
     "Evaluator and stepper are consistent (disabled, #2128)", `Quick, () => {
@@ -285,8 +279,8 @@ let qcheck_preservation_test =
  * reuse_check path at all; if we regenerated the tree from source the
  * id spaces would be disjoint and nothing would match prev.
  *
- * Known skips below (return `true`): expressions with no int literal to
- * edit (nothing to test), anything that hits the step limit, and anything
+ * Known skips (the property still passes): expressions with no int literal
+ * to edit (nothing to test), anything that hits the step limit, and anything
  * that raises from statics/evaluation (filtered the same way as the
  * other evaluator QCheck tests in this file). */
 
@@ -339,13 +333,10 @@ let eval_limited =
     elab,
   );
 
-/* Bump the int literal at `target_id` by one, evaluate the edited program two
-   ways — incrementally, reusing the unedited run's cache, and from scratch —
-   and `check` the two against each other with `testable`: pass
-   `testable_core_exp` to assert they agree, or `neg(testable_core_exp)` to
-   assert they still differ. Both sides share one elaboration, so a
-   disagreement is a reuse / dirty-propagation bug rather than a semantic one.
-   Returns false when the case was filtered out and nothing was compared. */
+/* Bump the int literal at `target_id` by one and `check` the edited program
+   evaluated incrementally against it evaluated fresh: pass `testable_core_exp`
+   to assert they agree, or `neg(testable_core_exp)` to assert they still
+   differ. False when the case was filtered out and nothing was compared. */
 let check_incremental_against_fresh_after_edit =
     (
       ~target_id: Id.t,
@@ -428,8 +419,7 @@ let qcheck_incremental_matches_fresh_after_edit =
     | lits =>
       let (target_id, old_value) =
         List.nth(lits, seed mod List.length(lits));
-      /* `check` raises on a disagreement; a filtered-out case is not a
-         failure, so the compared/not-compared answer is discarded here. */
+      /* Failure arrives as a raise from `check`; the bool is only vacuity. */
       ignore(
         check_incremental_against_fresh_after_edit(
           ~target_id,
@@ -443,10 +433,9 @@ let qcheck_incremental_matches_fresh_after_edit =
     }
   );
 
-/* Disabled: fails on any seed that draws the shape below. Known bug
-   https://github.com/hazelgrove/hazel/issues/2457. The test after this one
-   pins that counterexample and goes red once the bug is fixed, which is the
-   signal to re-enable this property. */
+/* Disabled: fails on any seed that draws the shape below — known bug
+   https://github.com/hazelgrove/hazel/issues/2457. The test below pins that
+   counterexample and goes red once it is fixed. */
 let qcheck_incremental_matches_fresh_after_edit_disabled =
   test_case(
     "Incremental eval agrees with fresh eval after a literal edit (disabled, #2457)",

--- a/test/evaluator/Test_Evaluator_Properties.re
+++ b/test/evaluator/Test_Evaluator_Properties.re
@@ -351,13 +351,12 @@ let eval_limited =
     elab,
   );
 
-/* Check that incremental eval and fresh eval agree on `exp` with the int
-   literal at `target_id` bumped by one. Skips and `require_comparison` as
-   above. */
+/* Check that incremental eval and fresh eval agree on `exp` with one of its int
+   literals bumped by one — `literal_index`, taken modulo how many there are.
+   Skips and `require_comparison` as above. */
 let check_incremental_against_fresh_after_edit =
     (
-      ~target_id: Id.t,
-      ~old_value: Bigint.t,
+      ~literal_index: int,
       ~testable: testable(Exp.t),
       ~msg: string,
       ~require_comparison: bool,
@@ -387,49 +386,56 @@ let check_incremental_against_fresh_after_edit =
     try(Some(statics_and_elab(exp))) {
     | _ => None
     };
-  /* +1 keeps the type fixed, so the edit typechecks the same as the
-   * original while still changing the value at `target_id`. */
-  let new_value = Bigint.(old_value + of_int(1));
-  let edited = replace_int_lit_by_id(~target=target_id, ~to_=new_value, exp);
-  switch (try_statics(exp), try_statics(edited)) {
-  | (Some((info_map_orig, elab_orig)), Some((info_map_edit, elab_edit))) =>
-    let info_slice_orig =
-      EvalInfo.of_info_map(
-        ~probe_all=CoreSettings.on.probe_all,
-        ~targets=Id.Map.empty,
-        info_map_orig,
-      );
-    let info_slice_edit =
-      EvalInfo.of_info_map(
-        ~probe_all=CoreSettings.on.probe_all,
-        ~targets=Id.Map.empty,
-        info_map_edit,
-      );
-    /* Baseline run (no prev) of the original — its incr_eval becomes
-     * the cache handed to the incremental run of the edited exp. */
-    switch (try_eval(info_slice_orig, elab_orig)) {
-    | None
-    | Some(StepLimitExceeded) =>
-      no_comparison("the unedited program did not evaluate to a result")
-    | Some(LimitedCompleted((_, state_before))) =>
-      /* Edited evaluated two ways: incrementally (reusing the baseline's
-       * cache) and from scratch (empty prev). These must agree. */
-      let fresh = try_eval(info_slice_edit, elab_edit);
-      let incr_eval_result =
-        try_eval(~prev=state_before.incr_eval, info_slice_edit, elab_edit);
-      switch (fresh, incr_eval_result) {
-      | (
-          Some(LimitedCompleted((e_fresh, _))),
-          Some(LimitedCompleted((e_incr, _))),
-        ) =>
-        check(testable, msg, e_fresh, e_incr)
-      | _ =>
-        no_comparison(
-          "the edited program did not evaluate to a result both ways",
-        )
+  switch (collect_int_lits(exp)) {
+  | [] => no_comparison("the program has no int literal to edit")
+  | lits =>
+    let (target_id, old_value) =
+      List.nth(lits, literal_index mod List.length(lits));
+    /* +1 keeps the type fixed, so the edit typechecks the same as the
+     * original while still changing the value at `target_id`. */
+    let new_value = Bigint.(old_value + of_int(1));
+    let edited =
+      replace_int_lit_by_id(~target=target_id, ~to_=new_value, exp);
+    switch (try_statics(exp), try_statics(edited)) {
+    | (Some((info_map_orig, elab_orig)), Some((info_map_edit, elab_edit))) =>
+      let info_slice_orig =
+        EvalInfo.of_info_map(
+          ~probe_all=CoreSettings.on.probe_all,
+          ~targets=Id.Map.empty,
+          info_map_orig,
+        );
+      let info_slice_edit =
+        EvalInfo.of_info_map(
+          ~probe_all=CoreSettings.on.probe_all,
+          ~targets=Id.Map.empty,
+          info_map_edit,
+        );
+      /* Baseline run (no prev) of the original — its incr_eval becomes
+       * the cache handed to the incremental run of the edited exp. */
+      switch (try_eval(info_slice_orig, elab_orig)) {
+      | None
+      | Some(StepLimitExceeded) =>
+        no_comparison("the unedited program did not evaluate to a result")
+      | Some(LimitedCompleted((_, state_before))) =>
+        /* Edited evaluated two ways: incrementally (reusing the baseline's
+         * cache) and from scratch (empty prev). These must agree. */
+        let fresh = try_eval(info_slice_edit, elab_edit);
+        let incr_eval_result =
+          try_eval(~prev=state_before.incr_eval, info_slice_edit, elab_edit);
+        switch (fresh, incr_eval_result) {
+        | (
+            Some(LimitedCompleted((e_fresh, _))),
+            Some(LimitedCompleted((e_incr, _))),
+          ) =>
+          check(testable, msg, e_fresh, e_incr)
+        | _ =>
+          no_comparison(
+            "the edited program did not evaluate to a result both ways",
+          )
+        };
       };
+    | _ => no_comparison("the program did not pass statics")
     };
-  | _ => no_comparison("the program did not pass statics")
   };
 };
 
@@ -454,22 +460,16 @@ let qcheck_incremental_matches_fresh_after_edit_disabled =
               QCheck.small_nat,
               QCheck_Util.arb_exp(~minimal_idents=true, 30),
             ),
-            ((seed, exp)) =>
-            switch (collect_int_lits(exp)) {
-            | [] => true /* Nothing to edit — the property is vacuously true. */
-            | lits =>
-              let (target_id, old_value) =
-                List.nth(lits, seed mod List.length(lits));
+            ((seed, exp)) => {
               check_incremental_against_fresh_after_edit(
-                ~target_id,
-                ~old_value,
+                ~literal_index=seed,
                 ~testable=testable_core_exp,
                 ~msg="Incremental eval and fresh eval agree",
                 ~require_comparison=false,
                 exp,
               );
               true;
-            }
+            },
           ),
         ),
       );
@@ -480,27 +480,15 @@ let incremental_literal_edit_known_bug_test =
   test_case(
     "Known bug #2457: incremental eval disagrees with fresh after a literal edit",
     `Quick,
-    () => {
-      let exp = parse_exp("{ let x = (); let _ = 4; let true = A }");
-      let (target_id, old_value) =
-        switch (collect_int_lits(exp)) {
-        | [lit] => lit
-        | lits =>
-          failf(
-            "expected exactly one int literal to edit, found %d",
-            List.length(lits),
-          )
-        };
-      check_incremental_against_fresh_after_edit(
-        ~target_id,
-        ~old_value,
-        ~testable=neg(testable_core_exp),
-        ~msg=
-          "#2457 looks fixed: re-enable `Incremental eval agrees with fresh eval after a literal edit`, delete this test",
-        ~require_comparison=true,
-        exp,
-      );
-    },
+    () =>
+    check_incremental_against_fresh_after_edit(
+      ~literal_index=0,
+      ~testable=neg(testable_core_exp),
+      ~msg=
+        "#2457 looks fixed: re-enable `Incremental eval agrees with fresh eval after a literal edit`, delete this test",
+      ~require_comparison=true,
+      parse_exp("{ let x = (); let _ = 4; let true = A }"),
+    )
   );
 
 let rec finish_yielding = (~remaining_slices: int, evaluation) => {

--- a/test/evaluator/Test_Evaluator_Properties.re
+++ b/test/evaluator/Test_Evaluator_Properties.re
@@ -54,11 +54,22 @@ let testable_core_exp =
 
 /* Reduce `uexp` with the evaluator and with the stepper and `check` the two
    against each other: pass `testable_core_exp` to assert they agree, or
-   `neg(testable_core_exp)` to assert they still differ. False when the case was
-   filtered out and nothing was compared. */
+   `neg(testable_core_exp)` to assert they still differ.
+
+   A case that never reaches that comparison — reduction not terminating inside
+   `step_limit`, or statics/evaluation raising — is skipped when
+   `require_comparison` is false, which is what the property wants of a random
+   draw. A fixed counterexample passes true: reaching no comparison means it no
+   longer pins anything and needs re-minimizing, so say so rather than pass. */
 let check_evaluator_against_stepper =
-    (~step_limit: int, ~testable: testable(Exp.t), ~msg: string, uexp: Exp.t)
-    : bool =>
+    (
+      ~step_limit: int,
+      ~testable: testable(Exp.t),
+      ~msg: string,
+      ~require_comparison: bool,
+      uexp: Exp.t,
+    )
+    : unit =>
   switch (
     {
       let (_, elab) =
@@ -76,21 +87,38 @@ let check_evaluator_against_stepper =
       full_small_step_reduction(~step_limit, elaborated_exp),
     ) {
     | (LimitedCompleted((bigstep_exp, _)), LimitedCompleted(smallstep_exp)) =>
-      check(testable, msg, fst(smallstep_exp), bigstep_exp);
-      true;
+      check(testable, msg, fst(smallstep_exp), bigstep_exp)
     | (_, StepLimitExceeded)
-    | (StepLimitExceeded, _) => false
+    | (StepLimitExceeded, _) =>
+      if (require_comparison) {
+        failf(
+          "reduction did not terminate within %d steps, so nothing was compared; re-minimize the counterexample",
+          step_limit,
+        );
+      }
     | exception e =>
-      print_endline(
-        "Skipping evaluation failure: " ++ Printexc.to_string(e),
-      );
-      false;
+      if (require_comparison) {
+        failf(
+          "evaluation raised %s, so nothing was compared; re-minimize the counterexample",
+          Printexc.to_string(e),
+        );
+      } else {
+        print_endline(
+          "Skipping evaluation failure: " ++ Printexc.to_string(e),
+        );
+      }
     }
   | exception e =>
-    print_endline(
-      "Skipping statics/elaborate failure: " ++ Printexc.to_string(e),
-    );
-    false;
+    if (require_comparison) {
+      failf(
+        "statics/elaborate raised %s, so nothing was compared; re-minimize the counterexample",
+        Printexc.to_string(e),
+      );
+    } else {
+      print_endline(
+        "Skipping statics/elaborate failure: " ++ Printexc.to_string(e),
+      );
+    }
   };
 
 let qcheck_stepper_confluence =
@@ -99,14 +127,12 @@ let qcheck_stepper_confluence =
     ~count=1000,
     QCheck_Util.arb_exp(~minimal_idents=true, 10),
     uexp => {
-      /* Failure arrives as a raise from `check`; the bool is only vacuity. */
-      ignore(
-        check_evaluator_against_stepper(
-          ~step_limit=100,
-          ~testable=testable_core_exp,
-          ~msg="Small step reduction and big step reduction are equal",
-          uexp,
-        ): bool,
+      check_evaluator_against_stepper(
+        ~step_limit=100,
+        ~testable=testable_core_exp,
+        ~msg="Small step reduction and big step reduction are equal",
+        ~require_comparison=false,
+        uexp,
       );
       true;
     },
@@ -130,17 +156,13 @@ let stepper_confluence_known_bug_test =
     "Known bug #2128: evaluator and stepper disagree on a duplicate binder",
     `Quick,
     () =>
-    check(
-      bool,
-      "counterexample still reduces under both; re-minimize it otherwise",
-      true,
-      check_evaluator_against_stepper(
-        ~step_limit=100,
-        ~testable=neg(testable_core_exp),
-        ~msg=
-          "#2128 looks fixed: re-enable `Evaluator and stepper are consistent`, delete this test",
-        parse_exp("fun (x::x) -> x"),
-      ),
+    check_evaluator_against_stepper(
+      ~step_limit=100,
+      ~testable=neg(testable_core_exp),
+      ~msg=
+        "#2128 looks fixed: re-enable `Evaluator and stepper are consistent`, delete this test",
+      ~require_comparison=true,
+      parse_exp("fun (x::x) -> x"),
     )
   );
 
@@ -336,16 +358,26 @@ let eval_limited =
 /* Bump the int literal at `target_id` by one and `check` the edited program
    evaluated incrementally against it evaluated fresh: pass `testable_core_exp`
    to assert they agree, or `neg(testable_core_exp)` to assert they still
-   differ. False when the case was filtered out and nothing was compared. */
+   differ. `require_comparison` as in `check_evaluator_against_stepper`. */
 let check_incremental_against_fresh_after_edit =
     (
       ~target_id: Id.t,
       ~old_value: Bigint.t,
       ~testable: testable(Exp.t),
       ~msg: string,
+      ~require_comparison: bool,
       exp: Exp.t,
     )
-    : bool => {
+    : unit => {
+  /* Reaching no comparison is a skip for the property and a failure for the
+     fixed counterexample — see `check_evaluator_against_stepper`. */
+  let no_comparison = reason =>
+    if (require_comparison) {
+      failf(
+        "%s, so nothing was compared; re-minimize the counterexample",
+        reason,
+      );
+    };
   /* Only swallow known-benign static/dynamic failures so real
    * incremental-eval disagreements surface as clean failures. */
   let try_eval = (~prev=?, eval_info, elab) =>
@@ -384,7 +416,8 @@ let check_incremental_against_fresh_after_edit =
      * the cache handed to the incremental run of the edited exp. */
     switch (try_eval(info_slice_orig, elab_orig)) {
     | None
-    | Some(StepLimitExceeded) => false
+    | Some(StepLimitExceeded) =>
+      no_comparison("the unedited program did not evaluate to a result")
     | Some(LimitedCompleted((_, state_before))) =>
       /* Edited evaluated two ways: incrementally (reusing the baseline's
        * cache) and from scratch (empty prev). These must agree. */
@@ -396,12 +429,14 @@ let check_incremental_against_fresh_after_edit =
           Some(LimitedCompleted((e_fresh, _))),
           Some(LimitedCompleted((e_incr, _))),
         ) =>
-        check(testable, msg, e_fresh, e_incr);
-        true;
-      | _ => false
+        check(testable, msg, e_fresh, e_incr)
+      | _ =>
+        no_comparison(
+          "the edited program did not evaluate to a result both ways",
+        )
       };
     };
-  | _ => false
+  | _ => no_comparison("the program did not pass statics")
   };
 };
 
@@ -419,15 +454,13 @@ let qcheck_incremental_matches_fresh_after_edit =
     | lits =>
       let (target_id, old_value) =
         List.nth(lits, seed mod List.length(lits));
-      /* Failure arrives as a raise from `check`; the bool is only vacuity. */
-      ignore(
-        check_incremental_against_fresh_after_edit(
-          ~target_id,
-          ~old_value,
-          ~testable=testable_core_exp,
-          ~msg="Incremental eval and fresh eval agree",
-          exp,
-        ): bool,
+      check_incremental_against_fresh_after_edit(
+        ~target_id,
+        ~old_value,
+        ~testable=testable_core_exp,
+        ~msg="Incremental eval and fresh eval agree",
+        ~require_comparison=false,
+        exp,
       );
       true;
     }
@@ -467,18 +500,14 @@ let incremental_literal_edit_known_bug_test =
             List.length(lits),
           )
         };
-      check(
-        bool,
-        "counterexample still evaluates both ways; re-minimize it otherwise",
-        true,
-        check_incremental_against_fresh_after_edit(
-          ~target_id,
-          ~old_value,
-          ~testable=neg(testable_core_exp),
-          ~msg=
-            "#2457 looks fixed: re-enable `Incremental eval agrees with fresh eval after a literal edit`, delete this test",
-          exp,
-        ),
+      check_incremental_against_fresh_after_edit(
+        ~target_id,
+        ~old_value,
+        ~testable=neg(testable_core_exp),
+        ~msg=
+          "#2457 looks fixed: re-enable `Incremental eval agrees with fresh eval after a literal edit`, delete this test",
+        ~require_comparison=true,
+        exp,
       );
     },
   );

--- a/test/evaluator/Test_Evaluator_Properties.re
+++ b/test/evaluator/Test_Evaluator_Properties.re
@@ -52,16 +52,11 @@ let testable_core_exp =
     Equality.semantic.exp,
   );
 
-/* Reduce `uexp` with the evaluator and with the stepper and `check` the two
-   against each other: pass `testable_core_exp` to assert they agree, or
-   `neg(testable_core_exp)` to assert they still differ.
-
-   A case that never reaches that comparison — reduction not terminating inside
-   `step_limit`, or statics/evaluation raising — is skipped when
-   `require_comparison` is false, which is what the property wants of a random
-   draw. A fixed counterexample passes true: reaching no comparison means it no
-   longer pins anything and needs re-minimizing, so say so rather than pass. */
-let check_evaluator_against_stepper =
+/* Check that the evaluator and the stepper are consistent on `uexp`. The step
+   limit and known issues that raise are skipped — or, with
+   `require_comparison`, failed, so a fixed counterexample that stops reaching
+   the comparison says so instead of passing. */
+let check_evaluator_stepper_consistent =
     (
       ~step_limit: int,
       ~testable: testable(Exp.t),
@@ -121,23 +116,6 @@ let check_evaluator_against_stepper =
     }
   };
 
-let qcheck_stepper_confluence =
-  QCheck.Test.make(
-    ~name="Evaluator and stepper are consistent",
-    ~count=1000,
-    QCheck_Util.arb_exp(~minimal_idents=true, 10),
-    uexp => {
-      check_evaluator_against_stepper(
-        ~step_limit=100,
-        ~testable=testable_core_exp,
-        ~msg="Small step reduction and big step reduction are equal",
-        ~require_comparison=false,
-        uexp,
-      );
-      true;
-    },
-  );
-
 /* Disabled: fails on any seed that draws a duplicate binder — known bug
    https://github.com/hazelgrove/hazel/issues/2128 (dup #2372). The test below
    pins that counterexample and goes red once it is fixed. */
@@ -147,7 +125,25 @@ let qcheck_stepper_confluence_disabled =
     [@warning "-21"]
     {
       Alcotest.skip();
-      ignore(QCheck_alcotest.to_alcotest(qcheck_stepper_confluence));
+      ignore(
+        QCheck_alcotest.to_alcotest(
+          QCheck.Test.make(
+            ~name="Evaluator and stepper are consistent",
+            ~count=1000,
+            QCheck_Util.arb_exp(~minimal_idents=true, 10),
+            uexp => {
+              check_evaluator_stepper_consistent(
+                ~step_limit=100,
+                ~testable=testable_core_exp,
+                ~msg="Small step reduction and big step reduction are equal",
+                ~require_comparison=false,
+                uexp,
+              );
+              true;
+            },
+          ),
+        ),
+      );
     }
   });
 
@@ -156,7 +152,7 @@ let stepper_confluence_known_bug_test =
     "Known bug #2128: evaluator and stepper disagree on a duplicate binder",
     `Quick,
     () =>
-    check_evaluator_against_stepper(
+    check_evaluator_stepper_consistent(
       ~step_limit=100,
       ~testable=neg(testable_core_exp),
       ~msg=
@@ -355,10 +351,9 @@ let eval_limited =
     elab,
   );
 
-/* Bump the int literal at `target_id` by one and `check` the edited program
-   evaluated incrementally against it evaluated fresh: pass `testable_core_exp`
-   to assert they agree, or `neg(testable_core_exp)` to assert they still
-   differ. `require_comparison` as in `check_evaluator_against_stepper`. */
+/* Check that incremental eval and fresh eval agree on `exp` with the int
+   literal at `target_id` bumped by one. Skips and `require_comparison` as
+   above. */
 let check_incremental_against_fresh_after_edit =
     (
       ~target_id: Id.t,
@@ -369,8 +364,6 @@ let check_incremental_against_fresh_after_edit =
       exp: Exp.t,
     )
     : unit => {
-  /* Reaching no comparison is a skip for the property and a failure for the
-     fixed counterexample — see `check_evaluator_against_stepper`. */
   let no_comparison = reason =>
     if (require_comparison) {
       failf(
@@ -440,32 +433,6 @@ let check_incremental_against_fresh_after_edit =
   };
 };
 
-let qcheck_incremental_matches_fresh_after_edit =
-  QCheck.Test.make(
-    ~name="Incremental eval agrees with fresh eval after a literal edit",
-    ~count=2000,
-    QCheck.pair(
-      QCheck.small_nat,
-      QCheck_Util.arb_exp(~minimal_idents=true, 30),
-    ),
-    ((seed, exp)) =>
-    switch (collect_int_lits(exp)) {
-    | [] => true /* Nothing to edit — the property is vacuously true. */
-    | lits =>
-      let (target_id, old_value) =
-        List.nth(lits, seed mod List.length(lits));
-      check_incremental_against_fresh_after_edit(
-        ~target_id,
-        ~old_value,
-        ~testable=testable_core_exp,
-        ~msg="Incremental eval and fresh eval agree",
-        ~require_comparison=false,
-        exp,
-      );
-      true;
-    }
-  );
-
 /* Disabled: fails on any seed that draws the shape below — known bug
    https://github.com/hazelgrove/hazel/issues/2457. The test below pins that
    counterexample and goes red once it is fixed. */
@@ -479,7 +446,31 @@ let qcheck_incremental_matches_fresh_after_edit_disabled =
       Alcotest.skip();
       ignore(
         QCheck_alcotest.to_alcotest(
-          qcheck_incremental_matches_fresh_after_edit,
+          QCheck.Test.make(
+            ~name=
+              "Incremental eval agrees with fresh eval after a literal edit",
+            ~count=2000,
+            QCheck.pair(
+              QCheck.small_nat,
+              QCheck_Util.arb_exp(~minimal_idents=true, 30),
+            ),
+            ((seed, exp)) =>
+            switch (collect_int_lits(exp)) {
+            | [] => true /* Nothing to edit — the property is vacuously true. */
+            | lits =>
+              let (target_id, old_value) =
+                List.nth(lits, seed mod List.length(lits));
+              check_incremental_against_fresh_after_edit(
+                ~target_id,
+                ~old_value,
+                ~testable=testable_core_exp,
+                ~msg="Incremental eval and fresh eval agree",
+                ~require_comparison=false,
+                exp,
+              );
+              true;
+            }
+          ),
         ),
       );
     }

--- a/test/evaluator/Test_Evaluator_Properties.re
+++ b/test/evaluator/Test_Evaluator_Properties.re
@@ -3,49 +3,6 @@ open Language;
 open Test_Evaluator_Prelude;
 open Alcotest;
 
-/* The verdict on one case of a property. `Holds` and `Fails` are evidence;
-   `Vacuous` means the case was filtered out — a step limit, or one of the
-   raises these properties deliberately skip — and is neither. Producing a
-   verdict rather than a pair of results lets the property below and the
-   counterexample pinning its known bug share one function: the property
-   checks the verdict holds, the counterexample checks it still fails. */
-type verdict =
-  | Holds
-  | Fails(string) /* rendered disagreement, for the failure output */
-  | Vacuous;
-
-/* Read a verdict as a QCheck predicate: only real evidence of a failure fails
-   the property. */
-let holds = (verdict: verdict): bool =>
-  switch (verdict) {
-  | Holds
-  | Vacuous => true
-  | Fails(rendered) =>
-    print_endline(rendered);
-    false;
-  };
-
-/* Read a verdict as a counterexample pinning a known bug: the disagreement
-   must still be there, so this goes red once the bug is fixed and names the
-   property to re-enable. */
-let check_still_fails =
-    (~issue: string, ~property: string, verdict: verdict): unit =>
-  switch (verdict) {
-  | Fails(_) => ()
-  | Holds =>
-    failf(
-      "%s looks fixed: re-enable the `%s` property, delete this",
-      issue,
-      property,
-    )
-  | Vacuous =>
-    failf(
-      "this counterexample no longer reaches a result; re-minimize it against the `%s` property (%s)",
-      property,
-      issue,
-    )
-  };
-
 let qcheck_evaluator_does_not_crash_test =
   QCheck.Test.make(
     ~name="Evaluator does not crash",
@@ -99,10 +56,19 @@ let show_core_exp = exp =>
      )
   |> Printer.of_segment(~holes="?", _);
 
-/* Elaborate `uexp`, then reduce it with the evaluator and with the stepper:
-   the two must land on the same expression. Rendered through ExpToSegment,
-   which reads better but can lose information. */
-let evaluator_and_stepper_agree = (~step_limit: int, uexp: Exp.t): verdict =>
+/* Output is easier to view through ExpToSegment. This may result in a loss of
+   information. */
+let testable_core_exp =
+  testable(Fmt.using(show_core_exp, Fmt.string), Equality.semantic.exp);
+
+/* Elaborate `uexp`, reduce it with the evaluator and with the stepper, and
+   `check` the two results against each other with `testable`: pass
+   `testable_core_exp` to assert they agree, or `neg(testable_core_exp)` to
+   assert they still differ. Returns false when the case was filtered out — a
+   step limit, or a raise these properties skip — and nothing was compared. */
+let check_evaluator_against_stepper =
+    (~step_limit: int, ~testable: testable(Exp.t), ~msg: string, uexp: Exp.t)
+    : bool =>
   switch (
     {
       let (_, elab) =
@@ -120,28 +86,21 @@ let evaluator_and_stepper_agree = (~step_limit: int, uexp: Exp.t): verdict =>
       full_small_step_reduction(~step_limit, elaborated_exp),
     ) {
     | (LimitedCompleted((bigstep_exp, _)), LimitedCompleted(smallstep_exp)) =>
-      let smallstep_exp = fst(smallstep_exp);
-      Equality.semantic.exp(bigstep_exp, smallstep_exp)
-        ? Holds
-        : Fails(
-            "small step reduction and big step reduction differ:\n  small step: "
-            ++ show_core_exp(smallstep_exp)
-            ++ "\n  big step:   "
-            ++ show_core_exp(bigstep_exp),
-          );
+      check(testable, msg, fst(smallstep_exp), bigstep_exp);
+      true;
     | (_, StepLimitExceeded)
-    | (StepLimitExceeded, _) => Vacuous
+    | (StepLimitExceeded, _) => false
     | exception e =>
       print_endline(
         "Skipping evaluation failure: " ++ Printexc.to_string(e),
       );
-      Vacuous;
+      false;
     }
   | exception e =>
     print_endline(
       "Skipping statics/elaborate failure: " ++ Printexc.to_string(e),
     );
-    Vacuous;
+    false;
   };
 
 let qcheck_stepper_confluence =
@@ -149,8 +108,19 @@ let qcheck_stepper_confluence =
     ~name="Evaluator and stepper are consistent",
     ~count=1000,
     QCheck_Util.arb_exp(~minimal_idents=true, 10),
-    uexp =>
-    holds(evaluator_and_stepper_agree(~step_limit=100, uexp))
+    uexp => {
+      /* `check` raises on a disagreement; a filtered-out case is not a
+         failure, so the compared/not-compared answer is discarded here. */
+      ignore(
+        check_evaluator_against_stepper(
+          ~step_limit=100,
+          ~testable=testable_core_exp,
+          ~msg="Small step reduction and big step reduction are equal",
+          uexp,
+        ): bool,
+      );
+      true;
+    },
   );
 
 /* Disabled: fails on any seed that draws a duplicate binder, where one of the
@@ -173,11 +143,15 @@ let stepper_confluence_known_bug_test =
     "Known bug #2128: evaluator and stepper disagree on a duplicate binder",
     `Quick,
     () =>
-    check_still_fails(
-      ~issue="https://github.com/hazelgrove/hazel/issues/2128",
-      ~property="Evaluator and stepper are consistent",
-      evaluator_and_stepper_agree(
+    check(
+      bool,
+      "counterexample still reduces under both; re-minimize it otherwise",
+      true,
+      check_evaluator_against_stepper(
         ~step_limit=100,
+        ~testable=neg(testable_core_exp),
+        ~msg=
+          "#2128 looks fixed: re-enable `Evaluator and stepper are consistent`, delete this test",
         parse_exp("fun (x::x) -> x"),
       ),
     )
@@ -368,12 +342,22 @@ let eval_limited =
     elab,
   );
 
-/* Bump the int literal at `target_id` by one, then evaluate the edited program
-   two ways: incrementally, reusing the unedited run's cache, and from scratch.
-   Both must land on the same result. Both sides share one elaboration, so a
-   disagreement is a reuse / dirty-propagation bug rather than a semantic one. */
-let incremental_agrees_with_fresh_after_edit =
-    (~target_id: Id.t, ~old_value: Bigint.t, exp: Exp.t): verdict => {
+/* Bump the int literal at `target_id` by one, evaluate the edited program two
+   ways — incrementally, reusing the unedited run's cache, and from scratch —
+   and `check` the two against each other with `testable`: pass
+   `testable_core_exp` to assert they agree, or `neg(testable_core_exp)` to
+   assert they still differ. Both sides share one elaboration, so a
+   disagreement is a reuse / dirty-propagation bug rather than a semantic one.
+   Returns false when the case was filtered out and nothing was compared. */
+let check_incremental_against_fresh_after_edit =
+    (
+      ~target_id: Id.t,
+      ~old_value: Bigint.t,
+      ~testable: testable(Exp.t),
+      ~msg: string,
+      exp: Exp.t,
+    )
+    : bool => {
   /* Only swallow known-benign static/dynamic failures so real
    * incremental-eval disagreements surface as clean failures. */
   let try_eval = (~prev=?, eval_info, elab) =>
@@ -412,7 +396,7 @@ let incremental_agrees_with_fresh_after_edit =
      * the cache handed to the incremental run of the edited exp. */
     switch (try_eval(info_slice_orig, elab_orig)) {
     | None
-    | Some(StepLimitExceeded) => Vacuous
+    | Some(StepLimitExceeded) => false
     | Some(LimitedCompleted((_, state_before))) =>
       /* Edited evaluated two ways: incrementally (reusing the baseline's
        * cache) and from scratch (empty prev). These must agree. */
@@ -424,18 +408,12 @@ let incremental_agrees_with_fresh_after_edit =
           Some(LimitedCompleted((e_fresh, _))),
           Some(LimitedCompleted((e_incr, _))),
         ) =>
-        Equality.semantic.exp(e_fresh, e_incr)
-          ? Holds
-          : Fails(
-              "fresh and incremental eval differ:\n  fresh:       "
-              ++ show_core_exp(e_fresh)
-              ++ "\n  incremental: "
-              ++ show_core_exp(e_incr),
-            )
-      | _ => Vacuous
+        check(testable, msg, e_fresh, e_incr);
+        true;
+      | _ => false
       };
     };
-  | _ => Vacuous
+  | _ => false
   };
 };
 
@@ -453,9 +431,18 @@ let qcheck_incremental_matches_fresh_after_edit =
     | lits =>
       let (target_id, old_value) =
         List.nth(lits, seed mod List.length(lits));
-      holds(
-        incremental_agrees_with_fresh_after_edit(~target_id, ~old_value, exp),
+      /* `check` raises on a disagreement; a filtered-out case is not a
+         failure, so the compared/not-compared answer is discarded here. */
+      ignore(
+        check_incremental_against_fresh_after_edit(
+          ~target_id,
+          ~old_value,
+          ~testable=testable_core_exp,
+          ~msg="Incremental eval and fresh eval agree",
+          exp,
+        ): bool,
       );
+      true;
     }
   );
 
@@ -494,11 +481,18 @@ let incremental_literal_edit_known_bug_test =
             List.length(lits),
           )
         };
-      check_still_fails(
-        ~issue="https://github.com/hazelgrove/hazel/issues/2457",
-        ~property=
-          "Incremental eval agrees with fresh eval after a literal edit",
-        incremental_agrees_with_fresh_after_edit(~target_id, ~old_value, exp),
+      check(
+        bool,
+        "counterexample still evaluates both ways; re-minimize it otherwise",
+        true,
+        check_incremental_against_fresh_after_edit(
+          ~target_id,
+          ~old_value,
+          ~testable=neg(testable_core_exp),
+          ~msg=
+            "#2457 looks fixed: re-enable `Incremental eval agrees with fresh eval after a literal edit`, delete this test",
+          exp,
+        ),
       );
     },
   );

--- a/test/evaluator/Test_Evaluator_Properties.re
+++ b/test/evaluator/Test_Evaluator_Properties.re
@@ -3,6 +3,49 @@ open Language;
 open Test_Evaluator_Prelude;
 open Alcotest;
 
+/* The verdict on one case of a property. `Holds` and `Fails` are evidence;
+   `Vacuous` means the case was filtered out — a step limit, or one of the
+   raises these properties deliberately skip — and is neither. Producing a
+   verdict rather than a pair of results lets the property below and the
+   counterexample pinning its known bug share one function: the property
+   checks the verdict holds, the counterexample checks it still fails. */
+type verdict =
+  | Holds
+  | Fails(string) /* rendered disagreement, for the failure output */
+  | Vacuous;
+
+/* Read a verdict as a QCheck predicate: only real evidence of a failure fails
+   the property. */
+let holds = (verdict: verdict): bool =>
+  switch (verdict) {
+  | Holds
+  | Vacuous => true
+  | Fails(rendered) =>
+    print_endline(rendered);
+    false;
+  };
+
+/* Read a verdict as a counterexample pinning a known bug: the disagreement
+   must still be there, so this goes red once the bug is fixed and names the
+   property to re-enable. */
+let check_still_fails =
+    (~issue: string, ~property: string, verdict: verdict): unit =>
+  switch (verdict) {
+  | Fails(_) => ()
+  | Holds =>
+    failf(
+      "%s looks fixed: re-enable the `%s` property, delete this",
+      issue,
+      property,
+    )
+  | Vacuous =>
+    failf(
+      "this counterexample no longer reaches a result; re-minimize it against the `%s` property (%s)",
+      property,
+      issue,
+    )
+  };
+
 let qcheck_evaluator_does_not_crash_test =
   QCheck.Test.make(
     ~name="Evaluator does not crash",
@@ -56,15 +99,10 @@ let show_core_exp = exp =>
      )
   |> Printer.of_segment(~holes="?", _);
 
-/* Elaborate `uexp` and reduce it with both engines, returning
- * `Some((bigstep, smallstep))` when both land on a result. `None` means the
- * case is vacuous — either engine hit the step limit, or statics/evaluation
- * raised (filtered the same way as the other evaluator QCheck tests here).
- *
- * Shared by the confluence property and by the deterministic #2128 pin, so
- * the two cannot drift apart. */
-let reduce_both_engines =
-    (~step_limit: int, uexp: Exp.t): option((Exp.t, Exp.t)) =>
+/* Elaborate `uexp`, then reduce it with the evaluator and with the stepper:
+   the two must land on the same expression. Rendered through ExpToSegment,
+   which reads better but can lose information. */
+let evaluator_and_stepper_agree = (~step_limit: int, uexp: Exp.t): verdict =>
   switch (
     {
       let (_, elab) =
@@ -82,26 +120,29 @@ let reduce_both_engines =
       full_small_step_reduction(~step_limit, elaborated_exp),
     ) {
     | (LimitedCompleted((bigstep_exp, _)), LimitedCompleted(smallstep_exp)) =>
-      Some((bigstep_exp, smallstep_exp |> fst))
+      let smallstep_exp = fst(smallstep_exp);
+      Equality.semantic.exp(bigstep_exp, smallstep_exp)
+        ? Holds
+        : Fails(
+            "small step reduction and big step reduction differ:\n  small step: "
+            ++ show_core_exp(smallstep_exp)
+            ++ "\n  big step:   "
+            ++ show_core_exp(bigstep_exp),
+          );
     | (_, StepLimitExceeded)
-    | (StepLimitExceeded, _) => None
+    | (StepLimitExceeded, _) => Vacuous
     | exception e =>
       print_endline(
         "Skipping evaluation failure: " ++ Printexc.to_string(e),
       );
-      None;
+      Vacuous;
     }
   | exception e =>
     print_endline(
       "Skipping statics/elaborate failure: " ++ Printexc.to_string(e),
     );
-    None;
+    Vacuous;
   };
-
-/* Output is easier to view through ExpToSegment. This may result in a loss of
-   information. */
-let testable_core_exp =
-  testable(Fmt.using(show_core_exp, Fmt.string), Equality.semantic.exp);
 
 let qcheck_stepper_confluence =
   QCheck.Test.make(
@@ -109,50 +150,37 @@ let qcheck_stepper_confluence =
     ~count=1000,
     QCheck_Util.arb_exp(~minimal_idents=true, 10),
     uexp =>
-    switch (reduce_both_engines(~step_limit=100, uexp)) {
-    | None => true
-    | Some((bigstep_exp, smallstep_exp)) =>
-      Alcotest.check(
-        testable_core_exp,
-        "Small step reduction and big step reduction are equal",
-        smallstep_exp,
-        bigstep_exp,
-      );
-      true;
-    }
+    holds(evaluator_and_stepper_agree(~step_limit=100, uexp))
   );
 
-/* The counterexample from #2128/#2372, driven directly instead of waited for
- * from the generator: a duplicate binder in a cons pattern. One engine
- * freshens the second `x` and the other does not, and `Equality.semantic.exp`
- * does not equate the two alpha-variants.
- *
- * This asserts the CURRENT, WRONG behaviour, so it goes red the day the
- * engines agree and tells us to re-enable `qcheck_stepper_confluence` above.
- * A plain `Alcotest.skip()` would stay silent forever instead. */
+/* Disabled: fails on any seed that draws a duplicate binder, where one of the
+   two freshens it and the other does not. Known bug
+   https://github.com/hazelgrove/hazel/issues/2128 (dup #2372). The test after
+   this one pins that counterexample and goes red once the bug is fixed, which
+   is the signal to re-enable this property. */
+let qcheck_stepper_confluence_disabled =
+  test_case(
+    "Evaluator and stepper are consistent (disabled, #2128)", `Quick, () => {
+    [@warning "-21"]
+    {
+      Alcotest.skip();
+      ignore(QCheck_alcotest.to_alcotest(qcheck_stepper_confluence));
+    }
+  });
+
 let stepper_confluence_known_bug_test =
   test_case(
-    "Known Bug #2128: evaluator and stepper disagree on a duplicate binder",
+    "Known bug #2128: evaluator and stepper disagree on a duplicate binder",
     `Quick,
-    () => {
-      let uexp = parse_exp("fun (x::x) -> x");
-      switch (reduce_both_engines(~step_limit=100, uexp)) {
-      | None =>
-        fail(
-          "the #2128 counterexample no longer reduces under both engines; "
-          ++ "re-minimize it against the property before trusting this pin",
-        )
-      | Some((bigstep_exp, smallstep_exp)) =>
-        check(
-          bool,
-          "#2128/#2372 appear FIXED: re-enable the disabled "
-          ++ "`Evaluator and stepper are consistent` property and delete this "
-          ++ "expected-failure pin",
-          false,
-          Equality.semantic.exp(bigstep_exp, smallstep_exp),
-        )
-      };
-    },
+    () =>
+    check_still_fails(
+      ~issue="https://github.com/hazelgrove/hazel/issues/2128",
+      ~property="Evaluator and stepper are consistent",
+      evaluator_and_stepper_agree(
+        ~step_limit=100,
+        parse_exp("fun (x::x) -> x"),
+      ),
+    )
   );
 
 // Property that states let x : T = e in x is equivalent to e : T
@@ -340,17 +368,12 @@ let eval_limited =
     elab,
   );
 
-/* Run the one-literal-edit experiment on `exp`: bump the int literal at
- * `target_id` by one, then evaluate the edited program both incrementally
- * (against the cache from the unedited run) and from scratch. `None` means
- * the case is vacuous — a known-benign statics/dynamics failure or the step
- * limit — and callers should treat it as no evidence either way.
- *
- * Shared by the property below and by the deterministic #2457 pin, so the
- * two cannot drift apart. */
-let eval_after_literal_edit =
-    (~target_id: Id.t, ~old_value: Bigint.t, exp: Exp.t)
-    : option((Exp.t, Exp.t)) => {
+/* Bump the int literal at `target_id` by one, then evaluate the edited program
+   two ways: incrementally, reusing the unedited run's cache, and from scratch.
+   Both must land on the same result. Both sides share one elaboration, so a
+   disagreement is a reuse / dirty-propagation bug rather than a semantic one. */
+let incremental_agrees_with_fresh_after_edit =
+    (~target_id: Id.t, ~old_value: Bigint.t, exp: Exp.t): verdict => {
   /* Only swallow known-benign static/dynamic failures so real
    * incremental-eval disagreements surface as clean failures. */
   let try_eval = (~prev=?, eval_info, elab) =>
@@ -389,7 +412,7 @@ let eval_after_literal_edit =
      * the cache handed to the incremental run of the edited exp. */
     switch (try_eval(info_slice_orig, elab_orig)) {
     | None
-    | Some(StepLimitExceeded) => None
+    | Some(StepLimitExceeded) => Vacuous
     | Some(LimitedCompleted((_, state_before))) =>
       /* Edited evaluated two ways: incrementally (reusing the baseline's
        * cache) and from scratch (empty prev). These must agree. */
@@ -401,11 +424,18 @@ let eval_after_literal_edit =
           Some(LimitedCompleted((e_fresh, _))),
           Some(LimitedCompleted((e_incr, _))),
         ) =>
-        Some((e_fresh, e_incr))
-      | _ => None
+        Equality.semantic.exp(e_fresh, e_incr)
+          ? Holds
+          : Fails(
+              "fresh and incremental eval differ:\n  fresh:       "
+              ++ show_core_exp(e_fresh)
+              ++ "\n  incremental: "
+              ++ show_core_exp(e_incr),
+            )
+      | _ => Vacuous
       };
     };
-  | _ => None
+  | _ => Vacuous
   };
 };
 
@@ -417,33 +447,41 @@ let qcheck_incremental_matches_fresh_after_edit =
       QCheck.small_nat,
       QCheck_Util.arb_exp(~minimal_idents=true, 30),
     ),
-    ((seed, exp)) => {
+    ((seed, exp)) =>
     switch (collect_int_lits(exp)) {
     | [] => true /* Nothing to edit — the property is vacuously true. */
     | lits =>
       let (target_id, old_value) =
         List.nth(lits, seed mod List.length(lits));
-      switch (eval_after_literal_edit(~target_id, ~old_value, exp)) {
-      | None => true
-      | Some((e_fresh, e_incr)) => Equality.semantic.exp(e_fresh, e_incr)
-      };
+      holds(
+        incremental_agrees_with_fresh_after_edit(~target_id, ~old_value, exp),
+      );
+    }
+  );
+
+/* Disabled: fails on any seed that draws the shape below. Known bug
+   https://github.com/hazelgrove/hazel/issues/2457. The test after this one
+   pins that counterexample and goes red once the bug is fixed, which is the
+   signal to re-enable this property. */
+let qcheck_incremental_matches_fresh_after_edit_disabled =
+  test_case(
+    "Incremental eval agrees with fresh eval after a literal edit (disabled, #2457)",
+    `Quick,
+    () => {
+    [@warning "-21"]
+    {
+      Alcotest.skip();
+      ignore(
+        QCheck_alcotest.to_alcotest(
+          qcheck_incremental_matches_fresh_after_edit,
+        ),
+      );
     }
   });
 
-/* The minimal counterexample from #2457, driven directly instead of waited
- * for from the generator. Every ingredient matters: a *named* binding that
- * survives into the residual, the edited literal bound to `_`, and
- * evaluation getting stuck *after* the literal via a failing pattern match.
- *
- * This asserts the CURRENT, WRONG behaviour — fresh eval substitutes `x`'s
- * value into the residual environment, incremental eval leaves `x` as a
- * variable. It is deliberately NOT an `Alcotest.skip()` like
- * `skip_known_bug` elsewhere in test/: a skipped test stays silent forever,
- * whereas this one goes red the day #2457 is fixed and tells us to re-enable
- * `qcheck_incremental_matches_fresh_after_edit` above. */
 let incremental_literal_edit_known_bug_test =
   test_case(
-    "Known Bug #2457: incremental eval disagrees with fresh after a literal edit",
+    "Known bug #2457: incremental eval disagrees with fresh after a literal edit",
     `Quick,
     () => {
       let exp = parse_exp("{ let x = (); let _ = 4; let true = A }");
@@ -456,22 +494,12 @@ let incremental_literal_edit_known_bug_test =
             List.length(lits),
           )
         };
-      switch (eval_after_literal_edit(~target_id, ~old_value, exp)) {
-      | None =>
-        fail(
-          "the #2457 counterexample no longer reaches a completed evaluation; "
-          ++ "re-minimize it against the property before trusting this pin",
-        )
-      | Some((e_fresh, e_incr)) =>
-        check(
-          bool,
-          "#2457 appears FIXED: re-enable the disabled "
-          ++ "`Incremental eval agrees with fresh eval after a literal edit` "
-          ++ "property and delete this expected-failure pin",
-          false,
-          Equality.semantic.exp(e_fresh, e_incr),
-        )
-      };
+      check_still_fails(
+        ~issue="https://github.com/hazelgrove/hazel/issues/2457",
+        ~property=
+          "Incremental eval agrees with fresh eval after a literal edit",
+        incremental_agrees_with_fresh_after_edit(~target_id, ~old_value, exp),
+      );
     },
   );
 
@@ -762,37 +790,10 @@ let tests = (
     yielding_streaming_current_state_test,
     yielding_streaming_current_id_invalid_race_test,
     QCheck_alcotest.to_alcotest(qcheck_evaluator_does_not_crash_test),
-    /* Disabled: fails for any seed that generates a duplicate binder
-       (#2128/#2372), which has reddened Full tests on unrelated PRs. The
-       deterministic pin below keeps the bug covered. #2408 fixes a different
-       confluence cause, so it will not on its own make this safe to re-enable. */
-    test_case(
-      "Evaluator and stepper are consistent (disabled, #2128)", `Quick, () => {
-      [@warning "-21"]
-      {
-        Alcotest.skip();
-        ignore(QCheck_alcotest.to_alcotest(qcheck_stepper_confluence));
-      }
-    }),
+    qcheck_stepper_confluence_disabled,
     stepper_confluence_known_bug_test,
     QCheck_alcotest.to_alcotest(qcheck_pattern_equivalence_test),
-    /* Disabled: fails for any seed that generates the #2457 shape, which has
-       reddened Full tests on unrelated PRs. The deterministic pin below keeps
-       the bug covered and will fail once #2457 is fixed. */
-    test_case(
-      "Incremental eval agrees with fresh eval after a literal edit (disabled, #2457)",
-      `Quick,
-      () => {
-      [@warning "-21"]
-      {
-        Alcotest.skip();
-        ignore(
-          QCheck_alcotest.to_alcotest(
-            qcheck_incremental_matches_fresh_after_edit,
-          ),
-        );
-      }
-    }),
+    qcheck_incremental_matches_fresh_after_edit_disabled,
     incremental_literal_edit_known_bug_test,
     /* Preservation does not currently hold: stepping can produce a type that
        is not more precise than the original. */

--- a/test/evaluator/Test_Evaluator_Properties.re
+++ b/test/evaluator/Test_Evaluator_Properties.re
@@ -47,69 +47,6 @@ let qcheck_evaluator_does_not_crash_test =
     }
   });
 
-let qcheck_stepper_confluence =
-  QCheck.Test.make(
-    ~name="Evaluator and stepper are consistent",
-    ~count=1000,
-    QCheck_Util.arb_exp(~minimal_idents=true, 10),
-    uexp => {
-    switch (
-      {
-        let (_, elab) =
-          Statics.mk(CoreSettings.on, Builtins.ctx_init(Some(Int)), uexp);
-        elab;
-      }
-    ) {
-    | elaborated_exp =>
-      switch (
-        Evaluator.evaluate_and_limit(
-          ~env=Builtins.env_init,
-          ~step_limit=100,
-          elaborated_exp,
-        ),
-        full_small_step_reduction(~step_limit=100, elaborated_exp),
-      ) {
-      | (
-          LimitedCompleted((bigstep_exp, _)),
-          LimitedCompleted(smallstep_exp),
-        ) =>
-        let show_core_exp = exp =>
-          exp
-          |> ExpToSegment.exp_to_segment(
-               ~settings=
-                 ExpToSegment.Settings.of_core(
-                   ~inline=true,
-                   CoreSettings.off,
-                 ),
-               _,
-             )
-          |> Printer.of_segment(~holes="?", _);
-
-        Alcotest.check(
-          testable(
-            Fmt.using(show_core_exp, Fmt.string),
-            Equality.semantic.exp,
-          ), // Output is easier to view through ExpToSegment. This may result in a loss of information
-          "Small step reduction and big step reduction are equal",
-          smallstep_exp |> fst,
-          bigstep_exp,
-        );
-        true;
-      | (_, StepLimitExceeded)
-      | (StepLimitExceeded, _) => true
-      | exception e =>
-        print_endline(
-          "Skipping evaluation failure: " ++ Printexc.to_string(e),
-        );
-        true;
-      }
-    | exception e =>
-      print_endline(
-        "Skipping statics/elaborate failure: " ++ Printexc.to_string(e),
-      );
-      true;
-    }
-  });
 let show_core_exp = exp =>
   exp
   |> ExpToSegment.exp_to_segment(
@@ -118,6 +55,105 @@ let show_core_exp = exp =>
        _,
      )
   |> Printer.of_segment(~holes="?", _);
+
+/* Elaborate `uexp` and reduce it with both engines, returning
+ * `Some((bigstep, smallstep))` when both land on a result. `None` means the
+ * case is vacuous — either engine hit the step limit, or statics/evaluation
+ * raised (filtered the same way as the other evaluator QCheck tests here).
+ *
+ * Shared by the confluence property and by the deterministic #2128 pin, so
+ * the two cannot drift apart. */
+let reduce_both_engines =
+    (~step_limit: int, uexp: Exp.t): option((Exp.t, Exp.t)) =>
+  switch (
+    {
+      let (_, elab) =
+        Statics.mk(CoreSettings.on, Builtins.ctx_init(Some(Int)), uexp);
+      elab;
+    }
+  ) {
+  | elaborated_exp =>
+    switch (
+      Evaluator.evaluate_and_limit(
+        ~env=Builtins.env_init,
+        ~step_limit,
+        elaborated_exp,
+      ),
+      full_small_step_reduction(~step_limit, elaborated_exp),
+    ) {
+    | (LimitedCompleted((bigstep_exp, _)), LimitedCompleted(smallstep_exp)) =>
+      Some((bigstep_exp, smallstep_exp |> fst))
+    | (_, StepLimitExceeded)
+    | (StepLimitExceeded, _) => None
+    | exception e =>
+      print_endline(
+        "Skipping evaluation failure: " ++ Printexc.to_string(e),
+      );
+      None;
+    }
+  | exception e =>
+    print_endline(
+      "Skipping statics/elaborate failure: " ++ Printexc.to_string(e),
+    );
+    None;
+  };
+
+/* Output is easier to view through ExpToSegment. This may result in a loss of
+   information. */
+let testable_core_exp =
+  testable(Fmt.using(show_core_exp, Fmt.string), Equality.semantic.exp);
+
+let qcheck_stepper_confluence =
+  QCheck.Test.make(
+    ~name="Evaluator and stepper are consistent",
+    ~count=1000,
+    QCheck_Util.arb_exp(~minimal_idents=true, 10),
+    uexp =>
+    switch (reduce_both_engines(~step_limit=100, uexp)) {
+    | None => true
+    | Some((bigstep_exp, smallstep_exp)) =>
+      Alcotest.check(
+        testable_core_exp,
+        "Small step reduction and big step reduction are equal",
+        smallstep_exp,
+        bigstep_exp,
+      );
+      true;
+    }
+  );
+
+/* The counterexample from #2128/#2372, driven directly instead of waited for
+ * from the generator: a duplicate binder in a cons pattern. One engine
+ * freshens the second `x` and the other does not, and `Equality.semantic.exp`
+ * does not equate the two alpha-variants.
+ *
+ * This asserts the CURRENT, WRONG behaviour, so it goes red the day the
+ * engines agree and tells us to re-enable `qcheck_stepper_confluence` above.
+ * A plain `Alcotest.skip()` would stay silent forever instead. */
+let stepper_confluence_known_bug_test =
+  test_case(
+    "Known Bug #2128: evaluator and stepper disagree on a duplicate binder",
+    `Quick,
+    () => {
+      let uexp = parse_exp("fun (x::x) -> x");
+      switch (reduce_both_engines(~step_limit=100, uexp)) {
+      | None =>
+        fail(
+          "the #2128 counterexample no longer reduces under both engines; "
+          ++ "re-minimize it against the property before trusting this pin",
+        )
+      | Some((bigstep_exp, smallstep_exp)) =>
+        check(
+          bool,
+          "#2128/#2372 appear FIXED: re-enable the disabled "
+          ++ "`Evaluator and stepper are consistent` property and delete this "
+          ++ "expected-failure pin",
+          false,
+          Equality.semantic.exp(bigstep_exp, smallstep_exp),
+        )
+      };
+    },
+  );
 
 // Property that states let x : T = e in x is equivalent to e : T
 let qcheck_pattern_equivalence_test =
@@ -304,6 +340,75 @@ let eval_limited =
     elab,
   );
 
+/* Run the one-literal-edit experiment on `exp`: bump the int literal at
+ * `target_id` by one, then evaluate the edited program both incrementally
+ * (against the cache from the unedited run) and from scratch. `None` means
+ * the case is vacuous — a known-benign statics/dynamics failure or the step
+ * limit — and callers should treat it as no evidence either way.
+ *
+ * Shared by the property below and by the deterministic #2457 pin, so the
+ * two cannot drift apart. */
+let eval_after_literal_edit =
+    (~target_id: Id.t, ~old_value: Bigint.t, exp: Exp.t)
+    : option((Exp.t, Exp.t)) => {
+  /* Only swallow known-benign static/dynamic failures so real
+   * incremental-eval disagreements surface as clean failures. */
+  let try_eval = (~prev=?, eval_info, elab) =>
+    try(Some(eval_limited(~prev?, ~eval_info, ~step_limit=10000, elab))) {
+    | Failure(msg)
+        when
+          List.exists(
+            (==)(msg),
+            ["type application in dynamics", "Type meet of ap"],
+          ) =>
+      None
+    };
+  let try_statics = exp =>
+    try(Some(statics_and_elab(exp))) {
+    | _ => None
+    };
+  /* +1 keeps the type fixed, so the edit typechecks the same as the
+   * original while still changing the value at `target_id`. */
+  let new_value = Bigint.(old_value + of_int(1));
+  let edited = replace_int_lit_by_id(~target=target_id, ~to_=new_value, exp);
+  switch (try_statics(exp), try_statics(edited)) {
+  | (Some((info_map_orig, elab_orig)), Some((info_map_edit, elab_edit))) =>
+    let info_slice_orig =
+      EvalInfo.of_info_map(
+        ~probe_all=CoreSettings.on.probe_all,
+        ~targets=Id.Map.empty,
+        info_map_orig,
+      );
+    let info_slice_edit =
+      EvalInfo.of_info_map(
+        ~probe_all=CoreSettings.on.probe_all,
+        ~targets=Id.Map.empty,
+        info_map_edit,
+      );
+    /* Baseline run (no prev) of the original — its incr_eval becomes
+     * the cache handed to the incremental run of the edited exp. */
+    switch (try_eval(info_slice_orig, elab_orig)) {
+    | None
+    | Some(StepLimitExceeded) => None
+    | Some(LimitedCompleted((_, state_before))) =>
+      /* Edited evaluated two ways: incrementally (reusing the baseline's
+       * cache) and from scratch (empty prev). These must agree. */
+      let fresh = try_eval(info_slice_edit, elab_edit);
+      let incr_eval_result =
+        try_eval(~prev=state_before.incr_eval, info_slice_edit, elab_edit);
+      switch (fresh, incr_eval_result) {
+      | (
+          Some(LimitedCompleted((e_fresh, _))),
+          Some(LimitedCompleted((e_incr, _))),
+        ) =>
+        Some((e_fresh, e_incr))
+      | _ => None
+      };
+    };
+  | _ => None
+  };
+};
+
 let qcheck_incremental_matches_fresh_after_edit =
   QCheck.Test.make(
     ~name="Incremental eval agrees with fresh eval after a literal edit",
@@ -313,75 +418,59 @@ let qcheck_incremental_matches_fresh_after_edit =
       QCheck_Util.arb_exp(~minimal_idents=true, 30),
     ),
     ((seed, exp)) => {
-      /* Only swallow known-benign static/dynamic failures so real
-       * incremental-eval disagreements surface as clean PBT failures. */
-      let try_eval = (~prev=?, eval_info, elab) =>
-        try(Some(eval_limited(~prev?, ~eval_info, ~step_limit=10000, elab))) {
-        | Failure(msg)
-            when
-              List.exists(
-                (==)(msg),
-                ["type application in dynamics", "Type meet of ap"],
-              ) =>
-          None
+    switch (collect_int_lits(exp)) {
+    | [] => true /* Nothing to edit — the property is vacuously true. */
+    | lits =>
+      let (target_id, old_value) =
+        List.nth(lits, seed mod List.length(lits));
+      switch (eval_after_literal_edit(~target_id, ~old_value, exp)) {
+      | None => true
+      | Some((e_fresh, e_incr)) => Equality.semantic.exp(e_fresh, e_incr)
+      };
+    }
+  });
+
+/* The minimal counterexample from #2457, driven directly instead of waited
+ * for from the generator. Every ingredient matters: a *named* binding that
+ * survives into the residual, the edited literal bound to `_`, and
+ * evaluation getting stuck *after* the literal via a failing pattern match.
+ *
+ * This asserts the CURRENT, WRONG behaviour — fresh eval substitutes `x`'s
+ * value into the residual environment, incremental eval leaves `x` as a
+ * variable. It is deliberately NOT an `Alcotest.skip()` like
+ * `skip_known_bug` elsewhere in test/: a skipped test stays silent forever,
+ * whereas this one goes red the day #2457 is fixed and tells us to re-enable
+ * `qcheck_incremental_matches_fresh_after_edit` above. */
+let incremental_literal_edit_known_bug_test =
+  test_case(
+    "Known Bug #2457: incremental eval disagrees with fresh after a literal edit",
+    `Quick,
+    () => {
+      let exp = parse_exp("{ let x = (); let _ = 4; let true = A }");
+      let (target_id, old_value) =
+        switch (collect_int_lits(exp)) {
+        | [lit] => lit
+        | lits =>
+          failf(
+            "expected exactly one int literal to edit, found %d",
+            List.length(lits),
+          )
         };
-      let try_statics = exp =>
-        try(Some(statics_and_elab(exp))) {
-        | _ => None
-        };
-      switch (collect_int_lits(exp)) {
-      | [] => true /* Nothing to edit — the property is vacuously true. */
-      | lits =>
-        let (target_id, old_value) =
-          List.nth(lits, seed mod List.length(lits));
-        /* +1 keeps the type fixed, so the edit typechecks the same as the
-         * original while still changing the value at `target_id`. */
-        let new_value = Bigint.(old_value + of_int(1));
-        let edited =
-          replace_int_lit_by_id(~target=target_id, ~to_=new_value, exp);
-        switch (try_statics(exp), try_statics(edited)) {
-        | (
-            Some((info_map_orig, elab_orig)),
-            Some((info_map_edit, elab_edit)),
-          ) =>
-          let info_slice_orig =
-            EvalInfo.of_info_map(
-              ~probe_all=CoreSettings.on.probe_all,
-              ~targets=Id.Map.empty,
-              info_map_orig,
-            );
-          let info_slice_edit =
-            EvalInfo.of_info_map(
-              ~probe_all=CoreSettings.on.probe_all,
-              ~targets=Id.Map.empty,
-              info_map_edit,
-            );
-          /* Baseline run (no prev) of the original — its incr_eval becomes
-           * the cache handed to the incremental run of the edited exp. */
-          switch (try_eval(info_slice_orig, elab_orig)) {
-          | None
-          | Some(StepLimitExceeded) => true
-          | Some(LimitedCompleted((_, state_before))) =>
-            /* Edited evaluated two ways: incrementally (reusing the baseline's
-             * cache) and from scratch (empty prev). These must agree. */
-            let fresh = try_eval(info_slice_edit, elab_edit);
-            let incr_eval_result =
-              try_eval(
-                ~prev=state_before.incr_eval,
-                info_slice_edit,
-                elab_edit,
-              );
-            switch (fresh, incr_eval_result) {
-            | (
-                Some(LimitedCompleted((e_fresh, _))),
-                Some(LimitedCompleted((e_incr, _))),
-              ) =>
-              Equality.semantic.exp(e_fresh, e_incr)
-            | _ => true
-            };
-          };
-        | _ => true
-        };
+      switch (eval_after_literal_edit(~target_id, ~old_value, exp)) {
+      | None =>
+        fail(
+          "the #2457 counterexample no longer reaches a completed evaluation; "
+          ++ "re-minimize it against the property before trusting this pin",
+        )
+      | Some((e_fresh, e_incr)) =>
+        check(
+          bool,
+          "#2457 appears FIXED: re-enable the disabled "
+          ++ "`Incremental eval agrees with fresh eval after a literal edit` "
+          ++ "property and delete this expected-failure pin",
+          false,
+          Equality.semantic.exp(e_fresh, e_incr),
+        )
       };
     },
   );
@@ -673,9 +762,38 @@ let tests = (
     yielding_streaming_current_state_test,
     yielding_streaming_current_id_invalid_race_test,
     QCheck_alcotest.to_alcotest(qcheck_evaluator_does_not_crash_test),
-    QCheck_alcotest.to_alcotest(qcheck_stepper_confluence),
+    /* Disabled: fails for any seed that generates a duplicate binder
+       (#2128/#2372), which has reddened Full tests on unrelated PRs. The
+       deterministic pin below keeps the bug covered. #2408 fixes a different
+       confluence cause, so it will not on its own make this safe to re-enable. */
+    test_case(
+      "Evaluator and stepper are consistent (disabled, #2128)", `Quick, () => {
+      [@warning "-21"]
+      {
+        Alcotest.skip();
+        ignore(QCheck_alcotest.to_alcotest(qcheck_stepper_confluence));
+      }
+    }),
+    stepper_confluence_known_bug_test,
     QCheck_alcotest.to_alcotest(qcheck_pattern_equivalence_test),
-    QCheck_alcotest.to_alcotest(qcheck_incremental_matches_fresh_after_edit),
+    /* Disabled: fails for any seed that generates the #2457 shape, which has
+       reddened Full tests on unrelated PRs. The deterministic pin below keeps
+       the bug covered and will fail once #2457 is fixed. */
+    test_case(
+      "Incremental eval agrees with fresh eval after a literal edit (disabled, #2457)",
+      `Quick,
+      () => {
+      [@warning "-21"]
+      {
+        Alcotest.skip();
+        ignore(
+          QCheck_alcotest.to_alcotest(
+            qcheck_incremental_matches_fresh_after_edit,
+          ),
+        );
+      }
+    }),
+    incremental_literal_edit_known_bug_test,
     /* Preservation does not currently hold: stepping can produce a type that
        is not more precise than the original. */
     test_case("Preservation of types (disabled)", `Quick, () => {


### PR DESCRIPTION
Two `Evaluator.Properties` QCheck properties fail occasionally.

This disables both and pins each bug deterministically instead. **It fixes neither bug** — #2128, #2372 and #2457 stay open.

| property | issue | reddened |
|---|---|---|
| `Evaluator and stepper are consistent` (case 5) | #2128, dup #2372 | a random local seed while preparing this PR |
| `Incremental eval agrees with fresh eval after a literal edit` (case 7) | #2457 | [33513972427](https://github.com/hazelgrove/hazel/actions/runs/33513972427), [33513747011](https://github.com/hazelgrove/hazel/actions/runs/33513747011), [33412342909](https://github.com/hazelgrove/hazel/actions/runs/33412342909) — three unrelated branches, each dying on case 7 alone |

Disabled the way `Preservation of types (disabled)` already is here: a `test_case` that skips but still `ignore`s the QCheck test, so it keeps compiling and re-enabling is one line.

### The pins

Each disabled property is replaced by a unit test on its issue's counterexample:

- **#2128/#2372** — `fun (x::x) -> x`: one engine freshens the duplicate binder, the other doesn't, and `Equality.semantic.exp` doesn't equate the alpha-variants.
- **#2457** — `{ let x = (); let _ = 4; let true = A }` with the literal bumped: fresh eval substitutes `x` into the residual environment, incremental leaves it a variable.

Both assert the **current, wrong** behaviour, so they go red the day the bug is fixed and name the property to re-enable. Hence not `skip_known_bug` (`test/Test_Elaboration.re:456`, `test/statics/Test_Statics_Prelude.re:269`) — a skipped test can never fail, so it stays silent forever.

So pin and property can't drift, the shared work is extracted and called by both: `reduce_both_engines` and `eval_after_literal_edit`, each returning `None` for vacuous cases (step limit, known-benign raise).

### Notes

**#2408** fixes a different confluence cause — uncollapsed casts in indeterminate `if` branches, not binder freshening — so the #2128 pin should still be red after it lands. Both PRs edit this file; happy to rebase on it, or to drop the confluence half here and keep only the #2457 disable.

**#2397** is untouched: "Pattern equivalence" exhausts node's 4 GB heap on ~1 seed in 6, and an OOM kills the process rather than failing a test, so it can't be pinned this way. Wants a lower `~count`/step limit, separately.

### Verification

`make ci-check` (release, warnings-as-errors over `test/`) and `dune fmt` clean. `Evaluator.Properties` green, including #2457's seeds 3 and 468045375 which previously failed. Both pins confirmed to fail when the disagreement they assert goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
