### PR TITLE
Anchor the table column menu to its header cell (#2521)

### DIFF
--- a/src/haz3lcore/projectors/implementations/ProbeProj.re
+++ b/src/haz3lcore/projectors/implementations/ProbeProj.re
@@ -2367,52 +2367,6 @@ module M: Projector = {
     };
   };
 
-  let modal_overlay =
-      (
-        ~settings,
-        model,
-        info,
-        ~local: action => Ui_effect.t(unit),
-        ~parent,
-        ~view_seg,
-        ~sort,
-      )
-      : list(Node.t) => {
-    switch (
-      rich_content(~settings, model, info, ~local, ~parent, ~view_seg, ~sort)
-    ) {
-    | None => []
-    | Some(content) => [
-        div(
-          ~attrs=[Attr.classes(["modal-backdrop", "live-offside"])],
-          [
-            div(
-              ~attrs=[
-                Attr.classes(["modal"]),
-                Attr.on_click(_ => Effect.Stop_propagation),
-              ],
-              (
-                model.active_renderer != None
-                  ? [
-                    div(
-                      ~attrs=[
-                        Attr.classes(["modal-close-btn"]),
-                        Attr.title("Close"),
-                        Attr.on_click(_ => local(ToggleModal(None))),
-                      ],
-                      [text("×")],
-                    ),
-                  ]
-                  : []
-              )
-              @ [content],
-            ),
-          ],
-        ),
-      ]
-    };
-  };
-
   let error = (_, _): option(ProjectorBase.error) => None;
 
   let view =
@@ -2456,8 +2410,7 @@ module M: Projector = {
         }
       );
     /* In drawer mode an active rich renderer replaces the sample view in
-     * the drawer itself; the anchored modal overlay is inline-mode only
-     * (anchored to the nav-bar stub, it renders detached/clipped). */
+     * the drawer itself; inline mode embeds small rich views in the chip. */
     let rich_drawer =
       drawer
       && (
@@ -2486,21 +2439,10 @@ module M: Projector = {
                )
              )
         : None;
