### PR TITLE
[bugfix] prevent proof steps menus stacking behind later rows

### DIFF
--- a/src/web/www/style/stepper.css
+++ b/src/web/www/style/stepper.css
@@ -126,6 +126,14 @@
   position: absolute;
 }
 
+/* Every result row is an isolated stacking context. Raise the active proof
+ * row (and any containing result rows) so later placeholder/target siblings
+ * cannot paint over its controls or an open assumptions/rewrite panel. */
+.cell-result:has(.missing-step-overlay-align) {
+  position: relative;
+  z-index: var(--context-inspector-z);
+}
+
 .proof-context-box {
   position: absolute;
   top: calc(100% + 0.5em);


### PR DESCRIPTION
## Summary
Keep proof controls and open Algebra/Assumptions panels above following placeholder and target rows. This was blocking using the IH in proofs by induction in the Stepper.

## Test
- `make`
- Manually verified the proof controls and Assumptions dropdown

## Before
<img width="601" height="185" alt="Screenshot 2026-09-02 at 1 14 26 PM" src="https://github.com/user-attachments/assets/33df4bae-ef7d-4322-aae2-c6d72119dd25" />

## After
<img width="605" height="177" alt="Screenshot 2026-09-02 at 1 14 43 PM" src="https://github.com/user-attachments/assets/8852f07a-835c-48ee-90df-cae3abcc80b6" />