### PR TITLE
Quote keyword labels when printing (#2512)

### DIFF
--- a/src/haz3lcore/lang/Token.re
+++ b/src/haz3lcore/lang/Token.re
@@ -277,8 +277,10 @@ let capitalized_name_regexp =
   unicode_regexp("^" ++ uppercase_start ++ name_rest_class ++ "*$");
 let is_ctr = unicode_match(capitalized_name_regexp);
 
+/* Keywords pass is_var but cannot lex as an identifier in label position,
+   so they need the quotes too (#2512). */
 let quote_label_when_necessary = (l: string): string =>
-  is_var(l) || is_ctr(l) ? l : label_quote(l);
+  (is_var(l) || is_ctr(l)) && !is_keyword(l) ? l : label_quote(l);
 /* Atom type names recognized by MakeTerm as Atom(...) in Typ sort.
  * Also includes Drv* names recognized as DrvQuoteTy(sort).
  * Keep in sync with Ctx.is_base_typ. */

--- a/test/Test_ExpToSegment.re
+++ b/test/Test_ExpToSegment.re
@@ -756,6 +756,21 @@ in f(42)|},
       {|(`hello world`=42)|},
     ),
     roundtrip_test({|QuotedLabel: empty works|}, {|(``=1)|}),
+    /* Keywords pass Token.is_var but can't lex as identifiers in label
+       position, so they must keep their backticks (#2512). */
+    roundtrip_test({|QuotedLabel: keyword label in exp|}, {|(`type`=3)|}),
+    roundtrip_test(
+      {|QuotedLabel: keyword label in projection|},
+      {|let t = (`fun`=3) in t.`fun`|},
+    ),
+    roundtrip_test(
+      {|QuotedLabel: keyword label in pattern|},
+      {|fun `let`=n -> n|},
+    ),
+    roundtrip_test(
+      {|QuotedLabel: keyword label in type|},
+      {|let t : (`if`=Int) = (`if`=1) in t|},
+    ),
     /* Float power operator (**.) - using normalized float format */
     roundtrip_test({|FPower: standard|}, {|2.000000 **. 3.000000|}),
     roundtrip_test({|FPower: compact|}, {|2.000000**.3.000000|}),


### PR DESCRIPTION
Fixes #2512.

`(`type` = 3)` evaluated to `(type=3)`, which no longer parses. Keywords pass `Token.is_var`, so `quote_label_when_necessary` left them bare. Now `(`type`=3)`, in exp, pat, typ and projection position. Four round-trip tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cv949hpUiNTZRXrUJYVjg