-    /* the anchored modal is retired: small rich views replace the
-       offside row, big ones live in the drawer */
-    let modal_nodes = [];
-    let _unused_modal = modal_overlay;
-    /* Wrap in a div only when the modal is open, to avoid an extra DOM level
-     * around the positioned .live-offside otherwise. */
-    let offside_node =
-      switch (modal_nodes) {
-      | [] => offside_main
-      | _ => div([offside_main] @ modal_nodes)
-      };
     View.{
       inline: Node.div([]),
       overlay: None,
-      offside: Some(offside_node),
+      offside: Some(offside_main),
       below:
         switch (data_opt, drawer) {
         | (Some(data), true) =>

--- a/src/haz3lcore/projectors/implementations/TableRenderer.re
+++ b/src/haz3lcore/projectors/implementations/TableRenderer.re
@@ -413,12 +413,7 @@ let render =
               Node.div(
                 ~attrs=[
                   Attr.id("column-menu-" ++ string_of_int(i)),
-                  Attr.classes([
-                    "context-menu",
-                    "nut-menu",
-                    "column-menu",
-                    dir_class,
-                  ]),
+                  Attr.classes(["context-menu", "column-menu", dir_class]),
                 ],
                 [
                   WebUtil.div_c(

--- a/src/web/www/style/projectors/proj-cards.css
+++ b/src/web/www/style/projectors/proj-cards.css
@@ -9,24 +9,6 @@
   --card-height: 47px;
 }
 
-/* Modal context: the .projector base style is position:absolute, so the modal
-   doesn't size to the card. Pin it to relative so the modal sizes to content
-   and the close button at right:-18px sits cleanly outside the cards. */
-.modal-backdrop.live-offside .modal:has(> .projector.card) {
-  background-color: transparent;
-  border-radius: 0;
-  box-shadow: none;
-}
-.modal-backdrop.live-offside .modal > .projector.card {
-  position: relative;
-  padding: 0 24px 0 0;
-}
-.modal-backdrop.live-offside .modal > .projector.card .card-wrapper.show,
-.modal-backdrop.live-offside .modal > .projector.card .card-wrapper.flipped {
-  width: var(--card-width);
-  height: var(--card-height);
-}
-
 .code-deco:has(~ .projectors .projector.card.indicated) .indication {
   display: none;
 }

--- a/src/web/www/style/projectors/proj-table-probe.css
+++ b/src/web/www/style/projectors/proj-table-probe.css
@@ -67,105 +67,17 @@
     to   { opacity: 1; transform: scale(1); }
 }
 
-/* Indicate which column the open menu belongs to. */
-.modal .table th.menu-open {
-    background-color: var(--df-hover-bg);
-}
-
-.modal .table th.menu-open .closure-nav-button {
-    background-color: var(--df-hover-bg);
-}
-
-/* Modal backdrop for rich probe table */
-.modal-backdrop.live-offside {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: var(--modal-z);
-  margin-top: 5px;
-}
-
-/* When the rich-probe modal is open, pull the active sample menu into
-   normal flow so the modal's `top: 100%` anchor includes the menu's
-   height — modal stacks below the menu instead of overlapping it. */
-.projector.probe:has(.modal-backdrop)
-  .live-offside
-  .sample-context-menu.dropdown-active {
-  position: relative;
-}
-
-/* Top-align samples and sample-groups so the one growing to fit its
-   in-flow menu extends downward rather than shifting up relative to
-   its neighbors. */
-.projector.probe:has(.modal-backdrop) .live-offside,
-.projector.probe:has(.modal-backdrop) .live-offside .sample-groups,
-.projector.probe:has(.modal-backdrop) .live-offside .sample-group {
-  align-items: flex-start;
-}
-
-.modal-backdrop.live-offside .modal {
-  background-color: var(--df-bg);
-  border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  padding: 0;
-  overflow: visible;
-  pointer-events: auto;
-  position: relative;
-}
-
-.modal-backdrop.live-offside .modal .modal-close-btn {
-  position: absolute;
-  top: 0;
-  right: -18px;
-  width: 16px;
-  height: 16px;
-  line-height: 14px;
-  text-align: center;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--BR2);
-  cursor: pointer;
-  user-select: none;
-  /* Must exceed .table th z-index (projector-z + 1) so the button
-     stays visible if it ever overlaps sticky headers. */
-  z-index: calc(var(--projector-z) + 10);
-}
-
-.modal-backdrop.live-offside .modal .modal-close-btn:hover {
-  color: var(--R1);
-}
-
-.modal .table th {
+/* The open menu anchors to its header cell (the .cm-* offsets above
+ * resolve against the nearest positioned ancestor). Tall drawers make
+ * every th sticky, which is a containing block too; this covers the
+ * short, non-scrolling case where nothing else positions the cell. */
+.table th.menu-open {
     position: relative;
-    padding-left: 15px;
-    padding-right: 15px;
-    /* Keep header label and the inline-block column-options button on the
-     * same line even when the modal-backdrop (position: absolute, inside a
-     * flex .sample-group) shrinks under an empty/indet sample value. */
-    white-space: nowrap;
+    background-color: var(--df-hover-bg);
 }
 
-.modal .table {
-    width: 100%;
-    margin-left: 0;
-    margin-right: 0;
-    border-radius: 8px;
-}
-
-.modal .table th:first-child {
-    border-top-left-radius: 8px;
-}
-
-.modal .table th:last-child {
-    border-top-right-radius: 8px;
-}
-
-.modal .table tr:last-child td:first-child {
-    border-bottom-left-radius: 8px;
-}
-
-.modal .table tr:last-child td:last-child {
-    border-bottom-right-radius: 8px;
+.table th.menu-open .closure-nav-button {
+    background-color: var(--df-hover-bg);
 }
 
 /* Add Column Header Button */


### PR DESCRIPTION
Fixes #2521.

In a short (non-scrolling) drawer, a column's ⋮ menu opened at the bottom of the table: retiring the anchored modal removed the only rule that positioned the `th`, so `top: 100%` resolved against the whole drawer. The cell with an open menu is now its own containing block (`.table th.menu-open { position: relative }`); tall drawers already had one via sticky headers, and the standalone table projector renders no column menus, so neither changes.

Also drops what the retirement left behind: `modal_overlay`, the `.modal` CSS blocks (table and card), and the inert `nut-menu` class on the column menu.

Verified in headless Chrome: menu top = header bottom in both the 5-row and 20-row (sticky) cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cv949hpUiNTZRXrUJYVjg