### PR TITLE
non-`dev` (`user-livelits`): Type-check the expansion of each user-defined livelit

### DIFF
--- a/docs/livelits.md
+++ b/docs/livelits.md
@@ -23,6 +23,7 @@ A Hazel program can define a livelit by binding a livelit name to a module:
 let ^pct = {
   type Model = Int;
   type Action = Int;
+  type Expansion = Int;
   let init : Model = 50;
   let update = fun (m, a) : (Model, Action) -> a;
   let view = fun m : Model -> ...;
@@ -35,10 +36,34 @@ with `update: (Model, Action) => Model`, `view: Model => HTML` (handlers emit
 Actions, as in the MVU apps — see mvu.md), and `expand: Model => Expansion`.
 An optional member `shape = Inline(width) | Block(width, height) |
 Tab(width, height)` (a `LivelitShape`) sets the projector's footprint in
-character cells. Type members are accepted but not yet semantically
-load-bearing. Helpers are ordinary additional members. Since modules are
-sugar for labeled tuples, a positional `(init, update, view, expand[, shape])`
-tuple is accepted as the equivalent form.
+character cells. Helpers are ordinary additional members.
+
+All three type members are required, and they are the livelit's interface.
+`Model` types each use's argument, `Action` types what the view emits, and
+`Expansion` is what clients type against. There is no tuple form: a tuple
+has nowhere to declare the types.
+
+## Type-Checking the Expansion
+
+A use of `^pct` synthesizes the declared `Expansion` — not the type of
+whatever code `expand` produced. That is the abstract reasoning principle
+of the paper: a client reads the livelit's declared type and never the
+expansion. The obligation it creates is discharged at each use, where
+statics types the expansion (in synthetic mode, on a throwaway info map)
+and compares the result with the declaration. An inconsistency is reported
+on the use as `BadLivelitExpansion` — "Livelit expands to type Int, but
+declares Expansion = String" — locating the fault in the livelit rather
+than in the client's surrounding code.
+
+Consistency, not equality, is the test, as everywhere else in the language:
+an expansion that synthesizes `Unknown` (an unannotated `expand` whose body
+gives statics nothing to go on, or a builtin livelit generating a hole)
+stays gradual and is not marked. What the declaration buys in that case is
+still real — clients type against a known type instead of `Unknown`.
+
+The expansion typed is the one built from the *surface* model, since statics
+traverses surface syntax only; the elaborated model, which a user-defined
+livelit's expansion embeds, is what actually evaluates.
 
 Each use elaborates to `^name.expand(model)` through the runtime `^name`
 binding, so shadowing and scoping behave like ordinary lets, and each use's

--- a/docs/livelits.md
+++ b/docs/livelits.md
@@ -7,6 +7,21 @@ Hazel implements a version of the live literals (livelits) mechanism described i
 - No parameters
 - No splices
 
+Splices are the remaining gap, and they will arrive as a `SpliceRef` primitive type with
+operations over it (`new_splice`, `set_splice`, `eval_splice`, in the paper's `UpdateCmd`
+and `ViewCmd` monads). When they land, `expand` extends to return a pair with the list of
+`SpliceRef`s, as in Fig. 3 of the paper:
+
+```
+expand : Model -> (Exp, List(SpliceRef))
+```
+
+The pair is there because the expansion must treat splices parametrically: the first
+component takes one argument per listed `SpliceRef` and returns the expansion type.
+`expand` itself stays pure — splices bring the monads, but not to `expand`. Until then the
+splice list is empty, so `expand : Model -> Expansion` is an equivalent encoding of the
+paper's closed expansion rather than a deviation from it.
+
 ## Overview
 
 A livelit is a live GUI widget which can be inserted into expressions and generates code by expansion to an expression of some given type. To invoke a livelit, insert the name of the livelit (always prefixed with ^) then press space.
@@ -45,21 +60,30 @@ has nowhere to declare the types.
 
 ## Type-Checking the Expansion
 
-A use of `^pct` synthesizes the declared `Expansion` — not the type of
-whatever code `expand` produced. That is the abstract reasoning principle
-of the paper: a client reads the livelit's declared type and never the
-expansion. The obligation it creates is discharged at each use, where
-statics types the expansion (in synthetic mode, on a throwaway info map)
-and compares the result with the declaration. An inconsistency is reported
-on the use as `BadLivelitExpansion` — "Livelit expands to type Int, but
-declares Expansion = String" — locating the fault in the livelit rather
+A use of `^pct` synthesizes the declared `Expansion`, not the type of whatever
+code `expand` produced. The check that earns this is performed for each
+expansion, on its output: statics types the expansion (in synthetic mode, on a
+throwaway info map) and compares the result with the declaration, marking the
+use `BadLivelitExpansion` on an inconsistency — "Livelit expands to type Int,
+but declares Expansion = String". The fault is located in the livelit rather
 than in the client's surrounding code.
 
-Consistency, not equality, is the test, as everywhere else in the language:
-an expansion that synthesizes `Unknown` (an unannotated `expand` whose body
-gives statics nothing to go on, or a builtin livelit generating a hole)
-stays gradual and is not marked. What the declaration buys in that case is
-still real — clients type against a known type instead of `Unknown`.
+Checking at the use site is the PLDI 2021 paper's own strategy rather than a
+deviation from it. §3.2.5 records that Hazel does not statically check
+`expand`'s definition, and that the parameterized expansion is instead
+"validated at each livelit invocation site, with errors reported to the
+client". With no splices that expansion takes no arguments, so validating it
+degenerates to checking the expansion at the expansion type, which is what
+happens here. The paper names definition-site verification via "a typed
+quotation system as in, e.g., MetaOCaml" as the alternative, awkward because
+"the type of the quotation depends on the type of each splice in the splice
+list".
+
+Consistency, not equality, is the test, as everywhere else in the language: an
+expansion that synthesizes `Unknown` (an unannotated `expand` whose body gives
+statics nothing to go on, or a builtin livelit generating a hole) stays gradual
+and is not marked. What the declaration buys in that case is still real —
+clients type against a known type instead of `Unknown`.
 
 The expansion typed is the one built from the *surface* model, since statics
 traverses surface syntax only; the elaborated model, which a user-defined

--- a/hazel-programs/docs/livelits/README.md
+++ b/hazel-programs/docs/livelits/README.md
@@ -12,6 +12,7 @@ A livelit definition binds a livelit name to a module:
 let ^name = {
   type Model = ...;
   type Action = ...;
+  type Expansion = ...;
   let init : Model = ...;
   let update = fun (m, a) : (Model, Action) -> ...;
   let view = fun m : Model -> ...;
@@ -19,18 +20,28 @@ let ^name = {
 } in ...
 ```
 
+All three type members are required — they are the livelit's interface:
+
+- `type Model`: the state a use carries, in its own argument
+- `type Action`: what the view's handlers emit
+- `type Expansion`: what a use means to the program. This is the type
+  clients see, so a use of `^name` has type `Expansion` however `expand`
+  is written; statics checks each use's expansion against the declaration
+  and marks the use when the two are inconsistent.
+
+and the four value members:
+
 - `init`: the model a fresh use starts with (`^name` + space inserts it)
 - `update: (Model, Action) => Model`
 - `view: Model => HTML` — handlers emit Actions (same HTML API as the MVU
   apps, see ../mvu/README.md)
-- `expand: Model => Expansion` — what a use means to the program
+- `expand: Model => Expansion`
 - optional member `shape`: `Inline(width)`, `Block(width, height)`, or
   `Tab(width, height)` — the widget's footprint in character cells
 
-Type members are accepted but not yet load-bearing; helpers (like the color
-picker's `css` and `pick`) are ordinary members. A positional
-`(init, update, view, expand[, shape])` tuple is the desugared equivalent.
-The definition must be closed — its functions evaluate in the builtin
+Helpers (like the color picker's `css` and `pick`) are ordinary extra
+members. There is no tuple form: a tuple has nowhere to declare the three
+types. The definition must be closed — its functions evaluate in the builtin
 environment — so helpers belong among the members. Each use's model is
 stored in its own argument syntax, so state survives in the program text.
 

--- a/hazel-programs/docs/livelits/color-picker.hz
+++ b/hazel-programs/docs/livelits/color-picker.hz
@@ -8,6 +8,7 @@
 let ^hwb = {
   type Model = (Int, Int, Int);
   type Action = Model;
+  type Expansion = String;
 
   let css = fun (h, w, b) : Model ->
     "hwb(" ++ string_of_int(h) ++ " "

--- a/hazel-programs/docs/livelits/defined-slider.hz
+++ b/hazel-programs/docs/livelits/defined-slider.hz
@@ -3,14 +3,22 @@
 # A livelit is a live GUI for a value in your program. Define one #
 # with a livelit name (^name) bound to a module: #
 
+# Three types declare the interface. Expansion is the one clients #
+# see: a use of ^pct has type Expansion, whatever expand returns. #
+
+# Model:     the state a use carries, stored in its argument #
+# Action:    what the GUI emits #
+# Expansion: what a use MEANS to the program #
+
 # init:   the model a fresh use starts with #
 # update: (Model, Action) -> Model, run when the GUI acts #
 # view:   Model -> HTML, whose handlers emit Actions #
-# expand: Model -> value, what a use means to the program #
+# expand: Model -> Expansion, checked against the declaration #
 
 let ^pct = {
   type Model = Int;
   type Action = Int;
+  type Expansion = Int;
 
   let init : Model = 50;
 

--- a/hazel-programs/docs/livelits/emotion.hz
+++ b/hazel-programs/docs/livelits/emotion.hz
@@ -8,6 +8,7 @@ let ^mood = {
   # 200 + value - 2 * grab-y (the bias keeps it positive). #
   type Model = (Int, Int);
   type Action = + Down(Int) + MoveTo(Int) + Up;
+  type Expansion = String;
 
   let init : Model = (50, -1);
 

--- a/hazel-programs/docs/livelits/graph-editor.hz
+++ b/hazel-programs/docs/livelits/graph-editor.hz
@@ -2,6 +2,7 @@ type Graph = ([(Int, Int)], [(Int, Int)]) in
 let ^graph = {
   type Model = ([(Int, Int)], [(Int, Int)], Int, Int, Bool);
   type Action = + Down(Int, Int) + MoveTo(Int, Int) + Up + Clear;
+  type Expansion = Graph;
   let init : Model = ([(40, 40), (150, 40), (95, 115)], [(0, 1), (1, 2)], -1, -1, false);
   let len : [(Int, Int)] -> Int = fun xs -> case xs | [] => 0 | _ :: tl => 1 + len(tl) end;
   let near : ([(Int, Int)], Int, Int, Int) -> Int =

--- a/src/haz3lcore/CompositionCore/prompt_factory/DocPacks.re
+++ b/src/haz3lcore/CompositionCore/prompt_factory/DocPacks.re
@@ -131,6 +131,7 @@ module bound to a livelit name (`^` prefix):
 let ^pct = {
 type Model = Int;
 type Action = Int;
+type Expansion = Int;
 let init : Model = 50;
 let update(m: Model, a: Action) = a;
 let view(m: Model) =
@@ -144,20 +145,33 @@ let expand(m: Model) = m
 ^^livelit(^pct(25)) + ^^livelit(^pct(75))
 ```
 
+All three type members are REQUIRED — they are the livelit's interface:
+
+- `type Model` — the state a use carries, in its own argument
+- `type Action` — what the view's handlers emit
+- `type Expansion` — what a use MEANS to the program. This is the type
+  clients see: `^pct(25)` has type Expansion no matter what `expand`
+  returns, and statics checks each use's expansion against it (an
+  inconsistency is reported on the use, as the livelit's fault).
+
+and the four value members:
+
 - `init : Model` — the model a fresh use starts with
 - `update : (Model, Action) -> Model` — no commands, unlike apps
 - `view : Model -> HTML` — same HTML/handler vocabulary as apps
   (see read_docs("mvu")); handlers emit Actions
-- `expand : Model -> T` — what a use MEANS to the program: `^pct(25)`
-  evaluates to `expand(25)`
+- `expand : Model -> Expansion` — `^pct(25)` evaluates to `expand(25)`
 
 ## Rules
 
 - Each use `^name(model)` carries its own model in its own argument.
   Wrap uses in `^^livelit(...)` so the GUI shows; a bare `^name(model)`
   is still a valid expression, just without the widget.
-- Helpers and type members are ordinary module members; keep the
-  definition self-contained (helpers inside the module).
+- Helpers are ordinary extra module members; keep the definition
+  self-contained (helpers inside the module).
+- A definition missing any of the three types or four members is
+  rejected, and the livelit name stays unbound. There is no tuple
+  form: it has nowhere to declare the types.
 - Optional member `let shape = ...` sets the widget's TEXT footprint
   (a LivelitShape): `Inline(w)` is one line, w columns; `Block(w, h)`
   is h lines with code flowing below; `Tab(w, h)` is h lines with code

--- a/src/haz3lcore/CompositionCore/prompt_factory/ProjectorCatalog.re
+++ b/src/haz3lcore/CompositionCore/prompt_factory/ProjectorCatalog.re
@@ -30,7 +30,7 @@ let livelit_line = (k: ProjectorKind.t): option(string) =>
   | TextArea => Some("- **text** — Multiline string literal editor.")
   | Livelit =>
     Some(
-      "- **livelit** — Shows a livelit's GUI at a use `^name(model)`. Programs can DEFINE their own livelits — `let ^name = { init; update; view; expand } in ...` — giving any data type an embedded editing widget; write uses as `^^livelit(^name(model))`. Call `read_docs(\"livelits\")` before defining one.",
+      "- **livelit** — Shows a livelit's GUI at a use `^name(model)`. Programs can DEFINE their own livelits — `let ^name = { type Model; type Action; type Expansion; init; update; view; expand } in ...` — giving any data type an embedded editing widget; write uses as `^^livelit(^name(model))`. Call `read_docs(\"livelits\")` before defining one.",
     )
   | Table =>
     Some(

--- a/src/haz3lcore/TyDi/ErrorPrint.re
+++ b/src/haz3lcore/TyDi/ErrorPrint.re
@@ -140,15 +140,21 @@ let exp_mark_to_string = (ctx: Ctx.t, ana: Typ.t, m: Mark.t): string => {
   | TupleExtensionRequiresTuples => "Expected tuples for both arguments"
   | BadOperator(_) => "Invalid operator"
   | BadLivelitModel(_) => "Bad internal livelit model"
-  | InvalidLivelitDef(DefNotTuple) => "Livelit definition should be a module with members init, update, view, expand"
-  | InvalidLivelitDef(DefBadArity(n)) =>
+  | BadLivelitExpansion({declared, actual}) =>
     prn(
-      "Livelit definition should have fields (init, update, view, expand), got %d",
-      n,
+      "Livelit expands to type %s, but declares Expansion = %s",
+      Print.typ(actual),
+      Print.typ(declared),
     )
+  | InvalidLivelitDef(DefNotModule) => "Livelit definition should be a module declaring types Model, Action, Expansion and members init, update, view, expand"
   | InvalidLivelitDef(DefMissingMembers(missing)) =>
     prn(
       "Livelit definition is missing members: %s",
+      String.concat(", ", missing),
+    )
+  | InvalidLivelitDef(DefMissingTypes(missing)) =>
+    prn(
+      "Livelit definition is missing type members: %s",
       String.concat(", ", missing),
     )
   | BadTheorem(typ) =>

--- a/src/haz3lcore/projectors/implementations/LivelitProj.re
+++ b/src/haz3lcore/projectors/implementations/LivelitProj.re
@@ -186,33 +186,21 @@ module M: Projector = {
       |> Option.map(snd)
     };
 
-  /* Extract a member from the evaluated definition record: by label when
-     labeled (modules desugar to labeled tuples, any size); positional only
-     for a plain (init, update, view, expand) tuple */
+  /* Extract a member from the evaluated definition record. A definition is
+     always a module, and modules desugar to LABELED tuples, so members are
+     found by name and member order and helper count don't matter. */
   let record_field =
-      (record: TermBase.Exp.t, label: string, index: int)
-      : option(TermBase.Exp.t) =>
+      (record: TermBase.Exp.t, label: string): option(TermBase.Exp.t) =>
     switch (MvuShape.of_tuple(MvuShape.strip_wrappers(record))) {
     | Some(fs) =>
-      switch (
-        List.find_map(
-          f =>
-            switch (MvuShape.of_field(f)) {
-            | Some((l, v)) when l == label => Some(v)
-            | _ => None
-            },
-          fs,
-        )
-      ) {
-      | Some(v) => Some(v)
-      | None when List.length(fs) >= 4 =>
-        let f = List.nth(fs, index);
-        switch (MvuShape.of_field(f)) {
-        | Some((_, v)) => Some(v)
-        | None => Some(f)
-        };
-      | None => None
-      }
+      List.find_map(
+        f =>
+          switch (MvuShape.of_field(f)) {
+          | Some((l, v)) when l == label => Some(v)
+          | _ => None
+          },
+        fs,
+      )
     | None => None
     };
 
@@ -350,7 +338,7 @@ module M: Projector = {
        (uncommittable model), so like a transient event it leaves the
        set of "ours" syntax states alone. */
     let store_entry = (new_model, record, ~committed) =>
-      switch (record_field(record, "view", 2)) {
+      switch (record_field(record, "view")) {
       | Some(view_fn) =>
         switch (MvuShape.safe_evaluate(ap(Forward, view_fn, new_model))) {
         | Ok(html) when MvuShape.is_html(html) =>
@@ -417,7 +405,7 @@ module M: Projector = {
       switch (MvuShape.safe_evaluate(def_elab)) {
       | Error(e) => `Error("definition error: " ++ e)
       | Ok(record) =>
-        switch (record_field(record, "update", 1)) {
+        switch (record_field(record, "update")) {
         | None => `Error("definition is missing update")
         | Some(update_fn) =>
           let applied =
@@ -602,7 +590,7 @@ module M: Projector = {
       switch (MvuShape.safe_evaluate(def_elab)) {
       | Error(e) => err("livelit definition error: " ++ e)
       | Ok(record) =>
-        switch (record_field(record, "view", 2)) {
+        switch (record_field(record, "view")) {
         | None => err("livelit definition is missing view")
         | Some(view_fn) =>
           switch (MvuShape.safe_evaluate(ap(Forward, view_fn, model))) {

--- a/src/language/statics/LivelitCtx.re
+++ b/src/language/statics/LivelitCtx.re
@@ -26,9 +26,10 @@ type raw_livelit = {
   update: (action_exp, model_exp) => model_exp,
   view: (model_exp, send_action) => Virtual_dom.Vdom.Node.t,
   shape: ProjectorShape.t,
-  /* User-defined livelits only: the elaborated definition record
-     (init, update, view, expand). The projector evaluates it at render
-     time; `update`/`view` above are unused placeholders in that case. */
+  /* User-defined livelits only: the elaborated definition module, whose
+     members are init, update, view, expand (plus helpers). The projector
+     evaluates it at render time; `update`/`view` above are unused
+     placeholders in that case. */
   user_def: option(TermBase.Exp.t),
 };
 

--- a/src/language/statics/Mark.re
+++ b/src/language/statics/Mark.re
@@ -30,9 +30,9 @@ type error_builtin =
 
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
 type livelit_def_error =
-  | DefNotTuple
-  | DefBadArity(int)
-  | DefMissingMembers(list(string));
+  | DefNotModule
+  | DefMissingMembers(list(string))
+  | DefMissingTypes(list(string));
 
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
 type tpat_shadow_src =
@@ -68,6 +68,13 @@ type t =
   | LabelNotFound(LabeledTuple.label, list(LabeledTuple.label))
   | BadOperator(string)
   | BadLivelitModel(Typ.t)
+  /* The livelit's expansion does not have the type the definition
+     declares for it (`type Expansion`). The declared type is what
+     clients type against, so the fault is the livelit's, not the use's. */
+  | BadLivelitExpansion({
+      declared: Typ.t,
+      actual: Typ.t,
+    })
   | InvalidLivelitDef(livelit_def_error)
   | BadTheorem(Typ.t)
   | IsLivelitName({

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -1682,12 +1682,18 @@ and uexp_to_info_map =
              product is the mark owed when the expansion's own type is
              inconsistent with the declaration. Statics traverses surface
              syntax only, so what gets typed is the expansion of the SURFACE
-             model even where the elaborated one is what gets evaluated. */
+             model even where the elaborated one is what gets evaluated.
+             That re-traverses the model, so a use costs twice its model
+             subtree — small in practice, since a model is a literal or a
+             committed transition over one. */
           let expansion_marks = (expanded: Exp.t) => {
             let to_check =
               Option.is_some(user_def)
                 ? expand(arg.user_term) : Some(expanded);
             switch (to_check) {
+            /* mk_expand_dot always expands, so None is unreachable for a
+               user livelit; skipping the check is the safe reading if
+               that ever changes. */
             | None => []
             | Some(to_check) =>
               let (checked, _, _) = go(~ana=syn, to_check, m);

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -1674,7 +1674,8 @@ and uexp_to_info_map =
           let model_for_expand =
             Option.is_some(user_def) ? arg_elab : arg.user_term;
 
-          /* Type the expansion. The DECLARED expansion type is still what
+          /* Type the expansion — the paper's per-invocation-site validation
+             (PLDI 2021, S3.2.5). The DECLARED expansion type is still what
              the use synthesizes — clients reason against the livelit's
              interface, not against whatever code came out of expand — so
              this pass runs in syn mode and throws its map away; its one

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -1674,6 +1674,30 @@ and uexp_to_info_map =
           let model_for_expand =
             Option.is_some(user_def) ? arg_elab : arg.user_term;
 
+          /* Type the expansion. The DECLARED expansion type is still what
+             the use synthesizes — clients reason against the livelit's
+             interface, not against whatever code came out of expand — so
+             this pass runs in syn mode and throws its map away; its one
+             product is the mark owed when the expansion's own type is
+             inconsistent with the declaration. Statics traverses surface
+             syntax only, so what gets typed is the expansion of the SURFACE
+             model even where the elaborated one is what gets evaluated. */
+          let expansion_marks = (expanded: Exp.t) => {
+            let to_check =
+              Option.is_some(user_def)
+                ? expand(arg.user_term) : Some(expanded);
+            switch (to_check) {
+            | None => []
+            | Some(to_check) =>
+              let (checked, _, _) = go(~ana=syn, to_check, m);
+              UserLivelit.expansion_mark(
+                ctx,
+                ~declared=expansion_t,
+                ~actual=checked.elab_syn_ty,
+              );
+            };
+          };
+
           // try to expand
           switch (expand(model_for_expand)) {
           | Some(expanded) =>
@@ -1681,7 +1705,7 @@ and uexp_to_info_map =
               add(
                 ~elab_term=expanded,
                 ~elab_syn_ty=expansion_t,
-                ~marks=[],
+                ~marks=expansion_marks(expanded),
                 ~co_ctx=CoCtx.union([fn.co_ctx, arg.co_ctx]),
                 ~probe_targets=
                   SubexpProbeTargets.union_all([
@@ -2202,20 +2226,22 @@ and uexp_to_info_map =
           | _ => p_ana_ctx
           }
         };
-      /* Bind a livelit: `let ^name = (init, update, view, expand) in ...`
-         additionally puts a LivelitEntry in the body's context. The
-         definition also remains an ordinary binding of `^name`, which the
-         expansion of each use references at runtime. */
+      /* Bind a livelit: `let ^name = { ...members } in ...` additionally
+         puts a LivelitEntry in the body's context, carrying the module's
+         declared Model, Action and Expansion types. The definition also
+         remains an ordinary binding of `^name`, which the expansion of
+         each use references at runtime — and which typing that expansion
+         consults, so the declaration is an obligation, not an assertion. */
       let (p_ana_ctx, livelit_marks) =
         switch (UserLivelit.binder_name(p)) {
         | Some(ll_name) =>
           switch (
             UserLivelit.mk(
+              ~ctx,
               ~name=ll_name,
               ~id=Pat.rep_id(p),
               ~def_user=def.user_term,
               ~def_elab,
-              ~def_ty=def.ty,
             )
           ) {
           | Ok(ll) => (Ctx.extend(p_ana_ctx, Ctx.LivelitEntry(ll)), [])

--- a/src/language/statics/UserLivelit.re
+++ b/src/language/statics/UserLivelit.re
@@ -20,6 +20,15 @@ open Util;
    obligation that buys it is discharged at each use, where statics types
    the expansion and marks the use with BadLivelitExpansion if its type is
    inconsistent with the declared one (the LivelitName case of Statics.re).
+   Checking per use rather than once per definition is the paper's own
+   strategy (PLDI 2021, S3.2.5), not an approximation of it: the expansion
+   is validated at each invocation site, with errors reported to the client.
+
+   Splices are the part of the paper still absent. When they arrive as a
+   SpliceRef type with operations over it, `expand` extends to return a
+   pair whose second component is the list of SpliceRefs, and the check
+   here becomes a check of that pair's parameterized first component. With
+   the splice list empty it degenerates to what this file does.
 
    Optional member `shape = Inline(w) | Block(w, h) | Tab(w, h)` (a
    LivelitShape) sets the projector's footprint in character cells. Helpers

--- a/src/language/statics/UserLivelit.re
+++ b/src/language/statics/UserLivelit.re
@@ -1,22 +1,29 @@
 open Util;
 
-/* User-defined livelits. The canonical definition form is a module:
+/* User-defined livelits. A definition is a module declaring three types
+   and four members:
 
      let ^name = {
-       type Model = ...;
-       type Action = ...;
+       type Model = ...;                the livelit's internal state
+       type Action = ...;               what the GUI emits
+       type Expansion = ...;            what a use MEANS to the program
        let init : Model = ...;          initial model, inserted on ^name<space>
        let update = fun (m, a) -> ...;  (Model, Action) => Model
        let view = fun m -> ...;         Model => HTML, handlers emit Actions
        let expand = fun m -> ...        Model => Expansion
      } in ...
 
+   The three type members are the livelit's interface, and all three are
+   required. `Expansion` in particular is what clients type against: a use
+   of ^name synthesizes Expansion whatever the expansion turns out to be,
+   which is the abstract reasoning principle of the livelits paper. The
+   obligation that buys it is discharged at each use, where statics types
+   the expansion and marks the use with BadLivelitExpansion if its type is
+   inconsistent with the declared one (the LivelitName case of Statics.re).
+
    Optional member `shape = Inline(w) | Block(w, h) | Tab(w, h)` (a
-   LivelitShape) sets the projector's footprint in character cells. Type
-   members are accepted (and encouraged) but not yet semantically
-   load-bearing. Helpers are ordinary additional members.
-   Since modules are sugar for labeled tuples, a positional 4/5-tuple
-   (init, update, view, expand[, shape]) is accepted as the equivalent form.
+   LivelitShape) sets the projector's footprint in character cells. Helpers
+   are ordinary additional members.
 
    Expansion and view instrumentation are built syntactically here — no
    evaluation during statics. A projected use's view runs in the main
@@ -24,8 +31,6 @@ open Util;
    HTML; `update` runs at event time in the builtin environment via
    `user_def`, so definitions should be closed, with helpers among their
    members. */
-
-let expand_slot = 3;
 
 let is_livelit_name = (name: string): bool =>
   String.length(name) > 1 && name.[0] == '^';
@@ -57,12 +62,18 @@ let rec pat_name = (p: TermBase.Pat.t): option(string) =>
   | _ => None
   };
 
+/* A well-formed definition: the four required members (plus any helpers and
+   the optional `shape`) and the three declared interface types. */
 [@deriving show({with_path: false})]
-type shape =
-  | ModuleDef(list((string, TermBase.Exp.t))) /* member -> bound syntax */
-  | TupleDef(list(TermBase.Exp.t)); /* 4/5 positional or labeled fields */
+type def = {
+  members: list((string, TermBase.Exp.t)), /* member -> bound syntax */
+  model_t: TermBase.Typ.t,
+  action_t: TermBase.Typ.t,
+  expansion_t: TermBase.Typ.t,
+};
 
 let required_members = ["init", "update", "view", "expand"];
+let required_types = ["Model", "Action", "Expansion"];
 
 /* Module members, in order; a repeated name keeps the LAST binding, matching
    module shadowing semantics. */
@@ -82,110 +93,47 @@ let module_members =
     items,
   );
 
-/* The definition record is the trailing module or tuple, looking through
-   helper bindings: `let helper = ... in {...}`. */
-let rec detect = (def: TermBase.Exp.t): result(shape, Mark.livelit_def_error) =>
+let missing = (required: list(string), have: list((string, 'a))) =>
+  List.filter(r => !List.mem_assoc(r, have), required);
+
+/* The definition is the trailing module, looking through helper bindings:
+   `let helper = ... in {...}`. A helper type alias is brought into scope on
+   the way down, so a member type may be stated in terms of it. */
+let rec detect =
+        (~ctx: Ctx.t, def: TermBase.Exp.t)
+        : result(def, Mark.livelit_def_error) =>
   switch (strip_parens(def).term) {
-  | Let(_, _, body)
-  | TyAlias(_, _, body) => detect(body)
+  | Let(_, _, body) => detect(~ctx, body)
+  | TyAlias(tp, ty, body) =>
+    let ctx =
+      switch (tp.term) {
+      | Var(name) => Ctx.extend_alias(ctx, name, TPat.rep_id(tp), ty)
+      | _ => ctx
+      };
+    detect(~ctx, body);
   | Module(items) =>
     let members = module_members(items);
-    switch (List.filter(r => !List.mem_assoc(r, members), required_members)) {
-    | [] => Ok(ModuleDef(members))
-    | missing => Error(DefMissingMembers(missing))
+    /* the same resolution the module's own type members get, so a member
+       type may name an earlier one (`type Expansion = Model`) */
+    let types = ModuleHelpers.collect_type_exports(ctx, items);
+    switch (
+      missing(required_members, members),
+      missing(required_types, types),
+    ) {
+    | ([_, ..._] as ms, _) => Error(DefMissingMembers(ms))
+    | ([], [_, ..._] as ts) => Error(DefMissingTypes(ts))
+    | ([], []) =>
+      Ok({
+        members,
+        model_t: List.assoc("Model", types),
+        action_t: List.assoc("Action", types),
+        expansion_t: List.assoc("Expansion", types),
+      })
     };
-  | Tuple([_, _, _, _] as fs)
-  | Tuple([_, _, _, _, _] as fs) => Ok(TupleDef(fs))
-  | Tuple(fs) => Error(DefBadArity(List.length(fs)))
-  | _ => Error(DefNotTuple)
+  | _ => Error(DefNotModule)
   };
-
-let field_label = (e: TermBase.Exp.t): option(string) =>
-  switch (strip_parens(e).term) {
-  | TupLabel({term: Label(l), _}, _) => Some(l)
-  | _ => None
-  };
-
-let field_payload = (e: TermBase.Exp.t): TermBase.Exp.t =>
-  switch (strip_parens(e).term) {
-  | TupLabel(_, v) => v
-  | _ => e
-  };
-
-/* Select a tuple field by label when labeled, positionally otherwise */
-let slot_index = (fs: list(TermBase.Exp.t), ~label: string, ~index: int): int => {
-  let rec find = (i, fs) =>
-    switch (fs) {
-    | [] => index
-    | [f, ..._] when field_label(f) == Some(label) => i
-    | [_, ...fs] => find(i + 1, fs)
-    };
-  find(0, fs);
-};
-
-let slot = (fs: list(TermBase.Exp.t), ~label: string, ~index: int) =>
-  List.nth(fs, slot_index(fs, ~label, ~index));
 
 let unknown = () => IdTagged.FreshGrammar.Typ.unknown(Internal);
-
-let arrow_of = (ty: option(TermBase.Typ.t)) =>
-  switch (Option.map(Typ.term_of, ty)) {
-  | Some(Arrow(a, b)) => Some((a, b))
-  | _ => None
-  };
-
-/* Loose typing: model/expansion types from the expand member's arrow type,
-   action type from update's second argument, Unknown where unannotated. */
-let types_of =
-    (~update_ty: option(TermBase.Typ.t), ~expand_ty: option(TermBase.Typ.t))
-    : (TermBase.Typ.t, TermBase.Typ.t, TermBase.Typ.t) => {
-  let (model_t, expansion_t) =
-    switch (arrow_of(expand_ty)) {
-    | Some((m, e)) => (m, e)
-    | None => (unknown(), unknown())
-    };
-  let action_t =
-    switch (arrow_of(update_ty)) {
-    | Some((args, _)) =>
-      switch (Typ.term_of(args)) {
-      | Prod([_, a]) => a
-      | _ => unknown()
-      }
-    | None => unknown()
-    };
-  (model_t, expansion_t, action_t);
-};
-
-/* The def's type is a (labeled) product; find a member's type by label,
-   falling back to position for unlabeled tuples. */
-let ty_member =
-    (def_ty: TermBase.Typ.t, ~label: string, ~index: option(int))
-    : option(TermBase.Typ.t) => {
-  let strip_ty = (ty: TermBase.Typ.t) =>
-    switch (Typ.term_of(ty)) {
-    | TupLabel(_, ty) => ty
-    | _ => ty
-    };
-  switch (Typ.term_of(def_ty)) {
-  | Prod(tys) =>
-    let by_label =
-      List.find_map(
-        ty =>
-          switch (Typ.term_of(ty)) {
-          | TupLabel({term: Label(l), _}, t) when l == label => Some(t)
-          | _ => None
-          },
-        tys,
-      );
-    switch (by_label, index) {
-    | (Some(t), _) => Some(t)
-    | (None, Some(i)) when List.length(tys) > i =>
-      Some(strip_ty(List.nth(tys, i)))
-    | _ => None
-    };
-  | _ => None
-  };
-};
 
 /* The `shape` member: a LivelitShape constructor. Inline(w) is one
    line; Block(w, h) / Tab(w, h) are h LINES tall (the internal
@@ -205,7 +153,7 @@ let shape_of = (e: TermBase.Exp.t): option(ProjectorShape.t) => {
       }
     | _ => None
     };
-  switch (strip_parens(field_payload(e)).term) {
+  switch (strip_parens(e).term) {
   | Ap(_, ctr, arg) =>
     switch (strip_parens(ctr).term) {
     | Constructor("Inline", _) =>
@@ -245,9 +193,11 @@ let default_shape: ProjectorShape.t = {
 
 /* The expansion of `^name(model)`: fetch the expand member from the runtime
    binding and apply it to the model. Scoping comes for free: `^name`
-   resolves to the nearest enclosing livelit let. Module and labeled-tuple
-   definitions use member access; unlabeled tuples destructure positionally
-   (`%expand` is not a lexable token, so user code cannot capture it). */
+   resolves to the nearest enclosing livelit let. Note that this reaches the
+   member through the ordinary `Var` binding, not the `^name.expand` surface
+   form, so typing it consults the definition's ACTUAL expand member rather
+   than the interface `member_ty` advertises — which is what makes the
+   use-site expansion check below non-vacuous. */
 let mk_expand_dot = (~name: string, model: TermBase.Exp.t) => {
   IdTagged.FreshGrammar.(
     Some(
@@ -260,29 +210,15 @@ let mk_expand_dot = (~name: string, model: TermBase.Exp.t) => {
   );
 };
 
-let mk_expand_positional =
-    (~name: string, ~n_fields: int, ~expand_i: int, model: TermBase.Exp.t) => {
-  open IdTagged.FreshGrammar;
-  let hidden = "%expand";
-  let pats =
-    List.init(n_fields, i => i == expand_i ? Pat.var(hidden) : Pat.wild());
-  Some(
-    Exp.let_(
-      Pat.tuple(pats),
-      Exp.var("^" ++ name),
-      Exp.ap(Operators.Forward, Exp.var(hidden), model),
-    ),
-  );
-};
-
 let is_user_livelit = (ctx: Ctx.t, name: string): bool =>
   switch (Ctx.lookup_livelit(ctx, name)) {
   | Some({user_def: Some(_), _}) => true
   | _ => false
   };
 
-/* Surface member access (^name.member) types loosely, from the member
-   shapes the record convention implies */
+/* Surface member access (^name.member) types against the livelit's DECLARED
+   interface (Model, Action, Expansion), not against the definition's actual
+   members — the same abstraction a use of ^name gets. */
 let member_ty = (ctx: Ctx.t, name: string, member: string): TermBase.Typ.t =>
   switch (Ctx.lookup_livelit(ctx, name)) {
   | Some({model_t, action_t, expansion_t, _}) =>
@@ -370,63 +306,52 @@ let instrument_view =
 
 let mk =
     (
+      ~ctx: Ctx.t,
       ~name: string,
       ~id: Id.t,
       ~def_user: TermBase.Exp.t,
       ~def_elab: TermBase.Exp.t,
-      ~def_ty: TermBase.Typ.t,
     )
-    : result(LivelitCtx.raw_livelit, Mark.livelit_def_error) => {
-  let build = (~init, ~shape, ~expand, ~update_ty, ~expand_ty) => {
-    let (model_t, expansion_t, action_t) = types_of(~update_ty, ~expand_ty);
-    {
+    : result(LivelitCtx.raw_livelit, Mark.livelit_def_error) =>
+  switch (detect(~ctx, def_user)) {
+  | Error(e) => Error(e)
+  | Ok({members, model_t, action_t, expansion_t}) =>
+    Ok({
       LivelitCtx.name,
       id,
       model_t,
-      model_default: Exp.replace_all_ids(field_payload(init)),
+      model_default: Exp.replace_all_ids(List.assoc("init", members)),
       expansion_t,
-      expand,
+      expand: mk_expand_dot(~name),
       action_t,
       update: (_action, model) => model,
       view: (_model, _send) =>
         Virtual_dom.Vdom.Node.text("user-defined livelit"),
       shape:
-        switch (Option.bind(shape, shape_of)) {
+        switch (Option.bind(List.assoc_opt("shape", members), shape_of)) {
         | Some(shape) => shape
         | None => default_shape
         },
       user_def: Some(def_elab),
-    };
+    })
   };
-  switch (detect(def_user)) {
-  | Error(e) => Error(e)
-  | Ok(ModuleDef(members)) =>
-    Ok(
-      build(
-        ~init=List.assoc("init", members),
-        ~shape=List.assoc_opt("shape", members),
-        ~expand=mk_expand_dot(~name),
-        ~update_ty=ty_member(def_ty, ~label="update", ~index=None),
-        ~expand_ty=ty_member(def_ty, ~label="expand", ~index=None),
-      ),
-    )
-  | Ok(TupleDef(fs)) =>
-    let update_i = slot_index(fs, ~label="update", ~index=1);
-    let expand_i = slot_index(fs, ~label="expand", ~index=expand_slot);
-    let expand =
-      field_label(List.nth(fs, expand_i)) != None
-        ? mk_expand_dot(~name)
-        : mk_expand_positional(~name, ~n_fields=List.length(fs), ~expand_i);
-    Ok(
-      build(
-        ~init=slot(fs, ~label="init", ~index=0),
-        ~shape=
-          List.length(fs) == 5
-            ? Some(slot(fs, ~label="shape", ~index=4)) : None,
-        ~expand,
-        ~update_ty=ty_member(def_ty, ~label="update", ~index=Some(update_i)),
-        ~expand_ty=ty_member(def_ty, ~label="expand", ~index=Some(expand_i)),
-      ),
-    );
+
+/* The use-site expansion obligation: a use of ^name synthesizes the DECLARED
+   expansion type, so statics owes a check that the expansion actually has
+   that type. `actual` is the type the expansion synthesizes on its own; a
+   mark is due when the two are inconsistent. Consistency, not equality, is
+   the test: an expansion that synthesizes Unknown (an unannotated `expand`,
+   or a builtin livelit generating a hole) stays gradual, exactly as it would
+   anywhere else in the language. */
+let expansion_mark =
+    (ctx: Ctx.t, ~declared: TermBase.Typ.t, ~actual: TermBase.Typ.t)
+    : list(Mark.t) =>
+  switch (Typ.meet(ctx, declared, actual)) {
+  | Some(_) => []
+  | None => [
+      Mark.BadLivelitExpansion({
+        declared,
+        actual,
+      }),
+    ]
   };
-};

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -263,6 +263,7 @@ let core_mark_err_view =
     | LabelNotFound(_)
     | BadOperator(_)
     | BadLivelitModel(_)
+    | BadLivelitExpansion(_)
     | InvalidLivelitDef(_)
     | BadTheorem(_)
     | Redundant
@@ -732,20 +733,30 @@ let exp_mark_err_view =
       ...List.map(label_view, labels),
     ])
   | BadLivelitModel(_) => div_err([text("Bad internal livelit model")])
-  | InvalidLivelitDef(DefNotTuple) =>
+  | BadLivelitExpansion({declared, actual}) =>
     div_err([
-      text("Livelit definition should be a module with members "),
-      code("init, update, view, expand"),
+      text("Livelit expands to type "),
+      view_type(actual),
+      text(", but declares "),
+      code("Expansion"),
+      text(" = "),
+      view_type(declared),
     ])
-  | InvalidLivelitDef(DefBadArity(n)) =>
+  | InvalidLivelitDef(DefNotModule) =>
     div_err([
-      text("Livelit definition should have fields "),
-      code("(init, update, view, expand)"),
-      text(", got " ++ string_of_int(n)),
+      text("Livelit definition should be a module declaring "),
+      code("type Model, Action, Expansion"),
+      text(" and members "),
+      code("init, update, view, expand"),
     ])
   | InvalidLivelitDef(DefMissingMembers(missing)) =>
     div_err([
       text("Livelit definition is missing members: "),
+      ...List.map(code, missing),
+    ])
+  | InvalidLivelitDef(DefMissingTypes(missing)) =>
+    div_err([
+      text("Livelit definition is missing type members: "),
       ...List.map(code, missing),
     ])
   | BadTheorem(typ) =>

--- a/test/Test_UserLivelits.re
+++ b/test/Test_UserLivelits.re
@@ -42,6 +42,21 @@ let view = fun m -> 0;
 let expand = fun m -> m * 2
 }";
 
+/* The standard definition plus one extra member, for tests about members
+   other than the four required ones. */
+let def_with = (~extra: string) =>
+  "{
+type Model = Int;
+type Action = Int;
+type Expansion = Int;
+let init = 0;
+let update = fun (m, a) -> a;
+let view = fun m -> 0;
+let expand = fun m -> m * 2"
+  ++ (extra == "" ? "" : ";\n" ++ extra)
+  ++ "
+}";
+
 /* Everything but the declared types and expand held fixed, so a test can
    vary just the interface it is about. */
 let def = (~expansion: string, ~expand: string) =>
@@ -188,42 +203,82 @@ let module_missing_members = () => {
   );
 };
 
-let module_adapter = () => {
-  let def_text = "{
-type Model = Int;
-type Action = Int;
-type Expansion = Int;
-let init = 50;
-let update = fun (m, a) -> a;
-let view = fun m -> Text(\"hi\");
-let expand = fun m -> m;
-let shape = Tab(30, 5)
-}";
+/* Build the livelit the adapter would put in the context, or fail. */
+let mk_ll = (def_text: string): LivelitCtx.raw_livelit => {
   let def_user = parse_exp(def_text);
   let ctx = Builtins.ctx_init(Some(Int));
   let (_, def_elab) = Statics.mk(CoreSettings.on, ctx, def_user);
   switch (
     UserLivelit.mk(~ctx, ~name="s", ~id=Id.invalid, ~def_user, ~def_elab)
   ) {
-  | Ok(ll) =>
-    check(
-      dhexp_typ,
-      "model_default is the init member",
-      parse_exp("50"),
-      ll.model_default,
-    );
-    check(
-      bool,
-      "shape member sets the projector shape",
-      true,
-      ll.shape
-      == {
-           horizontal: 30,
-           vertical: Tab(4) /* 5 lines = 4 linebreaks */
-         },
-    );
+  | Ok(ll) => ll
   | Error(_) => fail("adapter rejected a well-formed module definition")
   };
+};
+
+let module_adapter = () => {
+  let ll = mk_ll(def_with(~extra="let shape = Tab(30, 5)"));
+  check(
+    dhexp_typ,
+    "model_default is the init member",
+    parse_exp("0"),
+    ll.model_default,
+  );
+  check(
+    bool,
+    "shape member sets the projector shape",
+    true,
+    ll.shape
+    == {
+         horizontal: 30,
+         vertical: Tab(4) /* 5 lines = 4 linebreaks */
+       },
+  );
+};
+
+/* Each LivelitShape constructor, since the vertical is derived: Inline is one
+   line, Block and Tab are h LINES and the internal count is linebreaks. A
+   one-line Block or Tab degenerates to Inline. */
+let shape_member = () => {
+  let shape = (s: string) =>
+    mk_ll(def_with(~extra="let shape = " ++ s)).shape;
+  let expect = (s, want: Util.ProjectorShape.t) =>
+    check(bool, s, true, shape(s) == want);
+  expect(
+    "Inline(20)",
+    {
+      horizontal: 20,
+      vertical: Inline,
+    },
+  );
+  expect(
+    "Block(32, 8)",
+    {
+      horizontal: 32,
+      vertical: Block(7),
+    },
+  );
+  expect(
+    "Tab(16, 5)",
+    {
+      horizontal: 16,
+      vertical: Tab(4),
+    },
+  );
+  expect(
+    "Block(12, 1)",
+    {
+      horizontal: 12,
+      vertical: Inline,
+    },
+  );
+  /* no shape member at all falls back to the default */
+  check(
+    bool,
+    "default shape without the member",
+    true,
+    mk_ll(def_with(~extra="")).shape == UserLivelit.default_shape,
+  );
 };
 
 let bad_def_marked = () => {
@@ -851,6 +906,7 @@ let tests = [
       test_case("module missing members", `Quick, module_missing_members),
       test_case("module missing types", `Quick, missing_types_marked),
       test_case("module adapter", `Quick, module_adapter),
+      test_case("shape member", `Quick, shape_member),
       test_case("multiple uses", `Quick, multiple_uses),
       test_case("members out of order", `Quick, members_out_of_order),
       test_case("helpers inside definition", `Quick, helpers_in_def),

--- a/test/Test_UserLivelits.re
+++ b/test/Test_UserLivelits.re
@@ -2,8 +2,10 @@ open Alcotest;
 open Language;
 open Test_Evaluator_Prelude;
 
-/* User-defined livelits: `let ^name = (init, update, view, expand) in ...`
-   binds a livelit whose uses elaborate through the runtime binding. */
+/* User-defined livelits: `let ^name = { type Model; type Action;
+   type Expansion; init; update; view; expand } in ...` binds a livelit
+   whose uses elaborate through the runtime binding, synthesizing the
+   declared Expansion. */
 
 let statics = (text: string): (Statics.Map.t, Exp.t) => {
   let term = parse_exp(text);
@@ -28,15 +30,33 @@ let has_mark = (pred: Mark.t => bool, m: Statics.Map.t): bool =>
     m,
   );
 
-let dbl_def = "(0, fun (m, a) -> a, fun m -> 0, fun m -> m * 2)";
-
-let dbl_module = "{
+/* A definition is a module declaring Model, Action and Expansion and
+   binding init, update, view and expand. `dbl` means twice its model. */
+let dbl_def = "{
 type Model = Int;
 type Action = Int;
+type Expansion = Int;
 let init : Model = 0;
 let update = fun (m, a) -> a;
 let view = fun m -> 0;
 let expand = fun m -> m * 2
+}";
+
+/* Everything but the declared types and expand held fixed, so a test can
+   vary just the interface it is about. */
+let def = (~expansion: string, ~expand: string) =>
+  "{
+type Model = Int;
+type Action = Int;
+type Expansion = "
+  ++ expansion
+  ++ ";
+let init : Model = 0;
+let update = fun (m, a) -> a;
+let view = fun m -> 0;
+let expand = "
+  ++ expand
+  ++ "
 }";
 
 let parses_as_binder = () => {
@@ -65,25 +85,48 @@ let multiple_uses = () =>
     "let ^dbl = " ++ dbl_def ++ " in ^dbl(1) + ^dbl(2) + ^dbl(3)",
   );
 
-let labeled_out_of_order = () =>
+let members_out_of_order = () =>
   run_test(
-    "labeled fields select by name",
+    "members and types are found by name, in any order",
     "42",
-    "let ^dbl = (expand=fun m -> m * 2, init=0, update=fun (m, a) -> a, view=fun m -> 0) in ^dbl(21)",
+    "let ^dbl = {
+let expand = fun m -> m * 2;
+type Expansion = Int;
+let view = fun m -> 0;
+type Model = Int;
+let init = 0;
+type Action = Int;
+let update = fun (m, a) -> a
+} in ^dbl(21)",
   );
 
 let helpers_in_def = () =>
   run_test(
-    "helpers bind inside the definition",
+    "helpers bind outside the definition module",
     "5",
-    "let ^inc = (let f = fun x -> x + 1 in (0, fun (m, a) -> a, fun m -> 0, fun m -> f(m))) in ^inc(4)",
+    "let ^inc = (let f = fun x -> x + 1 in "
+    ++ def(~expansion="Int", ~expand="fun m -> f(m)")
+    ++ ") in ^inc(4)",
+  );
+
+/* detect() descends through a leading type alias, and carries it into
+   scope so a declared member type may be stated in terms of it. */
+let type_alias_before_def = () =>
+  run_test(
+    "a type alias in front of the module is in scope for Expansion",
+    "42",
+    "let ^dbl = (type Pct = Int in "
+    ++ def(~expansion="Pct", ~expand="fun m -> m * 2")
+    ++ ") in ^dbl(21)",
   );
 
 let shadows_builtin = () =>
   run_test(
     "a user ^slider shadows the builtin",
     "105",
-    "let ^slider = (0, fun (m, a) -> a, fun m -> 0, fun m -> m + 100) in ^slider(5)",
+    "let ^slider = "
+    ++ def(~expansion="Int", ~expand="fun m -> m + 100")
+    ++ " in ^slider(5)",
   );
 
 let nested_shadowing = () =>
@@ -92,14 +135,9 @@ let nested_shadowing = () =>
     "30",
     "let ^d = "
     ++ dbl_def
-    ++ " in let ^d = (0, fun (m, a) -> a, fun m -> 0, fun m -> m * 3) in ^d(10)",
-  );
-
-let module_evaluates = () =>
-  run_test(
-    "module definition with type members",
-    "42",
-    "let ^dbl = " ++ dbl_module ++ " in ^dbl(21)",
+    ++ " in let ^d = "
+    ++ def(~expansion="Int", ~expand="fun m -> m * 3")
+    ++ " in ^d(10)",
   );
 
 let module_helpers = () =>
@@ -107,6 +145,9 @@ let module_helpers = () =>
     "helpers are ordinary module members",
     "15",
     "let ^inc = {
+type Model = Int;
+type Action = Int;
+type Expansion = Int;
 let bump = fun x -> x + 1;
 let init = 0;
 let update = fun (m, a) -> a;
@@ -120,6 +161,9 @@ let module_funlet_members = () =>
     "funlet-form members are recognized by name",
     "8",
     "let ^dbl = {
+type Model = Int;
+type Action = Int;
+type Expansion = Int;
 let init = 0;
 let update(m, a) = a;
 let view(m) = 0;
@@ -146,6 +190,9 @@ let module_missing_members = () => {
 
 let module_adapter = () => {
   let def_text = "{
+type Model = Int;
+type Action = Int;
+type Expansion = Int;
 let init = 50;
 let update = fun (m, a) -> a;
 let view = fun m -> Text(\"hi\");
@@ -153,16 +200,10 @@ let expand = fun m -> m;
 let shape = Tab(30, 5)
 }";
   let def_user = parse_exp(def_text);
-  let (_, def_elab) =
-    Statics.mk(CoreSettings.on, Builtins.ctx_init(Some(Int)), def_user);
+  let ctx = Builtins.ctx_init(Some(Int));
+  let (_, def_elab) = Statics.mk(CoreSettings.on, ctx, def_user);
   switch (
-    UserLivelit.mk(
-      ~name="s",
-      ~id=Id.invalid,
-      ~def_user,
-      ~def_elab,
-      ~def_ty=IdTagged.FreshGrammar.Typ.unknown(Internal),
-    )
+    UserLivelit.mk(~ctx, ~name="s", ~id=Id.invalid, ~def_user, ~def_elab)
   ) {
   | Ok(ll) =>
     check(
@@ -189,26 +230,55 @@ let bad_def_marked = () => {
   let (m, _) = statics("let ^x = 5 in 1");
   check(
     bool,
-    "non-tuple definition gets InvalidLivelitDef",
+    "non-module definition gets InvalidLivelitDef",
     true,
     has_mark(
       fun
-      | Mark.InvalidLivelitDef(DefNotTuple) => true
+      | Mark.InvalidLivelitDef(DefNotModule) => true
       | _ => false,
       m,
     ),
   );
 };
 
-let bad_arity_marked = () => {
-  let (m, _) = statics("let ^x = (1, 2) in 1");
+/* A tuple has nowhere to declare Model, Action and Expansion, so the form
+   the module desugars to is no longer a definition on its own. */
+let tuple_def_marked = () => {
+  let (m, _) =
+    statics("let ^x = (0, fun (m, a) -> a, fun m -> 0, fun m -> m) in 1");
   check(
     bool,
-    "wrong-arity tuple gets InvalidLivelitDef",
+    "the tuple form is no longer a definition",
     true,
     has_mark(
       fun
-      | Mark.InvalidLivelitDef(DefBadArity(2)) => true
+      | Mark.InvalidLivelitDef(DefNotModule) => true
+      | _ => false,
+      m,
+    ),
+  );
+};
+
+let missing_types_marked = () => {
+  let (m, _) =
+    statics(
+      "let ^x = {
+let init = 0;
+let update = fun (m, a) -> a;
+let view = fun m -> 0;
+let expand = fun m -> m
+} in 1",
+    );
+  check(
+    bool,
+    "missing type members reported by name",
+    true,
+    has_mark(
+      fun
+      | Mark.InvalidLivelitDef(
+          DefMissingTypes(["Model", "Action", "Expansion"]),
+        ) =>
+        true
       | _ => false,
       m,
     ),
@@ -239,6 +309,7 @@ let good_def_unmarked = () => {
     has_mark(
       fun
       | Mark.InvalidLivelitDef(_)
+      | Mark.BadLivelitExpansion(_)
       | Mark.Free(_) => true
       | _ => false,
       m,
@@ -249,19 +320,21 @@ let good_def_unmarked = () => {
 /* The adapter contract LivelitProj relies on: the captured definition
    evaluates closed, its fields extract, and view(model) yields HTML. */
 let adapter = () => {
-  let def_text = "(50, fun (m, a) -> a, fun m -> Text(\"hi\"), fun m -> m)";
+  let def_text = "{
+type Model = Int;
+type Action = Int;
+type Expansion = Int;
+let init = 50;
+let update = fun (m, a) -> a;
+let view = fun m -> Text(\"hi\");
+let expand = fun m -> m
+}";
   let def_user = parse_exp(def_text);
-  let (_, def_elab) =
-    Statics.mk(CoreSettings.on, Builtins.ctx_init(Some(Int)), def_user);
+  let ctx = Builtins.ctx_init(Some(Int));
+  let (_, def_elab) = Statics.mk(CoreSettings.on, ctx, def_user);
   let ll =
     switch (
-      UserLivelit.mk(
-        ~name="s",
-        ~id=Id.invalid,
-        ~def_user,
-        ~def_elab,
-        ~def_ty=IdTagged.FreshGrammar.Typ.unknown(Internal),
-      )
+      UserLivelit.mk(~ctx, ~name="s", ~id=Id.invalid, ~def_user, ~def_elab)
     ) {
     | Ok(ll) => ll
     | Error(_) => fail("adapter rejected a well-formed definition")
@@ -279,10 +352,25 @@ let adapter = () => {
     | Some(def) => evaluate(def)
     | None => fail("user_def not captured")
     };
-  switch (
-    Haz3lcore.MvuShape.of_tuple(Haz3lcore.MvuShape.strip_wrappers(record))
-  ) {
-  | Some([_, _, view_fn, _]) =>
+  /* modules desugar to LABELED tuples, so members come out by name --
+     the lookup LivelitProj.record_field does at render time */
+  let member = (label: string) =>
+    switch (
+      Haz3lcore.MvuShape.of_tuple(Haz3lcore.MvuShape.strip_wrappers(record))
+    ) {
+    | Some(fs) =>
+      List.find_map(
+        f =>
+          switch (Haz3lcore.MvuShape.of_field(f)) {
+          | Some((l, v)) when l == label => Some(v)
+          | _ => None
+          },
+        fs,
+      )
+    | None => None
+    };
+  switch (member("view")) {
+  | Some(view_fn) =>
     let html =
       evaluate(
         IdTagged.FreshGrammar.Exp.ap(Forward, view_fn, parse_exp("50")),
@@ -293,36 +381,7 @@ let adapter = () => {
       true,
       Haz3lcore.MvuShape.is_html(html),
     );
-  | _ => fail("definition did not evaluate to a 4-tuple")
-  };
-};
-
-let shape_field = () => {
-  let def_user =
-    parse_exp("(0, fun (m, a) -> a, fun m -> 0, fun m -> m, Block(30, 5))");
-  let (_, def_elab) =
-    Statics.mk(CoreSettings.on, Builtins.ctx_init(Some(Int)), def_user);
-  switch (
-    UserLivelit.mk(
-      ~name="s",
-      ~id=Id.invalid,
-      ~def_user,
-      ~def_elab,
-      ~def_ty=IdTagged.FreshGrammar.Typ.unknown(Internal),
-    )
-  ) {
-  | Ok(ll) =>
-    check(
-      bool,
-      "fifth field sets the projector shape",
-      true,
-      ll.shape
-      == {
-           horizontal: 30,
-           vertical: Block(4) /* 5 lines = 4 linebreaks */
-         },
-    )
-  | Error(_) => fail("adapter rejected a 5-field definition")
+  | None => fail("definition record has no view member")
   };
 };
 
@@ -396,6 +455,9 @@ let probe_run = (text: string) => {
 };
 
 let view_probe_def = "let ^dbl = {
+type Model = Int;
+type Action = Int;
+type Expansion = Int;
 let init = 0;
 let update = fun (m, a) -> a;
 let view = fun m -> Text(string_of_int(^^probe(m * 3)));
@@ -467,17 +529,20 @@ let member_access = () =>
   run_test(
     "^name.member accesses the definition record",
     "51",
-    "let ^dbl = " ++ dbl_module ++ " in ^dbl.expand(21) + ^dbl.update((3, 9))",
+    "let ^dbl = " ++ dbl_def ++ " in ^dbl.expand(21) + ^dbl.update((3, 9))",
   );
 
 let redex_as_model = () =>
   run_test(
     "a committed transition normalizes in the main run",
     "18",
-    "let ^dbl = " ++ dbl_module ++ " in ^dbl(^dbl.update(3, 9))",
+    "let ^dbl = " ++ dbl_def ++ " in ^dbl(^dbl.update(3, 9))",
   );
 
 let update_probe_def = "let ^dbl = {
+type Model = Int;
+type Action = Int;
+type Expansion = Int;
 let init = 0;
 let update = fun (m, a) -> ^^probe(m + a);
 let view = fun m -> Text(string_of_int(m));
@@ -543,7 +608,7 @@ let redex_roundtrip = () => {
   run_test(
     "committed transition text round-trips: " ++ text,
     "18",
-    "let ^dbl = " ++ dbl_module ++ " in ^dbl(" ++ text ++ ")",
+    "let ^dbl = " ++ dbl_def ++ " in ^dbl(" ++ text ++ ")",
   );
 };
 
@@ -554,6 +619,9 @@ let sampled_handlers_are_closed = () => {
   let (mtr, _, probes) =
     probe_run(
       "let ^pk = {
+type Model = Int;
+type Action = Int;
+type Expansion = Int;
 let bump = fun x -> x + 1;
 let init = 0;
 let update = fun (m, a) -> a;
@@ -608,28 +676,226 @@ let expand = fun m -> m
   };
 };
 
+/* ---- The expansion obligation ----
+
+   A use of ^name synthesizes the DECLARED Expansion, so statics owes a
+   check that the expansion actually has that type. */
+
+let expansion_mark = (m: Statics.Map.t): option(Mark.t) =>
+  Id.Map.fold(
+    (_, info, acc) =>
+      switch (acc, info: Info.t) {
+      | (Some(_), _) => acc
+      | (None, InfoExp({marks, _})) =>
+        List.find_opt(
+          fun
+          | Mark.BadLivelitExpansion(_) => true
+          | _ => false,
+          marks,
+        )
+      | (None, _) => None
+      },
+    m,
+    None,
+  );
+
+let expansion_mismatch_marked = () => {
+  let (m, _) =
+    statics(
+      "let ^s = "
+      ++ def(~expansion="String", ~expand="fun m : Model -> m")
+      ++ " in ^s(1)",
+    );
+  switch (expansion_mark(m)) {
+  | Some(BadLivelitExpansion({declared, actual})) =>
+    check(
+      bool,
+      "declared type reported",
+      true,
+      Typ.fast_equal(declared, IdTagged.FreshGrammar.Typ.string()),
+    );
+    check(
+      bool,
+      "actual type reported",
+      true,
+      Typ.fast_equal(actual, IdTagged.FreshGrammar.Typ.int()),
+    );
+  | _ => fail("expected BadLivelitExpansion on the use")
+  };
+};
+
+/* The check is discharged per use, since the expansion is a function of
+   that use's model. A use spreads its info over its own ids and its
+   expansion's, so count relative to one use rather than absolutely. */
+let expansion_mismatch_at_each_use = () => {
+  let marked = (uses: string) => {
+    let (m, _) =
+      statics(
+        "let ^s = "
+        ++ def(~expansion="String", ~expand="fun m : Model -> m")
+        ++ " in "
+        ++ uses,
+      );
+    Id.Map.fold(
+      (_, info, acc) =>
+        switch ((info: Info.t)) {
+        | InfoExp({marks, _}) =>
+          acc
+          + List.length(
+              List.filter(
+                fun
+                | Mark.BadLivelitExpansion(_) => true
+                | _ => false,
+                marks,
+              ),
+            )
+        | _ => acc
+        },
+      m,
+      0,
+    );
+  };
+  let one = marked("^s(1)");
+  check(bool, "one use is marked", true, one > 0);
+  check(
+    int,
+    "two uses are marked twice over",
+    2 * one,
+    marked("(^s(1), ^s(2))"),
+  );
+};
+
+/* The declaration is what clients type against: `^s(7) ++ "!"` is fine
+   because Expansion is String, whatever expand happens to return. */
+let declared_type_is_the_interface = () =>
+  run_test(
+    "clients type against the declared Expansion",
+    "\"7!\"",
+    "let ^s = "
+    ++ def(~expansion="String", ~expand="fun m -> string_of_int(m)")
+    ++ " in ^s(7) ++ \"!\"",
+  );
+
+let declared_type_no_marks = () => {
+  let (m, _) =
+    statics(
+      "let ^s = "
+      ++ def(~expansion="String", ~expand="fun m -> string_of_int(m)")
+      ++ " in ^s(7) ++ \"!\"",
+    );
+  check(
+    bool,
+    "a consistent expansion is unmarked",
+    false,
+    has_mark(
+      fun
+      | Mark.BadLivelitExpansion(_) => true
+      | _ => false,
+      m,
+    ),
+  );
+};
+
+/* Consistency, not equality, is the test — an expansion statics can only
+   type as Unknown stays gradual, as it would anywhere else. */
+let unknown_expansion_not_marked = () => {
+  let (m, _) =
+    statics(
+      "let ^s = "
+      ++ def(~expansion="String", ~expand="fun m -> m")
+      ++ " in ^s(1)",
+    );
+  check(
+    bool,
+    "an Unknown expansion is not marked",
+    false,
+    has_mark(
+      fun
+      | Mark.BadLivelitExpansion(_) => true
+      | _ => false,
+      m,
+    ),
+  );
+};
+
+/* The declared type is stated independently of the definition, so a
+   deliberately abstract Expansion narrows what clients may assume. */
+let abstract_expansion_hides_the_model = () => {
+  let (m, _) =
+    statics(
+      "let ^s = "
+      ++ def(~expansion="String", ~expand="fun m -> string_of_int(m)")
+      ++ " in ^s(7) + 1",
+    );
+  check(
+    bool,
+    "the client's misuse of Expansion is the client's error",
+    true,
+    has_mark(
+      fun
+      | Mark.ExpectationMismatch(_) => true
+      | _ => false,
+      m,
+    ),
+  );
+};
+
 let tests = [
   (
     "UserLivelits",
     [
       test_case("pattern parses as binder", `Quick, parses_as_binder),
       test_case("expansion evaluates", `Quick, evaluates),
-      test_case("module definition", `Quick, module_evaluates),
       test_case("module helpers", `Quick, module_helpers),
       test_case("module funlet members", `Quick, module_funlet_members),
       test_case("module missing members", `Quick, module_missing_members),
+      test_case("module missing types", `Quick, missing_types_marked),
       test_case("module adapter", `Quick, module_adapter),
       test_case("multiple uses", `Quick, multiple_uses),
-      test_case("labeled out of order", `Quick, labeled_out_of_order),
+      test_case("members out of order", `Quick, members_out_of_order),
       test_case("helpers inside definition", `Quick, helpers_in_def),
+      test_case(
+        "type alias before definition",
+        `Quick,
+        type_alias_before_def,
+      ),
       test_case("shadows builtin", `Quick, shadows_builtin),
       test_case("nested shadowing", `Quick, nested_shadowing),
       test_case("bad definition marked", `Quick, bad_def_marked),
-      test_case("bad arity marked", `Quick, bad_arity_marked),
+      test_case("tuple definition marked", `Quick, tuple_def_marked),
       test_case("unbound use marked", `Quick, unbound_use_marked),
       test_case("good definition unmarked", `Quick, good_def_unmarked),
       test_case("adapter contract", `Quick, adapter),
-      test_case("positional shape field", `Quick, shape_field),
+      test_case(
+        "expansion mismatch marked",
+        `Quick,
+        expansion_mismatch_marked,
+      ),
+      test_case(
+        "expansion mismatch at each use",
+        `Quick,
+        expansion_mismatch_at_each_use,
+      ),
+      test_case(
+        "declared type is the interface",
+        `Quick,
+        declared_type_is_the_interface,
+      ),
+      test_case(
+        "consistent expansion unmarked",
+        `Quick,
+        declared_type_no_marks,
+      ),
+      test_case(
+        "unknown expansion not marked",
+        `Quick,
+        unknown_expansion_not_marked,
+      ),
+      test_case(
+        "abstract expansion hides the model",
+        `Quick,
+        abstract_expansion_hides_the_model,
+      ),
       test_case("commit vs ephemeral decision", `Quick, commit_decision),
       test_case("view probes fire when projected", `Quick, view_probes_fire),
       test_case(

--- a/test/statics/Test_Statics_Prelude.re
+++ b/test/statics/Test_Statics_Prelude.re
@@ -103,6 +103,11 @@ let rec equal_mark: (Mark.t, Mark.t) => bool =
       l1 == l2 && ls1 == ls2
     | (BadOperator(s1), BadOperator(s2)) => s1 == s2
     | (BadLivelitModel(t1), BadLivelitModel(t2)) => Typ.fast_equal(t1, t2)
+    | (
+        BadLivelitExpansion({declared: d1, actual: a1}),
+        BadLivelitExpansion({declared: d2, actual: a2}),
+      ) =>
+      Typ.fast_equal(d1, d2) && Typ.fast_equal(a1, a2)
     | (BadTheorem(t1), BadTheorem(t2)) => Typ.fast_equal(t1, t2)
     | (Redundant, Redundant) => true
     | (ExpectedConstructor, ExpectedConstructor) => true


### PR DESCRIPTION
`user-livelits` does the heavy lifting. This is a small modification on top of it.

Before:

- No `Expansion` type member being looked at.
- No check against this absent member.

Now:

- The type member `Expansion` is required, and so are `Model` and `Action`.
- The check is performed for each expansion, on its output.

The tuple definition form goes with this, having nowhere to declare the types.

### Coming into alignment with livelits in PLDI 2021

**Part 1 — this PR.** The check against the statically named type, performed at the dynamic sites. That is the paper's own strategy rather than an approximation of it: §3.2.5 records that Hazel does not statically check `expand`'s definition, and that the parameterized expansion is instead "validated at each livelit invocation site, with errors reported to the client." With no splices that expansion takes no arguments, so validating it degenerates to checking the expansion at the expansion type.

**Parts 2+ — outside the scope here, and absent from `dev` too.** These introduce:

- the `SpliceRef` primitive type and its operations — `new_splice`, `set_splice` and `eval_splice`, in the paper's `UpdateCmd` and `ViewCmd` monads;
- the quoted AST — `Exp`, an encoding of Hazel's syntax, whose introduction form is quasiquotation, `` `0` `` (§3.2.1);
- `expand` extended to return a pair with that list of `SpliceRef`s, as in Fig. 3 of the [paper](https://hazel.org/papers/livelits-pldi2021.pdf): `expand : Model -> (Exp, List(SpliceRef))`.

The pair is there because "the expansion must treat splices parametrically" (§3.2.5): the first component takes one argument per listed `SpliceRef` and returns the expansion type. Note that `expand` itself stays pure — splices bring the monads, but not to `expand`.

The quotation is entailed by the splices rather than an independent choice. We can do without `Exp` here only because the splice list is empty: a closed expansion need not be code at all, so `expand` returns an ordinary value of the expansion type and application does the work quotation would have done. Splices force the issue, since a parameterized expansion embedding client-site expressions cannot be an ordinary value. (§3 flags the paper's quasiquotation and do notation as presentational sugar rather than implemented Hazel, so both are new surface syntax, not just new library types.)

The paper names one further alternative we are not pursuing: definition-site verification via "a typed quotation system as in, e.g., MetaOCaml." That is a distinct thing from the quasiquotation above — untyped quotation merely introduces `Exp`, whereas typed quotation is what would move Part 1's check from the invocation site to the definition site. The paper notes it is awkward because "the type of the quotation depends on the type of each splice in the splice list."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
