### PR TITLE
non-`dev` (`livelit-expansion-typing`): Report each error once, not once per wrapper

### DIFF
--- a/src/haz3lcore/ProblemCollection.re
+++ b/src/haz3lcore/ProblemCollection.re
@@ -96,17 +96,70 @@ let make_problem_context =
      own term so problems don't leak across groups. */
   let id_in_this_editor = id =>
     TermData.root_piece(id, syntax.term_data) != None;
+  /* One error, one row. A transparent wrapper re-states the marks of the
+     term it wraps (`Parens` and `Projector` in Statics pass `~marks`
+     straight through), so a single error occupies a chain of nested ids:
+     `(y)` carries the free-variable mark on the variable AND on the
+     parens, and a projected livelit use carries the expansion mark on
+     `^name(model)` AND on the projector around it. Statics hands the
+     wrapper the child's mark list itself, so physical equality picks out
+     exactly the ids that inherited a mark and never two equal-looking
+     marks on unrelated terms. */
+  let inherits_marks = (marks: list(Mark.t), id: Id.t): bool =>
+    switch (Statics.Map.lookup(id, info_map)) {
+    | Some(anc) => Info.marks_of(anc) === marks
+    | None => false
+    };
+  let wrappers_of = (id: Id.t): list(Id.t) =>
+    switch (Option.map(Info.marks_of, Statics.Map.lookup(id, info_map))) {
+    /* An error reported without marks (Drv) has no chain to collapse;
+       [] is physically equal to every other [], so never compare it. */
+    | None
+    | Some([]) => []
+    | Some(marks) =>
+      Statics.Map.ancestors_of(id, info_map)
+      |> List.filter(inherits_marks(marks))
+    };
+  /* The innermost id of a chain owns the mark; the wrappers above it are
+     the ones to drop. */
+  let inherited =
+    List.fold_left(
+      (acc, id) =>
+        List.fold_left(
+          (acc, anc) => Id.Set.add(anc, acc),
+          acc,
+          wrappers_of(id),
+        ),
+      Id.Set.empty,
+      statics.error_ids,
+    );
+  /* Ids under a projector are invisible — absent from `measured` — so
+     when the owner of a mark is hidden, report the innermost wrapper the
+     user can actually see instead of the owner itself. */
+  let reported_id = (id: Id.t): Id.t =>
+    switch (Measured.find_by_id(id, measured)) {
+    | Some(_) => id
+    | None =>
+      wrappers_of(id)
+      |> List.find_opt(anc => Measured.find_by_id(anc, measured) != None)
+      |> Option.value(~default=id)
+    };
   /* Partition error_ids into syntax and static in a single pass */
   let (syntax_error_ids, static_error_ids) =
     List.fold_right(
       (id, (syn, stat)) =>
         switch (Statics.Map.lookup(id, info_map)) {
-        | Some(ci) when Info.is_error(ci) && id_in_this_editor(id) =>
+        | Some(ci)
+            when
+              Info.is_error(ci)
+              && id_in_this_editor(id)
+              && !Id.Set.mem(id, inherited) =>
+          let id = reported_id(id);
           if (Info.is_syntax_error(ci)) {
             ([(id, ci), ...syn], stat);
           } else {
             (syn, [(id, ci), ...stat]);
-          }
+          };
         | _ => (syn, stat)
         },
       statics.error_ids,

--- a/test/Test_ProblemCollection.re
+++ b/test/Test_ProblemCollection.re
@@ -479,6 +479,110 @@ let projector_error_collection = () => {
   );
 };
 
