### PR TITLE
Fix: red labeled-tuple = and infix minus 

### DIFF
--- a/src/haz3lcore/derived/MultiProbe.re
+++ b/src/haz3lcore/derived/MultiProbe.re
@@ -402,9 +402,8 @@ let is_incomplete_binding_form = (candidate_id: Id.t, data: TermData.t): bool =>
  * of typing and should never be probed or count as alternatives. */
 let is_delimiter_prefix = (candidate_id: Id.t, data: TermData.t): bool =>
   switch (TermData.root_tile(candidate_id, data)) {
-  | Some({label: [t], mold, _}) =>
-    Mold.is_infix_op(mold) && Form.is_infix_delimiter_op_prefix(t)
-  | _ => false
+  | Some(t) => Piece.is_infix_delimiter_op_prefix(Tile(t))
+  | None => false
   };
 
 /* Check if an id represents a "meaningful" alternative (not a hole,

--- a/src/haz3lcore/lang/Form.re
+++ b/src/haz3lcore/lang/Form.re
@@ -603,6 +603,18 @@ let is_infix_delimiter_op_prefix: Token.t => bool = {
   t => Hashtbl.mem(tbl, t);
 };
 
+/* Backup molds handed to delimiter prefixes in operator position. Mold
+   identity, not token, is what tells a backup-molded `-` (pending `->`)
+   from real infix minus or a labeled-tuple `=`. */
+let infix_delimiter_prefix_molds: list(Mold.t) = [
+  Mold.mk_bin(Precedence.concave_grout, Exp, []),
+  Mold.mk_bin(Precedence.concave_grout, Pat, []),
+  Mold.mk_bin(Precedence.concave_grout, Typ, []),
+  Mold.mk_bin(Precedence.concave_grout, TPat, []),
+];
+let is_infix_delimiter_prefix_mold = (m: Mold.t): bool =>
+  List.mem(m, infix_delimiter_prefix_molds);
+
 /* Tokens that appear both as single-token labels and in other forms labels.
  * These have special put-down behavior to make sure we can actually enter
  * the single-delimiter variant during left-to-right entry */
@@ -639,12 +651,7 @@ let get_atomic_form: atomic_form => (Token.t => bool, list(Mold.t)) =
   | Var => (Token.is_var, [op(Exp), op(Pat)])
   | InfixDelimiterPrefix => (
       is_infix_delimiter_op_prefix,
-      [
-        Mold.mk_bin(Precedence.concave_grout, Exp, []),
-        Mold.mk_bin(Precedence.concave_grout, Pat, []),
-        Mold.mk_bin(Precedence.concave_grout, Typ, []),
-        Mold.mk_bin(Precedence.concave_grout, TPat, []),
-      ],
+      infix_delimiter_prefix_molds,
     )
   | ExplicitHole => (
       Token.is_explicit_hole,

--- a/src/haz3lcore/tiles/Piece.re
+++ b/src/haz3lcore/tiles/Piece.re
@@ -163,7 +163,8 @@ let is_term = (p: t) =>
 let is_infix_delimiter_op_prefix = (p: t) =>
   switch (p) {
   | Tile({label: [t], mold, _}) =>
-    Mold.is_infix_op(mold) && Form.is_infix_delimiter_op_prefix(t)
+    Form.is_infix_delimiter_op_prefix(t)
+    && Form.is_infix_delimiter_prefix_mold(mold)
   | _ => false
   };
 

--- a/src/web/app/editors/code/Code.re
+++ b/src/web/app/editors/code/Code.re
@@ -136,8 +136,7 @@ let view =
       is_consistent(sort, t),
       List.mem(t.id, buffer_ids),
       Tile.is_complete(t),
-      Mold.is_infix_op(t.mold)
-      && Form.is_infix_delimiter_op_prefix(List.nth(t.label, i)),
+      Piece.is_infix_delimiter_op_prefix(Tile(t)),
       font_metrics,
     );
   };

--- a/test/Test_Editing.re
+++ b/test/Test_Editing.re
@@ -5277,8 +5277,77 @@ let pending_delim_tests = [
   ),
 ];
 
