### PR TITLE
Remove the unread Projector.dynamics flag (#2522)

### DIFF
--- a/src/haz3lcore/projectors/ProjectorBase.re
+++ b/src/haz3lcore/projectors/ProjectorBase.re
@@ -203,10 +203,6 @@ module type Projector = {
    * caret & keyboard handlers? If so, provide handlers
    * here (see Focusable for more information) */
   let focusable: Focusable.t;
-  /* If dynamics is true, this projector will be
-   * instrumented with a probe to collect dynamic
-   * information during evaluation */
-  let dynamics: bool;
   /* Whether this projector needs type-elaborated syntax.
    *
    * Some projectors (e.g. TableProj) require syntactic features
@@ -268,7 +264,6 @@ module Cook = (C: Projector) : Cooked => {
   let deserialize_a = s => s |> Sexplib.Sexp.of_string |> C.action_of_sexp;
   let init = any => C.init(any) |> Option.map(serialize_m);
   let focusable = C.focusable;
-  let dynamics = C.dynamics;
   let elaborate_syntax = C.elaborate_syntax;
   let view = (args: View.args(model, action)) =>
     C.view({

--- a/src/haz3lcore/projectors/implementations/CSVProjector.re
+++ b/src/haz3lcore/projectors/implementations/CSVProjector.re
@@ -95,7 +95,6 @@ module M: Projector = {
   };
 
   let focusable = Focusable.non;
-  let dynamics = false;
   let elaborate_syntax = false;
   let placeholder = (m, _) =>
     switch (m) {

--- a/src/haz3lcore/projectors/implementations/CardProj.re
+++ b/src/haz3lcore/projectors/implementations/CardProj.re
@@ -276,7 +276,6 @@ module M: Projector = {
   [@deriving (show({with_path: false}), sexp, yojson)]
   type action = a;
   let focusable = Focusable.non;
-  let dynamics = false;
   let elaborate_syntax = false;
 
   let init = (info: TermBase.Any.t): option(model) =>

--- a/src/haz3lcore/projectors/implementations/CheckboxProj.re
+++ b/src/haz3lcore/projectors/implementations/CheckboxProj.re
@@ -47,7 +47,6 @@ module M: Projector = {
     };
 
   let focusable = Focusable.non;
-  let dynamics = false;
   let elaborate_syntax = false;
   let placeholder = (_, _) => ProjectorCore.Shape.inline(2);
   let update = (model, _, _) => model;

--- a/src/haz3lcore/projectors/implementations/FoldProj.re
+++ b/src/haz3lcore/projectors/implementations/FoldProj.re
@@ -33,7 +33,6 @@ module M: Projector = {
   let init = _ => Some(default);
 
   let focusable = Focusable.non;
-  let dynamics = false;
   let elaborate_syntax = false;
 
   let placeholder = (m, _) =>

--- a/src/haz3lcore/projectors/implementations/LivelitProj.re
+++ b/src/haz3lcore/projectors/implementations/LivelitProj.re
@@ -77,7 +77,6 @@ module M: Projector = {
       keyboard: None,
     };
 
-  let dynamics = false;
   let elaborate_syntax = false;
   let error = (_, _): option(ProjectorBase.error) => None;
 

--- a/src/haz3lcore/projectors/implementations/ProbeProj.re
+++ b/src/haz3lcore/projectors/implementations/ProbeProj.re
@@ -2245,7 +2245,6 @@ module M: Projector = {
     };
   };
 
-  let dynamics = true;
   let elaborate_syntax = false;
 
   let focusable =

--- a/src/haz3lcore/projectors/implementations/SliderCore.re
+++ b/src/haz3lcore/projectors/implementations/SliderCore.re
@@ -63,7 +63,6 @@ module Make = (P: PARAMS) : Projector => {
     };
 
   let focusable = Focusable.non;
-  let dynamics = false;
   let elaborate_syntax = false;
   let placeholder = (_, _) => ProjectorCore.Shape.inline(10);
   let update = (model, _, _) => model;

--- a/src/haz3lcore/projectors/implementations/TableProj.re
+++ b/src/haz3lcore/projectors/implementations/TableProj.re
@@ -57,7 +57,6 @@ module M: Projector = {
       pointer: None,
       keyboard: None,
     };
-  let dynamics = false;
   let elaborate_syntax = true;
   let placeholder = (_, info) =>
     switch (get(info)) {

--- a/src/haz3lcore/projectors/implementations/TextAreaProj.re
+++ b/src/haz3lcore/projectors/implementations/TextAreaProj.re
@@ -126,7 +126,6 @@ module M: Projector = {
       pointer: Some(focus_pointer),
       keyboard: Some(focus_keyboard),
     };
-  let dynamics = false;
   let elaborate_syntax = false;
   let placeholder = (_, info) => {
     let str = info |> get;

--- a/src/haz3lcore/projectors/implementations/TypeProj.re
+++ b/src/haz3lcore/projectors/implementations/TypeProj.re
@@ -43,7 +43,6 @@ module M: Projector = {
     };
   };
 
-  let dynamics = false;
   let elaborate_syntax = false;
   let focusable = Focusable.non;
 


### PR DESCRIPTION
Fixes #2522.

Nothing has read `Projector.dynamics` since `MakeTerm.should_instrument` went in 9a8cd47887; `ProjectorInfo` populates every projector's dynamics from the map regardless. Removes the signature entry, the `Cook` forwarding and the ten implementations' values. Zero behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cv949hpUiNTZRXrUJYVjg