### PR TITLE
Swap ¿ markers for Grout in place (#2518)

### DIFF
--- a/src/haz3lcore/zipper/MarkerParse.re
+++ b/src/haz3lcore/zipper/MarkerParse.re
@@ -11,15 +11,15 @@
    round-trip distinct from implicit Grout.
 
    Reparsing marked text yields literal `¿` TILES, which the original
-   program never had. [of_text] parses, then Destructs each marker
-   tile; the remold/regrout pass that runs on every edit re-inserts
-   Grout wherever shape requires it, reconstructing the original
-   zipper. This is the RECOVERING-PARSER half: the fast path reads the
+   program never had. [of_text] parses, then swaps each marker tile for
+   a Grout piece in place. (It used to Destruct the tile and let the
+   edit-time regrout put Grout back, but that only recovers a hole
+   where regrout independently wants one: `[¿]` came back as `[]`,
+   #2518.) This is the RECOVERING-PARSER half: the fast path reads the
    same markers structurally during its weave (see FastParse), but the
    recovering parser has no notion of `¿`, and incomplete programs —
    the grout-heavy ones — are exactly what falls back to it. Sits
    below PersistentZipper so persistence loading can fall back to it. */
-open Util;
 open Base;
 
 let default_implicit_hole = Token.implicit_hole_marker;
@@ -48,76 +48,36 @@ let to_text = (~implicit_hole=default_implicit_hole, z: Zipper.t): string =>
     Zipper.unselect_and_zip(~erase_buffer=true, z),
   );
 
-let is_marker = (~implicit_hole: string, p: piece): bool =>
-  switch (p) {
-  | Tile(t) => t.label == [implicit_hole]
-  | _ => false
-  };
-
-let rec find_marker = (~implicit_hole: string, seg: Segment.t): option(Id.t) => {
-  let rec scan = (rest: list(piece)): option(Id.t) =>
-    switch (rest) {
-    | [] => None
-    | [p, ...tail] =>
-      if (is_marker(~implicit_hole, p)) {
-        Some(Piece.id(p));
-      } else {
-        switch (descend(p)) {
-        | Some(id) => Some(id)
-        | None => scan(tail)
-        };
+/* Swap every marker tile for a convex Grout with the same id. Projector
+   contents are not entered: markers inside projector syntax (`^^fold(¿)`)
+   are a KNOWN GAP (#2455) — the fast path handles those (its weave maps
+   ¿ to Grout before materializing the projector), so only a slow-path
+   load of a projector-wrapped hole leaves a literal ¿ tile inside. */
+let replace_markers = (~implicit_hole: string, seg: Segment.t): Segment.t =>
+  List.map(
+    Base.map_piece(~f_piece=(rec_call, p: piece) =>
+      switch (p) {
+      | Tile({id, label: [marker], _}) when marker == implicit_hole =>
+        Grout({
+          id,
+          shape: Convex,
+        })
+      | _ => rec_call(p)
       }
-    }
-  and descend = (p: piece): option(Id.t) =>
-    switch (p) {
-    | Tile(t) =>
-      List.fold_left(
-        (acc, child) =>
-          switch (acc) {
-          | Some(_) => acc
-          | None => find_marker(~implicit_hole, child)
-          },
-        None,
-        t.children,
-      )
-    | Projector(_) =>
-      /* KNOWN GAP: markers inside projector syntax (`^^fold(¿)`) are not
-         found — and the strip below couldn't destruct inside a projector
-         anyway. The fast path handles these (its weave maps ¿ to Grout
-         before materializing the projector), so only a slow-path load of
-         a projector-wrapped hole leaves a literal ¿ tile inside. */
-      None
-    | _ => None
-    };
-  scan(seg);
-};
+    ),
+    seg,
+  );
 
-let rec strip_implicit_holes =
-        (~implicit_hole: string, ~root, z: Zipper.t): Zipper.t => {
-  let segment = Zipper.zip(z);
-  switch (find_marker(~implicit_hole, segment)) {
-  | None => z
-  | Some(id) =>
-    /* Select the whole marker tile first, otherwise Destruct nibbles one
-     * char at a time via Token.rm_edge and never removes the full tile. */
-    switch (Select.tile(id, z)) {
-    | None => z
-    | Some(z) =>
-      switch (Destruct.go(Left, z, ~root)) {
-      | None => z
-      | Some(z) => strip_implicit_holes(~implicit_hole, ~root, z)
-      }
-    }
-  };
-};
+let strip_implicit_holes = (~implicit_hole: string, z: Zipper.t): Zipper.t =>
+  Zipper.zip(z)
+  |> replace_markers(~implicit_hole)
+  |> Zipper.unzip
+  |> ZipperBase.update_refractors(_, _ => z.refractors);
 
 let of_text =
     (~implicit_hole=default_implicit_hole, ~root, text: string)
     : option(Zipper.t) =>
   switch (Parser.to_zipper(~root, text)) {
   | None => None
-  | Some(z) =>
-    let refractors = z.refractors;
-    let z = strip_implicit_holes(~implicit_hole, ~root, z);
-    Some(ZipperBase.update_refractors(z, _ => refractors));
+  | Some(z) => Some(strip_implicit_holes(~implicit_hole, z))
   };

--- a/test/Test_TextRoundtrip.re
+++ b/test/Test_TextRoundtrip.re
@@ -131,6 +131,40 @@ let text_reproducer_cases = [
   ),
 ];
 
+/* A marker whose removal leaves a complete term used to be lost (#2518):
+   `[¿]` reloaded as `[]`, because of_text destructed the marker and relied
+   on regrout to put Grout back. Markers are now swapped for Grout in
+   place; check the reload prints the same text AND that the hole survives
+   the load-time regrout (PersistentZipper's fast path runs one). */
+let sole_hole_case = (~name, text) =>
+  test_case(
+    name,
+    `Quick,
+    () => {
+      let z = parse_or_fail(text);
+      check(
+        string,
+        "marker preserved by of_text",
+        text,
+        MarkerParse.to_text(z),
+      );
+      let z = Zipper.remold_regrout(Left, ~root=Exp, z);
+      check(string, "hole survives regrout", text, MarkerParse.to_text(z));
+    },
+  );
+
+let sole_hole_cases = [
+  sole_hole_case(~name="sole list element", "[¿]"),
+  sole_hole_case(
+    ~name="sole list element, typed let",
+    "let xs : [Int] = [¿] in xs",
+  ),
+  sole_hole_case(~name="nested sole list element", "[[¿]]"),
+  sole_hole_case(~name="sole parenthesized", "(¿)"),
+  sole_hole_case(~name="sole argument", "f(¿)"),
+  sole_hole_case(~name="list with hole and element", "[¿, 1]"),
+];
+
 /* Render an arbitrary `Exp.t` to source text (same path
  * `QCheck_Util.arb_exp` uses for `show`), then parse it. Going through
  * the parser canonicalizes the segment so the fixed-point check is
@@ -159,6 +193,7 @@ let arb_exp_roundtrip =
 
 let tests = [
   ("TextRoundtrip.TextReproducers", text_reproducer_cases),
+  ("TextRoundtrip.SoleHoles", sole_hole_cases),
   ("TextRoundtrip.DocSlides", doc_slide_cases),
   (
     "TextRoundtrip.Property",


### PR DESCRIPTION
Fixes #2518.

`let xs : [Int] = [¿] in xs` reloaded as `[]` on the slow parse path: `MarkerParse.of_text` destructed the marker tile and relied on the edit-time regrout to put Grout back, which only happens where regrout independently wants a hole. `(¿)` and `f(¿)` were dropped the same way.

Replace each marker tile with a convex Grout of the same id, so an authored hole stays wherever it was written. The new `TextRoundtrip.SoleHoles` cases also check the hole survives `remold_regrout` (the fast-path load runs one); five of six fail on dev.

Note for #2479: the concave marker can take the same swap with `shape: Concave` instead of a second destruct pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cv949hpUiNTZRXrUJYVjg