+/* ---------- One error, one row ----------
+
+   A transparent wrapper restates the marks of the term it wraps, so
+   without collapsing those chains the sidebar reports the same error
+   once per nesting level. */
+
+let static_ids = (problems: list(ProblemCollection.problem)) =>
+  List.filter_map(
+    (p: ProblemCollection.problem) =>
+      p.category == Static ? Some(p.id) : None,
+    problems,
+  );
+
+let parens_report_one_error = () => {
+  let count = s => {
+    let (_, problems) = from_string_exn(s);
+    count_by_category(Static, problems);
+  };
+  check(int, "bare free variable", 1, count("y"));
+  check(int, "free variable in parens", 1, count("(y)"));
+  check(int, "free variable in nested parens", 1, count("((y))"));
+};
+
+let parens_report_the_marked_term = () => {
+  /* The variable owns the mark and is visible, so it stays the row's id
+     — the parens around it are what drop out. */
+  let (bare_ctx, bare) = from_string_exn("y");
+  let (ctx, problems) = from_string_exn("(y)");
+  switch (static_ids(bare), static_ids(problems)) {
+  | ([bare_id], [id]) =>
+    check(
+      bool,
+      "reported id is in measured",
+      true,
+      Haz3lcore.Measured.find_by_id(id, ctx.measured) != None,
+    );
+    check(
+      bool,
+      "reported id is the variable's, not the parens'",
+      true,
+      Haz3lcore.Measured.find_by_id(bare_id, bare_ctx.measured) != None,
+    );
+  | (bare_ids, ids) =>
+    fail(
+      "expected one static error each, got "
+      ++ string_of_int(List.length(bare_ids))
+      ++ " and "
+      ++ string_of_int(List.length(ids)),
+    )
+  };
+};
+
+/* A livelit use is always inside a projector, so its expansion error hit
+   this every time: once on `^s(model)`, once on the projector. */
+let livelit_def = {|{
+type Model = Int;
+type Action = Int;
+type Expansion = String;
+let init : Model = 0;
+let update = fun (m, a) -> a;
+let view = fun m -> 0;
+let expand = fun m : Model -> m
+}|};
+
+let projected_use_reports_one_error = () => {
+  let count = s => {
+    let (_, problems) = from_string_exn(s);
+    count_by_category(Static, problems);
+  };
+  check(
+    int,
+    "bare use of a livelit with a mistyped expansion",
+    1,
+    count("let ^s = " ++ livelit_def ++ " in ^s(1)"),
+  );
+  check(
+    int,
+    "the same use inside its projector",
+    1,
+    count("let ^s = " ++ livelit_def ++ " in ^^livelit(^s(1))"),
+  );
+};
+
+let projected_use_reports_a_visible_id = () => {
+  /* The marked application lives under the projector and so has no
+     measurement of its own; the row must land on the projector, which
+     the user can see and click. */
+  let (ctx, problems) =
+    from_string_exn("let ^s = " ++ livelit_def ++ " in ^^livelit(^s(1))");
+  switch (static_ids(problems)) {
+  | [id] =>
+    check(
+      bool,
+      "reported id is in measured",
+      true,
+      Haz3lcore.Measured.find_by_id(id, ctx.measured) != None,
+    )
+  | ids =>
+    fail(
+      "expected one static error, got " ++ string_of_int(List.length(ids)),
+    )
+  };
+};
+
 let collect_cases = [
   test_case("Clean program has no errors", `Quick, clean_program),
   test_case("Juxtaposed literals", `Quick, juxtaposed_literals),
@@ -490,6 +594,26 @@ let collect_cases = [
     "Projector errors surface as problems",
     `Quick,
     projector_error_collection,
+  ),
+  test_case(
+    "Parens do not multiply an error",
+    `Quick,
+    parens_report_one_error,
+  ),
+  test_case(
+    "A collapsed chain reports the marked term",
+    `Quick,
+    parens_report_the_marked_term,
+  ),
+  test_case(
+    "A projected livelit use reports one error",
+    `Quick,
+    projected_use_reports_one_error,
+  ),
+  test_case(
+    "A hidden marked term reports at its projector",
+    `Quick,
+    projected_use_reports_a_visible_id,
   ),
 ];
 


### PR DESCRIPTION
Follows #2488, and parked here rather than folded into it until reviewers weigh in on which layer the fix belongs in (see https://github.com/hazelgrove/hazel/pull/2488#issuecomment-5529767668).

## The problem

A transparent wrapper restates the marks of the term it wraps — `Parens` and `Projector` in `Statics` pass `~marks` straight through — so one error occupies a chain of nested ids and the problems sidebar lists every one of them:

| program | static errors reported |
| --- | --- |
| `y` | 1 |
| `(y)` | 2 |
| `((y))` | 3 |
| `^s(1)` (mistyped `expand`) | 1 |
| `^^livelit(^s(1))` (same) | 2 |

Not livelit-specific, but guaranteed to bite for livelits: a use is always inside a projector, so a `BadLivelitExpansion` was always duplicated.

## The fix

Collapse each chain at the collection layer (`ProblemCollection.make_problem_context`). `Statics` hands a wrapper the child's mark list itself, so physical equality identifies exactly the ids that inherited a mark — never two equal-looking marks on unrelated terms — and the innermost id of a chain is the one that owns it.

Ids under a projector have no measurement of their own, so when the owner of a mark is hidden the row is reported at the innermost wrapper the user can actually see: the projector. That keeps the row clickable and lets it highlight with the caret.

`statics.error_ids` is untouched, so code decorations — including the projector's own error styling — are unchanged.

## The open question

The alternative is to stop propagating marks through wrappers in `Statics` at all. Cleaner in principle, but the projector's error decoration reads the projector node's info, so it would go with it. Happy to move the fix there instead if that's the preference.

## Testing

Four cases added to `Test_ProblemCollection`: parens don't multiply an error, a collapsed chain reports the marked term, a projected livelit use reports one error, a hidden marked term reports at its projector. `ProblemCollection` (19), `UserLivelits` (34), `AgentTools` (174) and `ErrorPrint` (5) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