+/* Consumers (token color, arms, probing, indentation) recognize a pending
+ * delimiter by its backup mold, so a `-` or `=` carrying a real infix mold
+ * must not read as one. */
+let rec find_tile = (tok: string, seg: Segment.t): option(Tile.t) =>
+  List.fold_left(
+    (acc, p: Piece.t) =>
+      switch (acc, p) {
+      | (Some(_), _) => acc
+      | (None, Tile(t)) when t.label == [tok] => Some(t)
+      | (None, Tile(t)) =>
+        List.fold_left(
+          (acc, kid) => acc == None ? find_tile(tok, kid) : acc,
+          None,
+          t.children,
+        )
+      | (None, _) => None
+      },
+    None,
+    seg,
+  );
+
+let test_delim_prefix = (~name, ~acts, ~tok, ~expect): test_case(_) =>
+  test_case(name, `Quick, () =>
+    switch (find_tile(tok, acts |> perform(Zipper.init()) |> Zipper.zip)) {
+    | None => Alcotest.fail("no tile with label " ++ tok)
+    | Some(t) =>
+      check(
+        bool,
+        "Piece.is_infix_delimiter_op_prefix",
+        expect,
+        Piece.is_infix_delimiter_op_prefix(Tile(t)),
+      )
+    }
+  );
+
+let delim_prefix_class_tests = [
+  test_delim_prefix(
+    ~name="Pat: minus pending -> is a delimiter prefix",
+    ~acts=mk({|fun x -¦|}),
+    ~tok="-",
+    ~expect=true,
+  ),
+  test_delim_prefix(
+    ~name="Exp: partial keyword is a delimiter prefix",
+    ~acts=mk({|if x th¦|}),
+    ~tok="th",
+    ~expect=true,
+  ),
+  test_delim_prefix(
+    ~name="Exp: infix minus is not a delimiter prefix",
+    ~acts=mk({|1 - 2¦|}),
+    ~tok="-",
+    ~expect=false,
+  ),
+  test_delim_prefix(
+    ~name="Exp: labeled tuple = is not a delimiter prefix",
+    ~acts=mk({|(a=1)¦|}),
+    ~tok="=",
+    ~expect=false,
+  ),
+  test_delim_prefix(
+    ~name="Pat: labeled tuple = is not a delimiter prefix",
+    ~acts=mk({|fun (a=x) -> x¦|}),
+    ~tok="=",
+    ~expect=false,
+  ),
+];
+
 let tests = [
   ("Editing.PendingDelim", pending_delim_tests),
+  ("Editing.DelimPrefixClass", delim_prefix_class_tests),
   ("Editing.DragToZeroWidth", drag_to_zero_width_tests),
   ("Editing.MoveAfterCharSelect", move_after_char_select_tests),
   ("Editing.SmartSelection", smart_selection_tests),

--- a/test/Test_MultiProbe.re
+++ b/test/Test_MultiProbe.re
@@ -288,6 +288,11 @@ list # no probe #|},
 /* TUPLABEL SPECIAL CASES - probe RHS value, not the label */
 let tuplabel_tests = [
   test_probe_placement(
+    ~name="Infix minus - a real operator, not a pending -> prefix",
+    ~code={|let x = 1 - 2 in # 1 - 2 #
+x # no probe #|},
+  ),
+  test_probe_placement(
     ~name="Multi-line record - probe values not tuplabels",
     ~code=
       {|let x = ( # x #


### PR DESCRIPTION
On dev, `(a=1)` renders its `=` in error red, and `let x = 1 - 2 in` probes `2` instead of `1 - 2`.

#2460 added `-` and `=` to `Form.is_infix_delimiter_op_prefix` so `fun x -` molds as a pending `->`. The consumers that recognize such backup-molded tiles (token color, arms, multi-probe, indentation) checked token membership plus "is infix", which also matches real infix minus and the labeled-tuple `=`.

Fix: lift the backup molds to `Form.infix_delimiter_prefix_molds` and have `Piece.is_infix_delimiter_op_prefix` require one of them; Code.re and MultiProbe route through it. Molding is untouched (PendingDelim tests unchanged). New tests: Editing.DelimPrefixClass and a MultiProbe infix-minus case, both verified to fail on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
