### PR TITLE
Printer and incremental-eval fixes surfaced by the modules stack

### DIFF
--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -727,11 +727,11 @@ and parenthesize_typ =
 
   // Other forms
   | Parens(t) =>
-    Parens(
-      parenthesize_typ(~already_paren=true, t)
-      |> paren_typ_at(Precedence.min),
-    )
-    |> rewrap
+    /* No defensive parens on the content: the wrapper we are emitting is
+       already the protection, and adding another made printing
+       non-idempotent for every type whose precedence IS min -- a Sig, a bare
+       sum, a multihole -- which gained a paren layer on every trip. */
+    Parens(parenthesize_typ(~already_paren=true, t)) |> rewrap
   | Projector(data, t) =>
     Projector(data, parenthesize_typ(t) |> paren_typ_at(Precedence.min))
     |> rewrap

--- a/src/haz3lcore/pretty/ExpToSegment.re
+++ b/src/haz3lcore/pretty/ExpToSegment.re
@@ -993,8 +993,12 @@ let should_add_space = (s1, s2) =>
   | _ when String.starts_with(s2, ~prefix=":") => false
   | _ when String.ends_with(s1, ~suffix="::") => true
   | _ when String.ends_with(s1, ~suffix=":") =>
+    /* `:` is an operator character, so anything glued to it that also starts
+       with one lexes as a single operator token -- `let _ :+ T` in a sig came
+       back as `:+`, which is no form at all. `$` is a name character but still
+       needs the gap. */
     String.starts_with(s2, ~prefix="$")
-    || String.starts_with(s2, ~prefix="!")
+    || Token.begins_with_potential_operator(s2)
   | _ when String.ends_with(s1, ~suffix=" ") => false
   | _ when String.starts_with(s2, ~prefix=" ") => false
   | _ when String.ends_with(s1, ~suffix="\n") => false

--- a/src/language/dynamics/IncrEval.re
+++ b/src/language/dynamics/IncrEval.re
@@ -13,7 +13,10 @@ type projection =
   | ConsTail
   | ConstructorArg(string)
   | TupleLabel(option(string))
-  | Ascribed;
+  /* The binding went through `p : ty`. The type is part of the provenance:
+     an ascription changes the bound value (it seals a module, casts a
+     value), so a dependent computed under a different ascription is stale. */
+  | Ascribed(Typ.t);
 
 [@deriving (show({with_path: false}), sexp, yojson)]
 type flag =
