### PR TITLE
Load the Fumola runtime from a list of sources, not one

### DIFF
--- a/src/web/www/prebundle.js
+++ b/src/web/www/prebundle.js
@@ -63,9 +63,9 @@ hotkeys.filter = event => {
 window.fumola = (() => {
   let wasm = null;
   let loadError = null;
-  // "local" or "published", once something has loaded. Worth being able to
-  // ask: the two are indistinguishable in behaviour, so without this there is
-  // no way to tell which one a page is actually running.
+  // The name of the source that answered, once something has loaded. Worth
+  // being able to ask: the sources are indistinguishable in behaviour, so
+  // without this there is no way to tell which one a page is running.
   let loadedFrom = null;
 
   // instance_id -> owner token (a projector's Hazel id)
@@ -78,7 +78,8 @@ window.fumola = (() => {
   // invariant that sigma(i) is synchronized with the model's program text.
   const lastEval = new Map();
 
-  // Where the runtime is fetched from.
+  // Where the runtime is fetched from. Tried in order; the first that loads
+  // wins, and the rest are never asked.
   //
   // The local pair is what scripts/build-fumola-wasm.sh writes, and is used
   // when working on Fumola and Hazel together. Otherwise the canonical build
@@ -87,18 +88,39 @@ window.fumola = (() => {
   // (A GitHub release asset cannot be used -- release downloads carry no
   // Access-Control-Allow-Origin header, so a browser cannot fetch one.)
   //
+  // That published build is listed twice, under the two names the same files
+  // answer to. fumola.org is where the Fumola Pages site is going;
+  // adapton.github.io is where it is served from until that domain is
+  // claimed. Both are here because the switch cannot be made atomically from
+  // this side: giving a Pages site a custom domain makes its old URL 301 to
+  // the new one, and a redirect response carries no
+  // Access-Control-Allow-Origin -- which a cross-origin import must have on
+  // every hop of the chain, not merely on the last. So each URL works on
+  // exactly one side of the switch, and listing both spans it from either
+  // side. Once the domain has settled, the adapton.github.io entry only ever
+  // redirects, and can be dropped.
+  //
   // The glue and the .wasm are always taken from the same place. They are
   // generated together by wasm-bindgen and will not load if their versions
   // disagree.
   const here = (path) => new URL(path, document.baseURI).href;
-  const LOCAL = {
-    glue: here("./fumola/fumola_wasm.js"),
-    wasm: here("./fumola/fumola_wasm_bg.wasm"),
-  };
-  const PUBLISHED = {
-    glue: "https://adapton.github.io/fumola/fumola_wasm.js",
-    wasm: "https://adapton.github.io/fumola/fumola_wasm_bg.wasm",
-  };
+  const SOURCES = [
+    {
+      name: "local",
+      glue: here("./fumola/fumola_wasm.js"),
+      wasm: here("./fumola/fumola_wasm_bg.wasm"),
+    },
+    {
+      name: "fumola.org",
+      glue: "https://fumola.org/fumola_wasm.js",
+      wasm: "https://fumola.org/fumola_wasm_bg.wasm",
+    },
+    {
+      name: "adapton.github.io",
+      glue: "https://adapton.github.io/fumola/fumola_wasm.js",
+      wasm: "https://adapton.github.io/fumola/fumola_wasm_bg.wasm",
+    },
+  ];
 
   // Hidden from the bundler so that Hazel builds without the generated files.
   const dynamicImport = new Function("p", "return import(p)");
@@ -107,25 +129,23 @@ window.fumola = (() => {
     await mod.default({ module_or_path: from.wasm });
     return mod;
   };
-  load(LOCAL)
-    .then((mod) => {
-      loadedFrom = "local";
-      return mod;
-    })
-    .catch(() =>
-      load(PUBLISHED).then((mod) => {
-        loadedFrom = "published";
-        return mod;
-      })
-    )
-    .then((mod) => {
-      wasm = mod;
-      console.info("Fumola livelit: runtime loaded from the " + loadedFrom + " build");
-    })
-    .catch((e) => {
-      loadError = String(e);
-      console.warn("Fumola livelit: wasm runtime unavailable:", e);
-    });
+  (async () => {
+    // Sequential on purpose: a later source is a fallback, not a race. Loading
+    // two runtimes and discarding one would instantiate wasm twice.
+    const failures = [];
+    for (const from of SOURCES) {
+      try {
+        wasm = await load(from);
+        loadedFrom = from.name;
+        console.info("Fumola livelit: runtime loaded from " + from.name);
+        return;
+      } catch (e) {
+        failures.push(from.name + " (" + e + ")");
+      }
+    }
+    loadError = "tried " + failures.join("; ");
+    console.warn("Fumola livelit: wasm runtime unavailable: " + loadError);
+  })();
 
   const ready = () => wasm !== null;
 


### PR DESCRIPTION
Groundwork for pointing **fumola.org** at the Fumola Pages site. No behaviour change today.

### Why

`prebundle.js` hard-codes one published URL for the wasm runtime:

```js
glue: "https://adapton.github.io/fumola/fumola_wasm.js",
wasm: "https://adapton.github.io/fumola/fumola_wasm_bg.wasm",
```

Once `Adapton/fumola` takes `fumola.org` as its Pages custom domain, those URLs 301 to `https://fumola.org/...`. A GitHub Pages custom-domain redirect carries **no `Access-Control-Allow-Origin` header** — verified against a live example (`pytorch.github.io/examples/`, whose org site is CNAME'd to docs.pytorch.org) — and a CORS-mode `import()` must pass the CORS check on *every* hop of a redirect chain, not just the final response. The runtime files themselves do serve `access-control-allow-origin: *`; it's the redirect in front of them that doesn't.

So the old URL works before the switch and fails after; the new one fails before and works after. Neither spans it, which would leave the deployed preview without its published-runtime fallback for as long as the two sides are out of step.

### What

`LOCAL` / `PUBLISHED` become a `SOURCES` list, tried in order — local, then `fumola.org`, then `adapton.github.io` — and the promise chain becomes a loop. Local stays first, so working on Fumola and Hazel together is unchanged. Whichever published URL is live answers; the other fails fast and costs one request.

When every source fails, `loadError` now names all of them and what each said, instead of only the last error.

### After the domain settles

The `adapton.github.io` entry will only ever redirect, and should be dropped.

### Checking it

Open the preview and look at the console: it now logs `runtime loaded from <name>`, and `window.fumola.source()` returns that name. Before the domain moves, expect `adapton.github.io`; after, `fumola.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)