### PR TITLE
Blackboard MVP.

### DIFF
--- a/docs/blackboard.md
+++ b/docs/blackboard.md
@@ -1,0 +1,244 @@
+# Blackboard in Hazel
+
+An MVP of **Blackboard: A Clean Slate Proof Assistant** — a core logic with a
+type of all types, an internal typing relation, and no lambda — as a
+sub-language of Hazel. Branch `blackboard-mvp`, PR
+[#2525](https://github.com/hazelgrove/hazel/pull/2525).
+
+This document records what is actually implemented, what is deliberately a
+placeholder, and what is open. It was written to answer two questions from the
+paper's author, which are the two questions anyone should ask of a proof
+assistant MVP: *are the constructions real?* and *how does it typecheck?*
+
+| Where | What |
+|---|---|
+| `src/language/blackboard/` | the kernel (`BbTerm`, `BbCheck`, `BbError`, `BbParse`) and the editor sort (`BbSort`, `BbGrammar`, `BbTermBase`, `Bb`, `BbInfo`) |
+| `src/language/statics/Statics.re` | `bb_to_info_map`: checking as the editor runs it |
+| `src/web/blackboard/BbCursorInspector.re` | what the caret says |
+| `mech/Blackboard.v` | the Rocq reference semantics |
+| `hazel-programs/docs/blackboard/` | six documentation slides |
+| `test/blackboard/` | 34 tests |
+
+## What is real
+
+The checker. `BbCheck` is a genuine bidirectional implementation of the
+decidable fragment the paper calls `tychk`: `synth` finds a term's type,
+`is_type` checks formation, `has_type` compares
+([`BbCheck.re:52`](../src/language/blackboard/BbCheck.re#L52)). Every step is
+an instance of a rule of the corrected Figure 1 — `hyp`, `type`, `ap`,
+`arrow`, `in`, and `in-` for hypotheses — so whatever passes is derivable.
+Much that is derivable does not pass, and the paper says so.
+
+It is not a stub, and the evidence is that it finds the paper's own slips:
+
+| Fixture | What the checker reports |
+|---|---|
+| `cong-ap` as printed | `B : A -> type` used bare where `B a` is meant; `a1` bound twice, leaving `a2` unbound |
+| `cong-ap` repaired | exactly one error: `f2 a2 : B a2` against an expected `B a1` — the step needing `a1 = a2` |
+| `int-elim` as printed | two mismatches, `h : M x` where `s` and `p` expect an `int` |
+| `quot` | `eq-rel` is never defined |
+| `arrow-small` | `A : U` is not a type without the coercion the paper leaves implicit |
+
+These are pinned as tests in `test/blackboard/Test_Blackboard.re`, and they run
+on every keystroke in the editor, not only from tests.
+
+## What is a placeholder
+
+**`by proof` is still a placeholder, exactly as in the paper.** So is
+`by definition`, `by tychk` and `by quotient`. A tactic is parsed as a bare
+name ([`Bb.re:221`](../src/language/blackboard/Bb.re#L221), "a tactic is a
+name") and kept as a string.
+
+**There is no definitional mechanism at all** — no defined constants, no
+unfolding, no δ.
+
+So what a `construct` block does today is: check its signature entries exactly
+as an `assume` block's are (each type a type in the context of the entries
+before it), put the names in the context, record the tactic, and report it as
+`pending` ([`BbCheck.re:149`](../src/language/blackboard/BbCheck.re#L149)),
+which nothing discharges. In the editor the only difference from `assume` is
+the block tint and a cursor-inspector line reading *"constructed: a
+conservative extension, owing a witness"*. **Construct is assume, plus a
+colour, plus an IOU.**
+
+What did change against the paper is that the placeholder now has a precise,
+machine-checked meaning. `mech/Blackboard.v` Part III writes the obligation of
+a construction block as a term:
+
+```
+witness(T1 ... Tn)  =  (M : type) -> ((x1 : T1) -> ... -> (xn : Tn) -> M) -> M
+```
+
+and `Theorem conservativity` proves that if the signature is well formed and
+`G |- witness Ts`, then anything derivable using the block and not mentioning
+the `xi` — and that is itself a type — was already derivable. Rocq 9.2,
+`Print Assumptions` closed under the global context on all eight main
+theorems, no axioms.
+
+So "by proof" now means something exact: **produce a term of that witness
+type.** Nothing in the MVP produces or checks one. There is no proof-term
+language beyond the signature language itself, and no tactic engine.
+
+## Typing
+
+### Substitution — yes, in one place
+
+The `ap` rule. When `f : (x : A) -> B` and the argument checks, the result
+type is `subst(x, a, cod)`
+([`BbCheck.re:66`](../src/language/blackboard/BbCheck.re#L66)). Binders are
+named, as users write them, so `subst` is capture-avoiding with freshening
+([`BbTerm.re:58`](../src/language/blackboard/BbTerm.re#L58)); the de Bruijn
+reference semantics is the Rocq development. A capture test is in
+`Test_Blackboard`.
+
+### Conversion — there is none
+
+`alpha_eq` ([`BbTerm.re:79`](../src/language/blackboard/BbTerm.re#L79)) is the
+checker's only notion of "same type": α-equivalence and nothing more. No β, no
+η, no δ. Grepping the kernel for reduce / whnf / normalize returns nothing.
+
+This is deliberate rather than unfinished. The logic as given has **no
+reduction**, so conversion has no content to implement. Where the paper's
+examples need an *equation*, the checker reports a mismatch rather than
+quietly accepting: the repaired `cong-ap` still errors, and that test asserts
+the mismatch is the *only* remaining error.
+
+### The one escape hatch is the paper's own
+
+Because typing is internal, a hypothesis `h : (t : T)` in the context
+establishes `t : T`. `has_type` looks for an α-matching membership hypothesis
+*before* it synthesizes
+([`BbCheck.re:81`](../src/language/blackboard/BbCheck.re#L81),
+[`:27`](../src/language/blackboard/BbCheck.re#L27)). That is rules `hyp` and
+`in-`, and it is what makes the Section 4 refinement and intersection
+eliminators check at all.
+
+It is a lookup, not a congruence: it does not close under subterm replacement,
+so it is not conversion wearing a hat.
+
+### `(t : T) : type`
+
+Needs only that `T` is a type and that `t` has *some* type (paper, l. 80), not
+that `t` has type `T` ([`BbCheck.re:95`](../src/language/blackboard/BbCheck.re#L95)).
+
+## Error localization
+
+Kernel terms carry no editor ids, deliberately: the kernel does not depend on
+tiles or the web layer. So errors carry the subterm they are about
+(`BbError.subject`), and the statics layer finds the node by **re-reading** —
+walk the editor term, convert each node back to a kernel term, mark the first
+one that is α-equal to the subject
+([`Statics.re:78`](../src/language/statics/Statics.re#L78)). Unbound names are
+special-cased: every occurrence of the name in the entry is marked. If nothing
+matches, the error lands on the whole entry.
+
+Checking is **per entry, not per document**. An entry that cannot be read at
+all still enters the context so its neighbours are still checked — an
+all-or-nothing check goes silent exactly when the user has just made a
+mistake. `Test_BlackboardStatics` pins this.
+
+Two known weaknesses, neither yet a problem at paper scale:
+
+- Two α-equal occurrences of the same subterm in one entry are
+  indistinguishable to that search, and the first one takes the mark.
+- The search re-converts at every node, so it is quadratic in entry size.
+
+## Editor integration
+
+`Bb(BbSort.Term)` is a nested sort following the ALFA derivation sub-language
+in `src/language/derivation/`. One sort covers terms, signature entries and
+blocks; the distinctions are made by form. Concrete syntax, molding and the
+`rotate_entry` convention are documented in
+[`src/language/blackboard/README.md`](../src/language/blackboard/README.md).
+
+Two facts worth knowing:
+
+- **The colon binds tighter than the arrow**, so `(x : A) -> x : B` reads as
+  the paper writes it. In a signature entry the colon is a declaration
+  instead, and is loosest; `Bb.rotate_entry` rotates the spine back.
+- **Blackboard is a closed sub-language.** `Insert.effective_sort` does not
+  fall back to the enclosing sort inside it, so `type` stays a Blackboard
+  token instead of expanding into Hazel's `type _ = _ in`.
+
+A `blackboard ... end` expression is **inert** in Hazel: it has type
+`Unknown(Internal)`, and it is already a value — it does not evaluate
+(`Transition.re`). Its document is still checked
+([`Statics.re:637`](../src/language/statics/Statics.re#L637)).
+
+## Testing
+
+```
+dune build test/idb_stub.js test/haz3ltest.bc.js --profile dev
+bash test/run_node.sh test Blackboard
+```
+
+34 tests across four groups: `Blackboard` (kernel), `Blackboard editor`
+(reading editor terms), `Blackboard slides` (every shipped slide reads back as
+a document), `Blackboard statics` (the messages the cursor inspector shows, so
+a silent editor fails here).
+
+## Open questions
+
+### About the logic — for the paper's author
+
+1. **Consistency of the Section 4 postulate library** (equality with
+   `replace`, refinement, intersection, quotients, the small universe with
+   combinators). Open, and the obstacle is `type : type`: the extension of
+   `(X : type) -> X` is defined in terms of itself, so the usual PER models,
+   which need stratified universes, do not apply directly. Candidate routes
+   are a coinductive extension relation with a functionality proof, or a
+   stratification theorem in the style of Harper and Pollack's typical
+   ambiguity.
+2. **What is a proof term?** Theorem 2 says what `by proof` owes — an
+   inhabitant of `witness(T1 ... Tn)`. The logic has no lambda, so the
+   language in which such a witness is *written* is not settled by Figure 1.
+   Until it is, `by proof` cannot be discharged even in principle.
+3. **How do equations get used?** Several of the paper's own examples need an
+   equation as a rewrite (`cong-ap`'s conclusion, `int-elim`'s quotient, the
+   `U = refine type small` coercion). `replace` is postulated, but nothing
+   applies it. Is the intent that the user applies `replace` explicitly, or
+   that some decidable layer does it? The first is checkable today; the second
+   needs a design.
+4. **`by definition` and `by tychk` as tactics.** `tychk` exists as the
+   ambient checker but not as a tactic that discharges an obligation. What
+   does a tactic *return*, given (2)?
+5. **Implicit arguments and user `syntax`.** The paper uses both; the fixtures
+   expand braces by hand and write `eq A a b` for `=`. These are elaboration
+   questions that interact with the editor's tile grammar, so they should be
+   settled on paper first.
+
+### About the implementation
+
+6. **Nothing surfaces the pending obligations.** `BbCheck.check_doc` computes
+   `pending` per block, and only the tests read it. A document with ten
+   construct blocks should show ten outstanding obligations somewhere — a goal
+   panel, or a count in the sidebar. Today the only signal is the block tint.
+7. **Conservativity is not checked, and cannot be flagged as unchecked.**
+   Since a construct block enters the context exactly as an assume does, a
+   document that has "proved" everything by `by proof` is indistinguishable,
+   to the checker, from one that postulated it all. Whether that should be a
+   warning is a design call.
+8. **Localization by structural re-match** (above) should eventually be
+   replaced by threading ids through `term_to_kernel`, which means kernel
+   terms parameterized by an annotation — the same shape `BbGrammar` already
+   has.
+
+### About Hazel integration
+
+9. **`BbQuote` has no dynamics and no type.** It is inert with type
+   `Unknown(Internal)`. What *should* a Blackboard document mean as a Hazel
+   value — a checked-document record, a list of obligations, a first-class
+   signature? This is the question that decides whether Blackboard is embedded
+   in Hazel or merely hosted by it.
+10. **`BbInfo` keeps its own `status` rather than joining `Mark.t`**, whose
+    declaration order is load-bearing for the other sorts. That is a
+    deliberate dodge; the sub-languages will keep paying for it.
+11. **The menhir fast path has no Blackboard productions.**
+    `src/menhirParser/Conversion.re` raises `Failure("BbQuote not supported")`,
+    which is caught, and every Blackboard slide falls back to the quadratic
+    parser. This is the cost measured in
+    [#2541, DocSlides is ~60% of suite wall time](https://github.com/hazelgrove/hazel/issues/2541).
+12. **Names cannot contain hyphens**, so slides use `falsity_eq` where the
+    paper writes `falsity-eq`, and `false` is a boolean literal rather than a
+    name. This is the shared-tokenizer constraint catalogued in
+    [#2542, the tokenizer is the binding constraint for sub-language tiles](https://github.com/hazelgrove/hazel/issues/2542).

--- a/hazel-programs/docs/blackboard/case-studies.hz
+++ b/hazel-programs/docs/blackboard/case-studies.hz
@@ -1,0 +1,438 @@
+# BLACKBOARD: THE PAPER'S CASE STUDIES, AS DOCUMENTS #
+
+# An appendix. Section 4 of the draft gives four extended examples. #
+# Each is transcribed below, as close to the paper as this editor can #
+# hold it, so you can put the cursor in one and see what checks. #
+
+# FOUR NOTATIONAL SUBSTITUTIONS #
+# The paper uses four things the MVP grammar does not have yet, so #
+# every listing below is rewritten the same way throughout: #
+#   `syntax (A <: B) (subtype A B)` -- no user-defined notation yet, #
+#      so an operator is always written applied: `subtype(A, B)`. #
+#   `{X : U} ->` -- no implicit arguments, so every one is explicit. #
+#   `a = b` -- equality is not primitive; the paper assumes it in #
+#      Section 3, so here it is assumed as `eq(T, a, b)` and applied. #
+#   `(A B : type) ->` -- one binder per arrow: `(A : type) -> (B : type) ->`. #
+# Hyphens are not name characters in Hazel, so `refine-intro` is #
+# `refine_intro`, as on the Terms slide. #
+
+# WHAT TO EXPECT #
+# 4.1 checks clean. The other three report errors, and every one of #
+# them has the same cause: Blackboard's typing is extensional, so a #
+# step may go through an EQUATION, and the editor has none yet. Each #
+# listing is followed by a note naming the equation it wanted. #
+
+# 4.1 SUBTYPING, INTERSECTIONS, AND REFINEMENTS #
+# The point of this one is that subtyping is DEFINED, not built in: #
+# `A <: B` is just the type of proofs that everything in A is in B, #
+# which you can only write down if membership is an internal type. #
+
+blackboard
+
+assume
+  eq : (A : type) -> (a1 : A) -> (a2 : A) -> type
+by tychk
+
+; construct
+  subtype : (A : type) -> (B : type) -> type;
+  subtype_eq :
+    (A : type) ->
+    (B : type) ->
+    eq(type, subtype(A, B), (x : A) -> x : B)
+by definition
+
+; assume
+  type_ext :
+    (A : type) ->
+    (B : type) ->
+    subtype(A, B) ->
+    subtype(B, A) ->
+    eq(type, A, B)
+by tychk
+
+; assume
+  refine : (A : type) -> (P : A -> type) -> type;
+  refine_intro :
+    (A : type) ->
+    (P : A -> type) ->
+    (x : A) ->
+    P(x) ->
+    x : refine(A, P);
+  refine_elim :
+    (A : type) ->
+    (M : type) ->
+    (P : A -> type) ->
+    (x : refine(A, P)) ->
+    ((h : (x : A)) -> P(x) -> M) ->
+    M
+by tychk
+
+; assume
+  intersect : (A : type) -> (B : type) -> type;
+  intersect_intro :
+    (A : type) ->
+    (B : type) ->
+    (x : A) ->
+    (h : (x : B)) ->
+    x : intersect(A, B);
+  intersect_elim :
+    (A : type) ->
+    (B : type) ->
+    (M : type) ->
+    (x : intersect(A, B)) ->
+    ((h1 : (x : A)) -> (h2 : (x : B)) -> M) ->
+    M
+by tychk
+
+; construct
+  refinement_subtype_1 :
+    (A : type) ->
+    (P : A -> type) ->
+    subtype(refine(A, P), A);
+  refinement_subtype_2 :
+    (A : type) ->
+    (P1 : A -> type) ->
+    (P2 : A -> type) ->
+    ((x : A) -> P1(x) -> P2(x)) ->
+    subtype(refine(A, P1), refine(A, P2));
+  intersect_subtype_1 :
+    (A : type) ->
+    (B : type) ->
+    subtype(intersect(A, B), A);
+  intersect_subtype_2 :
+    (A : type) ->
+    (B : type) ->
+    subtype(intersect(A, B), B);
+  intersect_subtype_3 :
+    (A : type) ->
+    (B : type) ->
+    (C : type) ->
+    subtype(C, A) ->
+    subtype(C, B) ->
+    subtype(C, intersect(A, B))
+by proof
+
+end;
+
+# WHAT THE EDITOR SAYS ABOUT 4.1 #
+# Nothing: every entry above is well formed, and the parts the paper #
+# leaves to a tactic -- `by definition`, `by proof` -- are recorded as #
+# obligations rather than checked. The interesting content is in the #
+# TYPES, and those the editor does check, in order, each in the #
+# context of the entries before it. #
+
+# 4.2 QUOTIENT TYPES #
+# Quotients are postulated, then the integers are built as a quotient #
+# inductive type. This is the example where the construct/assume #
+# distinction earns its keep: the integers are CONSTRUCTED, so the #
+# von Neumann encoding underneath them never becomes visible. #
+
+blackboard
+
+assume
+  eq : (A : type) -> (a1 : A) -> (a2 : A) -> type;
+  eq_rel : (A : type) -> type
+by tychk
+
+; construct
+  prod : (A : type) -> (B : type) -> type;
+  prod_eq :
+    (A : type) ->
+    (B : type) ->
+    eq(type, prod(A, B), (M : type) -> A -> B -> M)
+by definition
+
+; assume
+  quot : (A : type) -> (R : eq_rel(A)) -> type;
+  quot_intro :
+    (A : type) ->
+    (R : eq_rel(A)) ->
+    A ->
+    quot(A, R);
+  quot_eq :
+    (A : type) ->
+    (R : eq_rel(A)) ->
+    (a1 : A) ->
+    (a2 : A) ->
+    eq(type,
+       eq(quot(A, R), quot_intro(A, R, a1), quot_intro(A, R, a2)),
+       R(a1, a2));
+  quot_elim :
+    (A : type) ->
+    (R : eq_rel(A)) ->
+    (M : quot(A, R) -> type) ->
+    (f : (a : A) -> M(quot_intro(A, R, a))) ->
+    (inv :
+       (a1 : A) ->
+       (a2 : A) ->
+       R(a1, a2) ->
+       eq(M(quot_intro(A, R, a1)), f(a1), f(a2))) ->
+    (x : quot(A, R)) ->
+    M(x);
+  quot_comp :
+    (A : type) ->
+    (R : eq_rel(A)) ->
+    (M : quot(A, R) -> type) ->
+    (f : (a : A) -> M(quot_intro(A, R, a))) ->
+    (inv :
+       (a1 : A) ->
+       (a2 : A) ->
+       R(a1, a2) ->
+       eq(M(quot_intro(A, R, a1)), f(a1), f(a2))) ->
+    (a : A) ->
+    eq(M(quot_intro(A, R, a)),
+       quot_elim(A, R, M, f, inv, quot_intro(A, R, a)),
+       f(a))
+by tychk
+
+end;
+
+# TWO THINGS THE EDITOR REPORTS HERE, AND WHY #
+# `R is applied, but it has type eq_rel A, not an arrow`. True: #
+# applying R needs `eq_rel(A) = A -> A -> type`, which the paper #
+# leaves implicit and the editor cannot use. #
+# And in `inv`, `f a2 has type M (quot_intro A R a2)` where the #
+# equation is stated at `M (quot_intro A R a1)`; only the hypothesis #
+# `R a1 a2` bridges them, again by an equation. #
+# Both are the Checking slide's limit, not new mistakes. #
+
+# THE INTEGERS #
+# `int_elim` and `int_comp` in the paper disagree about whether the #
+# successor case takes its index: `int_elim` declares #
+# `s : (x : int) -> M x -> M (succ x)` but then writes `s(p h)`, with #
+# one argument, which is only well formed under `int_comp`'s implicit #
+# `{x : int}`. Written out explicitly, as below, the index is passed. #
+
+blackboard
+
+assume
+  eq : (A : type) -> (a1 : A) -> (a2 : A) -> type;
+  prod : (A : type) -> (B : type) -> type
+by tychk
+
+; construct
+  int : type;
+  zero : int;
+  succ : int -> int;
+  pred : int -> int;
+  succ_pred : (x : int) -> eq(int, succ(pred(x)), x);
+  pred_succ : (x : int) -> eq(int, pred(succ(x)), x);
+  int_elim :
+    (M : int -> type) ->
+    (z : M(zero)) ->
+    (s : (x : int) -> M(x) -> M(succ(x))) ->
+    (p : (x : int) -> M(x) -> M(pred(x))) ->
+    (sp : (x : int) -> (h : M(x)) -> eq(M(x), s(pred(x), p(x, h)), h)) ->
+    (ps : (x : int) -> (h : M(x)) -> eq(M(x), p(succ(x), s(x, h)), h)) ->
+    (x : int) ->
+    M(x);
+  int_comp :
+    (M : int -> type) ->
+    (z : M(zero)) ->
+    (s : (x : int) -> M(x) -> M(succ(x))) ->
+    (p : (x : int) -> M(x) -> M(pred(x))) ->
+    (sp : (x : int) -> (h : M(x)) -> eq(M(x), s(pred(x), p(x, h)), h)) ->
+    (ps : (x : int) -> (h : M(x)) -> eq(M(x), p(succ(x), s(x, h)), h)) ->
+    prod(
+      eq(M(zero), int_elim(M, z, s, p, sp, ps, zero), z),
+      prod(
+        (x : int) ->
+          eq(M(succ(x)),
+             int_elim(M, z, s, p, sp, ps, succ(x)),
+             s(x, int_elim(M, z, s, p, sp, ps, x))),
+        (x : int) ->
+          eq(M(pred(x)),
+             int_elim(M, z, s, p, sp, ps, pred(x)),
+             p(x, int_elim(M, z, s, p, sp, ps, x)))))
+by quotient
+
+end;
+
+# `s(pred(x), p(x, h))` inhabits `M(succ(pred(x)))`, and the equation #
+# is stated at `M(x)`. Those are the same type only by `succ_pred`. #
+# The editor reports the mismatch for the reason slide 3 gives: it #
+# compares terms up to renaming, and cannot yet use an equation. #
+
+# PATTERN MATCHING #
+# A construction whose signature is a set of equations. The paper #
+# notes these must be TRUE equations, not first-match: the tactic owes #
+# a proof that the branches respect the constructor equations, so the #
+# clauses have to be order-independent. #
+
+blackboard
+
+assume
+  eq : (A : type) -> (a1 : A) -> (a2 : A) -> type;
+  int : type;
+  zero : int;
+  succ : int -> int;
+  pred : int -> int
+by tychk
+
+; construct
+  negative : int -> int;
+  negative_zero : eq(int, negative(zero), zero);
+  negative_succ :
+    (x : int) -> eq(int, negative(succ(x)), pred(negative(x)));
+  negative_pred :
+    (x : int) -> eq(int, negative(pred(x)), succ(negative(x)))
+by pattern_matching
+
+end;
+
+# 4.3 SMALL TYPES AND ABSTRACTION #
+# A universe of small types, from a smallness predicate and a #
+# refinement, plus combinators to build functions over it. This is #
+# the case study to read alongside the Metatheory slide: `U` is #
+# assumed SMALL-free on purpose. Assuming `small(U)` as well would #
+# put the universe in itself, which is the shape of Girard's paradox. #
+
+blackboard
+
+assume
+  eq : (A : type) -> (a1 : A) -> (a2 : A) -> type;
+  refine : (A : type) -> (P : A -> type) -> type
+by tychk
+
+; assume
+  small : type -> type;
+  U : type;
+  U_eq : eq(type, U, refine(type, small));
+  arrow_small :
+    (A : U) ->
+    (B : A -> U) ->
+    small((a : A) -> B(a));
+  abs_const :
+    (X : U) ->
+    (A : U) ->
+    (a : A) ->
+    (x : X) ->
+    A;
+  abs_const_comp :
+    (X : U) ->
+    (A : U) ->
+    (a : A) ->
+    (x : X) ->
+    eq(A, abs_const(X, A, a, x), a);
+  abs_id :
+    (X : U) ->
+    (x : X) ->
+    X;
+  abs_id_comp :
+    (X : U) ->
+    (x : X) ->
+    eq(X, abs_id(X, x), x);
+  abs_ap :
+    (X : U) ->
+    (A : X -> U) ->
+    (B : (x : X) -> A(x) -> U) ->
+    (f : (x : X) -> (a : A(x)) -> B(x, a)) ->
+    (a : (x : X) -> A(x)) ->
+    (x : X) ->
+    B(x, a(x));
+  abs_ap_comp :
+    (X : U) ->
+    (A : X -> U) ->
+    (B : (x : X) -> A(x) -> U) ->
+    (f : (x : X) -> (a : A(x)) -> B(x, a)) ->
+    (a : (x : X) -> A(x)) ->
+    (x : X) ->
+    eq(B(x, a(x)), abs_ap(X, A, B, f, a, x), f(x, a(x)));
+  N : type;
+  N_small : small(N)
+by tychk
+
+; construct
+  apply_twice : (N -> N) -> (N -> N);
+  apply_twice_eq :
+    (f : N -> N) ->
+    (n : N) ->
+    eq(N, apply_twice(f, n), f(f(n)))
+by abstraction
+
+end;
+
+# `(A : U)` USED AS A TYPE #
+# The editor reports `A is used as a type, but it has type U`, nine #
+# times over. It is right that this needs an argument: `A : U` binds #
+# A as an ELEMENT of U, and `B : A -> U` then puts A in type #
+# position. What licenses that is `U_eq`, which says U is the type #
+# refined from `type`, so its elements are types. That is an assumed #
+# equation, and the editor has none. #
+# This is also the `small U` question from the second reading. The #
+# combinators are sound here only because `U` itself is never #
+# assumed small; `small(U)` would put the universe in itself. #
+
+# 4.4 LINEAR ABSTRACTIONS #
+# Linearity as a refinement of the function type, with its own #
+# combinators. `A -o B` is written `linear_arrow(A, B)` here. #
+
+blackboard
+
+assume
+  eq : (A : type) -> (a1 : A) -> (a2 : A) -> type;
+  refine : (A : type) -> (P : A -> type) -> type;
+  N : type
+by tychk
+
+; assume
+  linear : (A : type) -> (B : type) -> (A -> B) -> type;
+  linear_arrow : (A : type) -> (B : type) -> type;
+  linear_arrow_eq :
+    (A : type) ->
+    (B : type) ->
+    eq(type, linear_arrow(A, B), refine(A -> B, linear(A, B)));
+  labs_id : (X : type) -> linear_arrow(X, X);
+  labs_id_eq :
+    (X : type) ->
+    (x : X) ->
+    eq(X, labs_id(X, x), x);
+  labs_lap :
+    (X : type) ->
+    (A : type) ->
+    (B : type) ->
+    (f : linear_arrow(X, A -> B)) ->
+    (a : A) ->
+    linear_arrow(X, B);
+  labs_lap_eq :
+    (X : type) ->
+    (A : type) ->
+    (B : type) ->
+    (f : linear_arrow(X, A -> B)) ->
+    (a : A) ->
+    (x : X) ->
+    eq(B, labs_lap(X, A, B, f, a, x), f(x, a));
+  labs_rap :
+    (X : type) ->
+    (A : type) ->
+    (B : type) ->
+    (f : linear_arrow(A, B)) ->
+    (a : linear_arrow(X, A)) ->
+    linear_arrow(X, B);
+  labs_rap_eq :
+    (X : type) ->
+    (A : type) ->
+    (B : type) ->
+    (f : linear_arrow(A, B)) ->
+    (a : linear_arrow(X, A)) ->
+    (x : X) ->
+    eq(B, labs_rap(X, A, B, f, a, x), f(a(x)))
+by tychk
+
+; construct
+  swapped_apply :
+    linear_arrow(N, linear_arrow(linear_arrow(N, N), N));
+  swapped_apply_eq :
+    (n : N) ->
+    (f : linear_arrow(N, N)) ->
+    eq(N, swapped_apply(n, f), f(n))
+by linear_abstraction
+
+end
+
+# THE SAME SHAPE AS 4.3 #
+# `labs_id is applied, but it has type linear_arrow X X, not an #
+# arrow`, and three more like it. Applying a linear function is well #
+# typed only through `linear_arrow_eq` and the refinement: an element #
+# of `(A -> B | linear A B)` is an element of `A -> B`. Every error #
+# reported in this document traces back to that one step. #

--- a/hazel-programs/docs/blackboard/checking.hz
+++ b/hazel-programs/docs/blackboard/checking.hz
@@ -37,7 +37,7 @@ assume
   # `f2(a2)` has type `B(a2)`, and the conclusion wants `B(a1)`. #
   # Only the hypothesis a1 = a2 bridges them, by extensional typing. #
   # The editor cannot use equations yet, so it reports the mismatch. #
-  cong-ap :
+  cong_ap :
     eq((a : A) -> B(a), f1, f2) ->
     eq(A, a1, a2) ->
     eq(B(a1), f1(a1), f2(a2))

--- a/hazel-programs/docs/blackboard/checking.hz
+++ b/hazel-programs/docs/blackboard/checking.hz
@@ -1,0 +1,46 @@
+# BLACKBOARD: WHAT THE EDITOR CHECKS #
+
+# The editor checks the decidable part: every declared type is a type, #
+# in the context of the entries before it. That catches real mistakes. #
+# Both of the slips below are in the paper this work is based on. #
+
+blackboard
+
+assume
+  A : type;
+  B : A -> type;
+  f1 : (a : A) -> B;
+  a1 : A;
+  a2 : A
+by tychk;
+
+# THE SLIP ABOVE: `B` is a family, `A -> type`, so `B` on its own is #
+# not a type. It has to be applied: `(a : A) -> B(a)`. A second slip #
+# in the same signature in the paper binds `a1` twice, leaving `a2` #
+# unbound -- the checker reports that too. #
+
+# WHAT IT DOES NOT CHECK #
+# Typing in Blackboard is undecidable, and the logic has no reduction. #
+# `same type` here means the same term up to renaming bound variables. #
+# So a step that needs an EQUATION is out of reach, and is reported as #
+# a mismatch rather than silently accepted. #
+
+assume
+  eq : (X : type) -> (x1 : X) -> (x2 : X) -> type;
+  A : type;
+  B : A -> type;
+  a1 : A;
+  a2 : A;
+  f1 : (a : A) -> B(a);
+  f2 : (a : A) -> B(a);
+
+  # `f2(a2)` has type `B(a2)`, and the conclusion wants `B(a1)`. #
+  # Only the hypothesis a1 = a2 bridges them, by extensional typing. #
+  # The editor cannot use equations yet, so it reports the mismatch. #
+  cong-ap :
+    eq((a : A) -> B(a), f1, f2) ->
+    eq(A, a1, a2) ->
+    eq(B(a1), f1(a1), f2(a2))
+by tychk
+
+end

--- a/hazel-programs/docs/blackboard/metatheory.hz
+++ b/hazel-programs/docs/blackboard/metatheory.hz
@@ -15,7 +15,7 @@ blackboard
 
 assume
   absurd : type;
-  absurd-eq : (X : type) -> X
+  absurd_eq : (X : type) -> X
 by tychk
 
 end

--- a/hazel-programs/docs/blackboard/metatheory.hz
+++ b/hazel-programs/docs/blackboard/metatheory.hz
@@ -1,0 +1,48 @@
+# BLACKBOARD: METATHEORY #
+
+# The rules in these slides are not taken on trust. They are formalized #
+# in Rocq, in the repository under mech/Blackboard.v, and every theorem #
+# below is machine-checked with no axioms. #
+
+# The file covers BOTH versions of the rules at once: the figure as #
+# first written, and the corrected one whose arrow-introduction rule #
+# also demands that the domain be a type. A flag selects between them. #
+
+# THEOREM 1: THE CORE LOGIC IS CONSISTENT #
+# There is no closed proof of the empty type. #
+
+blackboard
+
+assume
+  absurd : type;
+  absurd-eq : (X : type) -> X
+by tychk
+
+end
+
+# The proof is a two-point model: read every type as true or false, #
+# read `t : T` as T, read an arrow as implication, and check that all #
+# eight rules preserve truth. `(X : type) -> X` reads as `for all b, b`, #
+# which is false, so it is not derivable. #
+
+# THEOREM 2: CONSTRUCTION BLOCKS ARE CONSERVATIVE #
+# If a construct block meets its obligation, anything it lets you prove #
+# that does not mention the new names was already provable. Proved for #
+# a signature of any length. #
+
+# WHAT THE MODELS DO NOT SETTLE #
+# The two-point model says nothing about the assumptions in these #
+# slides, because it makes every equation true. A five-point model gets #
+# further -- it proves the first version of the rules is NOT regular, #
+# since it derives an inhabited arrow whose domain is not a type -- but #
+# it still cannot validate the rule that transports along an equation. #
+
+# THE OPEN PROBLEM #
+# Consistency of the assumptions used in practice -- equality with #
+# transport, refinement, intersection, quotients, a small universe -- #
+# is open. The obstacle is that the meaning of `(X : type) -> X` is #
+# defined in terms of itself, which is the semantic face of Type:Type. #
+# The promising route is a stratification theorem: show that any #
+# derivation can be assigned universe levels after the fact. That would #
+# be the precise form of the claim that abstraction, not Type:Type, is #
+# what has to be restrained. #

--- a/hazel-programs/docs/blackboard/overview.hz
+++ b/hazel-programs/docs/blackboard/overview.hz
@@ -1,0 +1,43 @@
+# BLACKBOARD: OVERVIEW #
+
+# Blackboard is a proof assistant designed for expressiveness with very #
+# few primitive concepts: four term formers and eight inference rules. #
+# This is an early experiment embedding its core logic in Hazel. #
+
+# The core logic has ONE syntactic class. A term may be: #
+#   a name             x #
+#   the type of types  type #
+#   a membership       t : T #
+#   a function type    (x : A) -> B #
+#   an application     f(a) #
+
+# There is no lambda. Functions are postulated, never introduced. That #
+# is what lets Blackboard keep a self-containing type of types without #
+# becoming inconsistent: the paradoxes need abstraction, not Type:Type. #
+
+blackboard
+
+# A document is a sequence of blocks. An `assume` block postulates #
+# names; its only obligation is that each declared type IS a type. #
+
+assume
+  eq : (A : type) -> (a1 : A) -> (a2 : A) -> type;
+  refl : (A : type) -> (a : A) -> eq(A, a, a)
+by tychk;
+
+# A `construct` block instead claims a conservative extension: the #
+# signature must be shown inhabited, and the witness is then discarded. #
+# Only the signature carries meaning. #
+
+construct
+  false : type;
+  false-eq : eq(type, false, (X : type) -> X)
+by definition
+
+end
+
+# WHERE TO GO NEXT #
+# 1. Terms       the five forms, and how they nest #
+# 2. Signatures  assume, construct, and what `by` means #
+# 3. Checking    what the editor checks, and what it cannot #
+# 4. Metatheory  the machine-checked proofs behind the rules #

--- a/hazel-programs/docs/blackboard/overview.hz
+++ b/hazel-programs/docs/blackboard/overview.hz
@@ -30,8 +30,8 @@ by tychk;
 # Only the signature carries meaning. #
 
 construct
-  false : type;
-  false-eq : eq(type, false, (X : type) -> X)
+  falsity : type;
+  falsity_eq : eq(type, falsity, (X : type) -> X)
 by definition
 
 end

--- a/hazel-programs/docs/blackboard/signatures.hz
+++ b/hazel-programs/docs/blackboard/signatures.hz
@@ -1,0 +1,44 @@
+# BLACKBOARD: SIGNATURES AND BLOCKS #
+
+# A document is a sequence of blocks, separated by `;`. Each block has #
+# a signature -- a list of `name : type` entries -- and a tactic after #
+# `by`. The two kinds of block differ in what they OWE. #
+
+# ASSUME owes only well-typedness: each declared type must be a type. #
+# What you assume is yours to justify; results depend on it. #
+
+blackboard
+
+assume
+  int : type;
+  zero : int;
+  succ : int -> int;
+  pred : int -> int
+by tychk
+
+# CONSTRUCT owes inhabitation. To add these names you must prove #
+#   (M : type) -> ((x1 : T1) -> ... -> (xn : Tn) -> M) -> M #
+# which says the signature could have been filled in. The filling is #
+# then thrown away: the interface is the meaning, the witness is not. #
+# This is why 1 is not an element of 3 here, even if the integers are #
+# built from von Neumann ordinals underneath. #
+
+; construct
+  eq : (A : type) -> (a1 : A) -> (a2 : A) -> type;
+  succ-pred : (x : int) -> eq(int, succ(pred(x)), x);
+  pred-succ : (x : int) -> eq(int, pred(succ(x)), x)
+by quotient
+
+end
+
+# WHY THIS IS SAFE #
+# Conservativity is proved, not assumed: a construct block whose #
+# obligation is met adds no new theorems about the names that were #
+# already there. The proof is machine-checked; see the Metatheory #
+# slide. It needs one hypothesis the paper does not state -- that the #
+# goal is itself a type. #
+
+# TACTICS #
+# `by tychk`, `by definition`, `by quotient` name the tactic that would #
+# discharge the obligation. No tactic language exists yet, so the #
+# editor records the obligation as pending and checks the signature. #

--- a/hazel-programs/docs/blackboard/signatures.hz
+++ b/hazel-programs/docs/blackboard/signatures.hz
@@ -25,8 +25,8 @@ by tychk
 
 ; construct
   eq : (A : type) -> (a1 : A) -> (a2 : A) -> type;
-  succ-pred : (x : int) -> eq(int, succ(pred(x)), x);
-  pred-succ : (x : int) -> eq(int, pred(succ(x)), x)
+  succ_pred : (x : int) -> eq(int, succ(pred(x)), x);
+  pred_succ : (x : int) -> eq(int, pred(succ(x)), x)
 by quotient
 
 end

--- a/hazel-programs/docs/blackboard/terms.hz
+++ b/hazel-programs/docs/blackboard/terms.hz
@@ -3,6 +3,9 @@
 # Every Blackboard term is built from five forms. Put the cursor on any #
 # part of a term to see what the checker makes of it. #
 
+# One deviation from the paper: Hazel names cannot contain a hyphen, #
+# so `subtype-eq` is written `subtype_eq` here. #
+
 blackboard
 
 assume
@@ -16,14 +19,14 @@ assume
   # For `t : T` to be a type, T must be a type and t must have SOME #
   # type. It need NOT already have type T -- that is the point. #
   a : A;
-  witness : a : A;
+  witness : (a : A);
 
   # 3. FUNCTION TYPES. Non-dependent: #
   f : A -> A;
 
   # 4. DEPENDENT function types bind a name in the domain. #
   # The binder is written as a parenthesized membership. #
-  id-ty : (X : type) -> X -> X;
+  id_ty : (X : type) -> X -> X;
 
   # 5. APPLICATION. Several arguments are written f(a, b), which #
   # means f applied to a, then to b. #
@@ -39,7 +42,7 @@ by tychk;
 
 construct
   subtype : (A : type) -> (B : type) -> type;
-  subtype-eq :
+  subtype_eq :
     (A : type) -> (B : type) ->
     eq(type, subtype(A, B), (x : A) -> x : B)
 by definition

--- a/hazel-programs/docs/blackboard/terms.hz
+++ b/hazel-programs/docs/blackboard/terms.hz
@@ -1,0 +1,47 @@
+# BLACKBOARD: TERMS #
+
+# Every Blackboard term is built from five forms. Put the cursor on any #
+# part of a term to see what the checker makes of it. #
+
+blackboard
+
+assume
+
+  # 1. NAMES and THE TYPE OF TYPES #
+  # `type` is the type of all types, and is itself a type. #
+  A : type;
+
+  # 2. MEMBERSHIP: `t : T` is a TERM, not a judgment. #
+  # It is a type whose inhabitants are proofs that t has type T. #
+  # For `t : T` to be a type, T must be a type and t must have SOME #
+  # type. It need NOT already have type T -- that is the point. #
+  a : A;
+  witness : a : A;
+
+  # 3. FUNCTION TYPES. Non-dependent: #
+  f : A -> A;
+
+  # 4. DEPENDENT function types bind a name in the domain. #
+  # The binder is written as a parenthesized membership. #
+  id-ty : (X : type) -> X -> X;
+
+  # 5. APPLICATION. Several arguments are written f(a, b), which #
+  # means f applied to a, then to b. #
+  eq : (X : type) -> (x1 : X) -> (x2 : X) -> type;
+  fa : eq(A, f(a), a)
+
+by tychk;
+
+# SUBTYPING, FOR FREE #
+# Because membership is an ordinary term, subtyping is DEFINABLE. #
+# In Lean, Rocq and Agda it cannot be written down at all: there is no #
+# internal typing relation to write it with. #
+
+construct
+  subtype : (A : type) -> (B : type) -> type;
+  subtype-eq :
+    (A : type) -> (B : type) ->
+    eq(type, subtype(A, B), (x : A) -> x : B)
+by definition
+
+end

--- a/mech/Blackboard.v
+++ b/mech/Blackboard.v
@@ -1,0 +1,1162 @@
+(* ------------------------------------------------------------------------ *)
+(*  Blackboard.v                                                            *)
+(*                                                                          *)
+(*  Mechanized metatheory for the core logic of Blackboard: A Clean Slate  *)
+(*  Proof Assistant (Figure 1), in both the form first printed and the     *)
+(*  author's corrected form (arrow+ with premise G |- T1 : type).           *)
+(*  Part I: Theorem 1, consistency: no closed instance of (X : type) -> X  *)
+(*  is derivable.  Parts II-III: Theorem 2, conservativity of construction *)
+(*  blocks.  Part IV: a five-point model settling regularity questions.    *)
+(*                                                                          *)
+(*  Method: a two-point model.  Every term denotes a Boolean; "t : T" is    *)
+(*  inhabited iff T is; the dependent function type is implication, with   *)
+(*  its bound variable ranging over {true,false}; applications denote      *)
+(*  true.  All eight rules preserve truth; (X : type) -> X denotes          *)
+(*  "for all b, b", which is false.                                         *)
+(*                                                                          *)
+(*  Checked with Rocq 9.2.  No axioms (see Print Assumptions at the end).  *)
+(* ------------------------------------------------------------------------ *)
+
+From Stdlib Require Import List Bool Arith Lia.
+Import ListNotations.
+
+(** * Syntax (Figure 1, first three lines), with de Bruijn indices *)
+
+Inductive term : Type :=
+| Var : nat -> term            (* identifier x                        *)
+| Mem : term -> term -> term   (* t : T   (internal type membership)  *)
+| Ty  : term                   (* type                                *)
+| Pi  : term -> term -> term   (* (x : A) -> B;  B binds Var 0         *)
+| App : term -> term -> term.  (* t u                                 *)
+
+(** Renaming and parallel substitution. *)
+
+Definition up_ren (xi : nat -> nat) : nat -> nat :=
+  fun n => match n with 0 => 0 | S n => S (xi n) end.
+
+Fixpoint rename (xi : nat -> nat) (t : term) : term :=
+  match t with
+  | Var n   => Var (xi n)
+  | Mem t T => Mem (rename xi t) (rename xi T)
+  | Ty      => Ty
+  | Pi A B  => Pi (rename xi A) (rename (up_ren xi) B)
+  | App t u => App (rename xi t) (rename xi u)
+  end.
+
+(** Weakening by one variable, and by n. *)
+Definition shift : term -> term := rename S.
+
+Fixpoint shiftn (k : nat) (t : term) : term :=
+  match k with 0 => t | S k => shift (shiftn k t) end.
+
+Definition up_sub (sigma : nat -> term) : nat -> term :=
+  fun n => match n with 0 => Var 0 | S n => shift (sigma n) end.
+
+Fixpoint subst (sigma : nat -> term) (t : term) : term :=
+  match t with
+  | Var n   => sigma n
+  | Mem t T => Mem (subst sigma t) (subst sigma T)
+  | Ty      => Ty
+  | Pi A B  => Pi (subst sigma A) (subst (up_sub sigma) B)
+  | App t u => App (subst sigma t) (subst sigma u)
+  end.
+
+Definition scons (a : term) (sigma : nat -> term) : nat -> term :=
+  fun n => match n with 0 => a | S n => sigma n end.
+
+(** B[a/x], the substitution used by the ap rule. *)
+Definition subst1 (B a : term) : term := subst (scons a Var) B.
+
+(** * The eight rules of Figure 1 *)
+
+(** A context is a list of types.  Entry n is the type of Var n and lives
+    in the context after position n, so at position n it is weakened by
+    n+1.  The paper's side condition x \notin fv(T') on cut is expressed
+    by requiring the premise's goal to be a weakening (shift T').  There
+    is no well-formedness condition on contexts: none is in Figure 1.
+
+    Two versions of arrow+ are in play.  As first printed, arrow+ had the
+    single premise  G, x : T1 |- T2.  The author's corrected Figure 1 adds
+    the premise  G |- T1 : type.  Everything below is developed for both at
+    once: the section variable s selects the corrected form (s = true) or
+    the printed form (s = false); the extra premise is guarded by s = true.
+    After the section, [corrected] and [printed] name the two systems. *)
+
+Definition ctx := list term.
+
+Section Rules.
+Variable s : bool.
+
+Reserved Notation "G |- T" (at level 70).
+
+Inductive derivable : ctx -> term -> Prop :=
+| r_hyp G n T :
+    nth_error G n = Some T ->
+    G |- Mem (Var n) (shiftn (S n) T)
+| r_in G t T T' :
+    G |- Mem T Ty ->
+    G |- Mem t T' ->
+    G |- Mem (Mem t T) Ty
+| r_in_minus G t T :
+    G |- Mem t T ->
+    G |- T
+| r_cut G T T' :
+    G |- T ->
+    (T :: G) |- shift T' ->
+    G |- T'
+| r_type G :
+    G |- Mem Ty Ty
+| r_arrow G A B :
+    G |- Mem A Ty ->
+    (A :: G) |- Mem B Ty ->
+    G |- Mem (Pi A B) Ty
+| r_ap G f a A B :
+    G |- Mem f (Pi A B) ->
+    G |- Mem a A ->
+    G |- Mem (App f a) (subst1 B a)
+| r_arrow_plus G A B :
+    (s = true -> G |- Mem A Ty) ->     (* corrected form only *)
+    (A :: G) |- B ->
+    G |- Pi A B
+where "G |- T" := (derivable G T).
+
+(** * The two-point model *)
+
+Definition env := nat -> bool.
+Definition econs (b : bool) (rho : env) : env :=
+  fun n => match n with 0 => b | S n => rho n end.
+Definition etail (rho : env) : env := fun n => rho (S n).
+
+(** [eval T rho = true] reads "T is inhabited under rho".
+    For Pi we write  A -> (B[true] /\ B[false]),  which is the same
+    truth function as  forall b in {true,false}, A -> B[b]. *)
+Fixpoint eval (t : term) (rho : env) : bool :=
+  match t with
+  | Var n   => rho n
+  | Mem _ T => eval T rho
+  | Ty      => true
+  | Pi A B  => implb (eval A rho) (eval B (econs true rho) && eval B (econs false rho))
+  | App _ _ => true
+  end.
+
+(** rho satisfies G when every type in G is inhabited under the
+    environment for its own position. *)
+Fixpoint sat (rho : env) (G : ctx) : Prop :=
+  match G with
+  | []      => True
+  | T :: G' => eval T (etail rho) = true /\ sat (etail rho) G'
+  end.
+
+(** ** Environments are used extensionally *)
+
+Lemma econs_ext : forall b rho rho',
+  (forall n, rho n = rho' n) -> forall n, econs b rho n = econs b rho' n.
+Proof. intros b rho rho' H [|n]; simpl; auto. Qed.
+
+Lemma eval_ext : forall t rho rho',
+  (forall n, rho n = rho' n) -> eval t rho = eval t rho'.
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros rho rho' H; simpl.
+  - apply H.
+  - exact (IHT rho rho' H).
+  - reflexivity.
+  - rewrite (IHA rho rho' H),
+            (IHB (econs true rho) (econs true rho') (econs_ext _ _ _ H)),
+            (IHB (econs false rho) (econs false rho') (econs_ext _ _ _ H)).
+    reflexivity.
+  - reflexivity.
+Qed.
+
+(** ** Renaming lemma *)
+
+Lemma up_ren_econs : forall xi b rho n,
+  econs b rho (up_ren xi n) = econs b (fun m => rho (xi m)) n.
+Proof. intros xi b rho [|n]; reflexivity. Qed.
+
+Lemma eval_rename : forall t xi rho,
+  eval (rename xi t) rho = eval t (fun n => rho (xi n)).
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros xi rho; simpl.
+  - reflexivity.
+  - apply IHT.
+  - reflexivity.
+  - rewrite IHA,
+            (IHB (up_ren xi) (econs true rho)),
+            (IHB (up_ren xi) (econs false rho)),
+            (eval_ext B _ _ (up_ren_econs xi true rho)),
+            (eval_ext B _ _ (up_ren_econs xi false rho)).
+    reflexivity.
+  - reflexivity.
+Qed.
+
+Lemma eval_shift : forall t rho, eval (shift t) rho = eval t (etail rho).
+Proof. intros t rho. unfold shift. rewrite eval_rename. reflexivity. Qed.
+
+Fixpoint etailn (k : nat) (rho : env) : env :=
+  match k with 0 => rho | S k => etailn k (etail rho) end.
+
+Lemma eval_shiftn : forall k t rho, eval (shiftn k t) rho = eval t (etailn k rho).
+Proof.
+  induction k as [|k IH]; intros t rho.
+  - reflexivity.
+  - change (eval (shift (shiftn k t)) rho = eval t (etailn k (etail rho))).
+    rewrite eval_shift. apply IH.
+Qed.
+
+(** ** Substitution lemma *)
+
+Lemma up_sub_econs : forall sigma b rho n,
+  eval (up_sub sigma n) (econs b rho) = econs b (fun m => eval (sigma m) rho) n.
+Proof.
+  intros sigma b rho n. unfold up_sub, shift. destruct n as [|n].
+  - reflexivity.
+  - rewrite eval_rename. apply eval_ext. intro k. reflexivity.
+Qed.
+
+Lemma eval_subst : forall t sigma rho,
+  eval (subst sigma t) rho = eval t (fun n => eval (sigma n) rho).
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros sigma rho; simpl.
+  - reflexivity.
+  - apply IHT.
+  - reflexivity.
+  - rewrite IHA,
+            (IHB (up_sub sigma) (econs true rho)),
+            (IHB (up_sub sigma) (econs false rho)),
+            (eval_ext B _ _ (up_sub_econs sigma true rho)),
+            (eval_ext B _ _ (up_sub_econs sigma false rho)).
+    reflexivity.
+  - reflexivity.
+Qed.
+
+Lemma eval_subst1 : forall B a rho,
+  eval (subst1 B a) rho = eval B (econs (eval a rho) rho).
+Proof.
+  intros B a rho. unfold subst1. rewrite eval_subst.
+  apply eval_ext. intros [|n]; reflexivity.
+Qed.
+
+(** ** Contexts *)
+
+Lemma sat_nth : forall G n T rho,
+  sat rho G -> nth_error G n = Some T -> eval T (etailn (S n) rho) = true.
+Proof.
+  induction G as [|T0 G IH]; intros n T rho Hsat Hnth.
+  - destruct n; discriminate.
+  - destruct n as [|n]; simpl in Hnth.
+    + injection Hnth as Heq. subst T. destruct Hsat as [H _]. exact H.
+    + destruct Hsat as [_ Hsat']. exact (IH n T (etail rho) Hsat' Hnth).
+Qed.
+
+(** A context entry constrains only the type, never the value of the
+    variable: any b extends a satisfying rho. *)
+Lemma sat_econs : forall G A b rho,
+  sat rho G -> eval A rho = true -> sat (econs b rho) (A :: G).
+Proof.
+  intros G A b rho Hsat HA. split.
+  - rewrite (eval_ext A (etail (econs b rho)) rho (fun n => eq_refl)). exact HA.
+  - exact Hsat.
+Qed.
+
+(** * Soundness: every derivable judgment is true in the model *)
+
+Theorem soundness : forall G T, G |- T -> forall rho, sat rho G -> eval T rho = true.
+Proof.
+  intros G T D. induction D as [G n T H | G t T T' D1 IHD1 D2 IHD2 | G t T D IHD | G T T' D1 IHD1 D2 IHD2 | G | G A B D1 IHD1 D2 IHD2 | G f a A B D1 IHD1 D2 IHD2 | G A B H1 IHD1 D2 IHD2]; intros rho Hsat.
+  - (* hyp *)
+    change (eval (shiftn (S n) T) rho = true).
+    rewrite eval_shiftn. exact (sat_nth G n T rho Hsat H).
+  - (* in *)      reflexivity.
+  - (* in- *)     exact (IHD rho Hsat).
+  - (* cut *)
+    specialize (IHD2 (econs true rho) (sat_econs G T true rho Hsat (IHD1 rho Hsat))).
+    rewrite eval_shift in IHD2.
+    rewrite (eval_ext T' (etail (econs true rho)) rho (fun n => eq_refl)) in IHD2.
+    exact IHD2.
+  - (* type *)    reflexivity.
+  - (* arrow *)   reflexivity.
+  - (* ap *)
+    change (eval (subst1 B a) rho = true).
+    rewrite eval_subst1.
+    specialize (IHD1 rho Hsat). specialize (IHD2 rho Hsat).
+    change (eval A rho = true) in IHD2.
+    change (implb (eval A rho) (eval B (econs true rho) && eval B (econs false rho)) = true) in IHD1.
+    rewrite IHD2 in IHD1. simpl in IHD1.
+    apply andb_true_iff in IHD1. destruct IHD1 as [Ht Hf].
+    destruct (eval a rho); assumption.
+  - (* arrow+ *)
+    simpl. destruct (eval A rho) eqn:HA.
+    + simpl.
+      rewrite (IHD2 (econs true rho) (sat_econs G A true rho Hsat HA)),
+              (IHD2 (econs false rho) (sat_econs G A false rho Hsat HA)).
+      reflexivity.
+    + reflexivity.
+Qed.
+
+(** * Consistency *)
+
+(** (X : type) -> X, in de Bruijn form. *)
+Definition absurd : term := Pi Ty (Var 0).
+
+Theorem consistency : ~ ([] |- absurd).
+Proof.
+  intro D.
+  pose proof (soundness [] absurd D (fun _ => false) I) as H.
+  discriminate H.
+Qed.
+
+(** More generally: any closed type that is false under some valuation
+    is underivable in the empty context. *)
+Corollary underivable_if_refutable : forall T rho,
+  eval T rho = false -> ~ ([] |- T).
+Proof.
+  intros T rho Hf D. rewrite (soundness [] T D rho I) in Hf. discriminate.
+Qed.
+
+(** * Remarks checked alongside *)
+
+(** Two of the paper's postulates, with eq as a free variable (Var 0 at
+    the outer level, so shifted under binders).  The type of refl is
+    valid in the model; the type of replace is not.  This is why
+    Theorem 1 says nothing about the Section 4 assumption blocks: the
+    model validates formation and introduction postulates but not the
+    ones with logical content. *)
+
+(* refl : (A : type) -> (a : A) -> eq A a a *)
+Definition refl_ty : term :=
+  Pi Ty (Pi (Var 0) (App (App (App (Var 2) (Var 1)) (Var 0)) (Var 0))).
+
+(* replace : (A1 A2 : type) -> eq type A1 A2 -> A1 -> A2 *)
+Definition replace_ty : term :=
+  Pi Ty (Pi Ty (Pi (App (App (App (Var 2) Ty) (Var 1)) (Var 0))
+                   (Pi (Var 2) (Var 2)))).
+
+Example refl_ty_valid : forall rho, eval refl_ty rho = true.
+Proof. intro rho. reflexivity. Qed.
+
+Example replace_ty_not_valid : eval replace_ty (fun _ => false) = false.
+Proof. reflexivity. Qed.
+
+Corollary replace_not_derivable_bare : ~ ([] |- replace_ty).
+Proof. exact (underivable_if_refutable replace_ty (fun _ => false) replace_ty_not_valid). Qed.
+
+
+(* ======================================================================== *)
+(*  Part II.  Renaming of derivations, weakening, and Theorem 2:            *)
+(*  a construction block with one declaration is a conservative extension.  *)
+(* ======================================================================== *)
+
+(** * Substitution algebra (the usual de Bruijn lemmas) *)
+
+Lemma up_ren_ext : forall xi xi',
+  (forall n, xi n = xi' n) -> forall n, up_ren xi n = up_ren xi' n.
+Proof. intros xi xi' H [|n]; simpl; auto. Qed.
+
+Lemma rename_ext : forall t xi xi',
+  (forall n, xi n = xi' n) -> rename xi t = rename xi' t.
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros xi xi' H; simpl.
+  - rewrite H. reflexivity.
+  - rewrite (IHt _ _ H), (IHT _ _ H). reflexivity.
+  - reflexivity.
+  - rewrite (IHA _ _ H), (IHB _ _ (up_ren_ext _ _ H)). reflexivity.
+  - rewrite (IHt _ _ H), (IHu _ _ H). reflexivity.
+Qed.
+
+Lemma up_ren_comp : forall xi zeta n,
+  up_ren xi (up_ren zeta n) = up_ren (fun m => xi (zeta m)) n.
+Proof. intros xi zeta [|n]; reflexivity. Qed.
+
+Lemma rename_comp : forall t xi zeta,
+  rename xi (rename zeta t) = rename (fun n => xi (zeta n)) t.
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros xi zeta; simpl.
+  - reflexivity.
+  - rewrite IHt, IHT. reflexivity.
+  - reflexivity.
+  - rewrite IHA, IHB, (rename_ext B _ _ (up_ren_comp xi zeta)). reflexivity.
+  - rewrite IHt, IHu. reflexivity.
+Qed.
+
+Lemma up_sub_ext : forall sigma sigma',
+  (forall n, sigma n = sigma' n) -> forall n, up_sub sigma n = up_sub sigma' n.
+Proof. intros sigma sigma' H [|n]; simpl; [reflexivity | rewrite H; reflexivity]. Qed.
+
+Lemma subst_ext : forall t sigma sigma',
+  (forall n, sigma n = sigma' n) -> subst sigma t = subst sigma' t.
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros sigma sigma' H; simpl.
+  - apply H.
+  - rewrite (IHt _ _ H), (IHT _ _ H). reflexivity.
+  - reflexivity.
+  - rewrite (IHA _ _ H), (IHB _ _ (up_sub_ext _ _ H)). reflexivity.
+  - rewrite (IHt _ _ H), (IHu _ _ H). reflexivity.
+Qed.
+
+Lemma up_sub_ren : forall sigma zeta n,
+  up_sub sigma (up_ren zeta n) = up_sub (fun m => sigma (zeta m)) n.
+Proof. intros sigma zeta [|n]; reflexivity. Qed.
+
+Lemma subst_rename : forall t sigma zeta,
+  subst sigma (rename zeta t) = subst (fun n => sigma (zeta n)) t.
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros sigma zeta; simpl.
+  - reflexivity.
+  - rewrite IHt, IHT. reflexivity.
+  - reflexivity.
+  - rewrite IHA, IHB, (subst_ext B _ _ (up_sub_ren sigma zeta)). reflexivity.
+  - rewrite IHt, IHu. reflexivity.
+Qed.
+
+Lemma up_ren_sub : forall xi sigma n,
+  rename (up_ren xi) (up_sub sigma n) = up_sub (fun m => rename xi (sigma m)) n.
+Proof.
+  intros xi sigma [|n].
+  - reflexivity.
+  - unfold up_sub, shift. rewrite !rename_comp. apply rename_ext. intro m. reflexivity.
+Qed.
+
+Lemma rename_subst : forall t xi sigma,
+  rename xi (subst sigma t) = subst (fun n => rename xi (sigma n)) t.
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros xi sigma; simpl.
+  - reflexivity.
+  - rewrite IHt, IHT. reflexivity.
+  - reflexivity.
+  - rewrite IHA, IHB, (subst_ext B _ _ (up_ren_sub xi sigma)). reflexivity.
+  - rewrite IHt, IHu. reflexivity.
+Qed.
+
+Lemma up_sub_id : forall n, up_sub Var n = Var n.
+Proof. intros [|n]; reflexivity. Qed.
+
+Lemma subst_id : forall t, subst Var t = t.
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu]; simpl.
+  - reflexivity.
+  - rewrite IHt, IHT. reflexivity.
+  - reflexivity.
+  - rewrite IHA, (subst_ext B _ _ up_sub_id), IHB. reflexivity.
+  - rewrite IHt, IHu. reflexivity.
+Qed.
+
+(** The three facts the derivations below actually use. *)
+
+Lemma rename_subst1 : forall xi B a,
+  rename xi (subst1 B a) = subst1 (rename (up_ren xi) B) (rename xi a).
+Proof.
+  intros xi B a. unfold subst1. rewrite rename_subst, subst_rename.
+  apply subst_ext. intros [|n]; reflexivity.
+Qed.
+
+Lemma shift_rename : forall xi t, rename (up_ren xi) (shift t) = shift (rename xi t).
+Proof.
+  intros xi t. unfold shift. rewrite !rename_comp. apply rename_ext. intro n. reflexivity.
+Qed.
+
+(** Substituting into a weakened term is the identity: (shift T)[a/x] = T. *)
+Lemma subst_scons_shift : forall a X, subst (scons a Var) (shift X) = X.
+Proof.
+  intros a X. unfold shift. rewrite subst_rename.
+  transitivity (subst Var X); [apply subst_ext; intro n; reflexivity | apply subst_id].
+Qed.
+
+Lemma shift_subst1 : forall a T, subst1 (shift T) a = T.
+Proof. intros a T. apply subst_scons_shift. Qed.
+
+(** * Renaming of derivations *)
+
+(** [ren_ok xi G G'] : the renaming xi sends every variable of G to a
+    variable of G' with the correspondingly renamed type. *)
+Definition ren_ok (xi : nat -> nat) (G G' : ctx) : Prop :=
+  forall n T, nth_error G n = Some T ->
+    exists T', nth_error G' (xi n) = Some T'
+            /\ shiftn (S (xi n)) T' = rename xi (shiftn (S n) T).
+
+Lemma ren_ok_up : forall xi G G' A,
+  ren_ok xi G G' -> ren_ok (up_ren xi) (A :: G) (rename xi A :: G').
+Proof.
+  intros xi G G' A H [|n] T Hn.
+  - simpl in Hn. injection Hn as Heq. subst T.
+    exists (rename xi A). split; [reflexivity |].
+    change (shift (rename xi A) = rename (up_ren xi) (shift A)).
+    symmetry. apply shift_rename.
+  - simpl in Hn. destruct (H n T Hn) as [T' [HT' Heq]].
+    exists T'. split; [exact HT' |].
+    change (shift (shiftn (S (xi n)) T') = rename (up_ren xi) (shift (shiftn (S n) T))).
+    rewrite Heq. symmetry. apply shift_rename.
+Qed.
+
+Lemma derivable_rename : forall G T,
+  G |- T -> forall xi G', ren_ok xi G G' -> G' |- rename xi T.
+Proof.
+  intros G T D. induction D as [G n T H | G t T T' D1 IHD1 D2 IHD2 | G t T D IHD | G T T' D1 IHD1 D2 IHD2 | G | G A B D1 IHD1 D2 IHD2 | G f a A B D1 IHD1 D2 IHD2 | G A B H1 IHD1 D2 IHD2]; intros xi G' Hok; cbn [rename].
+  - (* hyp *)
+    destruct (Hok n T H) as [T' [HT' Heq]].
+    rewrite <- Heq. apply r_hyp. exact HT'.
+  - (* in *)
+    apply r_in with (T' := rename xi T'); [exact (IHD1 xi G' Hok) | exact (IHD2 xi G' Hok)].
+  - (* in- *)
+    apply r_in_minus with (t := rename xi t). exact (IHD xi G' Hok).
+  - (* cut *)
+    apply r_cut with (T := rename xi T); [exact (IHD1 xi G' Hok) |].
+    rewrite <- shift_rename. exact (IHD2 (up_ren xi) _ (ren_ok_up xi G G' T Hok)).
+  - (* type *)
+    apply r_type.
+  - (* arrow *)
+    apply r_arrow; [exact (IHD1 xi G' Hok) | exact (IHD2 (up_ren xi) _ (ren_ok_up xi G G' A Hok))].
+  - (* ap *)
+    rewrite rename_subst1.
+    apply r_ap with (A := rename xi A); [exact (IHD1 xi G' Hok) | exact (IHD2 xi G' Hok)].
+  - (* arrow+ *)
+    apply r_arrow_plus.
+    + intro Hs. exact (IHD1 Hs xi G' Hok).
+    + exact (IHD2 (up_ren xi) _ (ren_ok_up xi G G' A Hok)).
+Qed.
+
+(** * Weakening *)
+
+Lemma ren_ok_shift : forall G U, ren_ok S G (U :: G).
+Proof. intros G U n T Hn. exists T. split; [exact Hn | reflexivity]. Qed.
+
+Theorem weakening : forall G T U, G |- T -> (U :: G) |- shift T.
+Proof. intros G T U D. exact (derivable_rename G T D S (U :: G) (ren_ok_shift G U)). Qed.
+
+(** * Theorem 2 (one declaration): construction blocks are conservative *)
+
+(** The obligation of a construction block with signature x : T1, from
+    l. 150-151 of the paper:  (M : type) -> ((x : T1) -> M) -> M.
+    In de Bruijn form M is Var 1 under the two inner binders, and T1 is
+    weakened past the binder for M. *)
+Definition witness1 (T1 : term) : term :=
+  Pi Ty (Pi (Pi (shift T1) (Var 1)) (Var 1)).
+
+Lemma shift_witness1 : forall X, shift (witness1 X) = witness1 (shift X).
+Proof.
+  intro X. unfold witness1.
+  change (Pi Ty (Pi (Pi (rename (up_ren S) (shift X)) (Var 1)) (Var 1))
+          = Pi Ty (Pi (Pi (shift (shift X)) (Var 1)) (Var 1))).
+  rewrite shift_rename. reflexivity.
+Qed.
+
+(** ((x : X) -> M) -> M with M := a. *)
+Lemma subst1_body : forall X a,
+  subst1 (Pi (Pi (shift X) (Var 1)) (Var 1)) a = Pi (Pi X (shift a)) (shift a).
+Proof.
+  intros X a. unfold subst1.
+  change (Pi (Pi (subst (scons a Var) (shift X)) (shift a)) (shift a)
+          = Pi (Pi X (shift a)) (shift a)).
+  rewrite subst_scons_shift. reflexivity.
+Qed.
+
+(** If the block's obligation is met, then anything proved with the new
+    declaration x : T1, and not mentioning x, was already provable,
+    PROVIDED it is a type.  The last hypothesis is not in the paper: it is
+    forced by the second premise of the ap rule, since the witness has to
+    be applied to T' : type. *)
+Theorem conservativity1 : forall G T1 T',
+  (s = true -> G |- Mem T1 Ty) ->  (* the declaration's type is a type *)
+  G |- witness1 T1 ->
+  (T1 :: G) |- shift T' ->
+  G |- Mem T' Ty ->
+  G |- T'.
+Proof.
+  intros G T1 T' HT1 HW HD HT.
+  set (S1 := Pi T1 (shift T')).
+  (* (x : T1) -> T' is inhabited, by arrow+ *)
+  assert (HS : G |- S1) by (apply r_arrow_plus; [exact HT1 | exact HD]).
+  (* cut in y : witness1 T1, then z : (x : T1) -> T' *)
+  apply r_cut with (T := witness1 T1); [exact HW |].
+  apply r_cut with (T := shift S1); [apply weakening; exact HS |].
+  set (G2 := shift S1 :: witness1 T1 :: G).
+  set (T2 := shift (shift T')).
+  (* y = Var 1 *)
+  assert (Hy : G2 |- Mem (Var 1) (witness1 (shift (shift T1)))).
+  { rewrite <- !shift_witness1. apply (r_hyp G2 1 (witness1 T1)). reflexivity. }
+  (* z = Var 0 *)
+  assert (Hz : G2 |- Mem (Var 0) (Pi (shift (shift T1)) (shift T2))).
+  { assert (E : shift (shift S1) = Pi (shift (shift T1)) (shift T2)).
+    { unfold S1, T2.
+      change (Pi (shift (shift T1)) (rename (up_ren S) (rename (up_ren S) (shift T')))
+              = Pi (shift (shift T1)) (shift (shift (shift T')))).
+      rewrite !shift_rename. reflexivity. }
+    rewrite <- E. apply (r_hyp G2 0 (shift S1)). reflexivity. }
+  (* T' is still a type two hypotheses later *)
+  assert (HT2 : G2 |- Mem T2 Ty).
+  { apply (weakening (witness1 T1 :: G) (Mem (shift T') Ty) (shift S1)).
+    apply (weakening G (Mem T' Ty) (witness1 T1)). exact HT. }
+  (* y T' : ((x : T1) -> T') -> T' *)
+  assert (Hy1 : G2 |- Mem (App (Var 1) T2) (Pi (Pi (shift (shift T1)) (shift T2)) (shift T2))).
+  { rewrite <- subst1_body. apply r_ap with (A := Ty); [exact Hy | exact HT2]. }
+  (* y T' z : T' *)
+  pose proof (r_ap G2 (App (Var 1) T2) (Var 0) (Pi (shift (shift T1)) (shift T2)) (shift T2) Hy1 Hz) as Hyz.
+  rewrite shift_subst1 in Hyz.
+  exact (r_in_minus G2 _ T2 Hyz).
+Qed.
+
+
+(* ======================================================================== *)
+(*  Part III.  Theorem 2 in general: a construction block with a signature *)
+(*  x1 : T1, ..., xn : Tn is a conservative extension.                       *)
+(* ======================================================================== *)
+
+(** * Conservativity for an arbitrary body Q *)
+
+(** The one-declaration proof above only used the shape
+      (M : type) -> Q[M] -> M
+    of the witness type, never the shape of Q.  So prove it once for any Q. *)
+Theorem conservativity_gen : forall G Q T',
+  G |- Pi Ty (Pi Q (Var 1)) ->
+  G |- subst1 Q T' ->
+  G |- Mem T' Ty ->
+  G |- T'.
+Proof.
+  intros G Q T' HW HS HT.
+  apply r_cut with (T := Pi Ty (Pi Q (Var 1))); [exact HW |].
+  apply r_cut with (T := shift (subst1 Q T')); [apply weakening; exact HS |].
+  set (W := Pi Ty (Pi Q (Var 1))).
+  set (G2 := shift (subst1 Q T') :: W :: G).
+  set (T2 := shift (shift T')).
+  set (Q2 := rename (up_ren S) (rename (up_ren S) Q)).
+  (* y = Var 1 : (M : type) -> Q2[M] -> M *)
+  assert (Hy : G2 |- Mem (Var 1) (Pi Ty (Pi Q2 (Var 1)))).
+  { apply (r_hyp G2 1 W). reflexivity. }
+  (* z = Var 0 : Q2[T'] *)
+  assert (Hz : G2 |- Mem (Var 0) (subst1 Q2 T2)).
+  { unfold Q2, T2, shift. rewrite <- !rename_subst1.
+    apply (r_hyp G2 0 (shift (subst1 Q T'))). reflexivity. }
+  (* T' is still a type *)
+  assert (HT2 : G2 |- Mem T2 Ty).
+  { apply (weakening (W :: G) (Mem (shift T') Ty)).
+    apply (weakening G (Mem T' Ty)). exact HT. }
+  (* y T' : Q2[T'] -> T' *)
+  assert (Hy1 : G2 |- Mem (App (Var 1) T2) (Pi (subst1 Q2 T2) (shift T2))).
+  { change (G2 |- Mem (App (Var 1) T2) (subst1 (Pi Q2 (Var 1)) T2)).
+    apply r_ap with (A := Ty); [exact Hy | exact HT2]. }
+  (* y T' z : T' *)
+  pose proof (r_ap G2 (App (Var 1) T2) (Var 0) (subst1 Q2 T2) (shift T2) Hy1 Hz) as Hyz.
+  rewrite shift_subst1 in Hyz.
+  exact (r_in_minus G2 _ T2 Hyz).
+Qed.
+
+(** * Signatures as telescopes *)
+
+(** A signature is a list of types, outermost first; T_{i+1} may mention
+    x_1 .. x_i.  [tele Ts M] is (x1 : T1) -> ... -> (xn : Tn) -> M. *)
+Fixpoint tele (Ts : list term) (M : term) : term :=
+  match Ts with [] => M | T :: Ts' => Pi T (tele Ts' M) end.
+
+(** Renaming a signature, deeper entries under more binders. *)
+Fixpoint rename_sig (xi : nat -> nat) (Ts : list term) : list term :=
+  match Ts with [] => [] | T :: Ts' => rename xi T :: rename_sig (up_ren xi) Ts' end.
+
+(** The obligation of a construction block (l. 150-151):
+      (M : type) -> ((x1 : T1) -> ... -> (xn : Tn) -> M) -> M.
+    The signature is weakened past the binder for M; under the n binders
+    of the telescope, M is Var n. *)
+Definition witness (Ts : list term) : term :=
+  Pi Ty (Pi (tele (rename_sig S Ts) (Var (length Ts))) (Var 1)).
+
+Lemma witness_one : forall T1, witness [T1] = witness1 T1.
+Proof. reflexivity. Qed.
+
+(** A well-formed signature: each type is a type in the context of the
+    entries before it (the obligation of an assumption block, l. 149).
+    Only demanded in the corrected system. *)
+Fixpoint wf_sig (G : ctx) (Ts : list term) : Prop :=
+  match Ts with
+  | []      => True
+  | T :: Ts' => (s = true -> G |- Mem T Ty) /\ wf_sig (T :: G) Ts'
+  end.
+
+(** n uses of arrow+. *)
+Lemma tele_intro : forall Ts G M, wf_sig G Ts -> (rev Ts ++ G) |- M -> G |- tele Ts M.
+Proof.
+  induction Ts as [|T Ts IH]; intros G M Hwf H.
+  - exact H.
+  - destruct Hwf as [HT Hwf]. simpl. apply r_arrow_plus; [exact HT |].
+    apply IH; [exact Hwf |]. simpl in H. rewrite <- app_assoc in H. exact H.
+Qed.
+
+(** ** Iterated up, and how it acts on variables *)
+
+Fixpoint upn (k : nat) (xi : nat -> nat) : nat -> nat :=
+  match k with 0 => xi | S k => up_ren (upn k xi) end.
+
+Fixpoint upsn (k : nat) (sigma : nat -> term) : nat -> term :=
+  match k with 0 => sigma | S k => up_sub (upsn k sigma) end.
+
+Lemma upn_lt : forall k xi m, m < k -> upn k xi m = m.
+Proof.
+  induction k as [|k IH]; intros xi m Hm.
+  - inversion Hm.
+  - destruct m as [|m]; [reflexivity | simpl; rewrite (IH xi m); [reflexivity | lia]].
+Qed.
+
+Lemma upn_ge : forall k xi j, upn k xi (k + j) = k + xi j.
+Proof.
+  induction k as [|k IH]; intros xi j.
+  - reflexivity.
+  - simpl. rewrite IH. reflexivity.
+Qed.
+
+Lemma upsn_lt : forall k sigma m, m < k -> upsn k sigma m = Var m.
+Proof.
+  induction k as [|k IH]; intros sigma m Hm.
+  - inversion Hm.
+  - destruct m as [|m]; [reflexivity | simpl; rewrite (IH sigma m); [reflexivity | lia]].
+Qed.
+
+Lemma shiftn_var : forall k j, shiftn k (Var j) = Var (k + j).
+Proof.
+  induction k as [|k IH]; intros j; [reflexivity | simpl; rewrite IH; reflexivity].
+Qed.
+
+Lemma upsn_ge : forall k sigma j, upsn k sigma (k + j) = shiftn k (sigma j).
+Proof.
+  induction k as [|k IH]; intros sigma j.
+  - reflexivity.
+  - simpl. rewrite IH. reflexivity.
+Qed.
+
+(** Under k binders, substituting a for the variable just outside them
+    undoes the weakening past that variable. *)
+Lemma upsn_upn_cancel : forall k a m, upsn k (scons a Var) (upn k S m) = Var m.
+Proof.
+  intros k a m. destruct (Nat.lt_ge_cases m k) as [Hlt | Hge].
+  - rewrite (upn_lt k S m Hlt). apply upsn_lt. exact Hlt.
+  - replace m with (k + (m - k)) by lia.
+    rewrite upn_ge, upsn_ge. cbn [scons]. apply shiftn_var.
+Qed.
+
+Lemma subst_upsn_rename_upn : forall k a T,
+  subst (upsn k (scons a Var)) (rename (upn k S) T) = T.
+Proof.
+  intros k a T. rewrite subst_rename.
+  transitivity (subst Var T); [apply subst_ext; intro m; apply upsn_upn_cancel | apply subst_id].
+Qed.
+
+(** The one computation the general theorem needs:
+      ((x1 : T1) -> ... -> (xn : Tn) -> M)[T'/M]  =  (x1 : T1) -> ... -> (xn : Tn) -> T'
+    (with T' weakened past the n binders), stated under k extra binders so
+    that the induction goes through. *)
+Lemma subst_tele : forall Ts k a,
+  subst (upsn k (scons a Var)) (tele (rename_sig (upn k S) Ts) (Var (length Ts + k)))
+  = tele Ts (shiftn (length Ts + k) a).
+Proof.
+  induction Ts as [|T Ts IH]; intros k a.
+  - change (upsn k (scons a Var) k = shiftn k a).
+    pose proof (upsn_ge k (scons a Var) 0) as E. rewrite Nat.add_0_r in E. exact E.
+  - change (Pi (subst (upsn k (scons a Var)) (rename (upn k S) T))
+               (subst (upsn (S k) (scons a Var))
+                      (tele (rename_sig (upn (S k) S) Ts) (Var (S (length Ts + k)))))
+            = Pi T (tele Ts (shiftn (S (length Ts + k)) a))).
+    rewrite subst_upsn_rename_upn.
+    rewrite <- (Nat.add_succ_r (length Ts) k).
+    rewrite (IH (S k) a). reflexivity.
+Qed.
+
+(** * Theorem 2, in general *)
+
+(** If a construction block with signature x1 : T1, ..., xn : Tn meets its
+    obligation, then anything provable using the block and not mentioning
+    the xi was already provable, provided it is a type. *)
+Theorem conservativity : forall G Ts T',
+  wf_sig G Ts ->
+  G |- witness Ts ->
+  (rev Ts ++ G) |- shiftn (length Ts) T' ->
+  G |- Mem T' Ty ->
+  G |- T'.
+Proof.
+  intros G Ts T' Hwf HW HD HT.
+  apply (conservativity_gen G (tele (rename_sig S Ts) (Var (length Ts))) T'); [exact HW | | exact HT].
+  pose proof (subst_tele Ts 0 T') as E.
+  rewrite Nat.add_0_r in E. cbn [upsn upn] in E.
+  unfold subst1. rewrite E. apply tele_intro; [exact Hwf | exact HD].
+Qed.
+
+(** The one-declaration theorem is the special case Ts = [T1]. *)
+Corollary conservativity1' : forall G T1 T',
+  (s = true -> G |- Mem T1 Ty) ->
+  G |- witness1 T1 -> (T1 :: G) |- shift T' -> G |- Mem T' Ty -> G |- T'.
+Proof.
+  intros G T1 T' HT1 HW HD HT. exact (conservativity G [T1] T' (conj HT1 I) HW HD HT).
+Qed.
+
+
+(* ======================================================================== *)
+(*  Part IV.  Towards Theorem 3: a five-point model.                        *)
+(*                                                                          *)
+(*  The two-point model of Part I collapses every application to 1, so it  *)
+(*  cannot tell a type from junk and validates no postulate with logical    *)
+(*  content.  This model adds just enough structure to distinguish          *)
+(*     vU  the type of types          vT  the inhabited type (and its only  *)
+(*     vF  the empty type                 element)                          *)
+(*     vN  inhabited, but not a type  vJ  junk (empty, not a type).        *)
+(*  Application is still degenerate: vT and vN act as the constant-vT       *)
+(*  function; everything else applied to anything is junk.                 *)
+(*                                                                          *)
+(*  It settles the half of Review 1's regularity remark that Part I could  *)
+(*  not: the printed rules derive (x : type type) -> type but NOT its       *)
+(*  formation ((x : type type) -> type) : type.  And it shows, by            *)
+(*  computation, that any model with degenerate application still fails    *)
+(*  the type of replace, so the equality block needs genuine functions.     *)
+(* ======================================================================== *)
+
+Inductive V : Type := vU | vT | vF | vN | vJ.
+
+(** ext a v : v is an element of a. *)
+Definition ext (a v : V) : bool :=
+  match a, v with
+  | vU, vU | vU, vT | vU, vF => true
+  | vT, vT => true
+  | vN, vT => true
+  | _, _ => false
+  end.
+
+Definition inh (a : V) : bool := match a with vU | vT | vN => true | vF | vJ => false end.
+Definition istype (a : V) : bool := ext vU a.
+Definition vapp (f a : V) : V := match f with vT | vN => vT | _ => vJ end.
+Definition allV : list V := [vU; vT; vF; vN; vJ].
+
+Lemma allV_full : forall v, In v allV.
+Proof.
+  intro v; destruct v;
+    [left | right; left | right; right; left | right; right; right; left | right; right; right; right; left];
+    reflexivity.
+Qed.
+
+(** The value of (x : A) -> B, given the value a of A and the values b v of
+    B at each v.  It is a type iff a is a type and every b v (v in a) is;
+    it is inhabited iff every b v (v in a) is. *)
+Definition pi_val (a : V) (b : V -> V) : V :=
+  let dom := filter (ext a) allV in
+  let ty  := istype a && forallb (fun v => istype (b v)) dom in
+  let ok  := forallb (fun v => inh (b v)) dom in
+  if ty then (if ok then vT else vF) else (if ok then vN else vJ).
+
+Lemma forallb_ext : forall (A : Type) (f g : A -> bool) (l : list A),
+  (forall x, f x = g x) -> forallb f l = forallb g l.
+Proof. intros A f g l H. induction l as [|x l IH]; simpl; [reflexivity | rewrite H, IH; reflexivity]. Qed.
+
+Lemma pi_val_ext : forall a b b', (forall v, b v = b' v) -> pi_val a b = pi_val a b'.
+Proof.
+  intros a b b' H. unfold pi_val.
+  rewrite (forallb_ext _ (fun v => istype (b v)) (fun v => istype (b' v))) by (intro v; rewrite H; reflexivity).
+  rewrite (forallb_ext _ (fun v => inh (b v)) (fun v => inh (b' v))) by (intro v; rewrite H; reflexivity).
+  reflexivity.
+Qed.
+
+Lemma forallb_dom : forall a (p : V -> bool),
+  (forall v, ext a v = true -> p v = true) -> forallb p (filter (ext a) allV) = true.
+Proof.
+  intros a p H. apply (proj2 (forallb_forall _ _)). intros v Hin.
+  apply filter_In in Hin. apply H, Hin.
+Qed.
+
+Lemma forallb_dom_inv : forall a (p : V -> bool),
+  forallb p (filter (ext a) allV) = true -> forall v, ext a v = true -> p v = true.
+Proof.
+  intros a p H v Hv. apply (proj1 (forallb_forall _ _) H).
+  apply filter_In. split; [apply allV_full | exact Hv].
+Qed.
+
+Lemma pi_val_inh : forall a b,
+  (forall v, ext a v = true -> inh (b v) = true) -> inh (pi_val a b) = true.
+Proof.
+  intros a b H. unfold pi_val. rewrite (forallb_dom a _ H).
+  destruct (istype a && forallb (fun v => istype (b v)) (filter (ext a) allV)); reflexivity.
+Qed.
+
+Lemma pi_val_istype : forall a b,
+  istype a = true -> (forall v, ext a v = true -> istype (b v) = true) ->
+  istype (pi_val a b) = true.
+Proof.
+  intros a b Ha Hb. unfold pi_val. rewrite Ha, (forallb_dom a _ Hb). cbn [andb].
+  destruct (forallb (fun v => inh (b v)) (filter (ext a) allV)); reflexivity.
+Qed.
+
+Lemma pi_val_ext_inv : forall a b w,
+  ext (pi_val a b) w = true -> w = vT /\ (forall v, ext a v = true -> inh (b v) = true).
+Proof.
+  intros a b w H. unfold pi_val in H.
+  destruct (istype a && forallb (fun v => istype (b v)) (filter (ext a) allV));
+  destruct (forallb (fun v => inh (b v)) (filter (ext a) allV)) eqn:Hok;
+  destruct w; simpl in H; try discriminate H; split; try reflexivity;
+  apply (forallb_dom_inv a _ Hok).
+Qed.
+
+Lemma inh_ext_T : forall w, inh w = true -> ext w vT = true.
+Proof. intros w H; destruct w; try discriminate; reflexivity. Qed.
+
+Lemma ext_inh : forall a w, ext a w = true -> inh a = true.
+Proof. intros a w H; destruct a; destruct w; try discriminate; reflexivity. Qed.
+
+(** ** Evaluation *)
+
+Definition env5 := nat -> V.
+Definition econs5 (v : V) (rho : env5) : env5 := fun n => match n with 0 => v | S n => rho n end.
+Definition etail5 (rho : env5) : env5 := fun n => rho (S n).
+
+Fixpoint eval5 (t : term) (rho : env5) : V :=
+  match t with
+  | Var n   => rho n
+  | Ty      => vU
+  | Mem t T => if ext (eval5 T rho) (eval5 t rho) then vT else vF
+  | Pi A B  => pi_val (eval5 A rho) (fun v => eval5 B (econs5 v rho))
+  | App t u => vapp (eval5 t rho) (eval5 u rho)
+  end.
+
+(** rho satisfies G when each variable's value is an element of its type. *)
+Fixpoint sat5 (rho : env5) (G : ctx) : Prop :=
+  match G with
+  | []      => True
+  | T :: G' => ext (eval5 T (etail5 rho)) (rho 0) = true /\ sat5 (etail5 rho) G'
+  end.
+
+Lemma econs5_ext : forall v rho rho',
+  (forall n, rho n = rho' n) -> forall n, econs5 v rho n = econs5 v rho' n.
+Proof. intros v rho rho' H [|n]; simpl; auto. Qed.
+
+Lemma eval5_ext : forall t rho rho',
+  (forall n, rho n = rho' n) -> eval5 t rho = eval5 t rho'.
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros rho rho' H; simpl.
+  - apply H.
+  - rewrite (IHt _ _ H), (IHT _ _ H). reflexivity.
+  - reflexivity.
+  - rewrite (IHA _ _ H). apply pi_val_ext. intro v. apply IHB. apply econs5_ext. exact H.
+  - rewrite (IHt _ _ H), (IHu _ _ H). reflexivity.
+Qed.
+
+Lemma up_ren_econs5 : forall xi v rho n,
+  econs5 v rho (up_ren xi n) = econs5 v (fun m => rho (xi m)) n.
+Proof. intros xi v rho [|n]; reflexivity. Qed.
+
+Lemma eval5_rename : forall t xi rho,
+  eval5 (rename xi t) rho = eval5 t (fun n => rho (xi n)).
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros xi rho; simpl.
+  - reflexivity.
+  - rewrite IHt, IHT. reflexivity.
+  - reflexivity.
+  - rewrite IHA. apply pi_val_ext. intro v. rewrite IHB.
+    apply eval5_ext. intro n. apply up_ren_econs5.
+  - rewrite IHt, IHu. reflexivity.
+Qed.
+
+Lemma eval5_shift : forall t rho, eval5 (shift t) rho = eval5 t (etail5 rho).
+Proof. intros t rho. unfold shift. rewrite eval5_rename. reflexivity. Qed.
+
+Fixpoint etailn5 (k : nat) (rho : env5) : env5 :=
+  match k with 0 => rho | S k => etailn5 k (etail5 rho) end.
+
+Lemma eval5_shiftn : forall k t rho, eval5 (shiftn k t) rho = eval5 t (etailn5 k rho).
+Proof.
+  induction k as [|k IH]; intros t rho.
+  - reflexivity.
+  - change (eval5 (shift (shiftn k t)) rho = eval5 t (etailn5 k (etail5 rho))).
+    rewrite eval5_shift. apply IH.
+Qed.
+
+Lemma etailn5_0 : forall n rho, etailn5 n rho 0 = rho n.
+Proof. induction n as [|n IH]; intros rho; [reflexivity | apply IH]. Qed.
+
+Lemma up_sub_econs5 : forall sigma v rho n,
+  eval5 (up_sub sigma n) (econs5 v rho) = econs5 v (fun m => eval5 (sigma m) rho) n.
+Proof.
+  intros sigma v rho n. unfold up_sub, shift. destruct n as [|n].
+  - reflexivity.
+  - rewrite eval5_rename. apply eval5_ext. intro k. reflexivity.
+Qed.
+
+Lemma eval5_subst : forall t sigma rho,
+  eval5 (subst sigma t) rho = eval5 t (fun n => eval5 (sigma n) rho).
+Proof.
+  induction t as [n | t IHt T IHT | | A IHA B IHB | t IHt u IHu];
+    intros sigma rho; simpl.
+  - reflexivity.
+  - rewrite IHt, IHT. reflexivity.
+  - reflexivity.
+  - rewrite IHA. apply pi_val_ext. intro v. rewrite IHB.
+    apply eval5_ext. intro n. apply up_sub_econs5.
+  - rewrite IHt, IHu. reflexivity.
+Qed.
+
+Lemma eval5_subst1 : forall B a rho,
+  eval5 (subst1 B a) rho = eval5 B (econs5 (eval5 a rho) rho).
+Proof.
+  intros B a rho. unfold subst1. rewrite eval5_subst.
+  apply eval5_ext. intros [|n]; reflexivity.
+Qed.
+
+Lemma sat5_nth : forall G n T rho,
+  sat5 rho G -> nth_error G n = Some T -> ext (eval5 T (etailn5 (S n) rho)) (rho n) = true.
+Proof.
+  induction G as [|T0 G IH]; intros n T rho Hsat Hnth.
+  - destruct n; discriminate.
+  - destruct n as [|n]; simpl in Hnth.
+    + injection Hnth as Heq. subst T. destruct Hsat as [H _]. exact H.
+    + destruct Hsat as [_ Hsat']. exact (IH n T (etail5 rho) Hsat' Hnth).
+Qed.
+
+Lemma sat5_econs : forall G A v rho,
+  sat5 rho G -> ext (eval5 A rho) v = true -> sat5 (econs5 v rho) (A :: G).
+Proof.
+  intros G A v rho Hsat HA. split.
+  - rewrite (eval5_ext A (etail5 (econs5 v rho)) rho (fun n => eq_refl)). exact HA.
+  - exact Hsat.
+Qed.
+
+(** Extracting "X is a type" from the truth of X : type. *)
+Lemma mem_ty_inv : forall X rho,
+  inh (eval5 (Mem X Ty) rho) = true -> istype (eval5 X rho) = true.
+Proof.
+  intros X rho H. change (inh (if ext vU (eval5 X rho) then vT else vF) = true) in H.
+  destruct (ext vU (eval5 X rho)) eqn:E; [exact E | discriminate H].
+Qed.
+
+(** ** Soundness *)
+
+Theorem soundness5 : forall G T, G |- T -> forall rho, sat5 rho G -> inh (eval5 T rho) = true.
+Proof.
+  intros G T D. induction D as [G n T H | G t T T' D1 IHD1 D2 IHD2 | G t T D IHD | G T T' D1 IHD1 D2 IHD2 | G | G A B D1 IHD1 D2 IHD2 | G f a A B D1 IHD1 D2 IHD2 | G A B H1 IHD1 D2 IHD2]; intros rho Hsat.
+  - (* hyp *)
+    change (inh (if ext (eval5 (shiftn (S n) T) rho) (rho n) then vT else vF) = true).
+    rewrite eval5_shiftn, (sat5_nth G n T rho Hsat H). reflexivity.
+  - (* in *)
+    change (inh (if ext vU (if ext (eval5 T rho) (eval5 t rho) then vT else vF) then vT else vF) = true).
+    destruct (ext (eval5 T rho) (eval5 t rho)); reflexivity.
+  - (* in- *)
+    specialize (IHD rho Hsat).
+    change (inh (if ext (eval5 T rho) (eval5 t rho) then vT else vF) = true) in IHD.
+    destruct (ext (eval5 T rho) (eval5 t rho)) eqn:E; [exact (ext_inh _ _ E) | discriminate IHD].
+  - (* cut *)
+    specialize (IHD1 rho Hsat).
+    specialize (IHD2 (econs5 vT rho) (sat5_econs G T vT rho Hsat (inh_ext_T _ IHD1))).
+    rewrite eval5_shift in IHD2.
+    rewrite (eval5_ext T' (etail5 (econs5 vT rho)) rho (fun n => eq_refl)) in IHD2.
+    exact IHD2.
+  - (* type *)
+    reflexivity.
+  - (* arrow *)
+    change (inh (if istype (pi_val (eval5 A rho) (fun v => eval5 B (econs5 v rho))) then vT else vF) = true).
+    rewrite pi_val_istype; [reflexivity | exact (mem_ty_inv A rho (IHD1 rho Hsat)) |].
+    intros v Hv. exact (mem_ty_inv B (econs5 v rho) (IHD2 (econs5 v rho) (sat5_econs G A v rho Hsat Hv))).
+  - (* ap *)
+    specialize (IHD1 rho Hsat). specialize (IHD2 rho Hsat).
+    change (inh (if ext (pi_val (eval5 A rho) (fun v => eval5 B (econs5 v rho))) (eval5 f rho) then vT else vF) = true) in IHD1.
+    change (inh (if ext (eval5 A rho) (eval5 a rho) then vT else vF) = true) in IHD2.
+    destruct (ext (pi_val (eval5 A rho) (fun v => eval5 B (econs5 v rho))) (eval5 f rho)) eqn:Ef; [| discriminate IHD1].
+    destruct (ext (eval5 A rho) (eval5 a rho)) eqn:Ea; [| discriminate IHD2].
+    destruct (pi_val_ext_inv _ _ _ Ef) as [Hf Hb].
+    change (inh (if ext (eval5 (subst1 B a) rho) (vapp (eval5 f rho) (eval5 a rho)) then vT else vF) = true).
+    rewrite eval5_subst1, Hf. simpl vapp.
+    pose proof (inh_ext_T _ (Hb _ Ea)) as E. cbn beta in E. rewrite E. reflexivity.
+  - (* arrow+ *)
+    simpl. apply pi_val_inh. intros v Hv.
+    exact (IHD2 (econs5 v rho) (sat5_econs G A v rho Hsat Hv)).
+Qed.
+
+(** ** What the five-point model settles *)
+
+Corollary underivable_if_uninhabited5 : forall T rho,
+  inh (eval5 T rho) = false -> ~ ([] |- T).
+Proof. intros T rho Hf D. rewrite (soundness5 [] T D rho I) in Hf. discriminate. Qed.
+
+(** Consistency again (the model refutes (X : type) -> X). *)
+Example absurd_5pt : eval5 absurd (fun _ => vJ) = vF.
+Proof. reflexivity. Qed.
+
+(** The junk arrow (x : type type) -> type is inhabited in the model
+    (value vN) but NOT a type: its formation judgment is false, hence
+    underivable, in either system. *)
+Example junk_arrow_5pt : eval5 (Pi (App Ty Ty) Ty) (fun _ => vJ) = vN.
+Proof. reflexivity. Qed.
+
+Theorem junk_formation_underivable : ~ ([] |- Mem (Pi (App Ty Ty) Ty) Ty).
+Proof. exact (underivable_if_uninhabited5 (Mem (Pi (App Ty Ty) Ty) Ty) (fun _ => vJ) eq_refl). Qed.
+
+(** The equality block, once more.  The type of eq,
+      (A : type) -> (a1 a2 : A) -> type,
+    evaluates to vT, whose only element is vT; so in this model the constant
+    eq can only be interpreted as vT, every equation a1 = a2 then evaluates
+    to vT (true), and the type of replace is uninhabited.  Any model with
+    degenerate application meets the same fate: validating replace needs
+    an interpretation of eq that actually looks at its arguments. *)
+Definition eq_ty : term := Pi Ty (Pi (Var 0) (Pi (Var 1) Ty)).
+
+Example eq_ty_val : eval5 eq_ty (fun _ => vJ) = vT.
+Proof. reflexivity. Qed.
+
+Example eq_forced_to_vT : forall v, ext (eval5 eq_ty (fun _ => vJ)) v = true -> v = vT.
+Proof. intros v H. rewrite eq_ty_val in H. destruct v; try discriminate; reflexivity. Qed.
+
+Example replace_ty_uninhabited_5pt : inh (eval5 replace_ty (fun _ => vT)) = false.
+Proof. reflexivity. Qed.
+
+End Rules.
+
+(* ======================================================================== *)
+(*  The two systems by name, and what separates them.                       *)
+(* ======================================================================== *)
+
+(** The author's corrected Figure 1 (arrow+ with the premise G |- T1 : type). *)
+Definition corrected := derivable true.
+(** Figure 1 as first printed (arrow+ without it). *)
+Definition printed := derivable false.
+
+(** Every corrected derivation is a printed derivation, so every theorem
+    proved above for printed (consistency in particular) transfers. *)
+Lemma corrected_printed : forall G T, corrected G T -> printed G T.
+Proof.
+  intros G T D. unfold corrected in D. unfold printed. induction D as [G n T H | G t T T' D1 IHD1 D2 IHD2 | G t T D IHD | G T T' D1 IHD1 D2 IHD2 | G | G A B D1 IHD1 D2 IHD2 | G f a A B D1 IHD1 D2 IHD2 | G A B H1 IHD1 D2 IHD2].
+  - apply r_hyp; assumption.
+  - apply r_in with (T' := T'); assumption.
+  - apply r_in_minus with (t := t); assumption.
+  - apply r_cut with (T := T); assumption.
+  - apply r_type.
+  - apply r_arrow; assumption.
+  - apply r_ap with (A := A); assumption.
+  - apply r_arrow_plus; [intro Hs; discriminate Hs | assumption].
+Qed.
+
+(** The printed rules derive an inhabited arrow whose domain, type type, is
+    not a type (Review 1, point 3) ... *)
+Example junk_inhabited : printed [] (Pi (App Ty Ty) Ty).
+Proof.
+  unfold printed. apply r_arrow_plus; [intro Hs; discriminate Hs |].
+  apply r_in_minus with (t := Ty). apply r_type.
+Qed.
+
+(** ... and, by the five-point model, cannot derive its formation.  So the
+    printed rules are not regular. *)
+Theorem printed_rules_not_regular :
+  printed [] (Pi (App Ty Ty) Ty) /\ ~ printed [] (Mem (Pi (App Ty Ty) Ty) Ty).
+Proof. split; [exact junk_inhabited | exact (junk_formation_underivable false)]. Qed.
+
+(** In the corrected system the same derivation is blocked by the new
+    premise, which would need type type : type; the five-point model shows
+    that judgment underivable there too.  Whether the corrected system is
+    regular remains open (see the discussion in the review). *)
+Theorem corrected_junk_premise_underivable : ~ corrected [] (Mem (App Ty Ty) Ty).
+Proof. exact (underivable_if_uninhabited5 true (Mem (App Ty Ty) Ty) (fun _ => vJ) eq_refl). Qed.
+
+Print Assumptions consistency.
+Print Assumptions soundness.
+Print Assumptions weakening.
+Print Assumptions conservativity1.
+Print Assumptions conservativity.
+Print Assumptions soundness5.
+Print Assumptions printed_rules_not_regular.
+Print Assumptions corrected_junk_premise_underivable.

--- a/mech/README.md
+++ b/mech/README.md
@@ -1,0 +1,37 @@
+# Mechanized metatheory of Blackboard's core logic
+
+`Blackboard.v` is a Rocq development about the core logic of *Blackboard: A
+Clean Slate Proof Assistant* (Figure 1), in both the form first printed and
+the author's corrected form, where the rule `arrow+` carries the premise
+`Γ ⊢ T₁ : type`. It is the reference for the checker in
+`src/language/blackboard/`: whatever the checker accepts must be derivable
+here, and the models here say what is *not* derivable.
+
+Checked with Rocq 9.2; `compile-output.txt` is the output of
+
+    rocq compile Blackboard.v
+
+The eight `Closed under the global context` lines are `Print Assumptions`
+for the main theorems: no axioms are used.
+
+## Contents
+
+| Part | What | Main names |
+|---|---|---|
+| I | Syntax with de Bruijn indices; the eight rules, parametric in a flag `s` that selects the corrected (`s = true`) or printed (`s = false`) `arrow+`; a two-point model; **Theorem 1**: the bare logic is consistent, `(X : type) → X` is not derivable | `derivable`, `soundness`, `consistency` |
+| II | Substitution algebra; renaming of derivations; weakening; **Theorem 2** for one declaration | `derivable_rename`, `weakening`, `conservativity1` |
+| III | **Theorem 2** in general: a construction block with signature `x₁ : T₁, …, xₙ : Tₙ` whose obligation `(M : type) → ((x₁ : T₁) → … → M) → M` is met is a conservative extension, for goals that are types | `witness`, `conservativity` |
+| IV | A five-point model with types, an empty type, an inhabited non-type and junk; the printed rules derive `(x : type type) → type` but not its formation, so they are not regular; in this model the type of `eq` forces every equation to hold and the type of `replace` is uninhabited, so the equality block needs genuine functions | `soundness5`, `printed_rules_not_regular`, `replace_ty_uninhabited_5pt` |
+
+After the section, `corrected` and `printed` name the two systems and
+`corrected_printed` shows the first is included in the second.
+
+## What is open
+
+Consistency of the Section 4 postulate library (equality with `replace`,
+refinement, intersection, quotients, the small universe with combinators).
+The obstacle is `type : type`: the extension of `(X : type) → X` is defined
+in terms of itself, so the usual PER models, which need stratified
+universes, do not apply directly. Candidate routes are a coinductive
+extension relation with a functionality proof, or a stratification theorem
+in the style of Harper and Pollack's typical ambiguity.

--- a/mech/compile-output.txt
+++ b/mech/compile-output.txt
@@ -1,0 +1,14 @@
+$ rocq --version
+The Rocq Prover, version 9.2
+compiled with OCaml 5.2.0
+
+$ rocq compile Blackboard.v
+Closed under the global context
+Closed under the global context
+Closed under the global context
+Closed under the global context
+Closed under the global context
+Closed under the global context
+Closed under the global context
+Closed under the global context
+exit status: 0

--- a/src/docslides/Slides.re
+++ b/src/docslides/Slides.re
@@ -23,6 +23,7 @@ let all_slides: list((string, Haz3lcore.PersistentZipper.t)) =
     ("Blackboard / 2. Signatures", [%blob "signatures.hz"]),
     ("Blackboard / 3. Checking", [%blob "checking.hz"]),
     ("Blackboard / 4. Metatheory", [%blob "metatheory.hz"]),
+    ("Blackboard / 5. Case Studies", [%blob "case-studies.hz"]),
   ]
   |> List.map(((name, text)) =>
        (name, Haz3lcore.PersistentZipper.of_slide_text(text))

--- a/src/docslides/Slides.re
+++ b/src/docslides/Slides.re
@@ -16,6 +16,13 @@ let all_slides: list((string, Haz3lcore.PersistentZipper.t)) =
     ("Cards", [%blob "cards.hz"]),
     ("Probes", [%blob "probes.hz"]),
     ("Livelits / Builtins", [%blob "livelits-builtins.hz"]),
+    /* Blackboard: an experiment embedding the core logic of the
+       Blackboard proof assistant as its own sort. */
+    ("Blackboard / 0. Overview", [%blob "overview.hz"]),
+    ("Blackboard / 1. Terms", [%blob "terms.hz"]),
+    ("Blackboard / 2. Signatures", [%blob "signatures.hz"]),
+    ("Blackboard / 3. Checking", [%blob "checking.hz"]),
+    ("Blackboard / 4. Metatheory", [%blob "metatheory.hz"]),
   ]
   |> List.map(((name, text)) =>
        (name, Haz3lcore.PersistentZipper.of_slide_text(text))

--- a/src/docslides/dune
+++ b/src/docslides/dune
@@ -2,6 +2,8 @@
 
 (copy_files ../../hazel-programs/docs/reference/*.hz)
 
+(copy_files ../../hazel-programs/docs/blackboard/*.hz)
+
 (library
  (name docslides)
  (libraries haz3lcore)

--- a/src/haz3lcore/CompositionCore/HighLevelNodeMap.re
+++ b/src/haz3lcore/CompositionCore/HighLevelNodeMap.re
@@ -108,6 +108,7 @@ module Utils = {
     | Module(_) => []
     | ModuleExp(_, def, body) => [def, body]
     | DrvQuote(_) => []
+    | BbQuote(_) => []
     };
   };
 

--- a/src/haz3lcore/TyDi/ErrorPrint.re
+++ b/src/haz3lcore/TyDi/ErrorPrint.re
@@ -235,6 +235,11 @@ let string_of_marks = (info: Info.t, marks: list(Mark.t)): string =>
     | Some(err) => drv_error(err)
     | None => "(static error)"
     }
+  | InfoBb(bb) =>
+    switch (BbInfo.error_of(bb)) {
+    | Some(err) => BbInfo.message(err)
+    | None => "(static error)"
+    }
   | InfoExp({ctx, ana, _}) =>
     switch (Mark.highest(marks)) {
     | Some(m) => exp_mark_to_string(ctx, ana, m)
@@ -268,6 +273,7 @@ let format_error = (term, error) =>
 let term_string_of: Info.t => string =
   fun
   | InfoDrv({term, _}) => Print.term(Drv(term))
+  | InfoBb({term, _}) => Print.term(Bb(term))
   | InfoExp({user_term, _}) => Print.term(Exp(user_term))
   | InfoPat({user_term, _}) => Print.term(Pat(user_term))
   | InfoTyp({user_term, _}) => Print.term(Typ(user_term))

--- a/src/haz3lcore/lang/Form.re
+++ b/src/haz3lcore/lang/Form.re
@@ -95,6 +95,8 @@ let mk_parens = (sort: Sort.t) =>
 type atomic_form =
   | Var
   | DrvVar
+  | BbVar
+  | BbType
   | ExplicitHole
   | ImplicitHoleMarker
   | LLMHole
@@ -193,6 +195,38 @@ type drv_compound_form =
   | ParenExp
   | ParenPat
   | ParenTyp;
+
+/* Blackboard forms.  One sort, Bb(Term), for terms, signature entries and
+   blocks; see BbSort.  Signature entries are membership terms `x : T`,
+   separated by `;`; blocks are `assume … by … end` and `construct … by …
+   end` operands, separated by `;`; the dependent arrow `(x : A) -> B` is
+   the infix arrow with a parenthesized membership on its left, recovered
+   in MakeTerm.  `blackboard … end` embeds a document in an expression. */
+[@deriving enumerate]
+type bb_compound_form =
+  | BbOf
+  | BbMem
+  | BbArrow
+  | BbAp
+  | BbComma
+  | BbSeq
+  | BbParens
+  | BbAssume
+  | BbConstruct;
+
+let bb_get: bb_compound_form => t =
+  fun
+  | BbOf => mk_op_c(L, ["blackboard", "end"], Exp, [Bb(Term)])
+  | BbMem => mk_infix(":", Bb(Term), P.bb_mem)
+  | BbArrow => mk_infix("->", Bb(Term), P.bb_arrow)
+  | BbAp => mk_post_c(LT, ["(", ")"], P.bb_ap, Bb(Term), [Bb(Term)])
+  | BbComma => mk_infix(",", Bb(Term), P.comma)
+  | BbSeq => mk_infix(";", Bb(Term), P.semi)
+  | BbParens => mk_parens(Bb(Term))
+  | BbAssume =>
+    mk_pre_c(L, ["assume", "by"], P.bb_block, Bb(Term), [Bb(Term)])
+  | BbConstruct =>
+    mk_pre_c(L, ["construct", "by"], P.bb_block, Bb(Term), [Bb(Term)]);
 
 /* let all_of_drv_compound_form: list(_) = []; */
 
@@ -405,6 +439,8 @@ type compound_form =
   | Use
   // Drv
   | Drv(drv_compound_form)
+  // Blackboard
+  | Bb(bb_compound_form)
   // TRIPLE DELIMITERS
   | Let
   | Theorem
@@ -514,6 +550,8 @@ let get: compound_form => t =
   | Use => mk_pre_c(L, ["use", "in"], P.let_, Exp, [Typ])
   // Drv
   | Drv(drv_compound_form) => drv_get(drv_compound_form)
+  // Blackboard
+  | Bb(bb_compound_form) => bb_get(bb_compound_form)
   // Theorem Capture
   | Theorem => mk_pre_c(L, ["theorem", "=", "in"], P.let_, Exp, [Pat, Exp])
   | ProofOf => mk_op_c(L, ["proof_of", "end"], Typ, [Exp])
@@ -648,14 +686,21 @@ let get_atomic_form: atomic_form => (Token.t => bool, list(Mold.t)) =
     )
   | ExplicitHole => (
       Token.is_explicit_hole,
-      [op(Exp), op(Pat), op(Typ), op(TPat), op(Drv(Typ))],
+      [
+        op(Exp),
+        op(Pat),
+        op(Typ),
+        op(TPat),
+        op(Drv(Typ)),
+        op(Bb(Term)),
+      ],
     )
   | ImplicitHoleMarker => (
       Token.is_implicit_hole_marker,
       [op(Exp), op(Pat), op(Typ), op(TPat), op(Drv(Typ))],
     )
   | LLMHole => (Token.is_llm_hole, [op(Exp), op(Pat), op(Typ), op(TPat)])
-  | Wild => (Token.is_wild, [op(Pat), op(Drv(Exp))])
+  | Wild => (Token.is_wild, [op(Pat), op(Drv(Exp)), op(Bb(Term))])
   | String => (Token.is_string, [op(Exp), op(Pat)])
   | QuotedLabel => (Token.is_quoted_label, [op(Exp), op(Pat), op(Typ)])
   | IntLit => (
@@ -686,7 +731,9 @@ let get_atomic_form: atomic_form => (Token.t => bool, list(Mold.t)) =
   | DrvVar => (
       Token.is_typ_var,
       [op(Drv(Exp)), op(Drv(Pat)), op(Drv(Typ)), op(Drv(TPat))],
-    );
+    )
+  | BbVar => ((t => t != "type" && Token.is_typ_var(t)), [op(Bb(Term))])
+  | BbType => ((t => t == "type"), [op(Bb(Term))]);
 
 module Molds = {
   let atomics: list((Token.t => bool, list(Mold.t))) =

--- a/src/haz3lcore/lang/MakeTerm.re
+++ b/src/haz3lcore/lang/MakeTerm.re
@@ -317,7 +317,9 @@ let rec go_s = (s: Sort.t, skel: Skel.t, seg: Segment.t): Any.t =>
       | TPat => TPat(drv_tpat(unsorted(Drv(TPat), skel, seg)))
       },
     )
-  | Bb(Term) => Bb(bb(unsorted(Bb(Term), skel, seg)))
+  /* Bb(Assumed) and Bb(Constructed) are display-only refinements produced by
+     statics; nothing is ever molded or parsed in them. */
+  | Bb(_) => Bb(bb(unsorted(Bb(Term), skel, seg)))
   | Pat => Pat(pat(unsorted(Pat, skel, seg)))
   | TPat => TPat(tpat(unsorted(TPat, skel, seg)))
   | Typ => Typ(typ(unsorted(Typ, skel, seg)))

--- a/src/haz3lcore/lang/MakeTerm.re
+++ b/src/haz3lcore/lang/MakeTerm.re
@@ -57,6 +57,8 @@ let is_tuple_exp = is_nary(Any.is_exp, ",");
 let is_tuple_pat = is_nary(Any.is_pat, ",");
 let is_tuple_typ = is_nary(Any.is_typ, ",");
 let is_tuple_drv_exp = is_nary(Any.is_drv_exp, ",");
+let is_tuple_bb = is_nary(Any.is_bb, ",");
+let is_seq_bb = is_nary(Any.is_bb, ";");
 let is_typ_bsum = is_nary(Any.is_typ, "+");
 let is_mod_seq = is_nary(Any.is_mod, ";");
 let is_sig_seq = is_nary(Any.is_sig, ";");
@@ -315,6 +317,7 @@ let rec go_s = (s: Sort.t, skel: Skel.t, seg: Segment.t): Any.t =>
       | TPat => TPat(drv_tpat(unsorted(Drv(TPat), skel, seg)))
       },
     )
+  | Bb(Term) => Bb(bb(unsorted(Bb(Term), skel, seg)))
   | Pat => Pat(pat(unsorted(Pat, skel, seg)))
   | TPat => TPat(tpat(unsorted(TPat, skel, seg)))
   | Typ => Typ(typ(unsorted(Typ, skel, seg)))
@@ -331,6 +334,65 @@ let rec go_s = (s: Sort.t, skel: Skel.t, seg: Segment.t): Any.t =>
       go_s(sort, skel, seg);
     };
   }
+and bb = unsorted => {
+  let (term, inner_ids) = bb_term(unsorted);
+  let ids = ids(unsorted) @ inner_ids;
+  return(
+    b => Bb(b),
+    ids,
+    {
+      annotation: IdTagged.IdTag.mk(ids, IdTagged.IdTag.empty_secondary),
+      term,
+    },
+  );
+}
+/* Blackboard tiles map one for one onto BbGrammar; see Form.bb_get.  The
+   dependent arrow and the reading of `x : T` as a signature entry happen
+   later, in Bb.to_kernel. */
+and bb_term: unsorted => (BbTermBase.term, list(Id.t)) = {
+  let ret = (tm: BbTermBase.term) => (tm, []);
+  let hole: unsorted => BbTermBase.term =
+    unsorted => Hole(Any.bb_hole(kids_of_unsorted(unsorted)));
+  fun
+  | Op(([(_id, t)], [])) as tm =>
+    switch (t) {
+    | ([t], []) =>
+      switch (t) {
+      | "type" => ret(Type)
+      | _ when Token.is_wild(t) => ret(Var("_"))
+      | _ when Token.is_typ_var(t) => ret(Var(t))
+      | _ => ret(hole(tm))
+      }
+    | (["(", ")"], [Bb(body)]) => ret(Parens(body))
+    | _ => ret(hole(tm))
+    }
+  | Pre(([(_id, (labels, [Bb(entries)]))], []), Bb(tactic)) as tm =>
+    switch (labels) {
+    | ["assume", "by"] => ret(Assume(entries, tactic))
+    | ["construct", "by"] => ret(Construct(entries, tactic))
+    | _ => ret(hole(tm))
+    }
+  | Bin(Bb(l), ([(_id, ([t], []))], []), Bb(r)) as tm =>
+    switch (t) {
+    | ":" => ret(Mem(l, r))
+    | "->" => ret(Arrow(l, r))
+    | "," => ret(Tuple([l, r]))
+    | ";" => ret(Seq([l, r]))
+    | _ => ret(hole(tm))
+    }
+  | Bin(Bb(l), tiles, Bb(r)) as tm =>
+    switch (is_tuple_bb(tiles), is_seq_bb(tiles)) {
+    | (Some(between), _) => ret(Tuple([l] @ between @ [r]))
+    | (_, Some(between)) => ret(Seq([l] @ between @ [r]))
+    | _ => ret(hole(tm))
+    }
+  | Post(Bb(l), ([(_id, t)], [])) as tm =>
+    switch (t) {
+    | (["(", ")"], [Bb(r)]) => ret(Ap(l, r))
+    | _ => ret(hole(tm))
+    }
+  | _ as tm => ret(hole(tm));
+}
 and drv_exp = unsorted => {
   let (term, inner_ids) = drv_exp_term(unsorted);
   let ids = ids(unsorted) @ inner_ids;
@@ -721,6 +783,8 @@ and exp_term: unsorted => (Exp.term, list(Id.t)) = {
         ret(DrvQuote(Pat(p), Pat))
       | (["of_alfa_tpat", "end"], [Drv(TPat(tp))]) =>
         ret(DrvQuote(TPat(tp), TPat))
+      /* [blackboard] / [end] lift a Blackboard document up to sort Exp. */
+      | (["blackboard", "end"], [Bb(b)]) => ret(BbQuote(b))
       | ([t], []) when is_hole_label(t) => ret(hole(tm))
       | ([t], []) when t != " " && !Token.is_explicit_hole(t) =>
         ret(Invalid(t))
@@ -1590,6 +1654,11 @@ let for_projection =
           switch (drv_exp(unsorted)) {
           | {term: Tuple(_), _} => None
           | _ => Some(Grammar.Drv(Exp(drv_exp(unsorted))))
+          }
+        | Bb(_) =>
+          switch (bb(unsorted)) {
+          | {term: Tuple(_) | Seq(_), _} => None
+          | b => Some(Grammar.Bb(b))
           }
         | Exp =>
           switch (exp(unsorted)) {

--- a/src/haz3lcore/lang/Precedence.re
+++ b/src/haz3lcore/lang/Precedence.re
@@ -38,6 +38,18 @@ let type_binder = 15;
 // poly t -> _____
 // rec t -> _____
 
+// ===== BLACKBOARD (its own sort; only the relative order matters) =====
+// f(_____)
+let bb_ap = 17;
+// _____ : T
+let bb_mem = 18 |> left_associative;
+// A -> _____
+let bb_arrow = 20 |> right_associative;
+// (x : A) -> _____
+/* Blocks must bind tighter than the `;` that separates them, so that a
+   block's tactic does not swallow the following block. */
+let bb_block = 30;
+
 // ======== PATTERNS =========
 // ======= EXPRESSIONS =======
 

--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -122,6 +122,7 @@ let rec external_precedence = (exp: Exp.t): Precedence.t => {
   | Invalid(_)
   | Atom(Bool(_) | Int(_) | SInt(_) | Float(_) | String(_) | Nat(_))
   | DrvQuote(_)
+  | BbQuote(_)
   | EmptyHole
   | Deferral(_)
   | ExplicitNonlabel
@@ -356,6 +357,7 @@ let rec parenthesize =
   | Invalid(_)
   | Atom(_)
   | DrvQuote(_)
+  | BbQuote(_)
   | EmptyHole
   | LivelitName(_)
   //| Constructor(_) // Not indivisible because of the type annotation!
@@ -976,6 +978,7 @@ and parenthesize_any =
      Pretty-printing produces the term as-is; this is sound (never adds
      invalid parens) but may omit disambiguating parens in nested contexts. */
   | Drv(_) => any
+  | Bb(_) => any
   | Mod(_) => any
   | Sig(_) => any
   | MPat(_) => any
@@ -1776,6 +1779,9 @@ let rec exp_to_pretty = (~settings: Settings.t, exp: Exp.t): pretty => {
       | TPat => OfAlfaTPat
       };
     [mk_form(Drv(form), exp |> Exp.rep_id, [d])];
+  | BbQuote(b) =>
+    let+ b = bb_to_pretty(~settings, b);
+    [mk_form(Bb(BbOf), exp |> Exp.rep_id, [b])];
   // TODO: Make sure types are correct
   | Constructor(c, _t) =>
     // let id = Id.mk();
@@ -3026,6 +3032,60 @@ and sig_to_pretty = (~settings: Settings.t, item: Sig.t): pretty => {
 and mpat_to_pretty = (~settings: Settings.t, mp: MPat.t): pretty => {
   p_just(mpat_to_seg(~settings, mp));
 }
+/* Blackboard terms print as the tiles they came from; see Form.bb_get.
+   Precedence-driven parenthesization is not yet defined for this sort, so
+   Parens nodes in the term are the only source of parentheses. */
+and bb_to_pretty = (~settings: Settings.t, b: Bb.Term.t): pretty => {
+  let mk_form = mk_form(~secondary=settings.secondary);
+  let go = bb_to_pretty(~settings);
+  let id = b |> Bb.Term.rep_id;
+  let infix = (form, l, r) => {
+    let+ l = go(l)
+    and+ r = go(r);
+    l @ [mk_form(Form.Bb(form), id, [])] @ r;
+  };
+  let rec sep = (form, ts) =>
+    switch (ts) {
+    | [] => p_just([])
+    | [t] => go(t)
+    | [t, ...rest] =>
+      let+ t = go(t)
+      and+ rest = sep(form, rest);
+      t @ [mk_form(Form.Bb(form), id, [])] @ rest;
+    };
+  switch (b |> Bb.Term.term_of) {
+  | Hole(Invalid(s)) => text_to_pretty(id, Sort.Bb(Term), s)
+  | Hole(EmptyHole) =>
+    p_just([
+      Grout({
+        id,
+        shape: Convex,
+      }),
+    ])
+  | Hole(MultiHole(ts)) => sep(BbSeq, ts)
+  | Var(x) => text_to_pretty(id, Sort.Bb(Term), x)
+  | Type => text_to_pretty(id, Sort.Bb(Term), "type")
+  | Parens(t) =>
+    let+ t = go(t);
+    [mk_form(Form.Bb(BbParens), id, [t])];
+  | Mem(l, r) => infix(BbMem, l, r)
+  | Arrow(l, r) => infix(BbArrow, l, r)
+  | Tuple(ts) => sep(BbComma, ts)
+  | Seq(ts) => sep(BbSeq, ts)
+  | Ap(f, a) =>
+    let+ f = go(f)
+    and+ a = go(a);
+    f @ [mk_form(Form.Bb(BbAp), id, [a])];
+  | Assume(entries, tactic) =>
+    let+ entries = go(entries)
+    and+ tactic = go(tactic);
+    [mk_form(Form.Bb(BbAssume), id, [entries])] @ tactic;
+  | Construct(entries, tactic) =>
+    let+ entries = go(entries)
+    and+ tactic = go(tactic);
+    [mk_form(Form.Bb(BbConstruct), id, [entries])] @ tactic;
+  };
+}
 and any_to_pretty = (~settings: Settings.t, any: Any.t): pretty => {
   switch (any) {
   | Exp(e) => exp_to_pretty(~settings: Settings.t, e)
@@ -3033,6 +3093,7 @@ and any_to_pretty = (~settings: Settings.t, any: Any.t): pretty => {
   | Typ(t) => typ_to_pretty(~settings: Settings.t, t)
   | TPat(tp) => tpat_to_pretty(~settings: Settings.t, tp)
   | Drv(d) => drv_to_pretty(~settings: Settings.t, d, ~sort=Jdmt)
+  | Bb(b) => bb_to_pretty(~settings, b)
   | Mod(m) => mod_to_pretty(~settings, m)
   | Sig(s) => sig_to_pretty(~settings, s)
   | MPat(mp) => mpat_to_pretty(~settings, mp)

--- a/src/haz3lcore/tiles/Segment.re
+++ b/src/haz3lcore/tiles/Segment.re
@@ -99,6 +99,7 @@ let shape_affix =
 let rec remold = (~shape=Nib.Shape.concave(), seg: t, s: Sort.t) =>
   switch (s) {
   | Drv(_) => remold_template(s, shape, seg)
+  | Bb(_) => remold_template(s, shape, seg)
   | Any => seg
   | Typ => remold_typ(shape, seg)
   | Pat => remold_pat(shape, seg)

--- a/src/haz3lcore/zipper/action/Insert.re
+++ b/src/haz3lcore/zipper/action/Insert.re
@@ -63,9 +63,13 @@ let effective_sort = (t: Token.t, z: t, ~root): Sort.t => {
     switch (Form.Expansion.try_get(local_sort, t)) {
     | Some(_) => local_sort
     | None =>
-      /* In Mod context, try Exp since bare expressions are valid module items.
-         This mirrors remold_mod which also falls back to Exp. */
-      if (local_sort == Sort.Mod) {
+      /* Blackboard is a closed sub-language: no Hazel form is valid inside
+         it, so a token with no Blackboard expansion must stay a monotile
+         rather than expanding into the enclosing sort's form.  Without this,
+         `type` inside a blackboard block expands to Hazel's `type _ = _ in`. */
+      if (Sort.is_bb(local_sort)) {
+        local_sort;
+      } else if (local_sort == Sort.Mod) {
         switch (Form.Expansion.try_get(Exp, t)) {
         | Some(_) => Exp
         | None => parent_sort

--- a/src/language/blackboard/Bb.re
+++ b/src/language/blackboard/Bb.re
@@ -1,0 +1,228 @@
+open Sexplib.Std;
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives;
+
+/* Blackboard terms in the editor: classes for the cursor inspector, the
+   usual id accessors, and the reading of editor terms as terms, signatures
+   and documents of the core logic (BbTerm). */
+
+module Term = {
+  [@deriving (show({with_path: false}), sexp, yojson, enumerate)]
+  type cls =
+    | Hole
+    | Var
+    | Type
+    | Parens
+    | Mem
+    | Arrow
+    | Ap
+    | Tuple
+    | Seq
+    | Assume
+    | Construct;
+
+  let show_cls =
+    fun
+    | Hole => "Hole"
+    | Var => "Name"
+    | Type => "The type of types"
+    | Parens => "Parentheses"
+    | Mem => "Membership"
+    | Arrow => "Function type"
+    | Ap => "Application"
+    | Tuple => "Argument list"
+    | Seq => "Sequence"
+    | Assume => "Assumption block"
+    | Construct => "Construction block";
+
+  [@deriving (show({with_path: false}), sexp, yojson)]
+  type t = BbTermBase.t;
+  type term = BbTermBase.term;
+
+  let rep_id: t => Id.t = IdTagged.rep_id;
+  let ids: t => list(Id.t) = IdTagged.ids;
+  let term_of: t => term = IdTagged.term_of;
+  let fresh: term => t = IdTagged.fresh;
+
+  let cls_of_term: term => cls =
+    fun
+    | Hole(_) => Hole
+    | Var(_) => Var
+    | Type => Type
+    | Parens(_) => Parens
+    | Mem(_) => Mem
+    | Arrow(_) => Arrow
+    | Ap(_) => Ap
+    | Tuple(_) => Tuple
+    | Seq(_) => Seq
+    | Assume(_) => Assume
+    | Construct(_) => Construct;
+
+  let cls_of = (t: t): cls => cls_of_term(term_of(t));
+
+  let sort: t => BbSort.t = _ => Term;
+
+  let is_hole = (t: t): bool =>
+    switch (term_of(t)) {
+    | Hole(_) => true
+    | _ => false
+    };
+};
+
+/* Reading editor terms as kernel terms.  A problem names the node that
+   could not be read and says why, in the user's terms. */
+[@deriving (show({with_path: false}), sexp, yojson)]
+type problem = {
+  id: Id.t,
+  message: string,
+};
+
+let ( let* ) = Result.bind;
+
+let problem = (t: Term.t, message: string) =>
+  Error({
+    id: Term.rep_id(t),
+    message,
+  });
+
+/* `(x : A)` used as the domain of an arrow is a binder.  This is the same
+   convention as BbParse and BbTerm.to_string: a non-dependent arrow whose
+   domain is a membership must be written with a `_` binder. */
+let binder_of = (dom: Term.t): option((string, Term.t)) =>
+  switch (Term.term_of(dom)) {
+  | Parens(inner) =>
+    switch (Term.term_of(inner)) {
+    | Mem({term: Var(x), _}, a) => Some((x, a))
+    | _ => None
+    }
+  | _ => None
+  };
+
+let rec term_to_kernel = (t: Term.t): result(BbTerm.t, problem) =>
+  switch (Term.term_of(t)) {
+  | Var(x) => Ok(BbTerm.Var(x))
+  | Type => Ok(BbTerm.Type)
+  | Parens(inner) => term_to_kernel(inner)
+  | Mem(a, b) =>
+    let* a = term_to_kernel(a);
+    let* b = term_to_kernel(b);
+    Ok(BbTerm.Mem(a, b));
+  | Arrow(dom, cod) =>
+    let* cod = term_to_kernel(cod);
+    switch (binder_of(dom)) {
+    | Some((x, a)) =>
+      let* a = term_to_kernel(a);
+      Ok(BbTerm.Pi(x, a, cod));
+    | None =>
+      let* dom = term_to_kernel(dom);
+      Ok(BbTerm.Pi("_", dom, cod));
+    };
+  | Ap(f, arg) =>
+    let* f = term_to_kernel(f);
+    let args =
+      switch (Term.term_of(arg)) {
+      | Tuple(args) => args
+      | _ => [arg]
+      };
+    List.fold_left(
+      (acc, a) => {
+        let* acc = acc;
+        let* a = term_to_kernel(a);
+        Ok(BbTerm.App(acc, a));
+      },
+      Ok(f),
+      args,
+    );
+  | Tuple(_) =>
+    problem(
+      t,
+      "a comma-separated list only makes sense as the argument of an application",
+    )
+  | Seq(_) => problem(t, "a sequence only makes sense inside a block")
+  | Assume(_)
+  | Construct(_) => problem(t, "a block is not a term")
+  | Hole(_) => problem(t, "incomplete term")
+  };
+
+let items_of = (t: Term.t): list(Term.t) =>
+  switch (Term.term_of(t)) {
+  | Seq(items) => items
+  | Hole(EmptyHole) => []
+  | _ => [t]
+  };
+
+/* In a signature entry the colon is a declaration, not a membership: it is
+   looser than everything to its right.  The membership tile binds tighter
+   than the arrow (as it must inside a type, so that `(x : A) -> x : B`
+   reads as the paper writes it), so `f : A -> B` arrives here as
+   `Arrow(Mem(f, A), B)` and the spine has to be rotated back. */
+let rec rotate_entry = (t: Term.t): option((string, Term.t)) =>
+  switch (Term.term_of(t)) {
+  | Mem({term: Var(name), _}, ty) => Some((name, ty))
+  | Arrow(l, r) =>
+    switch (rotate_entry(l)) {
+    | Some((name, dom)) =>
+      Some((
+        name,
+        Term.fresh(Arrow(dom, r)) |> IdTagged.fast_copy(Term.rep_id(t)),
+      ))
+    | None => None
+    }
+  | _ => None
+  };
+
+let entry_to_kernel = (t: Term.t): result(BbTerm.entry, problem) =>
+  switch (rotate_entry(t)) {
+  | Some((name, ty)) =>
+    let* ty = term_to_kernel(ty);
+    Ok(
+      BbTerm.{
+        name,
+        ty,
+      },
+    );
+  | None => problem(t, "a signature entry has the form  name : type")
+  };
+
+let signature_to_kernel = (t: Term.t): result(BbTerm.signature, problem) =>
+  List.fold_right(
+    (item, acc) => {
+      let* acc = acc;
+      let* e = entry_to_kernel(item);
+      Ok([e, ...acc]);
+    },
+    items_of(t),
+    Ok([]),
+  );
+
+/* A tactic is a name; an empty slot is no tactic. */
+let tactic_to_kernel = (t: Term.t): result(option(string), problem) =>
+  switch (Term.term_of(t)) {
+  | Hole(EmptyHole) => Ok(None)
+  | Var(x) => Ok(Some(x))
+  | _ => problem(t, "a tactic is a name")
+  };
+
+let rec block_to_kernel = (t: Term.t): result(BbTerm.block, problem) =>
+  switch (Term.term_of(t)) {
+  | Assume(entries, tactic) =>
+    let* s = signature_to_kernel(entries);
+    let* tac = tactic_to_kernel(tactic);
+    Ok(BbTerm.Assume(s, tac));
+  | Construct(entries, tactic) =>
+    let* s = signature_to_kernel(entries);
+    let* tac = tactic_to_kernel(tactic);
+    Ok(BbTerm.Construct(s, Option.value(~default="?", tac)));
+  | Parens(inner) => block_to_kernel(inner)
+  | _ => problem(t, "a document is a sequence of assume and construct blocks")
+  };
+
+let doc_to_kernel = (t: Term.t): result(BbTerm.doc, problem) =>
+  List.fold_right(
+    (item, acc) => {
+      let* acc = acc;
+      let* b = block_to_kernel(item);
+      Ok([b, ...acc]);
+    },
+    items_of(t),
+    Ok([]),
+  );

--- a/src/language/blackboard/Bb.re
+++ b/src/language/blackboard/Bb.re
@@ -84,19 +84,6 @@ let problem = (t: Term.t, message: string) =>
     message,
   });
 
-/* `(x : A)` used as the domain of an arrow is a binder.  This is the same
-   convention as BbParse and BbTerm.to_string: a non-dependent arrow whose
-   domain is a membership must be written with a `_` binder. */
-let binder_of = (dom: Term.t): option((string, Term.t)) =>
-  switch (Term.term_of(dom)) {
-  | Parens(inner) =>
-    switch (Term.term_of(inner)) {
-    | Mem({term: Var(x), _}, a) => Some((x, a))
-    | _ => None
-    }
-  | _ => None
-  };
-
 /* `;` is right-associative and `,` may group either way, so a list of
    three or more arrives nested. Both read as flat lists. */
 let rec flatten = (of_term, t: Term.t): list(Term.t) =>
@@ -120,6 +107,42 @@ let flatten_seq =
     | _ => None
     }
   );
+
+/* In a signature entry the colon is a declaration, not a membership: it is
+   looser than everything to its right.  The membership tile binds tighter
+   than the arrow (as it must inside a type, so that `(x : A) -> x : B`
+   reads as the paper writes it), so `f : A -> B` arrives here as
+   `Arrow(Mem(f, A), B)` and the spine has to be rotated back. */
+let rec rotate_entry = (t: Term.t): option((string, Term.t)) =>
+  switch (Term.term_of(t)) {
+  | Mem({term: Var(name), _}, ty) => Some((name, ty))
+  | Arrow(l, r) =>
+    switch (rotate_entry(l)) {
+    | Some((name, dom)) =>
+      Some((
+        name,
+        Term.fresh(Arrow(dom, r)) |> IdTagged.fast_copy(Term.rep_id(t)),
+      ))
+    | None => None
+    }
+  | _ => None
+  };
+
+/* `(x : A)` used as the domain of an arrow is a binder.  This is the same
+   convention as BbParse and BbTerm.to_string: a non-dependent arrow whose
+   domain is a membership must be written with a `_` binder.
+
+   The declaration inside may itself be an arrow -- `(P : A -> type)` -- and
+   arrives rotated, for the reason rotate_entry explains; it is the same
+   rotation, so the same function reads it.  A parenthesized membership on
+   the left, as in `((h : (x : A)) -> P x -> M)`, does not rotate: there the
+   arrow is the type, not the declaration, which is what tells the two
+   apart. */
+let binder_of = (dom: Term.t): option((string, Term.t)) =>
+  switch (Term.term_of(dom)) {
+  | Parens(inner) => rotate_entry(inner)
+  | _ => None
+  };
 
 let rec term_to_kernel = (t: Term.t): result(BbTerm.t, problem) =>
   switch (Term.term_of(t)) {
@@ -168,26 +191,6 @@ let items_of = (t: Term.t): list(Term.t) =>
   | Hole(EmptyHole) => []
   | Seq(_) => flatten_seq(t)
   | _ => [t]
-  };
-
-/* In a signature entry the colon is a declaration, not a membership: it is
-   looser than everything to its right.  The membership tile binds tighter
-   than the arrow (as it must inside a type, so that `(x : A) -> x : B`
-   reads as the paper writes it), so `f : A -> B` arrives here as
-   `Arrow(Mem(f, A), B)` and the spine has to be rotated back. */
-let rec rotate_entry = (t: Term.t): option((string, Term.t)) =>
-  switch (Term.term_of(t)) {
-  | Mem({term: Var(name), _}, ty) => Some((name, ty))
-  | Arrow(l, r) =>
-    switch (rotate_entry(l)) {
-    | Some((name, dom)) =>
-      Some((
-        name,
-        Term.fresh(Arrow(dom, r)) |> IdTagged.fast_copy(Term.rep_id(t)),
-      ))
-    | None => None
-    }
-  | _ => None
   };
 
 let entry_to_kernel = (t: Term.t): result(BbTerm.entry, problem) =>

--- a/src/language/blackboard/Bb.re
+++ b/src/language/blackboard/Bb.re
@@ -97,6 +97,30 @@ let binder_of = (dom: Term.t): option((string, Term.t)) =>
   | _ => None
   };
 
+/* `;` is right-associative and `,` may group either way, so a list of
+   three or more arrives nested. Both read as flat lists. */
+let rec flatten = (of_term, t: Term.t): list(Term.t) =>
+  switch (of_term(t)) {
+  | Some(items) => List.concat_map(flatten(of_term), items)
+  | None => [t]
+  };
+
+let flatten_tuple =
+  flatten(t =>
+    switch (Term.term_of(t)) {
+    | Tuple(items) => Some(items)
+    | _ => None
+    }
+  );
+
+let flatten_seq =
+  flatten(t =>
+    switch (Term.term_of(t)) {
+    | Seq(items) => Some(items)
+    | _ => None
+    }
+  );
+
 let rec term_to_kernel = (t: Term.t): result(BbTerm.t, problem) =>
   switch (Term.term_of(t)) {
   | Var(x) => Ok(BbTerm.Var(x))
@@ -118,11 +142,7 @@ let rec term_to_kernel = (t: Term.t): result(BbTerm.t, problem) =>
     };
   | Ap(f, arg) =>
     let* f = term_to_kernel(f);
-    let args =
-      switch (Term.term_of(arg)) {
-      | Tuple(args) => args
-      | _ => [arg]
-      };
+    let args = flatten_tuple(arg);
     List.fold_left(
       (acc, a) => {
         let* acc = acc;
@@ -145,8 +165,8 @@ let rec term_to_kernel = (t: Term.t): result(BbTerm.t, problem) =>
 
 let items_of = (t: Term.t): list(Term.t) =>
   switch (Term.term_of(t)) {
-  | Seq(items) => items
   | Hole(EmptyHole) => []
+  | Seq(_) => flatten_seq(t)
   | _ => [t]
   };
 

--- a/src/language/blackboard/BbCheck.re
+++ b/src/language/blackboard/BbCheck.re
@@ -1,0 +1,182 @@
+/* The decidable fragment of Blackboard's core logic that the paper assumes
+   under the name `tychk` (l. 154-156), minus conversion, since the logic has
+   no reduction.  Bidirectional: `synth` finds the type of a term, `is_type`
+   checks that a term is a type.  Every step is an instance of a rule of the
+   corrected Figure 1 (hyp, type, ap, arrow, in, and in- for hypotheses), so
+   whatever passes is derivable; much that is derivable does not pass, and
+   the paper says so.
+
+   Two Blackboard-specific points:
+
+   - `(t : T) : type` needs only that T is a type and t has SOME type
+     (l. 80), not that t has type T.
+
+   - Because typing is internal, a hypothesis h : (t : T) in the context
+     establishes t : T (rules hyp and in-).  The refinement and intersection
+     eliminators of Section 4 rely on this. */
+
+open BbTerm;
+
+/* Innermost binding first. */
+type ctx = list((string, BbTerm.t));
+
+let lookup = (ctx: ctx, x: string): option(BbTerm.t) =>
+  List.assoc_opt(x, ctx);
+
+/* Some hypothesis in the context asserts t : ty. */
+let membership_hyp = (ctx: ctx, t: BbTerm.t, ty: BbTerm.t): bool =>
+  List.exists(
+    ((_, h)) =>
+      switch (h) {
+      | Mem(t', ty') => alpha_eq(t, t') && alpha_eq(ty, ty')
+      | _ => false
+      },
+    ctx,
+  );
+
+/* Some hypothesis in the context asserts t : T for some T. */
+let some_membership_hyp = (ctx: ctx, t: BbTerm.t): bool =>
+  List.exists(
+    ((_, h)) =>
+      switch (h) {
+      | Mem(t', _) => alpha_eq(t, t')
+      | _ => false
+      },
+    ctx,
+  );
+
+/* Errors are collected where subterms are independent, so that several
+   slips in one signature entry are all reported. */
+type errors = list(BbError.t);
+
+let rec synth = (ctx: ctx, t: BbTerm.t): result(BbTerm.t, errors) =>
+  switch (t) {
+  | Var(x) =>
+    switch (lookup(ctx, x)) {
+    | Some(ty) => Ok(ty)
+    | None => Error([Unbound(x)])
+    }
+  | Type => Ok(Type)
+  | App(f, a) =>
+    switch (synth(ctx, f)) {
+    | Error(es) => Error(es)
+    | Ok(Pi(x, dom, cod)) =>
+      switch (has_type(ctx, a, dom)) {
+      | Error(es) => Error(es)
+      | Ok(None) => Ok(subst(x, a, cod))
+      | Ok(Some(actual)) => Error([ArgumentMismatch(f, a, dom, actual)])
+      }
+    | Ok(ty) => Error([NotAFunction(f, ty)])
+    }
+  | Mem(_)
+  | Pi(_) =>
+    switch (is_type(ctx, t)) {
+    | [] => Ok(Type)
+    | es => Error(es)
+    }
+  }
+
+/* Ok(None): t has type `expected`.  Ok(Some(actual)): it has another type.
+   Error: t is ill-formed. */
+and has_type =
+    (ctx: ctx, t: BbTerm.t, expected: BbTerm.t)
+    : result(option(BbTerm.t), errors) =>
+  if (membership_hyp(ctx, t, expected)) {
+    Ok(None);
+  } else {
+    switch (synth(ctx, t)) {
+    | Error(es) => Error(es)
+    | Ok(actual) =>
+      alpha_eq(actual, expected) ? Ok(None) : Ok(Some(actual))
+    };
+  }
+
+/* Empty list: t is a type in ctx. */
+and is_type = (ctx: ctx, t: BbTerm.t): errors =>
+  switch (t) {
+  | Type => []
+  | Pi(x, a, b) => is_type(ctx, a) @ is_type([(x, a), ...ctx], b)
+  | Mem(u, ty) =>
+    let has_some_type =
+      some_membership_hyp(ctx, u)
+        ? []
+        : (
+          switch (synth(ctx, u)) {
+          | Ok(_) => []
+          | Error(es) => es
+          }
+        );
+    is_type(ctx, ty) @ has_some_type;
+  | Var(_)
+  | App(_) =>
+    switch (has_type(ctx, t, Type)) {
+    | Ok(None) => []
+    | Ok(Some(actual)) => [NotAType(t, actual)]
+    | Error(es) => es
+    }
+  };
+
+/* Check a signature entry by entry, each in the context of the ones before
+   it (the obligation of an assumption block, l. 149).  An entry with errors
+   still enters the context, so later entries can be checked. */
+let check_signature = (ctx: ctx, s: signature): (ctx, list(BbError.located)) => {
+  let (ctx, errs) =
+    List.fold_left(
+      ((ctx, errs), {name, ty}) => {
+        let here =
+          List.map(
+            err =>
+              BbError.{
+                entry: name,
+                err,
+              },
+            is_type(ctx, ty),
+          );
+        ([(name, ty), ...ctx], List.rev_append(here, errs));
+      },
+      (ctx, []),
+      s,
+    );
+  (ctx, List.rev(errs));
+};
+
+/* What the checker can say about one block. */
+[@deriving (show({with_path: false}), eq)]
+type report = {
+  index: int,
+  errors: list(BbError.located),
+  /* a construct block's tactic, which nothing discharges yet */
+  pending: option(string),
+};
+
+let check_doc = (~ctx: ctx=[], d: doc): (ctx, list(report)) => {
+  let (ctx, reports, _) =
+    List.fold_left(
+      ((ctx, reports, index), block) => {
+        let (s, pending) =
+          switch (block) {
+          | Assume(s, _) => (s, None)
+          | Construct(s, tactic) => (s, Some(tactic))
+          };
+        let (ctx, errors) = check_signature(ctx, s);
+        (
+          ctx,
+          [
+            {
+              index,
+              errors,
+              pending,
+            },
+            ...reports,
+          ],
+          index + 1,
+        );
+      },
+      (ctx, [], 0),
+      d,
+    );
+  (ctx, List.rev(reports));
+};
+
+let all_errors = (reports: list(report)): list(BbError.located) =>
+  List.concat_map(r => r.errors, reports);

--- a/src/language/blackboard/BbError.re
+++ b/src/language/blackboard/BbError.re
@@ -1,0 +1,44 @@
+open Sexplib.Std;
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives;
+
+/* Errors reported by the Blackboard checker.  Data only: rendering belongs
+   to whoever shows them (tests, the cursor inspector). */
+
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type t =
+  | Unbound(string)
+  /* term used as a type; it has the given type instead of `type` */
+  | NotAType(BbTerm.t, BbTerm.t)
+  /* head of an application; it has the given non-arrow type */
+  | NotAFunction(BbTerm.t, BbTerm.t)
+  /* function, argument, expected domain, actual type of the argument */
+  | ArgumentMismatch(BbTerm.t, BbTerm.t, BbTerm.t, BbTerm.t);
+
+/* An error attributed to a named signature entry. */
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type located = {
+  entry: string,
+  err: t,
+};
+
+let to_string = (e: t): string => {
+  let s = BbTerm.to_string;
+  switch (e) {
+  | Unbound(x) => "unbound name " ++ x
+  | NotAType(t, ty) =>
+    s(t) ++ " is used as a type, but it has type " ++ s(ty)
+  | NotAFunction(t, ty) =>
+    s(t) ++ " is applied, but it has type " ++ s(ty) ++ ", not an arrow"
+  | ArgumentMismatch(f, a, expected, actual) =>
+    s(f)
+    ++ " expects an argument of type "
+    ++ s(expected)
+    ++ " but "
+    ++ s(a)
+    ++ " has type "
+    ++ s(actual)
+  };
+};
+
+let located_to_string = ({entry, err}: located): string =>
+  entry ++ ": " ++ to_string(err);

--- a/src/language/blackboard/BbError.re
+++ b/src/language/blackboard/BbError.re
@@ -42,3 +42,13 @@ let to_string = (e: t): string => {
 
 let located_to_string = ({entry, err}: located): string =>
   entry ++ ": " ++ to_string(err);
+
+/* The subterm an error is about, when there is one. The editor uses this to
+   place the error on the tile the user got wrong rather than on the whole
+   entry. */
+let subject: t => option(BbTerm.t) =
+  fun
+  | Unbound(_) => None
+  | NotAType(t, _)
+  | NotAFunction(t, _) => Some(t)
+  | ArgumentMismatch(_, a, _, _) => Some(a);

--- a/src/language/blackboard/BbGrammar.re
+++ b/src/language/blackboard/BbGrammar.re
@@ -1,0 +1,70 @@
+open Util;
+
+/* The shape of Blackboard terms as they appear in the editor, polymorphic in
+   the annotation carried at each node (ids, in the editor).  This mirrors
+   the tiles of Form.re one for one; reading these as terms of the core
+   logic is the job of Bb.to_kernel.  In particular the dependent arrow is
+   not a constructor here: `(x : A) -> B` is an Arrow whose domain is a
+   parenthesized membership, and only the kernel reading turns it into a
+   binder. */
+module M =
+       (
+         W: {
+           [@deriving (show({with_path: false}), sexp, yojson, eq)]
+           type t('a, 'b);
+         },
+       ) => {
+  [@deriving (show({with_path: false}), sexp, yojson, eq)]
+  type term('a) =
+    | Hole(hole('a))
+    | Var(Var.t)
+    | Type
+    | Parens(t('a))
+    | Mem(t('a), t('a)) /* t : T; also a signature entry when t is a name */
+    | Arrow(t('a), t('a)) /* A -> B, or (x : A) -> B */
+    | Ap(t('a), t('a)) /* f(a); f(a, b) is Ap(f, Tuple([a, b])) */
+    | Tuple(list(t('a))) /* commas; meaningful only as an argument */
+    | Seq(list(t('a))) /* semicolons: signature entries, document blocks */
+    | Assume(t('a), t('a)) /* assume entries by tactic end */
+    | Construct(t('a), t('a)) /* construct entries by tactic end */
+  and t('a) = W.t(term('a), 'a)
+  and hole('a) =
+    | Invalid(string)
+    | EmptyHole
+    | MultiHole(list(t('a)));
+};
+
+module M_Annotated = M(Annotated);
+include M_Annotated;
+
+
+let rec map_annotation: type a b. (a => b, t(a)) => t(b) =
+  (f, e) => {
+    let go = x => map_annotation(f, x);
+    let term: term(b) =
+      switch (e.term) {
+      | Hole(h) => Hole(map_hole_annotation(f, h))
+      | Var(x) => Var(x)
+      | Type => Type
+      | Parens(t) => Parens(go(t))
+      | Mem(a, b) => Mem(go(a), go(b))
+      | Arrow(a, b) => Arrow(go(a), go(b))
+      | Ap(a, b) => Ap(go(a), go(b))
+      | Tuple(ts) => Tuple(List.map(go, ts))
+      | Seq(ts) => Seq(List.map(go, ts))
+      | Assume(a, b) => Assume(go(a), go(b))
+      | Construct(a, b) => Construct(go(a), go(b))
+      };
+    {
+      term,
+      annotation: f(e.annotation),
+    };
+  }
+
+and map_hole_annotation: type a b. (a => b, hole(a)) => hole(b) =
+  (f, h) =>
+    switch (h) {
+    | Invalid(s) => Invalid(s)
+    | EmptyHole => EmptyHole
+    | MultiHole(ts) => MultiHole(List.map(x => map_annotation(f, x), ts))
+    };

--- a/src/language/blackboard/BbInfo.re
+++ b/src/language/blackboard/BbInfo.re
@@ -1,0 +1,72 @@
+open Util;
+
+/* Per-node static information for Blackboard terms, mirroring DrvInfo.
+   Errors come from BbCheck, which works on kernel terms; they are attached
+   here to the node whose subterm produced them.  Blackboard keeps its own
+   status rather than joining Mark.t, whose declaration order is
+   load-bearing for the other sorts. */
+
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type ancestors = list(Id.t);
+
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type error =
+  /* the term could not be read as a Blackboard document at all */
+  | Malformed(string)
+  /* an error the checker reported, already rendered by BbError */
+  | Check(BbError.t);
+
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type status =
+  | NotInHole
+  | InHole(error);
+
+/* Which kind of block a node sits in, when it sits in one. Used by the
+   editor to tint a block by its modality: what an `assume` block declares
+   is postulated, what a `construct` block declares is a conservative
+   extension that still owes a witness. */
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type modality =
+  | Assume
+  | Construct;
+
+[@deriving (show({with_path: false}), sexp, yojson)]
+type t = {
+  term: Bb.Term.t,
+  cls: Cls.t,
+  ancestors,
+  modality: option(modality),
+  status,
+};
+
+/* The display sort: which block this node sits in, so the code view can
+   tint it. See BbSort. */
+let sort_of: t => BbSort.t =
+  fun
+  | {modality: None, _} => BbSort.Term
+  | {modality: Some(Assume), _} => BbSort.Assumed
+  | {modality: Some(Construct), _} => BbSort.Constructed;
+let cls_of: t => Cls.t = ({cls, _}) => cls;
+let ancestors_of: t => ancestors = ({ancestors, _}) => ancestors;
+let id_of: t => Id.t = ({term, _}) => Bb.Term.rep_id(term);
+let modality_of: t => option(modality) = ({modality, _}) => modality;
+
+let error_of: t => option(error) =
+  fun
+  | {status: NotInHole, _} => None
+  | {status: InHole(err), _} => Some(err);
+
+let is_error: t => bool = t => error_of(t) != None;
+
+let derived = (term: Bb.Term.t, ~ancestors, ~modality, ~status): t => {
+  term,
+  cls: Cls.Bb(Bb.Term.cls_of(term)),
+  ancestors,
+  modality,
+  status,
+};
+
+let message: error => string =
+  fun
+  | Malformed(why) => why
+  | Check(err) => BbError.to_string(err);

--- a/src/language/blackboard/BbParse.re
+++ b/src/language/blackboard/BbParse.re
@@ -1,0 +1,295 @@
+/* A small parser for Blackboard's concrete syntax, close to the paper's
+   listings, for tests and fixtures until the tile-based forms exist.
+
+     term    ::= '(' name+ ':' term ')' '->' term       dependent arrow
+               | mem '->' term                          non-dependent arrow
+               | mem
+     mem     ::= app (':' app)?
+     app     ::= atom+
+     atom    ::= name | 'type' | '(' term ')'
+
+   Documents are line-based: `assume` and `construct` start blocks, `by t`
+   ends one with tactic t (the rest of the line), and every other logical
+   line is `name : term`.  A line beginning with whitespace continues the
+   previous line, so long types may be broken as in the paper.  Braces for
+   implicit arguments and user-defined `syntax` are not supported: write
+   the arguments explicitly, e.g. `eq A a1 a2`.  A multi-name binder
+   `(a1 a2 : A)` abbreviates `(a1 : A) -> (a2 : A)`. */
+
+open BbTerm;
+
+type token =
+  | Ident(string)
+  | LParen
+  | RParen
+  | Colon
+  | Arrow
+  | KwType;
+
+exception Parse_error(string);
+
+let is_ident_start = c =>
+  c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '_';
+let is_ident_char = c =>
+  is_ident_start(c) || c >= '0' && c <= '9' || c == '\'' || c == '-';
+
+/* Tokenize one logical line. */
+let tokenize = (line: string): list(token) => {
+  let n = String.length(line);
+  let rec go = (i, acc) =>
+    if (i >= n) {
+      List.rev(acc);
+    } else {
+      let c = line.[i];
+      if (c == ' ' || c == '\t' || c == '\r') {
+        go(i + 1, acc);
+      } else if (c == '(') {
+        go(i + 1, [LParen, ...acc]);
+      } else if (c == ')') {
+        go(i + 1, [RParen, ...acc]);
+      } else if (c == ':') {
+        go(i + 1, [Colon, ...acc]);
+      } else if (c == '-' && i + 1 < n && line.[i + 1] == '>') {
+        go(i + 2, [Arrow, ...acc]);
+      } else if (i
+                 + 2 < n
+                 && Char.code(c) == 0xE2
+                 && Char.code(line.[i + 1]) == 0x86
+                 && Char.code(line.[i + 2]) == 0x92) {
+        /* the arrow as a UTF-8 character */
+        go(i + 3, [Arrow, ...acc]);
+      } else if (is_ident_start(c)) {
+        let j = ref(i + 1);
+        while (j^ < n
+               && is_ident_char(line.[j^])
+               && !(line.[j^] == '-' && j^ + 1 < n && line.[j^ + 1] == '>')) {
+          incr(j);
+        };
+        let word = String.sub(line, i, j^ - i);
+        let tok = word == "type" ? KwType : Ident(word);
+        go(j^, [tok, ...acc]);
+      } else {
+        raise(
+          Parse_error("unexpected character '" ++ String.make(1, c) ++ "'"),
+        );
+      };
+    };
+  go(0, []);
+};
+
+/* Term parser over an array of tokens. */
+let parse_term_tokens = (toks: array(token)): BbTerm.t => {
+  let n = Array.length(toks);
+  let pos = ref(0);
+  let peek = () => pos^ < n ? Some(toks[pos^]) : None;
+  let advance = () => incr(pos);
+  let expect = (t, what) =>
+    switch (peek()) {
+    | Some(t') when t' == t => advance()
+    | _ => raise(Parse_error("expected " ++ what))
+    };
+  let starts_atom = () =>
+    switch (peek()) {
+    | Some(Ident(_) | KwType | LParen) => true
+    | _ => false
+    };
+  /* At '(': is this `( name+ : ... ) ->`? */
+  let looks_like_binder = () => {
+    let i = ref(pos^ + 1);
+    let names = ref(0);
+    while (i^ < n
+           && (
+             switch (toks[i^]) {
+             | Ident(_) => true
+             | _ => false
+             }
+           )) {
+      incr(names);
+      incr(i);
+    };
+    if (names^ == 0 || i^ >= n || toks[i^] != Colon) {
+      false;
+    } else {
+      /* find the matching ')' */
+      let depth = ref(1);
+      let j = ref(pos^ + 1);
+      while (j^ < n && depth^ > 0) {
+        switch (toks[j^]) {
+        | LParen => incr(depth)
+        | RParen => decr(depth)
+        | _ => ()
+        };
+        incr(j);
+      };
+      depth^ == 0 && j^ < n && toks[j^] == Arrow;
+    };
+  };
+  let rec term = () =>
+    if (peek() == Some(LParen) && looks_like_binder()) {
+      advance();
+      let rec names = acc =>
+        switch (peek()) {
+        | Some(Ident(x)) =>
+          advance();
+          names([x, ...acc]);
+        | _ => List.rev(acc)
+        };
+      let xs = names([]);
+      expect(Colon, "':' in binder");
+      let a = term();
+      expect(RParen, "')' closing binder");
+      expect(Arrow, "'->' after binder");
+      let b = term();
+      List.fold_right((x, body) => Pi(x, a, body), xs, b);
+    } else {
+      let lhs = mem();
+      switch (peek()) {
+      | Some(Arrow) =>
+        advance();
+        Pi("_", lhs, term());
+      | _ => lhs
+      };
+    }
+  and mem = () => {
+    let a = app();
+    switch (peek()) {
+    | Some(Colon) =>
+      advance();
+      Mem(a, app());
+    | _ => a
+    };
+  }
+  and app = () => {
+    let head = atom();
+    let rec args = f => starts_atom() ? args(App(f, atom())) : f;
+    args(head);
+  }
+  and atom = () =>
+    switch (peek()) {
+    | Some(Ident(x)) =>
+      advance();
+      Var(x);
+    | Some(KwType) =>
+      advance();
+      Type;
+    | Some(LParen) =>
+      advance();
+      let t = term();
+      expect(RParen, "')'");
+      t;
+    | Some(_) => raise(Parse_error("unexpected token"))
+    | None => raise(Parse_error("unexpected end of input"))
+    };
+  let t = term();
+  if (pos^ < n) {
+    raise(Parse_error("trailing tokens"));
+  };
+  t;
+};
+
+let term = (s: string): result(BbTerm.t, string) =>
+  switch (parse_term_tokens(Array.of_list(tokenize(s)))) {
+  | t => Ok(t)
+  | exception (Parse_error(msg)) => Error(msg ++ " in: " ++ s)
+  };
+
+/* Logical lines: a line beginning with whitespace continues the previous
+   one; blank lines are skipped. */
+let logical_lines = (s: string): list(string) => {
+  let lines = String.split_on_char('\n', s);
+  let is_blank = l => String.trim(l) == "";
+  let continues = l =>
+    String.length(l) > 0 && (l.[0] == ' ' || l.[0] == '\t');
+  List.fold_left(
+    (acc, l) =>
+      if (is_blank(l)) {
+        acc;
+      } else {
+        switch (acc) {
+        | [prev, ...rest] when continues(l) => [
+            prev ++ " " ++ String.trim(l),
+            ...rest,
+          ]
+        | _ => [String.trim(l), ...acc]
+        };
+      },
+    [],
+    lines,
+  )
+  |> List.rev;
+};
+
+let first_word = (l: string): (string, string) =>
+  switch (String.index_opt(l, ' ')) {
+  | None => (l, "")
+  | Some(i) => (
+      String.sub(l, 0, i),
+      String.trim(String.sub(l, i, String.length(l) - i)),
+    )
+  };
+
+let entry_of_line = (l: string): entry => {
+  switch (String.index_opt(l, ':')) {
+  | None => raise(Parse_error("expected `name : type` in: " ++ l))
+  | Some(i) =>
+    let name = String.trim(String.sub(l, 0, i));
+    if (name == ""
+        || !
+             List.for_all(
+               is_ident_char,
+               List.init(String.length(name), String.get(name)),
+             )) {
+      raise(Parse_error("bad entry name in: " ++ l));
+    };
+    let rest = String.sub(l, i + 1, String.length(l) - i - 1);
+    let ty = parse_term_tokens(Array.of_list(tokenize(rest)));
+    {
+      name,
+      ty,
+    };
+  };
+};
+
+type open_block =
+  | OAssume(list(entry))
+  | OConstruct(list(entry));
+
+let doc = (s: string): result(doc, string) => {
+  let close = (b, tactic) =>
+    switch (b) {
+    | OAssume(es) => Assume(List.rev(es), tactic)
+    | OConstruct(es) =>
+      switch (tactic) {
+      | Some(t) => Construct(List.rev(es), t)
+      | None => raise(Parse_error("construct block without `by`"))
+      }
+    };
+  let step = ((blocks, cur), line) => {
+    let (w, rest) = first_word(line);
+    switch (w, cur) {
+    | ("assume", None) => (blocks, Some(OAssume([])))
+    | ("construct", None) => (blocks, Some(OConstruct([])))
+    | ("assume" | "construct", Some(b)) =>
+      /* a block without `by` ends when the next one starts */
+      let blocks = [close(b, None), ...blocks];
+      (blocks, Some(w == "assume" ? OAssume([]) : OConstruct([])));
+    | ("by", Some(b)) => ([close(b, Some(rest)), ...blocks], None)
+    | ("by", None) => raise(Parse_error("`by` outside a block"))
+    | (_, None) =>
+      raise(Parse_error("declaration outside a block: " ++ line))
+    | (_, Some(OAssume(es))) => (
+        blocks,
+        Some(OAssume([entry_of_line(line), ...es])),
+      )
+    | (_, Some(OConstruct(es))) => (
+        blocks,
+        Some(OConstruct([entry_of_line(line), ...es])),
+      )
+    };
+  };
+  switch (List.fold_left(step, ([], None), logical_lines(s))) {
+  | (blocks, None) => Ok(List.rev(blocks))
+  | (blocks, Some(b)) => Ok(List.rev([close(b, None), ...blocks]))
+  | exception (Parse_error(msg)) => Error(msg)
+  };
+};

--- a/src/language/blackboard/BbSort.re
+++ b/src/language/blackboard/BbSort.re
@@ -1,26 +1,39 @@
 /**
   The sort of Blackboard terms.
 
-  Blackboard's core logic has one syntactic class, and for now the editor
-  uses one sort for everything Blackboard: terms, the `x : T` entries of a
-  signature, and the `assume`/`construct` blocks of a document. Following
-  DrvSort, which does the same for judgments, contexts and propositions
-  because of a remolding issue, the distinctions are made by form label in
-  MakeTerm rather than by sort.
+  Blackboard's core logic has one syntactic class, so [Term] is the only
+  sort the grammar and the molds ever use. [Assumed] and [Constructed] are
+  display-only refinements: statics knows which block a node sits in, and
+  [Info.refine_sort_from_mold] hands that to the code view so the editor can
+  tint a block by what it owes. They are deliberately absent from [all], so
+  nothing tries to mold or remold in them.
+
+  This mirrors DrvSort, where statics likewise refines a single molding sort
+  into the finer sorts the display wants.
  */
 
 [@deriving (show({with_path: false}), sexp, yojson, eq, enumerate)]
 type t =
-  | Term;
+  | Term
+  | Assumed
+  | Constructed;
+
+let all = [Term];
 
 let class_of =
   fun
-  | Term => "Bb";
+  | Term => "Bb"
+  | Assumed => "BbAssume"
+  | Constructed => "BbConstruct";
 
 let to_string =
   fun
-  | Term => "BbTerm";
+  | Term => "BbTerm"
+  | Assumed => "BbAssumed"
+  | Constructed => "BbConstructed";
 
 let to_string_short =
   fun
-  | Term => "Blackboard";
+  | Term => "Blackboard"
+  | Assumed => "Assumed"
+  | Constructed => "Constructed";

--- a/src/language/blackboard/BbSort.re
+++ b/src/language/blackboard/BbSort.re
@@ -1,6 +1,3 @@
-open Sexplib.Std;
-open Ppx_yojson_conv_lib.Yojson_conv.Primitives;
-
 /**
   The sort of Blackboard terms.
 

--- a/src/language/blackboard/BbSort.re
+++ b/src/language/blackboard/BbSort.re
@@ -1,0 +1,29 @@
+open Sexplib.Std;
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives;
+
+/**
+  The sort of Blackboard terms.
+
+  Blackboard's core logic has one syntactic class, and for now the editor
+  uses one sort for everything Blackboard: terms, the `x : T` entries of a
+  signature, and the `assume`/`construct` blocks of a document. Following
+  DrvSort, which does the same for judgments, contexts and propositions
+  because of a remolding issue, the distinctions are made by form label in
+  MakeTerm rather than by sort.
+ */
+
+[@deriving (show({with_path: false}), sexp, yojson, eq, enumerate)]
+type t =
+  | Term;
+
+let class_of =
+  fun
+  | Term => "Bb";
+
+let to_string =
+  fun
+  | Term => "BbTerm";
+
+let to_string_short =
+  fun
+  | Term => "Blackboard";

--- a/src/language/blackboard/BbTerm.re
+++ b/src/language/blackboard/BbTerm.re
@@ -1,0 +1,121 @@
+open Sexplib.Std;
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives;
+
+/* Blackboard core terms: Figure 1 of "Blackboard: A Clean Slate Proof
+   Assistant", in the author's corrected form.  One syntactic class:
+
+     t, T ::= x | t : T | type | (x : T1) -> T2 | t1 t2
+
+   Binders are named, as users write them.  The de Bruijn reference
+   semantics is the Rocq development in metatheory/Blackboard.v. */
+
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type t =
+  | Var(string)
+  | Type
+  | Mem(t, t) /* t : T, internal type membership */
+  | Pi(string, t, t) /* (x : A) -> B */
+  | App(t, t);
+
+/* A signature is an ordered list of declarations; later entries may
+   mention earlier names. */
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type entry = {
+  name: string,
+  ty: t,
+};
+
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type signature = list(entry);
+
+/* Documents are sequences of blocks (paper, Section 3).  An assume block
+   may omit its tactic, as the paper does after the first example. */
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type block =
+  | Assume(signature, option(string))
+  | Construct(signature, string);
+
+[@deriving (show({with_path: false}), sexp, yojson, eq)]
+type doc = list(block);
+
+module S = Set.Make(String);
+
+let rec free_vars = (t: t): S.t =>
+  switch (t) {
+  | Var(x) => S.singleton(x)
+  | Type => S.empty
+  | Mem(a, b)
+  | App(a, b) => S.union(free_vars(a), free_vars(b))
+  | Pi(x, a, b) => S.union(free_vars(a), S.remove(x, free_vars(b)))
+  };
+
+let fresh = (x: string, avoid: S.t): string => {
+  let rec go = y => S.mem(y, avoid) ? go(y ++ "'") : y;
+  go(x);
+};
+
+/* Capture-avoiding substitution t[s/x]. */
+let rec subst = (x: string, s: t, t: t): t =>
+  switch (t) {
+  | Var(z) => z == x ? s : t
+  | Type => Type
+  | Mem(a, b) => Mem(subst(x, s, a), subst(x, s, b))
+  | App(a, b) => App(subst(x, s, a), subst(x, s, b))
+  | Pi(y, a, b) =>
+    let a' = subst(x, s, a);
+    if (y == x) {
+      Pi(y, a', b);
+    } else if (S.mem(y, free_vars(s))) {
+      let avoid = S.union(free_vars(s), S.add(x, free_vars(b)));
+      let y' = fresh(y, avoid);
+      Pi(y', a', subst(x, s, subst(y, Var(y'), b)));
+    } else {
+      Pi(y, a', subst(x, s, b));
+    };
+  };
+
+/* Equality up to renaming of bound variables.  The only notion of "same
+   type" the checker has: the logic has no reduction. */
+let alpha_eq = (t1: t, t2: t): bool => {
+  let rec go = (env: list((string, string)), t1, t2) =>
+    switch (t1, t2) {
+    | (Var(x), Var(y)) =>
+      switch (List.assoc_opt(x, env)) {
+      | Some(y') => y == y'
+      | None => x == y && !List.exists(((_, b)) => b == y, env)
+      }
+    | (Type, Type) => true
+    | (Mem(a, b), Mem(c, d))
+    | (App(a, b), App(c, d)) => go(env, a, c) && go(env, b, d)
+    | (Pi(x, a, b), Pi(y, c, d)) =>
+      go(env, a, c) && go([(x, y), ...env], b, d)
+    | _ => false
+    };
+  go([], t1, t2);
+};
+
+/* Concrete syntax, as the paper writes it: application binds tightest,
+   then membership, then the arrow; the arrow is right-associative and a
+   dependent domain is written as a binder.  A non-dependent arrow whose
+   domain is itself a membership is printed with an explicit `_` binder so
+   that it re-parses unambiguously. */
+let rec print = (p: int, t: t): string => {
+  let paren = (q, s) => q < p ? "(" ++ s ++ ")" : s;
+  switch (t) {
+  | Var(x) => x
+  | Type => "type"
+  | App(f, a) => paren(2, print(2, f) ++ " " ++ print(3, a))
+  | Mem(a, b) => paren(1, print(2, a) ++ " : " ++ print(2, b))
+  | Pi(x, a, b) =>
+    let dependent = S.mem(x, free_vars(b));
+    let dom =
+      switch (a) {
+      | _ when dependent => "(" ++ x ++ " : " ++ print(0, a) ++ ")"
+      | Mem(_) => "(_ : " ++ print(0, a) ++ ")"
+      | _ => print(1, a)
+      };
+    paren(0, dom ++ " -> " ++ print(0, b));
+  };
+};
+
+let to_string: t => string = print(0);

--- a/src/language/blackboard/BbTermBase.re
+++ b/src/language/blackboard/BbTermBase.re
@@ -1,0 +1,10 @@
+/* Blackboard editor terms with ids at every node. */
+
+[@deriving (show({with_path: false}), sexp, yojson)]
+type t = BbGrammar.t(IdTagged.IdTag.t);
+
+[@deriving (show({with_path: false}), sexp, yojson)]
+type term = BbGrammar.term(IdTagged.IdTag.t);
+
+[@deriving (show({with_path: false}), sexp, yojson)]
+type hole = BbGrammar.hole(IdTagged.IdTag.t);

--- a/src/language/blackboard/README.md
+++ b/src/language/blackboard/README.md
@@ -27,5 +27,50 @@ as fixtures. The checker finds the paper's two slips in `cong-ap` and the
 two in `int-elim`, and reports where the paper's examples need equations
 the fragment cannot use.
 
-Plan for the editor integration (sort, forms, statics, inspector) follows
-the ALFA derivation sub-language (`src/language/derivation/`).
+## The editor sort (M1)
+
+`Bb(BbSort.Term)` is a nested sort in `Sort.t`, following the ALFA
+derivation sub-language (`src/language/derivation/`). One sort covers
+terms, signature entries and blocks; the distinctions are made by form,
+as `DrvSort` does for judgments and propositions.
+
+| Module | Role |
+|---|---|
+| `BbSort` | the sub-sort enum |
+| `BbGrammar` | the shape of editor terms, polymorphic in the annotation |
+| `BbTermBase` | the same at `IdTagged`, i.e. with ids |
+| `Bb` | classes for the cursor inspector, and the reading of editor terms as kernel terms, entries, blocks and documents |
+
+Concrete syntax, as molded by `Form.bb_get`:
+
+```
+x                       a name
+type                    the type of types
+t : T                   membership
+A -> B                  function type
+(x : A) -> B            dependent function type: a parenthesized membership
+f(a)   f(a, b)          application, curried
+e1; e2                  signature entries, or blocks
+assume <entries> by <tactic>
+construct <entries> by <tactic>
+blackboard <document> end        embeds a document in an expression
+```
+
+Two things are worth knowing:
+
+- **The colon binds tighter than the arrow**, so that `(x : A) -> x : B`
+  reads as the paper writes it. In a signature entry the colon is a
+  declaration instead, and is loosest; `Bb.rotate_entry` rotates the
+  spine back, so `f : A -> B` declares `f` of type `A -> B`.
+- **Blackboard is a closed sub-language.** `Insert.effective_sort` does
+  not fall back to the enclosing sort inside it, so `type` stays a
+  Blackboard token instead of expanding into Hazel's `type _ = _ in`.
+
+Statics and the cursor inspector are M2: today a `blackboard ... end`
+expression is inert, with an unknown type, and the checker runs only
+from tests.
+
+Documentation slides live in `hazel-programs/docs/blackboard/` and are
+registered in `src/docslides/Slides.re` under `Blackboard / …`. They
+load through the typing parser, since the menhir fast path has no
+Blackboard productions.

--- a/src/language/blackboard/README.md
+++ b/src/language/blackboard/README.md
@@ -1,0 +1,31 @@
+# Blackboard kernel (M0)
+
+The core logic of *Blackboard: A Clean Slate Proof Assistant*, as a small
+OCaml library with no dependence on tiles or the web layer. Specification:
+the author's corrected Figure 1, mechanized in [`../../../mech/Blackboard.v`](../../../mech/Blackboard.v).
+
+| Module | Role |
+|---|---|
+| `BbTerm` | Terms `x`, `t : T`, `type`, `(x : T₁) → T₂`, `t₁ t₂` with named binders; signatures, blocks, documents; substitution, α-equivalence, printing |
+| `BbCheck` | The decidable fragment the paper calls `tychk` (l. 154–156), without conversion: `synth`, `has_type`, `is_type`; `check_signature`, `check_doc` |
+| `BbError` | Errors as data: `Unbound`, `NotAType`, `NotAFunction`, `ArgumentMismatch`; located by signature entry |
+| `BbParse` | The paper's concrete syntax, line-based documents with `assume`/`construct … by tactic` |
+
+Every step of the checker is an instance of a rule of Figure 1 (`hyp`,
+`type`, `ap`, `arrow`, `in`, and `in-` for hypotheses), so what passes is
+derivable. Two Blackboard-specific readings matter: `(t : T) : type` needs
+only that `T` is a type and `t` has *some* type (l. 80); and a hypothesis
+`h : (t : T)` in the context establishes `t : T`, which the refinement and
+intersection eliminators of Section 4 rely on.
+
+Not here yet: implicit arguments, user `syntax`, tactics, equations used as
+rewriting. Construct blocks have their signatures checked and their `by`
+obligation reported as pending.
+
+Tests: `test/blackboard/Test_Blackboard.re`, using the paper's signatures
+as fixtures. The checker finds the paper's two slips in `cong-ap` and the
+two in `int-elim`, and reports where the paper's examples need equations
+the fragment cannot use.
+
+Plan for the editor integration (sort, forms, statics, inspector) follows
+the ALFA derivation sub-language (`src/language/derivation/`).

--- a/src/language/dynamics/DHExp.re
+++ b/src/language/dynamics/DHExp.re
@@ -116,6 +116,7 @@ let ty_subst = (s: Typ.t, tpat: TPat.t, exp: t): t => {
           | Var(_)
           | Atom(_)
           | DrvQuote(_)
+          | BbQuote(_)
           | MultiHole(_)
           | Deferral(_)
           | TyAlias(_)
@@ -191,6 +192,8 @@ let rec ty_comparable = (d1, d2) => {
   | (Atom(_), _) => false
   | (DrvQuote(_, t1), DrvQuote(_, t2)) => t1 == t2
   | (DrvQuote(_, _), _) => false
+  | (BbQuote(b1), BbQuote(b2)) => b1 == b2
+  | (BbQuote(_), _) => false
   | (Label(l1), Label(l2)) => l1 == l2
   | (Label(_), _) => false
   | (TupLabel(l1, d1), TupLabel(l2, d2)) =>
@@ -304,6 +307,8 @@ let rec poly_equal = (d1, d2): option(bool) => {
   | (DrvQuote(d1, _), DrvQuote(d2, _)) =>
     Drv.Any.eq(d1, d2, ~skip_hole=false) |> Option.some
   | (DrvQuote(_, _), _) => None
+  | (BbQuote(b1), BbQuote(b2)) => b1 == b2 |> Option.some
+  | (BbQuote(_), _) => None
   | (Label(l1), Label(l2)) => l1 == l2 ? Some(true) : None
   | (Label(_), _) => None
   | (ExplicitNonlabel, ExplicitNonlabel) => Some(true)

--- a/src/language/dynamics/Substitution.re
+++ b/src/language/dynamics/Substitution.re
@@ -77,6 +77,7 @@ let rec in_exp = (env: Environment.t(Exp.t), exp: Exp.t) =>
         | Deferral(_)
         | Atom(_)
         | DrvQuote(_)
+        | BbQuote(_)
         | ListLit(_)
         | Constructor(_)
         | TypFun(_)

--- a/src/language/dynamics/transition/Ascriptions.re
+++ b/src/language/dynamics/transition/Ascriptions.re
@@ -282,6 +282,7 @@ let rec transition = (~recursive=false, d: DHExp.t): option(DHExp.t) => {
     // These are handled above and must have the wrong type
     | (Atom(_), _)
     | (DrvQuote(_), _)
+    | (BbQuote(_), _)
     | (ListLit(_), _)
     | (TupLabel(_), _)
     | (Tuple(_), _)

--- a/src/language/dynamics/transition/Transition.re
+++ b/src/language/dynamics/transition/Transition.re
@@ -828,6 +828,10 @@ module Transition = (EV: EV_MODE) => {
     | BuiltinFun(_) =>
       let. _ = otherwise(env, d);
       Constructor;
+    /* A Blackboard document does not evaluate; it is already a value. */
+    | BbQuote(_) =>
+      let. _ = otherwise(env, d);
+      Constructor;
     | DrvQuote(_) =>
       let. _ = otherwise(env, d);
       let d' = drv_transition(env, d);

--- a/src/language/dynamics/transition/Unboxing.re
+++ b/src/language/dynamics/transition/Unboxing.re
@@ -184,7 +184,8 @@ let rec unbox: type a. (unbox_request(a), DHExp.t) => unboxed(a) =
     /* Forms that are the wrong type of value - these cases indicate an error */
     | (
         _,
-        Atom(_) | DrvQuote(_) | Label(_) | Constructor(_) | BuiltinFun(_) |
+        Atom(_) | DrvQuote(_) | BbQuote(_) | Label(_) | Constructor(_) |
+        BuiltinFun(_) |
         Deferral(_) |
         DeferredAp(_) |
         ListLit(_) |

--- a/src/language/proof/MatchExp.re
+++ b/src/language/proof/MatchExp.re
@@ -189,6 +189,8 @@ let rec match_exp =
       when DrvTermBase.Any.eq(e1, e2, ~skip_hole=false) =>
     Some(ctx)
   | (DrvQuote(_), _) => None
+  | (BbQuote(b1), BbQuote(b2)) when b1 == b2 => Some([])
+  | (BbQuote(_), _) => None
   | (If(e1, e2, e3), If(e4, e5, e6)) =>
     let* ctx = match_exp(alphas, ctx, e1, e4);
     let* ctx = match_exp(alphas, ctx, e2, e5);

--- a/src/language/proof/ProofHacks.re
+++ b/src/language/proof/ProofHacks.re
@@ -432,6 +432,7 @@ let rec replace_exp =
         | Deferral(_)
         | Atom(_)
         | DrvQuote(_, _)
+        | BbQuote(_)
         | ListLit(_)
         | Constructor(_)
         | TypFun(_)

--- a/src/language/statics/Info.re
+++ b/src/language/statics/Info.re
@@ -138,6 +138,7 @@ type secondary = {
 [@deriving (show({with_path: false}), sexp, yojson)]
 type t =
   | InfoDrv(DrvInfo.t)
+  | InfoBb(BbInfo.t)
   | InfoExp(exp)
   | InfoPat(pat)
   | InfoTyp(typ)
@@ -152,6 +153,7 @@ type t =
 let sort_of: t => Sort.t =
   fun
   | InfoDrv(drv) => Drv(DrvInfo.sort_of(drv))
+  | InfoBb(bb) => Bb(BbInfo.sort_of(bb))
   | InfoExp({cls: Mod(_), _}) => Mod
   | InfoExp(_) => Exp
   | InfoPat(_) => Pat
@@ -176,17 +178,26 @@ let refine_sort_from_mold =
     | Some(InfoDrv(drv)) => Drv(DrvInfo.sort_of(drv))
     | _ => mold_out
     }
+  /* Blackboard molds are all Bb(Term); statics refines them to Bb(Assumed)
+     or Bb(Constructed) so a block can be tinted by its modality. */
+  | Bb(_) =>
+    switch (Id.Map.find_opt(id, info_map)) {
+    | Some(InfoBb(bb)) => Bb(BbInfo.sort_of(bb))
+    | _ => mold_out
+    }
   | _ => mold_out
   };
 
 let class_of: t => string =
   fun
   | InfoDrv(drv) => DrvInfo.sort_of(drv) |> DrvSort.class_of
+  | InfoBb(bb) => BbInfo.sort_of(bb) |> BbSort.class_of
   | _ as i => sort_of(i) |> Sort.show;
 
 let cls_of: t => Cls.t =
   fun
   | InfoDrv(drv) => DrvInfo.cls_of(drv)
+  | InfoBb(bb) => BbInfo.cls_of(bb)
   | InfoExp({cls, _})
   | InfoPat({cls, _})
   | InfoTyp({cls, _})
@@ -212,6 +223,7 @@ let cls_label = (info: t): string =>
 let any_of: t => option(Any.t) =
   fun
   | InfoDrv({term, _}) => Some(Drv(term))
+  | InfoBb({term, _}) => Some(Bb(term))
   | InfoExp({user_term, _}) => Some(Exp(user_term))
   | InfoPat({user_term, _}) => Some(Pat(user_term))
   | InfoTyp({user_term, _}) => Some(Typ(user_term))
@@ -223,7 +235,8 @@ let any_of: t => option(Any.t) =
 
 let ctx_of: t => Ctx.t =
   fun
-  | InfoDrv(_) => Ctx.empty_pre_elaboration
+  | InfoDrv(_)
+  | InfoBb(_) => Ctx.empty_pre_elaboration
   | InfoExp({ctx, _})
   | InfoPat({ctx, _})
   | InfoTyp({ctx, _})
@@ -236,6 +249,7 @@ let ctx_of: t => Ctx.t =
 let ancestors_of: t => ancestors =
   fun
   | InfoDrv(drv) => DrvInfo.ancestors_of(drv)
+  | InfoBb(bb) => BbInfo.ancestors_of(bb)
   | InfoExp({ancestors, _})
   | InfoPat({ancestors, _})
   | InfoTyp({ancestors, _})
@@ -251,6 +265,7 @@ let parent_id_of: t => option(Id.t) =
 let id_of: t => Id.t =
   fun
   | InfoDrv(drv) => DrvInfo.id_of(drv)
+  | InfoBb(bb) => BbInfo.id_of(bb)
   | InfoExp(i) => Exp.rep_id(i.user_term)
   | InfoPat(i) => Pat.rep_id(i.user_term)
   | InfoTyp(i) => Typ.rep_id(i.user_term)
@@ -267,6 +282,7 @@ let marks_of: t => list(Mark.t) =
   | InfoTyp({marks, _})
   | InfoTPat({marks, _}) => marks
   | InfoDrv(_) /* Drv errors are tracked separately via DrvInfo.error_of. */
+  | InfoBb(_) /* Likewise Blackboard, via BbInfo.error_of. */
   | InfoMod(_)
   | InfoSig(_)
   | InfoMPat(_)
@@ -277,6 +293,7 @@ let marks_of: t => list(Mark.t) =
 let is_error = (ci: t): bool =>
   switch (ci) {
   | InfoDrv(drv) => DrvInfo.is_error(drv)
+  | InfoBb(bb) => BbInfo.is_error(bb)
   | _ => marks_of(ci) != []
   };
 
@@ -287,6 +304,7 @@ let warnings_of: t => list(Warning.list_item) =
   | InfoTyp({warnings, _})
   | InfoTPat({warnings, _}) => warnings
   | InfoDrv(_)
+  | InfoBb(_)
   | InfoMod(_)
   | InfoSig(_)
   | InfoMPat(_)
@@ -314,6 +332,7 @@ let is_typable_term: option(t) => bool =
     ) =>
     false
   | Some(InfoExp(_) | InfoPat(_)) => true
+  | Some(_)
   | None => false;
 
 let exp_co_ctx: exp => CoCtx.t = ({co_ctx, _}) => co_ctx;

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -11,6 +11,164 @@ include StaticsBase;
 let add_info = Map.add_info;
 let add_missing_info = Map.add_missing_info;
 
+/* BLACKBOARD STATICS
+
+   The Blackboard sort contains no Hazel subterms, so this does not take
+   part in the mutual recursion below.
+
+   Checking is per entry, not per document. A document that is half written,
+   or that has one malformed entry, must still report what it can about the
+   rest: an all-or-nothing check goes silent exactly when the user has just
+   made a mistake. So each signature entry is read and checked on its own,
+   in the context of the entries before it, and produces either a syntax
+   error (it could not be read as an entry at all) or the checker's errors.
+
+   Errors land on the name the user got wrong where that name is
+   identifiable, and on the entry otherwise. */
+let bb_to_info_map = (b: Bb.Term.t, m: Map.t, ~ancestors): Map.t => {
+  let statuses: ref(Id.Map.t(BbInfo.status)) = ref(Id.Map.empty);
+  let mark = (id, st) => statuses := Id.Map.add(id, st, statuses^);
+
+  /* Put an unbound-name error on every occurrence of that name. */
+  let rec mark_var = (t: Bb.Term.t, x: string, st) => {
+    switch (Bb.Term.term_of(t)) {
+    | Var(y) when y == x => mark(Bb.Term.rep_id(t), st)
+    | Var(_)
+    | Type
+    | Hole(Invalid(_) | EmptyHole) => ()
+    | Parens(a) => mark_var(a, x, st)
+    | Mem(a, b)
+    | Arrow(a, b)
+    | Ap(a, b) =>
+      mark_var(a, x, st);
+      mark_var(b, x, st);
+    | Tuple(ts)
+    | Seq(ts)
+    | Hole(MultiHole(ts)) => List.iter(t => mark_var(t, x, st), ts)
+    | Assume(a, b)
+    | Construct(a, b) =>
+      mark_var(a, x, st);
+      mark_var(b, x, st);
+    };
+  };
+
+  /* Check one entry in ctx, recording its errors; return the extended ctx. */
+  let check_entry = (item: Bb.Term.t, ctx: BbCheck.ctx): BbCheck.ctx =>
+    switch (Bb.rotate_entry(item)) {
+    | None =>
+      mark(
+        Bb.Term.rep_id(item),
+        BbInfo.InHole(
+          Malformed("a signature entry has the form  name : type"),
+        ),
+      );
+      ctx;
+    | Some((name, ty_term)) =>
+      switch (Bb.term_to_kernel(ty_term)) {
+      | Error({id, message}) =>
+        mark(id, BbInfo.InHole(Malformed(message)));
+        ctx;
+      | Ok(ty) =>
+        List.iter(
+          (err: BbError.t) =>
+            switch (err) {
+            | Unbound(x) => mark_var(ty_term, x, BbInfo.InHole(Check(err)))
+            | _ =>
+              let on =
+                switch (BbError.subject(err)) {
+                | Some(sub) =>
+                  /* place it on the subterm that is wrong, when we can find
+                     it; otherwise on the entry */
+                  let found = ref(None);
+                  let rec search = (t: Bb.Term.t) =>
+                    if (found^ == None) {
+                      switch (Bb.term_to_kernel(t)) {
+                      | Ok(k) when BbTerm.alpha_eq(k, sub) =>
+                        found := Some(Bb.Term.rep_id(t))
+                      | _ =>
+                        switch (Bb.Term.term_of(t)) {
+                        | Parens(a) => search(a)
+                        | Mem(a, b)
+                        | Arrow(a, b)
+                        | Ap(a, b) =>
+                          search(a);
+                          search(b);
+                        | Tuple(ts)
+                        | Seq(ts)
+                        | Hole(MultiHole(ts)) => List.iter(search, ts)
+                        | _ => ()
+                        }
+                      };
+                    };
+                  search(ty_term);
+                  Option.value(found^, ~default=Bb.Term.rep_id(item));
+                | None => Bb.Term.rep_id(item)
+                };
+              mark(on, BbInfo.InHole(Check(err)));
+            },
+          BbCheck.is_type(ctx, ty),
+        );
+        [(name, ty), ...ctx];
+      }
+    };
+
+  /* Walk the document, threading the context across blocks so a construct
+     block sees the names an earlier assume block introduced. */
+  let check_block = (blk: Bb.Term.t, ctx: BbCheck.ctx): BbCheck.ctx =>
+    switch (Bb.Term.term_of(blk)) {
+    | Assume(entries, _)
+    | Construct(entries, _) =>
+      List.fold_left(
+        (ctx, item) => check_entry(item, ctx),
+        ctx,
+        Bb.items_of(entries),
+      )
+    /* Not a block: nothing to check here. A bare term is a legitimate
+       thing to be holding mid-edit. */
+    | _ => ctx
+    };
+  let _ =
+    List.fold_left(
+      (ctx, blk) => check_block(blk, ctx),
+      [],
+      Bb.items_of(b),
+    );
+
+  /* Second pass: give every node an info entry, so the cursor inspector has
+     something to say anywhere, and attach the statuses found above. */
+  let rec go = (t: Bb.Term.t, m: Map.t, ~modality, ~ancestors): Map.t => {
+    let term = Bb.Term.term_of(t);
+    let status =
+      Id.Map.find_opt(Bb.Term.rep_id(t), statuses^)
+      |> Option.value(~default=BbInfo.NotInHole);
+    let info = BbInfo.derived(t, ~ancestors, ~modality, ~status);
+    let anc = [Bb.Term.rep_id(t), ...ancestors];
+    let child = (x, m) => go(x, m, ~modality, ~ancestors=anc);
+    let block = (entries, tactic, mod_, m) =>
+      m
+      |> go(entries, ~modality=Some(mod_), ~ancestors=anc)
+      |> go(tactic, ~modality=Some(mod_), ~ancestors=anc);
+    let m =
+      switch (term) {
+      | Hole(MultiHole(ts)) => List.fold_left((m, x) => child(x, m), m, ts)
+      | Hole(_)
+      | Var(_)
+      | Type => m
+      | Parens(x) => child(x, m)
+      | Mem(a, b)
+      | Arrow(a, b)
+      | Ap(a, b) => m |> child(a) |> child(b)
+      | Tuple(ts)
+      | Seq(ts) => List.fold_left((m, x) => child(x, m), m, ts)
+      | Assume(entries, tactic) => block(entries, tactic, BbInfo.Assume, m)
+      | Construct(entries, tactic) =>
+        block(entries, tactic, BbInfo.Construct, m)
+      };
+    add_info(Bb.Term.ids(t), InfoBb(info), m);
+  };
+  go(b, m, ~modality=None, ~ancestors);
+};
+
 let rec any_to_info_map =
         (
           ~ctx: Ctx.t,
@@ -48,7 +206,7 @@ let rec any_to_info_map =
     let m = drv_to_info_map(drv, m, ~ctx, ~ancestors, ~sort=Jdmt);
     (CoCtx.empty, Drv(drv), m);
   /* Blackboard statics arrive with the next milestone. */
-  | Bb(b) => (CoCtx.empty, Bb(b), m)
+  | Bb(b) => (CoCtx.empty, Bb(b), bb_to_info_map(b, m, ~ancestors))
   | Rul(r) => rul_to_info_map(~ctx, ~ancestors, ~probe_ids, r, m)
   | Mod(m_term) => mod_to_info_map(~ctx, ~ancestors, ~probe_ids, m_term, m)
   | Sig(s_term) => sig_to_info_map(~ctx, ~ancestors, ~probe_ids, s_term, m)
@@ -476,13 +634,14 @@ and uexp_to_info_map =
        no interesting Hazel type yet.  Checking the document itself, and a
        type that reflects it, arrive with the Blackboard statics. */
     | BbQuote(b) =>
+      let m = bb_to_info_map(b, m, ~ancestors=ancestors_inclusive);
       add(
         ~elab_term=BbQuote(b) |> rewrap,
         ~elab_syn_ty=Unknown(Internal) |> Typ.temp,
         ~marks=[],
         ~co_ctx=CoCtx.empty,
         m,
-      )
+      );
     | Atom(c) =>
       // Replace literal if necessary due to `use` or ana
       let c =

--- a/src/language/statics/Statics.re
+++ b/src/language/statics/Statics.re
@@ -47,6 +47,8 @@ let rec any_to_info_map =
   | Drv(drv) =>
     let m = drv_to_info_map(drv, m, ~ctx, ~ancestors, ~sort=Jdmt);
     (CoCtx.empty, Drv(drv), m);
+  /* Blackboard statics arrive with the next milestone. */
+  | Bb(b) => (CoCtx.empty, Bb(b), m)
   | Rul(r) => rul_to_info_map(~ctx, ~ancestors, ~probe_ids, r, m)
   | Mod(m_term) => mod_to_info_map(~ctx, ~ancestors, ~probe_ids, m_term, m)
   | Sig(s_term) => sig_to_info_map(~ctx, ~ancestors, ~probe_ids, s_term, m)
@@ -470,6 +472,17 @@ and uexp_to_info_map =
         ~co_ctx=CoCtx.empty,
         m,
       );
+    /* A Blackboard document is inert in an expression: it has no value and
+       no interesting Hazel type yet.  Checking the document itself, and a
+       type that reflects it, arrive with the Blackboard statics. */
+    | BbQuote(b) =>
+      add(
+        ~elab_term=BbQuote(b) |> rewrap,
+        ~elab_syn_ty=Unknown(Internal) |> Typ.temp,
+        ~marks=[],
+        ~co_ctx=CoCtx.empty,
+        m,
+      )
     | Atom(c) =>
       // Replace literal if necessary due to `use` or ana
       let c =

--- a/src/language/term/Abbreviate.re
+++ b/src/language/term/Abbreviate.re
@@ -514,6 +514,7 @@ let rec abbreviate_exp = (exp: Exp.t): Exp.t => {
           Atom(String(str));
         };
       | DrvQuote(_, _) => Invalid("<drv term>")
+      | BbQuote(_) => Invalid("<blackboard document>")
       | Var(v) => Var(abbreviate_str(available^, v))
       | Label(v) =>
         switch (abbreviate_label(v)) {
@@ -1795,6 +1796,7 @@ and abbreviate_any = (any: Any.t): Any.t =>
   | TPat(tp) => TPat(abbreviate_tpat(tp))
   | Rul(_) => any
   | Drv(_) => any
+  | Bb(_) => any
   | Mod(m) => Mod(abbreviate_mod_item(m))
   | Sig(s) => Sig(abbreviate_sig_item(s))
   | MPat(mp) => MPat(abbreviate_mpat(mp))

--- a/src/language/term/Any.re
+++ b/src/language/term/Any.re
@@ -33,6 +33,24 @@ let drv_hole = (tms: list(TermBase.Any.t)): DrvTermBase.type_hole =>
     | tms => DrvGrammar.MultiHole(tms)
   );
 
+let is_bb: t => option(BbTermBase.t) =
+  fun
+  | Bb(b) => Some(b)
+  | _ => None;
+
+let bb_hole = (tms: list(TermBase.Any.t)): BbTermBase.hole =>
+  tms
+  |> List.filter_map(
+       fun
+       | Grammar.Bb(b) => Some(b)
+       | _ => None,
+     )
+  |> (
+    fun
+    | [] => BbGrammar.EmptyHole
+    | tms => BbGrammar.MultiHole(tms)
+  );
+
 let is_mod: t => option(TermBase.Mod.t) =
   fun
   | Mod(m) => Some(m)
@@ -51,6 +69,7 @@ let rec ids: TermBase.any_t => list(Id.t) =
   | TPat(tm) => IdTagged.ids(tm)
   | Rul(tm) => Rul.ids(~any_ids=ids, tm)
   | Drv(tm) => Drv.Any.ids(tm)
+  | Bb(tm) => IdTagged.ids(tm)
   | Mod(tm) => IdTagged.ids(tm)
   | Sig(tm) => IdTagged.ids(tm)
   | MPat(tm) => IdTagged.ids(tm)
@@ -75,6 +94,7 @@ let rep_id =
   | TPat(tm) => TPat.rep_id(tm)
   | Rul(tm) => Rul.rep_id(~any_ids=ids, tm)
   | Drv(tm) => Drv.Any.rep_id(tm)
+  | Bb(tm) => IdTagged.rep_id(tm)
   | Mod(tm) => IdTagged.rep_id(tm)
   | Sig(tm) => IdTagged.rep_id(tm)
   | MPat(tm) => IdTagged.rep_id(tm)

--- a/src/language/term/Cls.re
+++ b/src/language/term/Cls.re
@@ -1,6 +1,7 @@
 [@deriving (show({with_path: false}), sexp, yojson, enumerate)]
 type t =
   | Drv(Drv.Any.cls)
+  | Bb(Bb.Term.cls)
   | Exp(Exp.cls)
   | Pat(Pat.cls)
   | Typ(Typ.cls)
@@ -14,6 +15,7 @@ type t =
 let show = (cls: t) =>
   switch (cls) {
   | Drv(cls) => "ALFA " ++ Drv.Any.show_cls(cls)
+  | Bb(cls) => "Blackboard " ++ Bb.Term.show_cls(cls)
   | Exp(cls) => Exp.show_cls(cls)
   | Pat(cls) => Pat.show_cls(cls)
   | Typ(cls) => Typ.show_cls(cls)

--- a/src/language/term/Equality.re
+++ b/src/language/term/Equality.re
@@ -438,6 +438,8 @@ let equality =
     | (ModuleExp(_, _, _), _) => false
     | (DrvQuote(d1, s1), DrvQuote(d2, s2)) => s1 == s2 && d1 == d2
     | (DrvQuote(_, _), _) => false
+    | (BbQuote(b1), BbQuote(b2)) => b1 == b2
+    | (BbQuote(_), _) => false
     };
   }
   /* Compare patterns with literal variable names (no alpha-renaming).
@@ -884,6 +886,8 @@ let equality =
     | (Any (), _) => false
     | (Drv(d1), Drv(d2)) => d1 == d2
     | (Drv(_), _) => false
+    | (Bb(b1), Bb(b2)) => b1 == b2
+    | (Bb(_), _) => false
     };
   };
 

--- a/src/language/term/Exp.re
+++ b/src/language/term/Exp.re
@@ -8,6 +8,7 @@ type cls =
   | Undefined
   | Atom(Atom.cls)
   | DrvQuote
+  | BbQuote
   | ListLit
   | Constructor
   | Fun
@@ -100,6 +101,7 @@ let rec cls_of_term: type a. Grammar.exp_term(a) => cls =
   | Undefined => Undefined
   | Atom(c) => Atom(Atom.cls_of_t(c))
   | DrvQuote(_) => DrvQuote
+  | BbQuote(_) => BbQuote
   | ListLit(_) => ListLit
   | Constructor(_) => Constructor
   | Fun(_) => Fun
@@ -161,6 +163,7 @@ let show_cls: cls => string =
   | Atom(Nat) => "Natural number literal"
   | Atom(SInt) => "System integer literal"
   | DrvQuote => "Derivation-Mode Quotation"
+  | BbQuote => "Blackboard Document"
   | ListLit => "List literal"
   | Constructor => "Constructor"
   | Fun => "Function literal"
@@ -256,6 +259,7 @@ let rec is_fun = (e: t) => {
   | Undefined
   | Atom(_)
   | DrvQuote(_)
+  | BbQuote(_)
   | Label(_)
   | ExplicitNonlabel
   | ListLit(_)
@@ -323,6 +327,7 @@ let rec is_tuple_of_functions = (e: t) =>
     | Undefined
     | Atom(_)
     | DrvQuote(_)
+    | BbQuote(_)
     | Label(_)
     | ExplicitNonlabel
     | ListLit(_)
@@ -424,6 +429,7 @@ let rec get_num_of_functions = (e: t) =>
     | Module(_)
     | ModuleExp(_)
     | DrvQuote(_) => None
+    | BbQuote(_) => None
     };
   };
 

--- a/src/language/term/Grammar.re
+++ b/src/language/term/Grammar.re
@@ -20,6 +20,7 @@ type any_t('a) =
   | TPat(tpat_t('a))
   | Rul(rul_t('a))
   | Drv(DrvGrammar.any_t('a))
+  | Bb(BbGrammar.t('a))
   | Mod(mod_t('a))
   | Sig(sig_t('a))
   | MPat(mpat_t('a))
@@ -33,6 +34,7 @@ and exp_term('a) =
   | Undefined
   | Atom(Atom.t)
   | DrvQuote(DrvGrammar.any_t('a), DrvSort.t)
+  | BbQuote(BbGrammar.t('a))
   | ListLit(list(exp_t('a)))
   /* The type double-option field of this constructor is required to assign the correct
      statics to constructors after evaluation. In dynamic expressions `Some(None)` means
@@ -185,6 +187,7 @@ let rec map_exp_annotation: type a b. (a => b, exp_t(a)) => exp_t(b) =
         | Undefined => Undefined
         | Atom(c) => Atom(c)
         | DrvQuote(d, s) => DrvQuote(DrvGrammar.map_any_annotation(f, d), s)
+        | BbQuote(b) => BbQuote(BbGrammar.map_annotation(f, b))
         | LivelitName(s) => LivelitName(s)
         | ListLit(l) => ListLit(List.map(x => map_exp_annotation(f, x), l))
         | Constructor(s, t) =>
@@ -312,6 +315,7 @@ and map_any_annotation: 'a 'b. ('a => 'b, any_t('a)) => any_t('b) =
     | TPat(tp) => TPat(map_tpat_annotation(f, tp))
     | Rul(r) => Rul(map_rul_annotation(f, r))
     | Drv(d) => Drv(DrvGrammar.map_any_annotation(f, d))
+    | Bb(b) => Bb(BbGrammar.map_annotation(f, b))
     | Mod(m) => Mod(map_mod_annotation(f, m))
     | Sig(s) => Sig(map_sig_annotation(f, s))
     | MPat(mp) => MPat(map_mpat_annotation(f, mp))
@@ -545,6 +549,12 @@ module Factory = (DefaultAnnotation: DefaultAnnotation) => {
 
   let default_annotation = ann =>
     Option.value(~default=DefaultAnnotation.default_value(), ann);
+  module BbGrammar = {
+    let placeholder = (~ann=?, ()): BbGrammar.t(DefaultAnnotation.t) => {
+      term: BbGrammar.Hole(EmptyHole),
+      annotation: default_annotation(ann),
+    };
+  };
   module DrvGrammar = {
     let placeholder = (~ann=?, ()): DrvGrammar.any_t(DefaultAnnotation.t) =>
       DrvGrammar.Exp({
@@ -606,6 +616,10 @@ module Factory = (DefaultAnnotation: DefaultAnnotation) => {
     };
     let nat = (~ann=?, i): exp_t(DefaultAnnotation.t) => {
       term: Atom(Nat(i)),
+      annotation: default_annotation(ann),
+    };
+    let bb_exp = (~ann=?, b): exp_t(DefaultAnnotation.t) => {
+      term: BbQuote(b),
       annotation: default_annotation(ann),
     };
     let drv_exp = (~ann=?, d, s): exp_t(DefaultAnnotation.t) => {

--- a/src/language/term/Sort.re
+++ b/src/language/term/Sort.re
@@ -1,6 +1,7 @@
 [@deriving (show({with_path: false}), sexp, yojson, eq)]
 type t =
   | Drv(DrvSort.t)
+  | Bb(BbSort.t)
   | Any
   | Pat
   | Typ
@@ -14,12 +15,23 @@ type t =
 let to_string =
   fun
   | Drv(s) => DrvSort.to_string(s)
+  | Bb(s) => BbSort.to_string(s)
   | _ as s => show(s);
 
 let class_of =
   fun
   | Drv(s) => DrvSort.class_of(s)
+  | Bb(s) => BbSort.class_of(s)
   | _ as s => show(s);
 
+/* Blackboard is a closed sub-language: its tiles never mix with Hazel's.
+   See Insert.effective_sort. */
+let is_bb =
+  fun
+  | Bb(_) => true
+  | _ => false;
+
 let all =
-  (DrvSort.all |> List.map(s => Drv(s))) @ [Any, Pat, Typ, Rul, Exp, TPat];
+  (DrvSort.all |> List.map(s => Drv(s)))
+  @ (BbSort.all |> List.map(s => Bb(s)))
+  @ [Any, Pat, Typ, Rul, Exp, TPat];

--- a/src/language/term/TermBase.re
+++ b/src/language/term/TermBase.re
@@ -129,6 +129,8 @@ module rec Any: {
       /* Drv terms have their own traversal machinery in DrvTermBase; the
          generic Any.map_term doesn't descend into them. */
       | Drv(x) => Drv(x)
+      /* Blackboard terms likewise. */
+      | Bb(x) => Bb(x)
       | Mod(x) =>
         Mod(Mod.map_term(~f_exp, ~f_pat, ~f_typ, ~f_tpat, ~f_rul, ~f_any, x))
       | Sig(x) =>
@@ -207,6 +209,7 @@ and Exp: {
         | Invalid(_)
         | Atom(_)
         | DrvQuote(_)
+        | BbQuote(_)
         | Constructor(_)
         | Label(_)
         | ExplicitNonlabel

--- a/src/menhirParser/Conversion.re
+++ b/src/menhirParser/Conversion.re
@@ -426,6 +426,7 @@ module rec Exp: {
        converting core DrvQuote values back to the menhir AST is not
        meaningful. */
     | DrvQuote(_) => raise(Failure("DrvQuote not supported"))
+    | BbQuote(_) => raise(Failure("BbQuote not supported"))
     | Projector(_, e) => of_core(e)
     | Module(items) => Module(List.map(ModItem.of_core, items))
     | ModuleExp(mp, def, body) =>

--- a/src/web/app/editors/EditorUtil.re
+++ b/src/web/app/editors/EditorUtil.re
@@ -24,6 +24,7 @@ let rec append_exp = (e1: Language.Exp.t, e2: Language.Exp.t): Language.Exp.t =>
   | Deferral(_)
   | Atom(_)
   | DrvQuote(_)
+  | BbQuote(_)
   | ListLit(_)
   | TupleExtension(_)
   | ExplicitNonlabel

--- a/src/web/app/editors/code/Code.re
+++ b/src/web/app/editors/code/Code.re
@@ -123,6 +123,9 @@ let view =
          strict sort equality with the statics-refined sort would spuriously
          flag judgments/contexts/propositions as inconsistent. */
       | (Drv(_), _) => true
+      /* Likewise Blackboard: molds are all Bb(Term), and statics refines
+         them to Bb(Assumed)/Bb(Constructed) purely for display. */
+      | (Bb(_), _) => true
       | _ => sort == data.sort
       }
     };

--- a/src/web/app/explainthis/ExplainThis.re
+++ b/src/web/app/explainthis/ExplainThis.re
@@ -741,6 +741,10 @@ let decide =
         Markdown(
           "A derivation-mode quotation embeds a derivation-mode term into a regular expression. There are 5 forms of quotation:\n1) `of_jdmt`\n2) `of_ctx`\n3) `of_prop`\n4) `of_alfa_exp`\n5) `of_alfa_typ`",
         )
+      | BbQuote(_) =>
+        Markdown(
+          "A `blackboard ... end` block embeds a Blackboard document into a regular expression. A document is a sequence of `assume` and `construct` blocks, separated by `;`.",
+        )
       | Invalid(_) => Prose("Not a valid expression")
       | DynamicErrorHole(_)
       | Closure(_) => Prose("Internal expression")

--- a/src/web/app/explainthis/ExplainThis.re
+++ b/src/web/app/explainthis/ExplainThis.re
@@ -1547,6 +1547,18 @@ let decide =
       | TPat(tpat) => DrvDoc.tpat_form(tpat)
       };
     DrvSyntax(syntax, msg);
+  | Some(InfoBb(i)) =>
+    switch (BbInfo.modality_of(i)) {
+    | Some(Assume) =>
+      Prose(
+        "An assumption block postulates names. Its only obligation is that each declared type is a type.",
+      )
+    | Some(Construct) =>
+      Prose(
+        "A construction block claims a conservative extension: the signature must be shown inhabited, and the witness is then discarded.",
+      )
+    | None => Prose("A Blackboard term")
+    }
   | Some(Secondary(s)) =>
     switch (s.cls) {
     | Secondary(Whitespace) => Prose("A semantic void, pervading but inert")

--- a/src/web/app/inspector/CursorInspector.re
+++ b/src/web/app/inspector/CursorInspector.re
@@ -65,6 +65,7 @@ let term_view = (~globals: Globals.t, ~force_error=false, ci) => {
       : (
         switch (Info.sort_of(ci)) {
         | Drv(s) => DrvSort.to_string_short(s)
+        | Bb(s) => BbSort.to_string_short(s)
         | s => Sort.to_string(s)
         }
       );
@@ -1058,6 +1059,7 @@ let view_of_info = (~globals, ci): list(Node.t) => {
   | InfoTPat({cls, marks, message, _}) =>
     wrapper(tpat_view(~globals, cls, ~marks, ~message))
   | InfoDrv(ci) => wrapper(DrvCursorInspector.drv_view(~globals, ci))
+  | InfoBb(ci) => wrapper(BbCursorInspector.bb_view(~globals, ci))
   };
 };
 

--- a/src/web/app/sidebar/DebugSidebar.re
+++ b/src/web/app/sidebar/DebugSidebar.re
@@ -541,6 +541,27 @@ let mpat_view = (~globals, ~raw, m: Info.mpat): list(Node.t) =>
 let drv_view = (~globals, _: DrvInfo.t): list(Node.t) =>
   section(~globals, "InfoDrv", () => [field_str("(see DrvInfo)", "—")]);
 
+let bb_view = (~globals, i: BbInfo.t): list(Node.t) =>
+  section(~globals, "InfoBb", () =>
+    [
+      field_str(
+        "modality",
+        switch (BbInfo.modality_of(i)) {
+        | None => "—"
+        | Some(Assume) => "assume"
+        | Some(Construct) => "construct"
+        },
+      ),
+      field_str(
+        "status",
+        switch (BbInfo.error_of(i)) {
+        | None => "ok"
+        | Some(err) => BbInfo.message(err)
+        },
+      ),
+    ]
+  );
+
 let info_view = (~globals, ~raw, ci: Info.t): list(Node.t) =>
   switch (ci) {
   | InfoExp(i) => exp_view(~globals, ~raw, i)
@@ -552,6 +573,7 @@ let info_view = (~globals, ~raw, ci: Info.t): list(Node.t) =>
   | InfoMPat(m) => mpat_view(~globals, ~raw, m)
   | Secondary(s) => secondary_view(~globals, s)
   | InfoDrv(d) => drv_view(~globals, d)
+  | InfoBb(b) => bb_view(~globals, b)
   };
 
 /* ---- Syntax sections: the syntactic/zipper layer under the cursor, ----

--- a/src/web/app/sidebar/ProblemSidebar.re
+++ b/src/web/app/sidebar/ProblemSidebar.re
@@ -66,6 +66,7 @@ let problem_status_view = (~globals, ci: Language.Info.t): Node.t =>
      defer entirely to the cursor inspector's drv_view rather than building
      a generic problem-row from cls/marks/message like the cases above. */
   | InfoDrv(ci) => DrvCursorInspector.drv_view(~globals, ci)
+  | InfoBb(ci) => BbCursorInspector.bb_view(~globals, ci)
   | InfoMod({cls, _})
   | InfoSig({cls, _})
   | InfoMPat({cls, _}) =>

--- a/src/web/blackboard/BbCursorInspector.re
+++ b/src/web/blackboard/BbCursorInspector.re
@@ -1,0 +1,38 @@
+open Virtual_dom.Vdom;
+open Node;
+open Util.WebUtil;
+open Language;
+
+let div_err = div(~attrs=[clss(["status", "error"])]);
+let div_ok = div(~attrs=[clss(["status", "ok"])]);
+
+/* What kind of block the caret is in, said in terms of what the block owes.
+   This is the same distinction the background tint draws. */
+let modality_note = (m: option(BbInfo.modality)) =>
+  switch (m) {
+  | None => []
+  | Some(Assume) => [
+      div(
+        ~attrs=[clss(["bb-modality", "bb-assume"])],
+        [text("assumed: postulated, and taken on trust")],
+      ),
+    ]
+  | Some(Construct) => [
+      div(
+        ~attrs=[clss(["bb-modality", "bb-construct"])],
+        [text("constructed: a conservative extension, owing a witness")],
+      ),
+    ]
+  };
+
+let bb_view = (~globals as _, info: BbInfo.t) =>
+  div(
+    ~attrs=[clss(["bb-info"])],
+    modality_note(BbInfo.modality_of(info))
+    @ [
+      switch (BbInfo.error_of(info)) {
+      | None => div_ok([])
+      | Some(err) => div_err([text(BbInfo.message(err))])
+      },
+    ],
+  );

--- a/src/web/exercises/SyntaxTest.re
+++ b/src/web/exercises/SyntaxTest.re
@@ -132,6 +132,7 @@ let rec find_fn = (name: string, uexp: Exp.t, l: list(Exp.t)): list(Exp.t) => {
   | Atom(_)
   | Label(_)
   | DrvQuote(_)
+  | BbQuote(_)
   | ExplicitNonlabel
   | LivelitName(_)
   | Constructor(_)
@@ -195,6 +196,7 @@ let rec var_mention = (name: string, uexp: Exp.t): bool => {
   | Atom(_)
   | Label(_)
   | DrvQuote(_)
+  | BbQuote(_)
   | ExplicitNonlabel
   | Constructor(_)
   | Undefined
@@ -285,6 +287,7 @@ let rec var_applied = (name: string, uexp: Exp.t): bool => {
   | Atom(_)
   | Label(_)
   | DrvQuote(_)
+  | BbQuote(_)
   | ExplicitNonlabel
   | Constructor(_)
   | Undefined
@@ -405,6 +408,7 @@ let rec tail_check = (name: string, uexp: Exp.t): bool => {
   | Atom(_)
   | Label(_)
   | DrvQuote(_)
+  | BbQuote(_)
   | Constructor(_)
   | Undefined
   | Var(_)

--- a/src/web/exercises/Tutorial.re
+++ b/src/web/exercises/Tutorial.re
@@ -193,6 +193,7 @@ let rec append_exp = (e1: Language.Exp.t, e2: Language.Exp.t): Language.Exp.t =>
   | Deferral(_)
   | Atom(_)
   | DrvQuote(_)
+  | BbQuote(_)
   | ListLit(_)
   | Constructor(_)
   | Closure(_)

--- a/src/web/www/style/cursor-inspector.css
+++ b/src/web/www/style/cursor-inspector.css
@@ -75,7 +75,9 @@
   background-color: var(--token-drv);
 }
 
-#cursor-inspector .Bb .gamma {
+#cursor-inspector .Bb .gamma,
+#cursor-inspector .BbAssume .gamma,
+#cursor-inspector .BbConstruct .gamma {
   background-color: var(--token-bb);
 }
 
@@ -184,7 +186,9 @@
   background-color: var(--token-drv);
 }
 
-#cursor-inspector .ci-header.ok.Bb .toggle-switch.active {
+#cursor-inspector .ci-header.ok.Bb .toggle-switch.active,
+#cursor-inspector .ci-header.ok.BbAssume .toggle-switch.active,
+#cursor-inspector .ci-header.ok.BbConstruct .toggle-switch.active {
   background-color: var(--token-bb);
 }
 
@@ -220,7 +224,9 @@
   color: var(--token-drv);
 }
 
-#cursor-inspector .ci-header.ok.Bb .toggle-switch .toggle-knob {
+#cursor-inspector .ci-header.ok.Bb .toggle-switch .toggle-knob,
+#cursor-inspector .ci-header.ok.BbAssume .toggle-switch .toggle-knob,
+#cursor-inspector .ci-header.ok.BbConstruct .toggle-switch .toggle-knob {
   color: var(--token-bb);
 }
 
@@ -266,7 +272,9 @@
   color: var(--token-drv);
 }
 
-#cursor-inspector .ci-header.ok.Bb {
+#cursor-inspector .ci-header.ok.Bb,
+#cursor-inspector .ci-header.ok.BbAssume,
+#cursor-inspector .ci-header.ok.BbConstruct {
   background-color: var(--shard-bb);
   color: var(--token-bb);
 }

--- a/src/web/www/style/cursor-inspector.css
+++ b/src/web/www/style/cursor-inspector.css
@@ -75,6 +75,10 @@
   background-color: var(--token-drv);
 }
 
+#cursor-inspector .Bb .gamma {
+  background-color: var(--token-bb);
+}
+
 #cursor-inspector .TPat .gamma {
   background-color: var(--token-tpat);
 }
@@ -180,6 +184,10 @@
   background-color: var(--token-drv);
 }
 
+#cursor-inspector .ci-header.ok.Bb .toggle-switch.active {
+  background-color: var(--token-bb);
+}
+
 #cursor-inspector .ci-header.ok.TPat .toggle-switch.active {
   background-color: var(--token-tpat);
 }
@@ -210,6 +218,10 @@
 
 #cursor-inspector .ci-header.ok.Drv .toggle-switch .toggle-knob {
   color: var(--token-drv);
+}
+
+#cursor-inspector .ci-header.ok.Bb .toggle-switch .toggle-knob {
+  color: var(--token-bb);
 }
 
 #cursor-inspector .ci-header.ok.TPat .toggle-switch .toggle-knob {
@@ -252,6 +264,11 @@
 #cursor-inspector .ci-header.ok.Drv {
   background-color: var(--shard-drv);
   color: var(--token-drv);
+}
+
+#cursor-inspector .ci-header.ok.Bb {
+  background-color: var(--shard-bb);
+  color: var(--token-bb);
 }
 
 #cursor-inspector .ci-header.ok.TPat {

--- a/src/web/www/style/editor.css
+++ b/src/web/www/style/editor.css
@@ -101,6 +101,9 @@
 .code .token.Drv {
   color: var(--token-drv);
 }
+.code .token.Bb {
+  color: var(--token-bb);
+}
 .code .token.Rul {
   color: var(--token-rul);
 }
@@ -248,6 +251,9 @@ svg.shard.indicated.Typ {
 svg.shard.indicated.Drv {
   filter: drop-shadow(var(--off-x) var(--off-y) var(--blur) var(--token-drv));
 }
+svg.shard.indicated.Bb {
+  filter: drop-shadow(var(--off-x) var(--off-y) var(--blur) var(--token-bb));
+}
 svg.shard.indicated.Rul {
   filter: drop-shadow(
     var(--off-x) var(--off-y) var(--blur) var(--shard-lines-rul)
@@ -280,6 +286,9 @@ svg.shard.indicated.Typ > path {
 }
 svg.shard.indicated.Drv > path {
   fill: var(--shard-drv);
+}
+svg.shard.indicated.Bb > path {
+  fill: var(--shard-bb);
 }
 svg.shard.indicated.Rul > path {
   fill: var(--shard-rul);
@@ -495,6 +504,9 @@ svg:has(.child-line) {
 }
 .child-line.Drv {
   stroke: var(--token-drv);
+}
+.child-line.Bb {
+  stroke: var(--token-bb);
 }
 .child-line.Rul {
   stroke: var(--shard-lines-rul);

--- a/src/web/www/style/editor.css
+++ b/src/web/www/style/editor.css
@@ -101,8 +101,27 @@
 .code .token.Drv {
   color: var(--token-drv);
 }
-.code .token.Bb {
+.code .token.Bb,
+.code .token.BbAssume,
+.code .token.BbConstruct {
   color: var(--token-bb);
+}
+
+/* A Blackboard block is tinted by its modality, so its extent is visible
+   and indentation reads as structure. The tint is vertical padding only:
+   the editor places glyphs at measured columns, so horizontal padding
+   overlaps the neighbouring token and clips it. */
+.code .token.BbAssume,
+.code .token.BbConstruct {
+  padding: 0.12em 0;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+.code .token.BbAssume {
+  background: var(--bb-assume-bg);
+}
+.code .token.BbConstruct {
+  background: var(--bb-construct-bg);
 }
 .code .token.Rul {
   color: var(--token-rul);
@@ -251,7 +270,12 @@ svg.shard.indicated.Typ {
 svg.shard.indicated.Drv {
   filter: drop-shadow(var(--off-x) var(--off-y) var(--blur) var(--token-drv));
 }
-svg.shard.indicated.Bb {
+/* The indicated shard must name every Blackboard sort class: statics
+   refines Bb to BbAssume/BbConstruct, and a shard whose class has no fill
+   rule falls back to black over the token it sits under. */
+svg.shard.indicated.Bb,
+svg.shard.indicated.BbAssume,
+svg.shard.indicated.BbConstruct {
   filter: drop-shadow(var(--off-x) var(--off-y) var(--blur) var(--token-bb));
 }
 svg.shard.indicated.Rul {
@@ -287,7 +311,9 @@ svg.shard.indicated.Typ > path {
 svg.shard.indicated.Drv > path {
   fill: var(--shard-drv);
 }
-svg.shard.indicated.Bb > path {
+svg.shard.indicated.Bb > path,
+svg.shard.indicated.BbAssume > path,
+svg.shard.indicated.BbConstruct > path {
   fill: var(--shard-bb);
 }
 svg.shard.indicated.Rul > path {
@@ -505,7 +531,9 @@ svg:has(.child-line) {
 .child-line.Drv {
   stroke: var(--token-drv);
 }
-.child-line.Bb {
+.child-line.Bb,
+.child-line.BbAssume,
+.child-line.BbConstruct {
   stroke: var(--token-bb);
 }
 .child-line.Rul {

--- a/src/web/www/style/variables.css
+++ b/src/web/www/style/variables.css
@@ -43,6 +43,9 @@
   /* GLASS - sorts */
   --TYP: oklch(60% 0.2 300);
   --DRV: oklch(60% 0.1 126);
+  /* Blackboard: indigo, dark enough to read on the sand background, and
+     clear of TYP (300), DRV (126) and PAT (225). */
+  --BB: oklch(48% 0.13 265);
   --PAT: oklch(from var(--TYP) l c calc(h - 1 * 75));
   --TPAT: var(--PAT);
   --MOD: var(--STONE); /* Module sort oklch(0.65 0.05 165)  */
@@ -112,6 +115,7 @@
   --token-pat: var(--PAT);
   --token-typ: var(--TYP);
   --token-drv: var(--DRV);
+  --token-bb: var(--BB);
   --token-tpat: var(--TPAT);
   --token-mod: var(--MOD);
   --token-sig: var(--SIG);
@@ -136,6 +140,7 @@
   --shard-caret-pat: oklch(from var(--token-pat) 95% calc(c/4) h);
   --shard-caret-typ: oklch(from var(--token-typ) 95% calc(c/4) h);
   --shard-caret-drv: oklch(from var(--token-drv) 95% calc(c/4) h);
+  --shard-caret-bb: oklch(from var(--token-bb) 95% calc(c/4) h);
   --shard-caret-tpat: oklch(from var(--token-tpat) 95% calc(c/4) h);
   --shard-caret-mod: oklch(from var(--token-mod) 95% calc(c/4) h);
   --shard-caret-sig: oklch(from var(--token-sig) 95% calc(c/4) h);
@@ -143,6 +148,7 @@
   --shard-pat: var(--shard-caret-pat);
   --shard-typ: var(--shard-caret-typ);
   --shard-drv: var(--shard-caret-drv);
+  --shard-bb: var(--shard-caret-bb);
   --shard-tpat: var(--shard-caret-tpat);
   --shard-mod: var(--shard-caret-mod);
   --shard-sig: var(--shard-caret-sig);

--- a/src/web/www/style/variables.css
+++ b/src/web/www/style/variables.css
@@ -116,6 +116,17 @@
   --token-typ: var(--TYP);
   --token-drv: var(--DRV);
   --token-bb: var(--BB);
+  /* Block modality tints. Faint enough to read through, distinct enough to
+     show a block's extent -- and so, its indentation -- at a glance.
+     Assumed is taken on trust; constructed still owes a witness.
+
+     Two constraints beyond looking right. The hues stay clear of the error
+     hole's warm fill (--ERRHOLE, hue 47) so an error inside a block is not
+     camouflaged by the block. And both are translucent, because the error
+     fill is an SVG shard painted behind the token: an opaque tint would
+     hide it however well the hue were chosen. */
+  --bb-assume-bg: oklch(68% 0.1 205 / 0.16);
+  --bb-construct-bg: oklch(58% 0.13 305 / 0.16);
   --token-tpat: var(--TPAT);
   --token-mod: var(--MOD);
   --token-sig: var(--SIG);

--- a/test/Test_FastParseCorpus.re
+++ b/test/Test_FastParseCorpus.re
@@ -46,6 +46,7 @@ let known_gaps: list(string) = [
   "signatures.hz",
   "checking.hz",
   "metatheory.hz",
+  "case-studies.hz",
 ];
 
 let tests = (

--- a/test/Test_FastParseCorpus.re
+++ b/test/Test_FastParseCorpus.re
@@ -30,11 +30,23 @@ let read_file = (path: string): string => {
    agents/users write falls back to the quadratic typing parser — fix
    FastParse or the printer rather than tolerating it. Skips silently
    when the corpus is unreachable (sandboxed dune runtest). */
-/* Empty as of 2026-08-08: every .hz in the repo takes the fast path.
-   A new entry here means a construct regressed off it — fix the
-   grammar/printer rather than ledgering, unless the file is a
-   deliberately-invalid or delimiter-incomplete exhibit. */
-let known_gaps: list(string) = [];
+/* A new entry here means a construct regressed off the fast path — fix
+   the grammar/printer rather than ledgering, unless the file is a
+   deliberately-invalid or delimiter-incomplete exhibit, or belongs to a
+   sub-language the menhir parser does not cover at all.
+
+   The Blackboard slides are the latter: `blackboard ... end` and the
+   Bb-sorted forms inside it have no menhir productions, as with the ALFA
+   derivation sub-language, so these files load through the typing parser.
+   Their fidelity is pinned by DocSlides.ReparseBackuptext. Remove these
+   entries if Blackboard gains menhir support. */
+let known_gaps: list(string) = [
+  "overview.hz",
+  "terms.hz",
+  "signatures.hz",
+  "checking.hz",
+  "metatheory.hz",
+];
 
 let tests = (
   "FastParseCorpus",

--- a/test/Test_Grammar.re
+++ b/test/Test_Grammar.re
@@ -44,6 +44,7 @@ let sample_expression = (cls_exp: Exp.cls): Grammar.UnitGrammar.exp => {
       | Atom(String) => string("hello")
       | Atom(Nat) => nat(Bigint.one)
       | DrvQuote => drv_exp(DrvGrammar.placeholder(), DrvSort.Jdmt)
+      | BbQuote => bb_exp(BbGrammar.placeholder())
       | ListLit => list_lit([])
       | Constructor => constructor("A", None)
       | Fun => fn(Pat.var("x"), var("x"), None, None)

--- a/test/blackboard/Test_Blackboard.re
+++ b/test/blackboard/Test_Blackboard.re
@@ -1,0 +1,313 @@
+/* Tests for the Blackboard kernel (src/language/blackboard).  The fixtures
+   are the paper's own signatures, with implicit braces expanded and `=`
+   written as `eq A a b`.  Two of them are the paper's typos, which the
+   checker should find; two others record known limits of the decidable
+   fragment, where the paper's examples lean on equations the checker does
+   not rewrite with. */
+
+open Alcotest;
+open Language;
+
+let located_t = testable(BbError.pp_located, BbError.equal_located);
+
+let parse_doc = (s: string): BbTerm.doc =>
+  switch (BbParse.doc(s)) {
+  | Ok(d) => d
+  | Error(m) => failf("parse error: %s", m)
+  };
+
+let parse_term = (s: string): BbTerm.t =>
+  switch (BbParse.term(s)) {
+  | Ok(t) => t
+  | Error(m) => failf("parse error: %s", m)
+  };
+
+let reports = (s: string): list(BbCheck.report) =>
+  snd(BbCheck.check_doc(parse_doc(s)));
+
+let errors = (s: string): list(BbError.located) =>
+  BbCheck.all_errors(reports(s));
+
+let errors_of_entry = (name: string, s: string): list(BbError.t) =>
+  errors(s)
+  |> List.filter((l: BbError.located) => l.entry == name)
+  |> List.map((l: BbError.located) => l.err);
+
+let pending = (s: string): list(string) =>
+  List.filter_map((r: BbCheck.report) => r.pending, reports(s));
+
+/* Paper, Section 2 (l. 158-172), braces expanded. */
+let eq_block = {|
+assume
+eq : (A : type) -> (a1 a2 : A) -> type
+refl : (A : type) -> (a : A) -> eq A a a
+replace : (A1 A2 : type) -> eq type A1 A2 -> A1 -> A2
+|};
+
+/* cong-ap exactly as printed at l. 164-171: `(a : A) -> B` with
+   B : A -> type, and `(a1 a1 : A)`. */
+let cong_ap_printed = {|
+cong-ap :
+  (A : type) ->
+  (B : A -> type) ->
+  (f1 f2 : (a : A) -> B) ->
+  (a1 a1 : A) ->
+  eq ((a : A) -> B) f1 f2 ->
+  eq A a1 a2 ->
+  eq (B a1) (f1 a1) (f2 a2)
+|};
+
+/* cong-ap with both slips repaired. */
+let cong_ap_fixed = {|
+cong-ap :
+  (A : type) ->
+  (B : A -> type) ->
+  (f1 f2 : (a : A) -> B a) ->
+  (a1 a2 : A) ->
+  eq ((a : A) -> B a) f1 f2 ->
+  eq A a1 a2 ->
+  eq (B a1) (f1 a1) (f2 a2)
+|};
+
+/* Paper, Section 4, subtyping, refinements, intersections (l. 231-298). */
+let section4 = {|
+assume
+eq : (A : type) -> (a1 a2 : A) -> type
+construct
+subtype : (A B : type) -> type
+subtype-eq : (A B : type) -> eq type (subtype A B) ((x : A) -> x : B)
+by definition
+assume
+type-ext : (A B : type) -> subtype A B -> subtype B A -> eq type A B
+assume
+refine : (A : type) -> (P : A -> type) -> type
+refine-intro : (A : type) -> (P : A -> type) -> (x : A) -> P x -> x : refine A P
+refine-elim :
+  (A M : type) ->
+  (P : A -> type) ->
+  (x : refine A P) ->
+  ((h : (x : A)) -> P x -> M) ->
+  M
+assume
+intersect : (A B : type) -> type
+intersect-intro : (A B : type) -> (x : A) -> (h : (x : B)) -> x : intersect A B
+intersect-elim :
+  (A B M : type) ->
+  (x : intersect A B) ->
+  ((h1 : (x : A)) -> (h2 : (x : B)) -> M) ->
+  M
+construct
+refinement-subtype-1 : (A : type) -> (P : A -> type) -> subtype (refine A P) A
+refinement-subtype-2 :
+  (A : type) ->
+  (P1 P2 : A -> type) ->
+  ((x : A) -> P1 x -> P2 x) ->
+  subtype (refine A P1) (refine A P2)
+intersect-subtype-1 : (A B : type) -> subtype (intersect A B) A
+intersect-subtype-2 : (A B : type) -> subtype (intersect A B) B
+intersect-subtype-3 : (A B C : type) -> subtype C A -> subtype C B -> subtype C (intersect A B)
+by proof
+|};
+
+/* Paper, l. 315-318: eq-rel is never defined. */
+let quot_block = {|
+assume
+eq : (A : type) -> (a1 a2 : A) -> type
+assume
+quot : (A : type) -> (R : eq-rel A) -> type
+|};
+
+/* Paper, l. 344-372, int-elim exactly as printed: s and p take an int
+   first, but sp and ps apply them as `s (p h)` with h : M x. */
+let int_block = {|
+assume
+eq : (A : type) -> (a1 a2 : A) -> type
+construct
+int : type
+zero : int
+succ : int -> int
+pred : int -> int
+succ-pred : (x : int) -> eq int (succ (pred x)) x
+pred-succ : (x : int) -> eq int (pred (succ x)) x
+int-elim :
+  (M : int -> type) ->
+  (z : M zero) ->
+  (s : (x : int) -> M x -> M (succ x)) ->
+  (p : (x : int) -> M x -> M (pred x)) ->
+  (sp : (x : int) -> (h : M x) -> eq (M x) (s (p h)) h) ->
+  (ps : (x : int) -> (h : M x) -> eq (M x) (p (s h)) h) ->
+  (x : int) ->
+  M x
+by quotient
+|};
+
+/* Paper, l. 401-408: A : U is used where a type is needed; the paper
+   relies on U = (type | small) and a coercion the checker cannot see. */
+let small_block = {|
+assume
+eq : (A : type) -> (a1 a2 : A) -> type
+refine : (A : type) -> (P : A -> type) -> type
+small : type -> type
+U : type
+U-eq : eq type U (refine type small)
+arrow-small : (A : U) -> (B : A -> U) -> small ((a : A) -> B a)
+|};
+
+let tests = (
+  "Blackboard",
+  [
+    test_case("Section 2 equality block checks", `Quick, () =>
+      check(list(located_t), "no errors", [], errors(eq_block))
+    ),
+    test_case(
+      "cong-ap as printed: both slips are reported",
+      `Quick,
+      () => {
+        let errs = errors_of_entry("cong-ap", eq_block ++ cong_ap_printed);
+        let b_not_a_type =
+          BbError.NotAType(Var("B"), Pi("_", Var("A"), Type));
+        check(
+          bool,
+          "B : A -> type is not a type",
+          true,
+          List.mem(b_not_a_type, errs),
+        );
+        check(
+          bool,
+          "a2 is unbound",
+          true,
+          List.mem(BbError.Unbound("a2"), errs),
+        );
+      },
+    ),
+    test_case(
+      "cong-ap repaired: the conclusion needs the equation a1 = a2",
+      `Quick,
+      () => {
+        let errs = errors_of_entry("cong-ap", eq_block ++ cong_ap_fixed);
+        switch (errs) {
+        | [
+            ArgumentMismatch(
+              _,
+              App(Var("f2"), Var("a2")),
+              App(Var("B"), Var("a1")),
+              App(Var("B"), Var("a2")),
+            ),
+          ] =>
+          ()
+        | _ =>
+          failf(
+            "expected exactly the mismatch of f2 a2 : B a2 against B a1, got %s",
+            String.concat("; ", List.map(BbError.to_string, errs)),
+          )
+        };
+      },
+    ),
+    test_case(
+      "Section 4 subtyping, refinement, intersection check",
+      `Quick,
+      () => {
+        check(list(located_t), "no errors", [], errors(section4));
+        check(
+          list(string),
+          "construct blocks leave their tactics pending",
+          ["definition", "proof"],
+          pending(section4),
+        );
+      },
+    ),
+    test_case("quot: eq-rel is not defined", `Quick, () =>
+      check(
+        bool,
+        "eq-rel unbound",
+        true,
+        List.mem(
+          BbError.Unbound("eq-rel"),
+          errors_of_entry("quot", quot_block),
+        ),
+      )
+    ),
+    test_case(
+      "int-elim as printed: s and p applied to h",
+      `Quick,
+      () => {
+        let errs = errors_of_entry("int-elim", int_block);
+        let is_h_for_int =
+          fun
+          | BbError.ArgumentMismatch(
+              _,
+              Var("h"),
+              Var("int"),
+              App(Var("M"), Var("x")),
+            ) =>
+            true
+          | _ => false;
+        check(int, "two mismatches", 2, List.length(errs));
+        check(
+          bool,
+          "each is h : M x where an int is expected",
+          true,
+          List.for_all(is_h_for_int, errs),
+        );
+      },
+    ),
+    test_case("small universe: A : U needs a coercion to type", `Quick, () =>
+      check(
+        bool,
+        "A is not a type",
+        true,
+        List.mem(
+          BbError.NotAType(Var("A"), Var("U")),
+          errors_of_entry("arrow-small", small_block),
+        ),
+      )
+    ),
+    test_case("printer and parser round-trip", `Quick, () =>
+      List.iter(
+        s => {
+          let t = parse_term(s);
+          let t' = parse_term(BbTerm.to_string(t));
+          check(bool, "round-trip of " ++ s, true, BbTerm.alpha_eq(t, t'));
+        },
+        [
+          "type",
+          "(A : type) -> (a1 a2 : A) -> type",
+          "(x : A) -> x : B",
+          "(A M : type) -> (P : A -> type) -> (x : refine A P) -> ((h : (x : A)) -> P x -> M) -> M",
+          "(_ : (x : A)) -> M",
+          "(t : T) : type",
+          "f (g x) y",
+        ],
+      )
+    ),
+    test_case(
+      "substitution avoids capture",
+      `Quick,
+      () => {
+        let t = BbTerm.subst("x", Var("y"), Pi("y", Type, Var("x")));
+        check(
+          bool,
+          "(y : type) -> x  [y/x]  is  (z : type) -> y",
+          true,
+          BbTerm.alpha_eq(t, Pi("z", Type, Var("y"))),
+        );
+      },
+    ),
+    test_case(
+      "a membership hypothesis establishes typing",
+      `Quick,
+      () => {
+        let ctx: BbCheck.ctx = [
+          ("h", Mem(Var("x"), Var("A"))),
+          ("x", Var("B")),
+          ("B", Type),
+          ("A", Type),
+        ];
+        switch (BbCheck.has_type(ctx, Var("x"), Var("A"))) {
+        | Ok(None) => ()
+        | _ => fail("x : A should follow from h : (x : A)")
+        };
+      },
+    ),
+  ],
+);

--- a/test/blackboard/Test_BlackboardEditor.re
+++ b/test/blackboard/Test_BlackboardEditor.re
@@ -1,0 +1,228 @@
+/* M1: Blackboard as an editor sort.  These tests type Blackboard text
+   through the editor's own molding (Parser.to_zipper is the insertion
+   path, one character at a time), read the resulting tiles as a term, and
+   check the round trip back to text through the pretty printer.  The
+   kernel tests in Test_Blackboard.re cover the checker itself. */
+
+open Alcotest;
+open Haz3lcore;
+open Language;
+
+/* Parse in the Bb sort and return the Blackboard term. */
+let parse_bb = (code: string): Bb.Term.t => {
+  let root = Sort.Bb(BbSort.Term);
+  switch (Parser.to_zipper(~root, code)) {
+  | None => failf("Parser.to_zipper failed for %S", code)
+  | Some(z) =>
+    switch (
+      MakeTerm.go_s(
+        root,
+        Segment.skel(Dump.to_segment(z, ~root)),
+        Dump.to_segment(z, ~root),
+      )
+    ) {
+    | Bb(b) => b
+    | other =>
+      failf(
+        "expected a Blackboard term for %S, got sort %s",
+        code,
+        Any.show(other),
+      )
+    }
+  };
+};
+
+let kernel = (code: string): BbTerm.t =>
+  switch (Bb.term_to_kernel(parse_bb(code))) {
+  | Ok(t) => t
+  | Error({message, _}) =>
+    failf("could not read %S as a term: %s", code, message)
+  };
+
+let print = (t: Bb.Term.t): string =>
+  ExpToSegment.any_to_segment(
+    ~settings=ExpToSegment.Settings.of_core(~inline=true, CoreSettings.on),
+    Bb(t),
+  )
+  |> Printer.of_segment(~holes="?", ~refractors=[]);
+
+let tests = (
+  "Blackboard editor",
+  [
+    test_case(
+      "a name and the type of types",
+      `Quick,
+      () => {
+        check(bool, "x", true, kernel("x") == BbTerm.Var("x"));
+        check(bool, "type", true, kernel("type") == BbTerm.Type);
+      },
+    ),
+    test_case("membership", `Quick, () =>
+      check(
+        bool,
+        "t : T",
+        true,
+        kernel("t : T") == BbTerm.Mem(Var("t"), Var("T")),
+      )
+    ),
+    test_case("the non-dependent arrow", `Quick, () =>
+      check(
+        bool,
+        "A -> B",
+        true,
+        kernel("A -> B") == BbTerm.Pi("_", Var("A"), Var("B")),
+      )
+    ),
+    test_case("the dependent arrow is a parenthesized membership", `Quick, () =>
+      check(
+        bool,
+        "(x : A) -> B",
+        true,
+        kernel("(x : A) -> B") == BbTerm.Pi("x", Var("A"), Var("B")),
+      )
+    ),
+    test_case("the arrow is right-associative", `Quick, () =>
+      check(
+        bool,
+        "A -> B -> C",
+        true,
+        kernel("A -> B -> C")
+        == BbTerm.Pi("_", Var("A"), Pi("_", Var("B"), Var("C"))),
+      )
+    ),
+    test_case(
+      "application, curried through an argument list",
+      `Quick,
+      () => {
+        check(
+          bool,
+          "f(a)",
+          true,
+          kernel("f(a)") == BbTerm.App(Var("f"), Var("a")),
+        );
+        check(
+          bool,
+          "eq(A, a1, a2)",
+          true,
+          kernel("eq(A, a1, a2)")
+          == BbTerm.App(
+               App(App(Var("eq"), Var("A")), Var("a1")),
+               Var("a2"),
+             ),
+        );
+      },
+    ),
+    test_case("subtyping, as the paper writes it at l. 234", `Quick, () =>
+      check(
+        bool,
+        "(x : A) -> x : B",
+        true,
+        kernel("(x : A) -> x : B")
+        == BbTerm.Pi("x", Var("A"), Mem(Var("x"), Var("B"))),
+      )
+    ),
+    test_case("a signature entry", `Quick, () =>
+      switch (Bb.entry_to_kernel(parse_bb("refl : (A : type) -> A"))) {
+      | Ok({name: "refl", ty}) =>
+        check(
+          bool,
+          "the entry's type",
+          true,
+          ty == BbTerm.Pi("A", Type, Var("A")),
+        )
+      | Ok({name, _}) => failf("wrong entry name %S", name)
+      | Error({message, _}) => failf("not an entry: %s", message)
+      }
+    ),
+    test_case(
+      "an assumption block becomes a document",
+      `Quick,
+      () => {
+        let b = parse_bb("assume x : type; y : x by tychk");
+        switch (Bb.doc_to_kernel(b)) {
+        | Ok([Assume([{name: "x", _}, {name: "y", _}], Some("tychk"))]) =>
+          ()
+        | Ok(d) => failf("unexpected document: %s", BbTerm.show_doc(d))
+        | Error({message, _}) => failf("not a document: %s", message)
+        };
+      },
+    ),
+    test_case("a construction block keeps its tactic", `Quick, () =>
+      switch (Bb.doc_to_kernel(parse_bb("construct f : type by definition"))) {
+      | Ok([Construct([{name: "f", _}], "definition")]) => ()
+      | Ok(d) => failf("unexpected document: %s", BbTerm.show_doc(d))
+      | Error({message, _}) => failf("not a document: %s", message)
+      }
+    ),
+    test_case(
+      "the checker runs on tiles the user typed",
+      `Quick,
+      () => {
+        let b =
+          parse_bb(
+            "assume eq : (A : type) -> (a1 : A) -> (a2 : A) -> type; bad : B by tychk",
+          );
+        switch (Bb.doc_to_kernel(b)) {
+        | Error({message, _}) => failf("not a document: %s", message)
+        | Ok(d) =>
+          let errs = BbCheck.all_errors(snd(BbCheck.check_doc(d)));
+          check(
+            bool,
+            "B is unbound, and nothing else is wrong",
+            true,
+            List.map((l: BbError.located) => (l.entry, l.err), errs)
+            == [("bad", BbError.Unbound("B"))],
+          );
+        };
+      },
+    ),
+    /* Printing is a fixed point: printing what was parsed from printed text
+       gives the same text back. */
+    test_case("text round-trips through the pretty printer", `Quick, () =>
+      List.iter(
+        code => {
+          let once = print(parse_bb(code));
+          let twice = print(parse_bb(once));
+          check(
+            string,
+            Printf.sprintf("%S prints as %S", code, once),
+            once,
+            twice,
+          );
+        },
+        [
+          "type",
+          "t : T",
+          "A -> B",
+          "(x : A) -> B",
+          "(x : A) -> x : B",
+          "eq(A, a1, a2)",
+          "assume x : type by tychk",
+          "assume x : type; y : x by tychk; construct f : type by definition",
+        ],
+      )
+    ),
+    test_case(
+      "a document embedded in an expression",
+      `Quick,
+      () => {
+        let root = Sort.Exp;
+        let code = "blackboard assume x : type by tychk end";
+        switch (Parser.to_zipper(~root, code)) {
+        | None => failf("Parser.to_zipper failed for %S", code)
+        | Some(z) =>
+          let e = MakeTerm.from_zip_for_sem(z, ~root).term;
+          switch (IdTagged.term_of(e)) {
+          | BbQuote(b) =>
+            switch (Bb.doc_to_kernel(b)) {
+            | Ok([Assume([{name: "x", _}], Some("tychk"))]) => ()
+            | Ok(d) => failf("unexpected document: %s", BbTerm.show_doc(d))
+            | Error({message, _}) => failf("not a document: %s", message)
+            }
+          | _ => failf("expected a blackboard block, got %s", Exp.show(e))
+          };
+        };
+      },
+    ),
+  ],
+);

--- a/test/blackboard/Test_BlackboardSlides.re
+++ b/test/blackboard/Test_BlackboardSlides.re
@@ -1,0 +1,86 @@
+/* Every shipped Blackboard slide must read back as a Blackboard document.
+   The slides are Hazel expressions, so a name that collides with a Hazel
+   token (`false` is a boolean literal, not an identifier) or an entry the
+   grammar cannot shape silently becomes a hole, and the slide still
+   round-trips as text -- DocSlides.ReparseBackuptext would not notice.
+   This is the ratchet that does.
+
+   Note that reading a document is not checking it: slide 3 deliberately
+   contains the paper's own mistakes, which the checker is supposed to
+   report. Here we only require that the document is well formed enough to
+   hand to the checker at all. */
+
+open Alcotest;
+open Haz3lcore;
+open Language;
+
+let slides: list((string, string)) =
+  Docslides.Slides.all_slides
+  |> List.filter_map(((name, z: PersistentZipper.t)) =>
+       switch (String.index_opt(name, '/')) {
+       | Some(i) when String.sub(name, 0, i) == "Blackboard " =>
+         Some((name, z.backup_text))
+       | _ => None
+       }
+     );
+
+/* Every Blackboard document embedded in a slide, in source order. */
+let documents_of = (text: string): list(Bb.Term.t) => {
+  let root = Sort.Exp;
+  switch (PersistentZipper.parse_text(~source="slide", ~root, text)) {
+  | None => failf("slide did not parse")
+  | Some(z) =>
+    let e = MakeTerm.from_zip_for_sem(z, ~root).term;
+    let found = ref([]);
+    let _ =
+      Exp.map_term(
+        ~f_exp=
+          (continue, e) => {
+            switch (IdTagged.term_of(e)) {
+            | BbQuote(b) => found := [b, ...found^]
+            | _ => ()
+            };
+            continue(e);
+          },
+        e,
+      );
+    List.rev(found^);
+  };
+};
+
+let tests = (
+  "Blackboard slides",
+  List.map(
+    ((name, text)) =>
+      test_case(
+        name,
+        `Quick,
+        () => {
+          let docs = documents_of(text);
+          check(
+            bool,
+            name ++ " embeds a Blackboard document",
+            true,
+            docs != [],
+          );
+          List.iter(
+            b =>
+              switch (Bb.doc_to_kernel(b)) {
+              | Ok([]) => failf("%s: the document is empty", name)
+              | Ok(_) => ()
+              | Error({message, _}) =>
+                /* A name that collides with a Hazel token, or an entry
+                   shape the grammar cannot hold, becomes a hole here. */
+                failf(
+                  "%s: the document does not read back: %s",
+                  name,
+                  message,
+                )
+              },
+            docs,
+          );
+        },
+      ),
+    slides,
+  ),
+);

--- a/test/blackboard/Test_BlackboardStatics.re
+++ b/test/blackboard/Test_BlackboardStatics.re
@@ -63,13 +63,11 @@ let tests = (
         ),
       )
     ),
+    /* `(P : A -> type)` arrives as `Arrow(Mem(P, A), type)`, because the colon
+       binds tighter than the arrow; without the same rotation the entry reader
+       does, P would not be bound at all. */
     test_case(
-      "a declaration inside a binder may itself be an arrow",
-      `Quick,
-      () =>
-      /* `(P : A -> type)` arrives as `Arrow(Mem(P, A), type)`, because the
-         colon binds tighter than the arrow; without the same rotation the
-         entry reader does, P would not be bound at all. */
+      "a declaration inside a binder may itself be an arrow", `Quick, () =>
       check(
         list(pair(string, string)),
         "no errors",

--- a/test/blackboard/Test_BlackboardStatics.re
+++ b/test/blackboard/Test_BlackboardStatics.re
@@ -1,0 +1,127 @@
+/* The checker, as the editor sees it: parse Blackboard text through the
+   editor, run statics, and read the errors back out of the info map. These
+   are the messages the cursor inspector shows, so a silent editor fails
+   here.
+
+   Two kinds of error must survive independently. A syntax error, where an
+   entry cannot be read at all, must not silence the checking of its
+   neighbours; and a check error must land on the name that caused it. */
+
+open Alcotest;
+open Haz3lcore;
+open Language;
+
+/* Every Blackboard error in a document, as (token, message) pairs. */
+let errors_of = (code: string): list((string, string)) => {
+  let root = Sort.Exp;
+  switch (Parser.to_zipper(~root, code)) {
+  | None => failf("Parser.to_zipper failed for %S", code)
+  | Some(z) =>
+    let term = MakeTerm.from_zip_for_sem(z, ~root).term;
+    let info_map =
+      fst(Statics.mk(CoreSettings.on, Builtins.ctx_init(Some(Int)), term));
+    let seg = Dump.to_segment(z, ~root);
+    /* Walk the segment so we can name the token each error sits on. */
+    let rec pieces = (seg: Segment.t): list((Id.t, string)) =>
+      List.concat_map(
+        (p: Piece.t) =>
+          switch (p) {
+          | Tile(t) =>
+            [(t.id, String.concat("", t.label))]
+            @ List.concat_map(pieces, t.children)
+          | Grout(_)
+          | Secondary(_)
+          | Projector(_) => []
+          },
+        seg,
+      );
+    List.filter_map(
+      ((id, label)) =>
+        switch (Statics.Map.lookup(id, info_map)) {
+        | Some(InfoBb(bb)) =>
+          switch (BbInfo.error_of(bb)) {
+          | Some(err) => Some((label, BbInfo.message(err)))
+          | None => None
+          }
+        | _ => None
+        },
+      pieces(seg),
+    );
+  };
+};
+
+let tests = (
+  "Blackboard statics",
+  [
+    test_case("a correct document reports nothing", `Quick, () =>
+      check(
+        list(pair(string, string)),
+        "no errors",
+        [],
+        errors_of(
+          "blackboard assume eq : (A : type) -> (a : A) -> type by tychk end",
+        ),
+      )
+    ),
+    test_case(
+      "an unbound name is reported on the name itself",
+      `Quick,
+      () => {
+        let errs =
+          errors_of("blackboard construct falsity : tyXXX by definition end");
+        check(
+          bool,
+          "tyXXX is flagged",
+          true,
+          List.exists(
+            ((tok, msg)) => tok == "tyXXX" && msg == "unbound name tyXXX",
+            errs,
+          ),
+        );
+      },
+    ),
+    test_case(
+      "a construct block is checked against an earlier assume",
+      `Quick,
+      () => {
+        let ok =
+          errors_of(
+            "blackboard assume int : type by tychk; construct zero : int by definition end",
+          );
+        check(list(pair(string, string)), "int is in scope", [], ok);
+        let bad =
+          errors_of(
+            "blackboard assume int : type by tychk; construct zero : nat by definition end",
+          );
+        check(
+          bool,
+          "nat is not",
+          true,
+          List.exists(((tok, _)) => tok == "nat", bad),
+        );
+      },
+    ),
+    test_case(
+      "one malformed entry does not silence its neighbours",
+      `Quick,
+      () => {
+        /* `type` alone is not an entry: it has no name. The entry after it
+           must still be checked. */
+        let errs =
+          errors_of("blackboard assume type; bad : nope by tychk end");
+        check(
+          bool,
+          "the malformed entry is reported",
+          true,
+          List.exists(((_, msg)) => msg != "unbound name nope", errs),
+        );
+        check(
+          bool,
+          "and the entry after it is still checked",
+          true,
+          List.exists(((_, msg)) => msg == "unbound name nope", errs),
+        );
+      },
+    ),
+  ],
+);

--- a/test/blackboard/Test_BlackboardStatics.re
+++ b/test/blackboard/Test_BlackboardStatics.re
@@ -64,6 +64,22 @@ let tests = (
       )
     ),
     test_case(
+      "a declaration inside a binder may itself be an arrow",
+      `Quick,
+      () =>
+      /* `(P : A -> type)` arrives as `Arrow(Mem(P, A), type)`, because the
+         colon binds tighter than the arrow; without the same rotation the
+         entry reader does, P would not be bound at all. */
+      check(
+        list(pair(string, string)),
+        "no errors",
+        [],
+        errors_of(
+          "blackboard assume A : type; f : (P : A -> type) -> (x : A) -> P(x) by tychk end",
+        ),
+      )
+    ),
+    test_case(
       "an unbound name is reported on the name itself",
       `Quick,
       () => {

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -79,6 +79,7 @@ let (suite, exit_with_test_status) =
     @ [Test_Derivation.tests]
     @ [Test_Blackboard.tests]
     @ [Test_BlackboardEditor.tests]
+    @ [Test_BlackboardSlides.tests]
     @ Test_DerivationCase.tests
     @ Test_PromptFactory.tests
     @ [Test_ExplainThis.tests],

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -80,6 +80,7 @@ let (suite, exit_with_test_status) =
     @ [Test_Blackboard.tests]
     @ [Test_BlackboardEditor.tests]
     @ [Test_BlackboardSlides.tests]
+    @ [Test_BlackboardStatics.tests]
     @ Test_DerivationCase.tests
     @ Test_PromptFactory.tests
     @ [Test_ExplainThis.tests],

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -78,6 +78,7 @@ let (suite, exit_with_test_status) =
     @ [Test_GradingReport.tests]
     @ [Test_Derivation.tests]
     @ [Test_Blackboard.tests]
+    @ [Test_BlackboardEditor.tests]
     @ Test_DerivationCase.tests
     @ Test_PromptFactory.tests
     @ [Test_ExplainThis.tests],

--- a/test/haz3ltest.re
+++ b/test/haz3ltest.re
@@ -77,6 +77,7 @@ let (suite, exit_with_test_status) =
     @ [Test_VarHighlight.tests]
     @ [Test_GradingReport.tests]
     @ [Test_Derivation.tests]
+    @ [Test_Blackboard.tests]
     @ Test_DerivationCase.tests
     @ Test_PromptFactory.tests
     @ [Test_ExplainThis.tests],


### PR DESCRIPTION
## Blackboard MVP: a proof assistant's core logic inside Hazel

An experiment: an MVP of **Blackboard**, a proposed "clean slate" proof assistant whose core logic has a type of all types, an internal typing relation, and no lambda. Three milestones are here: the kernel, the editor sort, and live checking.

**Try it:** Documentation → Blackboard → 0. Overview, at https://hazel.org/build/blackboard-mvp/

**What it does and does not do,** in one line each: the checker is real and finds the paper's own slips; `by proof` is still a placeholder; and there is no conversion, because the logic has no reduction. The long form is in `docs/blackboard.md`, added by this PR, and the open questions are collected in [#2543, what is implemented / what is a placeholder / five open questions for Hazel](https://github.com/hazelgrove/hazel/issues/2543).

### M0 — the kernel

`src/language/blackboard/` — `BbTerm` (terms `x`, `t : T`, `type`, `(x : T₁) → T₂`, `t₁ t₂`; signatures, blocks, documents; substitution, α-equivalence, printing), `BbCheck` (the decidable fragment the paper calls `tychk`, without conversion), `BbError` (errors as data, located by signature entry), `BbParse` (the paper's concrete syntax, for fixtures). No dependency on tiles or the web layer.

Tests use the paper's own signatures as fixtures. The checker finds the paper's two slips in `cong-ap` (a name bound twice; a family used as a type) and the two in `int-elim` (missing arguments), and records where the paper's examples lean on equations the fragment cannot use.

### M1 — the editor sort

`Bb(BbSort.Term)` is a nested sort, following the ALFA derivation sub-language in `src/language/derivation/`: forms in `Form.re`, molding, `MakeTerm`, a pretty printer, and `blackboard ... end` to embed a document in an expression. `BbGrammar` / `BbTermBase` / `Bb` carry editor terms and read them back as kernel terms, entries, blocks and documents.

Two decisions worth review:

- **The colon binds tighter than the arrow**, so `(x : A) -> x : B` reads as the paper writes it. In a signature entry the colon is a declaration instead, and is loosest; `Bb.rotate_entry` rotates the spine back, so `f : A -> B` declares `f` of type `A -> B`.
- **`Insert.effective_sort` no longer falls back to the enclosing sort inside Blackboard.** It is a closed sub-language, so a token with no Blackboard expansion stays a monotile. Without this, typing `type` inside a block expands into Hazel's `type _ = _ in`. This is the one change outside Blackboard-specific code that affects existing behaviour; it is guarded by `Sort.is_bb`.

### M2 — live checking, and a tint per modality

`Statics.bb_to_info_map` gives every Blackboard node an info entry and runs the checker as you type; `BbInfo` carries the status and the block modality; `BbCursorInspector` shows the message; the problem count and sidebar come free from `Info.is_error`.

The checker runs **per signature entry, not per document**, each in the context of the entries before it. An entry that cannot be read at all reports a syntax error and still enters the context, so its neighbours are still checked — an all-or-nothing check goes silent exactly when the user has just made a mistake. `Test_BlackboardStatics` pins this, and pins that the inspector actually says something: a silent editor fails the suite.

Errors land on the name the user got wrong where one is identifiable, and on the entry otherwise. Since kernel terms deliberately carry no ids, an error carries the subterm it is about and the node is found by re-reading; the consequences of that are written up in `docs/blackboard.md` and item 3 of #2543.

`BbSort` also gains display-only `Assumed` / `Constructed` sub-sorts, refined by `Info.refine_sort_from_mold` exactly as the `Drv` sub-sorts are, so a block is tinted by what it owes: an `assume` block is postulated, a `construct` block is a conservative extension that still owes a witness.

### Documentation slides

Six slides under **Documentation → Blackboard**: Overview, Terms, Signatures, Checking, Metatheory, and Case Studies, the last transcribing all four of the paper's Section 4 examples. They load through the typing parser, since menhir has no Blackboard productions (as with the derivation sub-language). Both corpus ratchets ledger them with a reason, and `DocSlides.ReparseBackuptext` pins their text fidelity.

The `Bb` sort also needed a colour: with no entry in the token palette, Blackboard code rendered in the fallback colour and was effectively unreadable. Measured against the code background, it is now 6.49:1, where `Exp` is 5.33, `Typ` 4.19, `Drv` 3.73 and `Pat` 3.32.

`Test_BlackboardSlides` requires every shipped slide to read back as a document. It earns its place: three separate content bugs made part of a slide silently become a hole while the text still round-tripped. Hazel names cannot contain a hyphen, so `falsity-eq` was three tokens; `false` is a boolean literal, not a name; and `witness : a : A` associates as `(witness : a) : A`. Slides therefore use underscores where the paper uses hyphens, noted on the Terms slide. Behind two of them was a reader bug: a signature of three or more entries nests to the right, and only the top level was being read.

### `docs/blackboard.md`

Written to answer two questions from the paper's author — *are the constructions real?* and *how does it typecheck?* — it records, with a line-level citation on every claim: what the checker really implements; that `by proof`, `by definition`, `by tychk` and `by quotient` are all parsed as bare names and nothing discharges them, so a `construct` block is an `assume` block plus a tint plus an undischarged obligation; that substitution on types happens at exactly one site, the `ap` rule; that α-equivalence is the only notion of "same type", deliberately, since the logic has no reduction; and that the membership-hypothesis lookup in `has_type` is the paper's own escape hatch, being rules `hyp` and `in-` rather than conversion in disguise.

It closes with twelve open questions, grouped by who can settle them: five for the paper, three for this implementation, four for Hazel. The Hazel ones are #2543.

### `mech/`

The Rocq mechanization of the core logic (`Blackboard.v`, Rocq 9.2, no axioms) and its compile log, as the reference semantics: consistency of the bare logic, conservativity of construction blocks, and a five-point model. It covers both the rules as first printed and the author's corrected `arrow+`. Not part of the build.

Theorem 2 is what makes `by proof` a placeholder with a precise meaning rather than a gap: a construction block's obligation is the term `(M : type) → ((x₁ : T₁) → … → (xₙ : Tₙ) → M) → M`, and meeting it makes the block a conservative extension for goals that are types. Nothing in the implementation produces or checks such a witness.

### Testing

```
dune build test/idb_stub.js test/haz3ltest.bc.js --profile dev
bash test/run_node.sh test Blackboard
```

34 Blackboard tests pass, across four groups: `Blackboard` (kernel), `Blackboard editor` (reading editor terms), `Blackboard slides`, `Blackboard statics`. The full suite was last run at M2 (9c5a880790) and was green, 3746 tests; the two commits after it are a documentation slide and a reformat, and this one adds only a markdown file.

### Not in this PR

Implicit arguments, user-defined syntax, tactics, equational rewriting, discharging any construction obligation, dynamics for an embedded document, and menhir support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