@@ -159,8 +162,18 @@ let visible_ids = (incr: t('state)): list(Id.t) => {
 /* Ids the UI should paint as "frozen" for a reuse plan / prediction. */
 let frozen_ids = (~incr: t('state)): list(Id.t) => visible_ids(incr);
 
+let equal_projection = (a: projection, b: projection): bool =>
+  switch (a, b) {
+  | (Ascribed(t1), Ascribed(t2)) => Typ.fast_equal(t1, t2)
+  | (Ascribed(_), _)
+  | (_, Ascribed(_)) => false
+  | _ => a == b
+  };
+
 let equal_provenance = (a: provenance, b: provenance): bool =>
-  Id.equal(a.source, b.source) && a.path == b.path && a.flag == b.flag;
+  Id.equal(a.source, b.source)
+  && List.equal(equal_projection, a.path, b.path)
+  && a.flag == b.flag;
 
 let make_clean = (reuse_map: reuse_map): reuse_map =>
   Maps.StringMap.map(
@@ -269,7 +282,7 @@ let pat_provenance = (~source_id: Id.t, ~flag: flag, pat: Pat.t): reuse_map => {
       ]
     | Parens(p)
     | Projector(_, p) => go(path, p)
-    | Asc(p, _) => go([Ascribed, ...path], p)
+    | Asc(p, ty) => go([Ascribed(ty), ...path], p)
     | TupLabel(label, p) => go([TupleLabel(pat_label(label)), ...path], p)
     | Ap(ctr, p) =>
       switch (Pat.ctr_name(ctr)) {

--- a/test/Test_ExpToSegment.re
+++ b/test/Test_ExpToSegment.re
@@ -1240,7 +1240,35 @@ let roundtrip_projector_tests = (
   ],
 );
 
+/* `:` is an operator character: printed flush against a following operator
+   character the two lex as one token (`:+` is no form), so should_add_space
+   keeps them apart. `$` is a name character and still needs the gap. */
+let spacing_tests = (
+  "Ascription spacing",
+  [
+    test_case(
+      "`:` stays apart from a following operator character",
+      `Quick,
+      () => {
+        check(
+          bool,
+          ": then +",
+          true,
+          ExpToSegment.should_add_space(":", "+"),
+        );
+        check(
+          bool,
+          ": then $",
+          true,
+          ExpToSegment.should_add_space(":", "$"),
+        );
+      },
+    ),
+  ],
+);
+
 let all = [
+  spacing_tests,
   tests,
   roundtrip_tests,
   roundtrip_defensive_paren_tests,

--- a/test/Test_ExpToSegment.re
+++ b/test/Test_ExpToSegment.re
@@ -1264,6 +1264,28 @@ let spacing_tests = (
         );
       },
     ),
+    test_case(
+      "printing a parenthesized bare sum is idempotent",
+      `Quick,
+      () => {
+        let src = {|type T = + Adid in ?|};
+        switch (Parser.to_term(src, ~root=Exp)) {
+        | None => fail("failed to parse " ++ src)
+        | Some(exp) =>
+          let once = print_seg(exp_to_segment(exp));
+          switch (Parser.to_term(once, ~root=Exp)) {
+          | None => fail("failed to reparse " ++ once)
+          | Some(exp') =>
+            check(
+              string,
+              "second print equals the first",
+              once,
+              print_seg(exp_to_segment(exp')),
+            )
+          };
+        };
+      },
+    ),
   ],
 );
 

--- a/test/evaluator/Test_Evaluator_Incremental.re
+++ b/test/evaluator/Test_Evaluator_Incremental.re
@@ -1678,6 +1678,48 @@ n|};
   );
 };
 
+/* Replace every type node [from] by [to_] in [exp], preserving every other
+ * id: an ascription edited in place. */
+let retype = (~from: Typ.term, ~to_: Typ.term, exp: Exp.t): Exp.t => {
+  let f_typ = (continue, t: Typ.t): Typ.t =>
+    Typ.fast_equal(
+      t,
+      {
+        ...t,
+        term: from,
+      },
+    )
+      ? {
+        ...t,
+        term: to_,
+      }
+      : continue(t);
+  TermBase.Exp.map_term(~f_typ, exp);
+};
+
+/* An ascription is part of a binding's value: `1` bound as `x : Int` is `1`,
+ * bound as `x : Bool` it is the failed cast, so editing the annotation must
+ * invalidate the cached use of `x` rather than hand back the old `1`. */
+let test_asc_edit_invalidates_binding = () => {
+  let exp1 = parse_exp({|let x : Int = 1 in x|});
+  let exp2 = retype(~from=Atom(Int), ~to_=Atom(Bool), exp1);
+  check(
+    bool,
+    "retype actually changed the expression",
+    true,
+    !Exp.fast_equal(exp1, exp2),
+  );
+  let (r_fresh, _, _) = eval_incr(exp2);
+  let (_, _, incr_prev) = eval_incr(exp1);
+  let (r_incr, _, _) = eval_incr(~prev=incr_prev, exp2);
+  check(
+    dhexp_typ,
+    "Incremental eval of edited matches fresh eval of edited",
+    r_fresh,
+    r_incr,
+  );
+};
+
 let tests = (
   "Evaluator.Incremental",
   [
@@ -1880,6 +1922,11 @@ let tests = (
       "BUILTIN: string_length(\"hello\") reuses after unrelated _=55 edit",
       `Quick,
       test_builtin_call_reuses_after_unrelated_edit,
+    ),
+    test_case(
+      "ASCRIPTION: retyping `x : Int` as `x : Bool` in place invalidates the cached x",
+      `Quick,
+      test_asc_edit_invalidates_binding,
     ),
   ],
 );


### PR DESCRIPTION
Three fixes to code that is on `dev` today, surfaced while building the modules stack (#2496). They were originally committed inside parts 2 and 4 of that stack; they are lifted out here so they can land on their own and the stack can sit on top. Each commit carries a test that fails without its fix on `dev`.

## Incremental eval: a binding's ascription is part of its provenance

Editing a binding's ascription in place left its dependents reusing values computed under the old type: the reuse provenance recorded only *that* the binding went through an ascription, not which type. An ascription changes the bound value (a cast; further up the stack, sealing a module), so the type now travels in the provenance as `Ascribed(Typ.t)`, compared with `Typ.fast_equal`.

Pinned by retyping `let x : Int = 1 in x` as `let x : Bool = 1 in x` in place: fresh evaluation reports the inconsistency, the stale reuse handed back the old `1`. (Retyping `Int` as `?`, or relabeling a tuple ascription, is *not* observable on `dev` — casts are stripped by the comparison and a projection's index comes from the new static type — which is why the test uses the inconsistent form.)

## Keep a printed `:` apart from a following operator

`:` is one of `Token.ascii_operator_chars`, and `Token.is_potential_operator` matches any run of them, so a `:` printed flush against a leading-plus sum lexed as the single operator token `:+`, which is no form at all; Menhir has its own lexer and split them, so the two parsers disagreed. `should_add_space` already kept `:` apart from `$` and `!`, as a list of two characters; it now asks `Token.begins_with_potential_operator` for the property they share (`$` stays listed: it is a name character). Pinned at the `should_add_space` level; reaching a `:` with an unparenthesized sum in a real program takes a signature member, so that form stays in the stack.

## Stop re-parenthesizing the content of a Parens type

Printing a parenthesized min-precedence type was not idempotent: `type T = + Adid` came out as `type T = (+ Adid)` and each further trip added a layer. `parenthesize_typ`'s `Parens` case ran its content through `paren_typ_at(Precedence.min)`, which wraps exactly the types whose precedence *is* min — a bare sum, a multihole, and up the stack a Sig — on every pass. The wrapper being emitted is already the protection, so the content needs none; `already_paren` is still passed down. Pinned by printing `type T = + Adid in ?` twice.

The last two were found by the Slow `Menhir and maketerm are equivalent` fuzz property on the stack's CI; the non-idempotence is why its counterexamples could not be pinned with the round-trip helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQDwH6tMjSMGSSykhjgQUP
